### PR TITLE
Fix Go TO "GET /server/{id}/deliveryservices" endpoint

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -791,7 +791,10 @@ func SDSSelectQuery() string {
 		miss_long,
 		multi_site_origin,
 		multi_site_origin_algorithm,
-		org_server_fqdn,
+		(SELECT o.protocol::text || '://' || o.fqdn || rtrim(concat(':', o.port::text), ':')
+		FROM origin o
+		WHERE o.deliveryservice = d.id
+		AND o.is_primary) as org_server_fqdn,
 		origin_shield,
 		profile,
 		protocol,


### PR DESCRIPTION
Recently, the org_server_fqdn column in the deliveryservice table was
removed and replaced to use the origin table instead. Correct the SELECT
query to use the origin table.

Fixes #2467 