### PR TITLE
Fix compiler error when building grovetccfg

### DIFF
--- a/grove/grovetccfg/grovetccfg.go
+++ b/grove/grovetccfg/grovetccfg.go
@@ -752,7 +752,7 @@ func createRulesOld(
 			}
 		}
 
-		dsType := strings.ToLower(ds.Type)
+		dsType := strings.ToLower(string(ds.Type))
 		if !strings.HasPrefix(dsType, "http") && !strings.HasPrefix(dsType, "dns") {
 			fmt.Printf(time.Now().Format(time.RFC3339Nano)+" createRules skipping deliveryservice %v - unknown type %v", ds.XMLID, ds.Type)
 			continue


### PR DESCRIPTION
A recent change to the deliveryservices struct in go-tc causes a compile error building grovetccfg.go with the compile error "./grovetccfg.go:755:31: cannot use ds.Type (type tc.DSType) as type string in argument to strings.ToLower".  tc.DSType is now defined in go-tc as a  'type string' in tc.enums.go and now has to be explicitly cast as a string in grovetccfg.go.