### PR TITLE
enhance traffic monitor to support configurable polling over ipv6

### DIFF
--- a/docs/source/admin/traffic_monitor_golang.rst
+++ b/docs/source/admin/traffic_monitor_golang.rst
@@ -55,7 +55,13 @@ Traffic Monitor is configured via two JSON configuration files, ``traffic_ops.cf
 
 The ``traffic_ops.cfg`` config contains Traffic Ops connection information. Specify the URL, username, and password for the instance of Traffic Ops for which this Traffic Monitor is a member.
 
-The ``traffic_monitor.cfg`` config contains log file locations, as well as detailed application configuration variables, such as processing flush times and initial poll intervals.
+The ``traffic_monitor.cfg`` config contains log file locations, as well as detailed application configuration variables, such as processing flush times, initial poll intervals and the polling protocols.
+
+polling protocol can be set for peers and caches and has 3 options:
+
+ipv4only (the default): TM will communicate with the peers or caches only over ipv4
+ipv6only: TM will communicate with the peers or caches only over ipv6 (use case for peers is if the other TMs are only available over ipv6)
+both: TM will alternate its communication between ipv4 and ipv6 (note: this does not affect the polling frequency so if polling frequency is 1 second ipv4 will be polled every 2 seconds)
 
 Once started with the correct configuration, Traffic Monitor downloads its configuration from Traffic Ops and begins polling caches. Once every cache has been polled, health protocol state is available via RESTful JSON endpoints.
 

--- a/traffic_monitor/cache/astats_test.go
+++ b/traffic_monitor/cache/astats_test.go
@@ -8,9 +8,9 @@ package cache
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,7 +18,6 @@ package cache
  * specific language governing permissions and limitations
  * under the License.
  */
