### PR TITLE
OnThrowable memory leak fix for Traffic Router Issue #2223

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/PeriodicResourceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/PeriodicResourceUpdater.java
@@ -290,12 +290,6 @@ public class PeriodicResourceUpdater {
 		@Override
 		public void onThrowable(final Throwable t){
 			LOGGER.warn("Failed request " + request.getUrl() + ": " + t, t);
-			if (asyncHttpClient!=null) {
-				while (!asyncHttpClient.isClosed()) {
-					asyncHttpClient.close();
-				}
-			}
-			asyncHttpClient = newAsyncClient();
 		}
 	};
 


### PR DESCRIPTION
removed code under OnThrowable that was causing yet another memory leak
Additional Fix for #2223 