### PR TITLE
ensure use_tenancy set to 1 rather than deleting the parameter

### DIFF
--- a/traffic_ops/app/db/patches.sql
+++ b/traffic_ops/app/db/patches.sql
@@ -70,8 +70,9 @@ $tenantnotnull$;
 ALTER TABLE tm_user ALTER COLUMN tenant_id SET NOT NULL;
 ALTER TABLE deliveryservice ALTER COLUMN tenant_id SET NOT NULL;
 ALTER TABLE origin ALTER COLUMN tenant SET NOT NULL;
--- get rid of the use_tenancy flag
-DELETE FROM parameter WHERE name = 'use_tenancy' AND config_file = 'global';
+-- set use_tenancy to 1 -- this should remain until code that depends on it is removed from both TO and TP
+-- NOTE that we know use_tenancy exists b/c it's inserted in seeds.sql
+UPDATE parameter SET value = '1' WHERE name = 'use_tenancy' AND config_file = 'global';
 
 -- never allow deep_caching_type to be NULL
 UPDATE deliveryservice SET deep_caching_type = 'NEVER' WHERE deep_caching_type IS NULL;

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -45,8 +45,8 @@ BEGIN
                 insert into profile_parameter (profile, parameter) values ( (select id from profile where name = 'GLOBAL'), (select id from parameter where name = 'tm.toolname' and config_file = 'global' and value = 'Traffic Ops') ) ON CONFLICT (profile, parameter) DO NOTHING;
         END IF;
         IF NOT EXISTS (SELECT id FROM PARAMETER WHERE name = 'use_tenancy' AND config_file = 'global') THEN
-                insert into parameter (name, config_file, value) values ('use_tenancy', 'global', '0');
-                insert into profile_parameter (profile, parameter) values ( (select id from profile where name = 'GLOBAL'), (select id from parameter where name = 'use_tenancy' and config_file = 'global' and value = '0') ) ON CONFLICT (profile, parameter) DO NOTHING;
+                insert into parameter (name, config_file, value) values ('use_tenancy', 'global', '1');
+                insert into profile_parameter (profile, parameter) values ( (select id from profile where name = 'GLOBAL'), (select id from parameter where name = 'use_tenancy' and config_file = 'global' and value = '1') ) ON CONFLICT (profile, parameter) DO NOTHING;
         END IF;
 END
 $do$;


### PR DESCRIPTION
this ensures that code dependent on this parameter continues to work.   That code should be eliminated prior to deleting this parameter.

Fixes #2687 and obsoletes #2685