### PR TITLE
TO Golang: Implemented Cachegroup Data Integrity Rules

### DIFF
--- a/traffic_ops/app/db/migrations/20180801101413_cachegroup_delete_restrict.sql
+++ b/traffic_ops/app/db/migrations/20180801101413_cachegroup_delete_restrict.sql
@@ -15,10 +15,10 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE server drop CONSTRAINT fk_server_cachegroup1;
-ALTER TABLE server add CONSTRAINT fk_server_cachegroup1 FOREIGN KEY(cachegroup) REFERENCES cachegroup(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+ALTER TABLE server DROP CONSTRAINT fk_server_cachegroup1;
+ALTER TABLE server ADD CONSTRAINT fk_server_cachegroup1 FOREIGN KEY(cachegroup) REFERENCES cachegroup(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-ALTER TABLE server drop CONSTRAINT fk_server_cachegroup1;
-ALTER TABLE server add CONSTRAINT fk_server_cachegroup1 FOREIGN KEY(cachegroup) REFERENCES cachegroup(id) ON UPDATE RESTRICT ON DELETE CASCADE;
+ALTER TABLE server DROP CONSTRAINT fk_server_cachegroup1;
+ALTER TABLE server ADD CONSTRAINT fk_server_cachegroup1 FOREIGN KEY(cachegroup) REFERENCES cachegroup(id) ON UPDATE RESTRICT ON DELETE CASCADE;

--- a/traffic_ops/app/db/migrations/20180801101413_cachegroup_delete_restrict.sql
+++ b/traffic_ops/app/db/migrations/20180801101413_cachegroup_delete_restrict.sql
@@ -1,0 +1,24 @@
+/*
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE server drop CONSTRAINT fk_server_cachegroup1;
+ALTER TABLE server add CONSTRAINT fk_server_cachegroup1 FOREIGN KEY(cachegroup) REFERENCES cachegroup(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+ALTER TABLE server drop CONSTRAINT fk_server_cachegroup1;
+ALTER TABLE server add CONSTRAINT fk_server_cachegroup1 FOREIGN KEY(cachegroup) REFERENCES cachegroup(id) ON UPDATE RESTRICT ON DELETE CASCADE;

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -101,10 +101,9 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `cachegroups/trimmed/?(\.json)?$`, cachegroup.TrimmedHandler(d.DB.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `cachegroups/?(\.json)?$`, api.ReadHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `cachegroups/{id}$`, api.ReadHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		// these were commented out because all of the rules on the Perl side were not captured. I.e. deleting a cg should not delete all the attached servers. Issue #2597.
-		//{1.1, http.MethodPut, `cachegroups/{id}$`, api.UpdateHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		//{1.1, http.MethodPost, `cachegroups/?$`, api.CreateHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		//{1.1, http.MethodDelete, `cachegroups/{id}$`, api.DeleteHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPut, `cachegroups/{id}$`, api.UpdateHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `cachegroups/?$`, api.CreateHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `cachegroups/{id}$`, api.DeleteHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodPost, `cachegroups/{id}/queue_update$`, cachegroup.QueueUpdates(d.DB.DB), auth.PrivLevelOperations, Authenticated, nil},
 


### PR DESCRIPTION
Will no longer delete cachegroup that is in use by either a server or asn.
A database migration was also added that edits a delete constraint.

Fixes #2597 
