### PR TITLE
Immutable ds cdn master

### DIFF
--- a/traffic_ops/app/lib/API/Deliveryservice.pm
+++ b/traffic_ops/app/lib/API/Deliveryservice.pm
@@ -316,6 +316,11 @@ sub update {
         return $self->alert( "A deliveryservice xmlId is immutable." );
     }
 
+	my $new_cdn_id = $params->{cdnId};
+	if ( $new_cdn_id ne $ds->cdn_id ) {
+		return $self->alert( "A deliveryservice cdnId is immutable." );
+	}
+
 	#setting tenant_id to undef if tenant is not set.
 	my $tenant_id = exists($params->{tenantId}) ? $params->{tenantId} :  undef;
 	if ($tenant_utils->use_tenancy() and !defined($tenant_id) and defined($ds->tenant_id)) {

--- a/traffic_ops/app/lib/UI/DeliveryService.pm
+++ b/traffic_ops/app/lib/UI/DeliveryService.pm
@@ -794,6 +794,15 @@ sub update {
 		return $self->redirect_to($referer);
 	}
 
+	my $ds = $self->db->resultset('Deliveryservice')->find( { id => $id } );
+	my $new_cdn_id = $self->paramAsScalar('ds.cdn_id');
+	if ( $new_cdn_id ne $ds->cdn_id ) {
+		my $err = "A deliveryservice cdnId is immutable.";
+		$self->flash( message => $err );
+		my $referer = $self->req->headers->header('referer');
+		return $self->redirect_to($referer);
+	}
+
 	if ( $self->check_deliveryservice_input( $self->param('ds.cdn_id'), $id ) ) {
 		# if error check passes
 		my %hash = (

--- a/traffic_ops/app/t/deliveryservice.t
+++ b/traffic_ops/app/t/deliveryservice.t
@@ -267,7 +267,7 @@ ok $t->post_ok(
 		'ds.multi_site_origin'           => '0',
 		'ds.multi_site_origin_algorithm' => '0',
 		'ds.profile'                     => '200',
-		'ds.cdn_id'                      => '200',
+		'ds.cdn_id'                      => '100',
 		'ds.qstring_ignore'              => '0',
 		'ds.signed'                      => '0',
 		'ds.type'                        => '7',


### PR DESCRIPTION
CDN of a DS is Immutable.

This is actually a workaround so we need to decide if we want to pull it or not.
It comes to solve the inconsistency with the riak DB when changing the the DS CDN.

One may argue that the real solution should update the riak as well, when changing the DS  CDN.  However, as the DS domain name changes as well under such circumstances, the SSL key would not be valid, and we will just "move the bug"

Please share your thoughts
Nir