### PR TITLE
Remove sudo from trafficrouter RPM scriptlets

### DIFF
--- a/traffic_router/core/src/main/scripts/postinstall.sh
+++ b/traffic_router/core/src/main/scripts/postinstall.sh
@@ -30,5 +30,5 @@ fi
 echo "Traffic Router installed successfully."
 
 systemctl daemon-reload
-echo "Start with 'sudo systemctl start traffic_router'"
+echo "Start with 'systemctl start traffic_router'"
 

--- a/traffic_router/core/src/main/scripts/preinstall.sh
+++ b/traffic_router/core/src/main/scripts/preinstall.sh
@@ -21,9 +21,9 @@ chkconfig --list tomcat >/dev/null
 if [ $? -eq 0 ]; then
   /sbin/service tomcat stop
 else
-  /usr/bin/sudo /usr/bin/systemctl list-unit-files traffic_router.service > /dev/null
+  /usr/bin/systemctl list-unit-files traffic_router.service > /dev/null
 
-  [ $? -eq 0 ] && /usr/bin/sudo /usr/bin/systemctl stop traffic_router
+  [ $? -eq 0 ] && /usr/bin/systemctl stop traffic_router
 fi
 
 # delete the expanded war files from the previous version

--- a/traffic_router/core/src/main/scripts/preremove.sh
+++ b/traffic_router/core/src/main/scripts/preremove.sh
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 
-/usr/bin/sudo /usr/bin/systemctl stop traffic_router
+/usr/bin/systemctl stop traffic_router

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -78,7 +78,7 @@ systemctl daemon-reload
 
 echo "Tomcat for Traffic Router installed successfully."
 echo ""
-echo "Start with 'sudo systemctl start traffic_router'"
+echo "Start with 'systemctl start traffic_router'"
 
 %preun
 


### PR DESCRIPTION
#### What does this PR do?

Remove superfluous usage of sudo within RPM scriptlet(s).

Fixes #2758

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [X] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

1) Rebuild trafficrouter from source.
2) Extract the scriptlet(s) from the RPM binary and GREP for sudo 
    Ex: rpm --scripts -qp ./traffic_router-3.0.0-XXXX.abcdef.el7.x86_64.rpm | grep sudo
3) Ensure the scriptlet output doesn't contain any sudo commands.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR does *NOT* fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



