### PR TITLE
Add CRConfig DS Modified fields

### DIFF
--- a/traffic_ops/app/db/migrations/20180913000000_add_ds_updated_triggers.sql
+++ b/traffic_ops/app/db/migrations/20180913000000_add_ds_updated_triggers.sql
@@ -1,0 +1,37 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+-- these triggers update the deliveryservice timestamp when a ds_regex, ds_server, or staticdnsentry is deleted. This is necessary to update the DS timestamp in the CRConfig, to notify the Traffic Router that the DS needs updated. Updates and inserts can be queried to aggregate their times, but deletes can't otherwise be detected.
+-- these triggers MUST be removed when the Self Service Timestamp plan is implemented, to avoid mangling the deliveryservice history. See https://cwiki.apache.org/confluence/display/TC/Traffic+Control++Self+Service+Proposal+for+Change+Integrity
+
+create or replace function delete_update_dsf() returns trigger as $$
+begin
+  update deliveryservice set last_updated=now() where id = old.deliveryservice;
+  return old;
+end;
+$$ language plpgsql;
+create trigger dss_delete_update_ds after delete on deliveryservice_server for each row execute procedure delete_update_dsf();
+create trigger sde_delete_update_ds after delete on staticdnsentry for each row execute procedure delete_update_dsf();
+create trigger dsr_delete_update_ds after delete on deliveryservice_regex for each row execute procedure delete_update_dsf();
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP TRIGGER IF EXISTS dss_delete_update_ds ON deliveryservice_server;
+DROP TRIGGER IF EXISTS sde_delete_update_ds ON staticdnsentry;
+DROP TRIGGER IF EXISTS dsr_delete_update_ds ON deliveryservice_regex;
+DROP FUNCTION IF EXISTS delete_update_dsf();

--- a/traffic_ops/app/db/migrations/20181129142200_add_cachegroup_fallbacks_last_updated.sql
+++ b/traffic_ops/app/db/migrations/20181129142200_add_cachegroup_fallbacks_last_updated.sql
@@ -1,0 +1,21 @@
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	    http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE cachegroup_fallbacks ADD COLUMN last_updated TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE cachegroup_fallbacks DROP COLUMN last_updated;

--- a/traffic_ops/traffic_ops_golang/crconfig/deliveryservice.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/deliveryservice.go
@@ -22,7 +22,6 @@ package crconfig
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -42,9 +41,21 @@ const DefaultTLDTTLNS = 3600 * time.Second
 const GeoProviderMaxmindStr = "maxmindGeolocationService"
 const GeoProviderNeustarStr = "neustarGeolocationService"
 
