### PR TITLE
adds a simple PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+#### What does this PR do?
+
+Fixes #(issue_number)
+
+#### Which TC components are affected by this PR?
+
+- [ ] Documentation
+- [ ] Grove
+- [ ] Traffic Analytics
+- [ ] Traffic Monitor
+- [ ] Traffic Ops
+- [ ] Traffic Ops ORT
+- [ ] Traffic Portal
+- [ ] Traffic Router
+- [ ] Traffic Stats
+- [ ] Traffic Vault
+- [ ] Other _________
+
+#### What is the best way to verify this PR?
+
+
+#### Check any that apply
+
+- [ ] This PR includes tests
+- [ ] This PR includes documentation updates
+- [ ] This PR includes an update to CHANGELOG.md
+- [ ] This PR includes all required license headers
+- [ ] This PR does *NOT* fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)
+
+


### PR DESCRIPTION
This template will be applied when any new PRs are created against Traffic Control. The idea is that it will help capture more information for potential reviewers/mergers and lead to better PRs and faster merges.