### PR TITLE
Update the traffic_ops database to add a GROVE_PROFILE enum value.

### DIFF
--- a/traffic_ops/app/db/patches.sql
+++ b/traffic_ops/app/db/patches.sql
@@ -34,3 +34,8 @@ ALTER TABLE deliveryservice ALTER COLUMN routing_name SET NOT NULL;
 ALTER TABLE deliveryservice ALTER COLUMN routing_name SET DEFAULT 'cdn';
 ALTER TABLE deliveryservice DROP CONSTRAINT IF EXISTS routing_name_not_empty;
 ALTER TABLE deliveryservice ADD CONSTRAINT routing_name_not_empty CHECK (length(routing_name) > 0);
+-- This patch adds a new enum value to profile_type
+-- We need to add the enum directly with sql as postgres will not allow
+-- altering any enum values within a transaction block and by default
+-- goose runs migrations within a transaction.
+ALTER TYPE profile_type ADD VALUE IF NOT EXISTS 'GROVE_PROFILE';


### PR DESCRIPTION
Updates the traffic_ops database by adding a GROVE_PROFILE ENUM value to profile_type.  This PR adds this value using a sql patch as postgres does not allow ALTER TYPE on an ENUM within a transaction and goose always runs migrations within a transaction.