### PR TITLE
Change qstring_ignore to grab everything up to query to fix https hosts

### DIFF
--- a/traffic_ops/app/lib/UI/DeliveryService.pm
+++ b/traffic_ops/app/lib/UI/DeliveryService.pm
@@ -1432,7 +1432,7 @@ sub get_qstring_ignore_remap {
 	my $ats_major_version = shift;
 
 	if ($ats_major_version >= 6) {
-		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/https?:\\/\\/([^?]*)/http:\\/\\/\$1/";
+		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/^([^?]*)/$1/";
 	}
 	else {
 		return " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";

--- a/traffic_ops/app/lib/UI/DeliveryService.pm
+++ b/traffic_ops/app/lib/UI/DeliveryService.pm
@@ -1432,7 +1432,7 @@ sub get_qstring_ignore_remap {
 	my $ats_major_version = shift;
 
 	if ($ats_major_version >= 6) {
-		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/http:\\/\\/([^?]*)/http:\\/\\/\$1/";
+		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/https?:\\/\\/([^?]*)/http:\\/\\/\$1/";
 	}
 	else {
 		return " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";


### PR DESCRIPTION
For issue https://github.com/apache/trafficcontrol/issues/2589

The ignore and pass up has a hardcoded cachekey, currently it is hardcoded to http. So if the set key uses https it gets thrown away. Adding s? to the key so both http and https will end up cached in the http key

This still needs to be tested but putting the PR out there