### PR TITLE
TO Go:  ignore param key(s) (e.g. "id") in JSON for PUT

### DIFF
--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -270,8 +270,8 @@ func UpdateHandler(typeFactory CRUDFactory) http.HandlerFunc {
 				return
 			}
 
-			if kf.Field == "id" && paramValue != "" {
-				// ignore id provided in JSON -- overwrite with paramValue
+			if paramValue != "" {
+				// if key's value provided in params,  overwrite it and ignore that provided in JSON
 				keys[kf.Field] = paramValue
 				u.SetKeys(keys)
 				continue

--- a/traffic_ops/traffic_ops_golang/tenant/tenant.go
+++ b/traffic_ops/traffic_ops_golang/tenant/tenant.go
@@ -284,7 +284,7 @@ func (ten *TOTenant) Update() (error, tc.ApiErrorType) {
 	for resultRows.Next() {
 		rowsAffected++
 		if err := resultRows.Scan(&lastUpdated); err != nil {
-			log.Error.Printf("could not scan lastUpdated from insert: %s\n", err)
+			log.Error.Printf("could not scan lastUpdated from update: %s\n", err)
 			return tc.DBError, tc.SystemError
 		}
 	}


### PR DESCRIPTION
This fixes #2496 .

If any of the keys provided from `u.GetKeys()` from any endpoint (usually it's only "id") is provided in JSON,  overwrite with the value from params (normally provided in path), e.g. `api/1.3/tenants/2`.   It needn't be required in the update JSON and, if provided, should be ignored.