### PR TITLE
Traffic Ops - Admin.pl load_schema proper exit codes and eval

### DIFF
--- a/traffic_ops/app/db/admin.pl
+++ b/traffic_ops/app/db/admin.pl
@@ -204,7 +204,7 @@ sub patches {
 sub load_schema {
 	print "Creating database tables.\n";
 	local $ENV{PGPASSWORD} = $db_password;
-	if ( system("psql -h $host_ip -p $host_port -d $db_name -U $db_user -e < db/create_tables.sql") != 0 ) {
+	if ( system("psql -h $host_ip -p $host_port -d $db_name -U $db_user -e -v ON_ERROR_STOP=1 < db/create_tables.sql") != 0 ) {
 		die "Can't create database tables\n";
 	}
 }

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -35,13 +35,6 @@ SET row_security = off;
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
 SET search_path = public, pg_catalog;
 
 --


### PR DESCRIPTION
Fixes #2667 (this phrase causes issue to be automatically closed) 

This PR will fix the following related to issue #2667 in the traffic_ops component:

- Update admin.pl load_schema function to use ON_ERROR_STOP=1 so that each SQL statement is evaluated for an error and to exit with retcode >0 if one is found.
- Update the create_tables.sql schema and remove the updated comment to extension plpgsql which always results in a SQL error (traffic_ops user does not own the plpgsql extension). 

Note: Issue #2006 is related and has already been fixed in a similar manner by adding ON_ERROR_STOP=1 to the psql command line.