### PR TITLE
Filter the list of potential Steering Targets in Traffic Portal

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/FormDeliveryServiceTargetController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/FormDeliveryServiceTargetController.js
@@ -17,12 +17,14 @@
  * under the License.
  */
 
-var FormDeliveryServiceTargetController = function(deliveryService, target, $scope, formUtils, locationUtils, deliveryServiceService, typeService) {
+var FormDeliveryServiceTargetController = function(deliveryService, currentTargets, target, $scope, formUtils, locationUtils, deliveryServiceService, typeService) {
 
 	var getDeliveryServices = function() {
-		deliveryServiceService.getDeliveryServices()
+		deliveryServiceService.getDeliveryServices({ cdn: deliveryService.cdnId })
 			.then(function(result) {
-				$scope.deliveryServices = result;
+				$scope.deliveryServices = _.filter(result, function(ds) {
+					return ds.type.startsWith('HTTP') && _.findWhere(currentTargets, {targetId: ds.id}) == undefined;
+				});
 			});
 	};
 
@@ -53,5 +55,5 @@ var FormDeliveryServiceTargetController = function(deliveryService, target, $sco
 
 };
 
-FormDeliveryServiceTargetController.$inject = ['deliveryService', 'target', '$scope', 'formUtils', 'locationUtils', 'deliveryServiceService', 'typeService'];
+FormDeliveryServiceTargetController.$inject = ['deliveryService', 'currentTargets', 'target', '$scope', 'formUtils', 'locationUtils', 'deliveryServiceService', 'typeService'];
 module.exports = FormDeliveryServiceTargetController;

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/edit/FormEditDeliveryServiceTargetController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/edit/FormEditDeliveryServiceTargetController.js
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-var FormEditDeliveryServiceTargetController = function(deliveryService, target, $scope, $controller, $uibModal, $anchorScroll, locationUtils, deliveryServiceService) {
+var FormEditDeliveryServiceTargetController = function(deliveryService, currentTargets, target, $scope, $controller, $uibModal, $anchorScroll, locationUtils, deliveryServiceService) {
 
 	// extends the FormDeliveryServiceTargetController to inherit common methods
-	angular.extend(this, $controller('FormDeliveryServiceTargetController', { deliveryService: deliveryService, target: target, $scope: $scope }));
+	angular.extend(this, $controller('FormDeliveryServiceTargetController', { deliveryService: deliveryService, currentTargets: currentTargets, target: target, $scope: $scope }));
 
 	var deleteTarget = function(target) {
 		deliveryServiceService.deleteDeliveryServiceTarget(target.deliveryServiceId, target.targetId)
@@ -65,5 +65,5 @@ var FormEditDeliveryServiceTargetController = function(deliveryService, target, 
 
 };
 
-FormEditDeliveryServiceTargetController.$inject = ['deliveryService', 'target', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'deliveryServiceService'];
+FormEditDeliveryServiceTargetController.$inject = ['deliveryService', 'currentTargets', 'target', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'deliveryServiceService'];
 module.exports = FormEditDeliveryServiceTargetController;

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/new/FormNewDeliveryServiceTargetController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/new/FormNewDeliveryServiceTargetController.js
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-var FormNewDeliveryServiceTargetController = function(deliveryService, target, $scope, $controller, deliveryServiceService) {
+var FormNewDeliveryServiceTargetController = function(deliveryService, currentTargets, target, $scope, $controller, deliveryServiceService) {
 
 	// extends the FormDeliveryServiceTargetController to inherit common methods
-	angular.extend(this, $controller('FormDeliveryServiceTargetController', { deliveryService: deliveryService, target: target, $scope: $scope }));
+	angular.extend(this, $controller('FormDeliveryServiceTargetController', { deliveryService: deliveryService, currentTargets: currentTargets, target: target, $scope: $scope }));
 
 	$scope.targetName = 'New';
 
@@ -35,5 +35,5 @@ var FormNewDeliveryServiceTargetController = function(deliveryService, target, $
 
 };
 
-FormNewDeliveryServiceTargetController.$inject = ['deliveryService', 'target', '$scope', '$controller', 'deliveryServiceService'];
+FormNewDeliveryServiceTargetController.$inject = ['deliveryService', 'currentTargets', 'target', '$scope', '$controller', 'deliveryServiceService'];
 module.exports = FormNewDeliveryServiceTargetController;

--- a/traffic_portal/app/src/modules/private/deliveryServices/targets/edit/index.js
+++ b/traffic_portal/app/src/modules/private/deliveryServices/targets/edit/index.js
@@ -30,6 +30,9 @@ module.exports = angular.module('trafficPortal.private.deliveryServices.targets.
 							deliveryService: function($stateParams, deliveryServiceService) {
 								return deliveryServiceService.getDeliveryService($stateParams.deliveryServiceId);
 							},
+							currentTargets: function() {
+								return [];
+							},
 							target: function($stateParams, deliveryServiceService) {
 								return deliveryServiceService.getDeliveryServiceTarget($stateParams.deliveryServiceId, $stateParams.targetId);
 							}

--- a/traffic_portal/app/src/modules/private/deliveryServices/targets/new/index.js
+++ b/traffic_portal/app/src/modules/private/deliveryServices/targets/new/index.js
@@ -30,6 +30,9 @@ module.exports = angular.module('trafficPortal.private.deliveryServices.targets.
 							deliveryService: function($stateParams, deliveryServiceService) {
 								return deliveryServiceService.getDeliveryService($stateParams.deliveryServiceId);
 							},
+							currentTargets: function($stateParams, deliveryServiceService) {
+								return deliveryServiceService.getDeliveryServiceTargets($stateParams.deliveryServiceId);
+							},
 							target: function(deliveryService) {
 								return {
 									deliveryServiceId: deliveryService.id


### PR DESCRIPTION
The old Perl UI lists HTTP-type DSes belonging to the same CDN as the
Steering DS that aren't already targets, and this makes Traffic Portal
do the same thing.

Fixes #1884.