### PR TITLE
Fixes #2651 - Set Serves Status dropdown to be enabled when creating new

### DIFF
--- a/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
@@ -48,7 +48,7 @@ under the License.
             <div class="form-group">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">Status *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="status" class="form-control" ng-model="server.statusId" ng-options="status.id as status.name for status in statuses" ng-disabled="true"></select>
+                    <select name="status" class="form-control" ng-model="server.statusId" ng-options="status.id as status.name for status in statuses" ng-disabled="!settings.isNew"></select>
                 </div>
             </div>
             <div class="form-group" ng-show="server.offlineReason.length > 0">

--- a/traffic_portal/app/src/common/modules/form/server/new/FormNewServerController.js
+++ b/traffic_portal/app/src/common/modules/form/server/new/FormNewServerController.js
@@ -26,7 +26,7 @@ var FormNewServerController = function(server, $scope, $controller, serverServic
         statusService.getStatuses()
             .then(function(result) {
                 $scope.statuses = result;
-                // new servers are set to OFFLINE by default
+                // Issue #2651 - Enabling server status for New Server but still defaulting enabled dropdown to OFFLINE
                 var offlineStatus = _.find(result, function(status){ return status.name == 'OFFLINE' });
                 $scope.server.statusId = offlineStatus.id;
             });


### PR DESCRIPTION
Fixes #2651 Allows users to set the initial state of server status when adding a new server with OFFLINE preselected in the dropdown menu.