### PR TITLE
Updated for TC Issue 2619

### DIFF
--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -118,9 +118,9 @@ func (prof *TOProfile) Read(parameters map[string]string) ([]interface{}, []erro
 	where, orderBy, queryValues, errs := dbhelpers.BuildWhereAndOrderBy(parameters, queryParamsToQueryCols)
 
 	// Narrow down if the query parameter is 'param'
-	if _, ok := parameters[ParamQueryParam]; ok {
-		queryValues["parameter_id"] = parameters[ParamQueryParam]
-		if len(parameters[ParamQueryParam]) > 0 {
+	if paramValue, ok := parameters[ParamQueryParam]; ok {
+		queryValues["parameter_id"] = paramValue
+		if len(paramValue) > 0 {
 			where += " LEFT JOIN profile_parameter pp ON prof.id  = pp.profile where pp.parameter=:parameter_id"
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -119,9 +119,9 @@ func (prof *TOProfile) Read(parameters map[string]string) ([]interface{}, []erro
 
 	// Narrow down if the query parameter is 'param'
 	if _, ok := parameters[ParamQueryParam]; ok {
-		paramValue := parameters[ParamQueryParam]
-		if len(paramValue) > 0 {
-			where = where + " LEFT JOIN profile_parameter pp ON prof.id  = pp.profile where pp.parameter=" + paramValue
+		queryValues["profile_id"] = parameters[ParamQueryParam]
+		if len(parameters[ParamQueryParam]) > 0 {
+			where += " LEFT JOIN profile_parameter pp ON prof.id  = pp.profile where pp.parameter=:parameter_id"
 		}
 	}
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -119,7 +119,7 @@ func (prof *TOProfile) Read(parameters map[string]string) ([]interface{}, []erro
 
 	// Narrow down if the query parameter is 'param'
 	if _, ok := parameters[ParamQueryParam]; ok {
-		queryValues["profile_id"] = parameters[ParamQueryParam]
+		queryValues["parameter_id"] = parameters[ParamQueryParam]
 		if len(parameters[ParamQueryParam]) > 0 {
 			where += " LEFT JOIN profile_parameter pp ON prof.id  = pp.profile where pp.parameter=:parameter_id"
 		}


### PR DESCRIPTION
updated to refer to the named parameter instead

