### PR TITLE
[TC-192] Differentiates between goTM and javaTM rpm builds

### DIFF
--- a/build/functions.sh
+++ b/build/functions.sh
@@ -76,7 +76,12 @@ function getVersion() {
 	local d="$1"
 	local vf="$d/VERSION"
 	[ -r $vf ] || { echo "Could not read $vf: $!"; exit 1; }
-	cat "$vf"
+	if [ "${TC_COMPILER}" == "go" ]; then
+		local version="$(cat ${vf})_go"
+		echo "${version}"
+	else
+		cat "$vf"
+	fi
 }
 
 # ---------------------------------------
@@ -118,6 +123,7 @@ function checkEnvironment {
 	echo "BUILD_NUMBER: $BUILD_NUMBER"
 	echo "RHEL_VERSION: $RHEL_VERSION"
 	echo "TC_VERSION: $TC_VERSION"
+	echo "TC_COMPILER: $TC_COMPILER"
 	echo "--------------------------------------------------"
 }
 

--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -34,16 +34,15 @@ services:
     volumes:
       - ../../..:/trafficcontrol
 
-  # NOTE: Disabled since rpm name collides with current traffic_monitor.  To
-  # build golang version,  uncomment this section and use `docker-compose ...
-  # up traffic_monitor_golang_build`
-  # traffic_monitor_golang_build:
-  #   image: traffic_monitor_golang_builder
-  #   build:
-  #     dockerfile: infrastructure/docker/build/Dockerfile-traffic_monitor_golang
-  #     context: ../../..
-  #   volumes:
-  #     - ../../..:/trafficcontrol
+  traffic_monitor_golang_build:
+    image: traffic_monitor_golang_builder
+    build:
+      dockerfile: infrastructure/docker/build/Dockerfile-traffic_monitor_golang
+      context: ../../..
+    volumes:
+      - ../../..:/trafficcontrol
+    environment:
+      - TC_COMPILER=go
 
   traffic_ops_build:
     image: traffic_ops_builder


### PR DESCRIPTION
Adds a version differentiator for building goTM and javaTM by including an environment variable in the build service for the golang version (TC_COMPILER), which is utilized by the build/functions.sh script to add "_go" to the version when building the golang version of TM.

Both projects were using the same VERSION file, and since both projects were name the same (traffic_monitor), they produced RPM packages with the same exact name.

Produces two different RPM packages and re-enables the traffic_monitor_golang_build service in the compose file.