### PR TITLE
TO postinstall -- use builtin perl var to check for root user

### DIFF
--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -821,7 +821,7 @@ sub main {
     }
 
     # check if the user running postinstall is root
-    if ( $ENV{USER} ne "root" ) {
+    if ( $> != 0 ) {
         errorOut("You must run this script as the root user");
     }
 


### PR DESCRIPTION
postinstall checks that it's being run as the root user using `$ENV{USER}`.   If running within a container, that doesn't exist.  Better to use `$>` (or `$EUID` if using `use English`).  It's much less dependent on the environment.

```
$ perl -le 'print $>'
298
$ sudo perl -le 'print $>'
0
```