### PR TITLE
Update weasel to v0.2.

### DIFF
--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - ../../..:/trafficcontrol:z
 
   weasel:
-    image: licenseweasel/weasel:0.1
+    image: licenseweasel/weasel:0.2
     volumes:
       - ../../..:/trafficcontrol:z
     command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']


### PR DESCRIPTION
This fixes several bugs, including autocreating the log file directory. Also, you can now pass `-d <subdir>` to weasel to run it on just a small part of the whole.