### PR TITLE
TP: Provide way to enable or disable cachegroup localization methods

### DIFF
--- a/traffic_portal/app/src/common/modules/form/cacheGroup/FormCacheGroupController.js
+++ b/traffic_portal/app/src/common/modules/form/cacheGroup/FormCacheGroupController.js
@@ -57,7 +57,41 @@ var FormCacheGroupController = function(cacheGroup, $scope, $location, formUtils
 
     $scope.hasPropertyError = formUtils.hasPropertyError;
 
+    $scope.localizationMethods = {
+        DEEP_CZ: false,
+        CZ: false,
+        GEO: false
+    };
+
+    $scope.setLocalizationMethods = function(cacheGroup) {
+        var methods = [];
+        var keys = Object.keys($scope.localizationMethods);
+        for (var i = 0; i < keys.length; i++) {
+            if ($scope.localizationMethods[keys[i]]) {
+                methods.push(keys[i]);
+            }
+        }
+        cacheGroup.localizationMethods = methods;
+    };
+
+    var initLocalizationMethods = function() {
+        // by default, no explicitly enabled methods means ALL are enabled
+        if (!cacheGroup.localizationMethods) {
+            var keys = Object.keys($scope.localizationMethods);
+            for (var i = 0; i < keys.length; i++) {
+                $scope.localizationMethods[keys[i]] = true;
+            }
+            return;
+        }
+        for (var i = 0; i < cacheGroup.localizationMethods.length; i++) {
+            if ($scope.localizationMethods.hasOwnProperty(cacheGroup.localizationMethods[i])) {
+                $scope.localizationMethods[cacheGroup.localizationMethods[i]] = true;
+            }
+        }
+    };
+
     var init = function () {
+        initLocalizationMethods();
         getCacheGroups();
         getTypes();
     };

--- a/traffic_portal/app/src/common/modules/form/cacheGroup/edit/FormEditCacheGroupController.js
+++ b/traffic_portal/app/src/common/modules/form/cacheGroup/edit/FormEditCacheGroupController.js
@@ -45,6 +45,7 @@ var FormEditCacheGroupController = function(cacheGroup, $scope, $controller, $ui
     };
 
     $scope.save = function(cacheGroup) {
+        $scope.setLocalizationMethods(cacheGroup);
         cacheGroupService.updateCacheGroup(cacheGroup).
             then(function() {
                 $scope.cacheGroupName = angular.copy(cacheGroup.name);

--- a/traffic_portal/app/src/common/modules/form/cacheGroup/form.cacheGroup.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/cacheGroup/form.cacheGroup.tpl.html
@@ -120,6 +120,14 @@ under the License.
                     <small ng-show="cacheGroup.secondaryParentCachegroupId"><a href="/#!/cache-groups/{{cacheGroup.secondaryParentCachegroupId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
+            <div class="form-group">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Enabled Localization Methods</label>
+                <div class="col-md-10 col-sm-10 col-xs-12">
+                    <input type="checkbox" name="CZEnabled" ng-model="localizationMethods.CZ"> Coverage Zone File</input><br>
+                    <input type="checkbox" name="DeepCZEnabled" ng-model="localizationMethods.DEEP_CZ"> Deep Coverage Zone File</input><br>
+                    <input type="checkbox" name="GeoEnabled" ng-model="localizationMethods.GEO"> Geo-IP Database</input>
+                </div>
+            </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-danger" ng-show="!settings.isNew" ng-click="confirmDelete(cacheGroup)">Delete</button>
                 <button type="button" class="btn btn-success" ng-disabled="cacheGroupForm.$pristine || cacheGroupForm.$invalid" ng-click="save(cacheGroup)">{{settings.saveLabel}}</button>

--- a/traffic_portal/app/src/common/modules/form/cacheGroup/new/FormNewCacheGroupController.js
+++ b/traffic_portal/app/src/common/modules/form/cacheGroup/new/FormNewCacheGroupController.js
@@ -30,6 +30,7 @@ var FormNewCacheGroupController = function(cacheGroup, $scope, $controller, cach
     };
 
     $scope.save = function(cacheGroup) {
+        $scope.setLocalizationMethods(cacheGroup);
         cacheGroupService.createCacheGroup(cacheGroup);
     };
 


### PR DESCRIPTION
With support via the TO API, add the ability to enable/disable localization methods (CZ, DEEP_CZ, GEO) in the cachegroup view.

This is done by having a checkbox per localization method (by default all are checked) which is then translated into an array of enabled localization methods that the API expects. This more naturally mapped to having a `select` with the `multiple` attribute which actually binds to an array in angularjs, but I think that provided a worse UX compared to checkboxes.

This depends on the API implementation in #2557 