### PR TITLE
Modify the grovetccfg rpm build script so that it uses the trafficcontrol versioning scheme.

### DIFF
--- a/grove/grovetccfg/build/build_rpm.sh
+++ b/grove/grovetccfg/build/build_rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,31 +12,91 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILDDIR="$HOME/rpmbuild"
+#----------------------------------------
+function importFunctions() {
+  TC_DIR=$(git rev-parse --show-toplevel)
+  [ ! -z "$TC_DIR" ] || { echo "Cannot find repository root." >&2 ; exit 1; }
+  export TC_DIR
+	functions_sh="$TC_DIR/build/functions.sh"
+	if [[ ! -r $functions_sh ]]; then
+		echo "Error: Can't find $functions_sh"
+		exit 1
+	fi
+	. "$functions_sh"
+}
 
-VERSION=`cat ./../VERSION`.`git rev-list --all --count`
+#----------------------------------------
+function checkGroveEnvironment() {
+	echo "Verifying the build configuration environment."
+	local script=$(readlink -f "$0")
+	local scriptdir=$(dirname "$script")
 
-# prep build environment
-rm -rf $BUILDDIR
-mkdir -p $BUILDDIR/{BUILD,RPMS,SOURCES}
-echo "$BUILDDIR" > ~/.rpmmacros
+	export GROVETC_DIR=$(dirname "$scriptdir")
+  export GROVE_DIR=$(dirname "$GROVETC_DIR")
+  export GROVE_VERSION=`cat ${GROVE_DIR}/VERSION`
+	export PACKAGE="grovetccfg"
+	export BUILD_NUMBER=${BUILD_NUMBER:-$(getBuildNumber)}
+	export RPMBUILD="${GROVE_DIR}/rpmbuild"
+	export DIST="${TC_DIR}/dist"
+	export RPM="${PACKAGE}-${GROVE_VERSION}-${BUILD_NUMBER}.x86_64.rpm"
 
-# get traffic_ops client
-# godir=src/github.com/apache/trafficcontrol/traffic_ops/client
-# ( mkdir -p "$godir" && \
-#   cd "$godir" && \
-#   cp -r ${GOPATH}/${godir}/* . && \
-#   go get -v \
-# ) || { echo "Could not build go program at $(pwd): $!"; exit 1; }
+	echo "=================================================="
+  echo "TC_DIR: $TC_DIR"
+  echo "PACKAGE: $PACKAGE"
+  echo "GROVE_DIR: $GROVE_DIR"
+  echo "GROVETC_DIR: $GROVETC_DIR"
+	echo "GROVE_VERSION: $GROVE_VERSION"
+	echo "BUILD_NUMBER: $BUILD_NUMBER"
+  echo "DIST: $DIST"
+	echo "RPM: $RPM"
+  echo "RPMBUILD: $RPMBUILD"
+	echo "--------------------------------------------------"
+}
 
-# build
-go build -v
+# ---------------------------------------
+function initBuildArea() {
+  cd "$GROVETC_DIR"
 
-# tar
-tar -cvzf $BUILDDIR/SOURCES/grovetccfg-${VERSION}.tgz grovetccfg
+  # prep build environment
+  [ -e $RPMBUILD ] && rm -rf $RPMBUILD
+  [ ! -e $RPMBUILD ] || { echo "Failed to clean up rpm build directory '$RPMBUILD': $?" >&2; exit 1; }
+  mkdir -p $RPMBUILD/{BUILD,RPMS,SOURCES} || { echo "Failed to create build directory '$RPMBUILD': $?" >&2; exit 1; }
+}
 
