### PR TITLE
add profile constraint cdn not null

### DIFF
--- a/traffic_ops/app/db/patches.sql
+++ b/traffic_ops/app/db/patches.sql
@@ -77,3 +77,7 @@ UPDATE parameter SET value = '1' WHERE name = 'use_tenancy' AND config_file = 'g
 -- never allow deep_caching_type to be NULL
 UPDATE deliveryservice SET deep_caching_type = 'NEVER' WHERE deep_caching_type IS NULL;
 ALTER TABLE deliveryservice ALTER COLUMN deep_caching_type SET NOT NULL;
+
+-- never allow profiles to have NULL cdn -- global profiles should use 'ALL'
+UPDATE profile SET cdn = (SELECT id FROM cdn WHERE name='ALL') WHERE cdn IS NULL;
+ALTER TABLE profile ALTER COLUMN cdn SET NOT NULL;

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -27,7 +27,7 @@ insert into job_status (name, description) values ('PENDING', 'Job is queued, bu
 
 -- parameters
 -- Moved into postinstall global parameters
-insert into profile (name, description, type) values ('GLOBAL', 'Global Traffic Ops profile, DO NOT DELETE', 'UNK_PROFILE') ON CONFLICT (name) DO NOTHING;
+insert into profile (name, description, type, cdn) values ('GLOBAL', 'Global Traffic Ops profile, DO NOT DELETE', 'UNK_PROFILE', (SELECT id FROM cdn WHERE name='ALL')) ON CONFLICT (name) DO NOTHING;
 
 ---------------------------------
 
@@ -57,13 +57,13 @@ $do$;
 
 -- profiles
 ---------------------------------
-insert into profile (name, description, type) values ('TRAFFIC_ANALYTICS', 'Traffic Analytics profile', 'UNK_PROFILE') ON CONFLICT (name) DO NOTHING;
-insert into profile (name, description, type) values ('TRAFFIC_OPS', 'Traffic Ops profile', 'UNK_PROFILE') ON CONFLICT (name) DO NOTHING;
-insert into profile (name, description, type) values ('TRAFFIC_OPS_DB', 'Traffic Ops DB profile', 'UNK_PROFILE') ON CONFLICT (name) DO NOTHING;
-insert into profile (name, description, type) values ('TRAFFIC_PORTAL', 'Traffic Portal profile', 'TP_PROFILE') ON CONFLICT (name) DO NOTHING;
-insert into profile (name, description, type) values ('TRAFFIC_STATS', 'Traffic Stats profile', 'TS_PROFILE') ON CONFLICT (name) DO NOTHING;
-insert into profile (name, description, type) values ('INFLUXDB', 'InfluxDb profile', 'INFLUXDB_PROFILE') ON CONFLICT (name) DO NOTHING;
-insert into profile (name, description, type) values ('RIAK_ALL', 'Riak profile for all CDNs', 'RIAK_PROFILE') ON CONFLICT (name) DO NOTHING;
+insert into profile (name, description, type, cdn) values ('TRAFFIC_ANALYTICS', 'Traffic Analytics profile', 'UNK_PROFILE', (SELECT id FROM cdn WHERE name='ALL')) ON CONFLICT (name) DO NOTHING;
+insert into profile (name, description, type, cdn) values ('TRAFFIC_OPS', 'Traffic Ops profile', 'UNK_PROFILE', (SELECT id FROM cdn WHERE name='ALL')) ON CONFLICT (name) DO NOTHING;
+insert into profile (name, description, type, cdn) values ('TRAFFIC_OPS_DB', 'Traffic Ops DB profile', 'UNK_PROFILE', (SELECT id FROM cdn WHERE name='ALL')) ON CONFLICT (name) DO NOTHING;
+insert into profile (name, description, type, cdn) values ('TRAFFIC_PORTAL', 'Traffic Portal profile', 'TP_PROFILE', (SELECT id FROM cdn WHERE name='ALL')) ON CONFLICT (name) DO NOTHING;
+insert into profile (name, description, type, cdn) values ('TRAFFIC_STATS', 'Traffic Stats profile', 'TS_PROFILE', (SELECT id FROM cdn WHERE name='ALL')) ON CONFLICT (name) DO NOTHING;
+insert into profile (name, description, type, cdn) values ('INFLUXDB', 'InfluxDb profile', 'INFLUXDB_PROFILE', (SELECT id FROM cdn WHERE name='ALL')) ON CONFLICT (name) DO NOTHING;
+insert into profile (name, description, type, cdn) values ('RIAK_ALL', 'Riak profile for all CDNs', 'RIAK_PROFILE', (SELECT id FROM cdn WHERE name='ALL')) ON CONFLICT (name) DO NOTHING;
 
 -- statuses
 insert into status (name, description) values ('OFFLINE', 'Server is Offline. Not active in any configuration.') ON CONFLICT (name) DO NOTHING;

--- a/traffic_ops/testing/api/config/config.go
+++ b/traffic_ops/testing/api/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 // TrafficOps - config section
 type TrafficOps struct {
 	// URL - The point to the Traffic Ops instance being tested
-	URL string `json:"URL" envconfig:"TO_URL" default:"https://localhost:8443"`
+	URL string `json:"URL" envconfig:"TO_URL"`
 
 	// UserPassword - The Traffic Ops test user password hitting the API
 	UserPassword string `json:"password" envconfig:"TO_USER_PASSWORD"`

--- a/traffic_ops/testing/api/v13/profiles_test.go
+++ b/traffic_ops/testing/api/v13/profiles_test.go
@@ -20,12 +20,16 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc/v13"
 )
 
 func TestProfiles(t *testing.T) {
 
 	CreateTestCDNs(t)
 	CreateTestTypes(t)
+
+	// attempt to create profiles with missing info
+	CreateBadProfiles(t)
 	CreateTestProfiles(t)
 	CreateTestParameters(t)
 	CreateTestProfileParameters(t)
@@ -37,7 +41,29 @@ func TestProfiles(t *testing.T) {
 	DeleteTestProfiles(t)
 	DeleteTestTypes(t)
 	DeleteTestCDNs(t)
+}
 
+// CreateBadProfiles ensures that profiles can't be created with bad values
+func CreateBadProfiles(t *testing.T) {
+
+	// blank profile
+	prs := []v13.Profile{
+		v13.Profile{Type: "", Name: "", Description: "", CDNID: 0},
+		v13.Profile{Type: "ATS_PROFILE", Name: "badprofile", Description: "description", CDNID: 0},
+		v13.Profile{Type: "ATS_PROFILE", Name: "badprofile", Description: "", CDNID: 1},
+		v13.Profile{Type: "ATS_PROFILE", Name: "", Description: "description", CDNID: 1},
+		v13.Profile{Type: "", Name: "badprofile", Description: "description", CDNID: 1},
+	}
+
+	for _, pr := range prs {
+		resp, _, err := TOSession.CreateProfile(pr)
+
+		if err == nil {
+			t.Errorf("Creating bad profile succeeded: %+v\nResponse is %+v", pr, resp)
+		} else {
+			log.Debugf("bad profile creation failed appropriately")
+		}
+	}
 }
 
 func CreateTestProfiles(t *testing.T) {
@@ -54,7 +80,6 @@ func CreateTestProfiles(t *testing.T) {
 			t.Errorf("could not CREATE profiles with name: %s %v\n", pr.Name, err)
 		}
 	}
-
 }
 
 func UpdateTestProfiles(t *testing.T) {


### PR DESCRIPTION
#### What does this PR do?
Adds constraint to profile table to disallow null cdn.
Only does this after ensuring that any null cdn currently in the db is set to the `ALL` cdn.

Fixes #2710 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
From a previous version of TO, get a copy of the database.

`psql ... traffic_ops -c '\d profile'` should not show `not null` in the description of the cdn column.    Run `db/admin.pl upgrade` and do the same psql command -- should now show `not null`.

Run `db/admin.pl reset` to put the db back to initial state.  That column should show `not null`.

Tests included in the api tests:
```
cd traffic_ops/testing/api/v13
go test -v -cfg=... -run TestProfiles
```
#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [x] This PR does *NOT* fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



