### PR TITLE
Modify the grove rpm version format

### DIFF
--- a/grove/build/grove.spec
+++ b/grove/build/grove.spec
@@ -13,7 +13,7 @@
 Summary: Grove HTTP Caching Proxy
 Name: grove
 Version: %{version}
-Release: 1
+Release: %{build_number}
 License: Apache License, Version 2.0
 Group: Base System/System Tools
 Prefix: /usr/sbin/%{name}


### PR DESCRIPTION
Modify the grove/build/build_rpm.sh to change the version format to add the last 9 digit commit hash on the grove/ directory as the releasewhen building the grove rpm.  Fixes #2468 