### PR TITLE
Make anonymousBlockingEnabled an optional field in the DS API

### DIFF
--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -239,6 +239,9 @@ func (ds *DeliveryServiceNullableV12) Sanitize() {
 	if ds.RoutingName == nil || *ds.RoutingName == "" {
 		ds.RoutingName = util.StrPtr(DefaultRoutingName)
 	}
+	if ds.AnonymousBlockingEnabled == nil {
+		ds.AnonymousBlockingEnabled = util.BoolPtr(false)
+	}
 }
 
 // getTypeData returns the type's name and use_in_table, true/false if the query returned data, and any error


### PR DESCRIPTION
The field cannot be required unless the API major version is
incremented, so make it optional instead by setting it to the default
value of false. This prevents client breakage.

Fixes #2573