### PR TITLE
Fix go DS API query params for filtering/ordering

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
@@ -621,8 +621,18 @@ func readGetDeliveryServices(params map[string]string, db *sqlx.DB, user auth.Cu
 	// Query Parameters to Database Query column mappings
 	// see the fields mapped in the SQL query
 	queryParamsToSQLCols := map[string]dbhelpers.WhereColumnInfo{
-		"id":       dbhelpers.WhereColumnInfo{"ds.id", api.IsInt},
-		"hostName": dbhelpers.WhereColumnInfo{"s.host_name", nil},
+		"id":               dbhelpers.WhereColumnInfo{"ds.id", api.IsInt},
+		"cdn":              dbhelpers.WhereColumnInfo{"ds.cdn_id", api.IsInt},
+		"xml_id":           dbhelpers.WhereColumnInfo{"ds.xml_id", nil},
+		"profile":          dbhelpers.WhereColumnInfo{"ds.profile", api.IsInt},
+		"type":             dbhelpers.WhereColumnInfo{"ds.type", api.IsInt},
+		"logsEnabled":      dbhelpers.WhereColumnInfo{"ds.logs_enabled", api.IsBool},
+		"tenant":           dbhelpers.WhereColumnInfo{"ds.tenant_id", api.IsInt},
+		"signingAlgorithm": dbhelpers.WhereColumnInfo{"ds.signing_algorithm", nil},
+	}
+
+	if _, ok := params["orderby"]; !ok {
+		params["orderby"] = "xml_id"
 	}
 
 	where, orderBy, queryValues, errs := dbhelpers.BuildWhereAndOrderBy(params, queryParamsToSQLCols)


### PR DESCRIPTION
Add ability to filter by the same columns the Perl version allows
filtering on.

By default, order GET deliveryservices by xml_id if an orderby query
parameter isn't specified in the request (this is what the Perl version
does).