### PR TITLE
require golang-1.9.4 using yum for all go components

### DIFF
--- a/infrastructure/docker/build/Dockerfile-grove
+++ b/infrastructure/docker/build/Dockerfile-grove
@@ -33,7 +33,7 @@ RUN	yum -y install \
 
 ### grove specific requirements
 RUN	yum -y install \
-		golang && \
+		golang-1.9.4 && \
 	yum -y clean all
 ###
 

--- a/infrastructure/docker/build/Dockerfile-traffic_monitor
+++ b/infrastructure/docker/build/Dockerfile-traffic_monitor
@@ -31,7 +31,7 @@ RUN	yum -y install \
 
 ### traffic_monitor specific requirements
 RUN	yum -y install \
-		golang && \
+		golang-1.9.4 && \
 	yum -y clean all
 ###
 

--- a/infrastructure/docker/build/Dockerfile-traffic_ops
+++ b/infrastructure/docker/build/Dockerfile-traffic_ops
@@ -33,15 +33,13 @@ RUN	yum -y install \
 RUN	yum -y install \
 		expat-devel \
 		gcc \
+		golang-1.9.4 \
 		libcurl-devel \
 		make \
 		openssl-devel \
 		perl-ExtUtils-MakeMaker \
 		tar && \
 	yum -y clean all
-
-ADD traffic_ops/install/bin/install_go.sh /
-RUN /install_go.sh
 
 ADD infrastructure/docker/build/clean_build.sh /
 CMD /clean_build.sh traffic_ops

--- a/infrastructure/docker/build/Dockerfile-traffic_stats
+++ b/infrastructure/docker/build/Dockerfile-traffic_stats
@@ -31,7 +31,7 @@ RUN	yum -y install \
 
 ### traffic_stats specific requirements
 RUN	yum -y install \
-		golang && \
+		golang-1.9.4 && \
 	yum -y clean all
 ###
 

--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -33,7 +33,7 @@ URL:              https://github.com/apache/trafficcontrol/
 Vendor:           Apache Software Foundation
 Packager:         daniel_kirkwood at Cable dot Comcast dot com
 AutoReqProv:      no
-Requires:         cpanminus, expat-devel, gcc-c++, libcurl, libpcap-devel, mkisofs, tar
+Requires:         cpanminus, expat-devel, gcc-c++, golang = 1.9.4, libcurl, libpcap-devel, mkisofs, tar
 Requires:         openssl-devel, perl, perl-core, perl-DBD-Pg, perl-DBI, perl-Digest-SHA1
 Requires:         libidn-devel, libcurl-devel, libcap
 Requires:         postgresql96 >= 9.6.2 , postgresql96-devel >= 9.6.2
@@ -56,7 +56,6 @@ Built: %(date) by %{getenv: USER}
     # update version referenced in the source
     perl -pi.bak -e 's/__VERSION__/%{version}-%{release}/' app/lib/UI/Utils.pm
 
-    export PATH=$PATH:/usr/local/go/bin
     export GOPATH=$(pwd)
 
     echo "PATH: $PATH"

--- a/traffic_ops/install/bin/postinstall
+++ b/traffic_ops/install/bin/postinstall
@@ -47,9 +47,6 @@ cd /opt/traffic_ops/app
 export POSTGRES_HOME=${POSTGRES_HOME:-/usr/pgsql-9.6}
 /usr/local/bin/carton
 
-# Install go 
-/opt/traffic_ops/install/bin/install_go.sh
-
 # Install go and goose
 /opt/traffic_ops/install/bin/install_goose.sh
 


### PR DESCRIPTION
to get some consistency in the version of Go used in all components,  install golang-1.9.4 package from yum when building.  Also requires golang-1.9.4 when installing the traffic_ops rpm,  since postinstall also uses the go compiler (for goose).