### PR TITLE
Protect ORT from errors caused by missing data in TO.

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -350,6 +350,10 @@ sub process_cfg_file {
 	( $log_level >> $INFO ) && print "\nINFO: ======== Start processing config file: $cfg_file ========\n";
 
 	my $config_dir = $cfg_file_tracker->{$cfg_file}->{'location'};
+	if (!$config_dir) {
+		( $log_level >> $ERROR ) && print "ERROR No location information for $cfg_file.\n";
+		return $CFG_FILE_NOT_PROCESSED;
+	}
 
 	$uri = &set_uri($cfg_file);
 


### PR DESCRIPTION
If a required file is not configured with a location parameter, ORT is
still attempting to process it, despite the fact that there is no file
name to process. This displays lots of errors that don't clearly
indicate what is happening or to which file it is happening. This error
message documents the problematic file and prevents its processing so
that things can continue, just without that file.