### PR TITLE
TO Go GET /user/current should have 'roleName' not 'rolename'

### DIFF
--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -109,7 +109,7 @@ type UserCurrent struct {
 	PostalCode      *string `json:"postalCode"`
 	PublicSSHKey    *string `json:"publicSshKey,omitempty"`
 	Role            *int    `json:"role,omitempty"`
-	RoleName        *string `json:"rolename,omitempty"`
+	RoleName        *string `json:"roleName,omitempty"`
 	StateOrProvince *string `json:"stateOrProvince"`
 	Tenant          *string `json:"tenant"`
 	TenantID        *uint64 `json:"tenantId"`


### PR DESCRIPTION
The field needs to be camelcased like it is in the Perl version,
otherwise clients are broken (i.e. TP which checks this field when
determining if a user can automatically fulfill a DSR).