### PR TITLE
Add information to errors when cdns/routing cannot contact TR.

### DIFF
--- a/traffic_ops/app/lib/API/Cdn.pm
+++ b/traffic_ops/app/lib/API/Cdn.pm
@@ -524,7 +524,8 @@ sub routing {
 			my $c = $self->get_traffic_router_connection( { hostname => $ccr_host } );
 			my $s = $c->get_crs_stats();
 			if ( !defined($s) ) {
-				return $self->internal_server_error( { "Internal Server" => "Error" } );
+				$self->app->log->error("Unable to contact $ccr_host for $cdn_name.");
+				return $self->internal_server_error( { "Internal Server" => "Error: Unable to contact $ccr_host" } );
 			}
 			else {
 


### PR DESCRIPTION
When a TR cannot be contacted, the cdns/routing endpoint returns a 500.
However, without information about why the 500 is being thrown, it can
be tricky to track down precisely what is going wrong. This adds the
name of the uncontactable host to the text of the error return as well
as adding a separate log entry, at ERROR level, to indicate the issue.