### PR TITLE
Fix #2006 - Proper exitcode for admin.pl DB migration

### DIFF
--- a/traffic_ops/app/db/admin.pl
+++ b/traffic_ops/app/db/admin.pl
@@ -188,7 +188,7 @@ sub migrate {
 sub seed {
 	print "Seeding database w/ required data.\n";
 	local $ENV{PGPASSWORD} = $db_password;
-	if ( system("psql -h $host_ip -p $host_port -d $db_name -U $db_user -e < db/seeds.sql") != 0 ) {
+	if ( system("psql -h $host_ip -p $host_port -d $db_name -U $db_user -e -v ON_ERROR_STOP=1 < db/seeds.sql") != 0 ) {
 		die "Can't seed database w/ required data\n";
 	}
 }
@@ -196,7 +196,7 @@ sub seed {
 sub patches {
 	print "Patching database with required data fixes.\n";
 	local $ENV{PGPASSWORD} = $db_password;
-	if ( system("psql -h $host_ip -p $host_port -d $db_name -U $db_user -e < db/patches.sql") != 0 ) {
+	if ( system("psql -h $host_ip -p $host_port -d $db_name -U $db_user -e -v ON_ERROR_STOP=1 < db/patches.sql") != 0 ) {
 		die "Can't patch database w/ required data\n";
 	}
 }


### PR DESCRIPTION
Fixes issue #2006 -  TO Database Migration Failures don't trigger non-zero exit codes

By setting ON_ERROR_STOP=1 variable, the psql cmdline utility will properly exit with correct error code (>0) for any valid SQL errors (constraints violated, etc).