-# build RPM
-rpmbuild --define "version ${VERSION}" -ba build/grovetccfg.spec
+# ---------------------------------------
+function buildRpmGrove() {
+  # build
+  go get -v -d . || { echo "Failed to go get dependencies: $?" >&2; exit 1; }
+  go build -v -ldflags "-X main.Version=$GROVE_VERSION" || { echo "Failed to build $PACKAGE: $?" >&2; exit 1; }
 
-# copy build RPM to .
-cp $BUILDDIR/RPMS/x86_64/grovetccfg-${VERSION}-1.x86_64.rpm .
+  # tar
+  tar -cvzf $RPMBUILD/SOURCES/${PACKAGE}-${GROVE_VERSION}.tgz ${PACKAGE}|| { echo "Failed to create archive for rpmbuild: $?" >&2; exit 1; }
+
+  # Work around bug in rpmbuild. Fixed in rpmbuild 4.13.
+  # See: https://github.com/rpm-software-management/rpm/commit/916d528b0bfcb33747e81a57021e01586aa82139
+  # Takes ownership of the spec file.
+  spec=build/${PACKAGE}.spec
+  spec_owner=$(stat -c%u $spec)
+  spec_group=$(stat -c%g $spec)
+  if ! id $spec_owner >/dev/null 2>&1; then
+	  chown $(id -u):$(id -g) build/${PACKAGE}.spec
+
+	  function give_spec_back {
+		chown ${spec_owner}:${spec_group} build/${PACKAGE}.spec
+	  }
+	  trap give_spec_back EXIT
+  fi
+
+  # build RPM
+  rpmbuild --define "_topdir $RPMBUILD" --define "version ${GROVE_VERSION}" --define "build_number ${BUILD_NUMBER}" -ba build/${PACKAGE}.spec || { echo "rpmbuild failed: $?" >&2; exit 1; }
+
+  # copy build RPM to .
+  [ -e $DIST ] || mkdir -p $DIST
+  cp $RPMBUILD/RPMS/x86_64/${RPM} $DIST
+}
+
+importFunctions
+checkGroveEnvironment
+initBuildArea
+buildRpmGrove
+

--- a/grove/grovetccfg/build/grovetccfg.spec
+++ b/grove/grovetccfg/build/grovetccfg.spec
@@ -13,7 +13,7 @@
 Summary: Grove HTTP Caching Proxy Traffic Control config generator
 Name: grovetccfg
 Version: %{version}
-Release: 1
+Release: %{build_number}
 License: Apache License, Version 2.0
 Group: Base System/System Tools
 Prefix: /usr/sbin/%{name}

--- a/infrastructure/docker/build/Dockerfile-grovetccfg
+++ b/infrastructure/docker/build/Dockerfile-grovetccfg
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+FROM centos:7
+
+MAINTAINER John Rushford
+
+# top level of trafficcontrol directory must be mounted as a volume:
+# docker run --volume /trafficcontrol:$(pwd) ...
+VOLUME /trafficcontrol
+
+### Common for all sub-component builds
+RUN	yum -y install \
+		epel-release && \
+	yum -y clean all
+RUN	yum -y install \
+		git \
+		rpm-build && \
+	yum -y clean all
+
+### grove specific requirements
+RUN	yum -y install \
+		golang-1.9.4 && \
+	yum -y clean all
+###
+
+ADD infrastructure/docker/build/clean_build.sh /
+
+ENV GOPATH=/go
+RUN mkdir -p /go/src/github.com/apache && ln -s /tmp/trafficcontrol /go/src/github.com/apache/trafficcontrol
+CMD /clean_build.sh grove/grovetccfg
+
+# vi:syntax=Dockerfile

--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -86,6 +86,14 @@ services:
     volumes:
       - ../../..:/trafficcontrol:z
 
+  grovetccfg_build:
+    image: grovetccfg_builder
+    build:
+      dockerfile: infrastructure/docker/build/Dockerfile-grovetccfg
+      context: ../../..
+    volumes:
+      - ../../..:/trafficcontrol:z
+
   weasel:
     image: licenseweasel/weasel:0.2
     volumes:


### PR DESCRIPTION
Update the grovetccfg build script to match the trafficcontrol versioning scheme.
Also adds grovetccfg to the docker build systems so that grovetccfg is built.