### PR TITLE
Improved logging around missing certificates. This resolves #2730.

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/CertificateChecker.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/CertificateChecker.java
@@ -45,11 +45,18 @@ public class CertificateChecker {
 	public boolean certificatesAreValid(final List<CertificateData> certificateDataList, final JsonNode deliveryServicesJson) {
 
 		final Iterator<String> deliveryServiceIdIter = deliveryServicesJson.fieldNames();
+		boolean invalidConfig = false;
+
 		while (deliveryServiceIdIter.hasNext()) {
 			if (!deliveryServiceHasValidCertificates(certificateDataList, deliveryServicesJson, deliveryServiceIdIter.next())) {
-				return false;
+				invalidConfig = true; // individual DS errors are logged when deliveryServiceHasValidCertificates() is called
 			}
 		}
+
+		if (invalidConfig) {
+			return false;
+		}
+
 		return true;
 	}
 
@@ -61,7 +68,7 @@ public class CertificateChecker {
 	}
 
     @SuppressWarnings("PMD.CyclomaticComplexity")
-	private Boolean deliveryServiceHasValidCertificates(final List<CertificateData> certificateDataList, final JsonNode deliveryServicesJson, final String deliveryServiceId) {
+	private boolean deliveryServiceHasValidCertificates(final List<CertificateData> certificateDataList, final JsonNode deliveryServicesJson, final String deliveryServiceId) {
 		final JsonNode deliveryServiceJson = deliveryServicesJson.get(deliveryServiceId);
 		final JsonNode protocolJson = deliveryServiceJson.get("protocol");
 


### PR DESCRIPTION
#### What does this PR do?

This PR improves logging around missing certificates. Previously only the first missing certificate was logged and processing would stop. This PR allows execution to continue so that we can log every missing certificate, and only then stop processing. This is a minor logging change and should not affect overall execution.

Fixes #2730

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [x] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Create delivery services without TLS certs and HTTPS enabled.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [x] This PR does *NOT* fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



