### PR TITLE
Edge retrieval from origin - Configuring go_direct from traffic ops. [WIP]

### DIFF
--- a/traffic_ops/app/db/migrations/20180604000000_go_direct.sql
+++ b/traffic_ops/app/db/migrations/20180604000000_go_direct.sql
@@ -1,0 +1,19 @@
+/*
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+alter table deliveryservice add column go_direct boolean NOT NULL default FALSE;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+alter table deliveryservice drop column go_direct;

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1092,10 +1092,12 @@ sub parent_ds_data {
 			my $ds_xml_id                   = $dsinfo->xml_id;
 			my $origin_shield               = $dsinfo->origin_shield;
 			my $multi_site_origin           = $dsinfo->multi_site_origin;
+			my $go_direct                   = $dsinfo->go_direct;
 
 			$response_obj->{dslist}->[$j]->{"org"}                         = $org_fqdn;
 			$response_obj->{dslist}->[$j]->{"type"}                        = $ds_type;
 			$response_obj->{dslist}->[$j]->{"qstring_ignore"}              = $qstring_ignore;
+			$response_obj->{dslist}->[$j]->{"go_direct"}                   = $go_direct ? "false" : "true";
 
 			if ( defined( $dsinfo->profile ) ) {
 				my $dsqstring = $self->db->resultset('ProfileParameter')
@@ -2528,11 +2530,12 @@ sub parent_dot_config { #fix qstring - should be ignore for quika
 			foreach my $ds ( sort @{ $data->{dslist} } ) {
 				my $text;
 				my $org = $ds->{org};
+				my $go_direct = " go_direct=" . $ds->{go_direct};
 				next if !defined $org || $org eq "";
 				next if $done{$org};
 				my $org_uri = URI->new($org);
 				if ( $ds->{type} eq "HTTP_NO_CACHE" || $ds->{type} eq "HTTP_LIVE" || $ds->{type} eq "DNS_LIVE" ) {
-					$text .= "dest_domain=" . $org_uri->host . " port=" . $org_uri->port . " go_direct=true\n";
+					$text .= "dest_domain=" . $org_uri->host . " port=" . $org_uri->port . $go_direct . "\n";
 				}
 				else {
 					# check for profile psel.qstring_handling.  If this parameter is assigned to the server profile,

--- a/traffic_ops/app/lib/Schema/Result/DeliveryServiceInfoForDomainList.pm
+++ b/traffic_ops/app/lib/Schema/Result/DeliveryServiceInfoForDomainList.pm
@@ -62,7 +62,8 @@ SELECT
     deliveryservice.remap_text,
     deliveryservice.protocol,
     deliveryservice.profile,
-    deliveryservice.anonymous_blocking_enabled
+    deliveryservice.anonymous_blocking_enabled,
+    deliveryservice.go_direct
 FROM
     deliveryservice
     JOIN deliveryservice_regex ON deliveryservice_regex.deliveryservice = deliveryservice.id
@@ -107,7 +108,8 @@ __PACKAGE__->add_columns(
 	"fq_pacing_rate",              { data_type => "bigint",  is_nullable => 0 },   
 	"origin_shield",               { data_type => "varchar", is_nullable => 0, size => 1024 },
 	"profile",                     { data_type => "integer", is_nullable => 1},
-    "anonymous_blocking_enabled",  { data_type => "boolean", is_nullable => 0 },
+        "anonymous_blocking_enabled",  { data_type => "boolean", is_nullable => 0 },
+	"go_direct",                   { data_type => "boolean", is_nullable => 0},
 );
 
 1;

--- a/traffic_ops/app/lib/Schema/Result/DeliveryServiceInfoForServerList.pm
+++ b/traffic_ops/app/lib/Schema/Result/DeliveryServiceInfoForServerList.pm
@@ -62,7 +62,8 @@ SELECT
     mid_header_rewrite as mid_header_rewrite,
     deliveryservice.protocol as protocol,
     deliveryservice.profile as profile,
-    deliveryservice.anonymous_blocking_enabled as anonymous_blocking_enabled
+    deliveryservice.anonymous_blocking_enabled as anonymous_blocking_enabled,
+    deliveryservice.go_direct as go_direct
 FROM
     deliveryservice
         JOIN deliveryservice_regex ON deliveryservice_regex.deliveryservice = deliveryservice.id
@@ -100,7 +101,8 @@ __PACKAGE__->add_columns(
         "fq_pacing_rate",              { data_type => "bigint",  is_nullable => 0},
 	"origin_shield",               { data_type => "varchar", is_nullable => 0, size => 1024 },
 	"profile",                     { data_type => "integer", is_nullable => 1},
-    "anonymous_blocking_enabled",  { data_type => "boolean", is_nullable => 0 },
+        "anonymous_blocking_enabled",  { data_type => "boolean", is_nullable => 0 },
+	"go_direct",                   { data_type => "boolean", is_nullable => 0},
 );
 
 1;

--- a/traffic_ops/app/lib/Schema/Result/Deliveryservice.pm
+++ b/traffic_ops/app/lib/Schema/Result/Deliveryservice.pm
@@ -46,6 +46,11 @@ __PACKAGE__->table("deliveryservice");
   default_value: false
   is_nullable: 0
 
+=head2 go_direct
+  data_type: 'boolean'
+  default_value: false
+  is_nullable: 0
+
 =head2 dscp
 
   data_type: 'bigint'
@@ -332,6 +337,8 @@ __PACKAGE__->add_columns(
   "active",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "anonymous_blocking_enabled",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "go_direct",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "dscp",
   { data_type => "bigint", is_nullable => 0 },

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -213,6 +213,7 @@ sub ds_data {
 		my $remap_text                  = $row->remap_text;
 		my $multi_site_origin           = $row->multi_site_origin;
 		my $multi_site_origin_algorithm = 0;
+		my $go_direct                   = ( $row->go_direct == 0) ? "false" : "true";
 
 		if ( $re_type eq 'HOST_REGEXP' ) {
 			my $host_re = $row->pattern;
@@ -281,6 +282,7 @@ sub ds_data {
 		$dsinfo->{dslist}->[$j]->{"remap_text"}                  = $remap_text;
 		$dsinfo->{dslist}->[$j]->{"multi_site_origin"}           = $multi_site_origin;
 		$dsinfo->{dslist}->[$j]->{"multi_site_origin_algorithm"} = $multi_site_origin_algorithm;
+		$dsinfo->{dslist}->[$j]->{"go_direct"}                   = $go_direct;
 
 		if ( defined($edge_header_rewrite) ) {
 			my $fname = "hdr_rw_" . $ds_xml_id . ".config";
@@ -1298,11 +1300,13 @@ sub parent_dot_config {
 
 		foreach my $remap ( @{ $data->{dslist} } ) {
 			my $org = $remap->{org};
+			my $go_direct = " go_direct=" . $remap->{go_direct};
+			my $ds_xml_id = $remap->{ds_xml_id};
 			next if !defined $org || $org eq "";
 			next if $done{$org};
 			my $org_uri = URI->new($org);
 			if ( $remap->{type} eq "HTTP_NO_CACHE" || $remap->{type} eq "HTTP_LIVE" || $remap->{type} eq "DNS_LIVE" ) {
-				$text .= "dest_domain=" . $org_uri->host . " port=" . $org_uri->port . " go_direct=true\n";
+				$text .= "dest_domain=" . $org_uri->host . " port=" . $org_uri->port . $go_direct . "\n";
 			}
 			else {
 				# check for profile psel.qstring_handling.  If this parameter is assigned to the server profile,
@@ -1344,7 +1348,6 @@ sub parent_dot_config {
 					$secparents = 'secondary_parent="' . join( '', @secondary_parent_info ) . '"';
 				}
 				my $round_robin = 'round_robin=consistent_hash';
-				my $go_direct   = 'go_direct=false';
 				$text
 					.= "dest_domain="
 					. $org_uri->host

--- a/traffic_ops/app/templates/delivery_service/_form.html.ep
+++ b/traffic_ops/app/templates/delivery_service/_form.html.ep
@@ -613,6 +613,21 @@
 			<% } %>
 		<% } %>
   </div>
+        <div class="block form-row" id="go_direct_row">
+        <% unless (field('ds.go_direct')->valid) { %>
+	        <span class="field-with-error"><%= field('ds.go_direct')->error %></span>
+		<% } %>
+        %= label_for 'go_direct' => 'Origin go direct', class => 'label'
+        <% if ($priv_level >= 20) { %>
+        %= field('ds.go_direct')->select([ [False => 0], [True => 1]]);
+        <% } else { %>
+			<%  if ($ds-> active == 0 ) {%>
+				%= field('ds.go_direct')->text(class => 'field', readonly => 'readonly', value => 'False');
+			<% } else { %>
+				%= field('ds.go_direct')->text(class => 'field', readonly => 'readonly', value => 'True');
+			<% } %>
+        <% } %>
+	</div>
 	<div class="block form-row" id="active_row">
 		<% unless (field('ds.active')->valid) { %>
 			<span class="field-with-error"><%= field('ds.active')->error %></span>

--- a/traffic_ops/app/templates/delivery_service/add.html.ep
+++ b/traffic_ops/app/templates/delivery_service/add.html.ep
@@ -144,6 +144,7 @@
             $('#geo_limit_countries_row').show(speed);
             check_geolimit_redirect_url_row_showhide(1, speed);
             $('#anonymous_blocking_enabled_row').show(speed);
+            $('#go_direct_row').show(speed);
 		}
 		else if (type_selected.match(/^DNS/)) {
 			$("#regexp_selector :nth-child(3)").attr('disabled','disabled');
@@ -188,6 +189,7 @@
             $('#geo_limit_countries_row').show(speed);
             check_geolimit_redirect_url_row_showhide(0, speed);
             $('#anonymous_blocking_enabled_row').show(speed);
+            $('#go_direct_row').show(speed);
 		}
 		else if (type_selected.match(/^ANY_MAP$/)) {
             $('#protocoli_row').hide(speed);
@@ -229,6 +231,7 @@
             $('#regexp_add').show(speed);
             $('#geo_limit_countries_row').show(speed);
             $('#anonymous_blocking_enabled_row').hide(speed);
+            $('#go_direct_row').show(speed);
 		}
 		else if (type_selected.match(/STEERING$/)) {
             $('#protocoli_row').show(speed);
@@ -276,6 +279,7 @@
             $('#geo_limit_countries_row').show(speed);
             check_geolimit_redirect_url_row_showhide(0, speed);
             $('#anonymous_blocking_enabled_row').hide(speed);
+            $('#go_direct_row').show(speed);
 		}
 		//
 	}

--- a/traffic_ops/app/templates/delivery_service/edit.html.ep
+++ b/traffic_ops/app/templates/delivery_service/edit.html.ep
@@ -237,6 +237,7 @@ function setup_form(speed) {
             $('#steering_button').hide(speed);
 	    check_geolimit_redirect_url_row_showhide(1, speed);
             $('#anonymous_blocking_enabled_row').show(speed);
+            $('#go_direct_row').show(speed);
 		}
 		else if (type_selected.match(/^DNS/)) {
 			$("#regexp_selector :nth-child(3)").attr('disabled','disabled');
@@ -280,6 +281,7 @@ function setup_form(speed) {
             $('#steering_button').hide(speed);
 	    $('#geolimit_redirect_url_row').hide(speed);
             $('#anonymous_blocking_enabled_row').hide(speed);
+            $('#go_direct_row').show(speed);
 		}
 		else if (type_selected.match(/^ANY_MAP$/)) {
             $('#protocoli_row').hide(speed);
@@ -321,6 +323,7 @@ function setup_form(speed) {
             $('#regexp_add').show(speed);
             $('#steering_button').hide(speed);
             $('#anonymous_blocking_enabled_row').hide(speed);
+            $('#go_direct_row').show(speed);
 		}
 		else if (type_selected.match(/STEERING$/)) {
             $('#protocoli_row').show(speed);
@@ -370,6 +373,7 @@ function setup_form(speed) {
             $('#steering_button').show(speed);
             $('#geo_limit_countries_row').show(speed);
             $('#anonymous_blocking_enabled_row').hide(speed);
+            $('#go_direct_row').show(speed);
 		}
 		//
 	}


### PR DESCRIPTION
All DS-es sharing an origin server should have same value for go_direct
(or)
No two Delivery service shares same origin.

Implementation:
Add a new column 'go_direct' in Deliveryservice table. Its value defaults to False.
Delivery service UI (Traffic Ops) and API will be enhanced to support this new column.

Conflicts:
1. DS Type HTTP_NO_CACHE and go direct False 
2. DS Type HTTP_LIVE and go direct False 
3. DS Type DNS_LIVE and go direct False 
4. MSO = true and go_direct = true 


When we have more than 2 DS-es sharing same origin, then updating one particular DS's go_direct value will result
in conflict, since all DS-es sharing an origin should have same value for go_direct
