### PR TITLE
Fix TO Go ds/sslkeys/generate to accept numbers

### DIFF
--- a/lib/go-tc/deliveryservice_ssl_keys.go
+++ b/lib/go-tc/deliveryservice_ssl_keys.go
@@ -61,7 +61,7 @@ type DeliveryServiceSSLKeysReq struct {
 	State           *string `json:"state,omitempty"`
 	// Key is the XMLID of the delivery service
 	Key         *string                            `json:"key"`
-	Version     *string                            `json:"version"`
+	Version     *util.JSONNumAsStr                 `json:"version"`
 	Certificate *DeliveryServiceSSLKeysCertificate `json:"certificate,omitempty"`
 }
 
@@ -75,7 +75,8 @@ func (r *DeliveryServiceSSLKeysReq) Sanitize() {
 		r.Key = &k
 	}
 	if r.Version == nil {
-		r.Version = util.StrPtr("")
+		numStr := util.JSONNumAsStr("")
+		r.Version = &numStr
 	}
 }
 

--- a/lib/go-util/num.go
+++ b/lib/go-util/num.go
@@ -80,6 +80,21 @@ func (i *JSONIntStr) UnmarshalJSON(d []byte) error {
 	return nil
 }
 
+// JSONNumAsStr unmarshals JSON strings or numbers into strings
+// This is designed to handle backwards-compatibility for old Perl endpoints which accept both. Please do not use this for new endpoints or new APIs, APIs should be well-typed.
+type JSONNumAsStr string
+
+func (s *JSONNumAsStr) UnmarshalJSON(d []byte) error {
+	if len(d) == 0 {
+		return errors.New("empty object")
+	}
+	if d[0] == '"' {
+		d = d[1 : len(d)-1] // strip JSON quotes
+	}
+	*s = JSONNumAsStr(d)
+	return nil
+}
+
 // BytesLenSplit splits the given byte array into an n-length arrays. If n > len(s), returns a slice with a single []byte containing all of s. If n <= 0, returns an empty slice.
 func BytesLenSplit(s []byte, n int) [][]byte {
 	ss := [][]byte{}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/sslkeys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/sslkeys.go
@@ -65,7 +65,7 @@ func generatePutRiakKeys(req tc.DeliveryServiceSSLKeysReq, tx *sql.Tx, cfg *conf
 		Country:         *req.Country,
 		State:           *req.State,
 		Key:             *req.Key,
-		Version:         *req.Version,
+		Version:         string(*req.Version),
 	}
 	if req.Certificate != nil {
 		dsSSLKeys.Certificate = *req.Certificate


### PR DESCRIPTION
The docs say the version is a string, but it appears Perl accepts both
and the Portal sends a number. This changes TO Go to accept both,
emulating the Perl behavior.

Fixes #2715

#### What does this PR do?

Fixes #2715

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Follow #2715 steps to reproduce.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [x] This PR does *NOT* fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



