### PR TITLE
Updates 'grovetccfg' to to write a grove.cfg from the grove servers profile

### DIFF
--- a/docs/source/admin/traffic_ops/default_profiles.rst
+++ b/docs/source/admin/traffic_ops/default_profiles.rst
@@ -35,6 +35,7 @@ Minimum Traffic Ops Profiles needed
    * TRAFFIC_MONITOR_PROFILE.traffic_ops
    * TRAFFIC_ROUTER_PROFILE.traffic_ops
    * TRAFFIC_STATS_PROFILE.traffic_ops
+   * EDGE_GROVE_PROFILE.traffic_ops
    
 
 

--- a/grove/README.md
+++ b/grove/README.md
@@ -103,7 +103,7 @@ The config file has the following fields:
 
 The remap rules file is specified in the [config file](#configuration).
 
-Note there exists a tool for generating remap rules from [Traffic Control](https://github.com/apache/trafficcontrol), available [here](https://github.com/apache/trafficcontrol/grove/tree/master/grovetccfg).
+Note there exists a tool for generating remap rules from [Traffic Control](https://github.com/apache/trafficcontrol), available [here](https://github.com/apache/trafficcontrol/tree/master/grove/grovetccfg).
 
 The remap rules file is JSON of the following form:
 

--- a/grove/grovetccfg/README.md
+++ b/grove/grovetccfg/README.md
@@ -45,6 +45,10 @@ go build
 
 # Running
 
+You may use a trafficserver profile with your grove deployment but `grovetccfg` will only read the `allow_ip` and the `allow_ip6` parameters from a
+traffic server profile when constructing the remap_rules file.  A sample `grove_profile.traffic_ops` file is provided to get you started in creating  a GROVE_PROFILE
+type.  When you use a GROVE_PROFILE type, `grovetccfg` will read the settings from the profile and generate the `grove.cfg` file from the settings in that profile.
+
 The `grovetccfg` tool has an RPM, but no service or config files. It must be run manually, even after installing the RPM. Consider running the tool in a cron job.
 
 Example:

--- a/grove/grovetccfg/grove_profile.traffic_ops
+++ b/grove/grovetccfg/grove_profile.traffic_ops
@@ -1,0 +1,190 @@
+{
+  "parameters": 
+  [
+    {
+      "value": "::1",
+      "name": "allow_ip6",
+      "config_file": "astats.config"
+    },
+    {
+      "value": "127.0.0.1,192.168.1.0/255",
+      "name": "allow_ip",
+      "config_file": "astats.config"
+    },
+    {
+      "value": "false",
+      "name": "rfc_compliant",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "80",
+      "name": "port",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "443",
+      "name": "https_port",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "50000000000",
+      "name": "cache_size_bytes",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "/etc/grove/remap.json",
+      "name": "remap_rules_file",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "100",
+      "name": "concurrent_rule_requests",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "/etc/grove/cert.pem",
+      "name": "cert_file",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "/etc/grove/key.pem",
+      "name": "key_file",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "bond0",
+      "name": "interface_name",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "false",
+      "name": "connection_close",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "/var/log/grove/error.log",
+      "name": "log_location_error",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "/var/log/grove/error.log",
+      "name": "log_location_warning",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "null",
+      "name": "log_location_info",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "null",
+      "name": "log_location_debug",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "/opt/trafficserver/var/log/trafficserver/custom_ats_2.log",
+      "name": "log_location_event",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "1000",
+      "name": "parent_request_timeout_ms",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "1000",
+      "name": "parent_request_keep_alive_ms",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "1000",
+      "name": "parent_request_max_idle_connections",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "1000",
+      "name": "parent_request_idle_connection_timeout_ms",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "5000",
+      "name": "server_read_timeout_ms",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "5000",
+      "name": "server_write_timeout_ms",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "5000",
+      "name": "server_idle_timeout_ms",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "ats_log",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "http_cacheinspector",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "http_callgc",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "http_memstats",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "http_stats",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "if_modified_since",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "modify_headers",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "modify_response_headers_global",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "modify_parent_request_headers",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "plugin",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "range_request_handler",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    },
+    {
+      "value": "record_stats",
+      "name": "plugins",
+      "config_file": "grove.cfg"
+    }
+  ],
+  "profile": {
+    "name": "EDGE_GROVE_PROFILE",
+    "type": "GROVE_PROFILE",
+    "description": "Edge Cache - Grove profile"
+  }
+}


### PR DESCRIPTION
Modified grovetccfg to read a grove server profile from the traffic_ops and write a grove.cfg from that profile id there have been changes. Fixes #2607 and depends on #2517 and #2523. Both #2517 and #2523 are merged onto master.