### PR TITLE
Add SSL private key and CSR generation functionality to traffic_ops_golang

### DIFF
--- a/lib/go-tc/deliveryservice_ssl_keys.go
+++ b/lib/go-tc/deliveryservice_ssl_keys.go
@@ -36,10 +36,10 @@ type DeliveryServiceSSLKeysCertificate struct {
 // DeliveryServiceSSLKeys ...
 type DeliveryServiceSSLKeys struct {
 	CDN             string                            `json:"cdn,omitempty"`
-	DeliveryService string                            `json:"DeliveryService,omitempty"`
-	BusinessUnit    string                            `json:"businessUnit,omitempty"`
+	DeliveryService string                            `json:"deliveryservice,omitempty"`
+	BusinessUnit    string                            `json:"unit,omitempty"`
 	City            string                            `json:"city,omitempty"`
-	Organization    string                            `json:"organization,omitempty"`
+	Organization    string                            `json:"org,omitempty"`
 	Hostname        string                            `json:"hostname,omitempty"`
 	Country         string                            `json:"country,omitempty"`
 	State           string                            `json:"state,omitempty"`

--- a/lib/go-tc/deliveryservice_ssl_keys.go
+++ b/lib/go-tc/deliveryservice_ssl_keys.go
@@ -36,10 +36,10 @@ type DeliveryServiceSSLKeysCertificate struct {
 // DeliveryServiceSSLKeys ...
 type DeliveryServiceSSLKeys struct {
 	CDN             string                            `json:"cdn,omitempty"`
-	DeliveryService string                            `json:"deliveryservice,omitempty"`
-	BusinessUnit    string                            `json:"unit,omitempty"`
+	DeliveryService string                            `json:"DeliveryService,omitempty"`
+	BusinessUnit    string                            `json:"businessUnit,omitempty"`
 	City            string                            `json:"city,omitempty"`
-	Organization    string                            `json:"org,omitempty"`
+	Organization    string                            `json:"organization,omitempty"`
 	Hostname        string                            `json:"hostname,omitempty"`
 	Country         string                            `json:"country,omitempty"`
 	State           string                            `json:"state,omitempty"`

--- a/traffic_ops/traffic_ops_golang/deliveryservices_keys_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservices_keys_test.go
@@ -22,9 +22,7 @@ package main
 import (
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"strings"
 	"testing"
@@ -244,7 +242,7 @@ func TestVerifyAndEncodeCertificate(t *testing.T) {
 	}
 }
 
-// tests the generateDeliveryServiceSSLKeysCertificate() function.
+// tests the generateSSLCertificate() function.
 // verifys the proper creation of a CSR and private key and that
 // both are encoded properly.
 func TestGenerateDeliveryServiceSSLKeysCertificate(t *testing.T) {
@@ -273,15 +271,10 @@ func TestGenerateDeliveryServiceSSLKeysCertificate(t *testing.T) {
 	}
 
 	// test generating a certificate request and privte key
-	err := generateDeliveryServiceSSLKeysCertificate(&dsSslKeys)
+	err := generateSSLCertificate(&dsSslKeys)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	respBts, err := json.MarshalIndent(dsSslKeys, "", " ")
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	fmt.Println(string(respBts))
 
 	// The Crt should be base64 encoded, test that it can be decoded.
 	crtPem := make([]byte, base64.StdEncoding.EncodedLen(len(dsSslKeys.Certificate.Crt)))

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -101,6 +101,7 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{1.2, http.MethodGet, `deliveryservices-wip/xmlId/{xmlID}/sslkeys$`, getDeliveryServiceSSLKeysByXMLIDHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		{1.2, http.MethodGet, `deliveryservices-wip/hostname/{hostName}/sslkeys$`, getDeliveryServiceSSLKeysByHostNameHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		{1.2, http.MethodPost, `deliveryservices-wip/hostname/{hostName}/sslkeys/add$`, addDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.2, http.MethodGet, `deliveryservices-wip/xmlId/{xmlID}/sslkeys$/delete`, deleteDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		//Statuses
 		{1.2, http.MethodGet, `statuses/?(\.json)?$`, statusesHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.2, http.MethodGet, `statuses/{id}$`, statusesHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -100,8 +100,8 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		//SSLKeys deliveryservice endpoints here that are marked  marked as '-wip' need to have tenancy checks added
 		{1.2, http.MethodGet, `deliveryservices-wip/xmlId/{xmlID}/sslkeys$`, getDeliveryServiceSSLKeysByXMLIDHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		{1.2, http.MethodGet, `deliveryservices-wip/hostname/{hostName}/sslkeys$`, getDeliveryServiceSSLKeysByHostNameHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
-		{1.2, http.MethodPost, `deliveryservices-wip/hostname/{hostName}/sslkeys/add$`, addDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
-		{1.2, http.MethodGet, `deliveryservices-wip/xmlId/{xmlID}/sslkeys$/delete`, deleteDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.2, http.MethodPost, `deliveryservices-wip/sslkeys/add$`, addDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.2, http.MethodGet, `deliveryservices-wip/xmlId/{xmlID}/sslkeys/delete`, deleteDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		//Statuses
 		{1.2, http.MethodGet, `statuses/?(\.json)?$`, statusesHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.2, http.MethodGet, `statuses/{id}$`, statusesHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},


### PR DESCRIPTION
This PR fixes the JSON metadata tags on tc.DeliveryServiceSSLKeys struct so that marshaled JSON keys match those on the perl side.  Also adds a function to generate an unencrypted private key, certificate request (CSR), and includes unit tests of the function.  To be used in the golang SSL API endpoint for generation of keys.
Fix: #1780 