### PR TITLE
Fix DS servers ReplaceHandler

### DIFF
--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -586,7 +586,7 @@ type UserDeliveryServicesResponse struct {
 }
 
 type DSServerIDs struct {
-	DeliveryServiceID *int  `json:"dsId", db:"deliveryservice"`
+	DeliveryServiceID *int  `json:"dsId" db:"deliveryservice"`
 	ServerIDs         []int `json:"servers"`
 	Replace           *bool `json:"replace"`
 }

--- a/traffic_ops/testing/api/v13/todb.go
+++ b/traffic_ops/testing/api/v13/todb.go
@@ -239,6 +239,7 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM regex;
 	DELETE FROM deliveryservice_server;
 	DELETE FROM deliveryservice;
+	DELETE FROM origin;
 	DELETE FROM server;
 	DELETE FROM phys_location;
 	DELETE FROM region;
@@ -247,6 +248,7 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM parameter;
 	DELETE FROM profile_parameter;
 	DELETE FROM cachegroup;
+	DELETE FROM coordinate;
 	DELETE FROM type;
 	DELETE FROM status;
 	DELETE FROM snapshot;

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -368,14 +368,12 @@ func GetReplaceHandler(db *sqlx.DB) http.HandlerFunc {
 
 		if *payload.Replace {
 			// delete existing
-			rows, err := tx.Queryx("DELETE FROM deliveryservice_server WHERE deliveryservice = $1", *dsId)
+			_, err := tx.Exec("DELETE FROM deliveryservice_server WHERE deliveryservice = $1", *dsId)
 			if err != nil {
 				log.Errorf("unable to remove the existing servers assigned to the delivery service: %s", err)
 				handleErrs(http.StatusInternalServerError, err)
 				return
 			}
-
-			defer rows.Close()
 		}
 
 		i := 0


### PR DESCRIPTION
Use tx.Exec not tx.Queryx for a DELETE statement that returns no rows.
The unclosed Rows struct was making the subsequent tx.NamedQuery() call
fail.