### PR TITLE
TO Go - if user has no tenant, check if tenancy is on and respond accordingly

### DIFF
--- a/traffic_ops/traffic_ops_golang/tenant/tenant.go
+++ b/traffic_ops/traffic_ops_golang/tenant/tenant.go
@@ -159,6 +159,11 @@ func (ten *TOTenant) Create() (error, tc.ApiErrorType) {
 func (ten *TOTenant) Read(parameters map[string]string) ([]interface{}, []error, tc.ApiErrorType) {
 	var rows *sqlx.Rows
 
+	if ten.ReqInfo == nil || ten.ReqInfo.User == nil {
+		// should never happen
+		return nil, []error{errors.New("missing request info")}, tc.SystemError
+	}
+
 	tenantID := ten.ReqInfo.User.TenantID
 	if tenantID == auth.TenantIDInvalid {
 		// NOTE: work around issue where user has no tenancy assigned.  If tenancy turned off, there


### PR DESCRIPTION
works around issue where `use_tenancy` is off and user tenant is NULL in the db.  Long term, tenancy will always be on and tenant will be required by db constraint.

Fixes #2539 
Fixes #2521 
also addresses part of #2520 
