### PR TITLE
WIP - Adds the grvssl package that lets one use the openssl library vs tls

### DIFF
--- a/grove/config/config.go
+++ b/grove/config/config.go
@@ -60,6 +60,9 @@ type Config struct {
 	CacheFiles           map[string][]CacheFile `json:"cache_files"`
 	// FileMemBytes is the amount of memory to use as an LRU in front of each name in CacheFiles, that is, each named group of files. E.g. if there are 10 files, the amount of memory used will be 10*FileMemBytes+CacheSizeBytes.
 	FileMemBytes int `json:"file_mem_bytes"`
+
+	// if set to true, grove will use the github.com/spamcemonkeygo/openssl library instead of golang/tls
+	UseOpenSSL bool `json:"use_openssl"`
 }
 
 type CacheFile struct {
@@ -107,6 +110,7 @@ var DefaultConfig = Config{
 	ServerWriteTimeoutMS:   3 * MSPerSec,
 	ServerReadTimeoutMS:    3 * MSPerSec,
 	FileMemBytes:           bytesPerMebibyte * 100,
+	UseOpenSSL:				false,
 }
 
 // LoadConfig loads the given config file. If an empty string is passed, the default config is returned.

--- a/grove/grove.go
+++ b/grove/grove.go
@@ -146,7 +146,7 @@ func main() {
 				return
 			}
 		} else {
-			defaultCtx, _, err = grvssl.NewCtxFromFiles(cfg.CertFile, cfg.KeyFile)
+			defaultCtx, cname, err := grvssl.NewCtxFromFiles(cfg.CertFile, cfg.KeyFile)
 			if err != nil {
 				log.Errorf("creating openssl listener %v %v\n", cfg.HTTPSPort, err)
 				return
@@ -156,6 +156,7 @@ func main() {
 				log.Errorf("1: creating HTTPS listener %v: %v\n", cfg.HTTPSPort, err)
 				return
 			}
+			grvssl.CtxStore.CtxMap[cname] = defaultCtx
 		}
 	}
 

