### PR TITLE
upgrade Go from 1.8.3 to 1.10.1 for traffic_ops

### DIFF
--- a/traffic_ops/install/bin/install_go.sh
+++ b/traffic_ops/install/bin/install_go.sh
@@ -15,7 +15,7 @@
 #
 
 GO_DOWNLOADS_URL=https://storage.googleapis.com/golang
-GO_TARBALL_VERSION=go1.8.3.linux-amd64.tar.gz
+GO_TARBALL_VERSION=go1.10.1.linux-amd64.tar.gz
 GO_TARBALL_URL=$GO_DOWNLOADS_URL/$GO_TARBALL_VERSION
 
 GO_TARBALL_VERSION_SHA_FILE=$GO_TARBALL_VERSION.sha256
@@ -30,8 +30,8 @@ yum -y install git
 rm -rf /usr/local/go
 
 cd /tmp
-rm $GO_TARBALL_VERSION
-rm $GO_TARBALL_VERSION_SHA_FILE
+rm -f $GO_TARBALL_VERSION
+rm -f $GO_TARBALL_VERSION_SHA_FILE
 curl -O $GO_TARBALL_URL
 curl -O $GO_TARBALL_VERSION_SHA_URL
 


### PR DESCRIPTION
This will require some testing of a full TO installation before being merged,   but I think it's time we start exploring upgrading go..