### PR TITLE
TO Go API: fix origin api tests -- add a tenantId

### DIFF
--- a/traffic_ops/testing/api/v13/tc-fixtures.json
+++ b/traffic_ops/testing/api/v13/tc-fixtures.json
@@ -351,7 +351,8 @@
             "ipAddress": "1.2.3.4",
             "ip6Address": "dead:beef:cafe::42",
             "port": 1234,
-            "protocol": "http"
+            "protocol": "http",
+            "tenantId": 2
         },
         {
             "name": "origin2",
@@ -359,7 +360,8 @@
             "ipAddress": "5.6.7.8",
             "ip6Address": "cafe::42",
             "port": 5678,
-            "protocol": "https"
+            "protocol": "https",
+            "tenantId": 2
         }
     ],
     "parameters": [


### PR DESCRIPTION
api test for origins is missing tenant id which causes it to fail on the new not-null db constraint.