### PR TITLE
TP: changed invalidation request field 'startTime' to UTC instead of local time

### DIFF
--- a/traffic_portal/app/src/modules/private/deliveryServices/jobs/new/index.js
+++ b/traffic_portal/app/src/modules/private/deliveryServices/jobs/new/index.js
@@ -31,7 +31,7 @@ module.exports = angular.module('trafficPortal.private.deliveryServices.jobs.new
 								return deliveryServiceService.getDeliveryService($stateParams.deliveryServiceId);
 							},
 							job: function($stateParams) {
-								return { dsId: $stateParams.deliveryServiceId, startTime: moment().format('YYYY-MM-DD HH:mm:ss') };
+								return { dsId: $stateParams.deliveryServiceId, startTime: moment().utc().format('YYYY-MM-DD HH:mm:ss') };
 							}
 						}
 					}

--- a/traffic_portal/app/src/modules/private/jobs/new/index.js
+++ b/traffic_portal/app/src/modules/private/jobs/new/index.js
@@ -28,7 +28,7 @@ module.exports = angular.module('trafficPortal.private.jobs.new', [])
 						controller: 'FormNewJobController',
 						resolve: {
 							job: function() {
-								return { startTime: moment().format('YYYY-MM-DD HH:mm:ss') };
+								return { startTime: moment().utc().format('YYYY-MM-DD HH:mm:ss') };
 							}
 						}
 					}


### PR DESCRIPTION
#### What does this PR do?
Changes invalidation requests to use UTC time instead of local time.

Fixes #2763 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Create an invalidation request in TP and check the database that the fields job.start_time and job.entered_time are both in UTC.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



