### PR TITLE
Fix TO Go profileparameters to match Perl

### DIFF
--- a/lib/go-tc/parameters.go
+++ b/lib/go-tc/parameters.go
@@ -258,3 +258,10 @@ func ParamsExist(ids []int64, tx *sql.Tx) (bool, error) {
 	}
 	return count == len(ids), nil
 }
+
+// ProfileParametersNullable is an object of the form returned by the Traffic Ops /profileparameters endpoint.
+type ProfileParametersNullable struct {
+	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
+	Profile     *string    `json:"profile" db:"profile"`
+	Parameter   *int       `json:"parameter" db:"parameter_id"`
+}

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -195,7 +195,7 @@ func (pp *TOProfileParameter) Read(parameters map[string]string) ([]interface{},
 
 	params := []interface{}{}
 	for rows.Next() {
-		var p v13.ProfileParameterNullable
+		p := tc.ProfileParametersNullable{}
 		if err = rows.StructScan(&p); err != nil {
 			log.Errorf("error parsing pp rows: %v", err)
 			return nil, []error{tc.DBError}, tc.SystemError
@@ -234,10 +234,8 @@ func selectQuery() string {
 
 	query := `SELECT
 pp.last_updated,
-pp.profile profile_id,
 pp.parameter parameter_id,
-prof.name profile,
-param.name parameter
+prof.name profile
 FROM profile_parameter pp
 JOIN profile prof ON prof.id = pp.profile
 JOIN parameter param ON param.id = pp.parameter`


### PR DESCRIPTION
Fixes the /profileparameters endpoint to match the old Perl. This
specifically matches Perl code, not the docs, because documentation
doesn't exist for this endpoint. I also wasn't able to run the Perl,
it appears to time out and returns a 502; but this change reflects
the Github case, and what the Perl code appears to do.

Fixes #2556