### PR TITLE
TO Go cdns/domains endpoint

### DIFF
--- a/lib/go-tc/v13/domains.go
+++ b/lib/go-tc/v13/domains.go
@@ -1,0 +1,72 @@
+package v13
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+TODO: Adapt the comments to be better used by swagger. I am writing comments
+that look similar to others in `go-tc/cdns.go`, but I'm unsure how it will
+end up looking. Note: I also made a few assumptions with the "required" field
+*/
+
+// A List of Domains Response
+// swagger:response DomainsResponse
+// in: body
+type DomainsResponse struct {
+	// in: body
+	Response []Domain `json:"response"`
+}
+
+// Domain ...
+type Domain struct {
+
+	// Profile ID
+	//
+	// required: true
+	ProfileID int `json:"profileId" db:"profile_id"`
+
+	// Parameter ID
+	//
+	// required: false
+	ParameterID int `json:"parameterId" db:"parameter_id"`
+
+	// Profile Name
+	//
+	// required: true
+	ProfileName string `json:"profileName" db:"profile_name"`
+
+	// Profile Description
+	//
+	// required: true
+	ProfileDescription string `json:"profileDescription" db:"profile_description"`
+
+	// DomainName of the CDN
+	//
+	// required: true
+	DomainName string `json:"domainName" db:"domain_name"`
+}
+
+// DomainNullable - a struct version that allows for all fields to be null, mostly used by the API side
+type DomainNullable struct {
+	ProfileID          *int    `json:"profileId" db:"profile_id"`
+	ParameterID        *int    `json:"parameterId" db:"parameter_id"`
+	ProfileName        *string `json:"profileName" db:"profile_name"`
+	ProfileDescription *string `json:"profileDescription" db:"profile_description"`
+	DomainName         *string `json:"domainName" db:"domain_name"`
+}

--- a/lib/go-tc/v13/domains.go
+++ b/lib/go-tc/v13/domains.go
@@ -19,46 +19,21 @@ package v13
  * under the License.
  */
 
-/*
-TODO: Adapt the comments to be better used by swagger. I am writing comments
-that look similar to others in `go-tc/cdns.go`, but I'm unsure how it will
-end up looking. Note: I also made a few assumptions with the "required" field
-*/
-
-// A List of Domains Response
-// swagger:response DomainsResponse
-// in: body
 type DomainsResponse struct {
-	// in: body
 	Response []Domain `json:"response"`
 }
 
-// Domain ...
 type Domain struct {
 
-	// Profile ID
-	//
-	// required: true
 	ProfileID int `json:"profileId" db:"profile_id"`
 
-	// Parameter ID
-	//
-	// required: false
 	ParameterID int `json:"parameterId" db:"parameter_id"`
 
-	// Profile Name
-	//
-	// required: true
 	ProfileName string `json:"profileName" db:"profile_name"`
 
-	// Profile Description
-	//
-	// required: true
 	ProfileDescription string `json:"profileDescription" db:"profile_description"`
 
 	// DomainName of the CDN
-	//
-	// required: true
 	DomainName string `json:"domainName" db:"domain_name"`
 }
 

