### PR TITLE
Improve TR logging when a certificate from TO fails to decode

### DIFF
--- a/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/secure/CertificateDataConverter.java
+++ b/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/secure/CertificateDataConverter.java
@@ -41,7 +41,9 @@ public class CertificateDataConverter {
 				x509Chain.toArray(new X509Certificate[x509Chain.size()]), privateKey);
 
 		} catch (Exception e) {
-			log.error("Failed to convert certificate data from traffic ops to handshake data! " + e.getClass().getSimpleName() + ": " + e.getMessage(), e);
+			log.error("Failed to convert certificate data (delivery service = " + certificateData.getDeliveryservice()
+					+ ", hostname = " + certificateData.getHostname() + ") from traffic ops to handshake data! "
+					+ e.getClass().getSimpleName() + ": " + e.getMessage(), e);
 		}
 		return null;
 	}


### PR DESCRIPTION
This adds the name of the delivery service as well as the hostname of
the certificate it failed to decode.