### PR TITLE
add checks that the parsed ldap config is complete

### DIFF
--- a/traffic_ops/traffic_ops_golang/config/config.go
+++ b/traffic_ops/traffic_ops_golang/config/config.go
@@ -27,6 +27,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"strings"
+
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/riaksvc"
 	"github.com/basho/riak-go-client"
@@ -309,6 +311,22 @@ func GetLDAPConfig(LDAPConfPath string) (bool, *ConfigLDAP, error) {
 	if err != nil {
 		return false, LDAPconf, fmt.Errorf("parsing LDAP conf '%v': %v", LDAPConfBytes, err)
 	}
+	if strings.TrimSpace(LDAPconf.AdminPass) == "" {
+		return false, LDAPconf, fmt.Errorf("LDAP conf missing admin_pass field")
+	}
+	if strings.TrimSpace(LDAPconf.SearchBase) == "" {
+		return false, LDAPconf, fmt.Errorf("LDAP conf missing search_base field")
+	}
+	if strings.TrimSpace(LDAPconf.AdminDN) == "" {
+		return false, LDAPconf, fmt.Errorf("LDAP conf missing admin_dn field")
+	}
+	if strings.TrimSpace(LDAPconf.Host) == "" {
+		return false, LDAPconf, fmt.Errorf("LDAP conf missing host field")
+	}
+	if strings.TrimSpace(LDAPconf.SearchQuery) == "" {
+		return false, LDAPconf, fmt.Errorf("LDAP conf missing search_query field")
+	}
+
 	return true, LDAPconf, nil
 }
 


### PR DESCRIPTION
#### What does this PR do?

Enhances LDAP config parsing to log an error and disable LDAP if the config is incomplete rather than blocking startup

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

startup traffic_ops_golang with an incomplete (even empty) ldap.conf alongside the cdn.conf, without this PR it will fail, with this pr an error should be logged and startup will continue.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [X] This PR does *NOT* fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