-
 
 import (
 	"fmt"

--- a/traffic_monitor/cache/cache.go
+++ b/traffic_monitor/cache/cache.go
@@ -77,7 +77,7 @@ type Result struct {
 	RequestTime     time.Duration
 	Vitals          Vitals
 	PollID          uint64
-	UsingIPV4       bool
+	UsingIPv4       bool
 	PollFinished    chan<- uint64
 	PrecomputedData PrecomputedData
 	Available       bool
@@ -273,14 +273,14 @@ func StatsMarshall(statResultHistory ResultStatHistory, statInfo ResultInfoHisto
 }
 
 // Handle handles results fetched from a cache, parsing the raw Reader data and passing it along to a chan for further processing.
-func (handler Handler) Handle(id string, r io.Reader, format string, reqTime time.Duration, reqEnd time.Time, reqErr error, pollID uint64, usingIPV4 bool, pollFinished chan<- uint64) {
+func (handler Handler) Handle(id string, r io.Reader, format string, reqTime time.Duration, reqEnd time.Time, reqErr error, pollID uint64, usingIPv4 bool, pollFinished chan<- uint64) {
 	log.Debugf("poll %v %v (format '%v') handle start\n", pollID, time.Now(), format)
 	result := Result{
 		ID:           tc.CacheName(id),
 		Time:         reqEnd,
 		RequestTime:  reqTime,
 		PollID:       pollID,
-		UsingIPV4:    usingIPV4,
+		UsingIPv4:    usingIPv4,
 		PollFinished: pollFinished,
 	}
 

--- a/traffic_monitor/cache/cache.go
+++ b/traffic_monitor/cache/cache.go
@@ -77,6 +77,7 @@ type Result struct {
 	RequestTime     time.Duration
 	Vitals          Vitals
 	PollID          uint64
+	UsingIPV4       bool
 	PollFinished    chan<- uint64
 	PrecomputedData PrecomputedData
 	Available       bool
@@ -272,13 +273,14 @@ func StatsMarshall(statResultHistory ResultStatHistory, statInfo ResultInfoHisto
 }
 
 // Handle handles results fetched from a cache, parsing the raw Reader data and passing it along to a chan for further processing.
-func (handler Handler) Handle(id string, r io.Reader, format string, reqTime time.Duration, reqEnd time.Time, reqErr error, pollID uint64, pollFinished chan<- uint64) {
+func (handler Handler) Handle(id string, r io.Reader, format string, reqTime time.Duration, reqEnd time.Time, reqErr error, pollID uint64, usingIPV4 bool, pollFinished chan<- uint64) {
 	log.Debugf("poll %v %v (format '%v') handle start\n", pollID, time.Now(), format)
 	result := Result{
 		ID:           tc.CacheName(id),
 		Time:         reqEnd,
 		RequestTime:  reqTime,
 		PollID:       pollID,
+		UsingIPV4:    usingIPV4,
 		PollFinished: pollFinished,
 	}
 

--- a/traffic_monitor/cache/data.go
+++ b/traffic_monitor/cache/data.go
@@ -33,15 +33,23 @@ import (
 const AvailableStatusReported = "REPORTED"
 
 type AvailableTuple struct {
-	IPV4 bool
-	IPV6 bool
+	IPv4 bool
+	IPv6 bool
+}
+
+func (a AvailableTuple) SetAvailability(usingIPv4 bool, isAvailable bool) {
+	if usingIPv4 {
+		a.IPv4 = isAvailable
+	} else {
+		a.IPv6 = isAvailable
+	}
 }
 
 // CacheAvailableStatus is the available status of the given cache. It includes a boolean available/unavailable flag, and a descriptive string.
 type AvailableStatus struct {
 	Available          AvailableTuple
 	ProcessedAvailable bool
-	LastCheckedIPV4    bool
+	LastCheckedIPv4    bool
 	Status             string
 	Why                string
 	// UnavailableStat is the stat whose threshold made the cache unavailable. If this is the empty string, the cache is unavailable for a non-threshold reason. This exists so a poller (health, stat) won't mark an unavailable cache as available if the stat whose threshold was reached isn't available on that poller.
@@ -200,7 +208,7 @@ type ResultInfo struct {
 	Vitals      Vitals
 	System      AstatsSystem
 	PollID      uint64
-	UsingIPV4   bool
+	UsingIPv4   bool
 	Available   bool
 }
 
@@ -212,7 +220,7 @@ func ToInfo(r Result) ResultInfo {
 		RequestTime: r.RequestTime,
 		Vitals:      r.Vitals,
 		PollID:      r.PollID,
-		UsingIPV4:   r.UsingIPV4,
+		UsingIPv4:   r.UsingIPv4,
 		Available:   r.Available,
 		System:      r.Astats.System,
 	}

--- a/traffic_monitor/cache/data.go
+++ b/traffic_monitor/cache/data.go
@@ -32,11 +32,18 @@ import (
 // TODO put somewhere more generic
 const AvailableStatusReported = "REPORTED"
 
+type AvailableTuple struct {
+	IPV4 bool
+	IPV6 bool
+}
+
 // CacheAvailableStatus is the available status of the given cache. It includes a boolean available/unavailable flag, and a descriptive string.
 type AvailableStatus struct {
-	Available bool
-	Status    string
-	Why       string
+	Available          AvailableTuple
+	ProcessedAvailable bool
+	LastCheckedIPV4    bool
+	Status             string
+	Why                string
 	// UnavailableStat is the stat whose threshold made the cache unavailable. If this is the empty string, the cache is unavailable for a non-threshold reason. This exists so a poller (health, stat) won't mark an unavailable cache as available if the stat whose threshold was reached isn't available on that poller.
 	UnavailableStat string
 	// Poller is the name of the poller which set this available status
@@ -193,6 +200,7 @@ type ResultInfo struct {
 	Vitals      Vitals
 	System      AstatsSystem
 	PollID      uint64
+	UsingIPV4   bool
 	Available   bool
 }
 
@@ -204,6 +212,7 @@ func ToInfo(r Result) ResultInfo {
 		RequestTime: r.RequestTime,
 		Vitals:      r.Vitals,
 		PollID:      r.PollID,
+		UsingIPV4:   r.UsingIPV4,
 		Available:   r.Available,
 		System:      r.Astats.System,
 	}

--- a/traffic_monitor/cache/data.go
+++ b/traffic_monitor/cache/data.go
@@ -37,7 +37,7 @@ type AvailableTuple struct {
 	IPv6 bool
 }
 
-func (a AvailableTuple) SetAvailability(usingIPv4 bool, isAvailable bool) {
+func (a *AvailableTuple) SetAvailability(usingIPv4 bool, isAvailable bool) {
 	if usingIPv4 {
 		a.IPv4 = isAvailable
 	} else {

--- a/traffic_monitor/cache/data_test.go
+++ b/traffic_monitor/cache/data_test.go
@@ -22,12 +22,13 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
-	"github.com/apache/incubator-trafficcontrol/traffic_monitor/dsdata"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/dsdata"
 )
 
 func randBool() bool {

--- a/traffic_monitor/cache/data_test.go
+++ b/traffic_monitor/cache/data_test.go
@@ -48,7 +48,7 @@ func randAvailableStatuses() AvailableStatuses {
 	a := AvailableStatuses{}
 	num := 100
 	for i := 0; i < num; i++ {
-		a[tc.CacheName(randStr())] = AvailableStatus{Available: randBool(), Status: randStr()}
+		a[tc.CacheName(randStr())] = AvailableStatus{Available: AvailableTuple{randBool(), randBool()}, Status: randStr()}
 	}
 	return a
 }
@@ -64,7 +64,7 @@ func TestAvailableStatusesCopy(t *testing.T) {
 		}
 
 		// verify a and b don't point to the same map
-		a[tc.CacheName(randStr())] = AvailableStatus{Available: randBool(), Status: randStr()}
+		a[tc.CacheName(randStr())] = AvailableStatus{Available: AvailableTuple{randBool(), randBool()}, Status: randStr()}
 		if reflect.DeepEqual(a, b) {
 			t.Errorf("expected a != b, actual a and b point to the same map", a)
 		}

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/apache/incubator-trafficcontrol/lib/go-log"
+	"strings"
 )
 
 // LogLocation is a location to log to. This may be stdout, stderr, null (/dev/null), or a valid file path.
@@ -41,29 +42,67 @@ const (
 	StaticFileDir = "/opt/traffic_monitor/static/"
 )
 
+type PollingProtocol string
+
+const (
+	IPV4Only               = PollingProtocol("IPV4Only")
+	IPV6Only               = PollingProtocol("IPV6Only")
+	Both                   = PollingProtocol("Both")
+	InvalidPollingProtocol = PollingProtocol("InvalidPollingProtocol")
+)
+
+func (t PollingProtocol) String() string {
+	switch t {
+	case IPV4Only:
+		return "IPV4Only"
+	case IPV6Only:
+		return "IPV6Only"
+	case Both:
+		return "Both"
+	default:
+		return "InvalidPollingProtocol"
+	}
+}
+
+func PollingProtocolFromString(s string) PollingProtocol {
+	s = strings.ToLower(s)
+	switch s {
+	case "ipv4only":
+		return IPV4Only
+	case "ipv6only":
+		return IPV6Only
+	case "both":
+		return Both
+	default:
+		return InvalidPollingProtocol
+	}
+}
+
 // Config is the configuration for the application. It includes myriad data, such as polling intervals and log locations.
 type Config struct {
-	CacheHealthPollingInterval   time.Duration `json:"-"`
-	CacheStatPollingInterval     time.Duration `json:"-"`
-	MonitorConfigPollingInterval time.Duration `json:"-"`
-	HTTPTimeout                  time.Duration `json:"-"`
-	PeerPollingInterval          time.Duration `json:"-"`
-	PeerOptimistic               bool          `json:"peer_optimistic"`
-	MaxEvents                    uint64        `json:"max_events"`
-	MaxStatHistory               uint64        `json:"max_stat_history"`
-	MaxHealthHistory             uint64        `json:"max_health_history"`
-	HealthFlushInterval          time.Duration `json:"-"`
-	StatFlushInterval            time.Duration `json:"-"`
-	LogLocationError             string        `json:"log_location_error"`
-	LogLocationWarning           string        `json:"log_location_warning"`
-	LogLocationInfo              string        `json:"log_location_info"`
-	LogLocationDebug             string        `json:"log_location_debug"`
-	LogLocationEvent             string        `json:"log_location_event"`
-	ServeReadTimeout             time.Duration `json:"-"`
-	ServeWriteTimeout            time.Duration `json:"-"`
-	HealthToStatRatio            uint64        `json:"health_to_stat_ratio"`
-	StaticFileDir                string        `json:"static_file_dir"`
-	CRConfigHistoryCount         uint64        `json:"crconfig_history_count"`
+	CacheHealthPollingInterval   time.Duration   `json:"-"`
+	CacheStatPollingInterval     time.Duration   `json:"-"`
+	MonitorConfigPollingInterval time.Duration   `json:"-"`
+	HTTPTimeout                  time.Duration   `json:"-"`
+	PeerPollingInterval          time.Duration   `json:"-"`
+	PeerOptimistic               bool            `json:"peer_optimistic"`
+	MaxEvents                    uint64          `json:"max_events"`
+	MaxStatHistory               uint64          `json:"max_stat_history"`
+	MaxHealthHistory             uint64          `json:"max_health_history"`
+	HealthFlushInterval          time.Duration   `json:"-"`
+	StatFlushInterval            time.Duration   `json:"-"`
+	LogLocationError             string          `json:"log_location_error"`
+	LogLocationWarning           string          `json:"log_location_warning"`
+	LogLocationInfo              string          `json:"log_location_info"`
+	LogLocationDebug             string          `json:"log_location_debug"`
+	LogLocationEvent             string          `json:"log_location_event"`
+	ServeReadTimeout             time.Duration   `json:"-"`
+	ServeWriteTimeout            time.Duration   `json:"-"`
+	HealthToStatRatio            uint64          `json:"health_to_stat_ratio"`
+	StaticFileDir                string          `json:"static_file_dir"`
+	CRConfigHistoryCount         uint64          `json:"crconfig_history_count"`
+	CachePollingProtocol         PollingProtocol `json:"cache_polling_protocol"`
+	PeerPollingProtocol          PollingProtocol `json:"peer_polling_protocol"`
 }
 
 func (c Config) ErrorLog() log.LogLocation   { return log.LogLocation(c.LogLocationError) }
@@ -95,6 +134,8 @@ var DefaultConfig = Config{
 	HealthToStatRatio:            4,
 	StaticFileDir:                StaticFileDir,
 	CRConfigHistoryCount:         20000,
+	CachePollingProtocol:         IPV4Only,
+	PeerPollingProtocol:          IPV4Only,
 }
 
 // MarshalJSON marshals custom millisecond durations. Aliasing inspired by http://choly.ca/post/go-json-marshalling/

--- a/traffic_monitor/datareq/cachestate.go
+++ b/traffic_monitor/datareq/cachestate.go
@@ -194,7 +194,7 @@ func cacheStatusAndPoller(server tc.CacheName, serverInfo tc.TrafficServer, loca
 	if statusVal.Why != "" {
 		return statusVal.Why, statusVal.Poller
 	}
-	if statusVal.Available {
+	if statusVal.ProcessedAvailable {
 		return fmt.Sprintf("%s - available", statusVal.Status), statusVal.Poller
 	}
 	return fmt.Sprintf("%s - unavailable", statusVal.Status), statusVal.Poller

--- a/traffic_monitor/datareq/cachestate.go
+++ b/traffic_monitor/datareq/cachestate.go
@@ -54,8 +54,8 @@ type CacheStatus struct {
 	BandwidthKbps          *float64 `json:"bandwidth_kbps,omitempty"`
 	BandwidthCapacityKbps  *float64 `json:"bandwidth_capacity_kbps,omitempty"`
 	ConnectionCount        *int64   `json:"connection_count,omitempty"`
-	IPV4Available          *bool    `json:"ipv4_available,omitempty"`
-	IPV6Available          *bool    `json:"ipv6_available,omitempty"`
+	IPv4Available          *bool    `json:"ipv4_available,omitempty"`
+	IPv6Available          *bool    `json:"ipv6_available,omitempty"`
 	CombinedAvailable      *bool    `json:"combined_available,omitempty"`
 }
 
@@ -173,14 +173,16 @@ func createCacheStatuses(
 			ConnectionCount:        connections,
 			Status:                 &status,
 			StatusPoller:           &statusPoller,
-			IPV4Available:          &ipv4,
-			IPV6Available:          &ipv6,
+			IPv4Available:          &ipv4,
+			IPv6Available:          &ipv6,
 			CombinedAvailable:      &combinedStatus,
 		}
 	}
 	return statii
 }
 
+//cacheStatusAndPoller returns the the reason why a cache is unavailable (or that is available), the poller, and 3 booleans in order:
+// IPv4 availability, IPv6 availability and Processed availability which is what the monitor reports based on the PollingProtocol chosen (ipv4only,ipv6only or both)
 func cacheStatusAndPoller(server tc.CacheName, serverInfo tc.TrafficServer, localCacheStatus cache.AvailableStatuses) (string, string, bool, bool, bool) {
 	switch status := tc.CacheStatusFromString(serverInfo.ServerStatus); status {
 	case tc.CacheStatusAdminDown:
@@ -196,14 +198,14 @@ func cacheStatusAndPoller(server tc.CacheName, serverInfo tc.TrafficServer, loca
 		log.Infof("cache not in statuses %s\n", server)
 		return "ERROR - not in statuses", "", false, false, false
 	}
-	
+
 	if statusVal.Why != "" {
-		return statusVal.Why, statusVal.Poller, statusVal.Available.IPV4, statusVal.Available.IPV6, statusVal.ProcessedAvailable
+		return statusVal.Why, statusVal.Poller, statusVal.Available.IPv4, statusVal.Available.IPv6, statusVal.ProcessedAvailable
 	}
 	if statusVal.ProcessedAvailable {
-		return fmt.Sprintf("%s - available", statusVal.Status), statusVal.Poller, statusVal.Available.IPV4, statusVal.Available.IPV6, statusVal.ProcessedAvailable
+		return fmt.Sprintf("%s - available", statusVal.Status), statusVal.Poller, statusVal.Available.IPv4, statusVal.Available.IPv6, statusVal.ProcessedAvailable
 	}
-	return fmt.Sprintf("%s - unavailable", statusVal.Status), statusVal.Poller, statusVal.Available.IPV4, statusVal.Available.IPV6, statusVal.ProcessedAvailable
+	return fmt.Sprintf("%s - unavailable", statusVal.Status), statusVal.Poller, statusVal.Available.IPv4, statusVal.Available.IPv6, statusVal.ProcessedAvailable
 }
 
 func createCacheConnections(statResultHistory cache.ResultStatHistory) map[tc.CacheName]int64 {

--- a/traffic_monitor/datareq/cachestatfilter.go
+++ b/traffic_monitor/datareq/cachestatfilter.go
@@ -25,8 +25,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
 )
 
 // CacheStatFilter fulfills the cache.Filter interface, for filtering stats. See the `NewCacheStatFilter` documentation for details on which query parameters are used to filter.

--- a/traffic_monitor/datareq/datareq.go
+++ b/traffic_monitor/datareq/datareq.go
@@ -316,11 +316,11 @@ func gzipIfAccepts(r *http.Request, w http.ResponseWriter, b []byte) ([]byte, er
 	zw := gzip.NewWriter(&buf)
 
 	if _, err := zw.Write(b); err != nil {
-		return nil, fmt.Errorf("gzipping bytes: %v")
+		return nil, fmt.Errorf("gzipping bytes: %v", err)
 	}
 
 	if err := zw.Close(); err != nil {
-		return nil, fmt.Errorf("closing gzip writer: %v")
+		return nil, fmt.Errorf("closing gzip writer: %v", err)
 	}
 
 	return buf.Bytes(), nil

--- a/traffic_monitor/fetcher/fetcher.go
+++ b/traffic_monitor/fetcher/fetcher.go
@@ -30,7 +30,7 @@ import (
 )
 
 type Fetcher interface {
-	Fetch(id string, url string, host string, format string, pollId uint64, usingIPV4 bool, pollFinishedChan chan<- uint64)
+	Fetch(id string, url string, host string, format string, pollId uint64, usingIPv4 bool, pollFinishedChan chan<- uint64)
 }
 
 type HttpFetcher struct {
@@ -46,7 +46,7 @@ type Result struct {
 	Error  error
 }
 
-func (f HttpFetcher) Fetch(id string, url string, host string, format string, pollId uint64, usingIPV4 bool, pollFinishedChan chan<- uint64) {
+func (f HttpFetcher) Fetch(id string, url string, host string, format string, pollId uint64, usingIPv4 bool, pollFinishedChan chan<- uint64) {
 	log.Debugf("poll %v %v fetch start for url: %s\n", pollId, time.Now(), url)
 	req, err := http.NewRequest("GET", url, nil)
 	// TODO: change this to use f.Headers. -jse
@@ -76,8 +76,8 @@ func (f HttpFetcher) Fetch(id string, url string, host string, format string, po
 
 	if err == nil && response != nil {
 		log.Debugf("poll %v %v fetch end\n", pollId, time.Now())
-		f.Handler.Handle(id, response.Body, format, reqTime, reqEnd, err, pollId, usingIPV4, pollFinishedChan)
+		f.Handler.Handle(id, response.Body, format, reqTime, reqEnd, err, pollId, usingIPv4, pollFinishedChan)
 	} else {
-		f.Handler.Handle(id, nil, format, reqTime, reqEnd, err, pollId, usingIPV4, pollFinishedChan)
+		f.Handler.Handle(id, nil, format, reqTime, reqEnd, err, pollId, usingIPv4, pollFinishedChan)
 	}
 }

--- a/traffic_monitor/fetcher/fetcher.go
+++ b/traffic_monitor/fetcher/fetcher.go
@@ -30,7 +30,7 @@ import (
 )
 
 type Fetcher interface {
-	Fetch(id string, url string, host string, format string, pollId uint64, pollFinishedChan chan<- uint64)
+	Fetch(id string, url string, host string, format string, pollId uint64, usingIPV4 bool, pollFinishedChan chan<- uint64)
 }
 
 type HttpFetcher struct {
@@ -46,8 +46,8 @@ type Result struct {
 	Error  error
 }
 
-func (f HttpFetcher) Fetch(id string, url string, host string, format string, pollId uint64, pollFinishedChan chan<- uint64) {
-	log.Debugf("poll %v %v fetch start\n", pollId, time.Now())
+func (f HttpFetcher) Fetch(id string, url string, host string, format string, pollId uint64, usingIPV4 bool, pollFinishedChan chan<- uint64) {
+	log.Debugf("poll %v %v fetch start for url: %s\n", pollId, time.Now(), url)
 	req, err := http.NewRequest("GET", url, nil)
 	// TODO: change this to use f.Headers. -jse
 	req.Header.Set("User-Agent", f.UserAgent)
@@ -76,8 +76,8 @@ func (f HttpFetcher) Fetch(id string, url string, host string, format string, po
 
 	if err == nil && response != nil {
 		log.Debugf("poll %v %v fetch end\n", pollId, time.Now())
-		f.Handler.Handle(id, response.Body, format, reqTime, reqEnd, err, pollId, pollFinishedChan)
+		f.Handler.Handle(id, response.Body, format, reqTime, reqEnd, err, pollId, usingIPV4, pollFinishedChan)
 	} else {
-		f.Handler.Handle(id, nil, format, reqTime, reqEnd, err, pollId, pollFinishedChan)
+		f.Handler.Handle(id, nil, format, reqTime, reqEnd, err, pollId, usingIPV4, pollFinishedChan)
 	}
 }

--- a/traffic_monitor/handler/handler.go
+++ b/traffic_monitor/handler/handler.go
@@ -40,5 +40,5 @@ type OpsConfig struct {
 }
 
 type Handler interface {
-	Handle(string, io.Reader, string, time.Duration, time.Time, error, uint64, chan<- uint64)
+	Handle(string, io.Reader, string, time.Duration, time.Time, error, uint64, bool, chan<- uint64)
 }

--- a/traffic_monitor/health/cache.go
+++ b/traffic_monitor/health/cache.go
@@ -93,19 +93,19 @@ func GetVitals(newResult *cache.Result, prevResult *cache.Result, mc *tc.Traffic
 	// log.Infoln(newResult.Id, "BytesOut", newResult.Vitals.BytesOut, "BytesIn", newResult.Vitals.BytesIn, "Kbps", newResult.Vitals.KbpsOut, "max", newResult.Vitals.MaxKbpsOut)
 }
 
-// EvalCache returns whether the given cache should be marked available, a string describing why, and which stat exceeded a threshold. The `stats` may be nil, for pollers which don't poll stats.
+// EvalCache returns whether the given cache should be marked available, a boolean of whether the result was over ipv4 (false means it was ipv6), a string describing why, and which stat exceeded a threshold. The `stats` may be nil, for pollers which don't poll stats.
 // The availability of EvalCache MAY NOT be used to directly set the cache's local availability, because the threshold stats may not be part of the poller which produced the result. Rather, if the cache was previously unavailable from a threshold, it must be verified that threshold stat is in the results before setting the cache to available.
 // TODO change to return a `cache.AvailableStatus`
 func EvalCache(result cache.ResultInfo, resultStats cache.ResultStatValHistory, mc *tc.TrafficMonitorConfigMap) (bool, bool, string, string) {
 	serverInfo, ok := mc.TrafficServer[string(result.ID)]
 	if !ok {
 		log.Errorf("Cache %v missing from from Traffic Ops Monitor Config - treating as OFFLINE\n", result.ID)
-		return false, result.UsingIPV4, "ERROR - server missing in Traffic Ops monitor config", ""
+		return false, result.UsingIPv4, "ERROR - server missing in Traffic Ops monitor config", ""
 	}
 	serverProfile, ok := mc.Profile[serverInfo.Profile]
 	if !ok {
 		log.Errorf("Cache %v profile %v missing from from Traffic Ops Monitor Config - treating as OFFLINE\n", result.ID, serverInfo.Profile)
-		return false, result.UsingIPV4, "ERROR - server profile missing in Traffic Ops monitor config", ""
+		return false, result.UsingIPv4, "ERROR - server profile missing in Traffic Ops monitor config", ""
 	}
 
 	status := tc.CacheStatusFromString(serverInfo.ServerStatus)
@@ -121,18 +121,18 @@ func EvalCache(result cache.ResultInfo, resultStats cache.ResultStatValHistory, 
 	switch {
 	case status == tc.CacheStatusInvalid:
 		log.Errorf("Cache %v got invalid status from Traffic Ops '%v' - treating as OFFLINE\n", result.ID, serverInfo.ServerStatus)
-		return false, result.UsingIPV4, eventDesc(status, availability+"; invalid status"), ""
+		return false, result.UsingIPv4, eventDesc(status, availability+"; invalid status"), ""
 	case status == tc.CacheStatusAdminDown:
-		return false, result.UsingIPV4, eventDesc(status, availability), ""
+		return false, result.UsingIPv4, eventDesc(status, availability), ""
 	case status == tc.CacheStatusOffline:
 		log.Errorf("Cache %v set to offline, but still polled\n", result.ID)
-		return false, result.UsingIPV4, eventDesc(status, availability), ""
+		return false, result.UsingIPv4, eventDesc(status, availability), ""
 	case status == tc.CacheStatusOnline:
-		return true, result.UsingIPV4, eventDesc(status, availability), ""
+		return true, result.UsingIPv4, eventDesc(status, availability), ""
 	case result.Error != nil:
-		return false, result.UsingIPV4, eventDesc(status, fmt.Sprintf("%v", result.Error)), ""
+		return false, result.UsingIPv4, eventDesc(status, fmt.Sprintf("%v", result.Error)), ""
 	case result.System.NotAvailable == true:
-		return false, result.UsingIPV4, eventDesc(status, fmt.Sprintf("system.notAvailable == %v", result.System.NotAvailable)), ""
+		return false, result.UsingIPv4, eventDesc(status, fmt.Sprintf("system.notAvailable == %v", result.System.NotAvailable)), ""
 	}
 
 	computedStats := cache.ComputedStats()
@@ -163,11 +163,11 @@ func EvalCache(result cache.ResultInfo, resultStats cache.ResultStatValHistory, 
 		}
 
 		if !inThreshold(threshold, resultStatNum) {
-			return false, result.UsingIPV4, eventDesc(status, exceedsThresholdMsg(stat, threshold, resultStatNum)), stat
+			return false, result.UsingIPv4, eventDesc(status, exceedsThresholdMsg(stat, threshold, resultStatNum)), stat
 		}
 	}
 
-	return result.Available, result.UsingIPV4, eventDesc(status, availability), ""
+	return result.Available, result.UsingIPv4, eventDesc(status, availability), ""
 }
 
 // CalcAvailability calculates the availability of the cache, from the given result. Availability is stored in `localCacheStatus` and `localStates`, and if the status changed an event is added to `events`. statResultHistory may be nil, for pollers which don't poll stats.
@@ -176,15 +176,14 @@ func CalcAvailability(results []cache.Result, pollerName string, statResultHisto
 	localCacheStatuses := localCacheStatusThreadsafe.Get().Copy()
 	processAvailableTuple := func(tuple cache.AvailableTuple) bool {
 		switch protocol {
-		case config.IPV4Only:
-			return tuple.IPV4
-			break
-		case config.IPV6Only:
-			return tuple.IPV6
-			break
+		case config.IPv4Only:
+			return tuple.IPv4
+		case config.IPv6Only:
+			return tuple.IPv6
 		case config.Both:
-			return tuple.IPV4 && tuple.IPV6
-			break
+			return tuple.IPv4 && tuple.IPv6
+		default:
+			log.Errorln("received an unknown PollingProtocol: " + protocol.String())
 		}
 		return false
 	}
@@ -195,20 +194,14 @@ func CalcAvailability(results []cache.Result, pollerName string, statResultHisto
 			statResults = statResultHistory[result.ID]
 		}
 
-		isAvailable, usingIPV4, whyAvailable, unavailableStat := EvalCache(cache.ToInfo(result), statResults, &mc)
+		isAvailable, usingIPv4, whyAvailable, unavailableStat := EvalCache(cache.ToInfo(result), statResults, &mc)
 		// if the cache is now Available, and was previously unavailable due to a threshold, make sure this poller contains the stat which exceeded the threshold.
 		previousStatus, hasPreviousStatus := localCacheStatuses[result.ID]
 		availableTuple := cache.AvailableTuple{}
 
-
 		if hasPreviousStatus {
-
 			availableTuple = previousStatus.Available
-			if usingIPV4 {
-				availableTuple.IPV4 = isAvailable
-			} else {
-				availableTuple.IPV6 = isAvailable
-			}
+			availableTuple.SetAvailability(usingIPv4, isAvailable)
 
 			if processAvailableTuple(availableTuple) {
 				if !processAvailableTuple(previousStatus.Available) && previousStatus.UnavailableStat != "" {
@@ -218,35 +211,31 @@ func CalcAvailability(results []cache.Result, pollerName string, statResultHisto
 				}
 			}
 		} else {
-			if usingIPV4 {
-				availableTuple.IPV4 = isAvailable
-			} else {
-				availableTuple.IPV6 = isAvailable
-			}
+			availableTuple.SetAvailability(usingIPv4, isAvailable)
 		}
 
-		currentAvailableState := processAvailableTuple(availableTuple)
+		newAvailableState := processAvailableTuple(availableTuple)
 
 		localCacheStatuses[result.ID] = cache.AvailableStatus{
 			Available:          availableTuple,
-			ProcessedAvailable: currentAvailableState,
+			ProcessedAvailable: newAvailableState,
 			Status:             mc.TrafficServer[string(result.ID)].ServerStatus,
 			Why:                whyAvailable,
 			UnavailableStat:    unavailableStat,
 			Poller:             pollerName,
-			LastCheckedIPV4:    usingIPV4,
+			LastCheckedIPv4:    usingIPv4,
 		} // TODO move within localStates?
 
-		if available, ok := localStates.GetCache(result.ID); !ok || available.IsAvailable != currentAvailableState {
+		if available, ok := localStates.GetCache(result.ID); !ok || available.IsAvailable != newAvailableState {
 			protocol := "IPv4"
-			if !usingIPV4 {
+			if !usingIPv4 {
 				protocol = "IPv6"
 			}
-			log.Infof("Changing state for %s was: %t now: %t because %s poller: %v on protocol %v error: %v", result.ID, available.IsAvailable, currentAvailableState, whyAvailable, pollerName, protocol, result.Error)
-			events.Add(Event{Time: Time(time.Now()), Description: "Protocol: (" + protocol + ") " + whyAvailable + " (" + pollerName + ")", Name: string(result.ID), Hostname: string(result.ID), Type: toData.ServerTypes[result.ID].String(), Available: currentAvailableState})
+			log.Infof("Changing state for %s was: %t now: %t because %s poller: %v on protocol %v error: %v", result.ID, available.IsAvailable, newAvailableState, whyAvailable, pollerName, protocol, result.Error)
+			events.Add(Event{Time: Time(time.Now()), Description: "Protocol: (" + protocol + ") " + whyAvailable + " (" + pollerName + ")", Name: string(result.ID), Hostname: string(result.ID), Type: toData.ServerTypes[result.ID].String(), Available: newAvailableState})
 		}
 
-		localStates.SetCache(result.ID, tc.IsAvailable{IsAvailable: currentAvailableState})
+		localStates.SetCache(result.ID, tc.IsAvailable{IsAvailable: newAvailableState})
 	}
 	calculateDeliveryServiceState(toData.DeliveryServiceServers, localStates, toData)
 	localCacheStatusThreadsafe.Set(localCacheStatuses)
@@ -338,7 +327,7 @@ func getDeliveryServiceCachegroupAvailability(dsCacheStates map[tc.CacheName]tc.
 	for cache, available := range dsCacheStates {
 		cg, ok := serverCachegroups[cache]
 		if !ok {
-			log.Errorf("cache %v not found in cachegroups!")
+			log.Errorf("cache %v not found in cachegroups!", cache)
 			continue
 		}
 		if _, ok := cgAvail[cg]; !ok || available.IsAvailable {

--- a/traffic_monitor/health/cache.go
+++ b/traffic_monitor/health/cache.go
@@ -196,10 +196,11 @@ func CalcAvailability(results []cache.Result, pollerName string, statResultHisto
 		}
 
 		isAvailable, usingIPV4, whyAvailable, unavailableStat := EvalCache(cache.ToInfo(result), statResults, &mc)
-
 		// if the cache is now Available, and was previously unavailable due to a threshold, make sure this poller contains the stat which exceeded the threshold.
 		previousStatus, hasPreviousStatus := localCacheStatuses[result.ID]
 		availableTuple := cache.AvailableTuple{}
+
+
 		if hasPreviousStatus {
 
 			availableTuple = previousStatus.Available

--- a/traffic_monitor/manager/health.go
+++ b/traffic_monitor/manager/health.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/apache/incubator-trafficcontrol/lib/go-log"
+	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/config"
-	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/health"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/peer"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/threadsafe"
@@ -184,7 +184,7 @@ func processHealthResult(
 		healthHistoryCopy[healthResult.ID] = pruneHistory(append([]cache.Result{healthResult}, healthHistoryCopy[healthResult.ID]...), maxHistory)
 	}
 
-	health.CalcAvailability(results, "health", nil, monitorConfigCopy, toDataCopy, localCacheStatusThreadsafe, localStates, events)
+	health.CalcAvailability(results, "health", nil, monitorConfigCopy, toDataCopy, localCacheStatusThreadsafe, localStates, events, cfg.CachePollingProtocol)
 
 	healthHistory.Set(healthHistoryCopy)
 	// TODO determine if we should combineCrStates() here

--- a/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/manager/manager.go
@@ -59,12 +59,12 @@ func Start(opsConfigFile string, cfg config.Config, staticAppData config.StaticA
 	toData := todata.NewThreadsafe()
 
 	cacheHealthHandler := cache.NewHandler()
-	cacheHealthPoller := poller.NewHTTP(cfg.CacheHealthPollingInterval, true, sharedClient, cacheHealthHandler, staticAppData.UserAgent)
+	cacheHealthPoller := poller.NewHTTP(cfg.CacheHealthPollingInterval, true, sharedClient, cacheHealthHandler, staticAppData.UserAgent, cfg.CachePollingProtocol)
 	cacheStatHandler := cache.NewPrecomputeHandler(toData)
-	cacheStatPoller := poller.NewHTTP(cfg.CacheStatPollingInterval, false, sharedClient, cacheStatHandler, staticAppData.UserAgent)
+	cacheStatPoller := poller.NewHTTP(cfg.CacheStatPollingInterval, false, sharedClient, cacheStatHandler, staticAppData.UserAgent, cfg.CachePollingProtocol)
 	monitorConfigPoller := poller.NewMonitorConfig(cfg.MonitorConfigPollingInterval)
 	peerHandler := peer.NewHandler()
-	peerPoller := poller.NewHTTP(cfg.PeerPollingInterval, false, sharedClient, peerHandler, staticAppData.UserAgent)
+	peerPoller := poller.NewHTTP(cfg.PeerPollingInterval, false, sharedClient, peerHandler, staticAppData.UserAgent, cfg.PeerPollingProtocol)
 
 	go monitorConfigPoller.Poll()
 	go cacheHealthPoller.Poll()

--- a/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/manager/manager.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"regexp"
 
 	"golang.org/x/sys/unix"
 
@@ -50,6 +51,8 @@ func Start(opsConfigFile string, cfg config.Config, staticAppData config.StaticA
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
 		Timeout:   cfg.HTTPTimeout,
 	}
+
+	url6Regex := regexp.MustCompile(`/\d+`)
 
 	localStates := peer.NewCRStatesThreadsafe() // this is the local state as discoverer by this traffic_monitor
 	fetchCount := threadsafe.NewUint()          // note this is the number of individual caches fetched from, not the number of times all the caches were polled.
@@ -89,6 +92,7 @@ func Start(opsConfigFile string, cfg config.Config, staticAppData config.StaticA
 		staticAppData,
 		toSession,
 		toData,
+		url6Regex,
 	)
 
 	combinedStates, combineStateFunc := StartStateCombiner(events, peerStates, localStates, toData)

--- a/traffic_monitor/manager/stat.go
+++ b/traffic_monitor/manager/stat.go
@@ -84,7 +84,7 @@ func StartStatHistoryManager(
 	overrideMap := map[tc.CacheName]bool{}
 
 	process := func(results []cache.Result) {
-		processStatResults(results, statInfoHistory, statResultHistory, statMaxKbpses, combinedStates, lastStats, toData.Get(), errorCount, dsStats, lastStatEndTimes, lastStatDurations, unpolledCaches, monitorConfig.Get(), precomputedData, lastResults, localStates, events, localCacheStatus, overrideMap, combineState)
+		processStatResults(results, statInfoHistory, statResultHistory, statMaxKbpses, combinedStates, lastStats, toData.Get(), errorCount, dsStats, lastStatEndTimes, lastStatDurations, unpolledCaches, monitorConfig.Get(), precomputedData, lastResults, localStates, events, localCacheStatus, overrideMap, combineState, cfg.CachePollingProtocol)
 	}
 
 	go func() {
@@ -145,6 +145,7 @@ func processStatResults(
 	localCacheStatusThreadsafe threadsafe.CacheAvailableStatus,
 	overrideMap map[tc.CacheName]bool,
 	combineState func(),
+	pollingProtocol config.PollingProtocol,
 ) {
 	if len(results) == 0 {
 		return
@@ -208,7 +209,7 @@ func processStatResults(
 		lastStats.Set(newLastStats)
 	}
 
-	health.CalcAvailability(results, "stat", statResultHistory, mc, toData, localCacheStatusThreadsafe, localStates, events)
+	health.CalcAvailability(results, "stat", statResultHistory, mc, toData, localCacheStatusThreadsafe, localStates, events, pollingProtocol)
 	combineState()
 
 	endTime := time.Now()

--- a/traffic_monitor/peer/peer.go
+++ b/traffic_monitor/peer/peer.go
@@ -49,7 +49,7 @@ type Result struct {
 }
 
 // Handle handles a response from a polled Traffic Monitor peer, parsing the data and forwarding it to the ResultChannel.
-func (handler Handler) Handle(id string, r io.Reader, format string, reqTime time.Duration, reqEnd time.Time, err error, pollID uint64, pollFinished chan<- uint64) {
+func (handler Handler) Handle(id string, r io.Reader, format string, reqTime time.Duration, reqEnd time.Time, err error, pollID uint64, usingIPV4 bool, pollFinished chan<- uint64) {
 	result := Result{
 		ID:           tc.TrafficMonitorName(id),
 		Available:    false,

--- a/traffic_monitor/peer/peer.go
+++ b/traffic_monitor/peer/peer.go
@@ -49,7 +49,7 @@ type Result struct {
 }
 
 // Handle handles a response from a polled Traffic Monitor peer, parsing the data and forwarding it to the ResultChannel.
-func (handler Handler) Handle(id string, r io.Reader, format string, reqTime time.Duration, reqEnd time.Time, err error, pollID uint64, usingIPV4 bool, pollFinished chan<- uint64) {
+func (handler Handler) Handle(id string, r io.Reader, format string, reqTime time.Duration, reqEnd time.Time, err error, pollID uint64, usingIPv4 bool, pollFinished chan<- uint64) {
 	result := Result{
 		ID:           tc.TrafficMonitorName(id),
 		Available:    false,

--- a/traffic_monitor/peer/peer_test.go
+++ b/traffic_monitor/peer/peer_test.go
@@ -8,9 +8,9 @@ package peer
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,7 +18,6 @@ package peer
  * specific language governing permissions and limitations
  * under the License.
  */
-
 
 import (
 	"fmt"

--- a/traffic_monitor/poller/file.go
+++ b/traffic_monitor/poller/file.go
@@ -21,8 +21,9 @@ package poller
 
 import (
 	"fmt"
-	"gopkg.in/fsnotify.v1"
 	"io/ioutil"
+
+	"gopkg.in/fsnotify.v1"
 )
 
 // FilePoller starts a goroutine polling the given file for changes. When changes occur, including an initial read, the result callback is called asynchronously. Returns a kill chan, which will kill the file poller when written to.

--- a/traffic_monitor/static/index.html
+++ b/traffic_monitor/static/index.html
@@ -295,7 +295,7 @@ under the License.
 							 row.classList.add("warning");
 							 row.classList.remove("error");
 							 row.classList.remove("stripes");
-						 } else if (!jdata[server].combined_available) {
+						 } else if (!jdata[server].combined_available && jdata[server].status.indexOf("ONLINE") != 0) {
 							 row.classList.add("error");
 							 row.classList.remove("warning");
 							 row.classList.remove("stripes");

--- a/traffic_monitor/static/index.html
+++ b/traffic_monitor/static/index.html
@@ -261,15 +261,17 @@ under the License.
 						 row.id = "cache-states-" + server
 						 row.insertCell(0).id = row.id + "-server";
 						 row.insertCell(1).id = row.id + "-type";
-						 row.insertCell(2).id = row.id + "-status";
-						 row.insertCell(3).id = row.id + "-load-average";
-						 row.insertCell(4).id = row.id + "-query-time";
-						 row.insertCell(5).id = row.id + "-health-time";
-						 row.insertCell(6).id = row.id + "-stat-time";
-						 row.insertCell(7).id = row.id + "-health-span";
-						 row.insertCell(8).id = row.id + "-stat-span";
-						 row.insertCell(9).id = row.id + "-bandwidth";
-						 row.insertCell(10).id = row.id + "-connection-count";
+						 row.insertCell(2).id = row.id + "-ipv4";
+						 row.insertCell(3).id = row.id + "-ipv6";
+						 row.insertCell(4).id = row.id + "-status";
+						 row.insertCell(5).id = row.id + "-load-average";
+						 row.insertCell(6).id = row.id + "-query-time";
+						 row.insertCell(7).id = row.id + "-health-time";
+						 row.insertCell(8).id = row.id + "-stat-time";
+						 row.insertCell(9).id = row.id + "-health-span";
+						 row.insertCell(10).id = row.id + "-stat-span";
+						 row.insertCell(11).id = row.id + "-bandwidth";
+						 row.insertCell(12).id = row.id + "-connection-count";
 						 document.getElementById(row.id + "-server").textContent = server;
 						 document.getElementById(row.id + "-server").style.whiteSpace = "nowrap";
 						 document.getElementById(row.id + "-load-average").style.textAlign = "right";
@@ -293,7 +295,7 @@ under the License.
 							 row.classList.add("warning");
 							 row.classList.remove("error");
 							 row.classList.remove("stripes");
-						 } else if (jdata[server].status.indexOf(" available") == -1 && jdata[server].status.indexOf("ONLINE") != 0) {
+						 } else if (!jdata[server].combined_available) {
 							 row.classList.add("error");
 							 row.classList.remove("warning");
 							 row.classList.remove("stripes");
@@ -302,6 +304,12 @@ under the License.
 							 row.classList.remove("warning");
 							 row.classList.remove("error");
 						 }
+					 }
+					 if (jdata[server].hasOwnProperty("ipv4_available")) {
+						 document.getElementById("cache-states-" + server + "-ipv4").textContent = jdata[server].ipv4_available;
+					 }
+					 if (jdata[server].hasOwnProperty("ipv6_available")) {
+						 document.getElementById("cache-states-" + server + "-ipv6").textContent = jdata[server].ipv6_available;
 					 }
 					 if (jdata[server].hasOwnProperty("load_average")) {
 						 document.getElementById("cache-states-" + server + "-load-average").textContent = jdata[server].load_average;
@@ -523,6 +531,8 @@ under the License.
 				<tr>
 					<th>Server</th>
 					<th>Type</th>
+					<th>IPv4</th>
+					<th>IPv6</th>
 					<th>Status</th>
 					<th align="right">Load Average</th>
 					<th align="right">Query Time (ms)</th>

--- a/traffic_monitor/static/index.html
+++ b/traffic_monitor/static/index.html
@@ -306,10 +306,18 @@ under the License.
 						 }
 					 }
 					 if (jdata[server].hasOwnProperty("ipv4_available")) {
-						 document.getElementById("cache-states-" + server + "-ipv4").textContent = jdata[server].ipv4_available;
+						if (jdata[server].status.indexOf("ONLINE") != 0) {
+					        	document.getElementById("cache-states-" + server + "-ipv4").textContent = jdata[server].ipv4_available;
+					     	} else {
+					         	document.getElementById("cache-states-" + server + "-ipv4").textContent = 'N/A'
+					 	}
 					 }
 					 if (jdata[server].hasOwnProperty("ipv6_available")) {
-						 document.getElementById("cache-states-" + server + "-ipv6").textContent = jdata[server].ipv6_available;
+                         			if (jdata[server].status.indexOf("ONLINE") != 0) {
+                         			    	document.getElementById("cache-states-" + server + "-ipv6").textContent = jdata[server].ipv6_available;
+                         			} else {
+                             				document.getElementById("cache-states-" + server + "-ipv6").textContent = 'N/A'
+                         			}
 					 }
 					 if (jdata[server].hasOwnProperty("load_average")) {
 						 document.getElementById("cache-states-" + server + "-load-average").textContent = jdata[server].load_average;

--- a/traffic_monitor/threadsafe/cacheavailablestatus.go
+++ b/traffic_monitor/threadsafe/cacheavailablestatus.go
@@ -20,8 +20,8 @@ package threadsafe
  */
 
 import (
-	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
 	"sync"
 )
 

--- a/traffic_monitor/threadsafe/cacheavailablestatus.go
+++ b/traffic_monitor/threadsafe/cacheavailablestatus.go
@@ -20,9 +20,10 @@ package threadsafe
  */
 
 import (
+	"sync"
+
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
-	"sync"
 )
 
 // CacheAvailableStatus wraps a map of cache available statuses to be safe for multiple reader goroutines and one writer.

--- a/traffic_monitor/threadsafe/cachemaxkbpses.go
+++ b/traffic_monitor/threadsafe/cachemaxkbpses.go
@@ -20,8 +20,8 @@ package threadsafe
  */
 
 import (
-	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
 	"sync"
 )
 

--- a/traffic_monitor/threadsafe/cachemaxkbpses.go
+++ b/traffic_monitor/threadsafe/cachemaxkbpses.go
@@ -20,9 +20,10 @@ package threadsafe
  */
 
 import (
+	"sync"
+
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/cache"
-	"sync"
 )
 
 // CacheAvailableStatus wraps a map of cache available statuses to be safe for multiple reader goroutines and one writer.

--- a/traffic_monitor/tmcheck/peerpoller.go
+++ b/traffic_monitor/tmcheck/peerpoller.go
@@ -21,9 +21,10 @@ package tmcheck
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	to "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
-	"time"
 )
 
 const PeerPollMax = time.Duration(10) * time.Second

--- a/traffic_monitor/todata/todata.go
+++ b/traffic_monitor/todata/todata.go
@@ -22,11 +22,12 @@ package todata
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
-	"github.com/apache/incubator-trafficcontrol/traffic_monitor/towrap"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/towrap"
 )
 
 // Regexes maps Delivery Service Regular Expressions to delivery services.

--- a/traffic_monitor/tools/nagios-validate-peerpoller.go
+++ b/traffic_monitor/tools/nagios-validate-peerpoller.go
@@ -22,6 +22,7 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/apache/incubator-trafficcontrol/lib/go-nagios"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/tmcheck"
 	to "github.com/apache/incubator-trafficcontrol/traffic_ops/client"

--- a/traffic_monitor/tools/nagios-validate-queryinterval.go
+++ b/traffic_monitor/tools/nagios-validate-queryinterval.go
@@ -22,6 +22,7 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/apache/incubator-trafficcontrol/lib/go-nagios"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor/tmcheck"
 	to "github.com/apache/incubator-trafficcontrol/traffic_ops/client"

--- a/traffic_monitor/tools/validator-service.go
+++ b/traffic_monitor/tools/validator-service.go
@@ -24,14 +24,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
-	"github.com/apache/incubator-trafficcontrol/traffic_monitor/tmcheck"
-	to "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 	"io"
 	"net/http"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/tmcheck"
+	to "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 )
 
 const UserAgent = "tm-offline-validator/0.1"


### PR DESCRIPTION
Currently, Traffic Monitor only polls caches over IPv4, this can lead to issues if a DS is ipv6 enabled and the ipv6 interface is down on a cache. This modifies Traffic Monitor such that it can poll on the necessary interfaces and report status based on the interfaces. 

The config has two new parameters: cache_polling_protocol and peer_polling_protocol
the available values are IPV4Only, IPV6Only or Both. They default to IPV4Only so with no changes to the config there will be no change in behavior.

cache_polling_protocol controls the interface used to poll the caches, setting it to both will cause it to alternate which interface it uses on each poll.

peer_polling_protocol was included for the case that the Traffic Monitor is deployed in an ipv6 only environment.

Polling caches over IPV6 requires that astats_over_http be upgraded to a build that includes: https://github.com/apache/incubator-trafficcontrol/pull/1619

fixes #2735 