### PR TITLE
Fix TP clone DS by adding proper DS origin resolution

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryService/clone/FormCloneDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/clone/FormCloneDeliveryServiceController.js
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-var FormCloneDeliveryServiceController = function(deliveryService, type, types, $scope, $controller) {
+var FormCloneDeliveryServiceController = function(deliveryService, origin, type, types, $scope, $controller) {
 
 	// extends the FormNewDeliveryServiceController to inherit common methods
-	angular.extend(this, $controller('FormNewDeliveryServiceController', { deliveryService: deliveryService, type: type, types: types, $scope: $scope }));
+	angular.extend(this, $controller('FormNewDeliveryServiceController', { deliveryService: deliveryService, origin: origin, type: type, types: types, $scope: $scope }));
 
 	$scope.deliveryServiceName = deliveryService.xmlId + ' clone';
 
@@ -40,5 +40,5 @@ var FormCloneDeliveryServiceController = function(deliveryService, type, types, 
 
 };
 
-FormCloneDeliveryServiceController.$inject = ['deliveryService', 'type', 'types', '$scope', '$controller'];
+FormCloneDeliveryServiceController.$inject = ['deliveryService', 'origin', 'type', 'types', '$scope', '$controller'];
 module.exports = FormCloneDeliveryServiceController;

--- a/traffic_portal/app/src/modules/private/deliveryServices/clone/index.js
+++ b/traffic_portal/app/src/modules/private/deliveryServices/clone/index.js
@@ -47,6 +47,9 @@ module.exports = angular.module('trafficPortal.private.deliveryServices.clone', 
 							deliveryService: function($stateParams, deliveryServiceService) {
 								return deliveryServiceService.getDeliveryService($stateParams.deliveryServiceId);
 							},
+							origin: function($stateParams, originService) {
+								return originService.getOrigins({ deliveryservice: $stateParams.deliveryServiceId, primary: true })
+							},
 							type: function($stateParams) {
 								return $stateParams.type;
 							},


### PR DESCRIPTION
The FormCloneDeliveryServiceController was missing the resolution of the
cloned DS's primary origin.

Fixes #2552.