### PR TITLE
TP: server.js - removes commented out code

### DIFF
--- a/traffic_portal/server.js
+++ b/traffic_portal/server.js
@@ -92,39 +92,6 @@ if (app.get('env') === 'dev') {
     app.set('env', 'production');
 }
 
-// special handling required for dbdump. haven't got this to work yet
-// app.get('/dbdump', function (req, res) {
-//     var port = (useSSL) ? config.sslPort : config.port,
-//         options = {
-//             method: 'GET',
-//             host: 'localhost',
-//             port: port,
-//             path: '/api/1.2/dbdump',
-//             headers: {
-//                 cookie: req.headers['cookie']
-//             }
-//         };
-//
-//     var request = http.request(options, function(response) {
-//         var data = [];
-//         console.log(response.statusCode);
-//         response.on('data', function(chunk) {
-//             data.push(chunk);
-//         });
-//         response.on('end', function() {
-//             data = Buffer.concat(data);
-//             res.writeHead(200, {
-//                 'Content-Type': 'application/download',
-//                 'Content-Disposition': 'attachment; filename=foo.dump.gz',
-//                 'Content-Length': data.length
-//             });
-//             res.end(data);
-//         });
-//     });
-//
-//     request.end();
-// });
-
 // Enable reverse proxy support in Express. This causes the
 // the "X-Forwarded-Proto" header field to be trusted so its
 // value can be used to determine the protocol. See


### PR DESCRIPTION
#### What does this PR do?

Removes some commented out code in server.js that was a failed attempt at dbdump.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Ensure that TP still starts via `service traffic_portal start` or `grunt`

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [x] This PR does *NOT* fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



