### PR TITLE
Add Go DS API query parameter alias for xml_id -> xmlId

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
@@ -624,6 +624,7 @@ func readGetDeliveryServices(params map[string]string, db *sqlx.DB, user auth.Cu
 		"id":               dbhelpers.WhereColumnInfo{"ds.id", api.IsInt},
 		"cdn":              dbhelpers.WhereColumnInfo{"ds.cdn_id", api.IsInt},
 		"xml_id":           dbhelpers.WhereColumnInfo{"ds.xml_id", nil},
+		"xmlId":            dbhelpers.WhereColumnInfo{"ds.xml_id", nil},
 		"profile":          dbhelpers.WhereColumnInfo{"ds.profile", api.IsInt},
 		"type":             dbhelpers.WhereColumnInfo{"ds.type", api.IsInt},
 		"logsEnabled":      dbhelpers.WhereColumnInfo{"ds.logs_enabled", api.IsBool},


### PR DESCRIPTION
The Perl version did not support this query parameter, but it probably
should have because it's more intuitive to have it match the field name.