--- a/traffic_ops/client/v13/cdn_domains.go
+++ b/traffic_ops/client/v13/cdn_domains.go
@@ -21,7 +21,7 @@ import (
 
 func (to *Session) GetDomains() ([]v13.Domain, ReqInf, error) {
 	var data v13.DomainsResponse
-	inf, err := get(to, "/api/1.3/cdns/domains", &data)
+	inf, err := get(to, apiBase + "/cdns/domains", &data)
 	if err != nil {
 		return nil, inf, err
 	}

--- a/traffic_ops/client/v13/cdn_domains.go
+++ b/traffic_ops/client/v13/cdn_domains.go
@@ -1,5 +1,9 @@
 package v13
 
+import (
+	"github.com/apache/trafficcontrol/lib/go-tc/v13"
+)
+
 /*
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,28 +19,11 @@ package v13
    limitations under the License.
 */
 
-import (
-	"testing"
-
-	log "github.com/apache/trafficcontrol/lib/go-log"
-)
-
-func GetTestDomains(t *testing.T) {
-	resp, _, err := TOSession.GetDomains()
-	log.Debugln("Response: ", resp)
+func (to *Session) GetDomains() ([]v13.Domain, ReqInf, error) {
+	var data v13.DomainsResponse
+	inf, err := get(to, "/api/1.3/cdns/domains", &data)
 	if err != nil {
-		t.Errorf("could not GET domains: %v\n", err)
+		return nil, inf, err
 	}
-}
-
-func TestDomains(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	GetTestDomains(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	return data.Response, inf, nil
 }

--- a/traffic_ops/testing/api/v13/cdn_domains_test.go
+++ b/traffic_ops/testing/api/v13/cdn_domains_test.go
@@ -18,7 +18,7 @@ package v13
 import (
 	"testing"
 
-	log "github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func GetTestDomains(t *testing.T) {

--- a/traffic_ops/testing/api/v13/cdn_domains_test.go
+++ b/traffic_ops/testing/api/v13/cdn_domains_test.go
@@ -1,0 +1,22 @@
+package v13
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import "testing"
+
+func TestDomains(t *testing.T) {
+  //
+}

--- a/traffic_ops/traffic_ops_golang/cdn/domains.go
+++ b/traffic_ops/traffic_ops_golang/cdn/domains.go
@@ -1,0 +1,97 @@
+package cdn
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+  "net/http"
+  //"database/sql"
+  //"github.com/jmoiron/sqlx" //sql extra
+  "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+)
+
+func DomainsHandler (w http.ResponseWriter, r *http.Request) {
+
+  // inf is of type APIInfo
+  inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+  if userErr != nil || sysErr != nil {
+    api.HandleErr(w, r, errCode, userErr, sysErr)
+    return
+  }
+  defer inf.Close()
+
+  var (
+    cdn         int
+    id          int
+    name        string
+    description string
+    domain_name string
+    resp []interface{} //really not sure about this
+  )
+
+  //how to prefetch 'cdn'?
+  q := `SELECT cdn, id, name, description FROM 'Profile' WHERE name LIKE 'CCR%'`
+  rows, err := inf.Tx.Query(q)
+  if err != nil {
+    //TODO change errCode, userErr, and sysErr
+    //which one is errors.New("Error: " + err.Error()?
+    //api.HandleErr(w, r, errCode, userErr, sysErr)
+    return
+  }
+  defer rows.Close()
+
+  for rows.Next() {
+
+    //Do I even need to check for errors here since the perl doesn't?
+    if err := rows.Scan(&cdn, &id, &name, &description); err != nil {
+      //api.HandleErr(w, r, HTTP CODE,
+      //  errors.New("Error scanning ...: " + err.Error())  user or system error?
+    }
+
+    err = inf.Tx.QueryRow("SELECT DOMAIN_NAME FROM CDN WHERE id = $1", 1).Scan(&domain_name)
+    if err != nil {
+      //api.HandleErr(w, r, HTTP CODE,
+      //  errors.New("Error scanning ...: " + err.Error()") user or system error?
+    }
+
+    data := struct {
+      domain_name string
+      param_id    int
+      id          int
+      name        string
+      description string
+    } {
+      domain_name,
+      -1, // it's not a parameter anymore
+      id,
+      name,
+      description,
+    }
+    resp = append(resp, data)
+  }
+
+  api.WriteResp(w, r, resp)
+  /* {
+    "domainName"         => $row->cdn->domain_name,
+    "parameterId"        => -1,  # it's not a parameter anymore
+    "profileId"          => $row->id,
+    "profileName"        => $row->name,
+    "profileDescription" => $row->description,
+  } */
+}

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -110,8 +110,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `cdns/metric_types`, notImplementedHandler, 0, NoAuth, nil}, // MUST NOT end in $, because the 1.x route is longer
 		{1.1, http.MethodGet, `cdns/capacity$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
 		{1.1, http.MethodGet, `cdns/configs/?(\.json)?$`, cdn.GetConfigs(d.DB.DB), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `cdns/domains$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}}, //old
-		//{1.1, http.MethodGet, `cdns/domains/?(\.json)?$`, cdn.DomainsHandler, auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `cdns/domains/?(\.json)?$`, cdn.DomainsHandler, auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `cdns/health$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
 		{1.1, http.MethodGet, `cdns/routing$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
 

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -110,7 +110,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `cdns/metric_types`, notImplementedHandler, 0, NoAuth, nil}, // MUST NOT end in $, because the 1.x route is longer
 		{1.1, http.MethodGet, `cdns/capacity$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
 		{1.1, http.MethodGet, `cdns/configs/?(\.json)?$`, cdn.GetConfigs(d.DB.DB), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `cdns/domains$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
+		{1.1, http.MethodGet, `cdns/domains$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}}, //old
+		//{1.1, http.MethodGet, `cdns/domains/?(\.json)?$`, cdn.DomainsHandler, auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `cdns/health$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
 		{1.1, http.MethodGet, `cdns/routing$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
 


### PR DESCRIPTION
Rewrote the domains endpoint. Both perl and go show good data in localhost, except perl's profile id is a string for some reason, which makes it fail the test I wrote. Considering we are replacing the perl code, this should all be fine.