### PR TITLE
add 15sec db timeout and configurable request handling timeout

### DIFF
--- a/traffic_ops/traffic_ops_golang/config/config.go
+++ b/traffic_ops/traffic_ops_golang/config/config.go
@@ -64,6 +64,7 @@ type ConfigTrafficOpsGolang struct {
 	ProxyTLSTimeout        int            `json:"proxy_tls_timeout"`
 	ProxyReadHeaderTimeout int            `json:"proxy_read_header_timeout"`
 	ReadTimeout            int            `json:"read_timeout"`
+	RequestTimeout         int            `json:"request_timeout"`
 	ReadHeaderTimeout      int            `json:"read_header_timeout"`
 	WriteTimeout           int            `json:"write_timeout"`
 	IdleTimeout            int            `json:"idle_timeout"`

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -147,8 +147,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		//Login
 		{1.1, http.MethodGet, `users/{id}/deliveryservices/?(\.json)?$`, user.GetDSes(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `user/{id}/deliveryservices/available/?(\.json)?$`, user.GetAvailableDSes(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.2, http.MethodPost, `user/login/?$`, wrapAccessLog(d.Secrets[0], auth.LoginHandler(d.DB, d.Config)), 0, NoAuth, nil},
-		{1.3, http.MethodPost, `user/login/?$`, wrapAccessLog(d.Secrets[0], auth.LoginHandler(d.DB, d.Config)), 0, NoAuth, nil},
+		{1.1, http.MethodPost, `user/login/?$`, auth.LoginHandler(d.DB, d.Config), 0, NoAuth, nil},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil},
 
@@ -448,6 +447,7 @@ func rootHandler(d ServerData) http.Handler {
 		}).DialContext,
 		TLSHandshakeTimeout:   time.Duration(d.Config.ProxyTLSTimeout) * time.Second,
 		ResponseHeaderTimeout: time.Duration(d.Config.ProxyReadHeaderTimeout) * time.Second,
+		//IdleConnTimeout: time.Duration(d.Config.ProxyIdleConnTimeout) * time.Second,
 		//Other knobs we can turn: ExpectContinueTimeout,IdleConnTimeout
 	}
 	rp := httputil.NewSingleHostReverseProxy(d.URL)

--- a/traffic_ops/traffic_ops_golang/routing_test.go
+++ b/traffic_ops/traffic_ops_golang/routing_test.go
@@ -69,7 +69,7 @@ func TestCreateRouteMap(t *testing.T) {
 	}
 
 	rawRoutes := []RawRoute{}
-	routeMap := CreateRouteMap(routes, rawRoutes, authBase)
+	routeMap := CreateRouteMap(routes, rawRoutes, authBase, 60)
 
 	route1Handler := routeMap["GET"][0].Handler
 

--- a/traffic_ops/traffic_ops_golang/server/servers_update_status_test.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_update_status_test.go
@@ -20,6 +20,7 @@ package server
  */
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestGetServerUpdateStatus(t *testing.T) {
 
 	mock.ExpectQuery("SELECT").WillReturnRows(serverStatusRow)
 
-	result, err := getServerUpdateStatus("host_name_1", db)
+	result, err := getServerUpdateStatus("host_name_1", db, context.Background())
 	if err != nil {
 		t.Errorf("getServerUpdateStatus: %v", err)
 	}


### PR DESCRIPTION
making the database timeout configurable either requires a semi-significant refactor or setting a package level variable; which I am against but could be convinced otherwise if it is valuable enough.

I think 15 seconds is overly generous and think 5 seconds (or even one) may be a better default but it felt somewhat aggressive.