### PR TITLE
Fix TM not starting with null ds matchset

### DIFF
--- a/traffic_monitor/todata/todata.go
+++ b/traffic_monitor/todata/todata.go
@@ -292,7 +292,8 @@ func getDeliveryServiceTypes(crc CRConfig) (map[tc.DeliveryServiceName]tc.DSType
 		dsTypeStr := dsData.Matchsets[0].Protocol
 		dsType := tc.DSTypeCategoryFromString(dsTypeStr)
 		if dsType == tc.DSTypeCategoryInvalid {
-			return nil, fmt.Errorf("CRConfig unknowng protocol for '%s': '%s'", dsName, dsTypeStr)
+			log.Warnln("CRConfig invalid matchset protocol for delivery service '" + string(dsName) + "' matchset protocol '" + dsTypeStr + "'; skipping")
+			continue
 		}
 		dsTypes[dsName] = dsType
 	}


### PR DESCRIPTION
Same issue as https://github.com/apache/trafficcontrol/pull/2091 just manifesting in a different place.

>This specifically fixes the Monitor to keep going, when there's a data bug in Traffic Ops / the CRConfig. We've specifically seen this data bug in our staging environment.
>
>Null matchlists in the CRConfig are a data bug, and should never happen. But if they do, this makes the Monitor warn and keep working, instead of failing.

