### PR TITLE
properly issue delete query in transaction

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -368,7 +368,7 @@ func GetReplaceHandler(db *sqlx.DB) http.HandlerFunc {
 
 		if *payload.Replace {
 			// delete existing
-			rows, err := db.Queryx("DELETE FROM deliveryservice_server WHERE deliveryservice = $1", *dsId)
+			rows, err := tx.Queryx("DELETE FROM deliveryservice_server WHERE deliveryservice = $1", *dsId)
 			if err != nil {
 				log.Errorf("unable to remove the existing servers assigned to the delivery service: %s", err)
 				handleErrs(http.StatusInternalServerError, err)


### PR DESCRIPTION
1) if the transaction is rolled back the delete should be too
2) issuing queries on the db when a tx is started causes deadlock when there is only one db connection available (meaning a handler that does this requires 2 db connections to respond)