-func makeDSes(cdn string, domain string, tx *sql.Tx) (map[string]tc.CRConfigDeliveryService, error) {
-	dses := map[string]tc.CRConfigDeliveryService{}
+// getServerDSesModifieds returns a map[ds]time of the lastest modified time for any server on each DS.
+func getServerDSesModifieds(serverDSNames map[tc.CacheName][]ServerDS) map[tc.DeliveryServiceName]time.Time {
+	dsModifieds := map[tc.DeliveryServiceName]time.Time{}
+	for _, dses := range serverDSNames {
+		for _, ds := range dses {
+			if ds.Modified.After(dsModifieds[ds.DS]) {
+				dsModifieds[ds.DS] = ds.Modified
+			}
+		}
+	}
+	return dsModifieds
+}
 
+func makeDSes(cdn string, domain string, serverDSNames map[tc.CacheName][]ServerDS, tx *sql.Tx) (map[string]tc.CRConfigDeliveryService, error) {
+	dses := map[string]tc.CRConfigDeliveryService{}
 	admin := CDNSOAAdmin
 	expireSecondsStr := strconv.Itoa(int(CDNSOAExpire / time.Second))
 	minimumSecondsStr := strconv.Itoa(int(CDNSOAMinimum / time.Second))
@@ -70,47 +81,75 @@ func makeDSes(cdn string, domain string, tx *sql.Tx) (map[string]tc.CRConfigDeli
 	geoProvider1 := GeoProviderNeustarStr
 	geoProviderDefault := geoProvider0
 
+	q := `
+SELECT
+d.xml_id,
+d.miss_lat,
+d.miss_long,
+d.protocol,
+d.ccr_dns_ttl as ttl,
+d.routing_name,
+d.geo_provider,
+t.name as type,
+d.geo_limit,
+d.geo_limit_countries,
+d.geolimit_redirect_url,
+d.initial_dispersion,
+d.regional_geo_blocking,
+d.tr_response_headers,
+d.max_dns_answers,
+p.name as profile,
+d.dns_bypass_ip,
+d.dns_bypass_ip6,
+d.dns_bypass_ttl,
+d.dns_bypass_cname,
+d.http_bypass_fqdn,
+d.ipv6_routing_enabled,
+d.deep_caching_type,
+d.tr_request_headers,
+d.tr_response_headers,
+d.anonymous_blocking_enabled,
+d.last_updated
+FROM deliveryservice as d
+JOIN type as t ON t.id = d.type
+LEFT OUTER JOIN profile as p ON p.id = d.profile
+WHERE d.cdn_id = (SELECT id FROM cdn WHERE name = $1)
+AND d.active = true
+AND t.name != '` + string(tc.DSTypeAnyMap) + `'
+`
+
 	serverParams, err := getServerProfileParams(cdn, tx)
 	if err != nil {
 		return nil, errors.New("getting deliveryservice parameters: " + err.Error())
 	}
-
 	dsParams, err := getDSParams(serverParams)
 	if err != nil {
 		return nil, errors.New("getting deliveryservice server parameters: " + err.Error())
 	}
-
-	dsmatchsets, dsdomains, err := getDSRegexesDomains(cdn, domain, tx)
+	dsmatchsets, dsdomains, dsMatchsetsNewestModifieds, err := getDSRegexesDomains(cdn, domain, tx)
 	if err != nil {
 		return nil, errors.New("getting regex matchsets: " + err.Error())
 	}
-
-	staticDNSEntries, err := getStaticDNSEntries(cdn, tx)
+	staticDNSEntries, staticDNSEntriesNewestModifieds, err := getStaticDNSEntries(cdn, tx)
 	if err != nil {
 		return nil, errors.New("getting static DNS entries: " + err.Error())
 	}
 
-	q := `
-select d.xml_id, d.miss_lat, d.miss_long, d.protocol, d.ccr_dns_ttl as ttl, d.routing_name, d.geo_provider, t.name as type, d.geo_limit, d.geo_limit_countries, d.geolimit_redirect_url, d.initial_dispersion, d.regional_geo_blocking, d.tr_response_headers, d.max_dns_answers, p.name as profile, d.dns_bypass_ip, d.dns_bypass_ip6, d.dns_bypass_ttl, d.dns_bypass_cname, d.http_bypass_fqdn, d.ipv6_routing_enabled, d.deep_caching_type, d.tr_request_headers, d.tr_response_headers, d.anonymous_blocking_enabled
-from deliveryservice as d
-inner join type as t on t.id = d.type
-left outer join profile as p on p.id = d.profile
-where d.cdn_id = (select id from cdn where name = $1)
-and d.active = true
-`
-	q += fmt.Sprintf(" and t.name != '%s'", tc.DSTypeAnyMap)
+	dsServerModifieds := getServerDSesModifieds(serverDSNames)
+
 	rows, err := tx.Query(q, cdn)
 	if err != nil {
 		return nil, errors.New("querying deliveryservices: " + err.Error())
 	}
 	defer rows.Close()
-
 	for rows.Next() {
 		ds := tc.CRConfigDeliveryService{
-			Protocol:        &tc.CRConfigDeliveryServiceProtocol{},
-			ResponseHeaders: map[string]string{},
-			Soa:             cdnSOA,
-			TTLs:            &tc.CRConfigTTL{},
+			CRConfigDeliveryServiceV11: tc.CRConfigDeliveryServiceV11{
+				Protocol:        &tc.CRConfigDeliveryServiceProtocol{},
+				ResponseHeaders: map[string]string{},
+				Soa:             cdnSOA,
+				TTLs:            &tc.CRConfigTTL{},
+			},
 		}
 
 		missLat := sql.NullFloat64{}
@@ -138,10 +177,16 @@ and d.active = true
 		trRequestHeaders := sql.NullString{}
 		trResponseHeaders := sql.NullString{}
 		anonymousBlocking := false
-		if err := rows.Scan(&xmlID, &missLat, &missLon, &protocol, &ds.TTL, &ds.RoutingName, &geoProvider, &ttype, &geoLimit, &geoLimitCountries, &geoLimitRedirectURL, &dispersion, &geoBlocking, &trRespHdrsStr, &maxDNSAnswers, &profile, &dnsBypassIP, &dnsBypassIP6, &dnsBypassTTL, &dnsBypassCName, &httpBypassFQDN, &ip6RoutingEnabled, &deepCachingType, &trRequestHeaders, &trResponseHeaders, &anonymousBlocking); err != nil {
+		if err := rows.Scan(&xmlID, &missLat, &missLon, &protocol, &ds.TTL, &ds.RoutingName, &geoProvider, &ttype, &geoLimit, &geoLimitCountries, &geoLimitRedirectURL, &dispersion, &geoBlocking, &trRespHdrsStr, &maxDNSAnswers, &profile, &dnsBypassIP, &dnsBypassIP6, &dnsBypassTTL, &dnsBypassCName, &httpBypassFQDN, &ip6RoutingEnabled, &deepCachingType, &trRequestHeaders, &trResponseHeaders, &anonymousBlocking, &ds.Modified); err != nil {
 			return nil, errors.New("scanning deliveryservice: " + err.Error())
 		}
+
+		ds.AnyModified = ds.Modified
+
+		ds.ServersModified = dsServerModifieds[tc.DeliveryServiceName(xmlID)]
+
 		// TODO prevent (lat XOR lon) in the Tx and UI
+
 		if missLat.Valid && missLon.Valid {
 			ds.MissLocation = &tc.CRConfigLatitudeLongitudeShort{Lat: missLat.Float64, Lon: missLon.Float64}
 		} else if missLat.Valid {
@@ -194,11 +239,15 @@ and d.active = true
 
 		if matchsets, ok := dsmatchsets[xmlID]; ok {
 			ds.MatchSets = matchsets
+			if matchsetModified, ok := dsMatchsetsNewestModifieds[xmlID]; ok && matchsetModified.After(ds.AnyModified) {
+				ds.AnyModified = matchsetModified
+			}
 		} else {
 			log.Warnln("no regex matchsets for delivery service: " + xmlID)
 		}
 		if domains, ok := dsdomains[xmlID]; ok {
 			ds.Domains = domains
+			// don't need to check domain modified here, since it's the same SQL data as matchsets - there may be a matchset without a domain, but there will never be a domain without a matchset
 		} else {
 			log.Warnln("no host regex for delivery service: " + xmlID)
 		}
@@ -227,17 +276,23 @@ and d.active = true
 		soaSeconds := DefaultTLDTTLSOA
 		if profile.Valid {
 			if sval, ok := dsParams["tld.ttls.SOA"]; ok {
-				if val, err := strconv.Atoi(sval); err == nil {
+				if val, err := strconv.Atoi(sval.Val); err == nil {
 					soaSeconds = time.Duration(val) * time.Second
+					if sval.Modified.After(ds.AnyModified) {
+						ds.AnyModified = sval.Modified
+					}
 				} else {
-					log.Errorln("delivery service " + xmlID + " profile " + profile.String + " param tld.ttls.SOA '" + sval + "' not a number - skipping")
+					log.Errorln("delivery service " + xmlID + " profile " + profile.String + " param tld.ttls.SOA '" + sval.Val + "' not a number - skipping")
 				}
 			}
 			if sval, ok := dsParams["tld.ttls.NS"]; ok {
-				if val, err := strconv.Atoi(sval); err == nil {
+				if val, err := strconv.Atoi(sval.Val); err == nil {
 					nsSeconds = time.Duration(val) * time.Second
+					if sval.Modified.After(ds.AnyModified) {
+						ds.AnyModified = sval.Modified
+					}
 				} else {
-					log.Errorln("delivery service " + xmlID + " profile " + profile.String + " param tld.ttls.NS '" + sval + "' not a number - skipping")
+					log.Errorln("delivery service " + xmlID + " profile " + profile.String + " param tld.ttls.NS '" + sval.Val + "' not a number - skipping")
 				}
 			}
 		}
@@ -332,6 +387,9 @@ and d.active = true
 		}
 
 		ds.StaticDNSEntries = staticDNSEntries[tc.DeliveryServiceName(xmlID)]
+		if sdeModified, ok := staticDNSEntriesNewestModifieds[tc.DeliveryServiceName(xmlID)]; ok && sdeModified.After(ds.AnyModified) {
+			ds.AnyModified = sdeModified
+		}
 
 		dses[xmlID] = ds
 	}
@@ -343,36 +401,45 @@ and d.active = true
 	return dses, nil
 }
 
-func getStaticDNSEntries(cdn string, tx *sql.Tx) (map[tc.DeliveryServiceName][]tc.CRConfigStaticDNSEntry, error) {
+func getStaticDNSEntries(cdn string, tx *sql.Tx) (map[tc.DeliveryServiceName][]tc.CRConfigStaticDNSEntry, map[tc.DeliveryServiceName]time.Time, error) {
 	entries := map[tc.DeliveryServiceName][]tc.CRConfigStaticDNSEntry{}
-
+	newestModified := map[tc.DeliveryServiceName]time.Time{}
 	q := `
-select d.xml_id as ds, e.host as name, e.ttl, e.address as value, t.name as type
-from staticdnsentry as e
-inner join deliveryservice as d on d.id = e.deliveryservice
-inner join type as t on t.id = e.type
-where d.cdn_id = (select id from cdn where name = $1)
-and d.active = true
+ SELECT d.xml_id as ds, e.host as name, e.ttl, e.address as value, t.name as type, greatest(e.last_updated, d.last_updated, t.last_updated, cdn.last_updated)
+FROM staticdnsentry as e
+JOIN deliveryservice as d on d.id = e.deliveryservice
+JOIN type as t on t.id = e.type
+JOIN cdn on cdn.id = d.cdn_id
+WHERE cdn.name = $1
+AND d.active = true
 `
 	rows, err := tx.Query(q, cdn)
 	if err != nil {
-		return nil, errors.New("querying static DNS entries: " + err.Error())
+		return nil, nil, errors.New("querying static DNS entries: " + err.Error())
 	}
 	defer rows.Close()
-
 	for rows.Next() {
 		ds := ""
 		name := ""
 		ttl := 0
 		value := ""
 		ttype := ""
-		if err := rows.Scan(&ds, &name, &ttl, &value, &ttype); err != nil {
-			return nil, errors.New("scanning static DNS entries: " + err.Error())
+		modified := time.Time{}
+		if err := rows.Scan(&ds, &name, &ttl, &value, &ttype, &modified); err != nil {
+			return nil, nil, errors.New("scanning static DNS entries: " + err.Error())
 		}
 		ttype = strings.Replace(ttype, "_RECORD", "", -1)
-		entries[tc.DeliveryServiceName(ds)] = append(entries[tc.DeliveryServiceName(ds)], tc.CRConfigStaticDNSEntry{Name: name, TTL: ttl, Value: value, Type: ttype})
+		entries[tc.DeliveryServiceName(ds)] = append(entries[tc.DeliveryServiceName(ds)], tc.CRConfigStaticDNSEntry{
+			Name:  name,
+			TTL:   ttl,
+			Value: value,
+			Type:  ttype,
+		})
+		if modified.After(newestModified[tc.DeliveryServiceName(ds)]) {
+			newestModified[tc.DeliveryServiceName(ds)] = modified
+		}
 	}
-	return entries, nil
+	return entries, newestModified, nil
 }
 
 func getProtocolStr(dsType string) string {
@@ -382,37 +449,39 @@ func getProtocolStr(dsType string) string {
 	return "HTTP"
 }
 
-func getDSRegexesDomains(cdn string, domain string, tx *sql.Tx) (map[string][]*tc.MatchSet, map[string][]string, error) {
+// getDSRegexesDomains returns a map[ds][]matchests, a map[ds][]domain, and a map[ds]lastestModifiedTime
+func getDSRegexesDomains(cdn string, domain string, tx *sql.Tx) (map[string][]*tc.MatchSet, map[string][]string, map[string]time.Time, error) {
 	dsmatchsets := map[string][]*tc.MatchSet{}
 	domains := map[string][]string{}
+	modifieds := map[string]time.Time{}
 	patternToHostReplacer := strings.NewReplacer(`\`, ``, `.*`, ``, `.`, ``)
 	q := `
-select r.pattern, t.name as type, dt.name as dstype, COALESCE(dr.set_number, 0), d.xml_id as dsname
-from regex as r
-inner join deliveryservice_regex as dr on r.id = dr.regex
-inner join deliveryservice as d on d.id = dr.deliveryservice
-inner join type as t on t.id = r.type
-inner join type as dt on dt.id = d.type
-where d.cdn_id = (select id from cdn where name = $1)
-and d.active = true
-order by dr.set_number asc
+SELECT r.pattern, t.name as type, dt.name as dstype, COALESCE(dr.set_number, 0), d.xml_id as dsname, greatest(r.last_updated, d.last_updated, dr.last_updated, t.last_updated, dt.last_updated, cdn.last_updated) as modified
+FROM regex as r
+JOIN deliveryservice_regex as dr ON r.id = dr.regex
+JOIN deliveryservice as d ON d.id = dr.deliveryservice
+JOIN type as t ON t.id = r.type
+JOIN type as dt ON dt.id = d.type
+JOIN cdn ON d.cdn_id = cdn.id
+WHERE cdn.name = $1
+AND d.active = true
+ORDER BY dr.set_number asc
 `
 	rows, err := tx.Query(q, cdn)
 	if err != nil {
-		return nil, nil, errors.New("querying deliveryservices: " + err.Error())
+		return nil, nil, nil, errors.New("querying deliveryservices: " + err.Error())
 	}
 	defer rows.Close()
-
 	for rows.Next() {
 		pattern := ""
 		ttype := ""
 		dstype := ""
 		setnum := 0
 		dsname := ""
-		if err := rows.Scan(&pattern, &ttype, &dstype, &setnum, &dsname); err != nil {
-			return nil, nil, errors.New("scanning deliveryservice regexes: " + err.Error())
+		modified := time.Time{}
+		if err := rows.Scan(&pattern, &ttype, &dstype, &setnum, &dsname, &modified); err != nil {
+			return nil, nil, nil, errors.New("scanning deliveryservice regexes: " + err.Error())
 		}
-
 		protocolStr := getProtocolStr(dstype)
 
 		for len(dsmatchsets[dsname]) <= setnum {
@@ -442,14 +511,15 @@ order by dr.set_number asc
 		if ttype == "HOST_REGEXP" && setnum == 0 {
 			domains[dsname] = append(domains[dsname], patternToHostReplacer.Replace(pattern)+"."+domain)
 		}
+		modifieds[dsname] = modified
 	}
-	return dsmatchsets, domains, nil
+	return dsmatchsets, domains, modifieds, nil
 }
 
 // getDSParams takes a map[serverProfile][paramName]paramVal and returns a map[paramName]paramVal.
 // The returned map of parameter values is used for DS settings for the current CDN.
 // If any profiles have conflicting parameters, an error is returned.
-func getDSParams(serverParams map[string]map[string]string) (map[string]string, error) {
+func getDSParams(serverParams map[string]map[string]ParamVal) (map[string]ParamVal, error) {
 	dsParamNames := map[string]struct{}{
 		"tld.soa.admin":     struct{}{},
 		"tld.soa.expire":    struct{}{},
@@ -460,7 +530,7 @@ func getDSParams(serverParams map[string]map[string]string) (map[string]string, 
 		"tld.ttls.NS":       struct{}{},
 		"LogRequestHeaders": struct{}{},
 	}
-	dsParams := map[string]string{}
+	dsParams := map[string]ParamVal{}
 	dsParamsOriginalProfile := map[string]string{} // map[paramName]profile - used exclusively for the error message
 	for profile, profileParams := range serverParams {
 		for paramName, _ := range dsParamNames {
@@ -468,8 +538,8 @@ func getDSParams(serverParams map[string]map[string]string) (map[string]string, 
 			if !profileHasParam {
 				continue
 			}
-			if dsParamVal, ok := dsParams[paramName]; ok && dsParamVal != paramVal {
-				return nil, errors.New("profiles " + profile + " and " + dsParamsOriginalProfile[paramName] + " have conflicting values '" + paramVal + "' and '" + dsParamVal + "'")
+			if dsParamVal, ok := dsParams[paramName]; ok && dsParamVal.Val != paramVal.Val {
+				return nil, errors.New("profiles " + profile + " and " + dsParamsOriginalProfile[paramName] + " have conflicting values '" + paramVal.Val + "' and '" + dsParamVal.Val + "'")
 			}
 			dsParams[paramName] = paramVal
 			dsParamsOriginalProfile[paramName] = profile
@@ -478,14 +548,21 @@ func getDSParams(serverParams map[string]map[string]string) (map[string]string, 
 	return dsParams, nil
 }
 
-// getDSProfileParams returns a map[dsname]map[paramname]paramvalue
-func getServerProfileParams(cdn string, tx *sql.Tx) (map[string]map[string]string, error) {
+type ParamVal struct {
+	Val      string
+	Modified time.Time
+}
+
+// getDSProfileParams returns a map[dsname]map[paramname]val
+func getServerProfileParams(cdn string, tx *sql.Tx) (map[string]map[string]ParamVal, error) {
 	q := `
-select parameter.name, parameter.value, profile.name as profile
-from profile
-inner join profile_parameter as pp on pp.profile = profile.id
-inner join parameter on parameter.id = pp.parameter
-where profile.id in (select profile from server where server.cdn_id = (select id from cdn where name = $1))
+SELECT parameter.name, parameter.value, profile.name as profile, greatest(parameter.last_updated, profile.last_updated, pp.last_updated, server.last_updated, cdn.last_updated) as modified
+FROM profile
+JOIN profile_parameter as pp ON pp.profile = profile.id
+JOIN parameter ON parameter.id = pp.parameter
+JOIN server ON server.profile = profile.id
+JOIN cdn ON cdn.id = server.id
+WHERE cdn.name = $1
 `
 	rows, err := tx.Query(q, cdn)
 	if err != nil {
@@ -493,20 +570,21 @@ where profile.id in (select profile from server where server.cdn_id = (select id
 	}
 	defer rows.Close()
 
-	params := map[string]map[string]string{}
+	params := map[string]map[string]ParamVal{}
 	debugCount := 0
 	for rows.Next() {
 		debugCount++
 		name := ""
 		val := ""
 		profile := ""
-		if err := rows.Scan(&name, &val, &profile); err != nil {
+		modified := time.Time{}
+		if err := rows.Scan(&name, &val, &profile, &modified); err != nil {
 			return nil, errors.New("scanning deliveryservice parameters: " + err.Error())
 		}
 		if _, ok := params[profile]; !ok {
-			params[profile] = map[string]string{}
+			params[profile] = map[string]ParamVal{}
 		}
-		params[profile][name] = val
+		params[profile][name] = ParamVal{Val: val, Modified: modified}
 	}
 
 	if err := rows.Err(); err != nil {

--- a/traffic_ops/traffic_ops_golang/crconfig/deliveryservice_test.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/deliveryservice_test.go
@@ -83,64 +83,66 @@ func randDS() tc.CRConfigDeliveryService {
 	ttlSOA := "86400"
 	geoProviderStr := GeoProviderMaxmindStr
 	return tc.CRConfigDeliveryService{
-		AnonymousBlockingEnabled: &falseStrPtr,
-		CoverageZoneOnly:         false,
-		Dispersion: &tc.CRConfigDispersion{
-			Limit:    42,
-			Shuffled: true,
-		},
-		// Domains: []string{"foo"},
-		GeoLocationProvider: &geoProviderStr,
-		// MatchSets:            randMatchsetArr(),
-		MissLocation: &tc.CRConfigLatitudeLongitudeShort{
-			Lat: *randFloat64(),
-			Lon: *randFloat64(),
-		},
-		Protocol: &tc.CRConfigDeliveryServiceProtocol{
-			// AcceptHTTP: &truePtr,
-			AcceptHTTPS:     false,
-			RedirectOnHTTPS: false,
-		},
-		RegionalGeoBlocking: &falseStrPtr,
-		ResponseHeaders:     nil,
-		RequestHeaders:      nil,
-		Soa: &tc.SOA{
-			Admin:          &ttlAdmin,
-			ExpireSeconds:  &ttlExpire,
-			MinimumSeconds: &ttlMinimum,
-			RefreshSeconds: &ttlRefresh,
-			RetrySeconds:   &ttlRetry,
-		},
-		SSLEnabled: false,
-		TTL:        ttl,
-		TTLs: &tc.CRConfigTTL{
-			ASeconds:    &ttlStr,
-			AAAASeconds: &ttlStr,
-			NSSeconds:   &ttlNS,
-			SOASeconds:  &ttlSOA,
-		},
-		// MaxDNSIPsForLocation: randInt(),
-		IP6RoutingEnabled: randBool(),
-		RoutingName:       randStr(),
-		BypassDestination: map[string]*tc.CRConfigBypassDestination{
-			"HTTP": &tc.CRConfigBypassDestination{
-				// IP: randStr(),
-				// IP6: randStr(),
-				// CName: randStr(),
-				// TTL: randInt(),
-				FQDN: randStr(),
-				// Port: randStr(),
+		CRConfigDeliveryServiceV11: tc.CRConfigDeliveryServiceV11{
+			AnonymousBlockingEnabled: &falseStrPtr,
+			CoverageZoneOnly:         false,
+			Dispersion: &tc.CRConfigDispersion{
+				Limit:    42,
+				Shuffled: true,
 			},
-		},
-		DeepCachingType: nil,
-		GeoEnabled:      nil,
-		// GeoLimitRedirectURL: randStr(),
-		StaticDNSEntries: []tc.CRConfigStaticDNSEntry{
-			tc.CRConfigStaticDNSEntry{
-				Name:  *randStr(),
-				TTL:   *randInt(),
-				Type:  *randStr(),
-				Value: *randStr(),
+			// Domains: []string{"foo"},
+			GeoLocationProvider: &geoProviderStr,
+			// MatchSets:            randMatchsetArr(),
+			MissLocation: &tc.CRConfigLatitudeLongitudeShort{
+				Lat: *randFloat64(),
+				Lon: *randFloat64(),
+			},
+			Protocol: &tc.CRConfigDeliveryServiceProtocol{
+				// AcceptHTTP: &truePtr,
+				AcceptHTTPS:     false,
+				RedirectOnHTTPS: false,
+			},
+			RegionalGeoBlocking: &falseStrPtr,
+			ResponseHeaders:     nil,
+			RequestHeaders:      nil,
+			Soa: &tc.SOA{
+				Admin:          &ttlAdmin,
+				ExpireSeconds:  &ttlExpire,
+				MinimumSeconds: &ttlMinimum,
+				RefreshSeconds: &ttlRefresh,
+				RetrySeconds:   &ttlRetry,
+			},
+			SSLEnabled: false,
+			TTL:        ttl,
+			TTLs: &tc.CRConfigTTL{
+				ASeconds:    &ttlStr,
+				AAAASeconds: &ttlStr,
+				NSSeconds:   &ttlNS,
+				SOASeconds:  &ttlSOA,
+			},
+			// MaxDNSIPsForLocation: randInt(),
+			IP6RoutingEnabled: randBool(),
+			RoutingName:       randStr(),
+			BypassDestination: map[string]*tc.CRConfigBypassDestination{
+				"HTTP": &tc.CRConfigBypassDestination{
+					// IP: randStr(),
+					// IP6: randStr(),
+					// CName: randStr(),
+					// TTL: randInt(),
+					FQDN: randStr(),
+					// Port: randStr(),
+				},
+			},
+			DeepCachingType: nil,
+			GeoEnabled:      nil,
+			// GeoLimitRedirectURL: randStr(),
+			StaticDNSEntries: []tc.CRConfigStaticDNSEntry{
+				tc.CRConfigStaticDNSEntry{
+					Name:  *randStr(),
+					TTL:   *randInt(),
+					Type:  *randStr(),
+					Value: *randStr(),
+				},
 			},
 		},
 	}
@@ -153,15 +155,20 @@ func ExpectedMakeDSes() map[string]tc.CRConfigDeliveryService {
 	}
 }
 
-func MockMakeDSes(mock sqlmock.Sqlmock, expected map[string]tc.CRConfigDeliveryService, cdn string) {
-	// select d.xml_id, d.miss_lat, d.miss_long, d.protocol, d.ccr_dns_ttl as ttl, d.routing_name, d.geo_provider, t.name as type, d.geo_limit, d.geo_limit_countries, d.geolimit_redirect_url, d.initial_dispersion, d.regional_geo_blocking, d.tr_response_headers, d.max_dns_answers, p.name as profile, d.dns_bypass_ip, d.dns_bypass_ip6, d.dns_bypass_ttl, d.dns_bypass_cname, d.http_bypass_fqdn, d.ipv6_routing_enabled, d.deep_caching_type, d.tr_request_headers, d.tr_response_headers, d.anonymous_blocking_enabled
+func ExpectedMakeDSesCacheDSes() map[tc.CacheName][]ServerDS {
+	return map[tc.CacheName][]ServerDS{}
+}
 
-	rows := sqlmock.NewRows([]string{"xml_id", "miss_lat", "miss_long", "protocol", "ttl", "routing_name", "geo_provider", "type", "geo_limit", "geo_limit_countries", "geeo_limit_redirect_url", "initial_dispersion", "regional_geo_blocking", "tr_response_headers", "max_dns_answers", "profile", "dns_bypass_ip", "dns_bypass_ip6", "dns_bypass_ttl", "dns_bypass_cname", "http_bypass_fqdn", "ipv6_routing_enabled", "deep_caching_type", "tr_request_headers", "tr_response_headers", "anonymous_blocking_enabled"})
+func MockMakeDSes(mock sqlmock.Sqlmock, expected map[string]tc.CRConfigDeliveryService, cdn string) {
+	// select d.xml_id, d.miss_lat, d.miss_long, d.protocol, d.ccr_dns_ttl as ttl, d.routing_name, d.geo_provider, t.name as type, d.geo_limit, d.geo_limit_countries, d.geolimit_redirect_url, d.initial_dispersion, d.regional_geo_blocking, d.tr_response_headers, d.max_dns_answers, p.name as profile, d.dns_bypass_ip, d.dns_bypass_ip6, d.dns_bypass_ttl, d.dns_bypass_cname, d.http_bypass_fqdn, d.ipv6_routing_enabled, d.deep_caching_type, d.tr_request_headers, d.tr_response_headers
+
+	rows := sqlmock.NewRows([]string{"xml_id", "miss_lat", "miss_long", "protocol", "ttl", "routing_name", "geo_provider", "type", "geo_limit", "geo_limit_countries", "geeo_limit_redirect_url", "initial_dispersion", "regional_geo_blocking", "tr_response_headers", "max_dns_answers", "profile", "dns_bypass_ip", "dns_bypass_ip6", "dns_bypass_ttl", "dns_bypass_cname", "http_bypass_fqdn", "ipv6_routing_enabled", "deep_caching_type", "tr_request_headers", "tr_response_headers", "anonymous_blocking_enabled", "updated"})
 
 	for dsName, ds := range expected {
-		rows = rows.AddRow(dsName, ds.MissLocation.Lat, ds.MissLocation.Lon, 0, *ds.TTL, *ds.RoutingName, 0, "HTTP", 0, "", "", 42, false, "", nil, "", "", "", 0, "", *ds.BypassDestination["HTTP"].FQDN, *ds.IP6RoutingEnabled, nil, "", "", false)
+		rows = rows.AddRow(dsName, ds.MissLocation.Lat, ds.MissLocation.Lon, 0, *ds.TTL, *ds.RoutingName, 0, "HTTP", 0, "", "", 42, false, "", nil, "", "", "", 0, "", *ds.BypassDestination["HTTP"].FQDN, *ds.IP6RoutingEnabled, nil, "", "", false, time.Time{})
+
 	}
-	mock.ExpectQuery("select").WithArgs(cdn).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT").WithArgs(cdn).WillReturnRows(rows)
 }
 
 func TestMakeDSes(t *testing.T) {
@@ -196,8 +203,10 @@ func TestMakeDSes(t *testing.T) {
 		t.Fatalf("creating transaction: %v", err)
 	}
 	defer tx.Commit()
+	MockMakeDSes(mock, expected, cdn)
 
-	actual, err := makeDSes(cdn, domain, tx)
+	cacheDSes := ExpectedMakeDSesCacheDSes()
+	actual, err := makeDSes(cdn, domain, cacheDSes, tx)
 	if err != nil {
 		t.Fatalf("makeDSes expected: nil error, actual: %v", err)
 	}
@@ -220,25 +229,25 @@ func TestMakeDSes(t *testing.T) {
 	}
 }
 
-func ExpectedGetServerProfileParams(expectedMakeDSes map[string]tc.CRConfigDeliveryService) map[string]map[string]string {
-	expected := map[string]map[string]string{}
+func ExpectedGetServerProfileParams(expectedMakeDSes map[string]tc.CRConfigDeliveryService) map[string]map[string]ParamVal {
+	expected := map[string]map[string]ParamVal{}
 	for dsName, _ := range expectedMakeDSes {
-		expected[dsName] = map[string]string{
-			"param0": "val0",
-			"param1": "val1",
+		expected[dsName] = map[string]ParamVal{
+			"param0": ParamVal{Val: "val0"},
+			"param1": ParamVal{Val: "val1"},
 		}
 	}
 	return expected
 }
 
-func MockGetServerProfileParams(mock sqlmock.Sqlmock, expected map[string]map[string]string, cdn string) {
-	rows := sqlmock.NewRows([]string{"name", "value", "profile"})
+func MockGetServerProfileParams(mock sqlmock.Sqlmock, expected map[string]map[string]ParamVal, cdn string) {
+	rows := sqlmock.NewRows([]string{"name", "value", "profile", "updated"})
 	for dsName, params := range expected {
 		for param, val := range params {
-			rows = rows.AddRow(param, val, dsName)
+			rows = rows.AddRow(param, val.Val, dsName, time.Time{})
 		}
 	}
-	mock.ExpectQuery("select").WithArgs(cdn).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT").WithArgs(cdn).WillReturnRows(rows)
 }
 
 func TestGetServerProfileParams(t *testing.T) {
@@ -285,7 +294,7 @@ func TestGetServerProfileParams(t *testing.T) {
 	}
 }
 
-func ExpectedGetDSRegexesDomains(expectedDSParams map[string]string) (map[string][]*tc.MatchSet, map[string][]string) {
+func ExpectedGetDSRegexesDomains(expectedDSParams map[string]ParamVal) (map[string][]*tc.MatchSet, map[string][]string) {
 	matchsets := map[string][]*tc.MatchSet{}
 	domains := map[string][]string{}
 
@@ -295,7 +304,7 @@ func ExpectedGetDSRegexesDomains(expectedDSParams map[string]string) (map[string
 
 	domain := "foo"
 	if val, ok := expectedDSParams["domain_name"]; ok {
-		domain = val
+		domain = val.Val
 	}
 
 	for dsName, _ := range expectedDSParams {
@@ -312,15 +321,15 @@ func ExpectedGetDSRegexesDomains(expectedDSParams map[string]string) (map[string
 }
 
 func MockGetDSRegexesDomains(mock sqlmock.Sqlmock, expectedMatchsets map[string][]*tc.MatchSet, expectedDomains map[string][]string, cdn string) {
-	rows := sqlmock.NewRows([]string{"pattern", "type", "dstype", "set_number", "xml_id"})
+	rows := sqlmock.NewRows([]string{"pattern", "type", "dstype", "set_number", "xml_id", "updated"})
 	for dsName, matchsets := range expectedMatchsets {
 		for _, matchset := range matchsets {
 			for _, matchlist := range matchset.MatchList {
-				rows = rows.AddRow(matchlist.Regex, "HOST", "HTTP", 0, dsName)
+				rows = rows.AddRow(matchlist.Regex, "HOST", "HTTP", 0, dsName, time.Time{})
 			}
 		}
 	}
-	mock.ExpectQuery("select").WithArgs(cdn).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT").WithArgs(cdn).WillReturnRows(rows)
 }
 
 func TestGetDSRegexesDomains(t *testing.T) {
@@ -352,7 +361,8 @@ func TestGetDSRegexesDomains(t *testing.T) {
 	}
 	defer tx.Commit()
 
-	actualMatchsets, actualDomains, err := getDSRegexesDomains(cdn, domain, tx)
+	actualMatchsets, actualDomains, actualDSModifieds, err := getDSRegexesDomains(cdn, domain, tx)
+	actualDSModifieds = actualDSModifieds
 	if err != nil {
 		t.Fatalf("getDSRegexesDomains expected: nil error, actual: %v", err)
 	}
@@ -383,13 +393,13 @@ func ExpectedGetStaticDNSEntries(expectedMakeDSes map[string]tc.CRConfigDelivery
 }
 
 func MockGetStaticDNSEntries(mock sqlmock.Sqlmock, expected map[tc.DeliveryServiceName][]tc.CRConfigStaticDNSEntry, cdn string) {
-	rows := sqlmock.NewRows([]string{"ds", "name", "ttl", "value", "type"})
+	rows := sqlmock.NewRows([]string{"ds", "name", "ttl", "value", "type", "updated"})
 	for dsName, entries := range expected {
 		for _, entry := range entries {
-			rows = rows.AddRow(dsName, entry.Name, entry.TTL, entry.Value, entry.Type+"_RECORD")
+			rows = rows.AddRow(dsName, entry.Name, entry.TTL, entry.Value, entry.Type+"_RECORD", time.Time{})
 		}
 	}
-	mock.ExpectQuery("select").WithArgs(cdn).WillReturnRows(rows)
+	mock.ExpectQuery("SELECT").WithArgs(cdn).WillReturnRows(rows)
 }
 
 func TestGetStaticDNSEntries(t *testing.T) {
@@ -415,7 +425,8 @@ func TestGetStaticDNSEntries(t *testing.T) {
 	}
 	defer tx.Commit()
 
-	actual, err := getStaticDNSEntries(cdn, tx)
+	actual, actualDSModifieds, err := getStaticDNSEntries(cdn, tx)
+	actualDSModifieds = actualDSModifieds
 	if err != nil {
 		t.Fatalf("getStaticDNSEntries expected: nil error, actual: %v", err)
 	}

--- a/traffic_ops/traffic_ops_golang/crconfig/edgelocations.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/edgelocations.go
@@ -22,17 +22,19 @@ package crconfig
 import (
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/lib/pq"
 )
 
-// getCachegroupFallbacks returns a map[primaryCacheGroupID][]fallbackCacheGroupName.
-func getCachegroupFallbacks(tx *sql.Tx) (map[int][]string, error) {
+// getCachegroupFallbacks returns a map[primaryCacheGroupID][]fallbackCacheGroupName, the last updated time of any fallback, and any error.
+func getCachegroupFallbacks(tx *sql.Tx) (map[int][]string, time.Time, error) {
 	q := `
 SELECT
   cachegroup_fallbacks.primary_cg,
-  cachegroup.name
+  cachegroup.name,
+  GREATEST(cachegroup.last_updated, cachegroup_fallbacks.last_updated) as last_updated
 FROM
   cachegroup_fallbacks
   JOIN cachegroup on cachegroup_fallbacks.backup_cg = cachegroup.id
@@ -40,51 +42,67 @@ ORDER BY cachegroup_fallbacks.set_order
 `
 	rows, err := tx.Query(q)
 	if err != nil {
-		return nil, errors.New("Error retrieving from cachegroup_fallbacks: " + err.Error())
+		return nil, time.Time{}, errors.New("Error retrieving from cachegroup_fallbacks: " + err.Error())
 	}
 	defer rows.Close()
 
+	lastUpdated := time.Time{}
 	fallbacks := map[int][]string{} // map[primaryCacheGroupID][]fallbackCacheGroupName
 	for rows.Next() {
 		primaryCGID := 0
 		fallbackCG := ""
-		if err := rows.Scan(&primaryCGID, &fallbackCG); err != nil {
-			return nil, errors.New("scanning cachegroup_fallbacks: " + err.Error())
+		fbLastUpdated := time.Time{}
+		if err := rows.Scan(&primaryCGID, &fallbackCG, &fbLastUpdated); err != nil {
+			return nil, time.Time{}, errors.New("scanning cachegroup_fallbacks: " + err.Error())
 		}
 		fallbacks[primaryCGID] = append(fallbacks[primaryCGID], fallbackCG)
+		if fbLastUpdated.After(lastUpdated) {
+			lastUpdated = fbLastUpdated
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, errors.New("cachegroup_fallbacks rows: " + err.Error())
+		return nil, time.Time{}, errors.New("cachegroup_fallbacks rows: " + err.Error())
 	}
-	return fallbacks, nil
+	return fallbacks, lastUpdated, nil
 }
 
-func makeLocations(cdn string, tx *sql.Tx) (map[string]tc.CRConfigLatitudeLongitude, map[string]tc.CRConfigLatitudeLongitude, error) {
+// makeLocations returns the map of edge locations, router locations, the last updated time of any location, and any error
+func makeLocations(cdn string, tx *sql.Tx) (map[string]tc.CRConfigLatitudeLongitude, map[string]tc.CRConfigLatitudeLongitude, time.Time, error) {
 	edgeLocs := map[string]tc.CRConfigLatitudeLongitude{}
 	routerLocs := map[string]tc.CRConfigLatitudeLongitude{}
 
-	fallbacks, err := getCachegroupFallbacks(tx)
+	fallbacks, lastUpdated, err := getCachegroupFallbacks(tx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, time.Time{}, err
 	}
 
 	// TODO test whether it's faster to do a single query, joining lat/lon into servers
-	q := `
-select cg.name, cg.id, t.name as type, co.latitude, co.longitude, COALESCE(cg.fallback_to_closest, TRUE),
-(SELECT array_agg(method::text) as localization_methods FROM cachegroup_localization_method WHERE cachegroup = cg.id)
-from cachegroup as cg
-left join coordinate as co on co.id = cg.coordinate
-inner join server as s on s.cachegroup = cg.id
-inner join type as t on t.id = s.type
-inner join status as st ON st.id = s.status
-where s.cdn_id = (select id from cdn where name = $1)
-and (t.name like 'EDGE%' or t.name = 'CCR')
-and (st.name = 'REPORTED' or st.name = 'ONLINE' or st.name = 'ADMIN_DOWN')
+	qry := `
+SELECT
+  cg.name,
+  cg.id,
+  t.name as type,
+  co.latitude,
+  co.longitude,
+  COALESCE(cg.fallback_to_closest, TRUE),
+  (SELECT array_agg(method::text) as localization_methods FROM cachegroup_localization_method WHERE cachegroup = cg.id),
+  GREATEST(cg.last_updated, co.last_updated) as last_updated
+FROM
+  cachegroup cg
+  LEFT JOIN coordinate co on co.id = cg.coordinate
+  JOIN server s on s.cachegroup = cg.id
+  JOIN type t on t.id = s.type
+  JOIN status st ON st.id = s.status
+  JOIN cdn ON cdn.id = s.cdn_id
+WHERE
+  cdn.name = $1
+  AND (t.name like 'EDGE%' or t.name = 'CCR')
+  AND (st.name = 'REPORTED' or st.name = 'ONLINE' or st.name = 'ADMIN_DOWN')
 `
 	// TODO pass edge type prefix, router type name
-	rows, err := tx.Query(q, cdn)
+	rows, err := tx.Query(qry, cdn)
 	if err != nil {
-		return nil, nil, errors.New("Error querying cachegroups: " + err.Error())
+		return nil, nil, time.Time{}, errors.New("Error querying cachegroups: " + err.Error())
 	}
 	defer rows.Close()
 
@@ -94,8 +112,9 @@ and (st.name = 'REPORTED' or st.name = 'ONLINE' or st.name = 'ADMIN_DOWN')
 		ttype := ""
 		fallbackToClosest := true
 		latlon := tc.CRConfigLatitudeLongitude{}
-		if err := rows.Scan(&cachegroup, &primaryCacheID, &ttype, &latlon.Lat, &latlon.Lon, &fallbackToClosest, pq.Array(&latlon.LocalizationMethods)); err != nil {
-			return nil, nil, errors.New("Error scanning cachegroup: " + err.Error())
+		cgLastUpdated := time.Time{}
+		if err := rows.Scan(&cachegroup, &primaryCacheID, &ttype, &latlon.Lat, &latlon.Lon, &fallbackToClosest, pq.Array(&latlon.LocalizationMethods), &cgLastUpdated); err != nil {
+			return nil, nil, time.Time{}, errors.New("Error scanning cachegroup: " + err.Error())
 		}
 		if len(latlon.LocalizationMethods) == 0 {
 			// to keep current default behavior when localizationMethods is unset/empty, enable all current localization methods
@@ -108,9 +127,12 @@ and (st.name = 'REPORTED' or st.name = 'ONLINE' or st.name = 'ADMIN_DOWN')
 			latlon.BackupLocations.List = fallbacks[primaryCacheID]
 			edgeLocs[cachegroup] = latlon
 		}
+		if cgLastUpdated.After(lastUpdated) {
+			lastUpdated = cgLastUpdated
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, nil, errors.New("Error iterating cachegroup rows: " + err.Error())
+		return nil, nil, time.Time{}, errors.New("Error iterating cachegroup rows: " + err.Error())
 	}
-	return edgeLocs, routerLocs, nil
+	return edgeLocs, routerLocs, lastUpdated, nil
 }

--- a/traffic_ops/traffic_ops_golang/crconfig/handler.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/handler.go
@@ -45,7 +45,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	crConfig, err := Make(inf.Tx.Tx, inf.Params["cdn"], inf.User.UserName, r.Host, r.URL.Path, inf.Config.Version)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
-		return
 	}
 	log.Infof("CRConfig time to generate: %+v\n", time.Since(start))
 	api.WriteResp(w, r, crConfig)


### PR DESCRIPTION
Adds a "modified" field to the CRConfig deliveryServices objects,
indicating the last time that DS's database table row was modified.

Adds a "anyModified" field to the CRConfig deliveryServices objects,
indicating the last time any database field used to create the JSON
object was modified, also including the server assignments (which
are in the contentServers key, not the deliveryServices key)

Adds a "version" field to the CRConfig object, indicating the API
version used to create that CRConfig.

Adds database triggers updating the deliveryservices last_modified
timestamp when a ds_regex, ds_server, or staticdnsentry is deleted.

These features are being added, with the goal of making it possible
for Traffic Router to determine if any individual DS in the CRConfig
has been modified, and only reload modified DSes, not everything.