--- a/grove/grove.go
+++ b/grove/grove.go
@@ -39,6 +39,7 @@ import (
 	"github.com/apache/trafficcontrol/grove/cache"
 	"github.com/apache/trafficcontrol/grove/config"
 	"github.com/apache/trafficcontrol/grove/diskcache"
+	"github.com/apache/trafficcontrol/grove/grvssl"
 	"github.com/apache/trafficcontrol/grove/icache"
 	"github.com/apache/trafficcontrol/grove/memcache"
 	"github.com/apache/trafficcontrol/grove/plugin"
@@ -47,11 +48,16 @@ import (
 	"github.com/apache/trafficcontrol/grove/stat"
 	"github.com/apache/trafficcontrol/grove/tiercache"
 	"github.com/apache/trafficcontrol/grove/web"
+	"github.com/spacemonkeygo/openssl"
 )
 
 const ShutdownTimeout = 60 * time.Second
 
 func main() {
+	var defaultCtx *openssl.Ctx
+	var certs []tls.Certificate
+	var tlsConfig *tls.Config
+
 	runtime.GOMAXPROCS(32) // DEBUG
 	configFileName := flag.String("cfg", "", "The config file path")
 	pprof := flag.Bool("pprof", false, "Whether to profile")
@@ -100,18 +106,26 @@ func main() {
 		os.Exit(1)
 	}
 
-	certs, err := loadCerts(remapper.Rules())
-	if err != nil {
-		log.Errorf("starting service: loading certificates: %v\n", err)
-		os.Exit(1)
-	}
-	defaultCert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
-	if err != nil {
-		log.Errorf("starting service: loading default certificate: %v\n", err)
-		os.Exit(1)
-	}
-	certs = append(certs, defaultCert)
+	if cfg.UseOpenSSL {
+		err = grvssl.CreateTlsCtxStore(remapper.Rules())
 
+		if err != nil {
+			log.Errorf("starting service: loading tls context store: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		certs, err = loadCerts(remapper.Rules())
+		if err != nil {
+			log.Errorf("starting service: loading certificates: %v\n", err)
+			os.Exit(1)
+		}
+		defaultCert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err != nil {
+			log.Errorf("starting service: loading default certificate: %v\n", err)
+			os.Exit(1)
+		}
+		certs = append(certs, defaultCert)
+	}
 	httpListener, httpConns, httpConnStateCallback, err := web.InterceptListen("tcp", fmt.Sprintf(":%d", cfg.Port))
 	if err != nil {
 		log.Errorf("creating HTTP listener %v: %v\n", cfg.Port, err)
@@ -122,11 +136,26 @@ func main() {
 	httpsServer := (*http.Server)(nil)
 	httpsListener := net.Listener(nil)
 	httpsConnStateCallback := (func(net.Conn, http.ConnState))(nil)
-	tlsConfig := (*tls.Config)(nil)
+
+	tlsConfig = (*tls.Config)(nil)
+
 	if cfg.CertFile != "" && cfg.KeyFile != "" {
-		if httpsListener, httpsConns, httpsConnStateCallback, tlsConfig, err = web.InterceptListenTLS("tcp", fmt.Sprintf(":%d", cfg.HTTPSPort), certs); err != nil {
-			log.Errorf("creating HTTPS listener %v: %v\n", cfg.HTTPSPort, err)
-			return
+		if !cfg.UseOpenSSL {
+			if httpsListener, httpsConns, httpsConnStateCallback, tlsConfig, err = web.InterceptListenTLS("tcp", fmt.Sprintf(":%d", cfg.HTTPSPort), certs); err != nil {
+				log.Errorf("creating HTTPS listener %v: %v\n", cfg.HTTPSPort, err)
+				return
+			}
+		} else {
+			defaultCtx, _, err = grvssl.NewCtxFromFiles(cfg.CertFile, cfg.KeyFile)
+			if err != nil {
+				log.Errorf("creating openssl listener %v %v\n", cfg.HTTPSPort, err)
+				return
+			}
+			defaultCtx.SetTLSExtServernameCallback(grvssl.SniCallback)
+			if httpsListener, httpsConns, httpsConnStateCallback, err = grvssl.InterceptListenTLS("tcp", fmt.Sprintf(":%d", cfg.HTTPSPort), defaultCtx); err != nil {
+				log.Errorf("1: creating HTTPS listener %v: %v\n", cfg.HTTPSPort, err)
+				return
+			}
 		}
 	}
 
@@ -166,7 +195,11 @@ func main() {
 	httpServer := startServer(httpHandler, httpListener, httpConnStateCallback, nil, cfg.Port, idleTimeout, readTimeout, writeTimeout, "http")
 
 	if cfg.CertFile != "" && cfg.KeyFile != "" {
-		httpsServer = startServer(httpsHandler, httpsListener, httpsConnStateCallback, tlsConfig, cfg.HTTPSPort, idleTimeout, readTimeout, writeTimeout, "https")
+		if !cfg.UseOpenSSL {
+			httpsServer = startServer(httpsHandler, httpsListener, httpsConnStateCallback, tlsConfig, cfg.HTTPSPort, idleTimeout, readTimeout, writeTimeout, "https")
+		} else {
+			httpsServer = grvssl.StartServer(httpsHandler, httpsListener, httpsConnStateCallback, cfg.HTTPSPort, idleTimeout, readTimeout, writeTimeout, "https")
+		}
 	}
 
 	reloadConfig := func() {
@@ -214,8 +247,14 @@ func main() {
 		}
 
 		if cfg.HTTPSPort != oldCfg.HTTPSPort {
-			if httpsListener, httpsConns, httpsConnStateCallback, tlsConfig, err = web.InterceptListenTLS("tcp", fmt.Sprintf(":%d", cfg.HTTPSPort), certs); err != nil {
-				log.Errorf("creating HTTPS listener %v: %v\n", cfg.HTTPSPort, err)
+			if !cfg.UseOpenSSL {
+				if httpsListener, httpsConns, httpsConnStateCallback, tlsConfig, err = web.InterceptListenTLS("tcp", fmt.Sprintf(":%d", cfg.HTTPSPort), certs); err != nil {
+					log.Errorf("2: creating HTTPS listener %v: %v\n", cfg.HTTPSPort, err)
+				}
+			} else {
+				if httpsListener, httpsConns, httpsConnStateCallback, err = grvssl.InterceptListenTLS("tcp", fmt.Sprintf(":%d", cfg.HTTPSPort), defaultCtx); err != nil {
+					log.Errorf("2: creating HTTPS listener %v: %v\n", cfg.HTTPSPort, err)
+				}
 			}
 		}
 
@@ -286,7 +325,11 @@ func main() {
 				}
 			}
 
-			httpsServer = startServer(httpsHandler, httpsListener, httpsConnStateCallback, tlsConfig, cfg.HTTPSPort, idleTimeout, readTimeout, writeTimeout, "https")
+			if !cfg.UseOpenSSL {
+				httpsServer = startServer(httpsHandler, httpsListener, httpsConnStateCallback, tlsConfig, cfg.HTTPSPort, idleTimeout, readTimeout, writeTimeout, "https")
+			} else {
+				httpsServer = grvssl.StartServer(httpsHandler, httpsListener, httpsConnStateCallback, cfg.HTTPSPort, idleTimeout, readTimeout, writeTimeout, "https")
+			}
 		}
 	}
 

--- a/grove/grvssl/grvssl.go
+++ b/grove/grvssl/grvssl.go
@@ -1,0 +1,205 @@
+package grvssl
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"strings"
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"fmt"
+	"time"
+
+	"github.com/spacemonkeygo/openssl"
+	"golang.org/x/net/http2"
+
+	"github.com/apache/trafficcontrol/grove/remapdata"
+	"github.com/apache/trafficcontrol/grove/web"
+)
+
+type TlsCtxStore struct {
+	CtxMap map[string]*openssl.Ctx
+}
+
+var CtxStore TlsCtxStore
+
+func CreateTlsCtxStore(rules []remapdata.RemapRule) error {
+
+	CtxStore = TlsCtxStore{
+		CtxMap: make(map[string]*openssl.Ctx),
+	}
+
+	for _, rule := range rules {
+		if rule.CertificateFile == "" && rule.CertificateKeyFile == "" {
+			continue
+		}
+		if rule.CertificateFile == "" {
+			log.Errorln("rule " + rule.Name + ": has a certificate but no key, using default certificate\n")
+			continue
+		}
+		if rule.CertificateKeyFile == "" {
+			log.Errorln("rule " + rule.Name + ": has a key but no certificate, using default certificate\n")
+			continue
+		}
+		ctx, cname, err := NewCtxFromFiles(rule.CertificateFile, rule.CertificateKeyFile)
+		if err != nil {
+			log.Errorln("rule " + rule.Name + ": unable to get a context for this certificate.")
+			continue
+		}
+		ctx.SetTLSExtServernameCallback(SniCallback)
+		CtxStore.CtxMap[cname] = ctx
+		fmt.Println("loaded context for rule " + rule.Name + " with cname: " + cname)
+	}
+	return nil
+}
+
+func InterceptListenTLS(network string, laddr string, defaultContext *openssl.Ctx) (net.Listener, *web.ConnMap, func(net.Conn, http.ConnState), error) {
+	l, err := net.Listen(network, laddr)
+
+	if err != nil {
+		return l, nil, nil, err
+	}
+
+
+	connMap := web.NewConnMap()
+	interceptListener := openssl.NewListener(l, defaultContext)
+	return interceptListener, connMap, web.GetConnStateCallback(connMap), nil
+}
+
+func NewCtxFromFiles(cert_file string, key_file string) (*openssl.Ctx, string, error) {
+	ctx, err := openssl.NewCtx()
+	if err != nil {
+		return nil, "", err
+	}
+
+	cert_bytes, err := ioutil.ReadFile(cert_file)
+	if err != nil {
+		return nil, "", err
+	}
+
+	certs := openssl.SplitPEM(cert_bytes)
+	if len(certs) == 0 {
+		return nil, "", fmt.Errorf("No PEM certificate found in '%s'", cert_file)
+	}
+	first, certs := certs[0], certs[1:]
+	cert, err := openssl.LoadCertificateFromPEM(first)
+	if err != nil {
+		return nil, "", err
+	}
+
+	name, err := cert.GetSubjectName()
+	if err != nil {
+		return nil, "", fmt.Errorf("Unable to parse the subject name from this certificate.")
+	}
+
+	cname, ok := name.GetEntry(openssl.NID_commonName)
+	if !ok {
+		return nil, "", fmt.Errorf("Unable to parse the common name from this certificate.")
+	}
+
+	err = ctx.UseCertificate(cert)
+	if err != nil {
+		return nil, "", err
+	}
+
+	for _, pem := range certs {
+		cert, err := openssl.LoadCertificateFromPEM(pem)
+		if err != nil {
+			return nil, "", err
+		}
+		err = ctx.AddChainCertificate(cert)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	key_bytes, err := ioutil.ReadFile(key_file)
+	if err != nil {
+		return nil, "", err
+	}
+
+	key, err := openssl.LoadPrivateKeyFromPEM(key_bytes)
+	if err != nil {
+		return nil, "", err
+	}
+
+	err = ctx.UsePrivateKey(key)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return ctx, cname, nil
+}
+
+func SniCallback(ssl *openssl.SSL) openssl.SSLTLSExtErr {
+	var ctx *openssl.Ctx
+	var i int = 0
+
+	hostname := ssl.GetServername()
+	cnames := make([]string, 3, 3)
+	dparts := strings.Split(hostname, ".")
+	domain := strings.Join(dparts[1:], ".")
+
+	cnames[0] = hostname
+	cnames[1] = domain
+	cnames[2] = ("*." + domain)
+
+	for _, name := range cnames {
+		ctx = CtxStore.CtxMap[name]
+		if ctx != nil {
+			break
+		}
+		i++
+	}
+
+	if ctx != nil {
+		ssl.SetSSLCtx(ctx)
+		log.Errorln("found a context for: " + cnames[i] + ", setting the ssl context")
+	} else {
+		for _, name := range cnames {
+			log.Errorln("could not find a context for: " + name)
+		}
+	}
+
+	return 0
+}
+
+func StartServer(handler http.Handler, listener net.Listener, connState func(net.Conn, http.ConnState), port int, idleTimeout time.Duration, readTimeout time.Duration, writeTimeout time.Duration, protocol string) *http.Server {
+	server := &http.Server{
+		Handler:      handler,
+		Addr:         fmt.Sprintf(":%d", port),
+		ConnState:    connState,
+		IdleTimeout:  idleTimeout,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
+	}
+
+	// TODO configurable H2 timeouts and buffer sizes
+	h2Conf := &http2.Server{
+		IdleTimeout: idleTimeout,
+	}
+	if err := http2.ConfigureServer(server, h2Conf); err != nil {
+		log.Errorln(" server configuring HTTP/2: " + err.Error())
+	}
+
+	go func() {
+		log.Infof("listening on %s://%d\n", protocol, port)
+		if err := server.Serve(listener); err != nil {
+			log.Errorf("serving %s port %v: %v\n", strings.ToUpper(protocol), port, err)
+		}
+	}()
+	return server
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/.gitignore
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/.gitignore
@@ -1,0 +1,1 @@
+openssl.test

--- a/grove/vendor/github.com/spacemonkeygo/openssl/AUTHORS
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/AUTHORS
@@ -1,0 +1,22 @@
+Andrew Brampton <github@bramp.net>
+Anton Baklanov <antonbaklanov@gmail.com>
+Carlos Martín Nieto <cmn@dwim.me>
+Charles Strahan <charles@cstrahan.com>
+Christopher Dudley <chris@github.chrisdudley.xyz>
+Christopher Fredericks <cfredmakecode@gmail.com>
+Colin Misare
+dequis <dx@dxzone.com.ar>
+Gabriel Russell <gabriel.russell@mongodb.com>
+Giulio <programmatore@ditieri.it>
+Jakob Unterwurzacher <jakobunt@gmail.com>
+Juuso Haavisto <juuso@mail.com>
+kujenga <ataylor0123@gmail.com>
+Phus Lu <phuslu@hotmail.com>
+Russ Egan <russ@safemonk.com>
+Ryan Hileman <lunixbochs@gmail.com>
+Scott J. Goldman <scottjg@github.com>
+Scott Kidder <skidder@brightcove.com>
+Space Monkey, Inc <hello@spacemonkey.com>
+Stephen Gallagher <sgallagh@redhat.com>
+Viacheslav Biriukov <v.v.biriukov@gmail.com>
+Zack Owens <zowens2009@gmail.com>

--- a/grove/vendor/github.com/spacemonkeygo/openssl/LICENSE
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/grove/vendor/github.com/spacemonkeygo/openssl/README.md
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/README.md
@@ -1,0 +1,30 @@
+# OpenSSL bindings for Go
+
+Please see http://godoc.org/github.com/spacemonkeygo/openssl for more info
+
+### License
+
+Copyright (C) 2017. See AUTHORS.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+### Using on macOS
+1. Install [homebrew](http://brew.sh/)
+2. `$ brew install openssl` or `$ brew install openssl@1.1`
+
+### Using on Windows
+1. Install [mingw-w64](http://mingw-w64.sourceforge.net/)
+2. Install [pkg-config-lite](http://sourceforge.net/projects/pkgconfiglite)
+3. Build (or install precompiled) openssl for mingw32-w64
+4. Set __PKG\_CONFIG\_PATH__ to the directory containing openssl.pc
+   (i.e. c:\mingw64\mingw64\lib\pkgconfig)

--- a/grove/vendor/github.com/spacemonkeygo/openssl/bio.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/bio.go
@@ -1,0 +1,305 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"io"
+	"reflect"
+	"sync"
+	"unsafe"
+)
+
+const (
+	SSLRecordSize = 16 * 1024
+)
+
+func nonCopyGoBytes(ptr uintptr, length int) []byte {
+	var slice []byte
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&slice))
+	header.Cap = length
+	header.Len = length
+	header.Data = ptr
+	return slice
+}
+
+func nonCopyCString(data *C.char, size C.int) []byte {
+	return nonCopyGoBytes(uintptr(unsafe.Pointer(data)), int(size))
+}
+
+var writeBioMapping = newMapping()
+
+type writeBio struct {
+	data_mtx        sync.Mutex
+	op_mtx          sync.Mutex
+	buf             []byte
+	release_buffers bool
+}
+
+func loadWritePtr(b *C.BIO) *writeBio {
+	t := token(C.X_BIO_get_data(b))
+	return (*writeBio)(writeBioMapping.Get(t))
+}
+
+func bioClearRetryFlags(b *C.BIO) {
+	C.X_BIO_clear_flags(b, C.BIO_FLAGS_RWS|C.BIO_FLAGS_SHOULD_RETRY)
+}
+
+func bioSetRetryRead(b *C.BIO) {
+	C.X_BIO_set_flags(b, C.BIO_FLAGS_READ|C.BIO_FLAGS_SHOULD_RETRY)
+}
+
+//export go_write_bio_write
+func go_write_bio_write(b *C.BIO, data *C.char, size C.int) (rc C.int) {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Critf("openssl: writeBioWrite panic'd: %v", err)
+			rc = -1
+		}
+	}()
+	ptr := loadWritePtr(b)
+	if ptr == nil || data == nil || size < 0 {
+		return -1
+	}
+	ptr.data_mtx.Lock()
+	defer ptr.data_mtx.Unlock()
+	bioClearRetryFlags(b)
+	ptr.buf = append(ptr.buf, nonCopyCString(data, size)...)
+	return size
+}
+
+//export go_write_bio_ctrl
+func go_write_bio_ctrl(b *C.BIO, cmd C.int, arg1 C.long, arg2 unsafe.Pointer) (
+	rc C.long) {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Critf("openssl: writeBioCtrl panic'd: %v", err)
+			rc = -1
+		}
+	}()
+	switch cmd {
+	case C.BIO_CTRL_WPENDING:
+		return writeBioPending(b)
+	case C.BIO_CTRL_DUP, C.BIO_CTRL_FLUSH:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func writeBioPending(b *C.BIO) C.long {
+	ptr := loadWritePtr(b)
+	if ptr == nil {
+		return 0
+	}
+	ptr.data_mtx.Lock()
+	defer ptr.data_mtx.Unlock()
+	return C.long(len(ptr.buf))
+}
+
+func (b *writeBio) WriteTo(w io.Writer) (rv int64, err error) {
+	b.op_mtx.Lock()
+	defer b.op_mtx.Unlock()
+
+	// write whatever data we currently have
+	b.data_mtx.Lock()
+	data := b.buf
+	b.data_mtx.Unlock()
+
+	if len(data) == 0 {
+		return 0, nil
+	}
+	n, err := w.Write(data)
+
+	// subtract however much data we wrote from the buffer
+	b.data_mtx.Lock()
+	b.buf = b.buf[:copy(b.buf, b.buf[n:])]
+	if b.release_buffers && len(b.buf) == 0 {
+		b.buf = nil
+	}
+	b.data_mtx.Unlock()
+
+	return int64(n), err
+}
+
+func (self *writeBio) Disconnect(b *C.BIO) {
+	if loadWritePtr(b) == self {
+		writeBioMapping.Del(token(C.X_BIO_get_data(b)))
+		C.X_BIO_set_data(b, nil)
+	}
+}
+
+func (b *writeBio) MakeCBIO() *C.BIO {
+	rv := C.X_BIO_new_write_bio()
+	token := writeBioMapping.Add(unsafe.Pointer(b))
+	C.X_BIO_set_data(rv, unsafe.Pointer(token))
+	return rv
+}
+
+var readBioMapping = newMapping()
+
+type readBio struct {
+	data_mtx        sync.Mutex
+	op_mtx          sync.Mutex
+	buf             []byte
+	eof             bool
+	release_buffers bool
+}
+
+func loadReadPtr(b *C.BIO) *readBio {
+	return (*readBio)(readBioMapping.Get(token(C.X_BIO_get_data(b))))
+}
+
+//export go_read_bio_read
+func go_read_bio_read(b *C.BIO, data *C.char, size C.int) (rc C.int) {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Critf("openssl: go_read_bio_read panic'd: %v", err)
+			rc = -1
+		}
+	}()
+	ptr := loadReadPtr(b)
+	if ptr == nil || size < 0 {
+		return -1
+	}
+	ptr.data_mtx.Lock()
+	defer ptr.data_mtx.Unlock()
+	bioClearRetryFlags(b)
+	if len(ptr.buf) == 0 {
+		if ptr.eof {
+			return 0
+		}
+		bioSetRetryRead(b)
+		return -1
+	}
+	if size == 0 || data == nil {
+		return C.int(len(ptr.buf))
+	}
+	n := copy(nonCopyCString(data, size), ptr.buf)
+	ptr.buf = ptr.buf[:copy(ptr.buf, ptr.buf[n:])]
+	if ptr.release_buffers && len(ptr.buf) == 0 {
+		ptr.buf = nil
+	}
+	return C.int(n)
+}
+
+//export go_read_bio_ctrl
+func go_read_bio_ctrl(b *C.BIO, cmd C.int, arg1 C.long, arg2 unsafe.Pointer) (
+	rc C.long) {
+
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Critf("openssl: readBioCtrl panic'd: %v", err)
+			rc = -1
+		}
+	}()
+	switch cmd {
+	case C.BIO_CTRL_PENDING:
+		return readBioPending(b)
+	case C.BIO_CTRL_DUP, C.BIO_CTRL_FLUSH:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func readBioPending(b *C.BIO) C.long {
+	ptr := loadReadPtr(b)
+	if ptr == nil {
+		return 0
+	}
+	ptr.data_mtx.Lock()
+	defer ptr.data_mtx.Unlock()
+	return C.long(len(ptr.buf))
+}
+
+func (b *readBio) ReadFromOnce(r io.Reader) (n int, err error) {
+	b.op_mtx.Lock()
+	defer b.op_mtx.Unlock()
+
+	// make sure we have a destination that fits at least one SSL record
+	b.data_mtx.Lock()
+	if cap(b.buf) < len(b.buf)+SSLRecordSize {
+		new_buf := make([]byte, len(b.buf), len(b.buf)+SSLRecordSize)
+		copy(new_buf, b.buf)
+		b.buf = new_buf
+	}
+	dst := b.buf[len(b.buf):cap(b.buf)]
+	dst_slice := b.buf
+	b.data_mtx.Unlock()
+
+	n, err = r.Read(dst)
+	b.data_mtx.Lock()
+	defer b.data_mtx.Unlock()
+	if n > 0 {
+		if len(dst_slice) != len(b.buf) {
+			// someone shrunk the buffer, so we read in too far ahead and we
+			// need to slide backwards
+			copy(b.buf[len(b.buf):len(b.buf)+n], dst)
+		}
+		b.buf = b.buf[:len(b.buf)+n]
+	}
+	return n, err
+}
+
+func (b *readBio) MakeCBIO() *C.BIO {
+	rv := C.X_BIO_new_read_bio()
+	token := readBioMapping.Add(unsafe.Pointer(b))
+	C.X_BIO_set_data(rv, unsafe.Pointer(token))
+	return rv
+}
+
+func (self *readBio) Disconnect(b *C.BIO) {
+	if loadReadPtr(b) == self {
+		readBioMapping.Del(token(C.X_BIO_get_data(b)))
+		C.X_BIO_set_data(b, nil)
+	}
+}
+
+func (b *readBio) MarkEOF() {
+	b.data_mtx.Lock()
+	defer b.data_mtx.Unlock()
+	b.eof = true
+}
+
+type anyBio C.BIO
+
+func asAnyBio(b *C.BIO) *anyBio { return (*anyBio)(b) }
+
+func (b *anyBio) Read(buf []byte) (n int, err error) {
+	if len(buf) == 0 {
+		return 0, nil
+	}
+	n = int(C.X_BIO_read((*C.BIO)(b), unsafe.Pointer(&buf[0]), C.int(len(buf))))
+	if n <= 0 {
+		return 0, io.EOF
+	}
+	return n, nil
+}
+
+func (b *anyBio) Write(buf []byte) (written int, err error) {
+	if len(buf) == 0 {
+		return 0, nil
+	}
+	n := int(C.X_BIO_write((*C.BIO)(b), unsafe.Pointer(&buf[0]),
+		C.int(len(buf))))
+	if n != len(buf) {
+		return n, errors.New("BIO write failed")
+	}
+	return n, nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/build.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/build.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !openssl_static
+
+package openssl
+
+// #cgo linux windows pkg-config: libssl libcrypto
+// #cgo linux CFLAGS: -Wno-deprecated-declarations
+// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
+import "C"

--- a/grove/vendor/github.com/spacemonkeygo/openssl/build_static.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/build_static.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build openssl_static
+
+package openssl
+
+// #cgo linux windows pkg-config: --static libssl libcrypto
+// #cgo linux CFLAGS: -Wno-deprecated-declarations
+// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
+// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
+import "C"

--- a/grove/vendor/github.com/spacemonkeygo/openssl/cert.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/cert.go
@@ -1,0 +1,390 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"io/ioutil"
+	"math/big"
+	"runtime"
+	"time"
+	"unsafe"
+)
+
+type EVP_MD int
+
+const (
+	EVP_NULL      EVP_MD = iota
+	EVP_MD5       EVP_MD = iota
+	EVP_SHA       EVP_MD = iota
+	EVP_SHA1      EVP_MD = iota
+	EVP_DSS       EVP_MD = iota
+	EVP_DSS1      EVP_MD = iota
+	EVP_MDC2      EVP_MD = iota
+	EVP_RIPEMD160 EVP_MD = iota
+	EVP_SHA224    EVP_MD = iota
+	EVP_SHA256    EVP_MD = iota
+	EVP_SHA384    EVP_MD = iota
+	EVP_SHA512    EVP_MD = iota
+)
+
+type Certificate struct {
+	x      *C.X509
+	Issuer *Certificate
+	ref    interface{}
+	pubKey PublicKey
+}
+
+type CertificateInfo struct {
+	Serial       *big.Int
+	Issued       time.Duration
+	Expires      time.Duration
+	Country      string
+	Organization string
+	CommonName   string
+}
+
+type Name struct {
+	name *C.X509_NAME
+}
+
+// Allocate and return a new Name object.
+func NewName() (*Name, error) {
+	n := C.X509_NAME_new()
+	if n == nil {
+		return nil, errors.New("could not create x509 name")
+	}
+	name := &Name{name: n}
+	runtime.SetFinalizer(name, func(n *Name) {
+		C.X509_NAME_free(n.name)
+	})
+	return name, nil
+}
+
+// AddTextEntry appends a text entry to an X509 NAME.
+func (n *Name) AddTextEntry(field, value string) error {
+	cfield := C.CString(field)
+	defer C.free(unsafe.Pointer(cfield))
+	cvalue := (*C.uchar)(unsafe.Pointer(C.CString(value)))
+	defer C.free(unsafe.Pointer(cvalue))
+	ret := C.X509_NAME_add_entry_by_txt(
+		n.name, cfield, C.MBSTRING_ASC, cvalue, -1, -1, 0)
+	if ret != 1 {
+		return errors.New("failed to add x509 name text entry")
+	}
+	return nil
+}
+
+// AddTextEntries allows adding multiple entries to a name in one call.
+func (n *Name) AddTextEntries(entries map[string]string) error {
+	for f, v := range entries {
+		if err := n.AddTextEntry(f, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetEntry returns a name entry based on NID.  If no entry, then ("", false) is
+// returned.
+func (n *Name) GetEntry(nid NID) (entry string, ok bool) {
+	entrylen := C.X509_NAME_get_text_by_NID(n.name, C.int(nid), nil, 0)
+	if entrylen == -1 {
+		return "", false
+	}
+	buf := (*C.char)(C.malloc(C.size_t(entrylen + 1)))
+	defer C.free(unsafe.Pointer(buf))
+	C.X509_NAME_get_text_by_NID(n.name, C.int(nid), buf, entrylen+1)
+	return C.GoStringN(buf, entrylen), true
+}
+
+// NewCertificate generates a basic certificate based
+// on the provided CertificateInfo struct
+func NewCertificate(info *CertificateInfo, key PublicKey) (*Certificate, error) {
+	c := &Certificate{x: C.X509_new()}
+	runtime.SetFinalizer(c, func(c *Certificate) {
+		C.X509_free(c.x)
+	})
+
+	name, err := c.GetSubjectName()
+	if err != nil {
+		return nil, err
+	}
+	err = name.AddTextEntries(map[string]string{
+		"C":  info.Country,
+		"O":  info.Organization,
+		"CN": info.CommonName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	// self-issue for now
+	if err := c.SetIssuerName(name); err != nil {
+		return nil, err
+	}
+	if err := c.SetSerial(info.Serial); err != nil {
+		return nil, err
+	}
+	if err := c.SetIssueDate(info.Issued); err != nil {
+		return nil, err
+	}
+	if err := c.SetExpireDate(info.Expires); err != nil {
+		return nil, err
+	}
+	if err := c.SetPubKey(key); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *Certificate) GetSubjectName() (*Name, error) {
+	n := C.X509_get_subject_name(c.x)
+	if n == nil {
+		return nil, errors.New("failed to get subject name")
+	}
+	return &Name{name: n}, nil
+}
+
+func (c *Certificate) GetIssuerName() (*Name, error) {
+	n := C.X509_get_issuer_name(c.x)
+	if n == nil {
+		return nil, errors.New("failed to get issuer name")
+	}
+	return &Name{name: n}, nil
+}
+
+func (c *Certificate) SetSubjectName(name *Name) error {
+	if C.X509_set_subject_name(c.x, name.name) != 1 {
+		return errors.New("failed to set subject name")
+	}
+	return nil
+}
+
+// SetIssuer updates the stored Issuer cert
+// and the internal x509 Issuer Name of a certificate.
+// The stored Issuer reference is used when adding extensions.
+func (c *Certificate) SetIssuer(issuer *Certificate) error {
+	name, err := issuer.GetSubjectName()
+	if err != nil {
+		return err
+	}
+	if err = c.SetIssuerName(name); err != nil {
+		return err
+	}
+	c.Issuer = issuer
+	return nil
+}
+
+// SetIssuerName populates the issuer name of a certificate.
+// Use SetIssuer instead, if possible.
+func (c *Certificate) SetIssuerName(name *Name) error {
+	if C.X509_set_issuer_name(c.x, name.name) != 1 {
+		return errors.New("failed to set subject name")
+	}
+	return nil
+}
+
+// SetSerial sets the serial of a certificate.
+func (c *Certificate) SetSerial(serial *big.Int) error {
+	sno := C.ASN1_INTEGER_new()
+	defer C.ASN1_INTEGER_free(sno)
+	bn := C.BN_new()
+	defer C.BN_free(bn)
+
+	serialBytes := serial.Bytes()
+	if bn = C.BN_bin2bn((*C.uchar)(unsafe.Pointer(&serialBytes[0])), C.int(len(serialBytes)), bn); bn == nil {
+		return errors.New("failed to set serial")
+	}
+	if sno = C.BN_to_ASN1_INTEGER(bn, sno); sno == nil {
+		return errors.New("failed to set serial")
+	}
+	if C.X509_set_serialNumber(c.x, sno) != 1 {
+		return errors.New("failed to set serial")
+	}
+	return nil
+}
+
+// SetIssueDate sets the certificate issue date relative to the current time.
+func (c *Certificate) SetIssueDate(when time.Duration) error {
+	offset := C.long(when / time.Second)
+	result := C.X509_gmtime_adj(C.X_X509_get0_notBefore(c.x), offset)
+	if result == nil {
+		return errors.New("failed to set issue date")
+	}
+	return nil
+}
+
+// SetExpireDate sets the certificate issue date relative to the current time.
+func (c *Certificate) SetExpireDate(when time.Duration) error {
+	offset := C.long(when / time.Second)
+	result := C.X509_gmtime_adj(C.X_X509_get0_notAfter(c.x), offset)
+	if result == nil {
+		return errors.New("failed to set expire date")
+	}
+	return nil
+}
+
+// SetPubKey assigns a new public key to a certificate.
+func (c *Certificate) SetPubKey(pubKey PublicKey) error {
+	c.pubKey = pubKey
+	if C.X509_set_pubkey(c.x, pubKey.evpPKey()) != 1 {
+		return errors.New("failed to set public key")
+	}
+	return nil
+}
+
+// Sign a certificate using a private key and a digest name.
+// Accepted digest names are 'sha256', 'sha384', and 'sha512'.
+func (c *Certificate) Sign(privKey PrivateKey, digest EVP_MD) error {
+	switch digest {
+	case EVP_SHA256:
+	case EVP_SHA384:
+	case EVP_SHA512:
+	default:
+		return errors.New("Unsupported digest" +
+			"You're probably looking for 'EVP_SHA256' or 'EVP_SHA512'.")
+	}
+	return c.insecureSign(privKey, digest)
+}
+
+func (c *Certificate) insecureSign(privKey PrivateKey, digest EVP_MD) error {
+	var md *C.EVP_MD = getDigestFunction(digest)
+	if C.X509_sign(c.x, privKey.evpPKey(), md) <= 0 {
+		return errors.New("failed to sign certificate")
+	}
+	return nil
+}
+
+func getDigestFunction(digest EVP_MD) (md *C.EVP_MD) {
+	switch digest {
+	// please don't use these digest functions
+	case EVP_NULL:
+		md = C.X_EVP_md_null()
+	case EVP_MD5:
+		md = C.X_EVP_md5()
+	case EVP_SHA:
+		md = C.X_EVP_sha()
+	case EVP_SHA1:
+		md = C.X_EVP_sha1()
+	case EVP_DSS:
+		md = C.X_EVP_dss()
+	case EVP_DSS1:
+		md = C.X_EVP_dss1()
+	case EVP_RIPEMD160:
+		md = C.X_EVP_ripemd160()
+	case EVP_SHA224:
+		md = C.X_EVP_sha224()
+	// you actually want one of these
+	case EVP_SHA256:
+		md = C.X_EVP_sha256()
+	case EVP_SHA384:
+		md = C.X_EVP_sha384()
+	case EVP_SHA512:
+		md = C.X_EVP_sha512()
+	}
+	return md
+}
+
+// Add an extension to a certificate.
+// Extension constants are NID_* as found in openssl.
+func (c *Certificate) AddExtension(nid NID, value string) error {
+	issuer := c
+	if c.Issuer != nil {
+		issuer = c.Issuer
+	}
+	var ctx C.X509V3_CTX
+	C.X509V3_set_ctx(&ctx, c.x, issuer.x, nil, nil, 0)
+	ex := C.X509V3_EXT_conf_nid(nil, &ctx, C.int(nid), C.CString(value))
+	if ex == nil {
+		return errors.New("failed to create x509v3 extension")
+	}
+	defer C.X509_EXTENSION_free(ex)
+	if C.X509_add_ext(c.x, ex, -1) <= 0 {
+		return errors.New("failed to add x509v3 extension")
+	}
+	return nil
+}
+
+// Wraps AddExtension using a map of NID to text extension.
+// Will return without finishing if it encounters an error.
+func (c *Certificate) AddExtensions(extensions map[NID]string) error {
+	for nid, value := range extensions {
+		if err := c.AddExtension(nid, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// LoadCertificateFromPEM loads an X509 certificate from a PEM-encoded block.
+func LoadCertificateFromPEM(pem_block []byte) (*Certificate, error) {
+	if len(pem_block) == 0 {
+		return nil, errors.New("empty pem block")
+	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
+		C.int(len(pem_block)))
+	cert := C.PEM_read_bio_X509(bio, nil, nil, nil)
+	C.BIO_free(bio)
+	if cert == nil {
+		return nil, errorFromErrorQueue()
+	}
+	x := &Certificate{x: cert}
+	runtime.SetFinalizer(x, func(x *Certificate) {
+		C.X509_free(x.x)
+	})
+	return x, nil
+}
+
+// MarshalPEM converts the X509 certificate to PEM-encoded format
+func (c *Certificate) MarshalPEM() (pem_block []byte, err error) {
+	bio := C.BIO_new(C.BIO_s_mem())
+	if bio == nil {
+		return nil, errors.New("failed to allocate memory BIO")
+	}
+	defer C.BIO_free(bio)
+	if int(C.PEM_write_bio_X509(bio, c.x)) != 1 {
+		return nil, errors.New("failed dumping certificate")
+	}
+	return ioutil.ReadAll(asAnyBio(bio))
+}
+
+// PublicKey returns the public key embedded in the X509 certificate.
+func (c *Certificate) PublicKey() (PublicKey, error) {
+	pkey := C.X509_get_pubkey(c.x)
+	if pkey == nil {
+		return nil, errors.New("no public key found")
+	}
+	key := &pKey{key: pkey}
+	runtime.SetFinalizer(key, func(key *pKey) {
+		C.EVP_PKEY_free(key.key)
+	})
+	return key, nil
+}
+
+// GetSerialNumberHex returns the certificate's serial number in hex format
+func (c *Certificate) GetSerialNumberHex() (serial string) {
+	asn1_i := C.X509_get_serialNumber(c.x)
+	bignum := C.ASN1_INTEGER_to_BN(asn1_i, nil)
+	hex := C.BN_bn2hex(bignum)
+	serial = C.GoString(hex)
+	C.BN_free(bignum)
+	C.X_OPENSSL_free(unsafe.Pointer(hex))
+	return
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/cert_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/cert_test.go
@@ -1,0 +1,139 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestCertGenerate(t *testing.T) {
+	key, err := GenerateRSAKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := &CertificateInfo{
+		Serial:       big.NewInt(int64(1)),
+		Issued:       0,
+		Expires:      24 * time.Hour,
+		Country:      "US",
+		Organization: "Test",
+		CommonName:   "localhost",
+	}
+	cert, err := NewCertificate(info, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cert.Sign(key, EVP_SHA256); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCAGenerate(t *testing.T) {
+	cakey, err := GenerateRSAKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := &CertificateInfo{
+		Serial:       big.NewInt(int64(1)),
+		Issued:       0,
+		Expires:      24 * time.Hour,
+		Country:      "US",
+		Organization: "Test CA",
+		CommonName:   "CA",
+	}
+	ca, err := NewCertificate(info, cakey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ca.AddExtensions(map[NID]string{
+		NID_basic_constraints:      "critical,CA:TRUE",
+		NID_key_usage:              "critical,keyCertSign,cRLSign",
+		NID_subject_key_identifier: "hash",
+		NID_netscape_cert_type:     "sslCA",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ca.Sign(cakey, EVP_SHA256); err != nil {
+		t.Fatal(err)
+	}
+	key, err := GenerateRSAKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info = &CertificateInfo{
+		Serial:       big.NewInt(int64(1)),
+		Issued:       0,
+		Expires:      24 * time.Hour,
+		Country:      "US",
+		Organization: "Test",
+		CommonName:   "localhost",
+	}
+	cert, err := NewCertificate(info, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cert.AddExtensions(map[NID]string{
+		NID_basic_constraints: "critical,CA:FALSE",
+		NID_key_usage:         "keyEncipherment",
+		NID_ext_key_usage:     "serverAuth",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cert.SetIssuer(ca); err != nil {
+		t.Fatal(err)
+	}
+	if err := cert.Sign(cakey, EVP_SHA256); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCertGetNameEntry(t *testing.T) {
+	key, err := GenerateRSAKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := &CertificateInfo{
+		Serial:       big.NewInt(int64(1)),
+		Issued:       0,
+		Expires:      24 * time.Hour,
+		Country:      "US",
+		Organization: "Test",
+		CommonName:   "localhost",
+	}
+	cert, err := NewCertificate(info, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name, err := cert.GetSubjectName()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := name.GetEntry(NID_commonName)
+	if !ok {
+		t.Fatal("no common name")
+	}
+	if entry != "localhost" {
+		t.Fatalf("expected localhost; got %q", entry)
+	}
+	entry, ok = name.GetEntry(NID_localityName)
+	if ok {
+		t.Fatal("did not expect a locality name")
+	}
+	if entry != "" {
+		t.Fatalf("entry should be empty; got %q", entry)
+	}
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/ciphers.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/ciphers.go
@@ -1,0 +1,321 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+const (
+	GCM_TAG_MAXLEN = 16
+)
+
+type CipherCtx interface {
+	Cipher() *Cipher
+	BlockSize() int
+	KeySize() int
+	IVSize() int
+}
+
+type Cipher struct {
+	ptr *C.EVP_CIPHER
+}
+
+func (c *Cipher) Nid() NID {
+	return NID(C.X_EVP_CIPHER_nid(c.ptr))
+}
+
+func (c *Cipher) ShortName() (string, error) {
+	return Nid2ShortName(c.Nid())
+}
+
+func (c *Cipher) BlockSize() int {
+	return int(C.X_EVP_CIPHER_block_size(c.ptr))
+}
+
+func (c *Cipher) KeySize() int {
+	return int(C.X_EVP_CIPHER_key_length(c.ptr))
+}
+
+func (c *Cipher) IVSize() int {
+	return int(C.X_EVP_CIPHER_iv_length(c.ptr))
+}
+
+func Nid2ShortName(nid NID) (string, error) {
+	sn := C.OBJ_nid2sn(C.int(nid))
+	if sn == nil {
+		return "", fmt.Errorf("NID %d not found", nid)
+	}
+	return C.GoString(sn), nil
+}
+
+func GetCipherByName(name string) (*Cipher, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	p := C.EVP_get_cipherbyname(cname)
+	if p == nil {
+		return nil, fmt.Errorf("Cipher %v not found", name)
+	}
+	// we can consider ciphers to use static mem; don't need to free
+	return &Cipher{ptr: p}, nil
+}
+
+func GetCipherByNid(nid NID) (*Cipher, error) {
+	sn, err := Nid2ShortName(nid)
+	if err != nil {
+		return nil, err
+	}
+	return GetCipherByName(sn)
+}
+
+type cipherCtx struct {
+	ctx *C.EVP_CIPHER_CTX
+}
+
+func newCipherCtx() (*cipherCtx, error) {
+	cctx := C.EVP_CIPHER_CTX_new()
+	if cctx == nil {
+		return nil, errors.New("failed to allocate cipher context")
+	}
+	ctx := &cipherCtx{cctx}
+	runtime.SetFinalizer(ctx, func(ctx *cipherCtx) {
+		C.EVP_CIPHER_CTX_free(ctx.ctx)
+	})
+	return ctx, nil
+}
+
+func (ctx *cipherCtx) applyKeyAndIV(key, iv []byte) error {
+	var kptr, iptr *C.uchar
+	if key != nil {
+		if len(key) != ctx.KeySize() {
+			return fmt.Errorf("bad key size (%d bytes instead of %d)",
+				len(key), ctx.KeySize())
+		}
+		kptr = (*C.uchar)(&key[0])
+	}
+	if iv != nil {
+		if len(iv) != ctx.IVSize() {
+			return fmt.Errorf("bad IV size (%d bytes instead of %d)",
+				len(iv), ctx.IVSize())
+		}
+		iptr = (*C.uchar)(&iv[0])
+	}
+	if kptr != nil || iptr != nil {
+		var res C.int
+		if C.X_EVP_CIPHER_CTX_encrypting(ctx.ctx) != 0 {
+			res = C.EVP_EncryptInit_ex(ctx.ctx, nil, nil, kptr, iptr)
+		} else {
+			res = C.EVP_DecryptInit_ex(ctx.ctx, nil, nil, kptr, iptr)
+		}
+		if 1 != res {
+			return errors.New("failed to apply key/IV")
+		}
+	}
+	return nil
+}
+
+func (ctx *cipherCtx) Cipher() *Cipher {
+	return &Cipher{ptr: C.X_EVP_CIPHER_CTX_cipher(ctx.ctx)}
+}
+
+func (ctx *cipherCtx) BlockSize() int {
+	return int(C.X_EVP_CIPHER_CTX_block_size(ctx.ctx))
+}
+
+func (ctx *cipherCtx) KeySize() int {
+	return int(C.X_EVP_CIPHER_CTX_key_length(ctx.ctx))
+}
+
+func (ctx *cipherCtx) IVSize() int {
+	return int(C.X_EVP_CIPHER_CTX_iv_length(ctx.ctx))
+}
+
+func (ctx *cipherCtx) setCtrl(code, arg int) error {
+	res := C.EVP_CIPHER_CTX_ctrl(ctx.ctx, C.int(code), C.int(arg), nil)
+	if res != 1 {
+		return fmt.Errorf("failed to set code %d to %d [result %d]",
+			code, arg, res)
+	}
+	return nil
+}
+
+func (ctx *cipherCtx) setCtrlBytes(code, arg int, value []byte) error {
+	res := C.EVP_CIPHER_CTX_ctrl(ctx.ctx, C.int(code), C.int(arg),
+		unsafe.Pointer(&value[0]))
+	if res != 1 {
+		return fmt.Errorf("failed to set code %d with arg %d to %x [result %d]",
+			code, arg, value, res)
+	}
+	return nil
+}
+
+func (ctx *cipherCtx) getCtrlInt(code, arg int) (int, error) {
+	var returnVal C.int
+	res := C.EVP_CIPHER_CTX_ctrl(ctx.ctx, C.int(code), C.int(arg),
+		unsafe.Pointer(&returnVal))
+	if res != 1 {
+		return 0, fmt.Errorf("failed to get code %d with arg %d [result %d]",
+			code, arg, res)
+	}
+	return int(returnVal), nil
+}
+
+func (ctx *cipherCtx) getCtrlBytes(code, arg, expectsize int) ([]byte, error) {
+	returnVal := make([]byte, expectsize)
+	res := C.EVP_CIPHER_CTX_ctrl(ctx.ctx, C.int(code), C.int(arg),
+		unsafe.Pointer(&returnVal[0]))
+	if res != 1 {
+		return nil, fmt.Errorf("failed to get code %d with arg %d [result %d]",
+			code, arg, res)
+	}
+	return returnVal, nil
+}
+
+type EncryptionCipherCtx interface {
+	CipherCtx
+
+	// pass in plaintext, get back ciphertext. can be called
+	// multiple times as needed
+	EncryptUpdate(input []byte) ([]byte, error)
+
+	// call after all plaintext has been passed in; may return
+	// additional ciphertext if needed to finish off a block
+	// or extra padding information
+	EncryptFinal() ([]byte, error)
+}
+
+type DecryptionCipherCtx interface {
+	CipherCtx
+
+	// pass in ciphertext, get back plaintext. can be called
+	// multiple times as needed
+	DecryptUpdate(input []byte) ([]byte, error)
+
+	// call after all ciphertext has been passed in; may return
+	// additional plaintext if needed to finish off a block
+	DecryptFinal() ([]byte, error)
+}
+
+type encryptionCipherCtx struct {
+	*cipherCtx
+}
+
+type decryptionCipherCtx struct {
+	*cipherCtx
+}
+
+func newEncryptionCipherCtx(c *Cipher, e *Engine, key, iv []byte) (
+	*encryptionCipherCtx, error) {
+	if c == nil {
+		return nil, errors.New("null cipher not allowed")
+	}
+	ctx, err := newCipherCtx()
+	if err != nil {
+		return nil, err
+	}
+	var eptr *C.ENGINE
+	if e != nil {
+		eptr = e.e
+	}
+	if 1 != C.EVP_EncryptInit_ex(ctx.ctx, c.ptr, eptr, nil, nil) {
+		return nil, errors.New("failed to initialize cipher context")
+	}
+	err = ctx.applyKeyAndIV(key, iv)
+	if err != nil {
+		return nil, err
+	}
+	return &encryptionCipherCtx{cipherCtx: ctx}, nil
+}
+
+func newDecryptionCipherCtx(c *Cipher, e *Engine, key, iv []byte) (
+	*decryptionCipherCtx, error) {
+	if c == nil {
+		return nil, errors.New("null cipher not allowed")
+	}
+	ctx, err := newCipherCtx()
+	if err != nil {
+		return nil, err
+	}
+	var eptr *C.ENGINE
+	if e != nil {
+		eptr = e.e
+	}
+	if 1 != C.EVP_DecryptInit_ex(ctx.ctx, c.ptr, eptr, nil, nil) {
+		return nil, errors.New("failed to initialize cipher context")
+	}
+	err = ctx.applyKeyAndIV(key, iv)
+	if err != nil {
+		return nil, err
+	}
+	return &decryptionCipherCtx{cipherCtx: ctx}, nil
+}
+
+func NewEncryptionCipherCtx(c *Cipher, e *Engine, key, iv []byte) (
+	EncryptionCipherCtx, error) {
+	return newEncryptionCipherCtx(c, e, key, iv)
+}
+
+func NewDecryptionCipherCtx(c *Cipher, e *Engine, key, iv []byte) (
+	DecryptionCipherCtx, error) {
+	return newDecryptionCipherCtx(c, e, key, iv)
+}
+
+func (ctx *encryptionCipherCtx) EncryptUpdate(input []byte) ([]byte, error) {
+	outbuf := make([]byte, len(input)+ctx.BlockSize())
+	outlen := C.int(len(outbuf))
+	res := C.EVP_EncryptUpdate(ctx.ctx, (*C.uchar)(&outbuf[0]), &outlen,
+		(*C.uchar)(&input[0]), C.int(len(input)))
+	if res != 1 {
+		return nil, fmt.Errorf("failed to encrypt [result %d]", res)
+	}
+	return outbuf[:outlen], nil
+}
+
+func (ctx *decryptionCipherCtx) DecryptUpdate(input []byte) ([]byte, error) {
+	outbuf := make([]byte, len(input)+ctx.BlockSize())
+	outlen := C.int(len(outbuf))
+	res := C.EVP_DecryptUpdate(ctx.ctx, (*C.uchar)(&outbuf[0]), &outlen,
+		(*C.uchar)(&input[0]), C.int(len(input)))
+	if res != 1 {
+		return nil, fmt.Errorf("failed to decrypt [result %d]", res)
+	}
+	return outbuf[:outlen], nil
+}
+
+func (ctx *encryptionCipherCtx) EncryptFinal() ([]byte, error) {
+	outbuf := make([]byte, ctx.BlockSize())
+	var outlen C.int
+	if 1 != C.EVP_EncryptFinal_ex(ctx.ctx, (*C.uchar)(&outbuf[0]), &outlen) {
+		return nil, errors.New("encryption failed")
+	}
+	return outbuf[:outlen], nil
+}
+
+func (ctx *decryptionCipherCtx) DecryptFinal() ([]byte, error) {
+	outbuf := make([]byte, ctx.BlockSize())
+	var outlen C.int
+	if 1 != C.EVP_DecryptFinal_ex(ctx.ctx, (*C.uchar)(&outbuf[0]), &outlen) {
+		// this may mean the tag failed to verify- all previous plaintext
+		// returned must be considered faked and invalid
+		return nil, errors.New("decryption failed")
+	}
+	return outbuf[:outlen], nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/ciphers_gcm.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/ciphers_gcm.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include <openssl/evp.h>
+import "C"
+
+import (
+	"errors"
+	"fmt"
+)
+
+type AuthenticatedEncryptionCipherCtx interface {
+	EncryptionCipherCtx
+
+	// data passed in to ExtraData() is part of the final output; it is
+	// not encrypted itself, but is part of the authenticated data. when
+	// decrypting or authenticating, pass back with the decryption
+	// context's ExtraData()
+	ExtraData([]byte) error
+
+	// use after finalizing encryption to get the authenticating tag
+	GetTag() ([]byte, error)
+}
+
+type AuthenticatedDecryptionCipherCtx interface {
+	DecryptionCipherCtx
+
+	// pass in any extra data that was added during encryption with the
+	// encryption context's ExtraData()
+	ExtraData([]byte) error
+
+	// use before finalizing decryption to tell the library what the
+	// tag is expected to be
+	SetTag([]byte) error
+}
+
+type authEncryptionCipherCtx struct {
+	*encryptionCipherCtx
+}
+
+type authDecryptionCipherCtx struct {
+	*decryptionCipherCtx
+}
+
+func getGCMCipher(blocksize int) (*Cipher, error) {
+	var cipherptr *C.EVP_CIPHER
+	switch blocksize {
+	case 256:
+		cipherptr = C.EVP_aes_256_gcm()
+	case 192:
+		cipherptr = C.EVP_aes_192_gcm()
+	case 128:
+		cipherptr = C.EVP_aes_128_gcm()
+	default:
+		return nil, fmt.Errorf("unknown block size %d", blocksize)
+	}
+	return &Cipher{ptr: cipherptr}, nil
+}
+
+func NewGCMEncryptionCipherCtx(blocksize int, e *Engine, key, iv []byte) (
+	AuthenticatedEncryptionCipherCtx, error) {
+	cipher, err := getGCMCipher(blocksize)
+	if err != nil {
+		return nil, err
+	}
+	ctx, err := newEncryptionCipherCtx(cipher, e, key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(iv) > 0 {
+		err := ctx.setCtrl(C.EVP_CTRL_GCM_SET_IVLEN, len(iv))
+		if err != nil {
+			return nil, fmt.Errorf("could not set IV len to %d: %s",
+				len(iv), err)
+		}
+		if 1 != C.EVP_EncryptInit_ex(ctx.ctx, nil, nil, nil,
+			(*C.uchar)(&iv[0])) {
+			return nil, errors.New("failed to apply IV")
+		}
+	}
+	return &authEncryptionCipherCtx{encryptionCipherCtx: ctx}, nil
+}
+
+func NewGCMDecryptionCipherCtx(blocksize int, e *Engine, key, iv []byte) (
+	AuthenticatedDecryptionCipherCtx, error) {
+	cipher, err := getGCMCipher(blocksize)
+	if err != nil {
+		return nil, err
+	}
+	ctx, err := newDecryptionCipherCtx(cipher, e, key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(iv) > 0 {
+		err := ctx.setCtrl(C.EVP_CTRL_GCM_SET_IVLEN, len(iv))
+		if err != nil {
+			return nil, fmt.Errorf("could not set IV len to %d: %s",
+				len(iv), err)
+		}
+		if 1 != C.EVP_DecryptInit_ex(ctx.ctx, nil, nil, nil,
+			(*C.uchar)(&iv[0])) {
+			return nil, errors.New("failed to apply IV")
+		}
+	}
+	return &authDecryptionCipherCtx{decryptionCipherCtx: ctx}, nil
+}
+
+func (ctx *authEncryptionCipherCtx) ExtraData(aad []byte) error {
+	if aad == nil {
+		return nil
+	}
+	var outlen C.int
+	if 1 != C.EVP_EncryptUpdate(ctx.ctx, nil, &outlen, (*C.uchar)(&aad[0]),
+		C.int(len(aad))) {
+		return errors.New("failed to add additional authenticated data")
+	}
+	return nil
+}
+
+func (ctx *authDecryptionCipherCtx) ExtraData(aad []byte) error {
+	if aad == nil {
+		return nil
+	}
+	var outlen C.int
+	if 1 != C.EVP_DecryptUpdate(ctx.ctx, nil, &outlen, (*C.uchar)(&aad[0]),
+		C.int(len(aad))) {
+		return errors.New("failed to add additional authenticated data")
+	}
+	return nil
+}
+
+func (ctx *authEncryptionCipherCtx) GetTag() ([]byte, error) {
+	return ctx.getCtrlBytes(C.EVP_CTRL_GCM_GET_TAG, GCM_TAG_MAXLEN,
+		GCM_TAG_MAXLEN)
+}
+
+func (ctx *authDecryptionCipherCtx) SetTag(tag []byte) error {
+	return ctx.setCtrlBytes(C.EVP_CTRL_GCM_SET_TAG, len(tag), tag)
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/ciphers_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/ciphers_test.go
@@ -1,0 +1,305 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func expectError(t *testing.T, err error, msg string) {
+	if err == nil {
+		t.Fatalf("Expected error containing %#v, but got none", msg)
+	}
+	if !strings.Contains(err.Error(), msg) {
+		t.Fatalf("Expected error containing %#v, but got %s", msg, err)
+	}
+}
+
+func TestBadInputs(t *testing.T) {
+	_, err := NewGCMEncryptionCipherCtx(256, nil,
+		[]byte("abcdefghijklmnopqrstuvwxyz"), nil)
+	expectError(t, err, "bad key size")
+	_, err = NewGCMEncryptionCipherCtx(128, nil,
+		[]byte("abcdefghijklmnopqrstuvwxyz"), nil)
+	expectError(t, err, "bad key size")
+	_, err = NewGCMEncryptionCipherCtx(200, nil,
+		[]byte("abcdefghijklmnopqrstuvwxy"), nil)
+	expectError(t, err, "unknown block size")
+	c, err := GetCipherByName("AES-128-CBC")
+	if err != nil {
+		t.Fatal("Could not look up AES-128-CBC")
+	}
+	_, err = NewEncryptionCipherCtx(c, nil, []byte("abcdefghijklmnop"),
+		[]byte("abc"))
+	expectError(t, err, "bad IV size")
+}
+
+func doEncryption(key, iv, aad, plaintext []byte, blocksize, bufsize int) (
+	ciphertext, tag []byte, err error) {
+	ectx, err := NewGCMEncryptionCipherCtx(blocksize, nil, key, iv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed making GCM encryption ctx: %s", err)
+	}
+	err = ectx.ExtraData(aad)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to add authenticated data: %s",
+			err)
+	}
+	plainb := bytes.NewBuffer(plaintext)
+	cipherb := new(bytes.Buffer)
+	for plainb.Len() > 0 {
+		moar, err := ectx.EncryptUpdate(plainb.Next(bufsize))
+		if err != nil {
+			return nil, nil, fmt.Errorf("Failed to perform an encryption: %s",
+				err)
+		}
+		cipherb.Write(moar)
+	}
+	moar, err := ectx.EncryptFinal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to finalize encryption: %s", err)
+	}
+	cipherb.Write(moar)
+	tag, err = ectx.GetTag()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to get GCM tag: %s", err)
+	}
+	return cipherb.Bytes(), tag, nil
+}
+
+func doDecryption(key, iv, aad, ciphertext, tag []byte, blocksize,
+	bufsize int) (plaintext []byte, err error) {
+	dctx, err := NewGCMDecryptionCipherCtx(blocksize, nil, key, iv)
+	if err != nil {
+		return nil, fmt.Errorf("Failed making GCM decryption ctx: %s", err)
+	}
+	aadbuf := bytes.NewBuffer(aad)
+	for aadbuf.Len() > 0 {
+		err = dctx.ExtraData(aadbuf.Next(bufsize))
+		if err != nil {
+			return nil, fmt.Errorf("Failed to add authenticated data: %s", err)
+		}
+	}
+	plainb := new(bytes.Buffer)
+	cipherb := bytes.NewBuffer(ciphertext)
+	for cipherb.Len() > 0 {
+		moar, err := dctx.DecryptUpdate(cipherb.Next(bufsize))
+		if err != nil {
+			return nil, fmt.Errorf("Failed to perform a decryption: %s", err)
+		}
+		plainb.Write(moar)
+	}
+	err = dctx.SetTag(tag)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to set expected GCM tag: %s", err)
+	}
+	moar, err := dctx.DecryptFinal()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to finalize decryption: %s", err)
+	}
+	plainb.Write(moar)
+	return plainb.Bytes(), nil
+}
+
+func checkEqual(t *testing.T, output []byte, original string) {
+	output_s := string(output)
+	if output_s != original {
+		t.Fatalf("output != original! %#v != %#v", output_s, original)
+	}
+}
+
+func TestGCM(t *testing.T) {
+	aad := []byte("foo bar baz")
+	key := []byte("nobody can guess this i'm sure..") // len=32
+	iv := []byte("just a bunch of bytes")
+	plaintext := "Long long ago, in a land far away..."
+
+	blocksizes_to_test := []int{256, 192, 128}
+
+	// best for this to have no common factors with blocksize, so that the
+	// buffering layer inside the CIPHER_CTX gets exercised
+	bufsize := 33
+
+	if len(plaintext)%8 == 0 {
+		plaintext += "!" // make sure padding is exercised
+	}
+
+	for _, bsize := range blocksizes_to_test {
+		subkey := key[:bsize/8]
+		ciphertext, tag, err := doEncryption(subkey, iv, aad, []byte(plaintext),
+			bsize, bufsize)
+		if err != nil {
+			t.Fatalf("Encryption with b=%d: %s", bsize, err)
+		}
+		plaintext_out, err := doDecryption(subkey, iv, aad, ciphertext, tag,
+			bsize, bufsize)
+		if err != nil {
+			t.Fatalf("Decryption with b=%d: %s", bsize, err)
+		}
+		checkEqual(t, plaintext_out, plaintext)
+	}
+}
+
+func TestGCMWithNoAAD(t *testing.T) {
+	key := []byte("0000111122223333")
+	iv := []byte("9999")
+	plaintext := "ABORT ABORT ABORT DANGAR"
+
+	ciphertext, tag, err := doEncryption(key, iv, nil, []byte(plaintext),
+		128, 32)
+	if err != nil {
+		t.Fatal("Encryption failure:", err)
+	}
+	plaintext_out, err := doDecryption(key, iv, nil, ciphertext, tag, 128, 129)
+	if err != nil {
+		t.Fatal("Decryption failure:", err)
+	}
+	checkEqual(t, plaintext_out, plaintext)
+}
+
+func TestBadTag(t *testing.T) {
+	key := []byte("abcdefghijklmnop")
+	iv := []byte("v7239qjfv3qr793fuaj")
+	plaintext := "The red rooster has flown the coop I REPEAT" +
+		"the red rooster has flown the coop!!1!"
+
+	ciphertext, tag, err := doEncryption(key, iv, nil, []byte(plaintext),
+		128, 32)
+	if err != nil {
+		t.Fatal("Encryption failure:", err)
+	}
+	// flip the last bit
+	tag[len(tag)-1] ^= 1
+	plaintext_out, err := doDecryption(key, iv, nil, ciphertext, tag, 128, 129)
+	if err == nil {
+		t.Fatal("Expected error for bad tag, but got none")
+	}
+	// flip it back, try again just to make sure
+	tag[len(tag)-1] ^= 1
+	plaintext_out, err = doDecryption(key, iv, nil, ciphertext, tag, 128, 129)
+	if err != nil {
+		t.Fatal("Decryption failure:", err)
+	}
+	checkEqual(t, plaintext_out, plaintext)
+}
+
+func TestBadCiphertext(t *testing.T) {
+	key := []byte("hard boiled eggs & bacon")
+	iv := []byte("x") // it's not a very /good/ IV, is it
+	aad := []byte("mu")
+	plaintext := "Roger roger bingo charlie, we have a niner fourteen tango"
+
+	ciphertext, tag, err := doEncryption(key, iv, aad, []byte(plaintext),
+		192, 1)
+	if err != nil {
+		t.Fatal("Encryption failure:", err)
+	}
+	// flip the last bit
+	ciphertext[len(ciphertext)-1] ^= 1
+	plaintext_out, err := doDecryption(key, iv, aad, ciphertext, tag, 192, 192)
+	if err == nil {
+		t.Fatal("Expected error for bad ciphertext, but got none")
+	}
+	// flip it back, try again just to make sure
+	ciphertext[len(ciphertext)-1] ^= 1
+	plaintext_out, err = doDecryption(key, iv, aad, ciphertext, tag, 192, 192)
+	if err != nil {
+		t.Fatal("Decryption failure:", err)
+	}
+	checkEqual(t, plaintext_out, plaintext)
+}
+
+func TestBadAAD(t *testing.T) {
+	key := []byte("Ive got a lovely buncha coconuts")
+	iv := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab")
+	aad := []byte("Hi i am a plain")
+	plaintext := "Whatever."
+
+	ciphertext, tag, err := doEncryption(key, iv, aad, []byte(plaintext),
+		256, 256)
+	if err != nil {
+		t.Fatal("Encryption failure:", err)
+	}
+	// flip the last bit
+	aad[len(aad)-1] ^= 1
+	plaintext_out, err := doDecryption(key, iv, aad, ciphertext, tag, 256, 256)
+	if err == nil {
+		t.Fatal("Expected error for bad AAD, but got none")
+	}
+	// flip it back, try again just to make sure
+	aad[len(aad)-1] ^= 1
+	plaintext_out, err = doDecryption(key, iv, aad, ciphertext, tag, 256, 256)
+	if err != nil {
+		t.Fatal("Decryption failure:", err)
+	}
+	checkEqual(t, plaintext_out, plaintext)
+}
+
+func TestNonAuthenticatedEncryption(t *testing.T) {
+	key := []byte("never gonna give you up, never g")
+	iv := []byte("onna let you dow")
+	plaintext1 := "n, never gonna run around"
+	plaintext2 := " and desert you"
+
+	cipher, err := GetCipherByName("aes-256-cbc")
+	if err != nil {
+		t.Fatal("Could not get cipher: ", err)
+	}
+
+	eCtx, err := NewEncryptionCipherCtx(cipher, nil, key, iv)
+	if err != nil {
+		t.Fatal("Could not create encryption context: ", err)
+	}
+	cipherbytes, err := eCtx.EncryptUpdate([]byte(plaintext1))
+	if err != nil {
+		t.Fatal("EncryptUpdate(plaintext1) failure: ", err)
+	}
+	ciphertext := string(cipherbytes)
+	cipherbytes, err = eCtx.EncryptUpdate([]byte(plaintext2))
+	if err != nil {
+		t.Fatal("EncryptUpdate(plaintext2) failure: ", err)
+	}
+	ciphertext += string(cipherbytes)
+	cipherbytes, err = eCtx.EncryptFinal()
+	if err != nil {
+		t.Fatal("EncryptFinal() failure: ", err)
+	}
+	ciphertext += string(cipherbytes)
+
+	dCtx, err := NewDecryptionCipherCtx(cipher, nil, key, iv)
+	if err != nil {
+		t.Fatal("Could not create decryption context: ", err)
+	}
+	plainbytes, err := dCtx.DecryptUpdate([]byte(ciphertext[:15]))
+	if err != nil {
+		t.Fatal("DecryptUpdate(ciphertext part 1) failure: ", err)
+	}
+	plainOutput := string(plainbytes)
+	plainbytes, err = dCtx.DecryptUpdate([]byte(ciphertext[15:]))
+	if err != nil {
+		t.Fatal("DecryptUpdate(ciphertext part 2) failure: ", err)
+	}
+	plainOutput += string(plainbytes)
+	plainbytes, err = dCtx.DecryptFinal()
+	if err != nil {
+		t.Fatal("DecryptFinal() failure: ", err)
+	}
+	plainOutput += string(plainbytes)
+
+	checkEqual(t, []byte(plainOutput), plaintext1+plaintext2)
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/conn.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/conn.go
@@ -1,0 +1,620 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"runtime"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/spacemonkeygo/openssl/utils"
+)
+
+var (
+	zeroReturn = errors.New("zero return")
+	wantRead   = errors.New("want read")
+	wantWrite  = errors.New("want write")
+	tryAgain   = errors.New("try again")
+)
+
+type Conn struct {
+	*SSL
+
+	conn             net.Conn
+	ctx              *Ctx // for gc
+	into_ssl         *readBio
+	from_ssl         *writeBio
+	is_shutdown      bool
+	mtx              sync.Mutex
+	want_read_future *utils.Future
+}
+
+type VerifyResult int
+
+const (
+	Ok                            VerifyResult = C.X509_V_OK
+	UnableToGetIssuerCert         VerifyResult = C.X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT
+	UnableToGetCrl                VerifyResult = C.X509_V_ERR_UNABLE_TO_GET_CRL
+	UnableToDecryptCertSignature  VerifyResult = C.X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE
+	UnableToDecryptCrlSignature   VerifyResult = C.X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE
+	UnableToDecodeIssuerPublicKey VerifyResult = C.X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY
+	CertSignatureFailure          VerifyResult = C.X509_V_ERR_CERT_SIGNATURE_FAILURE
+	CrlSignatureFailure           VerifyResult = C.X509_V_ERR_CRL_SIGNATURE_FAILURE
+	CertNotYetValid               VerifyResult = C.X509_V_ERR_CERT_NOT_YET_VALID
+	CertHasExpired                VerifyResult = C.X509_V_ERR_CERT_HAS_EXPIRED
+	CrlNotYetValid                VerifyResult = C.X509_V_ERR_CRL_NOT_YET_VALID
+	CrlHasExpired                 VerifyResult = C.X509_V_ERR_CRL_HAS_EXPIRED
+	ErrorInCertNotBeforeField     VerifyResult = C.X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD
+	ErrorInCertNotAfterField      VerifyResult = C.X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD
+	ErrorInCrlLastUpdateField     VerifyResult = C.X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD
+	ErrorInCrlNextUpdateField     VerifyResult = C.X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD
+	OutOfMem                      VerifyResult = C.X509_V_ERR_OUT_OF_MEM
+	DepthZeroSelfSignedCert       VerifyResult = C.X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
+	SelfSignedCertInChain         VerifyResult = C.X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN
+	UnableToGetIssuerCertLocally  VerifyResult = C.X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+	UnableToVerifyLeafSignature   VerifyResult = C.X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE
+	CertChainTooLong              VerifyResult = C.X509_V_ERR_CERT_CHAIN_TOO_LONG
+	CertRevoked                   VerifyResult = C.X509_V_ERR_CERT_REVOKED
+	InvalidCa                     VerifyResult = C.X509_V_ERR_INVALID_CA
+	PathLengthExceeded            VerifyResult = C.X509_V_ERR_PATH_LENGTH_EXCEEDED
+	InvalidPurpose                VerifyResult = C.X509_V_ERR_INVALID_PURPOSE
+	CertUntrusted                 VerifyResult = C.X509_V_ERR_CERT_UNTRUSTED
+	CertRejected                  VerifyResult = C.X509_V_ERR_CERT_REJECTED
+	SubjectIssuerMismatch         VerifyResult = C.X509_V_ERR_SUBJECT_ISSUER_MISMATCH
+	AkidSkidMismatch              VerifyResult = C.X509_V_ERR_AKID_SKID_MISMATCH
+	AkidIssuerSerialMismatch      VerifyResult = C.X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH
+	KeyusageNoCertsign            VerifyResult = C.X509_V_ERR_KEYUSAGE_NO_CERTSIGN
+	UnableToGetCrlIssuer          VerifyResult = C.X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER
+	UnhandledCriticalExtension    VerifyResult = C.X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION
+	KeyusageNoCrlSign             VerifyResult = C.X509_V_ERR_KEYUSAGE_NO_CRL_SIGN
+	UnhandledCriticalCrlExtension VerifyResult = C.X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION
+	InvalidNonCa                  VerifyResult = C.X509_V_ERR_INVALID_NON_CA
+	ProxyPathLengthExceeded       VerifyResult = C.X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED
+	KeyusageNoDigitalSignature    VerifyResult = C.X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE
+	ProxyCertificatesNotAllowed   VerifyResult = C.X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED
+	InvalidExtension              VerifyResult = C.X509_V_ERR_INVALID_EXTENSION
+	InvalidPolicyExtension        VerifyResult = C.X509_V_ERR_INVALID_POLICY_EXTENSION
+	NoExplicitPolicy              VerifyResult = C.X509_V_ERR_NO_EXPLICIT_POLICY
+	UnnestedResource              VerifyResult = C.X509_V_ERR_UNNESTED_RESOURCE
+	ApplicationVerification       VerifyResult = C.X509_V_ERR_APPLICATION_VERIFICATION
+)
+
+func newSSL(ctx *C.SSL_CTX) (*C.SSL, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	ssl := C.SSL_new(ctx)
+	if ssl == nil {
+		return nil, errorFromErrorQueue()
+	}
+	return ssl, nil
+}
+
+func newConn(conn net.Conn, ctx *Ctx) (*Conn, error) {
+	ssl, err := newSSL(ctx.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	into_ssl := &readBio{}
+	from_ssl := &writeBio{}
+
+	if ctx.GetMode()&ReleaseBuffers > 0 {
+		into_ssl.release_buffers = true
+		from_ssl.release_buffers = true
+	}
+
+	into_ssl_cbio := into_ssl.MakeCBIO()
+	from_ssl_cbio := from_ssl.MakeCBIO()
+	if into_ssl_cbio == nil || from_ssl_cbio == nil {
+		// these frees are null safe
+		C.BIO_free(into_ssl_cbio)
+		C.BIO_free(from_ssl_cbio)
+		C.SSL_free(ssl)
+		return nil, errors.New("failed to allocate memory BIO")
+	}
+
+	// the ssl object takes ownership of these objects now
+	C.SSL_set_bio(ssl, into_ssl_cbio, from_ssl_cbio)
+
+	s := &SSL{ssl: ssl}
+	C.SSL_set_ex_data(s.ssl, get_ssl_idx(), unsafe.Pointer(s))
+
+	c := &Conn{
+		SSL: s,
+
+		conn:     conn,
+		ctx:      ctx,
+		into_ssl: into_ssl,
+		from_ssl: from_ssl}
+	runtime.SetFinalizer(c, func(c *Conn) {
+		c.into_ssl.Disconnect(into_ssl_cbio)
+		c.from_ssl.Disconnect(from_ssl_cbio)
+		C.SSL_free(c.ssl)
+	})
+	return c, nil
+}
+
+// Client wraps an existing stream connection and puts it in the connect state
+// for any subsequent handshakes.
+//
+// IMPORTANT NOTE: if you use this method instead of Dial to construct an SSL
+// connection, you are responsible for verifying the peer's hostname.
+// Otherwise, you are vulnerable to MITM attacks.
+//
+// Client also does not set up SNI for you like Dial does.
+//
+// Client connections probably won't work for you unless you set a verify
+// location or add some certs to the certificate store of the client context
+// you're using. This library is not nice enough to use the system certificate
+// store by default for you yet.
+func Client(conn net.Conn, ctx *Ctx) (*Conn, error) {
+	c, err := newConn(conn, ctx)
+	if err != nil {
+		return nil, err
+	}
+	C.SSL_set_connect_state(c.ssl)
+	return c, nil
+}
+
+// Server wraps an existing stream connection and puts it in the accept state
+// for any subsequent handshakes.
+func Server(conn net.Conn, ctx *Ctx) (*Conn, error) {
+	c, err := newConn(conn, ctx)
+	if err != nil {
+		return nil, err
+	}
+	C.SSL_set_accept_state(c.ssl)
+	return c, nil
+}
+
+func (c *Conn) GetCtx() *Ctx { return c.ctx }
+
+func (c *Conn) CurrentCipher() (string, error) {
+	p := C.X_SSL_get_cipher_name(c.ssl)
+	if p == nil {
+		return "", errors.New("Session not established")
+	}
+
+	return C.GoString(p), nil
+}
+
+func (c *Conn) fillInputBuffer() error {
+	for {
+		n, err := c.into_ssl.ReadFromOnce(c.conn)
+		if n == 0 && err == nil {
+			continue
+		}
+		if err == io.EOF {
+			c.into_ssl.MarkEOF()
+			return c.Close()
+		}
+		return err
+	}
+}
+
+func (c *Conn) flushOutputBuffer() error {
+	_, err := c.from_ssl.WriteTo(c.conn)
+	return err
+}
+
+func (c *Conn) getErrorHandler(rv C.int, errno error) func() error {
+	errcode := C.SSL_get_error(c.ssl, rv)
+	switch errcode {
+	case C.SSL_ERROR_ZERO_RETURN:
+		return func() error {
+			c.Close()
+			return io.ErrUnexpectedEOF
+		}
+	case C.SSL_ERROR_WANT_READ:
+		go c.flushOutputBuffer()
+		if c.want_read_future != nil {
+			want_read_future := c.want_read_future
+			return func() error {
+				_, err := want_read_future.Get()
+				return err
+			}
+		}
+		c.want_read_future = utils.NewFuture()
+		want_read_future := c.want_read_future
+		return func() (err error) {
+			defer func() {
+				c.mtx.Lock()
+				c.want_read_future = nil
+				c.mtx.Unlock()
+				want_read_future.Set(nil, err)
+			}()
+			err = c.fillInputBuffer()
+			if err != nil {
+				return err
+			}
+			return tryAgain
+		}
+	case C.SSL_ERROR_WANT_WRITE:
+		return func() error {
+			err := c.flushOutputBuffer()
+			if err != nil {
+				return err
+			}
+			return tryAgain
+		}
+	case C.SSL_ERROR_SYSCALL:
+		var err error
+		if C.ERR_peek_error() == 0 {
+			switch rv {
+			case 0:
+				err = errors.New("protocol-violating EOF")
+			case -1:
+				err = errno
+			default:
+				err = errorFromErrorQueue()
+			}
+		} else {
+			err = errorFromErrorQueue()
+		}
+		return func() error { return err }
+	default:
+		err := errorFromErrorQueue()
+		return func() error { return err }
+	}
+}
+
+func (c *Conn) handleError(errcb func() error) error {
+	if errcb != nil {
+		return errcb()
+	}
+	return nil
+}
+
+func (c *Conn) handshake() func() error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if c.is_shutdown {
+		return func() error { return io.ErrUnexpectedEOF }
+	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	rv, errno := C.SSL_do_handshake(c.ssl)
+	if rv > 0 {
+		return nil
+	}
+	return c.getErrorHandler(rv, errno)
+}
+
+// Handshake performs an SSL handshake. If a handshake is not manually
+// triggered, it will run before the first I/O on the encrypted stream.
+func (c *Conn) Handshake() error {
+	err := tryAgain
+	for err == tryAgain {
+		err = c.handleError(c.handshake())
+	}
+	go c.flushOutputBuffer()
+	return err
+}
+
+// PeerCertificate returns the Certificate of the peer with which you're
+// communicating. Only valid after a handshake.
+func (c *Conn) PeerCertificate() (*Certificate, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if c.is_shutdown {
+		return nil, errors.New("connection closed")
+	}
+	x := C.SSL_get_peer_certificate(c.ssl)
+	if x == nil {
+		return nil, errors.New("no peer certificate found")
+	}
+	cert := &Certificate{x: x}
+	runtime.SetFinalizer(cert, func(cert *Certificate) {
+		C.X509_free(cert.x)
+	})
+	return cert, nil
+}
+
+// loadCertificateStack loads up a stack of x509 certificates and returns them,
+// handling memory ownership.
+func (c *Conn) loadCertificateStack(sk *C.struct_stack_st_X509) (
+	rv []*Certificate) {
+
+	sk_num := int(C.X_sk_X509_num(sk))
+	rv = make([]*Certificate, 0, sk_num)
+	for i := 0; i < sk_num; i++ {
+		x := C.X_sk_X509_value(sk, C.int(i))
+		// ref holds on to the underlying connection memory so we don't need to
+		// worry about incrementing refcounts manually or freeing the X509
+		rv = append(rv, &Certificate{x: x, ref: c})
+	}
+	return rv
+}
+
+// PeerCertificateChain returns the certificate chain of the peer. If called on
+// the client side, the stack also contains the peer's certificate; if called
+// on the server side, the peer's certificate must be obtained separately using
+// PeerCertificate.
+func (c *Conn) PeerCertificateChain() (rv []*Certificate, err error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if c.is_shutdown {
+		return nil, errors.New("connection closed")
+	}
+	sk := C.SSL_get_peer_cert_chain(c.ssl)
+	if sk == nil {
+		return nil, errors.New("no peer certificates found")
+	}
+	return c.loadCertificateStack(sk), nil
+}
+
+type ConnectionState struct {
+	Certificate           *Certificate
+	CertificateError      error
+	CertificateChain      []*Certificate
+	CertificateChainError error
+	SessionReused         bool
+}
+
+func (c *Conn) ConnectionState() (rv ConnectionState) {
+	rv.Certificate, rv.CertificateError = c.PeerCertificate()
+	rv.CertificateChain, rv.CertificateChainError = c.PeerCertificateChain()
+	rv.SessionReused = c.SessionReused()
+	return
+}
+
+func (c *Conn) shutdown() func() error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	rv, errno := C.SSL_shutdown(c.ssl)
+	if rv > 0 {
+		return nil
+	}
+	if rv == 0 {
+		// The OpenSSL docs say that in this case, the shutdown is not
+		// finished, and we should call SSL_shutdown() a second time, if a
+		// bidirectional shutdown is going to be performed. Further, the
+		// output of SSL_get_error may be misleading, as an erroneous
+		// SSL_ERROR_SYSCALL may be flagged even though no error occurred.
+		// So, TODO: revisit bidrectional shutdown, possibly trying again.
+		// Note: some broken clients won't engage in bidirectional shutdown
+		// without tickling them to close by sending a TCP_FIN packet, or
+		// shutting down the write-side of the connection.
+		return nil
+	} else {
+		return c.getErrorHandler(rv, errno)
+	}
+}
+
+func (c *Conn) shutdownLoop() error {
+	err := tryAgain
+	shutdown_tries := 0
+	for err == tryAgain {
+		shutdown_tries = shutdown_tries + 1
+		err = c.handleError(c.shutdown())
+		if err == nil {
+			return c.flushOutputBuffer()
+		}
+		if err == tryAgain && shutdown_tries >= 2 {
+			return errors.New("shutdown requested a third time?")
+		}
+	}
+	if err == io.ErrUnexpectedEOF {
+		err = nil
+	}
+	return err
+}
+
+// Close shuts down the SSL connection and closes the underlying wrapped
+// connection.
+func (c *Conn) Close() error {
+	c.mtx.Lock()
+	if c.is_shutdown {
+		c.mtx.Unlock()
+		return nil
+	}
+	c.is_shutdown = true
+	c.mtx.Unlock()
+	var errs utils.ErrorGroup
+	errs.Add(c.shutdownLoop())
+	errs.Add(c.conn.Close())
+	return errs.Finalize()
+}
+
+func (c *Conn) read(b []byte) (int, func() error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if c.is_shutdown {
+		return 0, func() error { return io.EOF }
+	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	rv, errno := C.SSL_read(c.ssl, unsafe.Pointer(&b[0]), C.int(len(b)))
+	if rv > 0 {
+		return int(rv), nil
+	}
+	return 0, c.getErrorHandler(rv, errno)
+}
+
+// Read reads up to len(b) bytes into b. It returns the number of bytes read
+// and an error if applicable. io.EOF is returned when the caller can expect
+// to see no more data.
+func (c *Conn) Read(b []byte) (n int, err error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+	err = tryAgain
+	for err == tryAgain {
+		n, errcb := c.read(b)
+		err = c.handleError(errcb)
+		if err == nil {
+			go c.flushOutputBuffer()
+			return n, nil
+		}
+		if err == io.ErrUnexpectedEOF {
+			err = io.EOF
+		}
+	}
+	return 0, err
+}
+
+func (c *Conn) write(b []byte) (int, func() error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if c.is_shutdown {
+		err := errors.New("connection closed")
+		return 0, func() error { return err }
+	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	rv, errno := C.SSL_write(c.ssl, unsafe.Pointer(&b[0]), C.int(len(b)))
+	if rv > 0 {
+		return int(rv), nil
+	}
+	return 0, c.getErrorHandler(rv, errno)
+}
+
+// Write will encrypt the contents of b and write it to the underlying stream.
+// Performance will be vastly improved if the size of b is a multiple of
+// SSLRecordSize.
+func (c *Conn) Write(b []byte) (written int, err error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+	err = tryAgain
+	for err == tryAgain {
+		n, errcb := c.write(b)
+		err = c.handleError(errcb)
+		if err == nil {
+			return n, c.flushOutputBuffer()
+		}
+	}
+	return 0, err
+}
+
+// VerifyHostname pulls the PeerCertificate and calls VerifyHostname on the
+// certificate.
+func (c *Conn) VerifyHostname(host string) error {
+	cert, err := c.PeerCertificate()
+	if err != nil {
+		return err
+	}
+	return cert.VerifyHostname(host)
+}
+
+// LocalAddr returns the underlying connection's local address
+func (c *Conn) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+// RemoteAddr returns the underlying connection's remote address
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+// SetDeadline calls SetDeadline on the underlying connection.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.conn.SetDeadline(t)
+}
+
+// SetReadDeadline calls SetReadDeadline on the underlying connection.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline calls SetWriteDeadline on the underlying connection.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
+}
+
+func (c *Conn) UnderlyingConn() net.Conn {
+	return c.conn
+}
+
+func (c *Conn) SetTlsExtHostName(name string) error {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	if C.X_SSL_set_tlsext_host_name(c.ssl, cname) == 0 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}
+
+func (c *Conn) VerifyResult() VerifyResult {
+	return VerifyResult(C.SSL_get_verify_result(c.ssl))
+}
+
+func (c *Conn) SessionReused() bool {
+	return C.X_SSL_session_reused(c.ssl) == 1
+}
+
+func (c *Conn) GetSession() ([]byte, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// get1 increases the refcount of the session, so we have to free it.
+	session := (*C.SSL_SESSION)(C.SSL_get1_session(c.ssl))
+	if session == nil {
+		return nil, errors.New("failed to get session")
+	}
+	defer C.SSL_SESSION_free(session)
+
+	// get the size of the encoding
+	slen := C.i2d_SSL_SESSION(session, nil)
+
+	buf := (*C.uchar)(C.malloc(C.size_t(slen)))
+	defer C.free(unsafe.Pointer(buf))
+
+	// this modifies the value of buf (seriously), so we have to pass in a temp
+	// var so that we can actually read the bytes from buf.
+	tmp := buf
+	slen2 := C.i2d_SSL_SESSION(session, &tmp)
+	if slen != slen2 {
+		return nil, errors.New("session had different lengths")
+	}
+
+	return C.GoBytes(unsafe.Pointer(buf), slen), nil
+}
+
+func (c *Conn) setSession(session []byte) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	ptr := (*C.uchar)(&session[0])
+	s := C.d2i_SSL_SESSION(nil, &ptr, C.long(len(session)))
+	if s == nil {
+		return fmt.Errorf("unable to load session: %s", errorFromErrorQueue())
+	}
+	defer C.SSL_SESSION_free(s)
+
+	ret := C.SSL_set_session(c.ssl, s)
+	if ret != 1 {
+		return fmt.Errorf("unable to set session: %s", errorFromErrorQueue())
+	}
+	return nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/ctx.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/ctx.go
@@ -1,0 +1,568 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/spacemonkeygo/spacelog"
+)
+
+var (
+	ssl_ctx_idx = C.X_SSL_CTX_new_index()
+
+	logger = spacelog.GetLogger()
+)
+
+type Ctx struct {
+	ctx       *C.SSL_CTX
+	cert      *Certificate
+	chain     []*Certificate
+	key       PrivateKey
+	verify_cb VerifyCallback
+	sni_cb    TLSExtServernameCallback
+
+	ticket_store_mu sync.Mutex
+	ticket_store    *TicketStore
+}
+
+//export get_ssl_ctx_idx
+func get_ssl_ctx_idx() C.int {
+	return ssl_ctx_idx
+}
+
+func newCtx(method *C.SSL_METHOD) (*Ctx, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	ctx := C.SSL_CTX_new(method)
+	if ctx == nil {
+		return nil, errorFromErrorQueue()
+	}
+	c := &Ctx{ctx: ctx}
+	C.SSL_CTX_set_ex_data(ctx, get_ssl_ctx_idx(), unsafe.Pointer(c))
+	runtime.SetFinalizer(c, func(c *Ctx) {
+		C.SSL_CTX_free(c.ctx)
+	})
+	return c, nil
+}
+
+type SSLVersion int
+
+const (
+	SSLv3   SSLVersion = 0x02 // Vulnerable to "POODLE" attack.
+	TLSv1   SSLVersion = 0x03
+	TLSv1_1 SSLVersion = 0x04
+	TLSv1_2 SSLVersion = 0x05
+
+	// Make sure to disable SSLv2 and SSLv3 if you use this. SSLv3 is vulnerable
+	// to the "POODLE" attack, and SSLv2 is what, just don't even.
+	AnyVersion SSLVersion = 0x06
+)
+
+// NewCtxWithVersion creates an SSL context that is specific to the provided
+// SSL version. See http://www.openssl.org/docs/ssl/SSL_CTX_new.html for more.
+func NewCtxWithVersion(version SSLVersion) (*Ctx, error) {
+	var method *C.SSL_METHOD
+	switch version {
+	case SSLv3:
+		method = C.X_SSLv3_method()
+	case TLSv1:
+		method = C.X_TLSv1_method()
+	case TLSv1_1:
+		method = C.X_TLSv1_1_method()
+	case TLSv1_2:
+		method = C.X_TLSv1_2_method()
+	case AnyVersion:
+		method = C.X_SSLv23_method()
+	}
+	if method == nil {
+		return nil, errors.New("unknown ssl/tls version")
+	}
+	return newCtx(method)
+}
+
+// NewCtx creates a context that supports any TLS version 1.0 and newer.
+func NewCtx() (*Ctx, error) {
+	c, err := NewCtxWithVersion(AnyVersion)
+	if err == nil {
+		c.SetOptions(NoSSLv2 | NoSSLv3)
+	}
+	return c, err
+}
+
+// NewCtxFromFiles calls NewCtx, loads the provided files, and configures the
+// context to use them.
+func NewCtxFromFiles(cert_file string, key_file string) (*Ctx, error) {
+	ctx, err := NewCtx()
+	if err != nil {
+		return nil, err
+	}
+
+	cert_bytes, err := ioutil.ReadFile(cert_file)
+	if err != nil {
+		return nil, err
+	}
+
+	certs := SplitPEM(cert_bytes)
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("No PEM certificate found in '%s'", cert_file)
+	}
+	first, certs := certs[0], certs[1:]
+	cert, err := LoadCertificateFromPEM(first)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ctx.UseCertificate(cert)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pem := range certs {
+		cert, err := LoadCertificateFromPEM(pem)
+		if err != nil {
+			return nil, err
+		}
+		err = ctx.AddChainCertificate(cert)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	key_bytes, err := ioutil.ReadFile(key_file)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := LoadPrivateKeyFromPEM(key_bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ctx.UsePrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
+}
+
+// EllipticCurve repesents the ASN.1 OID of an elliptic curve.
+// see https://www.openssl.org/docs/apps/ecparam.html for a list of implemented curves.
+type EllipticCurve int
+
+const (
+	// P-256: X9.62/SECG curve over a 256 bit prime field
+	Prime256v1 EllipticCurve = C.NID_X9_62_prime256v1
+	// P-384: NIST/SECG curve over a 384 bit prime field
+	Secp384r1 EllipticCurve = C.NID_secp384r1
+	// P-521: NIST/SECG curve over a 521 bit prime field
+	Secp521r1 EllipticCurve = C.NID_secp521r1
+)
+
+// SetEllipticCurve sets the elliptic curve used by the SSL context to
+// enable an ECDH cipher suite to be selected during the handshake.
+func (c *Ctx) SetEllipticCurve(curve EllipticCurve) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	k := C.EC_KEY_new_by_curve_name(C.int(curve))
+	if k == nil {
+		return errors.New("Unknown curve")
+	}
+	defer C.EC_KEY_free(k)
+
+	if int(C.X_SSL_CTX_set_tmp_ecdh(c.ctx, k)) != 1 {
+		return errorFromErrorQueue()
+	}
+
+	return nil
+}
+
+// UseCertificate configures the context to present the given certificate to
+// peers.
+func (c *Ctx) UseCertificate(cert *Certificate) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	c.cert = cert
+	if int(C.SSL_CTX_use_certificate(c.ctx, cert.x)) != 1 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}
+
+// AddChainCertificate adds a certificate to the chain presented in the
+// handshake.
+func (c *Ctx) AddChainCertificate(cert *Certificate) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	c.chain = append(c.chain, cert)
+	if int(C.X_SSL_CTX_add_extra_chain_cert(c.ctx, cert.x)) != 1 {
+		return errorFromErrorQueue()
+	}
+	// OpenSSL takes ownership via SSL_CTX_add_extra_chain_cert
+	runtime.SetFinalizer(cert, nil)
+	return nil
+}
+
+// UsePrivateKey configures the context to use the given private key for SSL
+// handshakes.
+func (c *Ctx) UsePrivateKey(key PrivateKey) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	c.key = key
+	if int(C.SSL_CTX_use_PrivateKey(c.ctx, key.evpPKey())) != 1 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}
+
+type CertificateStore struct {
+	store *C.X509_STORE
+	// for GC
+	ctx   *Ctx
+	certs []*Certificate
+}
+
+// Allocate a new, empty CertificateStore
+func NewCertificateStore() (*CertificateStore, error) {
+	s := C.X509_STORE_new()
+	if s == nil {
+		return nil, errors.New("failed to allocate X509_STORE")
+	}
+	store := &CertificateStore{store: s}
+	runtime.SetFinalizer(store, func(s *CertificateStore) {
+		C.X509_STORE_free(s.store)
+	})
+	return store, nil
+}
+
+// Parse a chained PEM file, loading all certificates into the Store.
+func (s *CertificateStore) LoadCertificatesFromPEM(data []byte) error {
+	pems := SplitPEM(data)
+	for _, pem := range pems {
+		cert, err := LoadCertificateFromPEM(pem)
+		if err != nil {
+			return err
+		}
+		err = s.AddCertificate(cert)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetCertificateStore returns the context's certificate store that will be
+// used for peer validation.
+func (c *Ctx) GetCertificateStore() *CertificateStore {
+	// we don't need to dealloc the cert store pointer here, because it points
+	// to a ctx internal. so we do need to keep the ctx around
+	return &CertificateStore{
+		store: C.SSL_CTX_get_cert_store(c.ctx),
+		ctx:   c}
+}
+
+// AddCertificate marks the provided Certificate as a trusted certificate in
+// the given CertificateStore.
+func (s *CertificateStore) AddCertificate(cert *Certificate) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	s.certs = append(s.certs, cert)
+	if int(C.X509_STORE_add_cert(s.store, cert.x)) != 1 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}
+
+type CertificateStoreCtx struct {
+	ctx     *C.X509_STORE_CTX
+	ssl_ctx *Ctx
+}
+
+func (self *CertificateStoreCtx) VerifyResult() VerifyResult {
+	return VerifyResult(C.X509_STORE_CTX_get_error(self.ctx))
+}
+
+func (self *CertificateStoreCtx) Err() error {
+	code := C.X509_STORE_CTX_get_error(self.ctx)
+	if code == C.X509_V_OK {
+		return nil
+	}
+	return fmt.Errorf("openssl: %s",
+		C.GoString(C.X509_verify_cert_error_string(C.long(code))))
+}
+
+func (self *CertificateStoreCtx) Depth() int {
+	return int(C.X509_STORE_CTX_get_error_depth(self.ctx))
+}
+
+// the certicate returned is only valid for the lifetime of the underlying
+// X509_STORE_CTX
+func (self *CertificateStoreCtx) GetCurrentCert() *Certificate {
+	x509 := C.X509_STORE_CTX_get_current_cert(self.ctx)
+	if x509 == nil {
+		return nil
+	}
+	// add a ref
+	if 1 != C.X_X509_add_ref(x509) {
+		return nil
+	}
+	cert := &Certificate{
+		x: x509,
+	}
+	runtime.SetFinalizer(cert, func(cert *Certificate) {
+		C.X509_free(cert.x)
+	})
+	return cert
+}
+
+// LoadVerifyLocations tells the context to trust all certificate authorities
+// provided in either the ca_file or the ca_path.
+// See http://www.openssl.org/docs/ssl/SSL_CTX_load_verify_locations.html for
+// more.
+func (c *Ctx) LoadVerifyLocations(ca_file string, ca_path string) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	var c_ca_file, c_ca_path *C.char
+	if ca_file != "" {
+		c_ca_file = C.CString(ca_file)
+		defer C.free(unsafe.Pointer(c_ca_file))
+	}
+	if ca_path != "" {
+		c_ca_path = C.CString(ca_path)
+		defer C.free(unsafe.Pointer(c_ca_path))
+	}
+	if C.SSL_CTX_load_verify_locations(c.ctx, c_ca_file, c_ca_path) != 1 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}
+
+type Options int
+
+const (
+	// NoCompression is only valid if you are using OpenSSL 1.0.1 or newer
+	NoCompression                      Options = C.SSL_OP_NO_COMPRESSION
+	NoSSLv2                            Options = C.SSL_OP_NO_SSLv2
+	NoSSLv3                            Options = C.SSL_OP_NO_SSLv3
+	NoTLSv1                            Options = C.SSL_OP_NO_TLSv1
+	CipherServerPreference             Options = C.SSL_OP_CIPHER_SERVER_PREFERENCE
+	NoSessionResumptionOrRenegotiation Options = C.SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION
+	NoTicket                           Options = C.SSL_OP_NO_TICKET
+)
+
+// SetOptions sets context options. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+func (c *Ctx) SetOptions(options Options) Options {
+	return Options(C.X_SSL_CTX_set_options(
+		c.ctx, C.long(options)))
+}
+
+func (c *Ctx) ClearOptions(options Options) Options {
+	return Options(C.X_SSL_CTX_clear_options(
+		c.ctx, C.long(options)))
+}
+
+// GetOptions returns context options. See
+// https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+func (c *Ctx) GetOptions() Options {
+	return Options(C.X_SSL_CTX_get_options(c.ctx))
+}
+
+type Modes int
+
+const (
+	// ReleaseBuffers is only valid if you are using OpenSSL 1.0.1 or newer
+	ReleaseBuffers Modes = C.SSL_MODE_RELEASE_BUFFERS
+)
+
+// SetMode sets context modes. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_mode.html
+func (c *Ctx) SetMode(modes Modes) Modes {
+	return Modes(C.X_SSL_CTX_set_mode(c.ctx, C.long(modes)))
+}
+
+// GetMode returns context modes. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_mode.html
+func (c *Ctx) GetMode() Modes {
+	return Modes(C.X_SSL_CTX_get_mode(c.ctx))
+}
+
+type VerifyOptions int
+
+const (
+	VerifyNone             VerifyOptions = C.SSL_VERIFY_NONE
+	VerifyPeer             VerifyOptions = C.SSL_VERIFY_PEER
+	VerifyFailIfNoPeerCert VerifyOptions = C.SSL_VERIFY_FAIL_IF_NO_PEER_CERT
+	VerifyClientOnce       VerifyOptions = C.SSL_VERIFY_CLIENT_ONCE
+)
+
+type VerifyCallback func(ok bool, store *CertificateStoreCtx) bool
+
+//export go_ssl_ctx_verify_cb_thunk
+func go_ssl_ctx_verify_cb_thunk(p unsafe.Pointer, ok C.int, ctx *C.X509_STORE_CTX) C.int {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Critf("openssl: verify callback panic'd: %v", err)
+			os.Exit(1)
+		}
+	}()
+	verify_cb := (*Ctx)(p).verify_cb
+	// set up defaults just in case verify_cb is nil
+	if verify_cb != nil {
+		store := &CertificateStoreCtx{ctx: ctx}
+		if verify_cb(ok == 1, store) {
+			ok = 1
+		} else {
+			ok = 0
+		}
+	}
+	return ok
+}
+
+// SetVerify controls peer verification settings. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (c *Ctx) SetVerify(options VerifyOptions, verify_cb VerifyCallback) {
+	c.verify_cb = verify_cb
+	if verify_cb != nil {
+		C.SSL_CTX_set_verify(c.ctx, C.int(options), (*[0]byte)(C.X_SSL_CTX_verify_cb))
+	} else {
+		C.SSL_CTX_set_verify(c.ctx, C.int(options), nil)
+	}
+}
+
+func (c *Ctx) SetVerifyMode(options VerifyOptions) {
+	c.SetVerify(options, c.verify_cb)
+}
+
+func (c *Ctx) SetVerifyCallback(verify_cb VerifyCallback) {
+	c.SetVerify(c.VerifyMode(), verify_cb)
+}
+
+func (c *Ctx) GetVerifyCallback() VerifyCallback {
+	return c.verify_cb
+}
+
+func (c *Ctx) VerifyMode() VerifyOptions {
+	return VerifyOptions(C.SSL_CTX_get_verify_mode(c.ctx))
+}
+
+// SetVerifyDepth controls how many certificates deep the certificate
+// verification logic is willing to follow a certificate chain. See
+// https://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (c *Ctx) SetVerifyDepth(depth int) {
+	C.SSL_CTX_set_verify_depth(c.ctx, C.int(depth))
+}
+
+// GetVerifyDepth controls how many certificates deep the certificate
+// verification logic is willing to follow a certificate chain. See
+// https://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (c *Ctx) GetVerifyDepth() int {
+	return int(C.SSL_CTX_get_verify_depth(c.ctx))
+}
+
+type TLSExtServernameCallback func(ssl *SSL) SSLTLSExtErr
+
+// SetTLSExtServernameCallback sets callback function for Server Name Indication
+// (SNI) rfc6066 (http://tools.ietf.org/html/rfc6066). See
+// http://stackoverflow.com/questions/22373332/serving-multiple-domains-in-one-box-with-sni
+func (c *Ctx) SetTLSExtServernameCallback(sni_cb TLSExtServernameCallback) {
+	c.sni_cb = sni_cb
+	C.X_SSL_CTX_set_tlsext_servername_callback(c.ctx, (*[0]byte)(C.sni_cb))
+}
+
+func (c *Ctx) SetSessionId(session_id []byte) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	var ptr *C.uchar
+	if len(session_id) > 0 {
+		ptr = (*C.uchar)(unsafe.Pointer(&session_id[0]))
+	}
+	if int(C.SSL_CTX_set_session_id_context(c.ctx, ptr,
+		C.uint(len(session_id)))) == 0 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}
+
+// SetCipherList sets the list of available ciphers. The format of the list is
+// described at http://www.openssl.org/docs/apps/ciphers.html, but see
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_cipher_list.html for more.
+func (c *Ctx) SetCipherList(list string) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	clist := C.CString(list)
+	defer C.free(unsafe.Pointer(clist))
+	if int(C.SSL_CTX_set_cipher_list(c.ctx, clist)) == 0 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}
+
+type SessionCacheModes int
+
+const (
+	SessionCacheOff    SessionCacheModes = C.SSL_SESS_CACHE_OFF
+	SessionCacheClient SessionCacheModes = C.SSL_SESS_CACHE_CLIENT
+	SessionCacheServer SessionCacheModes = C.SSL_SESS_CACHE_SERVER
+	SessionCacheBoth   SessionCacheModes = C.SSL_SESS_CACHE_BOTH
+	NoAutoClear        SessionCacheModes = C.SSL_SESS_CACHE_NO_AUTO_CLEAR
+	NoInternalLookup   SessionCacheModes = C.SSL_SESS_CACHE_NO_INTERNAL_LOOKUP
+	NoInternalStore    SessionCacheModes = C.SSL_SESS_CACHE_NO_INTERNAL_STORE
+	NoInternal         SessionCacheModes = C.SSL_SESS_CACHE_NO_INTERNAL
+)
+
+// SetSessionCacheMode enables or disables session caching. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_session_cache_mode.html
+func (c *Ctx) SetSessionCacheMode(modes SessionCacheModes) SessionCacheModes {
+	return SessionCacheModes(
+		C.X_SSL_CTX_set_session_cache_mode(c.ctx, C.long(modes)))
+}
+
+// Set session cache timeout. Returns previously set value.
+// See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
+func (c *Ctx) SetTimeout(t time.Duration) time.Duration {
+	prev := C.X_SSL_CTX_set_timeout(c.ctx, C.long(t/time.Second))
+	return time.Duration(prev) * time.Second
+}
+
+// Get session cache timeout.
+// See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
+func (c *Ctx) GetTimeout() time.Duration {
+	return time.Duration(C.X_SSL_CTX_get_timeout(c.ctx)) * time.Second
+}
+
+// Set session cache size. Returns previously set value.
+// https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
+func (c *Ctx) SessSetCacheSize(t int) int {
+	return int(C.X_SSL_CTX_sess_set_cache_size(c.ctx, C.long(t)))
+}
+
+// Get session cache size.
+// https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
+func (c *Ctx) SessGetCacheSize() int {
+	return int(C.X_SSL_CTX_sess_get_cache_size(c.ctx))
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/ctx_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/ctx_test.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCtxTimeoutOption(t *testing.T) {
+	ctx, _ := NewCtx()
+	oldTimeout1 := ctx.GetTimeout()
+	newTimeout1 := oldTimeout1 + (time.Duration(99) * time.Second)
+	oldTimeout2 := ctx.SetTimeout(newTimeout1)
+	newTimeout2 := ctx.GetTimeout()
+	if oldTimeout1 != oldTimeout2 {
+		t.Error("SetTimeout() returns something undocumented")
+	}
+	if newTimeout1 != newTimeout2 {
+		t.Error("SetTimeout() does not save anything to ctx")
+	}
+}
+
+func TestCtxSessCacheSizeOption(t *testing.T) {
+	ctx, _ := NewCtx()
+	oldSize1 := ctx.SessGetCacheSize()
+	newSize1 := oldSize1 + 42
+	oldSize2 := ctx.SessSetCacheSize(newSize1)
+	newSize2 := ctx.SessGetCacheSize()
+	if oldSize1 != oldSize2 {
+		t.Error("SessSetCacheSize() returns something undocumented")
+	}
+	if newSize1 != newSize2 {
+		t.Error("SessSetCacheSize() does not save anything to ctx")
+	}
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/dh.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/dh.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+import (
+	"errors"
+	"unsafe"
+)
+
+// DeriveSharedSecret derives a shared secret using a private key and a peer's
+// public key.
+// The specific algorithm that is used depends on the types of the
+// keys, but it is most commonly a variant of Diffie-Hellman.
+func DeriveSharedSecret(private PrivateKey, public PublicKey) ([]byte, error) {
+	// Create context for the shared secret derivation
+	dhCtx := C.EVP_PKEY_CTX_new(private.evpPKey(), nil)
+	if dhCtx == nil {
+		return nil, errors.New("failed creating shared secret derivation context")
+	}
+	defer C.EVP_PKEY_CTX_free(dhCtx)
+
+	// Initialize the context
+	if int(C.EVP_PKEY_derive_init(dhCtx)) != 1 {
+		return nil, errors.New("failed initializing shared secret derivation context")
+	}
+
+	// Provide the peer's public key
+	if int(C.EVP_PKEY_derive_set_peer(dhCtx, public.evpPKey())) != 1 {
+		return nil, errors.New("failed adding peer public key to context")
+	}
+
+	// Determine how large of a buffer we need for the shared secret
+	var buffLen C.size_t
+	if int(C.EVP_PKEY_derive(dhCtx, nil, &buffLen)) != 1 {
+		return nil, errors.New("failed determining shared secret length")
+	}
+
+	// Allocate a buffer
+	buffer := C.X_OPENSSL_malloc(buffLen)
+	if buffer == nil {
+		return nil, errors.New("failed allocating buffer for shared secret")
+	}
+	defer C.X_OPENSSL_free(buffer)
+
+	// Derive the shared secret
+	if int(C.EVP_PKEY_derive(dhCtx, (*C.uchar)(buffer), &buffLen)) != 1 {
+		return nil, errors.New("failed deriving the shared secret")
+	}
+
+	secret := C.GoBytes(unsafe.Pointer(buffer), C.int(buffLen))
+	return secret, nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/dh_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/dh_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestECDH(t *testing.T) {
+	t.Parallel()
+
+	myKey, err := GenerateECKey(Prime256v1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerKey, err := GenerateECKey(Prime256v1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mySecret, err := DeriveSharedSecret(myKey, peerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	theirSecret, err := DeriveSharedSecret(peerKey, myKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(mySecret, theirSecret) != 0 {
+		t.Fatal("shared secrets are different")
+	}
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/dhparam.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/dhparam.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+type DH struct {
+	dh *C.struct_dh_st
+}
+
+// LoadDHParametersFromPEM loads the Diffie-Hellman parameters from
+// a PEM-encoded block.
+func LoadDHParametersFromPEM(pem_block []byte) (*DH, error) {
+	if len(pem_block) == 0 {
+		return nil, errors.New("empty pem block")
+	}
+	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
+		C.int(len(pem_block)))
+	if bio == nil {
+		return nil, errors.New("failed creating bio")
+	}
+	defer C.BIO_free(bio)
+
+	params := C.PEM_read_bio_DHparams(bio, nil, nil, nil)
+	if params == nil {
+		return nil, errors.New("failed reading dh parameters")
+	}
+	dhparams := &DH{dh: params}
+	runtime.SetFinalizer(dhparams, func(dhparams *DH) {
+		C.DH_free(dhparams.dh)
+	})
+	return dhparams, nil
+}
+
+// SetDHParameters sets the DH group (DH parameters) used to
+// negotiate an emphemeral DH key during handshaking.
+func (c *Ctx) SetDHParameters(dh *DH) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if int(C.X_SSL_CTX_set_tmp_dh(c.ctx, dh.dh)) != 1 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/digest.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/digest.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// Digest represents and openssl message digest.
+type Digest struct {
+	ptr *C.EVP_MD
+}
+
+// GetDigestByName returns the Digest with the name or nil and an error if the
+// digest was not found.
+func GetDigestByName(name string) (*Digest, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	p := C.X_EVP_get_digestbyname(cname)
+	if p == nil {
+		return nil, fmt.Errorf("Digest %v not found", name)
+	}
+	// we can consider digests to use static mem; don't need to free
+	return &Digest{ptr: p}, nil
+}
+
+// GetDigestByName returns the Digest with the NID or nil and an error if the
+// digest was not found.
+func GetDigestByNid(nid NID) (*Digest, error) {
+	sn, err := Nid2ShortName(nid)
+	if err != nil {
+		return nil, err
+	}
+	return GetDigestByName(sn)
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/engine.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/engine.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+/*
+#include "openssl/engine.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+type Engine struct {
+	e *C.ENGINE
+}
+
+func EngineById(name string) (*Engine, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	e := &Engine{
+		e: C.ENGINE_by_id(cname),
+	}
+	if e.e == nil {
+		return nil, fmt.Errorf("engine %s missing", name)
+	}
+	if C.ENGINE_init(e.e) == 0 {
+		C.ENGINE_free(e.e)
+		return nil, fmt.Errorf("engine %s not initialized", name)
+	}
+	runtime.SetFinalizer(e, func(e *Engine) {
+		C.ENGINE_finish(e.e)
+		C.ENGINE_free(e.e)
+	})
+	return e, nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/fips.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/fips.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+/*
+#include <openssl/ssl.h>
+*/
+import "C"
+import "runtime"
+
+// FIPSModeSet enables a FIPS 140-2 validated mode of operation.
+// https://wiki.openssl.org/index.php/FIPS_mode_set()
+func FIPSModeSet(mode bool) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var r C.int
+	if mode {
+		r = C.FIPS_mode_set(1)
+	} else {
+		r = C.FIPS_mode_set(0)
+	}
+	if r != 1 {
+		return errorFromErrorQueue()
+	}
+	return nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/hmac.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/hmac.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+type HMAC struct {
+	ctx    *C.HMAC_CTX
+	engine *Engine
+	md     *C.EVP_MD
+}
+
+func NewHMAC(key []byte, digestAlgorithm EVP_MD) (*HMAC, error) {
+	return NewHMACWithEngine(key, digestAlgorithm, nil)
+}
+
+func NewHMACWithEngine(key []byte, digestAlgorithm EVP_MD, e *Engine) (*HMAC, error) {
+	var md *C.EVP_MD = getDigestFunction(digestAlgorithm)
+	h := &HMAC{engine: e, md: md}
+	h.ctx = C.X_HMAC_CTX_new()
+	if h.ctx == nil {
+		return nil, errors.New("unable to allocate HMAC_CTX")
+	}
+
+	var c_e *C.ENGINE
+	if e != nil {
+		c_e = e.e
+	}
+	if rc := C.X_HMAC_Init_ex(h.ctx,
+		unsafe.Pointer(&key[0]),
+		C.int(len(key)),
+		md,
+		c_e); rc != 1 {
+		C.X_HMAC_CTX_free(h.ctx)
+		return nil, errors.New("failed to initialize HMAC_CTX")
+	}
+
+	runtime.SetFinalizer(h, func(h *HMAC) { h.Close() })
+	return h, nil
+}
+
+func (h *HMAC) Close() {
+	C.X_HMAC_CTX_free(h.ctx)
+}
+
+func (h *HMAC) Write(data []byte) (n int, err error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	if rc := C.X_HMAC_Update(h.ctx, (*C.uchar)(unsafe.Pointer(&data[0])),
+		C.size_t(len(data))); rc != 1 {
+		return 0, errors.New("failed to update HMAC")
+	}
+	return len(data), nil
+}
+
+func (h *HMAC) Reset() error {
+	if 1 != C.X_HMAC_Init_ex(h.ctx, nil, 0, nil, nil) {
+		return errors.New("failed to reset HMAC_CTX")
+	}
+	return nil
+}
+
+func (h *HMAC) Final() (result []byte, err error) {
+	mdLength := C.X_EVP_MD_size(h.md)
+	result = make([]byte, mdLength)
+	if rc := C.X_HMAC_Final(h.ctx, (*C.uchar)(unsafe.Pointer(&result[0])),
+		(*C.uint)(unsafe.Pointer(&mdLength))); rc != 1 {
+		return nil, errors.New("failed to finalized HMAC")
+	}
+	return result, h.Reset()
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/hmac_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/hmac_test.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestSHA256HMAC(t *testing.T) {
+	key := []byte("d741787cc61851af045ccd37")
+	data := []byte("5912EEFD-59EC-43E3-ADB8-D5325AEC3271")
+
+	h, err := NewHMAC(key, EVP_SHA256)
+	if err != nil {
+		t.Fatalf("Unable to create new HMAC: %s", err)
+	}
+	if _, err := h.Write(data); err != nil {
+		t.Fatalf("Unable to write data into HMAC: %s", err)
+	}
+
+	var actualHMACBytes []byte
+	if actualHMACBytes, err = h.Final(); err != nil {
+		t.Fatalf("Error while finalizing HMAC: %s", err)
+	}
+	actualString := hex.EncodeToString(actualHMACBytes)
+
+	// generate HMAC with built-in crypto lib
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	expectedString := hex.EncodeToString(mac.Sum(nil))
+
+	if expectedString != actualString {
+		t.Errorf("HMAC was incorrect: expected=%s, actual=%s", expectedString, actualString)
+	}
+}
+
+func BenchmarkSHA256HMAC(b *testing.B) {
+	key := []byte("d741787cc61851af045ccd37")
+	data := []byte("5912EEFD-59EC-43E3-ADB8-D5325AEC3271")
+
+	h, err := NewHMAC(key, EVP_SHA256)
+	if err != nil {
+		b.Fatalf("Unable to create new HMAC: %s", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := h.Write(data); err != nil {
+			b.Fatalf("Unable to write data into HMAC: %s", err)
+		}
+
+		var err error
+		if _, err = h.Final(); err != nil {
+			b.Fatalf("Error while finalizing HMAC: %s", err)
+		}
+	}
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/hostname.c
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/hostname.c
@@ -1,0 +1,373 @@
+/*
+ * Go-OpenSSL notice:
+ * This file is required for all OpenSSL versions prior to 1.1.0. This simply
+ * provides the new 1.1.0 X509_check_* methods for hostname validation if they
+ * don't already exist.
+ */
+
+#include <openssl/x509.h>
+
+#ifndef X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
+
+/* portions from x509v3.h and v3_utl.c */
+/* Written by Dr Stephen N Henson (steve@openssl.org) for the OpenSSL
+ * project.
+ */
+/* ====================================================================
+ * Copyright (c) 1999-2003 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.OpenSSL.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    licensing@OpenSSL.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.OpenSSL.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This product includes cryptographic software written by Eric Young
+ * (eay@cryptsoft.com).  This product includes software written by Tim
+ * Hudson (tjh@cryptsoft.com).
+ *
+ */
+/* X509 v3 extension utilities */
+
+#include <string.h>
+#include <stdlib.h>
+#include <openssl/ssl.h>
+#include <openssl/conf.h>
+#include <openssl/x509v3.h>
+
+#define X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT	0x1
+#define X509_CHECK_FLAG_NO_WILDCARDS	0x2
+
+typedef int (*equal_fn)(const unsigned char *pattern, size_t pattern_len,
+			const unsigned char *subject, size_t subject_len);
+
+/* Compare while ASCII ignoring case. */
+static int equal_nocase(const unsigned char *pattern, size_t pattern_len,
+			const unsigned char *subject, size_t subject_len)
+	{
+	if (pattern_len != subject_len)
+		return 0;
+	while (pattern_len)
+		{
+		unsigned char l = *pattern;
+		unsigned char r = *subject;
+		/* The pattern must not contain NUL characters. */
+		if (l == 0)
+			return 0;
+		if (l != r)
+			{
+			if ('A' <= l && l <= 'Z')
+				l = (l - 'A') + 'a';
+			if ('A' <= r && r <= 'Z')
+				r = (r - 'A') + 'a';
+			if (l != r)
+				return 0;
+			}
+		++pattern;
+		++subject;
+		--pattern_len;
+		}
+	return 1;
+	}
+
+/* Compare using memcmp. */
+static int equal_case(const unsigned char *pattern, size_t pattern_len,
+		      const unsigned char *subject, size_t subject_len)
+{
+	/* The pattern must not contain NUL characters. */
+	if (memchr(pattern, '\0', pattern_len) != NULL)
+		return 0;
+	if (pattern_len != subject_len)
+		return 0;
+	return !memcmp(pattern, subject, pattern_len);
+}
+
+/* RFC 5280, section 7.5, requires that only the domain is compared in
+   a case-insensitive manner. */
+static int equal_email(const unsigned char *a, size_t a_len,
+		       const unsigned char *b, size_t b_len)
+	{
+	size_t i = a_len;
+	if (a_len != b_len)
+		return 0;
+	/* We search backwards for the '@' character, so that we do
+	   not have to deal with quoted local-parts.  The domain part
+	   is compared in a case-insensitive manner. */
+	while (i > 0)
+		{
+		--i;
+		if (a[i] == '@' || b[i] == '@')
+			{
+			if (!equal_nocase(a + i, a_len - i,
+					  b + i, a_len - i))
+				return 0;
+			break;
+			}
+		}
+	if (i == 0)
+		i = a_len;
+	return equal_case(a, i, b, i);
+	}
+
+/* Compare the prefix and suffix with the subject, and check that the
+   characters in-between are valid. */
+static int wildcard_match(const unsigned char *prefix, size_t prefix_len,
+			  const unsigned char *suffix, size_t suffix_len,
+			  const unsigned char *subject, size_t subject_len)
+	{
+	const unsigned char *wildcard_start;
+	const unsigned char *wildcard_end;
+	const unsigned char *p;
+	if (subject_len < prefix_len + suffix_len)
+		return 0;
+	if (!equal_nocase(prefix, prefix_len, subject, prefix_len))
+		return 0;
+	wildcard_start = subject + prefix_len;
+	wildcard_end = subject + (subject_len - suffix_len);
+	if (!equal_nocase(wildcard_end, suffix_len, suffix, suffix_len))
+		return 0;
+	/* The wildcard must match at least one character. */
+	if (wildcard_start == wildcard_end)
+		return 0;
+	/* Check that the part matched by the wildcard contains only
+	   permitted characters and only matches a single label. */
+	for (p = wildcard_start; p != wildcard_end; ++p)
+		if (!(('0' <= *p && *p <= '9') ||
+		      ('A' <= *p && *p <= 'Z') ||
+		      ('a' <= *p && *p <= 'z') ||
+		      *p == '-'))
+			return 0;
+	return 1;
+	}
+
+/* Checks if the memory region consistens of [0-9A-Za-z.-]. */
+static int valid_domain_characters(const unsigned char *p, size_t len)
+	{
+	while (len)
+		{
+		if (!(('0' <= *p && *p <= '9') ||
+		      ('A' <= *p && *p <= 'Z') ||
+		      ('a' <= *p && *p <= 'z') ||
+		      *p == '-' || *p == '.'))
+			return 0;
+		++p;
+		--len;
+		}
+	return 1;
+	}
+
+/* Find the '*' in a wildcard pattern.  If no such character is found
+   or the pattern is otherwise invalid, returns NULL. */
+static const unsigned char *wildcard_find_star(const unsigned char *pattern,
+					       size_t pattern_len)
+	{
+	const unsigned char *star = memchr(pattern, '*', pattern_len);
+	size_t dot_count = 0;
+	const unsigned char *suffix_start;
+	size_t suffix_length;
+	if (star == NULL)
+		return NULL;
+	suffix_start = star + 1;
+	suffix_length = (pattern + pattern_len) - (star + 1);
+	if (!(valid_domain_characters(pattern, star - pattern) &&
+	      valid_domain_characters(suffix_start, suffix_length)))
+		return NULL;
+	/* Check that the suffix matches at least two labels. */
+	while (suffix_length)
+		{
+		if (*suffix_start == '.')
+			++dot_count;
+		++suffix_start;
+		--suffix_length;
+		}
+	if (dot_count < 2)
+		return NULL;
+	return star;
+	}
+
+/* Compare using wildcards. */
+static int equal_wildcard(const unsigned char *pattern, size_t pattern_len,
+			  const unsigned char *subject, size_t subject_len)
+	{
+	const unsigned char *star = wildcard_find_star(pattern, pattern_len);
+	if (star == NULL)
+		return equal_nocase(pattern, pattern_len,
+				    subject, subject_len);
+	return wildcard_match(pattern, star - pattern,
+			      star + 1, (pattern + pattern_len) - star - 1,
+			      subject, subject_len);
+	}
+
+/* Compare an ASN1_STRING to a supplied string. If they match
+ * return 1. If cmp_type > 0 only compare if string matches the
+ * type, otherwise convert it to UTF8.
+ */
+
+static int do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal,
+				const unsigned char *b, size_t blen)
+	{
+	if (!a->data || !a->length)
+		return 0;
+	if (cmp_type > 0)
+		{
+		if (cmp_type != a->type)
+			return 0;
+		if (cmp_type == V_ASN1_IA5STRING)
+			return equal(a->data, a->length, b, blen);
+		if (a->length == (int)blen && !memcmp(a->data, b, blen))
+			return 1;
+		else
+			return 0;
+		}
+	else
+		{
+		int astrlen, rv;
+		unsigned char *astr;
+		astrlen = ASN1_STRING_to_UTF8(&astr, a);
+		if (astrlen < 0)
+			return -1;
+		rv = equal(astr, astrlen, b, blen);
+		OPENSSL_free(astr);
+		return rv;
+		}
+	}
+
+static int do_x509_check(X509 *x, const unsigned char *chk, size_t chklen,
+					unsigned int flags, int check_type)
+	{
+	STACK_OF(GENERAL_NAME) *gens = NULL;
+	X509_NAME *name = NULL;
+	int i;
+	int cnid;
+	int alt_type;
+	equal_fn equal;
+	if (check_type == GEN_EMAIL)
+		{
+		cnid = NID_pkcs9_emailAddress;
+		alt_type = V_ASN1_IA5STRING;
+		equal = equal_email;
+		}
+	else if (check_type == GEN_DNS)
+		{
+		cnid = NID_commonName;
+		alt_type = V_ASN1_IA5STRING;
+		if (flags & X509_CHECK_FLAG_NO_WILDCARDS)
+			equal = equal_nocase;
+		else
+			equal = equal_wildcard;
+		}
+	else
+		{
+		cnid = 0;
+		alt_type = V_ASN1_OCTET_STRING;
+		equal = equal_case;
+		}
+
+	if (chklen == 0)
+		chklen = strlen((const char *)chk);
+
+	gens = X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
+	if (gens)
+		{
+		int rv = 0;
+		for (i = 0; i < sk_GENERAL_NAME_num(gens); i++)
+			{
+			GENERAL_NAME *gen;
+			ASN1_STRING *cstr;
+			gen = sk_GENERAL_NAME_value(gens, i);
+			if(gen->type != check_type)
+				continue;
+			if (check_type == GEN_EMAIL)
+				cstr = gen->d.rfc822Name;
+			else if (check_type == GEN_DNS)
+				cstr = gen->d.dNSName;
+			else
+				cstr = gen->d.iPAddress;
+			if (do_check_string(cstr, alt_type, equal, chk, chklen))
+				{
+				rv = 1;
+				break;
+				}
+			}
+		GENERAL_NAMES_free(gens);
+		if (rv)
+			return 1;
+		if (!(flags & X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT) || !cnid)
+			return 0;
+		}
+	i = -1;
+	name = X509_get_subject_name(x);
+	while((i = X509_NAME_get_index_by_NID(name, cnid, i)) >= 0)
+		{
+		X509_NAME_ENTRY *ne;
+		ASN1_STRING *str;
+		ne = X509_NAME_get_entry(name, i);
+		str = X509_NAME_ENTRY_get_data(ne);
+		if (do_check_string(str, -1, equal, chk, chklen))
+			return 1;
+		}
+	return 0;
+	}
+
+#if OPENSSL_VERSION_NUMBER < 0x1000200fL
+
+int X509_check_host(X509 *x, const unsigned char *chk, size_t chklen,
+					unsigned int flags, char **peername)
+	{
+	return do_x509_check(x, chk, chklen, flags, GEN_DNS);
+	}
+
+int X509_check_email(X509 *x, const unsigned char *chk, size_t chklen,
+					unsigned int flags)
+	{
+	return do_x509_check(x, chk, chklen, flags, GEN_EMAIL);
+	}
+
+int X509_check_ip(X509 *x, const unsigned char *chk, size_t chklen,
+					unsigned int flags)
+	{
+	return do_x509_check(x, chk, chklen, flags, GEN_IPADD);
+	}
+
+#endif /* OPENSSL_VERSION_NUMBER < 0x1000200fL */
+
+#endif

--- a/grove/vendor/github.com/spacemonkeygo/openssl/hostname.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/hostname.go
@@ -1,0 +1,132 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+/*
+#include <openssl/ssl.h>
+#include <openssl/conf.h>
+#include <openssl/x509.h>
+
+#ifndef X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
+#define X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT	0x1
+#define X509_CHECK_FLAG_NO_WILDCARDS	0x2
+
+extern int X509_check_host(X509 *x, const unsigned char *chk, size_t chklen,
+    unsigned int flags, char **peername);
+extern int X509_check_email(X509 *x, const unsigned char *chk, size_t chklen,
+    unsigned int flags);
+extern int X509_check_ip(X509 *x, const unsigned char *chk, size_t chklen,
+		unsigned int flags);
+#endif
+*/
+import "C"
+
+import (
+	"errors"
+	"net"
+	"unsafe"
+)
+
+var (
+	ValidationError = errors.New("Host validation error")
+)
+
+type CheckFlags int
+
+const (
+	AlwaysCheckSubject CheckFlags = C.X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
+	NoWildcards        CheckFlags = C.X509_CHECK_FLAG_NO_WILDCARDS
+)
+
+// CheckHost checks that the X509 certificate is signed for the provided
+// host name. See http://www.openssl.org/docs/crypto/X509_check_host.html for
+// more. Note that CheckHost does not check the IP field. See VerifyHostname.
+// Specifically returns ValidationError if the Certificate didn't match but
+// there was no internal error.
+func (c *Certificate) CheckHost(host string, flags CheckFlags) error {
+	chost := unsafe.Pointer(C.CString(host))
+	defer C.free(chost)
+
+	rv := C.X509_check_host(c.x, (*C.uchar)(chost), C.size_t(len(host)),
+		C.uint(flags), nil)
+	if rv > 0 {
+		return nil
+	}
+	if rv == 0 {
+		return ValidationError
+	}
+	return errors.New("hostname validation had an internal failure")
+}
+
+// CheckEmail checks that the X509 certificate is signed for the provided
+// email address. See http://www.openssl.org/docs/crypto/X509_check_host.html
+// for more.
+// Specifically returns ValidationError if the Certificate didn't match but
+// there was no internal error.
+func (c *Certificate) CheckEmail(email string, flags CheckFlags) error {
+	cemail := unsafe.Pointer(C.CString(email))
+	defer C.free(cemail)
+	rv := C.X509_check_email(c.x, (*C.uchar)(cemail), C.size_t(len(email)),
+		C.uint(flags))
+	if rv > 0 {
+		return nil
+	}
+	if rv == 0 {
+		return ValidationError
+	}
+	return errors.New("email validation had an internal failure")
+}
+
+// CheckIP checks that the X509 certificate is signed for the provided
+// IP address. See http://www.openssl.org/docs/crypto/X509_check_host.html
+// for more.
+// Specifically returns ValidationError if the Certificate didn't match but
+// there was no internal error.
+func (c *Certificate) CheckIP(ip net.IP, flags CheckFlags) error {
+	// X509_check_ip will fail to validate the 16-byte representation of an IPv4
+	// address, so convert to the 4-byte representation.
+	if ip4 := ip.To4(); ip4 != nil {
+		ip = ip4
+	}
+
+	cip := unsafe.Pointer(&ip[0])
+	rv := C.X509_check_ip(c.x, (*C.uchar)(cip), C.size_t(len(ip)),
+		C.uint(flags))
+	if rv > 0 {
+		return nil
+	}
+	if rv == 0 {
+		return ValidationError
+	}
+	return errors.New("ip validation had an internal failure")
+}
+
+// VerifyHostname is a combination of CheckHost and CheckIP. If the provided
+// hostname looks like an IP address, it will be checked as an IP address,
+// otherwise it will be checked as a hostname.
+// Specifically returns ValidationError if the Certificate didn't match but
+// there was no internal error.
+func (c *Certificate) VerifyHostname(host string) error {
+	var ip net.IP
+	if len(host) >= 3 && host[0] == '[' && host[len(host)-1] == ']' {
+		ip = net.ParseIP(host[1 : len(host)-1])
+	} else {
+		ip = net.ParseIP(host)
+	}
+	if ip != nil {
+		return c.CheckIP(ip, 0)
+	}
+	return c.CheckHost(host, 0)
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/http.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/http.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"net/http"
+)
+
+// ListenAndServeTLS will take an http.Handler and serve it using OpenSSL over
+// the given tcp address, configured to use the provided cert and key files.
+func ListenAndServeTLS(addr string, cert_file string, key_file string,
+	handler http.Handler) error {
+	return ServerListenAndServeTLS(
+		&http.Server{Addr: addr, Handler: handler}, cert_file, key_file)
+}
+
+// ServerListenAndServeTLS will take an http.Server and serve it using OpenSSL
+// configured to use the provided cert and key files.
+func ServerListenAndServeTLS(srv *http.Server,
+	cert_file, key_file string) error {
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+
+	ctx, err := NewCtxFromFiles(cert_file, key_file)
+	if err != nil {
+		return err
+	}
+
+	l, err := Listen("tcp", addr, ctx)
+	if err != nil {
+		return err
+	}
+
+	return srv.Serve(l)
+}
+
+// TODO: http client integration
+// holy crap, getting this integrated nicely with the Go stdlib HTTP client
+// stack so that it does proxying, connection pooling, and most importantly
+// hostname verification is really hard. So much stuff is hardcoded to just use
+// the built-in TLS lib. I think to get this to work either some crazy
+// hacktackery beyond me, an almost straight up fork of the HTTP client, or
+// serious stdlib internal refactoring is necessary.
+// even more so, good luck getting openssl to use the operating system default
+// root certificates if the user doesn't provide any. sadlol
+// NOTE: if you're going to try and write your own round tripper, at least use
+//  openssl.Dial, or equivalent logic

--- a/grove/vendor/github.com/spacemonkeygo/openssl/init.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/init.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package openssl is a light wrapper around OpenSSL for Go.
+
+It strives to provide a near-drop-in replacement for the Go standard library
+tls package, while allowing for:
+
+Performance
+
+OpenSSL is battle-tested and optimized C. While Go's built-in library shows
+great promise, it is still young and in some places, inefficient. This simple
+OpenSSL wrapper can often do at least 2x with the same cipher and protocol.
+
+On my lappytop, I get the following benchmarking speeds:
+  BenchmarkSHA1Large_openssl      1000  2611282 ns/op  401.56 MB/s
+  BenchmarkSHA1Large_stdlib        500  3963983 ns/op  264.53 MB/s
+  BenchmarkSHA1Small_openssl   1000000     3476 ns/op    0.29 MB/s
+  BenchmarkSHA1Small_stdlib    5000000      550 ns/op    1.82 MB/s
+  BenchmarkSHA256Large_openssl     200  8085314 ns/op  129.69 MB/s
+  BenchmarkSHA256Large_stdlib      100 18948189 ns/op   55.34 MB/s
+  BenchmarkSHA256Small_openssl 1000000     4262 ns/op    0.23 MB/s
+  BenchmarkSHA256Small_stdlib  1000000     1444 ns/op    0.69 MB/s
+  BenchmarkOpenSSLThroughput    100000    21634 ns/op   47.33 MB/s
+  BenchmarkStdlibThroughput      50000    58974 ns/op   17.36 MB/s
+
+Interoperability
+
+Many systems support OpenSSL with a variety of plugins and modules for things,
+such as hardware acceleration in embedded devices.
+
+Greater flexibility and configuration
+
+OpenSSL allows for far greater configuration of corner cases and backwards
+compatibility (such as support of SSLv2). You shouldn't be using SSLv2 if you
+can help but, but sometimes you can't help it.
+
+Security
+
+Yeah yeah, Heartbleed. But according to the author of the standard library's
+TLS implementation, Go's TLS library is vulnerable to timing attacks. And
+whether or not OpenSSL received the appropriate amount of scrutiny
+pre-Heartbleed, it sure is receiving it now.
+
+Usage
+
+Starting an HTTP server that uses OpenSSL is very easy. It's as simple as:
+  log.Fatal(openssl.ListenAndServeTLS(
+        ":8443", "my_server.crt", "my_server.key", myHandler))
+
+Getting a net.Listener that uses OpenSSL is also easy:
+  ctx, err := openssl.NewCtxFromFiles("my_server.crt", "my_server.key")
+  if err != nil {
+          log.Fatal(err)
+  }
+  l, err := openssl.Listen("tcp", ":7777", ctx)
+
+Making a client connection is straightforward too:
+  ctx, err := NewCtx()
+  if err != nil {
+          log.Fatal(err)
+  }
+  err = ctx.LoadVerifyLocations("/etc/ssl/certs/ca-certificates.crt", "")
+  if err != nil {
+          log.Fatal(err)
+  }
+  conn, err := openssl.Dial("tcp", "localhost:7777", ctx, 0)
+
+Help wanted: To get this library to work with net/http's client, we
+had to fork net/http. It would be nice if an alternate http client library
+supported the generality needed to use OpenSSL instead of crypto/tls.
+*/
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func init() {
+	if rc := C.X_shim_init(); rc != 0 {
+		panic(fmt.Errorf("X_shim_init failed with %d", rc))
+	}
+}
+
+// errorFromErrorQueue needs to run in the same OS thread as the operation
+// that caused the possible error
+func errorFromErrorQueue() error {
+	var errs []string
+	for {
+		err := C.ERR_get_error()
+		if err == 0 {
+			break
+		}
+		errs = append(errs, fmt.Sprintf("%s:%s:%s",
+			C.GoString(C.ERR_lib_error_string(err)),
+			C.GoString(C.ERR_func_error_string(err)),
+			C.GoString(C.ERR_reason_error_string(err))))
+	}
+	return errors.New(fmt.Sprintf("SSL errors: %s", strings.Join(errs, "\n")))
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/init_posix.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/init_posix.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux darwin solaris
+// +build !windows
+
+package openssl
+
+/*
+#include <errno.h>
+#include <openssl/crypto.h>
+#include <pthread.h>
+
+pthread_mutex_t* goopenssl_locks;
+
+int go_init_locks() {
+	int rc = 0;
+	int nlock;
+	int i;
+	int locks_needed = CRYPTO_num_locks();
+
+	goopenssl_locks = (pthread_mutex_t*)malloc(
+		sizeof(pthread_mutex_t) * locks_needed);
+	if (!goopenssl_locks) {
+		return ENOMEM;
+	}
+	for (nlock = 0; nlock < locks_needed; ++nlock) {
+		rc = pthread_mutex_init(&goopenssl_locks[nlock], NULL);
+		if (rc != 0) {
+			break;
+		}
+	}
+
+	if (rc != 0) {
+		for (i = nlock - 1; i >= 0; --i) {
+			pthread_mutex_destroy(&goopenssl_locks[i]);
+		}
+		free(goopenssl_locks);
+		goopenssl_locks = NULL;
+	}
+	return rc;
+}
+
+void go_thread_locking_callback(int mode, int n, const char *file,
+	int line) {
+	if (mode & CRYPTO_LOCK) {
+		pthread_mutex_lock(&goopenssl_locks[n]);
+	} else {
+		pthread_mutex_unlock(&goopenssl_locks[n]);
+	}
+}
+*/
+import "C"

--- a/grove/vendor/github.com/spacemonkeygo/openssl/init_windows.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/init_windows.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package openssl
+
+/*
+#include <errno.h>
+#include <openssl/crypto.h>
+#include <windows.h>
+
+CRITICAL_SECTION* goopenssl_locks;
+
+int go_init_locks() {
+	int rc = 0;
+	int nlock;
+	int i;
+	int locks_needed = CRYPTO_num_locks();
+
+	goopenssl_locks = (CRITICAL_SECTION*)malloc(
+		sizeof(*goopenssl_locks) * locks_needed);
+	if (!goopenssl_locks) {
+		return ENOMEM;
+	}
+	for (nlock = 0; nlock < locks_needed; ++nlock) {
+		InitializeCriticalSection(&goopenssl_locks[nlock]);
+	}
+
+	return 0;
+}
+
+void go_thread_locking_callback(int mode, int n, const char *file,
+	int line) {
+	if (mode & CRYPTO_LOCK) {
+		EnterCriticalSection(&goopenssl_locks[n]);
+	} else {
+		LeaveCriticalSection(&goopenssl_locks[n]);
+	}
+}
+*/
+import "C"

--- a/grove/vendor/github.com/spacemonkeygo/openssl/key.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/key.go
@@ -1,0 +1,422 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"io/ioutil"
+	"runtime"
+	"unsafe"
+)
+
+type Method *C.EVP_MD
+
+var (
+	SHA1_Method   Method = C.X_EVP_sha1()
+	SHA256_Method Method = C.X_EVP_sha256()
+	SHA512_Method Method = C.X_EVP_sha512()
+)
+
+// Constants for the various key types.
+// Mapping of name -> NID taken from openssl/evp.h
+const (
+	KeyTypeNone    = NID_undef
+	KeyTypeRSA     = NID_rsaEncryption
+	KeyTypeRSA2    = NID_rsa
+	KeyTypeDSA     = NID_dsa
+	KeyTypeDSA1    = NID_dsa_2
+	KeyTypeDSA2    = NID_dsaWithSHA
+	KeyTypeDSA3    = NID_dsaWithSHA1
+	KeyTypeDSA4    = NID_dsaWithSHA1_2
+	KeyTypeDH      = NID_dhKeyAgreement
+	KeyTypeDHX     = NID_dhpublicnumber
+	KeyTypeEC      = NID_X9_62_id_ecPublicKey
+	KeyTypeHMAC    = NID_hmac
+	KeyTypeCMAC    = NID_cmac
+	KeyTypeTLS1PRF = NID_tls1_prf
+	KeyTypeHKDF    = NID_hkdf
+)
+
+type PublicKey interface {
+	// Verifies the data signature using PKCS1.15
+	VerifyPKCS1v15(method Method, data, sig []byte) error
+
+	// MarshalPKIXPublicKeyPEM converts the public key to PEM-encoded PKIX
+	// format
+	MarshalPKIXPublicKeyPEM() (pem_block []byte, err error)
+
+	// MarshalPKIXPublicKeyDER converts the public key to DER-encoded PKIX
+	// format
+	MarshalPKIXPublicKeyDER() (der_block []byte, err error)
+
+	// KeyType returns an identifier for what kind of key is represented by this
+	// object.
+	KeyType() NID
+
+	// BaseType returns an identifier for what kind of key is represented
+	// by this object.
+	// Keys that share same algorithm but use different legacy formats
+	// will have the same BaseType.
+	//
+	// For example, a key with a `KeyType() == KeyTypeRSA` and a key with a
+	// `KeyType() == KeyTypeRSA2` would both have `BaseType() == KeyTypeRSA`.
+	BaseType() NID
+
+	evpPKey() *C.EVP_PKEY
+}
+
+type PrivateKey interface {
+	PublicKey
+
+	// Signs the data using PKCS1.15
+	SignPKCS1v15(Method, []byte) ([]byte, error)
+
+	// MarshalPKCS1PrivateKeyPEM converts the private key to PEM-encoded PKCS1
+	// format
+	MarshalPKCS1PrivateKeyPEM() (pem_block []byte, err error)
+
+	// MarshalPKCS1PrivateKeyDER converts the private key to DER-encoded PKCS1
+	// format
+	MarshalPKCS1PrivateKeyDER() (der_block []byte, err error)
+}
+
+type pKey struct {
+	key *C.EVP_PKEY
+}
+
+func (key *pKey) evpPKey() *C.EVP_PKEY { return key.key }
+
+func (key *pKey) KeyType() NID {
+	return NID(C.EVP_PKEY_id(key.key))
+}
+
+func (key *pKey) BaseType() NID {
+	return NID(C.EVP_PKEY_base_id(key.key))
+}
+
+func (key *pKey) SignPKCS1v15(method Method, data []byte) ([]byte, error) {
+	ctx := C.X_EVP_MD_CTX_new()
+	defer C.X_EVP_MD_CTX_free(ctx)
+
+	if 1 != C.X_EVP_SignInit(ctx, method) {
+		return nil, errors.New("signpkcs1v15: failed to init signature")
+	}
+	if len(data) > 0 {
+		if 1 != C.X_EVP_SignUpdate(
+			ctx, unsafe.Pointer(&data[0]), C.uint(len(data))) {
+			return nil, errors.New("signpkcs1v15: failed to update signature")
+		}
+	}
+	sig := make([]byte, C.X_EVP_PKEY_size(key.key))
+	var sigblen C.uint
+	if 1 != C.X_EVP_SignFinal(ctx,
+		((*C.uchar)(unsafe.Pointer(&sig[0]))), &sigblen, key.key) {
+		return nil, errors.New("signpkcs1v15: failed to finalize signature")
+	}
+	return sig[:sigblen], nil
+}
+
+func (key *pKey) VerifyPKCS1v15(method Method, data, sig []byte) error {
+	ctx := C.X_EVP_MD_CTX_new()
+	defer C.X_EVP_MD_CTX_free(ctx)
+
+	if 1 != C.X_EVP_VerifyInit(ctx, method) {
+		return errors.New("verifypkcs1v15: failed to init verify")
+	}
+	if len(data) > 0 {
+		if 1 != C.X_EVP_VerifyUpdate(
+			ctx, unsafe.Pointer(&data[0]), C.uint(len(data))) {
+			return errors.New("verifypkcs1v15: failed to update verify")
+		}
+	}
+	if 1 != C.X_EVP_VerifyFinal(ctx,
+		((*C.uchar)(unsafe.Pointer(&sig[0]))), C.uint(len(sig)), key.key) {
+		return errors.New("verifypkcs1v15: failed to finalize verify")
+	}
+	return nil
+}
+
+func (key *pKey) MarshalPKCS1PrivateKeyPEM() (pem_block []byte,
+	err error) {
+	bio := C.BIO_new(C.BIO_s_mem())
+	if bio == nil {
+		return nil, errors.New("failed to allocate memory BIO")
+	}
+	defer C.BIO_free(bio)
+
+	// PEM_write_bio_PrivateKey_traditional will use the key-specific PKCS1
+	// format if one is available for that key type, otherwise it will encode
+	// to a PKCS8 key.
+	if int(C.X_PEM_write_bio_PrivateKey_traditional(bio, key.key, nil, nil,
+		C.int(0), nil, nil)) != 1 {
+		return nil, errors.New("failed dumping private key")
+	}
+
+	return ioutil.ReadAll(asAnyBio(bio))
+}
+
+func (key *pKey) MarshalPKCS1PrivateKeyDER() (der_block []byte,
+	err error) {
+	bio := C.BIO_new(C.BIO_s_mem())
+	if bio == nil {
+		return nil, errors.New("failed to allocate memory BIO")
+	}
+	defer C.BIO_free(bio)
+
+	if int(C.i2d_PrivateKey_bio(bio, key.key)) != 1 {
+		return nil, errors.New("failed dumping private key der")
+	}
+
+	return ioutil.ReadAll(asAnyBio(bio))
+}
+
+func (key *pKey) MarshalPKIXPublicKeyPEM() (pem_block []byte,
+	err error) {
+	bio := C.BIO_new(C.BIO_s_mem())
+	if bio == nil {
+		return nil, errors.New("failed to allocate memory BIO")
+	}
+	defer C.BIO_free(bio)
+
+	if int(C.PEM_write_bio_PUBKEY(bio, key.key)) != 1 {
+		return nil, errors.New("failed dumping public key pem")
+	}
+
+	return ioutil.ReadAll(asAnyBio(bio))
+}
+
+func (key *pKey) MarshalPKIXPublicKeyDER() (der_block []byte,
+	err error) {
+	bio := C.BIO_new(C.BIO_s_mem())
+	if bio == nil {
+		return nil, errors.New("failed to allocate memory BIO")
+	}
+	defer C.BIO_free(bio)
+
+	if int(C.i2d_PUBKEY_bio(bio, key.key)) != 1 {
+		return nil, errors.New("failed dumping public key der")
+	}
+
+	return ioutil.ReadAll(asAnyBio(bio))
+}
+
+// LoadPrivateKeyFromPEM loads a private key from a PEM-encoded block.
+func LoadPrivateKeyFromPEM(pem_block []byte) (PrivateKey, error) {
+	if len(pem_block) == 0 {
+		return nil, errors.New("empty pem block")
+	}
+	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
+		C.int(len(pem_block)))
+	if bio == nil {
+		return nil, errors.New("failed creating bio")
+	}
+	defer C.BIO_free(bio)
+
+	key := C.PEM_read_bio_PrivateKey(bio, nil, nil, nil)
+	if key == nil {
+		return nil, errors.New("failed reading private key")
+	}
+
+	p := &pKey{key: key}
+	runtime.SetFinalizer(p, func(p *pKey) {
+		C.X_EVP_PKEY_free(p.key)
+	})
+	return p, nil
+}
+
+// LoadPrivateKeyFromPEMWithPassword loads a private key from a PEM-encoded block.
+func LoadPrivateKeyFromPEMWithPassword(pem_block []byte, password string) (
+	PrivateKey, error) {
+	if len(pem_block) == 0 {
+		return nil, errors.New("empty pem block")
+	}
+	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
+		C.int(len(pem_block)))
+	if bio == nil {
+		return nil, errors.New("failed creating bio")
+	}
+	defer C.BIO_free(bio)
+	cs := C.CString(password)
+	defer C.free(unsafe.Pointer(cs))
+	key := C.PEM_read_bio_PrivateKey(bio, nil, nil, unsafe.Pointer(cs))
+	if key == nil {
+		return nil, errors.New("failed reading private key")
+	}
+
+	p := &pKey{key: key}
+	runtime.SetFinalizer(p, func(p *pKey) {
+		C.X_EVP_PKEY_free(p.key)
+	})
+	return p, nil
+}
+
+// LoadPrivateKeyFromDER loads a private key from a DER-encoded block.
+func LoadPrivateKeyFromDER(der_block []byte) (PrivateKey, error) {
+	if len(der_block) == 0 {
+		return nil, errors.New("empty der block")
+	}
+	bio := C.BIO_new_mem_buf(unsafe.Pointer(&der_block[0]),
+		C.int(len(der_block)))
+	if bio == nil {
+		return nil, errors.New("failed creating bio")
+	}
+	defer C.BIO_free(bio)
+
+	key := C.d2i_PrivateKey_bio(bio, nil)
+	if key == nil {
+		return nil, errors.New("failed reading private key der")
+	}
+
+	p := &pKey{key: key}
+	runtime.SetFinalizer(p, func(p *pKey) {
+		C.X_EVP_PKEY_free(p.key)
+	})
+	return p, nil
+}
+
+// LoadPrivateKeyFromPEMWidthPassword loads a private key from a PEM-encoded block.
+// Backwards-compatible with typo
+func LoadPrivateKeyFromPEMWidthPassword(pem_block []byte, password string) (
+	PrivateKey, error) {
+	return LoadPrivateKeyFromPEMWithPassword(pem_block, password)
+}
+
+// LoadPublicKeyFromPEM loads a public key from a PEM-encoded block.
+func LoadPublicKeyFromPEM(pem_block []byte) (PublicKey, error) {
+	if len(pem_block) == 0 {
+		return nil, errors.New("empty pem block")
+	}
+	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
+		C.int(len(pem_block)))
+	if bio == nil {
+		return nil, errors.New("failed creating bio")
+	}
+	defer C.BIO_free(bio)
+
+	key := C.PEM_read_bio_PUBKEY(bio, nil, nil, nil)
+	if key == nil {
+		return nil, errors.New("failed reading public key der")
+	}
+
+	p := &pKey{key: key}
+	runtime.SetFinalizer(p, func(p *pKey) {
+		C.X_EVP_PKEY_free(p.key)
+	})
+	return p, nil
+}
+
+// LoadPublicKeyFromDER loads a public key from a DER-encoded block.
+func LoadPublicKeyFromDER(der_block []byte) (PublicKey, error) {
+	if len(der_block) == 0 {
+		return nil, errors.New("empty der block")
+	}
+	bio := C.BIO_new_mem_buf(unsafe.Pointer(&der_block[0]),
+		C.int(len(der_block)))
+	if bio == nil {
+		return nil, errors.New("failed creating bio")
+	}
+	defer C.BIO_free(bio)
+
+	key := C.d2i_PUBKEY_bio(bio, nil)
+	if key == nil {
+		return nil, errors.New("failed reading public key der")
+	}
+
+	p := &pKey{key: key}
+	runtime.SetFinalizer(p, func(p *pKey) {
+		C.X_EVP_PKEY_free(p.key)
+	})
+	return p, nil
+}
+
+// GenerateRSAKey generates a new RSA private key with an exponent of 3.
+func GenerateRSAKey(bits int) (PrivateKey, error) {
+	return GenerateRSAKeyWithExponent(bits, 3)
+}
+
+// GenerateRSAKeyWithExponent generates a new RSA private key.
+func GenerateRSAKeyWithExponent(bits int, exponent int) (PrivateKey, error) {
+	rsa := C.RSA_generate_key(C.int(bits), C.ulong(exponent), nil, nil)
+	if rsa == nil {
+		return nil, errors.New("failed to generate RSA key")
+	}
+	key := C.X_EVP_PKEY_new()
+	if key == nil {
+		return nil, errors.New("failed to allocate EVP_PKEY")
+	}
+	if C.X_EVP_PKEY_assign_charp(key, C.EVP_PKEY_RSA, (*C.char)(unsafe.Pointer(rsa))) != 1 {
+		C.X_EVP_PKEY_free(key)
+		return nil, errors.New("failed to assign RSA key")
+	}
+	p := &pKey{key: key}
+	runtime.SetFinalizer(p, func(p *pKey) {
+		C.X_EVP_PKEY_free(p.key)
+	})
+	return p, nil
+}
+
+// GenerateECKey generates a new elliptic curve private key on the speicified
+// curve.
+func GenerateECKey(curve EllipticCurve) (PrivateKey, error) {
+
+	// Create context for parameter generation
+	paramCtx := C.EVP_PKEY_CTX_new_id(C.EVP_PKEY_EC, nil)
+	if paramCtx == nil {
+		return nil, errors.New("failed creating EC parameter generation context")
+	}
+	defer C.EVP_PKEY_CTX_free(paramCtx)
+
+	// Intialize the parameter generation
+	if int(C.EVP_PKEY_paramgen_init(paramCtx)) != 1 {
+		return nil, errors.New("failed initializing EC parameter generation context")
+	}
+
+	// Set curve in EC parameter generation context
+	if int(C.X_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(paramCtx, C.int(curve))) != 1 {
+		return nil, errors.New("failed setting curve in EC parameter generation context")
+	}
+
+	// Create parameter object
+	var params *C.EVP_PKEY
+	if int(C.EVP_PKEY_paramgen(paramCtx, &params)) != 1 {
+		return nil, errors.New("failed creating EC key generation parameters")
+	}
+	defer C.EVP_PKEY_free(params)
+
+	// Create context for the key generation
+	keyCtx := C.EVP_PKEY_CTX_new(params, nil)
+	if keyCtx == nil {
+		return nil, errors.New("failed creating EC key generation context")
+	}
+	defer C.EVP_PKEY_CTX_free(keyCtx)
+
+	// Generate the key
+	var privKey *C.EVP_PKEY
+	if int(C.EVP_PKEY_keygen_init(keyCtx)) != 1 {
+		return nil, errors.New("failed initializing EC key generation context")
+	}
+	if int(C.EVP_PKEY_keygen(keyCtx, &privKey)) != 1 {
+		return nil, errors.New("failed generating EC private key")
+	}
+
+	p := &pKey{key: privKey}
+	runtime.SetFinalizer(p, func(p *pKey) {
+		C.X_EVP_PKEY_free(p.key)
+	})
+	return p, nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/key_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/key_test.go
@@ -1,0 +1,355 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	pem_pkg "encoding/pem"
+	"io/ioutil"
+	"testing"
+)
+
+func TestMarshal(t *testing.T) {
+	key, err := LoadPrivateKeyFromPEM(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := LoadCertificateFromPEM(certBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privateBlock, _ := pem_pkg.Decode(keyBytes)
+	key, err = LoadPrivateKeyFromDER(privateBlock.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pem, err := cert.MarshalPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(pem, certBytes) {
+		ioutil.WriteFile("generated", pem, 0644)
+		ioutil.WriteFile("hardcoded", certBytes, 0644)
+		t.Fatal("invalid cert pem bytes")
+	}
+
+	pem, err = key.MarshalPKCS1PrivateKeyPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(pem, keyBytes) {
+		ioutil.WriteFile("generated", pem, 0644)
+		ioutil.WriteFile("hardcoded", keyBytes, 0644)
+		t.Fatal("invalid private key pem bytes")
+	}
+	tls_cert, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_key, ok := tls_cert.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatal("FASDFASDF")
+	}
+	_ = tls_key
+
+	der, err := key.MarshalPKCS1PrivateKeyDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_der := x509.MarshalPKCS1PrivateKey(tls_key)
+	if !bytes.Equal(der, tls_der) {
+		t.Fatalf("invalid private key der bytes: %s\n v.s. %s\n",
+			hex.Dump(der), hex.Dump(tls_der))
+	}
+
+	der, err = key.MarshalPKIXPublicKeyDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_der, err = x509.MarshalPKIXPublicKey(&tls_key.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(der, tls_der) {
+		ioutil.WriteFile("generated", []byte(hex.Dump(der)), 0644)
+		ioutil.WriteFile("hardcoded", []byte(hex.Dump(tls_der)), 0644)
+		t.Fatal("invalid public key der bytes")
+	}
+
+	pem, err = key.MarshalPKIXPublicKeyPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_pem := pem_pkg.EncodeToMemory(&pem_pkg.Block{
+		Type: "PUBLIC KEY", Bytes: tls_der})
+	if !bytes.Equal(pem, tls_pem) {
+		ioutil.WriteFile("generated", pem, 0644)
+		ioutil.WriteFile("hardcoded", tls_pem, 0644)
+		t.Fatal("invalid public key pem bytes")
+	}
+
+	loaded_pubkey_from_pem, err := LoadPublicKeyFromPEM(pem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loaded_pubkey_from_der, err := LoadPublicKeyFromDER(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	new_der_from_pem, err := loaded_pubkey_from_pem.MarshalPKIXPublicKeyDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	new_der_from_der, err := loaded_pubkey_from_der.MarshalPKIXPublicKeyDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(new_der_from_der, tls_der) {
+		ioutil.WriteFile("generated", []byte(hex.Dump(new_der_from_der)), 0644)
+		ioutil.WriteFile("hardcoded", []byte(hex.Dump(tls_der)), 0644)
+		t.Fatal("invalid public key der bytes")
+	}
+
+	if !bytes.Equal(new_der_from_pem, tls_der) {
+		ioutil.WriteFile("generated", []byte(hex.Dump(new_der_from_pem)), 0644)
+		ioutil.WriteFile("hardcoded", []byte(hex.Dump(tls_der)), 0644)
+		t.Fatal("invalid public key der bytes")
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	key, err := GenerateRSAKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = key.MarshalPKIXPublicKeyPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = key.MarshalPKCS1PrivateKeyPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = GenerateRSAKeyWithExponent(1024, 65537)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateEC(t *testing.T) {
+	key, err := GenerateECKey(Prime256v1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = key.MarshalPKIXPublicKeyPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = key.MarshalPKCS1PrivateKeyPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSign(t *testing.T) {
+	key, _ := GenerateRSAKey(1024)
+	data := []byte("the quick brown fox jumps over the lazy dog")
+	_, err := key.SignPKCS1v15(SHA1_Method, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = key.SignPKCS1v15(SHA256_Method, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = key.SignPKCS1v15(SHA512_Method, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSignEC(t *testing.T) {
+	t.Parallel()
+
+	key, err := GenerateECKey(Prime256v1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := []byte("the quick brown fox jumps over the lazy dog")
+
+	t.Run("sha1", func(t *testing.T) {
+		t.Parallel()
+		sig, err := key.SignPKCS1v15(SHA1_Method, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = key.VerifyPKCS1v15(SHA1_Method, data, sig)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("sha256", func(t *testing.T) {
+		t.Parallel()
+		sig, err := key.SignPKCS1v15(SHA256_Method, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = key.VerifyPKCS1v15(SHA256_Method, data, sig)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("sha512", func(t *testing.T) {
+		t.Parallel()
+		sig, err := key.SignPKCS1v15(SHA512_Method, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = key.VerifyPKCS1v15(SHA512_Method, data, sig)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestMarshalEC(t *testing.T) {
+	key, err := LoadPrivateKeyFromPEM(prime256v1KeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := LoadCertificateFromPEM(prime256v1CertBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privateBlock, _ := pem_pkg.Decode(prime256v1KeyBytes)
+	key, err = LoadPrivateKeyFromDER(privateBlock.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pem, err := cert.MarshalPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(pem, prime256v1CertBytes) {
+		ioutil.WriteFile("generated", pem, 0644)
+		ioutil.WriteFile("hardcoded", prime256v1CertBytes, 0644)
+		t.Fatal("invalid cert pem bytes")
+	}
+
+	pem, err = key.MarshalPKCS1PrivateKeyPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(pem, prime256v1KeyBytes) {
+		ioutil.WriteFile("generated", pem, 0644)
+		ioutil.WriteFile("hardcoded", prime256v1KeyBytes, 0644)
+		t.Fatal("invalid private key pem bytes")
+	}
+	tls_cert, err := tls.X509KeyPair(prime256v1CertBytes, prime256v1KeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_key, ok := tls_cert.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		t.Fatal("FASDFASDF")
+	}
+	_ = tls_key
+
+	der, err := key.MarshalPKCS1PrivateKeyDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_der, err := x509.MarshalECPrivateKey(tls_key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(der, tls_der) {
+		t.Fatalf("invalid private key der bytes: %s\n v.s. %s\n",
+			hex.Dump(der), hex.Dump(tls_der))
+	}
+
+	der, err = key.MarshalPKIXPublicKeyDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_der, err = x509.MarshalPKIXPublicKey(&tls_key.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(der, tls_der) {
+		ioutil.WriteFile("generated", []byte(hex.Dump(der)), 0644)
+		ioutil.WriteFile("hardcoded", []byte(hex.Dump(tls_der)), 0644)
+		t.Fatal("invalid public key der bytes")
+	}
+
+	pem, err = key.MarshalPKIXPublicKeyPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_pem := pem_pkg.EncodeToMemory(&pem_pkg.Block{
+		Type: "PUBLIC KEY", Bytes: tls_der})
+	if !bytes.Equal(pem, tls_pem) {
+		ioutil.WriteFile("generated", pem, 0644)
+		ioutil.WriteFile("hardcoded", tls_pem, 0644)
+		t.Fatal("invalid public key pem bytes")
+	}
+
+	loaded_pubkey_from_pem, err := LoadPublicKeyFromPEM(pem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loaded_pubkey_from_der, err := LoadPublicKeyFromDER(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	new_der_from_pem, err := loaded_pubkey_from_pem.MarshalPKIXPublicKeyDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	new_der_from_der, err := loaded_pubkey_from_der.MarshalPKIXPublicKeyDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(new_der_from_der, tls_der) {
+		ioutil.WriteFile("generated", []byte(hex.Dump(new_der_from_der)), 0644)
+		ioutil.WriteFile("hardcoded", []byte(hex.Dump(tls_der)), 0644)
+		t.Fatal("invalid public key der bytes")
+	}
+
+	if !bytes.Equal(new_der_from_pem, tls_der) {
+		ioutil.WriteFile("generated", []byte(hex.Dump(new_der_from_pem)), 0644)
+		ioutil.WriteFile("hardcoded", []byte(hex.Dump(tls_der)), 0644)
+		t.Fatal("invalid public key der bytes")
+	}
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/mapping.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/mapping.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"sync"
+	"unsafe"
+)
+
+// #include <stdlib.h>
+import "C"
+
+type mapping struct {
+	lock   sync.Mutex
+	values map[token]unsafe.Pointer
+}
+
+func newMapping() *mapping {
+	return &mapping{
+		values: make(map[token]unsafe.Pointer),
+	}
+}
+
+type token unsafe.Pointer
+
+func (m *mapping) Add(x unsafe.Pointer) token {
+	res := token(C.malloc(1))
+
+	m.lock.Lock()
+	m.values[res] = x
+	m.lock.Unlock()
+
+	return res
+}
+
+func (m *mapping) Get(x token) unsafe.Pointer {
+	m.lock.Lock()
+	res := m.values[x]
+	m.lock.Unlock()
+
+	return res
+}
+
+func (m *mapping) Del(x token) {
+	m.lock.Lock()
+	delete(m.values, x)
+	m.lock.Unlock()
+
+	C.free(unsafe.Pointer(x))
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/net.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/net.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"errors"
+	"net"
+)
+
+type listener struct {
+	net.Listener
+	ctx *Ctx
+}
+
+func (l *listener) Accept() (c net.Conn, err error) {
+	c, err = l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	ssl_c, err := Server(c, l.ctx)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+	return ssl_c, nil
+}
+
+// NewListener wraps an existing net.Listener such that all accepted
+// connections are wrapped as OpenSSL server connections using the provided
+// context ctx.
+func NewListener(inner net.Listener, ctx *Ctx) net.Listener {
+	return &listener{
+		Listener: inner,
+		ctx:      ctx}
+}
+
+// Listen is a wrapper around net.Listen that wraps incoming connections with
+// an OpenSSL server connection using the provided context ctx.
+func Listen(network, laddr string, ctx *Ctx) (net.Listener, error) {
+	if ctx == nil {
+		return nil, errors.New("no ssl context provided")
+	}
+	l, err := net.Listen(network, laddr)
+	if err != nil {
+		return nil, err
+	}
+	return NewListener(l, ctx), nil
+}
+
+type DialFlags int
+
+const (
+	InsecureSkipHostVerification DialFlags = 1 << iota
+	DisableSNI
+)
+
+// Dial will connect to network/address and then wrap the corresponding
+// underlying connection with an OpenSSL client connection using context ctx.
+// If flags includes InsecureSkipHostVerification, the server certificate's
+// hostname will not be checked to match the hostname in addr. Otherwise, flags
+// should be 0.
+//
+// Dial probably won't work for you unless you set a verify location or add
+// some certs to the certificate store of the client context you're using.
+// This library is not nice enough to use the system certificate store by
+// default for you yet.
+func Dial(network, addr string, ctx *Ctx, flags DialFlags) (*Conn, error) {
+	return DialSession(network, addr, ctx, flags, nil)
+}
+
+// DialSession will connect to network/address and then wrap the corresponding
+// underlying connection with an OpenSSL client connection using context ctx.
+// If flags includes InsecureSkipHostVerification, the server certificate's
+// hostname will not be checked to match the hostname in addr. Otherwise, flags
+// should be 0.
+//
+// Dial probably won't work for you unless you set a verify location or add
+// some certs to the certificate store of the client context you're using.
+// This library is not nice enough to use the system certificate store by
+// default for you yet.
+//
+// If session is not nil it will be used to resume the tls state. The session
+// can be retrieved from the GetSession method on the Conn.
+func DialSession(network, addr string, ctx *Ctx, flags DialFlags,
+	session []byte) (*Conn, error) {
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		var err error
+		ctx, err = NewCtx()
+		if err != nil {
+			return nil, err
+		}
+		// TODO: use operating system default certificate chain?
+	}
+	c, err := net.Dial(network, addr)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := Client(c, ctx)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+	if session != nil {
+		err := conn.setSession(session)
+		if err != nil {
+			c.Close()
+			return nil, err
+		}
+	}
+	if flags&DisableSNI == 0 {
+		err = conn.SetTlsExtHostName(host)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+	err = conn.Handshake()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if flags&InsecureSkipHostVerification == 0 {
+		err = conn.VerifyHostname(host)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+	return conn, nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/nid.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/nid.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+type NID int
+
+const (
+	NID_undef                              NID = 0
+	NID_rsadsi                             NID = 1
+	NID_pkcs                               NID = 2
+	NID_md2                                NID = 3
+	NID_md5                                NID = 4
+	NID_rc4                                NID = 5
+	NID_rsaEncryption                      NID = 6
+	NID_md2WithRSAEncryption               NID = 7
+	NID_md5WithRSAEncryption               NID = 8
+	NID_pbeWithMD2AndDES_CBC               NID = 9
+	NID_pbeWithMD5AndDES_CBC               NID = 10
+	NID_X500                               NID = 11
+	NID_X509                               NID = 12
+	NID_commonName                         NID = 13
+	NID_countryName                        NID = 14
+	NID_localityName                       NID = 15
+	NID_stateOrProvinceName                NID = 16
+	NID_organizationName                   NID = 17
+	NID_organizationalUnitName             NID = 18
+	NID_rsa                                NID = 19
+	NID_pkcs7                              NID = 20
+	NID_pkcs7_data                         NID = 21
+	NID_pkcs7_signed                       NID = 22
+	NID_pkcs7_enveloped                    NID = 23
+	NID_pkcs7_signedAndEnveloped           NID = 24
+	NID_pkcs7_digest                       NID = 25
+	NID_pkcs7_encrypted                    NID = 26
+	NID_pkcs3                              NID = 27
+	NID_dhKeyAgreement                     NID = 28
+	NID_des_ecb                            NID = 29
+	NID_des_cfb64                          NID = 30
+	NID_des_cbc                            NID = 31
+	NID_des_ede                            NID = 32
+	NID_des_ede3                           NID = 33
+	NID_idea_cbc                           NID = 34
+	NID_idea_cfb64                         NID = 35
+	NID_idea_ecb                           NID = 36
+	NID_rc2_cbc                            NID = 37
+	NID_rc2_ecb                            NID = 38
+	NID_rc2_cfb64                          NID = 39
+	NID_rc2_ofb64                          NID = 40
+	NID_sha                                NID = 41
+	NID_shaWithRSAEncryption               NID = 42
+	NID_des_ede_cbc                        NID = 43
+	NID_des_ede3_cbc                       NID = 44
+	NID_des_ofb64                          NID = 45
+	NID_idea_ofb64                         NID = 46
+	NID_pkcs9                              NID = 47
+	NID_pkcs9_emailAddress                 NID = 48
+	NID_pkcs9_unstructuredName             NID = 49
+	NID_pkcs9_contentType                  NID = 50
+	NID_pkcs9_messageDigest                NID = 51
+	NID_pkcs9_signingTime                  NID = 52
+	NID_pkcs9_countersignature             NID = 53
+	NID_pkcs9_challengePassword            NID = 54
+	NID_pkcs9_unstructuredAddress          NID = 55
+	NID_pkcs9_extCertAttributes            NID = 56
+	NID_netscape                           NID = 57
+	NID_netscape_cert_extension            NID = 58
+	NID_netscape_data_type                 NID = 59
+	NID_des_ede_cfb64                      NID = 60
+	NID_des_ede3_cfb64                     NID = 61
+	NID_des_ede_ofb64                      NID = 62
+	NID_des_ede3_ofb64                     NID = 63
+	NID_sha1                               NID = 64
+	NID_sha1WithRSAEncryption              NID = 65
+	NID_dsaWithSHA                         NID = 66
+	NID_dsa_2                              NID = 67
+	NID_pbeWithSHA1AndRC2_CBC              NID = 68
+	NID_id_pbkdf2                          NID = 69
+	NID_dsaWithSHA1_2                      NID = 70
+	NID_netscape_cert_type                 NID = 71
+	NID_netscape_base_url                  NID = 72
+	NID_netscape_revocation_url            NID = 73
+	NID_netscape_ca_revocation_url         NID = 74
+	NID_netscape_renewal_url               NID = 75
+	NID_netscape_ca_policy_url             NID = 76
+	NID_netscape_ssl_server_name           NID = 77
+	NID_netscape_comment                   NID = 78
+	NID_netscape_cert_sequence             NID = 79
+	NID_desx_cbc                           NID = 80
+	NID_id_ce                              NID = 81
+	NID_subject_key_identifier             NID = 82
+	NID_key_usage                          NID = 83
+	NID_private_key_usage_period           NID = 84
+	NID_subject_alt_name                   NID = 85
+	NID_issuer_alt_name                    NID = 86
+	NID_basic_constraints                  NID = 87
+	NID_crl_number                         NID = 88
+	NID_certificate_policies               NID = 89
+	NID_authority_key_identifier           NID = 90
+	NID_bf_cbc                             NID = 91
+	NID_bf_ecb                             NID = 92
+	NID_bf_cfb64                           NID = 93
+	NID_bf_ofb64                           NID = 94
+	NID_mdc2                               NID = 95
+	NID_mdc2WithRSA                        NID = 96
+	NID_rc4_40                             NID = 97
+	NID_rc2_40_cbc                         NID = 98
+	NID_givenName                          NID = 99
+	NID_surname                            NID = 100
+	NID_initials                           NID = 101
+	NID_uniqueIdentifier                   NID = 102
+	NID_crl_distribution_points            NID = 103
+	NID_md5WithRSA                         NID = 104
+	NID_serialNumber                       NID = 105
+	NID_title                              NID = 106
+	NID_description                        NID = 107
+	NID_cast5_cbc                          NID = 108
+	NID_cast5_ecb                          NID = 109
+	NID_cast5_cfb64                        NID = 110
+	NID_cast5_ofb64                        NID = 111
+	NID_pbeWithMD5AndCast5_CBC             NID = 112
+	NID_dsaWithSHA1                        NID = 113
+	NID_md5_sha1                           NID = 114
+	NID_sha1WithRSA                        NID = 115
+	NID_dsa                                NID = 116
+	NID_ripemd160                          NID = 117
+	NID_ripemd160WithRSA                   NID = 119
+	NID_rc5_cbc                            NID = 120
+	NID_rc5_ecb                            NID = 121
+	NID_rc5_cfb64                          NID = 122
+	NID_rc5_ofb64                          NID = 123
+	NID_rle_compression                    NID = 124
+	NID_zlib_compression                   NID = 125
+	NID_ext_key_usage                      NID = 126
+	NID_id_pkix                            NID = 127
+	NID_id_kp                              NID = 128
+	NID_server_auth                        NID = 129
+	NID_client_auth                        NID = 130
+	NID_code_sign                          NID = 131
+	NID_email_protect                      NID = 132
+	NID_time_stamp                         NID = 133
+	NID_ms_code_ind                        NID = 134
+	NID_ms_code_com                        NID = 135
+	NID_ms_ctl_sign                        NID = 136
+	NID_ms_sgc                             NID = 137
+	NID_ms_efs                             NID = 138
+	NID_ns_sgc                             NID = 139
+	NID_delta_crl                          NID = 140
+	NID_crl_reason                         NID = 141
+	NID_invalidity_date                    NID = 142
+	NID_sxnet                              NID = 143
+	NID_pbe_WithSHA1And128BitRC4           NID = 144
+	NID_pbe_WithSHA1And40BitRC4            NID = 145
+	NID_pbe_WithSHA1And3_Key_TripleDES_CBC NID = 146
+	NID_pbe_WithSHA1And2_Key_TripleDES_CBC NID = 147
+	NID_pbe_WithSHA1And128BitRC2_CBC       NID = 148
+	NID_pbe_WithSHA1And40BitRC2_CBC        NID = 149
+	NID_keyBag                             NID = 150
+	NID_pkcs8ShroudedKeyBag                NID = 151
+	NID_certBag                            NID = 152
+	NID_crlBag                             NID = 153
+	NID_secretBag                          NID = 154
+	NID_safeContentsBag                    NID = 155
+	NID_friendlyName                       NID = 156
+	NID_localKeyID                         NID = 157
+	NID_x509Certificate                    NID = 158
+	NID_sdsiCertificate                    NID = 159
+	NID_x509Crl                            NID = 160
+	NID_pbes2                              NID = 161
+	NID_pbmac1                             NID = 162
+	NID_hmacWithSHA1                       NID = 163
+	NID_id_qt_cps                          NID = 164
+	NID_id_qt_unotice                      NID = 165
+	NID_rc2_64_cbc                         NID = 166
+	NID_SMIMECapabilities                  NID = 167
+	NID_pbeWithMD2AndRC2_CBC               NID = 168
+	NID_pbeWithMD5AndRC2_CBC               NID = 169
+	NID_pbeWithSHA1AndDES_CBC              NID = 170
+	NID_ms_ext_req                         NID = 171
+	NID_ext_req                            NID = 172
+	NID_name                               NID = 173
+	NID_dnQualifier                        NID = 174
+	NID_id_pe                              NID = 175
+	NID_id_ad                              NID = 176
+	NID_info_access                        NID = 177
+	NID_ad_OCSP                            NID = 178
+	NID_ad_ca_issuers                      NID = 179
+	NID_OCSP_sign                          NID = 180
+	NID_X9_62_id_ecPublicKey               NID = 408
+	NID_hmac                               NID = 855
+	NID_cmac                               NID = 894
+	NID_dhpublicnumber                     NID = 920
+	NID_tls1_prf                           NID = 1021
+	NID_hkdf                               NID = 1036
+)

--- a/grove/vendor/github.com/spacemonkeygo/openssl/pem.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/pem.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"regexp"
+)
+
+var pemSplit *regexp.Regexp = regexp.MustCompile(`(?sm)` +
+	`(^-----[\s-]*?BEGIN.*?-----$` +
+	`.*?` +
+	`^-----[\s-]*?END.*?-----$)`)
+
+func SplitPEM(data []byte) [][]byte {
+	var results [][]byte
+	for _, block := range pemSplit.FindAll(data, -1) {
+		results = append(results, block)
+	}
+	return results
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/sha1.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/sha1.go
@@ -1,0 +1,96 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+type SHA1Hash struct {
+	ctx    *C.EVP_MD_CTX
+	engine *Engine
+}
+
+func NewSHA1Hash() (*SHA1Hash, error) { return NewSHA1HashWithEngine(nil) }
+
+func NewSHA1HashWithEngine(e *Engine) (*SHA1Hash, error) {
+	hash := &SHA1Hash{engine: e}
+	hash.ctx = C.X_EVP_MD_CTX_new()
+	if hash.ctx == nil {
+		return nil, errors.New("openssl: sha1: unable to allocate ctx")
+	}
+	runtime.SetFinalizer(hash, func(hash *SHA1Hash) { hash.Close() })
+	if err := hash.Reset(); err != nil {
+		return nil, err
+	}
+	return hash, nil
+}
+
+func (s *SHA1Hash) Close() {
+	if s.ctx != nil {
+		C.X_EVP_MD_CTX_free(s.ctx)
+		s.ctx = nil
+	}
+}
+
+func engineRef(e *Engine) *C.ENGINE {
+	if e == nil {
+		return nil
+	}
+	return e.e
+}
+
+func (s *SHA1Hash) Reset() error {
+	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_sha1(), engineRef(s.engine)) {
+		return errors.New("openssl: sha1: cannot init digest ctx")
+	}
+	return nil
+}
+
+func (s *SHA1Hash) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if 1 != C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
+		C.size_t(len(p))) {
+		return 0, errors.New("openssl: sha1: cannot update digest")
+	}
+	return len(p), nil
+}
+
+func (s *SHA1Hash) Sum() (result [20]byte, err error) {
+	if 1 != C.X_EVP_DigestFinal_ex(s.ctx,
+		(*C.uchar)(unsafe.Pointer(&result[0])), nil) {
+		return result, errors.New("openssl: sha1: cannot finalize ctx")
+	}
+	return result, s.Reset()
+}
+
+func SHA1(data []byte) (result [20]byte, err error) {
+	hash, err := NewSHA1Hash()
+	if err != nil {
+		return result, err
+	}
+	defer hash.Close()
+	if _, err := hash.Write(data); err != nil {
+		return result, err
+	}
+	return hash.Sum()
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/sha1_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/sha1_test.go
@@ -1,0 +1,109 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"io"
+	"testing"
+)
+
+func TestSHA1(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		buf := make([]byte, 10*1024-i)
+		if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+			t.Fatal(err)
+		}
+
+		expected := sha1.Sum(buf)
+		got, err := SHA1(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected != got {
+			t.Fatalf("exp:%x got:%x", expected, got)
+		}
+	}
+}
+
+func TestSHA1Writer(t *testing.T) {
+	ohash, err := NewSHA1Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := sha1.New()
+
+	for i := 0; i < 100; i++ {
+		if err := ohash.Reset(); err != nil {
+			t.Fatal(err)
+		}
+		hash.Reset()
+		buf := make([]byte, 10*1024-i)
+		if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := ohash.Write(buf); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := hash.Write(buf); err != nil {
+			t.Fatal(err)
+		}
+
+		var got, exp [20]byte
+
+		hash.Sum(exp[:0])
+		got, err := ohash.Sum()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got != exp {
+			t.Fatalf("exp:%x got:%x", exp, got)
+		}
+	}
+}
+
+type shafunc func([]byte)
+
+func benchmarkSHA1(b *testing.B, length int64, fn shafunc) {
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(length)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fn(buf)
+	}
+}
+
+func BenchmarkSHA1Large_openssl(b *testing.B) {
+	benchmarkSHA1(b, 1024*1024, func(buf []byte) { SHA1(buf) })
+}
+
+func BenchmarkSHA1Large_stdlib(b *testing.B) {
+	benchmarkSHA1(b, 1024*1024, func(buf []byte) { sha1.Sum(buf) })
+}
+
+func BenchmarkSHA1Small_openssl(b *testing.B) {
+	benchmarkSHA1(b, 1, func(buf []byte) { SHA1(buf) })
+}
+
+func BenchmarkSHA1Small_stdlib(b *testing.B) {
+	benchmarkSHA1(b, 1, func(buf []byte) { sha1.Sum(buf) })
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/sha256.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/sha256.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+type SHA256Hash struct {
+	ctx    *C.EVP_MD_CTX
+	engine *Engine
+}
+
+func NewSHA256Hash() (*SHA256Hash, error) { return NewSHA256HashWithEngine(nil) }
+
+func NewSHA256HashWithEngine(e *Engine) (*SHA256Hash, error) {
+	hash := &SHA256Hash{engine: e}
+	hash.ctx = C.X_EVP_MD_CTX_new()
+	if hash.ctx == nil {
+		return nil, errors.New("openssl: sha256: unable to allocate ctx")
+	}
+	runtime.SetFinalizer(hash, func(hash *SHA256Hash) { hash.Close() })
+	if err := hash.Reset(); err != nil {
+		return nil, err
+	}
+	return hash, nil
+}
+
+func (s *SHA256Hash) Close() {
+	if s.ctx != nil {
+		C.X_EVP_MD_CTX_free(s.ctx)
+		s.ctx = nil
+	}
+}
+
+func (s *SHA256Hash) Reset() error {
+	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_sha256(), engineRef(s.engine)) {
+		return errors.New("openssl: sha256: cannot init digest ctx")
+	}
+	return nil
+}
+
+func (s *SHA256Hash) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if 1 != C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
+		C.size_t(len(p))) {
+		return 0, errors.New("openssl: sha256: cannot update digest")
+	}
+	return len(p), nil
+}
+
+func (s *SHA256Hash) Sum() (result [32]byte, err error) {
+	if 1 != C.X_EVP_DigestFinal_ex(s.ctx,
+		(*C.uchar)(unsafe.Pointer(&result[0])), nil) {
+		return result, errors.New("openssl: sha256: cannot finalize ctx")
+	}
+	return result, s.Reset()
+}
+
+func SHA256(data []byte) (result [32]byte, err error) {
+	hash, err := NewSHA256Hash()
+	if err != nil {
+		return result, err
+	}
+	defer hash.Close()
+	if _, err := hash.Write(data); err != nil {
+		return result, err
+	}
+	return hash.Sum()
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/sha256_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/sha256_test.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"io"
+	"testing"
+)
+
+func TestSHA256(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		buf := make([]byte, 10*1024-i)
+		if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+			t.Fatal(err)
+		}
+
+		expected := sha256.Sum256(buf)
+		got, err := SHA256(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if expected != got {
+			t.Fatalf("exp:%x got:%x", expected, got)
+		}
+	}
+}
+
+func TestSHA256Writer(t *testing.T) {
+	ohash, err := NewSHA256Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := sha256.New()
+
+	for i := 0; i < 100; i++ {
+		if err := ohash.Reset(); err != nil {
+			t.Fatal(err)
+		}
+		hash.Reset()
+		buf := make([]byte, 10*1024-i)
+		if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := ohash.Write(buf); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := hash.Write(buf); err != nil {
+			t.Fatal(err)
+		}
+
+		var got, exp [32]byte
+
+		hash.Sum(exp[:0])
+		got, err := ohash.Sum()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got != exp {
+			t.Fatalf("exp:%x got:%x", exp, got)
+		}
+	}
+}
+
+func benchmarkSHA256(b *testing.B, length int64, fn shafunc) {
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(length)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fn(buf)
+	}
+}
+
+func BenchmarkSHA256Large_openssl(b *testing.B) {
+	benchmarkSHA256(b, 1024*1024, func(buf []byte) { SHA256(buf) })
+}
+
+func BenchmarkSHA256Large_stdlib(b *testing.B) {
+	benchmarkSHA256(b, 1024*1024, func(buf []byte) { sha256.Sum256(buf) })
+}
+
+func BenchmarkSHA256Small_openssl(b *testing.B) {
+	benchmarkSHA256(b, 1, func(buf []byte) { SHA256(buf) })
+}
+
+func BenchmarkSHA256Small_stdlib(b *testing.B) {
+	benchmarkSHA256(b, 1, func(buf []byte) { sha256.Sum256(buf) })
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/shim.c
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/shim.c
@@ -1,0 +1,697 @@
+/*
+ * Copyright (C) 2014 Space Monkey, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <string.h>
+
+#include <openssl/conf.h>
+
+#include <openssl/bio.h>
+#include <openssl/crypto.h>
+#include <openssl/engine.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/ssl.h>
+
+#include "_cgo_export.h"
+
+/*
+ * Functions defined in other .c files
+ */
+extern int go_init_locks();
+extern void go_thread_locking_callback(int, int, const char*, int);
+static int go_write_bio_puts(BIO *b, const char *str) {
+	return go_write_bio_write(b, (char*)str, (int)strlen(str));
+}
+
+/*
+ ************************************************
+ * v1.1.X and later implementation
+ ************************************************
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+
+void X_BIO_set_data(BIO* bio, void* data) {
+	BIO_set_data(bio, data);
+}
+
+void* X_BIO_get_data(BIO* bio) {
+	return BIO_get_data(bio);
+}
+
+EVP_MD_CTX* X_EVP_MD_CTX_new() {
+	return EVP_MD_CTX_new();
+}
+
+void X_EVP_MD_CTX_free(EVP_MD_CTX* ctx) {
+	EVP_MD_CTX_free(ctx);
+}
+
+static int x_bio_create(BIO *b) {
+	BIO_set_shutdown(b, 1);
+	BIO_set_init(b, 1);
+	BIO_set_data(b, NULL);
+	BIO_clear_flags(b, ~0);
+	return 1;
+}
+
+static int x_bio_free(BIO *b) {
+	return 1;
+}
+
+static BIO_METHOD *writeBioMethod;
+static BIO_METHOD *readBioMethod;
+
+BIO_METHOD* BIO_s_readBio() { return readBioMethod; }
+BIO_METHOD* BIO_s_writeBio() { return writeBioMethod; }
+
+int x_bio_init_methods() {
+	writeBioMethod = BIO_meth_new(BIO_TYPE_SOURCE_SINK, "Go Write BIO");
+	if (!writeBioMethod) {
+		return 1;
+	}
+	if (1 != BIO_meth_set_write(writeBioMethod,
+				(int (*)(BIO *, const char *, int))go_write_bio_write)) {
+		return 2;
+	}
+	if (1 != BIO_meth_set_puts(writeBioMethod, go_write_bio_puts)) {
+		return 3;
+	}
+	if (1 != BIO_meth_set_ctrl(writeBioMethod, go_write_bio_ctrl)) {
+		return 4;
+	}
+	if (1 != BIO_meth_set_create(writeBioMethod, x_bio_create)) {
+		return 5;
+	}
+	if (1 != BIO_meth_set_destroy(writeBioMethod, x_bio_free)) {
+		return 6;
+	}
+
+	readBioMethod = BIO_meth_new(BIO_TYPE_SOURCE_SINK, "Go Read BIO");
+	if (!readBioMethod) {
+		return 7;
+	}
+	if (1 != BIO_meth_set_read(readBioMethod, go_read_bio_read)) {
+		return 8;
+	}
+	if (1 != BIO_meth_set_ctrl(readBioMethod, go_read_bio_ctrl)) {
+		return 9;
+	}
+	if (1 != BIO_meth_set_create(readBioMethod, x_bio_create)) {
+		return 10;
+	}
+	if (1 != BIO_meth_set_destroy(readBioMethod, x_bio_free)) {
+		return 11;
+	}
+
+	return 0;
+}
+
+const EVP_MD *X_EVP_dss() {
+	return NULL;
+}
+
+const EVP_MD *X_EVP_dss1() {
+	return NULL;
+}
+
+const EVP_MD *X_EVP_sha() {
+	return NULL;
+}
+
+int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx) {
+	return EVP_CIPHER_CTX_encrypting(ctx);
+}
+
+int X_X509_add_ref(X509* x509) {
+	return X509_up_ref(x509);
+}
+
+const ASN1_TIME *X_X509_get0_notBefore(const X509 *x) {
+	return X509_get0_notBefore(x);
+}
+
+const ASN1_TIME *X_X509_get0_notAfter(const X509 *x) {
+	return X509_get0_notAfter(x);
+}
+
+HMAC_CTX *X_HMAC_CTX_new(void) {
+	return HMAC_CTX_new();
+}
+
+void X_HMAC_CTX_free(HMAC_CTX *ctx) {
+	HMAC_CTX_free(ctx);
+}
+
+int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u) {
+	return PEM_write_bio_PrivateKey_traditional(bio, key, enc, kstr, klen, cb, u);
+}
+
+#endif
+
+
+
+/*
+ ************************************************
+ * v1.0.X implementation
+ ************************************************
+ */
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+
+static int x_bio_create(BIO *b) {
+	b->shutdown = 1;
+	b->init = 1;
+	b->num = -1;
+	b->ptr = NULL;
+	b->flags = 0;
+	return 1;
+}
+
+static int x_bio_free(BIO *b) {
+	return 1;
+}
+
+static BIO_METHOD writeBioMethod = {
+	BIO_TYPE_SOURCE_SINK,
+	"Go Write BIO",
+	(int (*)(BIO *, const char *, int))go_write_bio_write,
+	NULL,
+	go_write_bio_puts,
+	NULL,
+	go_write_bio_ctrl,
+	x_bio_create,
+	x_bio_free,
+	NULL};
+
+static BIO_METHOD* BIO_s_writeBio() { return &writeBioMethod; }
+
+static BIO_METHOD readBioMethod = {
+	BIO_TYPE_SOURCE_SINK,
+	"Go Read BIO",
+	NULL,
+	go_read_bio_read,
+	NULL,
+	NULL,
+	go_read_bio_ctrl,
+	x_bio_create,
+	x_bio_free,
+	NULL};
+
+static BIO_METHOD* BIO_s_readBio() { return &readBioMethod; }
+
+int x_bio_init_methods() {
+	/* statically initialized above */
+	return 0;
+}
+
+void X_BIO_set_data(BIO* bio, void* data) {
+	bio->ptr = data;
+}
+
+void* X_BIO_get_data(BIO* bio) {
+	return bio->ptr;
+}
+
+EVP_MD_CTX* X_EVP_MD_CTX_new() {
+	return EVP_MD_CTX_create();
+}
+
+void X_EVP_MD_CTX_free(EVP_MD_CTX* ctx) {
+	EVP_MD_CTX_destroy(ctx);
+}
+
+int X_X509_add_ref(X509* x509) {
+	CRYPTO_add(&x509->references, 1, CRYPTO_LOCK_X509);
+	return 1;
+}
+
+const ASN1_TIME *X_X509_get0_notBefore(const X509 *x) {
+	return x->cert_info->validity->notBefore;
+}
+
+const ASN1_TIME *X_X509_get0_notAfter(const X509 *x) {
+	return x->cert_info->validity->notAfter;
+}
+
+const EVP_MD *X_EVP_dss() {
+	return EVP_dss();
+}
+
+const EVP_MD *X_EVP_dss1() {
+	return EVP_dss1();
+}
+
+const EVP_MD *X_EVP_sha() {
+	return EVP_sha();
+}
+
+int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx) {
+	return ctx->encrypt;
+}
+
+HMAC_CTX *X_HMAC_CTX_new(void) {
+	/* v1.1.0 uses a OPENSSL_zalloc to allocate the memory which does not exist
+	 * in previous versions. malloc+memset to get the same behavior */
+	HMAC_CTX *ctx = (HMAC_CTX *)OPENSSL_malloc(sizeof(HMAC_CTX));
+	if (ctx) {
+		memset(ctx, 0, sizeof(HMAC_CTX));
+		HMAC_CTX_init(ctx);
+	}
+	return ctx;
+}
+
+void X_HMAC_CTX_free(HMAC_CTX *ctx) {
+	if (ctx) {
+		HMAC_CTX_cleanup(ctx);
+		OPENSSL_free(ctx);
+	}
+}
+
+int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u) {
+	/* PEM_write_bio_PrivateKey always tries to use the PKCS8 format if it
+	 * is available, instead of using the "traditional" format as stated in the
+	 * OpenSSL man page.
+	 * i2d_PrivateKey should give us the correct DER encoding, so we'll just
+	 * use PEM_ASN1_write_bio directly to write the DER encoding with the correct
+	 * type header. */
+
+	int ppkey_id, pkey_base_id, ppkey_flags;
+	const char *pinfo, *ppem_str;
+	char pem_type_str[80];
+
+	// Lookup the ASN1 method information to get the pem type
+	if (EVP_PKEY_asn1_get0_info(&ppkey_id, &pkey_base_id, &ppkey_flags, &pinfo, &ppem_str, key->ameth) != 1) {
+		return 0;
+	}
+	// Set up the PEM type string
+	if (BIO_snprintf(pem_type_str, 80, "%s PRIVATE KEY", ppem_str) <= 0) {
+		// Failed to write out the pem type string, something is really wrong.
+		return 0;
+	}
+	// Write out everything to the BIO
+	return PEM_ASN1_write_bio((i2d_of_void *)i2d_PrivateKey,
+		pem_type_str, bio, key, enc, kstr, klen, cb, u);
+}
+
+#endif
+
+
+
+/*
+ ************************************************
+ * common implementation
+ ************************************************
+ */
+
+int X_shim_init() {
+	int rc = 0;
+
+	OPENSSL_config(NULL);
+	ENGINE_load_builtin_engines();
+	SSL_load_error_strings();
+	SSL_library_init();
+	OpenSSL_add_all_algorithms();
+	//
+	// Set up OPENSSL thread safety callbacks.  We only set the locking
+	// callback because the default id callback implementation is good
+	// enough for us.
+	rc = go_init_locks();
+	if (rc != 0) {
+		return rc;
+	}
+	CRYPTO_set_locking_callback(go_thread_locking_callback);
+
+	rc = x_bio_init_methods();
+	if (rc != 0) {
+		return rc;
+	}
+
+	return 0;
+}
+
+void * X_OPENSSL_malloc(size_t size) {
+	return OPENSSL_malloc(size);
+}
+
+void X_OPENSSL_free(void *ref) {
+	OPENSSL_free(ref);
+}
+
+long X_SSL_set_options(SSL* ssl, long options) {
+	return SSL_set_options(ssl, options);
+}
+
+long X_SSL_get_options(SSL* ssl) {
+	return SSL_get_options(ssl);
+}
+
+long X_SSL_clear_options(SSL* ssl, long options) {
+	return SSL_clear_options(ssl, options);
+}
+
+long X_SSL_set_tlsext_host_name(SSL *ssl, const char *name) {
+   return SSL_set_tlsext_host_name(ssl, name);
+}
+const char * X_SSL_get_cipher_name(const SSL *ssl) {
+   return SSL_get_cipher_name(ssl);
+}
+int X_SSL_session_reused(SSL *ssl) {
+    return SSL_session_reused(ssl);
+}
+
+int X_SSL_new_index() {
+	return SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+}
+
+int X_SSL_verify_cb(int ok, X509_STORE_CTX* store) {
+	SSL* ssl = (SSL *)X509_STORE_CTX_get_ex_data(store,
+			SSL_get_ex_data_X509_STORE_CTX_idx());
+	void* p = SSL_get_ex_data(ssl, get_ssl_idx());
+	// get the pointer to the go Ctx object and pass it back into the thunk
+	return go_ssl_verify_cb_thunk(p, ok, store);
+}
+
+const SSL_METHOD *X_SSLv23_method() {
+	return SSLv23_method();
+}
+
+const SSL_METHOD *X_SSLv3_method() {
+#ifndef OPENSSL_NO_SSL3_METHOD
+	return SSLv3_method();
+#else
+	return NULL;
+#endif
+}
+
+const SSL_METHOD *X_TLSv1_method() {
+	return TLSv1_method();
+}
+
+const SSL_METHOD *X_TLSv1_1_method() {
+#if defined(TLS1_1_VERSION) && !defined(OPENSSL_SYSNAME_MACOSX)
+	return TLSv1_1_method();
+#else
+	return NULL;
+#endif
+}
+
+const SSL_METHOD *X_TLSv1_2_method() {
+#if defined(TLS1_2_VERSION) && !defined(OPENSSL_SYSNAME_MACOSX)
+	return TLSv1_2_method();
+#else
+	return NULL;
+#endif
+}
+
+int X_SSL_CTX_new_index() {
+	return SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+}
+
+long X_SSL_CTX_set_options(SSL_CTX* ctx, long options) {
+	return SSL_CTX_set_options(ctx, options);
+}
+
+long X_SSL_CTX_clear_options(SSL_CTX* ctx, long options) {
+	return SSL_CTX_clear_options(ctx, options);
+}
+
+long X_SSL_CTX_get_options(SSL_CTX* ctx) {
+	return SSL_CTX_get_options(ctx);
+}
+
+long X_SSL_CTX_set_mode(SSL_CTX* ctx, long modes) {
+	return SSL_CTX_set_mode(ctx, modes);
+}
+
+long X_SSL_CTX_get_mode(SSL_CTX* ctx) {
+	return SSL_CTX_get_mode(ctx);
+}
+
+long X_SSL_CTX_set_session_cache_mode(SSL_CTX* ctx, long modes) {
+	return SSL_CTX_set_session_cache_mode(ctx, modes);
+}
+
+long X_SSL_CTX_sess_set_cache_size(SSL_CTX* ctx, long t) {
+	return SSL_CTX_sess_set_cache_size(ctx, t);
+}
+
+long X_SSL_CTX_sess_get_cache_size(SSL_CTX* ctx) {
+	return SSL_CTX_sess_get_cache_size(ctx);
+}
+
+long X_SSL_CTX_set_timeout(SSL_CTX* ctx, long t) {
+	return SSL_CTX_set_timeout(ctx, t);
+}
+
+long X_SSL_CTX_get_timeout(SSL_CTX* ctx) {
+	return SSL_CTX_get_timeout(ctx);
+}
+
+long X_SSL_CTX_add_extra_chain_cert(SSL_CTX* ctx, X509 *cert) {
+	return SSL_CTX_add_extra_chain_cert(ctx, cert);
+}
+
+long X_SSL_CTX_set_tmp_ecdh(SSL_CTX* ctx, EC_KEY *key) {
+	return SSL_CTX_set_tmp_ecdh(ctx, key);
+}
+
+long X_SSL_CTX_set_tlsext_servername_callback(
+		SSL_CTX* ctx, int (*cb)(SSL *con, int *ad, void *args)) {
+	return SSL_CTX_set_tlsext_servername_callback(ctx, cb);
+}
+
+int X_SSL_CTX_verify_cb(int ok, X509_STORE_CTX* store) {
+	SSL* ssl = (SSL *)X509_STORE_CTX_get_ex_data(store,
+			SSL_get_ex_data_X509_STORE_CTX_idx());
+	SSL_CTX* ssl_ctx = SSL_get_SSL_CTX(ssl);
+	void* p = SSL_CTX_get_ex_data(ssl_ctx, get_ssl_ctx_idx());
+	// get the pointer to the go Ctx object and pass it back into the thunk
+	return go_ssl_ctx_verify_cb_thunk(p, ok, store);
+}
+
+long X_SSL_CTX_set_tmp_dh(SSL_CTX* ctx, DH *dh) {
+    return SSL_CTX_set_tmp_dh(ctx, dh);
+}
+
+long X_PEM_read_DHparams(SSL_CTX* ctx, DH *dh) {
+    return SSL_CTX_set_tmp_dh(ctx, dh);
+}
+
+int X_SSL_CTX_set_tlsext_ticket_key_cb(SSL_CTX *sslctx,
+        int (*cb)(SSL *s, unsigned char key_name[16],
+                  unsigned char iv[EVP_MAX_IV_LENGTH],
+                  EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc)) {
+    return SSL_CTX_set_tlsext_ticket_key_cb(sslctx, cb);
+}
+
+int X_SSL_CTX_ticket_key_cb(SSL *s, unsigned char key_name[16],
+		unsigned char iv[EVP_MAX_IV_LENGTH],
+		EVP_CIPHER_CTX *cctx, HMAC_CTX *hctx, int enc) {
+
+	SSL_CTX* ssl_ctx = SSL_get_SSL_CTX(s);
+	void* p = SSL_CTX_get_ex_data(ssl_ctx, get_ssl_ctx_idx());
+	// get the pointer to the go Ctx object and pass it back into the thunk
+	return go_ticket_key_cb_thunk(p, s, key_name, iv, cctx, hctx, enc);
+}
+
+int X_BIO_get_flags(BIO *b) {
+	return BIO_get_flags(b);
+}
+
+void X_BIO_set_flags(BIO *b, int flags) {
+	return BIO_set_flags(b, flags);
+}
+
+void X_BIO_clear_flags(BIO *b, int flags) {
+	BIO_clear_flags(b, flags);
+}
+
+int X_BIO_read(BIO *b, void *buf, int len) {
+	return BIO_read(b, buf, len);
+}
+
+int X_BIO_write(BIO *b, const void *buf, int len) {
+	return BIO_write(b, buf, len);
+}
+
+BIO *X_BIO_new_write_bio() {
+	return BIO_new(BIO_s_writeBio());
+}
+
+BIO *X_BIO_new_read_bio() {
+	return BIO_new(BIO_s_readBio());
+}
+
+const EVP_MD *X_EVP_get_digestbyname(const char *name) {
+	return EVP_get_digestbyname(name);
+}
+
+const EVP_MD *X_EVP_md_null() {
+	return EVP_md_null();
+}
+
+const EVP_MD *X_EVP_md5() {
+	return EVP_md5();
+}
+
+const EVP_MD *X_EVP_ripemd160() {
+	return EVP_ripemd160();
+}
+
+const EVP_MD *X_EVP_sha224() {
+	return EVP_sha224();
+}
+
+const EVP_MD *X_EVP_sha1() {
+	return EVP_sha1();
+}
+
+const EVP_MD *X_EVP_sha256() {
+	return EVP_sha256();
+}
+
+const EVP_MD *X_EVP_sha384() {
+	return EVP_sha384();
+}
+
+const EVP_MD *X_EVP_sha512() {
+	return EVP_sha512();
+}
+
+int X_EVP_MD_size(const EVP_MD *md) {
+	return EVP_MD_size(md);
+}
+
+int X_EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl) {
+	return EVP_DigestInit_ex(ctx, type, impl);
+}
+
+int X_EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) {
+	return EVP_DigestUpdate(ctx, d, cnt);
+}
+
+int X_EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
+	return EVP_DigestFinal_ex(ctx, md, s);
+}
+
+int X_EVP_SignInit(EVP_MD_CTX *ctx, const EVP_MD *type) {
+	return EVP_SignInit(ctx, type);
+}
+
+int X_EVP_SignUpdate(EVP_MD_CTX *ctx, const void *d, unsigned int cnt) {
+	return EVP_SignUpdate(ctx, d, cnt);
+}
+
+EVP_PKEY *X_EVP_PKEY_new(void) {
+	return EVP_PKEY_new();
+}
+
+void X_EVP_PKEY_free(EVP_PKEY *pkey) {
+	EVP_PKEY_free(pkey);
+}
+
+int X_EVP_PKEY_size(EVP_PKEY *pkey) {
+	return EVP_PKEY_size(pkey);
+}
+
+struct rsa_st *X_EVP_PKEY_get1_RSA(EVP_PKEY *pkey) {
+	return EVP_PKEY_get1_RSA(pkey);
+}
+
+int X_EVP_PKEY_set1_RSA(EVP_PKEY *pkey, struct rsa_st *key) {
+	return EVP_PKEY_set1_RSA(pkey, key);
+}
+
+int X_EVP_PKEY_assign_charp(EVP_PKEY *pkey, int type, char *key) {
+	return EVP_PKEY_assign(pkey, type, key);
+}
+
+int X_EVP_SignFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s, EVP_PKEY *pkey) {
+	return EVP_SignFinal(ctx, md, s, pkey);
+}
+
+int X_EVP_VerifyInit(EVP_MD_CTX *ctx, const EVP_MD *type) {
+	return EVP_VerifyInit(ctx, type);
+}
+
+int X_EVP_VerifyUpdate(EVP_MD_CTX *ctx, const void *d,
+		unsigned int cnt) {
+	return EVP_VerifyUpdate(ctx, d, cnt);
+}
+
+int X_EVP_VerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sigbuf, unsigned int siglen, EVP_PKEY *pkey) {
+	return EVP_VerifyFinal(ctx, sigbuf, siglen, pkey);
+}
+
+int X_EVP_CIPHER_block_size(EVP_CIPHER *c) {
+    return EVP_CIPHER_block_size(c);
+}
+
+int X_EVP_CIPHER_key_length(EVP_CIPHER *c) {
+    return EVP_CIPHER_key_length(c);
+}
+
+int X_EVP_CIPHER_iv_length(EVP_CIPHER *c) {
+    return EVP_CIPHER_iv_length(c);
+}
+
+int X_EVP_CIPHER_nid(EVP_CIPHER *c) {
+    return EVP_CIPHER_nid(c);
+}
+
+int X_EVP_CIPHER_CTX_block_size(EVP_CIPHER_CTX *ctx) {
+    return EVP_CIPHER_CTX_block_size(ctx);
+}
+
+int X_EVP_CIPHER_CTX_key_length(EVP_CIPHER_CTX *ctx) {
+    return EVP_CIPHER_CTX_key_length(ctx);
+}
+
+int X_EVP_CIPHER_CTX_iv_length(EVP_CIPHER_CTX *ctx) {
+    return EVP_CIPHER_CTX_iv_length(ctx);
+}
+
+const EVP_CIPHER *X_EVP_CIPHER_CTX_cipher(EVP_CIPHER_CTX *ctx) {
+    return EVP_CIPHER_CTX_cipher(ctx);
+}
+
+int X_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) {
+	return EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid);
+}
+
+size_t X_HMAC_size(const HMAC_CTX *e) {
+	return HMAC_size(e);
+}
+
+int X_HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len, const EVP_MD *md, ENGINE *impl) {
+	return HMAC_Init_ex(ctx, key, len, md, impl);
+}
+
+int X_HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, size_t len) {
+	return HMAC_Update(ctx, data, len);
+}
+
+int X_HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len) {
+	return HMAC_Final(ctx, md, len);
+}
+
+int X_sk_X509_num(STACK_OF(X509) *sk) {
+	return sk_X509_num(sk);
+}
+
+X509 *X_sk_X509_value(STACK_OF(X509)* sk, int i) {
+   return sk_X509_value(sk, i);
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/shim.h
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/shim.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2014 Space Monkey, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <openssl/bio.h>
+#include <openssl/crypto.h>
+#include <openssl/dh.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/x509v3.h>
+#include <openssl/ec.h>
+
+#ifndef SSL_MODE_RELEASE_BUFFERS
+#define SSL_MODE_RELEASE_BUFFERS 0
+#endif
+
+#ifndef SSL_OP_NO_COMPRESSION
+#define SSL_OP_NO_COMPRESSION 0
+#endif
+
+/* shim  methods */
+extern int X_shim_init();
+
+/* Library methods */
+extern void X_OPENSSL_free(void *ref);
+extern void *X_OPENSSL_malloc(size_t size);
+
+/* SSL methods */
+extern long X_SSL_set_options(SSL* ssl, long options);
+extern long X_SSL_get_options(SSL* ssl);
+extern long X_SSL_clear_options(SSL* ssl, long options);
+extern long X_SSL_set_tlsext_host_name(SSL *ssl, const char *name);
+extern const char * X_SSL_get_cipher_name(const SSL *ssl);
+extern int X_SSL_session_reused(SSL *ssl);
+extern int X_SSL_new_index();
+
+extern const SSL_METHOD *X_SSLv23_method();
+extern const SSL_METHOD *X_SSLv3_method();
+extern const SSL_METHOD *X_TLSv1_method();
+extern const SSL_METHOD *X_TLSv1_1_method();
+extern const SSL_METHOD *X_TLSv1_2_method();
+
+#if defined SSL_CTRL_SET_TLSEXT_HOSTNAME
+extern int sni_cb(SSL *ssl_conn, int *ad, void *arg);
+#endif
+extern int X_SSL_verify_cb(int ok, X509_STORE_CTX* store);
+
+/* SSL_CTX methods */
+extern int X_SSL_CTX_new_index();
+extern long X_SSL_CTX_set_options(SSL_CTX* ctx, long options);
+extern long X_SSL_CTX_clear_options(SSL_CTX* ctx, long options);
+extern long X_SSL_CTX_get_options(SSL_CTX* ctx);
+extern long X_SSL_CTX_set_mode(SSL_CTX* ctx, long modes);
+extern long X_SSL_CTX_get_mode(SSL_CTX* ctx);
+extern long X_SSL_CTX_set_session_cache_mode(SSL_CTX* ctx, long modes);
+extern long X_SSL_CTX_sess_set_cache_size(SSL_CTX* ctx, long t);
+extern long X_SSL_CTX_sess_get_cache_size(SSL_CTX* ctx);
+extern long X_SSL_CTX_set_timeout(SSL_CTX* ctx, long t);
+extern long X_SSL_CTX_get_timeout(SSL_CTX* ctx);
+extern long X_SSL_CTX_add_extra_chain_cert(SSL_CTX* ctx, X509 *cert);
+extern long X_SSL_CTX_set_tmp_ecdh(SSL_CTX* ctx, EC_KEY *key);
+extern long X_SSL_CTX_set_tlsext_servername_callback(SSL_CTX* ctx, int (*cb)(SSL *con, int *ad, void *args));
+extern int X_SSL_CTX_verify_cb(int ok, X509_STORE_CTX* store);
+extern long X_SSL_CTX_set_tmp_dh(SSL_CTX* ctx, DH *dh);
+extern long X_PEM_read_DHparams(SSL_CTX* ctx, DH *dh);
+extern int X_SSL_CTX_set_tlsext_ticket_key_cb(SSL_CTX *sslctx,
+        int (*cb)(SSL *s, unsigned char key_name[16],
+                  unsigned char iv[EVP_MAX_IV_LENGTH],
+                  EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc));
+extern int X_SSL_CTX_ticket_key_cb(SSL *s, unsigned char key_name[16],
+        unsigned char iv[EVP_MAX_IV_LENGTH],
+        EVP_CIPHER_CTX *cctx, HMAC_CTX *hctx, int enc);
+
+/* BIO methods */
+extern int X_BIO_get_flags(BIO *b);
+extern void X_BIO_set_flags(BIO *bio, int flags);
+extern void X_BIO_clear_flags(BIO *bio, int flags);
+extern void X_BIO_set_data(BIO *bio, void* data);
+extern void *X_BIO_get_data(BIO *bio);
+extern int X_BIO_read(BIO *b, void *buf, int len);
+extern int X_BIO_write(BIO *b, const void *buf, int len);
+extern BIO *X_BIO_new_write_bio();
+extern BIO *X_BIO_new_read_bio();
+
+/* EVP methods */
+extern const EVP_MD *X_EVP_get_digestbyname(const char *name);
+extern EVP_MD_CTX *X_EVP_MD_CTX_new();
+extern void X_EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+extern const EVP_MD *X_EVP_md_null();
+extern const EVP_MD *X_EVP_md5();
+extern const EVP_MD *X_EVP_sha();
+extern const EVP_MD *X_EVP_sha1();
+extern const EVP_MD *X_EVP_dss();
+extern const EVP_MD *X_EVP_dss1();
+extern const EVP_MD *X_EVP_ripemd160();
+extern const EVP_MD *X_EVP_sha224();
+extern const EVP_MD *X_EVP_sha256();
+extern const EVP_MD *X_EVP_sha384();
+extern const EVP_MD *X_EVP_sha512();
+extern int X_EVP_MD_size(const EVP_MD *md);
+extern int X_EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+extern int X_EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
+extern int X_EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+extern int X_EVP_SignInit(EVP_MD_CTX *ctx, const EVP_MD *type);
+extern int X_EVP_SignUpdate(EVP_MD_CTX *ctx, const void *d, unsigned int cnt);
+extern EVP_PKEY *X_EVP_PKEY_new(void);
+extern void X_EVP_PKEY_free(EVP_PKEY *pkey);
+extern int X_EVP_PKEY_size(EVP_PKEY *pkey);
+extern struct rsa_st *X_EVP_PKEY_get1_RSA(EVP_PKEY *pkey);
+extern int X_EVP_PKEY_set1_RSA(EVP_PKEY *pkey, struct rsa_st *key);
+extern int X_EVP_PKEY_assign_charp(EVP_PKEY *pkey, int type, char *key);
+extern int X_EVP_SignFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s, EVP_PKEY *pkey);
+extern int X_EVP_VerifyInit(EVP_MD_CTX *ctx, const EVP_MD *type);
+extern int X_EVP_VerifyUpdate(EVP_MD_CTX *ctx, const void *d, unsigned int cnt);
+extern int X_EVP_VerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sigbuf, unsigned int siglen, EVP_PKEY *pkey);
+extern int X_EVP_CIPHER_block_size(EVP_CIPHER *c);
+extern int X_EVP_CIPHER_key_length(EVP_CIPHER *c);
+extern int X_EVP_CIPHER_iv_length(EVP_CIPHER *c);
+extern int X_EVP_CIPHER_nid(EVP_CIPHER *c);
+extern int X_EVP_CIPHER_CTX_block_size(EVP_CIPHER_CTX *ctx);
+extern int X_EVP_CIPHER_CTX_key_length(EVP_CIPHER_CTX *ctx);
+extern int X_EVP_CIPHER_CTX_iv_length(EVP_CIPHER_CTX *ctx);
+extern const EVP_CIPHER *X_EVP_CIPHER_CTX_cipher(EVP_CIPHER_CTX *ctx);
+extern int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx);
+extern int X_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
+
+/* HMAC methods */
+extern size_t X_HMAC_size(const HMAC_CTX *e);
+extern HMAC_CTX *X_HMAC_CTX_new(void);
+extern void X_HMAC_CTX_free(HMAC_CTX *ctx);
+extern int X_HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len, const EVP_MD *md, ENGINE *impl);
+extern int X_HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, size_t len);
+extern int X_HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len);
+
+/* X509 methods */
+extern int X_X509_add_ref(X509* x509);
+extern const ASN1_TIME *X_X509_get0_notBefore(const X509 *x);
+extern const ASN1_TIME *X_X509_get0_notAfter(const X509 *x);
+extern int X_sk_X509_num(STACK_OF(X509) *sk);
+extern X509 *X_sk_X509_value(STACK_OF(X509)* sk, int i);
+
+/* PEM methods */
+extern int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u);

--- a/grove/vendor/github.com/spacemonkeygo/openssl/sni.c
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/sni.c
@@ -1,0 +1,23 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <openssl/ssl.h>
+#include "_cgo_export.h"
+#include <stdio.h>
+
+int sni_cb(SSL *con, int *ad, void *arg) {
+	SSL_CTX* ssl_ctx = ssl_ctx = SSL_get_SSL_CTX(con);
+	void* p = SSL_CTX_get_ex_data(ssl_ctx, get_ssl_ctx_idx());
+	return sni_cb_thunk(p, con, ad, arg);
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/sni_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/sni_test.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import "fmt"
+
+// We can implemant SNI rfc6066 (http://tools.ietf.org/html/rfc6066) on the server side using foolowing callback.
+// You should implement context storage (tlsCtxStorage) by your self.
+func ExampleSetTLSExtServernameCallback() {
+	fmt.Println("Hello")
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/ssl.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/ssl.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"os"
+	"unsafe"
+)
+
+type SSLTLSExtErr int
+
+const (
+	SSLTLSExtErrOK           SSLTLSExtErr = C.SSL_TLSEXT_ERR_OK
+	SSLTLSExtErrAlertWarning SSLTLSExtErr = C.SSL_TLSEXT_ERR_ALERT_WARNING
+	SSLTLSEXTErrAlertFatal   SSLTLSExtErr = C.SSL_TLSEXT_ERR_ALERT_FATAL
+	SSLTLSEXTErrNoAck        SSLTLSExtErr = C.SSL_TLSEXT_ERR_NOACK
+)
+
+var (
+	ssl_idx = C.X_SSL_new_index()
+)
+
+//export get_ssl_idx
+func get_ssl_idx() C.int {
+	return ssl_idx
+}
+
+type SSL struct {
+	ssl       *C.SSL
+	verify_cb VerifyCallback
+}
+
+//export go_ssl_verify_cb_thunk
+func go_ssl_verify_cb_thunk(p unsafe.Pointer, ok C.int, ctx *C.X509_STORE_CTX) C.int {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Critf("openssl: verify callback panic'd: %v", err)
+			os.Exit(1)
+		}
+	}()
+	verify_cb := (*SSL)(p).verify_cb
+	// set up defaults just in case verify_cb is nil
+	if verify_cb != nil {
+		store := &CertificateStoreCtx{ctx: ctx}
+		if verify_cb(ok == 1, store) {
+			ok = 1
+		} else {
+			ok = 0
+		}
+	}
+	return ok
+}
+
+// Wrapper around SSL_get_servername. Returns server name according to rfc6066
+// http://tools.ietf.org/html/rfc6066.
+func (s *SSL) GetServername() string {
+	return C.GoString(C.SSL_get_servername(s.ssl, C.TLSEXT_NAMETYPE_host_name))
+}
+
+// GetOptions returns SSL options. See
+// https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+func (s *SSL) GetOptions() Options {
+	return Options(C.X_SSL_get_options(s.ssl))
+}
+
+// SetOptions sets SSL options. See
+// https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+func (s *SSL) SetOptions(options Options) Options {
+	return Options(C.X_SSL_set_options(s.ssl, C.long(options)))
+}
+
+// ClearOptions clear SSL options. See
+// https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+func (s *SSL) ClearOptions(options Options) Options {
+	return Options(C.X_SSL_clear_options(s.ssl, C.long(options)))
+}
+
+// SetVerify controls peer verification settings. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (s *SSL) SetVerify(options VerifyOptions, verify_cb VerifyCallback) {
+	s.verify_cb = verify_cb
+	if verify_cb != nil {
+		C.SSL_set_verify(s.ssl, C.int(options), (*[0]byte)(C.X_SSL_verify_cb))
+	} else {
+		C.SSL_set_verify(s.ssl, C.int(options), nil)
+	}
+}
+
+// SetVerifyMode controls peer verification setting. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (s *SSL) SetVerifyMode(options VerifyOptions) {
+	s.SetVerify(options, s.verify_cb)
+}
+
+// SetVerifyCallback controls peer verification setting. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (s *SSL) SetVerifyCallback(verify_cb VerifyCallback) {
+	s.SetVerify(s.VerifyMode(), verify_cb)
+}
+
+// GetVerifyCallback returns callback function. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (s *SSL) GetVerifyCallback() VerifyCallback {
+	return s.verify_cb
+}
+
+// VerifyMode returns peer verification setting. See
+// http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (s *SSL) VerifyMode() VerifyOptions {
+	return VerifyOptions(C.SSL_get_verify_mode(s.ssl))
+}
+
+// SetVerifyDepth controls how many certificates deep the certificate
+// verification logic is willing to follow a certificate chain. See
+// https://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (s *SSL) SetVerifyDepth(depth int) {
+	C.SSL_set_verify_depth(s.ssl, C.int(depth))
+}
+
+// GetVerifyDepth controls how many certificates deep the certificate
+// verification logic is willing to follow a certificate chain. See
+// https://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
+func (s *SSL) GetVerifyDepth() int {
+	return int(C.SSL_get_verify_depth(s.ssl))
+}
+
+// SetSSLCtx changes context to new one. Useful for Server Name Indication (SNI)
+// rfc6066 http://tools.ietf.org/html/rfc6066. See
+// http://stackoverflow.com/questions/22373332/serving-multiple-domains-in-one-box-with-sni
+func (s *SSL) SetSSLCtx(ctx *Ctx) {
+	/*
+	 * SSL_set_SSL_CTX() only changes certs as of 1.0.0d
+	 * adjust other things we care about
+	 */
+	C.SSL_set_SSL_CTX(s.ssl, ctx.ctx)
+}
+
+//export sni_cb_thunk
+func sni_cb_thunk(p unsafe.Pointer, con *C.SSL, ad unsafe.Pointer, arg unsafe.Pointer) C.int {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Critf("openssl: verify callback sni panic'd: %v", err)
+			os.Exit(1)
+		}
+	}()
+
+	sni_cb := (*Ctx)(p).sni_cb
+
+	s := &SSL{ssl: con}
+	// This attaches a pointer to our SSL struct into the SNI callback.
+	C.SSL_set_ex_data(s.ssl, get_ssl_idx(), unsafe.Pointer(s))
+
+	// Note: this is ctx.sni_cb, not C.sni_cb
+	return C.int(sni_cb(s))
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/ssl_test.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/ssl_test.go
@@ -1,0 +1,656 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/tls"
+	"io"
+	"io/ioutil"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spacemonkeygo/openssl/utils"
+)
+
+var (
+	certBytes = []byte(`-----BEGIN CERTIFICATE-----
+MIIDxDCCAqygAwIBAgIVAMcK/0VWQr2O3MNfJCydqR7oVELcMA0GCSqGSIb3DQEB
+BQUAMIGQMUkwRwYDVQQDE0A1NjdjZGRmYzRjOWZiNTYwZTk1M2ZlZjA1N2M0NGFm
+MDdiYjc4MDIzODIxYTA5NThiY2RmMGMwNzJhOTdiMThhMQswCQYDVQQGEwJVUzEN
+MAsGA1UECBMEVXRhaDEQMA4GA1UEBxMHTWlkdmFsZTEVMBMGA1UEChMMU3BhY2Ug
+TW9ua2V5MB4XDTEzMTIxNzE4MzgyMloXDTIzMTIxNTE4MzgyMlowgZAxSTBHBgNV
+BAMTQDM4NTg3ODRkMjU1NTdiNTM1MWZmNjRmMmQzMTQ1ZjkwYTJlMTIzMDM4Y2Yz
+Mjc1Yzg1OTM1MjcxYWIzMmNiMDkxCzAJBgNVBAYTAlVTMQ0wCwYDVQQIEwRVdGFo
+MRAwDgYDVQQHEwdNaWR2YWxlMRUwEwYDVQQKEwxTcGFjZSBNb25rZXkwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDdf3icNvFsrlrnNLi8SocscqlSbFq+
+pEvmhcSoqgDLqebnqu8Ld73HJJ74MGXEgRX8xZT5FinOML31CR6t9E/j3dqV6p+G
+fdlFLe3IqtC0/bPVnCDBirBygBI4uCrMq+1VhAxPWclrDo7l9QRYbsExH9lfn+Ry
+vxeNMZiOASasvVZNncY8E9usBGRdH17EfDL/TPwXqWOLyxSN5o54GTztjjy9w9CG
+QP7jcCueKYyQJQCtEmnwc6P/q6/EPv5R6drBkX6loAPtmCUAkHqxkWOJrRq/v7Pw
+zRYhfY+ZpVHGc7WEkDnLzRiUypr1C9oxvLKS10etZEIwEdKyOkSg2fdPAgMBAAGj
+EzARMA8GA1UdEwEB/wQFMAMCAQAwDQYJKoZIhvcNAQEFBQADggEBAEcz0RTTJ99l
+HTK/zTyfV5VZEhtwqu6bwre/hD7lhI+1ji0DZYGIgCbJLKuZhj+cHn2h5nPhN7zE
+M9tc4pn0TgeVS0SVFSe6TGnIFipNogvP17E+vXpDZcW/xn9kPKeVCZc1hlDt1W4Z
+5q+ub3aUwuMwYs7bcArtDrumCmciJ3LFyNhebPi4mntb5ooeLFLaujEmVYyrQnpo
+tWKC9sMlJmLm4yAso64Sv9KLS2T9ivJBNn0ZtougozBCCTqrqgZVjha+B2yjHe9f
+sRkg/uxcJf7wC5Y0BLlp1+aPwdmZD87T3a1uQ1Ij93jmHG+2T9U20MklHAePOl0q
+yTqdSPnSH1c=
+-----END CERTIFICATE-----
+`)
+	keyBytes = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA3X94nDbxbK5a5zS4vEqHLHKpUmxavqRL5oXEqKoAy6nm56rv
+C3e9xySe+DBlxIEV/MWU+RYpzjC99QkerfRP493aleqfhn3ZRS3tyKrQtP2z1Zwg
+wYqwcoASOLgqzKvtVYQMT1nJaw6O5fUEWG7BMR/ZX5/kcr8XjTGYjgEmrL1WTZ3G
+PBPbrARkXR9exHwy/0z8F6lji8sUjeaOeBk87Y48vcPQhkD+43ArnimMkCUArRJp
+8HOj/6uvxD7+UenawZF+paAD7ZglAJB6sZFjia0av7+z8M0WIX2PmaVRxnO1hJA5
+y80YlMqa9QvaMbyyktdHrWRCMBHSsjpEoNn3TwIDAQABAoIBAQCwgp6YzmgCFce3
+LBpzYmjqEM3CMzr1ZXRe1gbr6d4Mbu7leyBX4SpJAnP0kIzo1X2yG7ol7XWPLOST
+2pqqQWFQ00EX6wsJYEy+hmVRXl5HfU3MUkkAMwd9l3Xt4UWqKPBPD5XHvmN2fvl9
+Y4388vXdseXGAGNK1eFs0TMjJuOtDxDyrmJcnxpJ7y/77y/Hb5rUa9DCvj8tkKHg
+HmeIwQE0HhIFofj+qCYbqeVyjbPAaYZMrISXb2HmcyULKEOGRbMH24IzInKA0NxV
+kdP9qmV8Y2bJ609Fft/y8Vpj31iEdq/OFXyobdVvnXMnaVyAetoaWy7AOTIQ2Cnw
+wGbJ/F8BAoGBAN/pCnLQrWREeVMuFjf+MgYgCtRRaQ8EOVvjYcXXi0PhtOMFTAb7
+djqhlgmBOFsmeXcb8YRZsF+pNtu1xk5RJOquyKfK8j1rUdAJfoxGHiaUFI2/1i9E
+zuXX/Ao0xNRkWMxMKuwYBmmt1fMuVo+1M8UEwFMdHRtgxe+/+eOV1J2PAoGBAP09
+7GLOYSYAI1OO3BN/bEVNau6tAxP5YShGmX2Qxy0+ooxHZ1V3D8yo6C0hSg+H+fPT
+mjMgGcvaW6K+QyCdHDjgbk2hfdZ+Beq92JApPrH9gMV7MPhwHzgwjzDDio9OFxYY
+3vjBQ2yX+9jvz9lkvq2NM3fqFqbsG6Et+5mCc6pBAoGBAI62bxVtEgbladrtdfXs
+S6ABzkUzOl362EBL9iZuUnJKqstDtgiBQALwuLuIJA5cwHB9W/t6WuMt7CwveJy0
+NW5rRrNDtBAXlgad9o2bp135ZfxO+EoadjCi8B7lMUsaRkq4hWcDjRrQVJxxvXRN
+DxkVBSw0Uzf+/0nnN3OqLODbAoGACCY+/isAC1YDzQOS53m5RT2pjEa7C6CB1Ob4
+t4a6MiWK25LMq35qXr6swg8JMBjDHWqY0r5ctievvTv8Mwd7SgVG526j+wwRKq2z
+U2hQYS/0Peap+8S37Hn7kakpQ1VS/t4MBttJTSxS6XdGLAvG6xTZLCm3UuXUOcqe
+ByGgkUECgYEAmop45kRi974g4MPvyLplcE4syb19ifrHj76gPRBi94Cp8jZosY1T
+ucCCa4lOGgPtXJ0Qf1c8yq5vh4yqkQjrgUTkr+CFDGR6y4CxmNDQxEMYIajaIiSY
+qmgvgyRayemfO2zR0CPgC6wSoGBth+xW6g+WA8y0z76ZSaWpFi8lVM4=
+-----END RSA PRIVATE KEY-----
+`)
+	prime256v1KeyBytes = []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIB/XL0zZSsAu+IQF1AI/nRneabb2S126WFlvvhzmYr1KoAoGCCqGSM49
+AwEHoUQDQgAESSFGWwF6W1hoatKGPPorh4+ipyk0FqpiWdiH+4jIiU39qtOeZGSh
+1QgSbzfdHxvoYI0FXM+mqE7wec0kIvrrHw==
+-----END EC PRIVATE KEY-----
+`)
+	prime256v1CertBytes = []byte(`-----BEGIN CERTIFICATE-----
+MIIChTCCAiqgAwIBAgIJAOQII2LQl4uxMAoGCCqGSM49BAMCMIGcMQswCQYDVQQG
+EwJVUzEPMA0GA1UECAwGS2Fuc2FzMRAwDgYDVQQHDAdOb3doZXJlMR8wHQYDVQQK
+DBZGYWtlIENlcnRpZmljYXRlcywgSW5jMUkwRwYDVQQDDEBhMWJkZDVmZjg5ZjQy
+N2IwZmNiOTdlNDMyZTY5Nzg2NjI2ODJhMWUyNzM4MDhkODE0ZWJiZjY4ODBlYzA3
+NDljMB4XDTE3MTIxNTIwNDU1MVoXDTI3MTIxMzIwNDU1MVowgZwxCzAJBgNVBAYT
+AlVTMQ8wDQYDVQQIDAZLYW5zYXMxEDAOBgNVBAcMB05vd2hlcmUxHzAdBgNVBAoM
+FkZha2UgQ2VydGlmaWNhdGVzLCBJbmMxSTBHBgNVBAMMQGExYmRkNWZmODlmNDI3
+YjBmY2I5N2U0MzJlNjk3ODY2MjY4MmExZTI3MzgwOGQ4MTRlYmJmNjg4MGVjMDc0
+OWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARJIUZbAXpbWGhq0oY8+iuHj6Kn
+KTQWqmJZ2If7iMiJTf2q055kZKHVCBJvN90fG+hgjQVcz6aoTvB5zSQi+usfo1Mw
+UTAdBgNVHQ4EFgQUfRYAFhlGM1wzvusyGrm26Vrbqm4wHwYDVR0jBBgwFoAUfRYA
+FhlGM1wzvusyGrm26Vrbqm4wDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNJ
+ADBGAiEA6PWNjm4B6zs3Wcha9qyDdfo1ILhHfk9rZEAGrnfyc2UCIQD1IDVJUkI4
+J/QVoOtP5DOdRPs/3XFy0Bk0qH+Uj5D7LQ==
+-----END CERTIFICATE-----
+`)
+)
+
+func NetPipe(t testing.TB) (net.Conn, net.Conn) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	client_future := utils.NewFuture()
+	go func() {
+		client_future.Set(net.Dial(l.Addr().Network(), l.Addr().String()))
+	}()
+	var errs utils.ErrorGroup
+	server_conn, err := l.Accept()
+	errs.Add(err)
+	client_conn, err := client_future.Get()
+	errs.Add(err)
+	err = errs.Finalize()
+	if err != nil {
+		if server_conn != nil {
+			server_conn.Close()
+		}
+		if client_conn != nil {
+			client_conn.(net.Conn).Close()
+		}
+		t.Fatal(err)
+	}
+	return server_conn, client_conn.(net.Conn)
+}
+
+type HandshakingConn interface {
+	net.Conn
+	Handshake() error
+}
+
+func SimpleConnTest(t testing.TB, constructor func(
+	t testing.TB, conn1, conn2 net.Conn) (sslconn1, sslconn2 HandshakingConn)) {
+	server_conn, client_conn := NetPipe(t)
+	defer server_conn.Close()
+	defer client_conn.Close()
+
+	data := "first test string\n"
+
+	server, client := constructor(t, server_conn, client_conn)
+	defer close_both(server, client)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		err := client.Handshake()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = io.Copy(client, bytes.NewReader([]byte(data)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = client.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+
+		err := server.Handshake()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		buf := bytes.NewBuffer(make([]byte, 0, len(data)))
+		_, err = io.CopyN(buf, server, int64(len(data)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(buf.Bytes()) != data {
+			t.Fatal("mismatched data")
+		}
+
+		err = server.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	wg.Wait()
+}
+
+func close_both(closer1, closer2 io.Closer) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		closer1.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		closer2.Close()
+	}()
+	wg.Wait()
+}
+
+func ClosingTest(t testing.TB, constructor func(
+	t testing.TB, conn1, conn2 net.Conn) (sslconn1, sslconn2 HandshakingConn)) {
+
+	run_test := func(close_tcp bool, server_writes bool) {
+		server_conn, client_conn := NetPipe(t)
+		defer server_conn.Close()
+		defer client_conn.Close()
+		server, client := constructor(t, server_conn, client_conn)
+		defer close_both(server, client)
+
+		var sslconn1, sslconn2 HandshakingConn
+		var conn1 net.Conn
+		if server_writes {
+			sslconn1 = server
+			conn1 = server_conn
+			sslconn2 = client
+		} else {
+			sslconn1 = client
+			conn1 = client_conn
+			sslconn2 = server
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_, err := sslconn1.Write([]byte("hello"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if close_tcp {
+				err = conn1.Close()
+			} else {
+				err = sslconn1.Close()
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			data, err := ioutil.ReadAll(sslconn2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(data, []byte("hello")) {
+				t.Fatal("bytes don't match")
+			}
+		}()
+
+		wg.Wait()
+	}
+
+	run_test(true, false)
+	run_test(false, false)
+	run_test(true, true)
+	run_test(false, true)
+}
+
+func ThroughputBenchmark(b *testing.B, constructor func(
+	t testing.TB, conn1, conn2 net.Conn) (sslconn1, sslconn2 HandshakingConn)) {
+	server_conn, client_conn := NetPipe(b)
+	defer server_conn.Close()
+	defer client_conn.Close()
+
+	server, client := constructor(b, server_conn, client_conn)
+	defer close_both(server, client)
+
+	b.SetBytes(1024)
+	data := make([]byte, b.N*1024)
+	_, err := io.ReadFull(rand.Reader, data[:])
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, err = io.Copy(client, bytes.NewReader([]byte(data)))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+
+		buf := &bytes.Buffer{}
+		_, err = io.CopyN(buf, server, int64(len(data)))
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !bytes.Equal(buf.Bytes(), data) {
+			b.Fatal("mismatched data")
+		}
+	}()
+	wg.Wait()
+	b.StopTimer()
+}
+
+func StdlibConstructor(t testing.TB, server_conn, client_conn net.Conn) (
+	server, client HandshakingConn) {
+	cert, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true,
+		CipherSuites:       []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA}}
+	server = tls.Server(server_conn, config)
+	client = tls.Client(client_conn, config)
+	return server, client
+}
+
+func passThruVerify(t testing.TB) func(bool, *CertificateStoreCtx) bool {
+	x := func(ok bool, store *CertificateStoreCtx) bool {
+		cert := store.GetCurrentCert()
+		if cert == nil {
+			t.Fatalf("Could not obtain cert from store\n")
+		}
+		sn := cert.GetSerialNumberHex()
+		if len(sn) == 0 {
+			t.Fatalf("Could not obtain serial number from cert")
+		}
+		return ok
+	}
+	return x
+}
+
+func OpenSSLConstructor(t testing.TB, server_conn, client_conn net.Conn) (
+	server, client HandshakingConn) {
+	ctx, err := NewCtx()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx.SetVerify(VerifyNone, passThruVerify(t))
+	key, err := LoadPrivateKeyFromPEM(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ctx.UsePrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := LoadCertificateFromPEM(certBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ctx.UseCertificate(cert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ctx.SetCipherList("AES128-SHA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err = Server(server_conn, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err = Client(client_conn, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return server, client
+}
+
+func StdlibOpenSSLConstructor(t testing.TB, server_conn, client_conn net.Conn) (
+	server, client HandshakingConn) {
+	server_std, _ := StdlibConstructor(t, server_conn, client_conn)
+	_, client_ssl := OpenSSLConstructor(t, server_conn, client_conn)
+	return server_std, client_ssl
+}
+
+func OpenSSLStdlibConstructor(t testing.TB, server_conn, client_conn net.Conn) (
+	server, client HandshakingConn) {
+	_, client_std := StdlibConstructor(t, server_conn, client_conn)
+	server_ssl, _ := OpenSSLConstructor(t, server_conn, client_conn)
+	return server_ssl, client_std
+}
+
+func TestStdlibSimple(t *testing.T) {
+	SimpleConnTest(t, StdlibConstructor)
+}
+
+func TestOpenSSLSimple(t *testing.T) {
+	SimpleConnTest(t, OpenSSLConstructor)
+}
+
+func TestStdlibClosing(t *testing.T) {
+	ClosingTest(t, StdlibConstructor)
+}
+
+func TestOpenSSLClosing(t *testing.T) {
+	ClosingTest(t, OpenSSLConstructor)
+}
+
+func BenchmarkStdlibThroughput(b *testing.B) {
+	ThroughputBenchmark(b, StdlibConstructor)
+}
+
+func BenchmarkOpenSSLThroughput(b *testing.B) {
+	ThroughputBenchmark(b, OpenSSLConstructor)
+}
+
+func TestStdlibOpenSSLSimple(t *testing.T) {
+	SimpleConnTest(t, StdlibOpenSSLConstructor)
+}
+
+func TestOpenSSLStdlibSimple(t *testing.T) {
+	SimpleConnTest(t, OpenSSLStdlibConstructor)
+}
+
+func TestStdlibOpenSSLClosing(t *testing.T) {
+	ClosingTest(t, StdlibOpenSSLConstructor)
+}
+
+func TestOpenSSLStdlibClosing(t *testing.T) {
+	ClosingTest(t, OpenSSLStdlibConstructor)
+}
+
+func BenchmarkStdlibOpenSSLThroughput(b *testing.B) {
+	ThroughputBenchmark(b, StdlibOpenSSLConstructor)
+}
+
+func BenchmarkOpenSSLStdlibThroughput(b *testing.B) {
+	ThroughputBenchmark(b, OpenSSLStdlibConstructor)
+}
+
+func FullDuplexRenegotiationTest(t testing.TB, constructor func(
+	t testing.TB, conn1, conn2 net.Conn) (sslconn1, sslconn2 HandshakingConn)) {
+
+	server_conn, client_conn := NetPipe(t)
+	defer server_conn.Close()
+	defer client_conn.Close()
+
+	times := 256
+	data_len := 4 * SSLRecordSize
+	data1 := make([]byte, data_len)
+	_, err := io.ReadFull(rand.Reader, data1[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	data2 := make([]byte, data_len)
+	_, err = io.ReadFull(rand.Reader, data1[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server, client := constructor(t, server_conn, client_conn)
+	defer close_both(server, client)
+
+	var wg sync.WaitGroup
+
+	send_func := func(sender HandshakingConn, data []byte) {
+		defer wg.Done()
+		for i := 0; i < times; i++ {
+			if i == times/2 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					err := sender.Handshake()
+					if err != nil {
+						t.Fatal(err)
+					}
+				}()
+			}
+			_, err := sender.Write(data)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	recv_func := func(receiver net.Conn, data []byte) {
+		defer wg.Done()
+
+		buf := make([]byte, len(data))
+		for i := 0; i < times; i++ {
+			n, err := io.ReadFull(receiver, buf[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(buf[:n], data) {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	wg.Add(4)
+	go recv_func(server, data1)
+	go send_func(client, data1)
+	go send_func(server, data2)
+	go recv_func(client, data2)
+	wg.Wait()
+}
+
+func TestStdlibFullDuplexRenegotiation(t *testing.T) {
+	FullDuplexRenegotiationTest(t, StdlibConstructor)
+}
+
+func TestOpenSSLFullDuplexRenegotiation(t *testing.T) {
+	FullDuplexRenegotiationTest(t, OpenSSLConstructor)
+}
+
+func TestOpenSSLStdlibFullDuplexRenegotiation(t *testing.T) {
+	FullDuplexRenegotiationTest(t, OpenSSLStdlibConstructor)
+}
+
+func TestStdlibOpenSSLFullDuplexRenegotiation(t *testing.T) {
+	FullDuplexRenegotiationTest(t, StdlibOpenSSLConstructor)
+}
+
+func LotsOfConns(t *testing.T, payload_size int64, loops, clients int,
+	sleep time.Duration, newListener func(net.Listener) net.Listener,
+	newClient func(net.Conn) (net.Conn, error)) {
+	tcp_listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ssl_listener := newListener(tcp_listener)
+	go func() {
+		for {
+			conn, err := ssl_listener.Accept()
+			if err != nil {
+				t.Fatalf("failed accept: %s", err)
+				continue
+			}
+			go func() {
+				defer func() {
+					err = conn.Close()
+					if err != nil {
+						t.Fatalf("failed closing: %s", err)
+					}
+				}()
+				for i := 0; i < loops; i++ {
+					_, err := io.Copy(ioutil.Discard,
+						io.LimitReader(conn, payload_size))
+					if err != nil {
+						t.Fatalf("failed reading: %s", err)
+						return
+					}
+					_, err = io.Copy(conn, io.LimitReader(rand.Reader,
+						payload_size))
+					if err != nil {
+						t.Fatalf("failed writing: %s", err)
+						return
+					}
+				}
+				time.Sleep(sleep)
+			}()
+		}
+	}()
+	var wg sync.WaitGroup
+	for i := 0; i < clients; i++ {
+		tcp_client, err := net.Dial(tcp_listener.Addr().Network(),
+			tcp_listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		ssl_client, err := newClient(tcp_client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Add(1)
+		go func(i int) {
+			defer func() {
+				err = ssl_client.Close()
+				if err != nil {
+					t.Fatalf("failed closing: %s", err)
+				}
+				wg.Done()
+			}()
+			for i := 0; i < loops; i++ {
+				_, err := io.Copy(ssl_client, io.LimitReader(rand.Reader,
+					payload_size))
+				if err != nil {
+					t.Fatalf("failed writing: %s", err)
+					return
+				}
+				_, err = io.Copy(ioutil.Discard,
+					io.LimitReader(ssl_client, payload_size))
+				if err != nil {
+					t.Fatalf("failed reading: %s", err)
+					return
+				}
+			}
+			time.Sleep(sleep)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestStdlibLotsOfConns(t *testing.T) {
+	tls_cert, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tls_config := &tls.Config{
+		Certificates:       []tls.Certificate{tls_cert},
+		InsecureSkipVerify: true,
+		CipherSuites:       []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA}}
+	LotsOfConns(t, 1024*64, 10, 100, 0*time.Second,
+		func(l net.Listener) net.Listener {
+			return tls.NewListener(l, tls_config)
+		}, func(c net.Conn) (net.Conn, error) {
+			return tls.Client(c, tls_config), nil
+		})
+}
+
+func TestOpenSSLLotsOfConns(t *testing.T) {
+	ctx, err := NewCtx()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := LoadPrivateKeyFromPEM(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ctx.UsePrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := LoadCertificateFromPEM(certBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ctx.UseCertificate(cert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ctx.SetCipherList("AES128-SHA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	LotsOfConns(t, 1024*64, 10, 100, 0*time.Second,
+		func(l net.Listener) net.Listener {
+			return NewListener(l, ctx)
+		}, func(c net.Conn) (net.Conn, error) {
+			return Client(c, ctx)
+		})
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/tickets.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/tickets.go
@@ -1,0 +1,222 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"os"
+	"unsafe"
+)
+
+const (
+	KeyNameSize = 16
+)
+
+// TicketCipherCtx describes the cipher that will be used by the ticket store
+// for encrypting the tickets. Engine may be nil if no engine is desired.
+type TicketCipherCtx struct {
+	Cipher *Cipher
+	Engine *Engine
+}
+
+// TicketDigestCtx describes the digest that will be used by the ticket store
+// to authenticate the data. Engine may be nil if no engine is desired.
+type TicketDigestCtx struct {
+	Digest *Digest
+	Engine *Engine
+}
+
+// TicketName is an identifier for the key material for a ticket.
+type TicketName [KeyNameSize]byte
+
+// TicketKey is the key material for a ticket. If this is lost, forward secrecy
+// is lost as it allows decrypting TLS sessions retroactively.
+type TicketKey struct {
+	Name      TicketName
+	CipherKey []byte
+	HMACKey   []byte
+	IV        []byte
+}
+
+// TicketKeyManager is a manager for TicketKeys. It allows one to control the
+// lifetime of tickets, causing renewals and expirations for keys that are
+// created. Calls to the manager are serialized.
+type TicketKeyManager interface {
+	// New should create a brand new TicketKey with a new name.
+	New() *TicketKey
+
+	// Current should return a key that is still valid.
+	Current() *TicketKey
+
+	// Lookup should return a key with the given name, or nil if no name
+	// exists.
+	Lookup(name TicketName) *TicketKey
+
+	// Expired should return if the key with the given name is expired and
+	// should not be used any more.
+	Expired(name TicketName) bool
+
+	// ShouldRenew should return if the key is still ok to use for the current
+	// session, but we should send a new key for the client.
+	ShouldRenew(name TicketName) bool
+}
+
+// TicketStore descibes the encryption and authentication methods the tickets
+// will use along with a key manager for generating and keeping track of the
+// secrets.
+type TicketStore struct {
+	CipherCtx TicketCipherCtx
+	DigestCtx TicketDigestCtx
+	Keys      TicketKeyManager
+}
+
+func (t *TicketStore) cipherEngine() *C.ENGINE {
+	if t.CipherCtx.Engine == nil {
+		return nil
+	}
+	return t.CipherCtx.Engine.e
+}
+
+func (t *TicketStore) digestEngine() *C.ENGINE {
+	if t.DigestCtx.Engine == nil {
+		return nil
+	}
+	return t.DigestCtx.Engine.e
+}
+
+const (
+	// instruct to do a handshake
+	ticket_resp_requireHandshake = 0
+	// crypto context is set up correctly
+	ticket_resp_sessionOk = 1
+	// crypto context is ok, but the ticket should be reissued
+	ticket_resp_renewSession = 2
+	// we had a problem that shouldn't fall back to doing a handshake
+	ticket_resp_error = -1
+
+	// asked to create session crypto context
+	ticket_req_newSession = 1
+	// asked to load crypto context for a previous session
+	ticket_req_lookupSession = 0
+)
+
+//export go_ticket_key_cb_thunk
+func go_ticket_key_cb_thunk(p unsafe.Pointer, s *C.SSL, key_name *C.uchar,
+	iv *C.uchar, cctx *C.EVP_CIPHER_CTX, hctx *C.HMAC_CTX, enc C.int) C.int {
+
+	// no panic's allowed. it's super hard to guarantee any state at this point
+	// so just abort everything.
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Critf("openssl: ticket key callback panic'd: %v", err)
+			os.Exit(1)
+		}
+	}()
+
+	ctx := (*Ctx)(p)
+	store := ctx.ticket_store
+	if store == nil {
+		// TODO(jeff): should this be an error condition? it doesn't make sense
+		// to be called if we don't have a store I believe, but that's probably
+		// not worth aborting the handshake which is what I believe returning
+		// an error would do.
+		return ticket_resp_requireHandshake
+	}
+
+	ctx.ticket_store_mu.Lock()
+	defer ctx.ticket_store_mu.Unlock()
+
+	switch enc {
+	case ticket_req_newSession:
+		key := store.Keys.Current()
+		if key == nil {
+			key = store.Keys.New()
+			if key == nil {
+				return ticket_resp_requireHandshake
+			}
+		}
+
+		C.memcpy(
+			unsafe.Pointer(key_name),
+			unsafe.Pointer(&key.Name[0]),
+			KeyNameSize)
+		C.EVP_EncryptInit_ex(
+			cctx,
+			store.CipherCtx.Cipher.ptr,
+			store.cipherEngine(),
+			(*C.uchar)(&key.CipherKey[0]),
+			(*C.uchar)(&key.IV[0]))
+		C.HMAC_Init_ex(
+			hctx,
+			unsafe.Pointer(&key.HMACKey[0]),
+			C.int(len(key.HMACKey)),
+			store.DigestCtx.Digest.ptr,
+			store.digestEngine())
+
+		return ticket_resp_sessionOk
+
+	case ticket_req_lookupSession:
+		var name TicketName
+		C.memcpy(
+			unsafe.Pointer(&name[0]),
+			unsafe.Pointer(key_name),
+			KeyNameSize)
+
+		key := store.Keys.Lookup(name)
+		if key == nil {
+			return ticket_resp_requireHandshake
+		}
+		if store.Keys.Expired(name) {
+			return ticket_resp_requireHandshake
+		}
+
+		C.EVP_DecryptInit_ex(
+			cctx,
+			store.CipherCtx.Cipher.ptr,
+			store.cipherEngine(),
+			(*C.uchar)(&key.CipherKey[0]),
+			(*C.uchar)(&key.IV[0]))
+		C.HMAC_Init_ex(
+			hctx,
+			unsafe.Pointer(&key.HMACKey[0]),
+			C.int(len(key.HMACKey)),
+			store.DigestCtx.Digest.ptr,
+			store.digestEngine())
+
+		if store.Keys.ShouldRenew(name) {
+			return ticket_resp_renewSession
+		}
+
+		return ticket_resp_sessionOk
+
+	default:
+		return ticket_resp_error
+	}
+}
+
+// SetTicketStore sets the ticket store for the context so that clients can do
+// ticket based session resumption. If the store is nil, the
+func (c *Ctx) SetTicketStore(store *TicketStore) {
+	c.ticket_store = store
+
+	if store == nil {
+		C.X_SSL_CTX_set_tlsext_ticket_key_cb(c.ctx, nil)
+	} else {
+		C.X_SSL_CTX_set_tlsext_ticket_key_cb(c.ctx,
+			(*[0]byte)(C.X_SSL_CTX_ticket_key_cb))
+	}
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/utils/errors.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/utils/errors.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrorGroup collates errors
+type ErrorGroup struct {
+	Errors []error
+}
+
+// Add adds an error to an existing error group
+func (e *ErrorGroup) Add(err error) {
+	if err != nil {
+		e.Errors = append(e.Errors, err)
+	}
+}
+
+// Finalize returns an error corresponding to the ErrorGroup state. If there's
+// no errors in the group, finalize returns nil. If there's only one error,
+// Finalize returns that error. Otherwise, Finalize will make a new error
+// consisting of the messages from the constituent errors.
+func (e *ErrorGroup) Finalize() error {
+	if len(e.Errors) == 0 {
+		return nil
+	}
+	if len(e.Errors) == 1 {
+		return e.Errors[0]
+	}
+	msgs := make([]string, 0, len(e.Errors))
+	for _, err := range e.Errors {
+		msgs = append(msgs, err.Error())
+	}
+	return errors.New(strings.Join(msgs, "\n"))
+}

--- a/grove/vendor/github.com/spacemonkeygo/openssl/utils/future.go
+++ b/grove/vendor/github.com/spacemonkeygo/openssl/utils/future.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"sync"
+)
+
+// Future is a type that is essentially the inverse of a channel. With a
+// channel, you have multiple senders and one receiver. With a future, you can
+// have multiple receivers and one sender. Additionally, a future protects
+// against double-sends. Since this is usually used for returning function
+// results, we also capture and return error values as well. Use NewFuture
+// to initialize.
+type Future struct {
+	mutex    *sync.Mutex
+	cond     *sync.Cond
+	received bool
+	val      interface{}
+	err      error
+}
+
+// NewFuture returns an initialized and ready Future.
+func NewFuture() *Future {
+	mutex := &sync.Mutex{}
+	return &Future{
+		mutex:    mutex,
+		cond:     sync.NewCond(mutex),
+		received: false,
+		val:      nil,
+		err:      nil,
+	}
+}
+
+// Get blocks until the Future has a value set.
+func (self *Future) Get() (interface{}, error) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+	for {
+		if self.received {
+			return self.val, self.err
+		}
+		self.cond.Wait()
+	}
+}
+
+// Fired returns whether or not a value has been set. If Fired is true, Get
+// won't block.
+func (self *Future) Fired() bool {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+	return self.received
+}
+
+// Set provides the value to present and future Get calls. If Set has already
+// been called, this is a no-op.
+func (self *Future) Set(val interface{}, err error) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+	if self.received {
+		return
+	}
+	self.received = true
+	self.val = val
+	self.err = err
+	self.cond.Broadcast()
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/.travis.yml
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - 1.7
+  - 1.8
+  - tip

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/LICENSE
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/README.md
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/README.md
@@ -1,0 +1,19 @@
+# spacelog [![Build Status](https://api.travis-ci.org/spacemonkeygo/spacelog.svg?branch=master)](https://travis-ci.org/spacemonkeygo/spacelog)
+
+Please see http://godoc.org/github.com/spacemonkeygo/spacelog for info
+
+### License
+
+Copyright (C) 2014 Space Monkey, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/capture.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/capture.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// CaptureOutputToFile opens a filehandle using the given path, then calls
+// CaptureOutputToFd on the associated filehandle.
+func CaptureOutputToFile(path string) error {
+	fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	return CaptureOutputToFd(int(fh.Fd()))
+}
+
+// CaptureOutputToProcess starts a process and using CaptureOutputToFd,
+// redirects stdout and stderr to the subprocess' stdin.
+// CaptureOutputToProcess expects the subcommand to last the lifetime of the
+// process, and if the subprocess dies, will panic.
+func CaptureOutputToProcess(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	out, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	type fder interface {
+		Fd() uintptr
+	}
+	out_fder, ok := out.(fder)
+	if !ok {
+		return fmt.Errorf("unable to get underlying pipe")
+	}
+	err = CaptureOutputToFd(int(out_fder.Fd()))
+	if err != nil {
+		return err
+	}
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+	go func() {
+		err := cmd.Wait()
+		if err != nil {
+			panic(fmt.Errorf("captured output process died! %s", err))
+		}
+	}()
+	return nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/capture_ae.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/capture_ae.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build appengine
+
+package spacelog
+
+import (
+	"fmt"
+)
+
+func CaptureOutputToFd(fd int) error {
+	return fmt.Errorf("CaptureOutputToFd not supported on App Engine")
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/capture_linux.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/capture_linux.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !appengine
+
+package spacelog
+
+import (
+	"syscall"
+)
+
+// CaptureOutputToFd redirects the current process' stdout and stderr file
+// descriptors to the given file descriptor, using the dup3 syscall.
+func CaptureOutputToFd(fd int) error {
+	err := syscall.Dup3(fd, syscall.Stdout, 0)
+	if err != nil {
+		return err
+	}
+	err = syscall.Dup3(fd, syscall.Stderr, 0)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/capture_other.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/capture_other.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+// +build !linux
+// +build !appengine
+// +build !solaris
+
+package spacelog
+
+import (
+	"syscall"
+)
+
+// CaptureOutputToFd redirects the current process' stdout and stderr file
+// descriptors to the given file descriptor, using the dup2 syscall.
+func CaptureOutputToFd(fd int) error {
+	err := syscall.Dup2(fd, syscall.Stdout)
+	if err != nil {
+		return err
+	}
+	err = syscall.Dup2(fd, syscall.Stderr)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/capture_solaris.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/capture_solaris.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// CaptureOutputToFd redirects the current process' stdout and stderr file
+// descriptors to the given file descriptor, using the dup2 syscall.
+func CaptureOutputToFd(fd int) error {
+	err := unix.Dup2(fd, unix.Stdout)
+	if err != nil {
+		return err
+	}
+	err = unix.Dup2(fd, unix.Stderr)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/capture_windows.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/capture_windows.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"fmt"
+)
+
+func CaptureOutputToFd(fd int) error {
+	return fmt.Errorf("CaptureOutputToFd not supported on Windows")
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/collection.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/collection.go
@@ -1,0 +1,271 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"text/template"
+)
+
+var (
+	// If set, these prefixes will be stripped out of automatic logger names.
+	IgnoredPrefixes []string
+
+	badChars = regexp.MustCompile("[^a-zA-Z0-9_.-]")
+	slashes  = regexp.MustCompile("[/]")
+)
+
+func callerName() string {
+	pc, _, _, ok := runtime.Caller(2)
+	if !ok {
+		return "unknown.unknown"
+	}
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return "unknown.unknown"
+	}
+	name := f.Name()
+	for _, prefix := range IgnoredPrefixes {
+		name = strings.TrimPrefix(name, prefix)
+	}
+	return badChars.ReplaceAllLiteralString(
+		slashes.ReplaceAllLiteralString(name, "."), "_")
+}
+
+// LoggerCollections contain all of the loggers a program might use. Typically
+// a codebase will just use the default logger collection.
+type LoggerCollection struct {
+	mtx     sync.Mutex
+	loggers map[string]*Logger
+	level   LogLevel
+	handler Handler
+}
+
+// NewLoggerCollection creates a new logger collection. It's unlikely you will
+// ever practically need this method. Use the DefaultLoggerCollection instead.
+func NewLoggerCollection() *LoggerCollection {
+	return &LoggerCollection{
+		loggers: make(map[string]*Logger),
+		level:   DefaultLevel,
+		handler: defaultHandler}
+}
+
+// GetLogger returns a new Logger with a name automatically generated using
+// the callstack. If you want to avoid automatic name generation check out
+// GetLoggerNamed
+func (c *LoggerCollection) GetLogger() *Logger {
+	return c.GetLoggerNamed(callerName())
+}
+
+func (c *LoggerCollection) getLogger(name string, level LogLevel,
+	handler Handler) *Logger {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	logger, exists := c.loggers[name]
+	if !exists {
+		logger = &Logger{level: level,
+			collection: c,
+			name:       name,
+			handler:    handler}
+		c.loggers[name] = logger
+	}
+	return logger
+}
+
+// ConfigureLoggers configures loggers according to the given string
+// specification, which specifies a set of loggers and their associated
+// logging levels.  Loggers are semicolon-separated; each
+// configuration is specified as <logger>=<level>.  White space outside of
+// logger names and levels is ignored.  The default level is specified
+// with the name "DEFAULT".
+//
+// An example specification:
+//	`DEFAULT=ERROR; foo.bar=WARNING`
+func (c *LoggerCollection) ConfigureLoggers(specification string) error {
+	confs := strings.Split(strings.TrimSpace(specification), ";")
+	for i := range confs {
+		conf := strings.SplitN(confs[i], "=", 2)
+		levelstr := strings.TrimSpace(conf[1])
+		name := strings.TrimSpace(conf[0])
+		level, err := LevelFromString(levelstr)
+		if err != nil {
+			return err
+		}
+		if name == "DEFAULT" {
+			c.SetLevel(nil, level)
+			continue
+		}
+		logger := c.GetLoggerNamed(name)
+		logger.setLevel(level)
+	}
+	return nil
+}
+
+// GetLoggerNamed returns a new Logger with the provided name. GetLogger is
+// more frequently used.
+func (c *LoggerCollection) GetLoggerNamed(name string) *Logger {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	logger, exists := c.loggers[name]
+	if !exists {
+		logger = &Logger{level: c.level,
+			collection: c,
+			name:       name,
+			handler:    c.handler}
+		c.loggers[name] = logger
+	}
+	return logger
+}
+
+// SetLevel will set the current log level for all loggers with names that
+// match a provided regular expression. If the regular expression is nil, then
+// all loggers match.
+func (c *LoggerCollection) SetLevel(re *regexp.Regexp, level LogLevel) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if re == nil {
+		c.level = level
+	}
+	for name, logger := range c.loggers {
+		if re == nil || re.MatchString(name) {
+			logger.setLevel(level)
+		}
+	}
+}
+
+// SetHandler will set the current log handler for all loggers with names that
+// match a provided regular expression. If the regular expression is nil, then
+// all loggers match.
+func (c *LoggerCollection) SetHandler(re *regexp.Regexp, handler Handler) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if re == nil {
+		c.handler = handler
+	}
+	for name, logger := range c.loggers {
+		if re == nil || re.MatchString(name) {
+			logger.setHandler(handler)
+		}
+	}
+}
+
+// SetTextTemplate will set the current text template for all loggers with
+// names that match a provided regular expression. If the regular expression
+// is nil, then all loggers match. Note that not every handler is guaranteed
+// to support text templates and a text template will only apply to
+// text-oriented and unstructured handlers.
+func (c *LoggerCollection) SetTextTemplate(re *regexp.Regexp,
+	t *template.Template) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if re == nil {
+		c.handler.SetTextTemplate(t)
+	}
+	for name, logger := range c.loggers {
+		if re == nil || re.MatchString(name) {
+			logger.getHandler().SetTextTemplate(t)
+		}
+	}
+}
+
+// SetTextOutput will set the current output interface for all loggers with
+// names that match a provided regular expression. If the regular expression
+// is nil, then all loggers match. Note that not every handler is guaranteed
+// to support text output and a text output interface will only apply to
+// text-oriented and unstructured handlers.
+func (c *LoggerCollection) SetTextOutput(re *regexp.Regexp,
+	output TextOutput) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if re == nil {
+		c.handler.SetTextOutput(output)
+	}
+	for name, logger := range c.loggers {
+		if re == nil || re.MatchString(name) {
+			logger.getHandler().SetTextOutput(output)
+		}
+	}
+}
+
+var (
+	// It's unlikely you'll need to use this directly
+	DefaultLoggerCollection = NewLoggerCollection()
+)
+
+// GetLogger returns an automatically-named logger on the default logger
+// collection.
+func GetLogger() *Logger {
+	return DefaultLoggerCollection.GetLoggerNamed(callerName())
+}
+
+// GetLoggerNamed returns a new Logger with the provided name on the default
+// logger collection. GetLogger is more frequently used.
+func GetLoggerNamed(name string) *Logger {
+	return DefaultLoggerCollection.GetLoggerNamed(name)
+}
+
+// ConfigureLoggers configures loggers according to the given string
+// specification, which specifies a set of loggers and their associated
+// logging levels.  Loggers are colon- or semicolon-separated; each
+// configuration is specified as <logger>=<level>.  White space outside of
+// logger names and levels is ignored.  The DEFAULT module is specified
+// with the name "DEFAULT".
+//
+// An example specification:
+//	`DEFAULT=ERROR; foo.bar=WARNING`
+func ConfigureLoggers(specification string) error {
+	return DefaultLoggerCollection.ConfigureLoggers(specification)
+}
+
+// SetLevel will set the current log level for all loggers on the default
+// collection with names that match a provided regular expression. If the
+// regular expression is nil, then all loggers match.
+func SetLevel(re *regexp.Regexp, level LogLevel) {
+	DefaultLoggerCollection.SetLevel(re, level)
+}
+
+// SetHandler will set the current log handler for all loggers on the default
+// collection with names that match a provided regular expression. If the
+// regular expression is nil, then all loggers match.
+func SetHandler(re *regexp.Regexp, handler Handler) {
+	DefaultLoggerCollection.SetHandler(re, handler)
+}
+
+// SetTextTemplate will set the current text template for all loggers on the
+// default collection with names that match a provided regular expression. If
+// the regular expression is nil, then all loggers match. Note that not every
+// handler is guaranteed to support text templates and a text template will
+// only apply to text-oriented and unstructured handlers.
+func SetTextTemplate(re *regexp.Regexp, t *template.Template) {
+	DefaultLoggerCollection.SetTextTemplate(re, t)
+}
+
+// SetTextOutput will set the current output interface for all loggers on the
+// default collection with names that match a provided regular expression. If
+// the regular expression is nil, then all loggers match. Note that not every
+// handler is guaranteed to support text output and a text output interface
+// will only apply to text-oriented and unstructured handlers.
+func SetTextOutput(re *regexp.Regexp, output TextOutput) {
+	DefaultLoggerCollection.SetTextOutput(re, output)
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/convenience.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/convenience.go
@@ -1,0 +1,296 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"fmt"
+	"io"
+)
+
+// Trace logs a collection of values if the logger's level is trace or even
+// more permissive.
+func (l *Logger) Trace(v ...interface{}) {
+	if l.getLevel() <= Trace {
+		l.getHandler().Log(l.name, Trace, fmt.Sprint(v...), 1)
+	}
+}
+
+// Tracef logs a format string with values if the logger's level is trace or
+// even more permissive.
+func (l *Logger) Tracef(format string, v ...interface{}) {
+	if l.getLevel() <= Trace {
+		l.getHandler().Log(l.name, Trace, fmt.Sprintf(format, v...), 1)
+	}
+}
+
+// Tracee logs an error value if the error is not nil and the logger's level
+// is trace or even more permissive.
+func (l *Logger) Tracee(err error) {
+	if l.getLevel() <= Trace && err != nil {
+		l.getHandler().Log(l.name, Trace, err.Error(), 1)
+	}
+}
+
+// TraceEnabled returns true if the logger's level is trace or even more
+// permissive.
+func (l *Logger) TraceEnabled() bool {
+	return l.getLevel() <= Trace
+}
+
+// Debug logs a collection of values if the logger's level is debug or even
+// more permissive.
+func (l *Logger) Debug(v ...interface{}) {
+	if l.getLevel() <= Debug {
+		l.getHandler().Log(l.name, Debug, fmt.Sprint(v...), 1)
+	}
+}
+
+// Debugf logs a format string with values if the logger's level is debug or
+// even more permissive.
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	if l.getLevel() <= Debug {
+		l.getHandler().Log(l.name, Debug, fmt.Sprintf(format, v...), 1)
+	}
+}
+
+// Debuge logs an error value if the error is not nil and the logger's level
+// is debug or even more permissive.
+func (l *Logger) Debuge(err error) {
+	if l.getLevel() <= Debug && err != nil {
+		l.getHandler().Log(l.name, Debug, err.Error(), 1)
+	}
+}
+
+// DebugEnabled returns true if the logger's level is debug or even more
+// permissive.
+func (l *Logger) DebugEnabled() bool {
+	return l.getLevel() <= Debug
+}
+
+// Info logs a collection of values if the logger's level is info or even
+// more permissive.
+func (l *Logger) Info(v ...interface{}) {
+	if l.getLevel() <= Info {
+		l.getHandler().Log(l.name, Info, fmt.Sprint(v...), 1)
+	}
+}
+
+// Infof logs a format string with values if the logger's level is info or
+// even more permissive.
+func (l *Logger) Infof(format string, v ...interface{}) {
+	if l.getLevel() <= Info {
+		l.getHandler().Log(l.name, Info, fmt.Sprintf(format, v...), 1)
+	}
+}
+
+// Infoe logs an error value if the error is not nil and the logger's level
+// is info or even more permissive.
+func (l *Logger) Infoe(err error) {
+	if l.getLevel() <= Info && err != nil {
+		l.getHandler().Log(l.name, Info, err.Error(), 1)
+	}
+}
+
+// InfoEnabled returns true if the logger's level is info or even more
+// permissive.
+func (l *Logger) InfoEnabled() bool {
+	return l.getLevel() <= Info
+}
+
+// Notice logs a collection of values if the logger's level is notice or even
+// more permissive.
+func (l *Logger) Notice(v ...interface{}) {
+	if l.getLevel() <= Notice {
+		l.getHandler().Log(l.name, Notice, fmt.Sprint(v...), 1)
+	}
+}
+
+// Noticef logs a format string with values if the logger's level is notice or
+// even more permissive.
+func (l *Logger) Noticef(format string, v ...interface{}) {
+	if l.getLevel() <= Notice {
+		l.getHandler().Log(l.name, Notice, fmt.Sprintf(format, v...), 1)
+	}
+}
+
+// Noticee logs an error value if the error is not nil and the logger's level
+// is notice or even more permissive.
+func (l *Logger) Noticee(err error) {
+	if l.getLevel() <= Notice && err != nil {
+		l.getHandler().Log(l.name, Notice, err.Error(), 1)
+	}
+}
+
+// NoticeEnabled returns true if the logger's level is notice or even more
+// permissive.
+func (l *Logger) NoticeEnabled() bool {
+	return l.getLevel() <= Notice
+}
+
+// Warn logs a collection of values if the logger's level is warning or even
+// more permissive.
+func (l *Logger) Warn(v ...interface{}) {
+	if l.getLevel() <= Warning {
+		l.getHandler().Log(l.name, Warning, fmt.Sprint(v...), 1)
+	}
+}
+
+// Warnf logs a format string with values if the logger's level is warning or
+// even more permissive.
+func (l *Logger) Warnf(format string, v ...interface{}) {
+	if l.getLevel() <= Warning {
+		l.getHandler().Log(l.name, Warning, fmt.Sprintf(format, v...), 1)
+	}
+}
+
+// Warne logs an error value if the error is not nil and the logger's level
+// is warning or even more permissive.
+func (l *Logger) Warne(err error) {
+	if l.getLevel() <= Warning && err != nil {
+		l.getHandler().Log(l.name, Warning, err.Error(), 1)
+	}
+}
+
+// WarnEnabled returns true if the logger's level is warning or even more
+// permissive.
+func (l *Logger) WarnEnabled() bool {
+	return l.getLevel() <= Warning
+}
+
+// Error logs a collection of values if the logger's level is error or even
+// more permissive.
+func (l *Logger) Error(v ...interface{}) {
+	if l.getLevel() <= Error {
+		l.getHandler().Log(l.name, Error, fmt.Sprint(v...), 1)
+	}
+}
+
+// Errorf logs a format string with values if the logger's level is error or
+// even more permissive.
+func (l *Logger) Errorf(format string, v ...interface{}) {
+	if l.getLevel() <= Error {
+		l.getHandler().Log(l.name, Error, fmt.Sprintf(format, v...), 1)
+	}
+}
+
+// Errore logs an error value if the error is not nil and the logger's level
+// is error or even more permissive.
+func (l *Logger) Errore(err error) {
+	if l.getLevel() <= Error && err != nil {
+		l.getHandler().Log(l.name, Error, err.Error(), 1)
+	}
+}
+
+// ErrorEnabled returns true if the logger's level is error or even more
+// permissive.
+func (l *Logger) ErrorEnabled() bool {
+	return l.getLevel() <= Error
+}
+
+// Crit logs a collection of values if the logger's level is critical or even
+// more permissive.
+func (l *Logger) Crit(v ...interface{}) {
+	if l.getLevel() <= Critical {
+		l.getHandler().Log(l.name, Critical, fmt.Sprint(v...), 1)
+	}
+}
+
+// Critf logs a format string with values if the logger's level is critical or
+// even more permissive.
+func (l *Logger) Critf(format string, v ...interface{}) {
+	if l.getLevel() <= Critical {
+		l.getHandler().Log(l.name, Critical, fmt.Sprintf(format, v...), 1)
+	}
+}
+
+// Crite logs an error value if the error is not nil and the logger's level
+// is critical or even more permissive.
+func (l *Logger) Crite(err error) {
+	if l.getLevel() <= Critical && err != nil {
+		l.getHandler().Log(l.name, Critical, err.Error(), 1)
+	}
+}
+
+// CritEnabled returns true if the logger's level is critical or even more
+// permissive.
+func (l *Logger) CritEnabled() bool {
+	return l.getLevel() <= Critical
+}
+
+// Log logs a collection of values if the logger's level is the provided level
+// or even more permissive.
+func (l *Logger) Log(level LogLevel, v ...interface{}) {
+	if l.getLevel() <= level {
+		l.getHandler().Log(l.name, level, fmt.Sprint(v...), 1)
+	}
+}
+
+// Logf logs a format string with values if the logger's level is the provided
+// level or even more permissive.
+func (l *Logger) Logf(level LogLevel, format string, v ...interface{}) {
+	if l.getLevel() <= level {
+		l.getHandler().Log(l.name, level, fmt.Sprintf(format, v...), 1)
+	}
+}
+
+// Loge logs an error value if the error is not nil and the logger's level
+// is the provided level or even more permissive.
+func (l *Logger) Loge(level LogLevel, err error) {
+	if l.getLevel() <= level && err != nil {
+		l.getHandler().Log(l.name, level, err.Error(), 1)
+	}
+}
+
+// LevelEnabled returns true if the logger's level is the provided level or
+// even more permissive.
+func (l *Logger) LevelEnabled(level LogLevel) bool {
+	return l.getLevel() <= level
+}
+
+type writer struct {
+	l     *Logger
+	level LogLevel
+}
+
+func (w *writer) Write(data []byte) (int, error) {
+	if w.l.getLevel() <= w.level {
+		w.l.getHandler().Log(w.l.name, w.level, string(data), 1)
+	}
+	return len(data), nil
+}
+
+// Writer returns an io.Writer that writes messages at the given log level.
+func (l *Logger) Writer(level LogLevel) io.Writer {
+	return &writer{l: l, level: level}
+}
+
+type writerNoCaller struct {
+	l     *Logger
+	level LogLevel
+}
+
+func (w *writerNoCaller) Write(data []byte) (int, error) {
+	if w.l.getLevel() <= w.level {
+		w.l.getHandler().Log(w.l.name, w.level, string(data), -1)
+	}
+	return len(data), nil
+}
+
+// WriterWithoutCaller returns an io.Writer that writes messages at the given
+// log level, but does not attempt to collect the Write caller, and provides
+// no caller information to the log event.
+func (l *Logger) WriterWithoutCaller(level LogLevel) io.Writer {
+	return &writerNoCaller{l: l, level: level}
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/doc.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/doc.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package spacelog is a collection of interface lego bricks designed to help you
+build a flexible logging system.
+
+spacelog is loosely inspired by the Python logging library.
+
+The basic interaction is between a Logger and a Handler. A Logger is
+what the programmer typically interacts with for creating log messages. A
+Logger will be at a given log level, and if log messages can clear that
+specific logger's log level filter, they will be passed off to the Handler.
+
+Loggers are instantiated from GetLogger and GetLoggerNamed.
+
+A Handler is a very generic interface for handling log events. You can provide
+your own Handler for doing structured JSON output or colorized output or
+countless other things.
+
+Provided are a simple TextHandler with a variety of log event templates and
+TextOutput sinks, such as io.Writer, Syslog, and so forth.
+
+Make sure to see the source of the setup subpackage for an example of easy and
+configurable logging setup at process start:
+  http://godoc.org/github.com/spacemonkeygo/spacelog/setup
+*/
+package spacelog

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/event.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/event.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// TermColors is a type that knows how to output terminal colors and formatting
+type TermColors struct{}
+
+// LogEvent is a type made by the default text handler for feeding to log
+// templates. It has as much contextual data about the log event as possible.
+type LogEvent struct {
+	LoggerName string
+	Level      LogLevel
+	Message    string
+	Filepath   string
+	Line       int
+	Timestamp  time.Time
+
+	TermColors
+}
+
+// Reset resets the color palette for terminals that support color
+func (TermColors) Reset() string     { return "\x1b[0m" }
+func (TermColors) Bold() string      { return "\x1b[1m" }
+func (TermColors) Underline() string { return "\x1b[4m" }
+func (TermColors) Black() string     { return "\x1b[30m" }
+func (TermColors) Red() string       { return "\x1b[31m" }
+func (TermColors) Green() string     { return "\x1b[32m" }
+func (TermColors) Yellow() string    { return "\x1b[33m" }
+func (TermColors) Blue() string      { return "\x1b[34m" }
+func (TermColors) Magenta() string   { return "\x1b[35m" }
+func (TermColors) Cyan() string      { return "\x1b[36m" }
+func (TermColors) White() string     { return "\x1b[37m" }
+
+func (l *LogEvent) Filename() string {
+	if l.Filepath == "" {
+		return ""
+	}
+	return filepath.Base(l.Filepath)
+}
+
+func (l *LogEvent) Time() string {
+	return l.Timestamp.Format("15:04:05")
+}
+
+func (l *LogEvent) Date() string {
+	return l.Timestamp.Format("2006/01/02")
+}
+
+// LevelJustified returns the log level in string form justified so that all
+// log levels take the same text width.
+func (l *LogEvent) LevelJustified() (rv string) {
+	rv = l.Level.String()
+	if len(rv) < 5 {
+		rv += strings.Repeat(" ", 5-len(rv))
+	}
+	return rv
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/handler.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/handler.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"text/template"
+)
+
+// Handler is an interface that knows how to process log events. This is the
+// basic interface type for building a logging system. If you want to route
+// structured log data somewhere, you would implement this interface.
+type Handler interface {
+	// Log is called for every message. if calldepth is negative, caller
+	// information is missing
+	Log(logger_name string, level LogLevel, msg string, calldepth int)
+
+	// These two calls are expected to be no-ops on non-text-output handlers
+	SetTextTemplate(t *template.Template)
+	SetTextOutput(output TextOutput)
+}
+
+// HandlerFunc is a type to make implementation of the Handler interface easier
+type HandlerFunc func(logger_name string, level LogLevel, msg string,
+	calldepth int)
+
+// Log simply calls f(logger_name, level, msg, calldepth)
+func (f HandlerFunc) Log(logger_name string, level LogLevel, msg string,
+	calldepth int) {
+	f(logger_name, level, msg, calldepth)
+}
+
+// SetTextTemplate is a no-op
+func (HandlerFunc) SetTextTemplate(t *template.Template) {}
+
+// SetTextOutput is a no-op
+func (HandlerFunc) SetTextOutput(output TextOutput) {}
+
+var (
+	defaultHandler = NewTextHandler(StdlibTemplate,
+		&StdlibOutput{})
+)

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/level.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/level.go
@@ -1,0 +1,136 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type LogLevel int32
+
+const (
+	Trace    LogLevel = 5
+	Debug    LogLevel = 10
+	Info     LogLevel = 20
+	Notice   LogLevel = 30
+	Warning  LogLevel = 40
+	Error    LogLevel = 50
+	Critical LogLevel = 60
+	// syslog has Alert
+	// syslog has Emerg
+
+	DefaultLevel = Notice
+)
+
+// String returns the log level name in short form
+func (l LogLevel) String() string {
+	switch l.Match() {
+	case Critical:
+		return "CRIT"
+	case Error:
+		return "ERR"
+	case Warning:
+		return "WARN"
+	case Notice:
+		return "NOTE"
+	case Info:
+		return "INFO"
+	case Debug:
+		return "DEBUG"
+	case Trace:
+		return "TRACE"
+	default:
+		return "UNSET"
+	}
+}
+
+// String returns the log level name in long human readable form
+func (l LogLevel) Name() string {
+	switch l.Match() {
+	case Critical:
+		return "critical"
+	case Error:
+		return "error"
+	case Warning:
+		return "warning"
+	case Notice:
+		return "notice"
+	case Info:
+		return "info"
+	case Debug:
+		return "debug"
+	case Trace:
+		return "trace"
+	default:
+		return "unset"
+	}
+}
+
+// Match returns the greatest named log level that is less than or equal to
+// the receiver log level. For example, if the log level is 43, Match() will
+// return 40 (Warning)
+func (l LogLevel) Match() LogLevel {
+	if l >= Critical {
+		return Critical
+	}
+	if l >= Error {
+		return Error
+	}
+	if l >= Warning {
+		return Warning
+	}
+	if l >= Notice {
+		return Notice
+	}
+	if l >= Info {
+		return Info
+	}
+	if l >= Debug {
+		return Debug
+	}
+	if l >= Trace {
+		return Trace
+	}
+	return 0
+}
+
+// LevelFromString will convert a named log level to its corresponding value
+// type, or error if both the name was unknown and an integer value was unable
+// to be parsed.
+func LevelFromString(str string) (LogLevel, error) {
+	switch strings.ToLower(str) {
+	case "crit", "critical":
+		return Critical, nil
+	case "err", "error":
+		return Error, nil
+	case "warn", "warning":
+		return Warning, nil
+	case "note", "notice":
+		return Notice, nil
+	case "info":
+		return Info, nil
+	case "debug":
+		return Debug, nil
+	case "trace":
+		return Trace, nil
+	}
+	val, err := strconv.ParseInt(str, 10, 32)
+	if err == nil {
+		return LogLevel(val), nil
+	}
+	return 0, fmt.Errorf("Invalid log level: %s", str)
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/logger.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/logger.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Logger is the basic type that allows for logging. A logger has an associated
+// name, given to it during construction, either through a logger collection,
+// GetLogger, GetLoggerNamed, or another Logger's Scope method. A logger also
+// has an associated level and handler, typically configured through the logger
+// collection to which it belongs.
+type Logger struct {
+	level      LogLevel
+	name       string
+	collection *LoggerCollection
+
+	handler_mtx sync.RWMutex
+	handler     Handler
+}
+
+// Scope returns a new Logger with the same level and handler, using the
+// receiver Logger's name as a prefix.
+func (l *Logger) Scope(name string) *Logger {
+	return l.collection.getLogger(l.name+"."+name, l.getLevel(),
+		l.getHandler())
+}
+
+func (l *Logger) setLevel(level LogLevel) {
+	atomic.StoreInt32((*int32)(&l.level), int32(level))
+}
+
+func (l *Logger) getLevel() LogLevel {
+	return LogLevel(atomic.LoadInt32((*int32)(&l.level)))
+}
+
+func (l *Logger) setHandler(handler Handler) {
+	l.handler_mtx.Lock()
+	defer l.handler_mtx.Unlock()
+	l.handler = handler
+}
+
+func (l *Logger) getHandler() Handler {
+	l.handler_mtx.RLock()
+	defer l.handler_mtx.RUnlock()
+	return l.handler
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/output.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/output.go
@@ -1,0 +1,178 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sync"
+)
+
+type TextOutput interface {
+	Output(LogLevel, []byte)
+}
+
+// WriterOutput is an io.Writer wrapper that matches the TextOutput interface
+type WriterOutput struct {
+	w io.Writer
+}
+
+// NewWriterOutput returns a TextOutput that writes messages to an io.Writer
+func NewWriterOutput(w io.Writer) *WriterOutput {
+	return &WriterOutput{w: w}
+}
+
+func (o *WriterOutput) Output(_ LogLevel, message []byte) {
+	o.w.Write(append(bytes.TrimRight(message, "\r\n"), platformNewline...))
+}
+
+// StdlibOutput is a TextOutput that simply writes to the default Go stdlib
+// logging system. It is the default. If you configure the Go stdlib to write
+// to spacelog, make sure to provide a new TextOutput to your logging
+// collection
+type StdlibOutput struct{}
+
+func (*StdlibOutput) Output(_ LogLevel, message []byte) {
+	log.Print(string(message))
+}
+
+type bufferMsg struct {
+	level   LogLevel
+	message []byte
+}
+
+// BufferedOutput uses a channel to synchronize writes to a wrapped TextOutput
+// and allows for buffering a limited amount of log events.
+type BufferedOutput struct {
+	o          TextOutput
+	c          chan bufferMsg
+	running    sync.Mutex
+	close_once sync.Once
+}
+
+// NewBufferedOutput returns a BufferedOutput wrapping output with a buffer
+// size of buffer.
+func NewBufferedOutput(output TextOutput, buffer int) *BufferedOutput {
+	if buffer < 0 {
+		buffer = 0
+	}
+	b := &BufferedOutput{
+		o: output,
+		c: make(chan bufferMsg, buffer)}
+	go b.process()
+	return b
+}
+
+// Close shuts down the BufferedOutput's processing
+func (b *BufferedOutput) Close() {
+	b.close_once.Do(func() {
+		close(b.c)
+	})
+	b.running.Lock()
+	b.running.Unlock()
+}
+
+func (b *BufferedOutput) Output(level LogLevel, message []byte) {
+	b.c <- bufferMsg{level: level, message: message}
+}
+
+func (b *BufferedOutput) process() {
+	b.running.Lock()
+	defer b.running.Unlock()
+	for {
+		msg, open := <-b.c
+		if !open {
+			break
+		}
+		b.o.Output(msg.level, msg.message)
+	}
+}
+
+// A TextOutput object that also implements HupHandlingTextOutput may have its
+// OnHup() method called when an administrative signal is sent to this process.
+type HupHandlingTextOutput interface {
+	TextOutput
+	OnHup()
+}
+
+// FileWriterOutput is like WriterOutput with a plain file handle, but it
+// knows how to reopen the file (or try to reopen it) if it hasn't been able
+// to open the file previously, or if an appropriate signal has been received.
+type FileWriterOutput struct {
+	*WriterOutput
+	path string
+}
+
+// Creates a new FileWriterOutput object. This is the only case where an
+// error opening the file will be reported to the caller; if we try to
+// reopen it later and the reopen fails, we'll just keep trying until it
+// works.
+func NewFileWriterOutput(path string) (*FileWriterOutput, error) {
+	fo := &FileWriterOutput{path: path}
+	fh, err := fo.openFile()
+	if err != nil {
+		return nil, err
+	}
+	fo.WriterOutput = NewWriterOutput(fh)
+	return fo, nil
+}
+
+// Try to open the file with the path associated with this object.
+func (fo *FileWriterOutput) openFile() (*os.File, error) {
+	return os.OpenFile(fo.path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+}
+
+// Try to communicate a message without using our log file. In all likelihood,
+// stderr is closed or redirected to /dev/null, but at least we can try
+// writing there. In the very worst case, if an admin attaches a ptrace to
+// this process, it will be more clear what the problem is.
+func (fo *FileWriterOutput) fallbackLog(tmpl string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, tmpl, args...)
+}
+
+// Output a log line by writing it to the file. If the file has been
+// released, try to open it again. If that fails, cry for a little
+// while, then throw away the message and carry on.
+func (fo *FileWriterOutput) Output(ll LogLevel, message []byte) {
+	if fo.WriterOutput == nil {
+		fh, err := fo.openFile()
+		if err != nil {
+			fo.fallbackLog("Could not open %#v: %s", fo.path, err)
+			return
+		}
+		fo.WriterOutput = NewWriterOutput(fh)
+	}
+	fo.WriterOutput.Output(ll, message)
+}
+
+// Throw away any references/handles to the output file. This probably
+// means the admin wants to rotate the file out and have this process
+// open a new one. Close the underlying io.Writer if that is a thing
+// that it knows how to do.
+func (fo *FileWriterOutput) OnHup() {
+	if fo.WriterOutput != nil {
+		wc, ok := fo.WriterOutput.w.(io.Closer)
+		if ok {
+			err := wc.Close()
+			if err != nil {
+				fo.fallbackLog("Closing %#v failed: %s", fo.path, err)
+			}
+		}
+		fo.WriterOutput = nil
+	}
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/output_other.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/output_other.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package spacelog
+
+var platformNewline = []byte("\n")

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/output_windows.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/output_windows.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+var platformNewline = []byte("\r\n")

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/setup.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/setup.go
@@ -1,0 +1,189 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"os/signal"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+// SetupConfig is a configuration struct meant to be used with
+//   github.com/spacemonkeygo/flagfile/utils.Setup
+// but can be used independently.
+type SetupConfig struct {
+	Output   string `default:"stderr" usage:"log output. can be stdout, stderr, syslog, or a path"`
+	Level    string `default:"" usage:"base logger level"`
+	Filter   string `default:"" usage:"sets loggers matching this regular expression to the lowest level"`
+	Format   string `default:"" usage:"format string to use"`
+	Stdlevel string `default:"warn" usage:"logger level for stdlib log integration"`
+	Subproc  string `default:"" usage:"process to run for stdout/stderr-captured logging. The command is first processed as a Go template that supports {{.Facility}}, {{.Level}}, and {{.Name}} fields, and then passed to sh. If set, will redirect stdout and stderr to the given process. A good default is 'setsid logger --priority {{.Facility}}.{{.Level}} --tag {{.Name}}'"`
+	Buffer   int    `default:"0" usage:"the number of messages to buffer. 0 for no buffer"`
+	// Facility defaults to syslog.LOG_USER (which is 8)
+	Facility  int    `default:"8" usage:"the syslog facility to use if syslog output is configured"`
+	HupRotate bool   `default:"false" usage:"if true, sending a HUP signal will reopen log files"`
+	Config    string `default:"" usage:"a semicolon separated list of logger=level; sets each log to the corresponding level"`
+}
+
+var (
+	stdlog  = GetLoggerNamed("stdlog")
+	funcmap = template.FuncMap{"ColorizeLevel": ColorizeLevel}
+)
+
+// SetFormatMethod adds functions to the template function map, such that
+// command-line and Setup provided templates can call methods added to the map
+// via this method. The map comes prepopulated with ColorizeLevel, but can be
+// overridden. SetFormatMethod should be called (if at all) before one of
+// this package's Setup methods.
+func SetFormatMethod(name string, fn interface{}) {
+	funcmap[name] = fn
+}
+
+// MustSetup is the same as Setup, but panics instead of returning an error
+func MustSetup(procname string, config SetupConfig) {
+	err := Setup(procname, config)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type subprocInfo struct {
+	Facility string
+	Level    string
+	Name     string
+}
+
+// Setup takes a given procname and sets spacelog up with the given
+// configuration. Setup supports:
+//  * capturing stdout and stderr to a subprocess
+//  * configuring the default level
+//  * configuring log filters (enabling only some loggers)
+//  * configuring the logging template
+//  * configuring the output (a file, syslog, stdout, stderr)
+//  * configuring log event buffering
+//  * capturing all standard library logging with configurable log level
+// It is expected that this method will be called once at process start.
+func Setup(procname string, config SetupConfig) error {
+	if config.Subproc != "" {
+		t, err := template.New("subproc").Parse(config.Subproc)
+		if err != nil {
+			return err
+		}
+		var buf bytes.Buffer
+		err = t.Execute(&buf, &subprocInfo{
+			Facility: fmt.Sprintf("%d", config.Facility),
+			Level:    fmt.Sprintf("%d", 2), // syslog.LOG_CRIT
+			Name:     procname})
+		if err != nil {
+			return err
+		}
+		err = CaptureOutputToProcess("sh", "-c", string(buf.Bytes()))
+		if err != nil {
+			return err
+		}
+	}
+	if config.Config != "" {
+		err := ConfigureLoggers(config.Config)
+		if err != nil {
+			return err
+		}
+	}
+	if config.Level != "" {
+		level_val, err := LevelFromString(config.Level)
+		if err != nil {
+			return err
+		}
+		if level_val != DefaultLevel {
+			SetLevel(nil, level_val)
+		}
+	}
+	if config.Filter != "" {
+		re, err := regexp.Compile(config.Filter)
+		if err != nil {
+			return err
+		}
+		SetLevel(re, LogLevel(math.MinInt32))
+	}
+	var t *template.Template
+	if config.Format != "" {
+		var err error
+		t, err = template.New("user").Funcs(funcmap).Parse(config.Format)
+		if err != nil {
+			return err
+		}
+	}
+	var textout TextOutput
+	switch strings.ToLower(config.Output) {
+	case "syslog":
+		w, err := NewSyslogOutput(SyslogPriority(config.Facility), procname)
+		if err != nil {
+			return err
+		}
+		if t == nil {
+			t = SyslogTemplate
+		}
+		textout = w
+	case "stdout":
+		if t == nil {
+			t = DefaultTemplate
+		}
+		textout = NewWriterOutput(os.Stdout)
+	case "stderr", "":
+		if t == nil {
+			t = DefaultTemplate
+		}
+		textout = NewWriterOutput(os.Stderr)
+	default:
+		if t == nil {
+			t = StandardTemplate
+		}
+		var err error
+		textout, err = NewFileWriterOutput(config.Output)
+		if err != nil {
+			return err
+		}
+	}
+	if config.HupRotate {
+		if hh, ok := textout.(HupHandlingTextOutput); ok {
+			sigchan := make(chan os.Signal)
+			signal.Notify(sigchan, sigHUP)
+			go func() {
+				for _ = range sigchan {
+					hh.OnHup()
+				}
+			}()
+		}
+	}
+	if config.Buffer > 0 {
+		textout = NewBufferedOutput(textout, config.Buffer)
+	}
+	SetHandler(nil, NewTextHandler(t, textout))
+	log.SetFlags(log.Lshortfile)
+	if config.Stdlevel == "" {
+		config.Stdlevel = "warn"
+	}
+	stdlog_level_val, err := LevelFromString(config.Stdlevel)
+	if err != nil {
+		return err
+	}
+	log.SetOutput(stdlog.WriterWithoutCaller(stdlog_level_val))
+	return nil
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/setup/setup.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/setup/setup.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package setup provides simple helpers for configuring spacelog from flags.
+
+This package adds the following flags:
+  --log.output - can either be stdout, stderr, syslog, or a file path
+  --log.level - the base logger level
+  --log.filter - loggers that match this regular expression get set to the
+      lowest level
+  --log.format - a go text template for log lines
+  --log.stdlevel - the logger level to assume the standard library logger is
+      using
+  --log.subproc - a process to run for stdout/stderr capturing
+  --log.buffer - the number of message to buffer
+*/
+package setup
+
+import (
+	"github.com/spacemonkeygo/flagfile/utils"
+	"github.com/spacemonkeygo/spacelog"
+)
+
+var (
+	config spacelog.SetupConfig
+)
+
+func init() {
+	utils.Setup("log", &config)
+}
+
+// SetFormatMethod in this subpackage is deprecated and will be removed soon.
+// Please see spacelog.SetFormatMethod instead
+func SetFormatMethod(name string, fn interface{}) {
+	spacelog.SetFormatMethod(name, fn)
+}
+
+// MustSetup calls spacelog.MustSetup with a flag-configured config struct
+// It's pretty useless to call this method without parsing flags first, via
+// flagfile.Load()
+func MustSetup(procname string) {
+	spacelog.MustSetup(procname, config)
+}
+
+// Setup calls spacelog.Setup with a flag-configured config struct
+// It's pretty useless to call this method without parsing flags first, via
+// flagfile.Load()
+func Setup(procname string) error {
+	return spacelog.Setup(procname, config)
+}
+
+// MustSetupWithFacility is deprecated and will be removed soon. Please
+// configure facility through the facility flag option.
+func MustSetupWithFacility(procname string, facility spacelog.SyslogPriority) {
+	err := SetupWithFacility(procname, facility)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetupWithFacility is deprecated and will be removed soon. Please
+// configure facility through the facility flag option.
+func SetupWithFacility(procname string,
+	facility spacelog.SyslogPriority) error {
+	config_copy := config
+	config_copy.Facility = int(facility)
+	return spacelog.Setup(procname, config_copy)
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/sighup_appengine.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/sighup_appengine.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2017 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build appengine
+
+package spacelog
+
+import (
+	"strconv"
+)
+
+const (
+	sigHUP = syscallSignal(0x1)
+)
+
+type syscallSignal int
+
+func (s syscallSignal) Signal() {}
+
+func (s syscallSignal) String() string {
+	switch s {
+	case sigHUP:
+		return "hangup"
+	}
+	return "signal " + strconv.Itoa(int(s))
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/sighup_other.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/sighup_other.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !appengine
+
+package spacelog
+
+import "syscall"
+
+const (
+	sigHUP = syscall.SIGHUP
+)

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/syslog.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/syslog.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package spacelog
+
+import (
+	"bytes"
+	"log/syslog"
+)
+
+type SyslogPriority syslog.Priority
+
+// SyslogOutput is a syslog client that matches the TextOutput interface
+type SyslogOutput struct {
+	w *syslog.Writer
+}
+
+// NewSyslogOutput returns a TextOutput object that writes to syslog using
+// the given facility and tag. The log level will be determined by the log
+// event.
+func NewSyslogOutput(facility SyslogPriority, tag string) (
+	TextOutput, error) {
+	w, err := syslog.New(syslog.Priority(facility), tag)
+	if err != nil {
+		return nil, err
+	}
+	return &SyslogOutput{w: w}, nil
+}
+
+func (o *SyslogOutput) Output(level LogLevel, message []byte) {
+	level = level.Match()
+	for _, msg := range bytes.Split(message, []byte{'\n'}) {
+		switch level {
+		case Critical:
+			o.w.Crit(string(msg))
+		case Error:
+			o.w.Err(string(msg))
+		case Warning:
+			o.w.Warning(string(msg))
+		case Notice:
+			o.w.Notice(string(msg))
+		case Info:
+			o.w.Info(string(msg))
+		case Debug:
+			fallthrough
+		case Trace:
+			fallthrough
+		default:
+			o.w.Debug(string(msg))
+		}
+	}
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/syslog_windows.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/syslog_windows.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"fmt"
+)
+
+type SyslogPriority int
+
+func NewSyslogOutput(facility SyslogPriority, tag string) (
+	TextOutput, error) {
+	return nil, fmt.Errorf("SyslogOutput not supported on Windows")
+}

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/templates.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/templates.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"text/template"
+)
+
+// ColorizeLevel returns a TermColor byte sequence for the appropriate color
+// for the level. If you'd like to configure your own color choices, you can
+// make your own template with its own function map to your own colorize
+// function.
+func ColorizeLevel(level LogLevel) string {
+	switch level.Match() {
+	case Critical, Error:
+		return TermColors{}.Red()
+	case Warning:
+		return TermColors{}.Magenta()
+	case Notice:
+		return TermColors{}.Yellow()
+	case Info, Debug, Trace:
+		return TermColors{}.Green()
+	}
+	return ""
+}
+
+var (
+	// ColorTemplate uses the default ColorizeLevel method for color choices.
+	ColorTemplate = template.Must(template.New("color").Funcs(template.FuncMap{
+		"ColorizeLevel": ColorizeLevel}).Parse(
+		`{{.Blue}}{{.Date}} {{.Time}}{{.Reset}} ` +
+			`{{.Bold}}{{ColorizeLevel .Level}}{{.LevelJustified}}{{.Reset}} ` +
+			`{{.Underline}}{{.LoggerName}}{{.Reset}} ` +
+			`{{if .Filename}}{{.Filename}}:{{.Line}} {{end}}- ` +
+			`{{ColorizeLevel .Level}}{{.Message}}{{.Reset}}`))
+
+	// StandardTemplate is like ColorTemplate with no color.
+	StandardTemplate = template.Must(template.New("standard").Parse(
+		`{{.Date}} {{.Time}} ` +
+			`{{.Level}} {{.LoggerName}} ` +
+			`{{if .Filename}}{{.Filename}}:{{.Line}} {{end}}` +
+			`- {{.Message}}`))
+
+	// SyslogTemplate is missing the date and time as syslog adds those
+	// things.
+	SyslogTemplate = template.Must(template.New("syslog").Parse(
+		`{{.Level}} {{.LoggerName}} ` +
+			`{{if .Filename}}{{.Filename}}:{{.Line}} {{end}}` +
+			`- {{.Message}}`))
+
+	// StdlibTemplate is missing the date and time as the stdlib logger often
+	// adds those things.
+	StdlibTemplate = template.Must(template.New("stdlib").Parse(
+		`{{.Level}} {{.LoggerName}} ` +
+			`{{if .Filename}}{{.Filename}}:{{.Line}} {{end}}` +
+			`- {{.Message}}`))
+)

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/templates_others.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/templates_others.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package spacelog
+
+var (
+	// DefaultTemplate is default template for stdout/stderr for the platform
+	DefaultTemplate = ColorTemplate
+)

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/templates_windows.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/templates_windows.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+var (
+	// DefaultTemplate is default template for stdout/stderr for the platform
+	DefaultTemplate = StandardTemplate
+)

--- a/grove/vendor/github.com/spacemonkeygo/spacelog/text.go
+++ b/grove/vendor/github.com/spacemonkeygo/spacelog/text.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spacelog
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+)
+
+// TextHandler is the default implementation of the Handler interface. A
+// TextHandler, on log events, makes LogEvent structures, passes them to the
+// configured template, and then passes that output to a configured TextOutput
+// interface.
+type TextHandler struct {
+	mtx      sync.RWMutex
+	template *template.Template
+	output   TextOutput
+}
+
+// NewTextHandler creates a Handler that creates LogEvents, passes them to
+// the given template, and passes the result to output
+func NewTextHandler(t *template.Template, output TextOutput) *TextHandler {
+	return &TextHandler{template: t, output: output}
+}
+
+// Log makes a LogEvent, formats it with the configured template, then passes
+// the output to configured output sink
+func (h *TextHandler) Log(logger_name string, level LogLevel, msg string,
+	calldepth int) {
+	h.mtx.RLock()
+	output, template := h.output, h.template
+	h.mtx.RUnlock()
+	event := LogEvent{
+		LoggerName: logger_name,
+		Level:      level,
+		Message:    strings.TrimRight(msg, "\n\r"),
+		Timestamp:  time.Now()}
+	if calldepth >= 0 {
+		_, event.Filepath, event.Line, _ = runtime.Caller(calldepth + 1)
+	}
+	var buf bytes.Buffer
+	err := template.Execute(&buf, &event)
+	if err != nil {
+		output.Output(level, []byte(
+			fmt.Sprintf("log format template failed: %s", err)))
+		return
+	}
+	output.Output(level, buf.Bytes())
+}
+
+// SetTextTemplate changes the TextHandler's text formatting template
+func (h *TextHandler) SetTextTemplate(t *template.Template) {
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+	h.template = t
+}
+
+// SetTextOutput changes the TextHandler's TextOutput sink
+func (h *TextHandler) SetTextOutput(output TextOutput) {
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+	h.output = output
+}

--- a/grove/web/listener.go
+++ b/grove/web/listener.go
@@ -32,7 +32,7 @@ type InterceptListener struct {
 	connMap      *ConnMap
 }
 
-func getConnStateCallback(connMap *ConnMap) func(net.Conn, http.ConnState) {
+func GetConnStateCallback(connMap *ConnMap) func(net.Conn, http.ConnState) {
 	return func(conn net.Conn, state http.ConnState) {
 		switch state {
 		case http.StateClosed:
@@ -63,7 +63,7 @@ func InterceptListen(network, laddr string) (net.Listener, *ConnMap, func(net.Co
 		return l, nil, nil, err
 	}
 	connMap := NewConnMap()
-	return &InterceptListener{realListener: l, connMap: connMap}, connMap, getConnStateCallback(connMap), nil
+	return &InterceptListener{realListener: l, connMap: connMap}, connMap, GetConnStateCallback(connMap), nil
 }
 
 // InterceptListenTLS is like InterceptListen but for serving HTTPS. It returns the tls.Config, which must be set on the http.Server using this listener for HTTP/2 to be set up.
@@ -80,7 +80,7 @@ func InterceptListenTLS(network string, laddr string, certs []tls.Certificate) (
 
 	interceptListener := &InterceptListener{realListener: l, connMap: connMap}
 	tlsListener := tls.NewListener(interceptListener, config)
-	return tlsListener, connMap, getConnStateCallback(connMap), config, nil
+	return tlsListener, connMap, GetConnStateCallback(connMap), config, nil
 }
 
 func (l *InterceptListener) Accept() (net.Conn, error) {


### PR DESCRIPTION
This is a work in progress, do not merge.  Looking for comments. 

This adds a 'grvssl' package that through the github.com/spacemonkeygo/openssl cgo library,
lets grove use the openssl library for servicing TLS connections.  The developer of the library
says that his openssl library is a plugin replacement for golang 'tls' and has twice the performance over the golang 'tls' encryption.

Also the use of the openssl library will allow the use of Hardware encryption cards to further improve tls performance.  See, http://www.silicom-usa.com/cats/server-adapters/encryption-compression-offload-server-adapters/encryption-compression-intel-based-server-adapters/
