### PR TITLE
Fix TO Go DS POST to 400 on duplicate, not 5xx

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
@@ -201,7 +201,7 @@ func create(db *sql.DB, cfg config.Config, user *auth.CurrentUser, ds tc.Deliver
 	if err != nil {
 		if pqerr, ok := err.(*pq.Error); ok {
 			err, _ := dbhelpers.ParsePQUniqueConstraintError(pqerr)
-			return tc.DeliveryServiceNullableV13{}, http.StatusInternalServerError, nil, errors.New("a delivery service with " + err.Error())
+			return tc.DeliveryServiceNullableV13{}, http.StatusBadRequest, errors.New("a delivery service with " + err.Error()), nil
 		}
 		return tc.DeliveryServiceNullableV13{}, http.StatusInternalServerError, nil, errors.New("inserting ds: " + err.Error())
 	}


### PR DESCRIPTION
Fixes Traffic Ops Golang to return a 400 with a message, when the user tries to POST a delivery service whose xml_id already exists. 

It was returning a 5xx with no message, and logging the error details, rather than giving them to the user. Which is completely unhelpful.