### PR TITLE
TO Go: upgrade go unit tests to go 1.9.4

### DIFF
--- a/traffic_ops/app/bin/tests/Dockerfile-golangtest
+++ b/traffic_ops/app/bin/tests/Dockerfile-golangtest
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.8
+FROM golang:1.9.4
 MAINTAINER Dan Kirkwood <dangogh@apache.org>
 ARG DIR=github.com/apache/trafficcontrol
 
@@ -20,6 +20,6 @@ ADD lib /go/src/$DIR/lib
 
 WORKDIR /go/src/$DIR/traffic_ops/traffic_ops_golang
 
-CMD bash -c 'go get -v && go test -cover -v $(go list ./... | grep -v vendor/) ../../lib/go-*'
+CMD bash -c 'go get -v && go test -cover -v ./... ../../lib/go-tc/...'
 #
 # vi:syntax=Dockerfile


### PR DESCRIPTION
previously using 1.8.   One test was failing which is resolved with this change.