### PR TITLE
Fix TO Go API PUT/POST type checking

### DIFF
--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -241,23 +241,6 @@ func (ds *DeliveryServiceNullableV12) Sanitize() {
 	}
 }
 
-// getTypeData returns the type's name and use_in_table, true/false if the query returned data, and any error
-func getTypeData(tx *sql.Tx, id int) (string, string, bool, error) {
-	name := ""
-	var useInTablePtr *string
-	if err := tx.QueryRow(`SELECT name, use_in_table from type where id=$1`, id).Scan(&name, &useInTablePtr); err != nil {
-		if err == sql.ErrNoRows {
-			return "", "", false, nil
-		}
-		return "", "", false, errors.New("querying type data: " + err.Error())
-	}
-	useInTable := ""
-	if useInTablePtr != nil {
-		useInTable = *useInTablePtr
-	}
-	return name, useInTable, true, nil
-}
-
 func requiredIfMatchesTypeName(patterns []string, typeName string) func(interface{}) error {
 	return func(value interface{}) error {
 		switch v := value.(type) {
@@ -293,30 +276,20 @@ func requiredIfMatchesTypeName(patterns []string, typeName string) func(interfac
 	}
 }
 
-// util.JoinErrs(errs).Error()
-
 func (ds *DeliveryServiceNullableV12) validateTypeFields(tx *sql.Tx) error {
 	// Validate the TypeName related fields below
-	typeName := ""
 	err := error(nil)
 	DNSRegexType := "^DNS.*$"
 	HTTPRegexType := "^HTTP.*$"
 	SteeringRegexType := "^STEERING.*$"
 	latitudeErr := "Must be a floating point number within the range +-90"
 	longitudeErr := "Must be a floating point number within the range +-180"
-	if ds.TypeID == nil {
-		return errors.New("missing type")
-	}
-	typeName, useInTable, ok, err := getTypeData(tx, *ds.TypeID)
+
+	typeName, err := ValidateTypeID(tx, ds.TypeID, "deliveryservice")
 	if err != nil {
-		return errors.New("getting type name: " + err.Error())
+		return err
 	}
-	if !ok {
-		return errors.New("type not found")
-	}
-	if useInTable != "deliveryservice" {
-		return errors.New("type is not a valid deliveryservice type")
-	}
+
 	errs := validation.Errors{
 		"initialDispersion": validation.Validate(ds.InitialDispersion,
 			validation.By(requiredIfMatchesTypeName([]string{HTTPRegexType}, typeName)),

--- a/lib/go-tc/types.go
+++ b/lib/go-tc/types.go
@@ -1,5 +1,10 @@
 package tc
 
+import (
+	"database/sql"
+	"errors"
+)
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -40,4 +45,41 @@ type TypeNullable struct {
 	Name        *string    `json:"name" db:"name"`
 	Description *string    `json:"description" db:"description"`
 	UseInTable  *string    `json:"useInTable" db:"use_in_table"`
+}
+
+// GetTypeData returns the type's name and use_in_table, true/false if the query returned data, and any error
+func GetTypeData(tx *sql.Tx, id int) (string, string, bool, error) {
+	name := ""
+	var useInTablePtr *string
+	if err := tx.QueryRow(`SELECT name, use_in_table from type where id=$1`, id).Scan(&name, &useInTablePtr); err != nil {
+		if err == sql.ErrNoRows {
+			return "", "", false, nil
+		}
+		return "", "", false, errors.New("querying type data: " + err.Error())
+	}
+	useInTable := ""
+	if useInTablePtr != nil {
+		useInTable = *useInTablePtr
+	}
+	return name, useInTable, true, nil
+}
+
+// ValidateTypeID validates that the typeID references a type with the expected use_in_table string and
+// returns "" and an error if the typeID is invalid. If valid, the type's name is returned.
+func ValidateTypeID(tx *sql.Tx, typeID *int, expectedUseInTable string) (string, error) {
+	if typeID == nil {
+		return "", errors.New("missing type")
+	}
+
+	typeName, useInTable, ok, err := GetTypeData(tx, *typeID)
+	if err != nil {
+		return "", errors.New("validating type: " + err.Error())
+	}
+	if !ok {
+		return "", errors.New("type not found")
+	}
+	if useInTable != expectedUseInTable {
+		return "", errors.New("type is not a valid " + expectedUseInTable + " type")
+	}
+	return typeName, nil
 }

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -149,6 +149,11 @@ func IsValidParentCachegroupID(id *int) bool {
 
 // Validate fulfills the api.Validator interface
 func (cg TOCacheGroup) Validate() error {
+
+	if _, err := tc.ValidateTypeID(cg.ReqInfo.Tx.Tx, cg.TypeID, "cachegroup"); err != nil {
+		return err
+	}
+
 	validName := validation.NewStringRule(IsValidCacheGroupName, "invalid characters found - Use alphanumeric . or - or _ .")
 	validShortName := validation.NewStringRule(IsValidCacheGroupName, "invalid characters found - Use alphanumeric . or - or _ .")
 	latitudeErr := "Must be a floating point number within the range +-90"

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -309,8 +309,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `deliveryservices_regexes/?(\.json)?$`, deliveryservicesregexes.Get(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `deliveryservices/{dsid}/regexes/?(\.json)?$`, deliveryservicesregexes.DSGet(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `deliveryservices/{dsid}/regexes/{regexid}?(\.json)?$`, deliveryservicesregexes.DSGetID(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPost, `deliveryservices/{dsid}/regexes/?(\.json)?$`, deliveryservicesregexes.Post(d.DB), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPut, `deliveryservices/{dsid}/regexes/{regexid}?(\.json)?$`, deliveryservicesregexes.Put(d.DB), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `deliveryservices/{dsid}/regexes/?(\.json)?$`, deliveryservicesregexes.Post(), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPut, `deliveryservices/{dsid}/regexes/{regexid}?(\.json)?$`, deliveryservicesregexes.Put(), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodDelete, `deliveryservices/{dsid}/regexes/{regexid}?(\.json)?$`, deliveryservicesregexes.Delete(d.DB), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Servers

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
@@ -80,6 +80,10 @@ func (staticDNSEntry *TOStaticDNSEntry) SetKeys(keys map[string]interface{}) {
 
 // Validate fulfills the api.Validator interface
 func (staticDNSEntry TOStaticDNSEntry) Validate() error {
+	if _, err := tc.ValidateTypeID(staticDNSEntry.ReqInfo.Tx.Tx, &staticDNSEntry.TypeID, "staticdnsentry"); err != nil {
+		return err
+	}
+
 	errs := validation.Errors{
 		"host":    validation.Validate(staticDNSEntry.Host, validation.Required),
 		"address": validation.Validate(staticDNSEntry.Address, validation.Required),


### PR DESCRIPTION
For entities that have a required type from the type table, validate
the type.

Fix the DS regex PUT/POST handlers to use transactions and some of the
shared api.NewInfo functionality.

Fixes #2560 