### PR TITLE
traffic router re-authentication on unauthorized

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/ProtectedFetcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/ProtectedFetcher.java
@@ -32,10 +32,15 @@ public class ProtectedFetcher extends Fetcher {
 
 	@Override
 	protected HttpURLConnection getConnection(final String url, final String data, final String method, final long lastFetchedTime) throws IOException {
-		if (!isCookieValid()) {
-			extractCookie(super.getConnection(getAuthorizationEndpoint(), getData(), POST_STR, 0L));
+
+		if (isCookieValid()) {
+			final HttpURLConnection connection = extractCookie(super.getConnection(url, data, method, lastFetchedTime));
+			if (connection.getResponseCode() != HttpURLConnection.HTTP_UNAUTHORIZED) {
+				return connection;
+			}
 		}
 
+		extractCookie(super.getConnection(getAuthorizationEndpoint(), getData(), POST_STR, 0L));
 		return extractCookie(super.getConnection(url, data, method, lastFetchedTime));
 	}
 


### PR DESCRIPTION
Traffic router pulls the steering and federation cfg directly for traffic-ops.
Every time it pulls the cfg, it tests if the cookie is still valid (by date only), and re-login if needed.
However, if the OPs fails and new OPs is put up instead, the router will not relogin as long as the cookie date is valid.
TR log will have the below messages indicating 401 http response.
This PR asks to fix it, by re-login in this case.

INFO  2018-01-25T13:46:28.467 [pool-9-thread-1] com.comcast.cdn.traffic_control.traffic_router.core.monitor.TrafficMonitorWatcher - Loading properties from /opt/traffic_router/conf/traffic_monitor.properties
INFO  2018-01-25T13:46:44.633 [pool-1-thread-1] com.comcast.cdn.traffic_control.traffic_router.core.util.Fetcher - GETing: federations.json; timeout is 15000
WARN  2018-01-25T13:46:44.689 [pool-1-thread-1] com.comcast.cdn.traffic_control.traffic_router.core.util.Fetcher - Failed Http Request to federations.json Status 401
