### PR TITLE
remove use of /usr/local/go

### DIFF
--- a/traffic_ops/install/bin/install_goose.sh
+++ b/traffic_ops/install/bin/install_goose.sh
@@ -14,14 +14,11 @@
 # limitations under the License.
 #
 
-GO_BINARY=/usr/local/go/bin/go
-
 echo "Now installing goose"
 export GOPATH=/opt/traffic_ops/go
 mkdir -p $GOPATH
 
-echo "GO_BINARY: $GO_BINARY"
-$GO_BINARY get bitbucket.org/liamstask/goose/cmd/goose
-$GO_BINARY get github.com/lib/pq
+go get bitbucket.org/liamstask/goose/cmd/goose
+go get github.com/lib/pq
 
 echo "Successfully installed goose to $GOPATH/bin/goose"


### PR DESCRIPTION
one more vestige of using the go installation downloaded directly rather than installed from yum.

install_goose.sh now expects go to be installed and available in the user's PATH.