### PR TITLE
Traffic Ops - Constraint violation(s) with Traffic Ops postinstall script

### DIFF
--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -617,8 +617,9 @@ QUERY
     # Skip the insert if the admin 'username' is already there.
     my $hashed_passwd = hash_pass( $adminconf->{"password"} );
     my $insert_admin = <<"ADMIN";
-    insert into tm_user (username, role, local_passwd, confirm_local_passwd)
+    insert into tm_user (username, tenant_id, role, local_passwd, confirm_local_passwd)
                 values  ('$adminconf->{"username"}',
+                        (select id from tenant where name = 'root'),
                         (select id from role where name = 'admin'),
                          '$hashed_passwd',
                         '$hashed_passwd' )
@@ -772,8 +773,8 @@ sub insert_profiles {
     my $insert_stmt = <<INSERTS;
 
     -- global parameters
-    insert into profile (name, description, type) 
-                values ('GLOBAL', 'Global Traffic Ops profile, DO NOT DELETE', 'UNK_PROFILE') 
+    insert into profile (name, description, type, cdn) 
+                values ('GLOBAL', 'Global Traffic Ops profile, DO NOT DELETE', 'UNK_PROFILE',  (SELECT id FROM cdn WHERE name='ALL')) 
                 ON CONFLICT (name) DO NOTHING;
 
     insert into profile_parameter (profile, parameter) 


### PR DESCRIPTION
 Constraint violation(s) with Traffic Ops postinstall script

* admin user doesn't get added to tm_user table due to missing tenant_id
* global profile doesn't get added to profile table due to missing cdn.id 

Fixes #2718 

Original SQL statement ERROR details:

```
ERROR:  null value in column "tenant_id" violates not-null constraint
DETAIL:  Failing row contains (5, admin, null, 1, null, null, SCRYPT:16384:8:1:m+XXXXXXXXX+qAf3SXylI8m2q44NBCMs8aHNaWm3S1oDxhc..., SCRYPT:16384:8:1:m+XXXXXXXXXXXXf3SXylI8m2q44NBCMs8aHNaWm3S1oDxhc..., 2018-08-20 15:35:35.817679-06, null, null, nu    ll, f, null, null, null, null, null, null, null, null, null, null).
SQL state: 23502
```

```
ERROR:  null value in column "cdn" violates not-null constraint
DETAIL:  Failing row contains (15, GLOBAL, Global Traffic Ops profile, DO NOT DELETE, 2018-08-20 16:41:51.641532-06, UNK_PROFILE, null, f).
SQL state: 23502
```

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [X] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

1. Run the postinstall script on newly created (empty) postgres DB instance.
2. Verify that the admin user has been successfully added to the tm_user table.
3. Verify that the global profile is in the profile table.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [X] This PR does *NOT* fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



