### PR TITLE
Display form feedback for origin name

### DIFF
--- a/traffic_portal/app/src/common/modules/form/origin/form.origin.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/origin/form.origin.tpl.html
@@ -37,10 +37,10 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(originForm.name), 'has-feedback': hasError(originForm.name)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">Name *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="name" type="text" class="form-control" ng-model="origin.name" ng-maxlength="100" ng-pattern="/^\S*$/" required autofocus>
-                    <small class="input-error" ng-show="hasPropertyError(originForm.hostName, 'required')">Required</small>
-                    <small class="input-error" ng-show="hasPropertyError(originForm.hostName, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(originForm.hostName, 'pattern')">No spaces</small>
+                    <input name="name" type="text" class="form-control" ng-model="origin.name" ng-maxlength="100" ng-pattern="/^\S+$/" required autofocus>
+                    <small class="input-error" ng-show="hasPropertyError(originForm.name, 'required')">Required</small>
+                    <small class="input-error" ng-show="hasPropertyError(originForm.name, 'maxlength')">Too Long</small>
+                    <small class="input-error" ng-show="hasPropertyError(originForm.name, 'pattern')">No spaces</small>
                     <span ng-show="hasError(originForm.name)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>


### PR DESCRIPTION
Fix a typo ('hostName' -> 'name') so that form feedback is actually
displayed for the origin "name" field.

Fixes #2553.