### PR TITLE
Fix Coordinate integration fixture

### DIFF
--- a/traffic_ops/app/lib/Fixtures/Integration/Coordinate.pm
+++ b/traffic_ops/app/lib/Fixtures/Integration/Coordinate.pm
@@ -147,7 +147,7 @@ sub get_definition {
 
 sub all_fixture_names {
 	# sort by db short_name to guarantee insertion order
-	return (sort { $definition_for{$a}{using}{short_name} cmp $definition_for{$b}{using}{short_name} } keys %definition_for);
+	return (sort { $definition_for{$a}{using}{name} cmp $definition_for{$b}{using}{name} } keys %definition_for);
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
Sort by 'name' rather than 'short_name'.