### PR TITLE
Modify the grove build scripts to insure that grove is built using go 1.11 or later.

### DIFF
--- a/build/functions.sh
+++ b/build/functions.sh
@@ -191,3 +191,40 @@ function createDocsTarball() {
         rm -r "$bndir"
         echo "$tarball"
 }
+
+# ----------------------------------------
+# verify if the go compiler is version 1.11 or higher, returns 0 if if not. returns 1 if it is.
+# 
+function verify_and_set_go_version () {
+  GO_VERSION="none"
+  GO="none"
+  go_in_path=`type -p go`
+  for g in $go_in_path /usr/bin/go /usr/local/go/bin/go; do
+    if [[ -z $g ]] || [[ ! -x $g ]]; then
+      continue
+    fi
+    
+    go_version=`$g version | awk '{print $3}'`
+
+    if [[ $go_version =~ go([1-9])\.([1-9]+) ]] && [[ ${BASH_REMATCH[1]} -ge 1 ]] && [[ ${BASH_REMATCH[2]} -ge 11 ]]; then
+      GO_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"; export GO_VERSION
+      GO=$g; export GO
+      PATH=`dirname $g`:$PATH; export PATH
+      echo "go version for $g is ${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+      echo "will use $g"
+      return 1
+    else
+      if [[ $go_version =~ go([1-9])\.([1-9]+) ]]; then
+        GO_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"; export GO_VERSION
+        echo "go version for $g is ${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+        continue
+      fi
+    fi
+  done
+
+  if [[ $GO == none ]]; then
+    echo "ERROR: this build needs go 1.11 or greater and no usable go compiler was found, found GO_VERSION: $GO_VERSION"
+    return 0
+  fi
+}
+

--- a/grove/build/build_rpm.sh
+++ b/grove/build/build_rpm.sh
@@ -14,9 +14,9 @@
 
 #----------------------------------------
 function importFunctions() {
-  TC_DIR=$(git rev-parse --show-toplevel)
-  [ ! -z "$TC_DIR" ] || { echo "Cannot find repository root." >&2 ; exit 1; }
-  export TC_DIR
+	TC_DIR=$(git rev-parse --show-toplevel)
+	[ ! -z "$TC_DIR" ] || { echo "Cannot find repository root." >&2 ; exit 1; }
+	export TC_DIR
 	functions_sh="$TC_DIR/build/functions.sh"
 	if [[ ! -r $functions_sh ]]; then
 		echo "Error: Can't find $functions_sh"
@@ -28,69 +28,77 @@ function importFunctions() {
 #----------------------------------------
 function checkGroveEnvironment() {
 	echo "Verifying the build configuration environment."
+
 	local script=$(readlink -f "$0")
 	local scriptdir=$(dirname "$script")
 
 	export GROVE_DIR=$(dirname "$scriptdir")
-  export GROVE_VERSION=`cat ${GROVE_DIR}/VERSION`
+	export GROVE_VERSION=`cat ${GROVE_DIR}/VERSION`
 	export PACKAGE="grove"
 	export BUILD_NUMBER=${BUILD_NUMBER:-$(getBuildNumber)}
 	export RPMBUILD="${GROVE_DIR}/rpmbuild"
 	export DIST="${TC_DIR}/dist"
 	export RPM="${PACKAGE}-${GROVE_VERSION}-${BUILD_NUMBER}.x86_64.rpm"
 
+	# grove needs to be built with go 1.11 or greater
+	verify_and_set_go_version
+	if [[ $? -ne 1 ]]; then
+		exit 0
+	fi
+
 	echo "=================================================="
-  echo "TC_DIR: $TC_DIR"
-  echo "PACKAGE: $PACKAGE"
-  echo "GROVE_DIR: $GROVE_DIR"
+	echo "GO_VERSION: $GO_VERSION"
+	echo "TC_DIR: $TC_DIR"
+	echo "PACKAGE: $PACKAGE"
+	echo "GROVE_DIR: $GROVE_DIR"
 	echo "GROVE_VERSION: $GROVE_VERSION"
 	echo "BUILD_NUMBER: $BUILD_NUMBER"
-  echo "DIST: $DIST"
+	echo "DIST: $DIST"
 	echo "RPM: $RPM"
-  echo "RPMBUILD: $RPMBUILD"
+	echo "RPMBUILD: $RPMBUILD"
 	echo "--------------------------------------------------"
 }
 
 # ---------------------------------------
 function initBuildArea() {
-  cd "$GROVE_DIR"
+	cd "$GROVE_DIR"
 
-  # prep build environment
-  [ -e $RPMBUILD ] && rm -rf $RPMBUILD
-  [ ! -e $RPMBUILD ] || { echo "Failed to clean up rpm build directory '$RPMBUILD': $?" >&2; exit 1; }
-  mkdir -p $RPMBUILD/{BUILD,RPMS,SOURCES} || { echo "Failed to create build directory '$RPMBUILD': $?" >&2; exit 1; }
+	# prep build environment
+	[ -e $RPMBUILD ] && rm -rf $RPMBUILD
+	[ ! -e $RPMBUILD ] || { echo "Failed to clean up rpm build directory '$RPMBUILD': $?" >&2; exit 1; }
+	mkdir -p $RPMBUILD/{BUILD,RPMS,SOURCES} || { echo "Failed to create build directory '$RPMBUILD': $?" >&2; exit 1; }
 }
 
 # ---------------------------------------
 function buildRpmGrove() {
-  # build
-  go get -v -d . || { echo "Failed to go get dependencies: $?" >&2; exit 1; }
-  go build -v -ldflags "-X main.Version=$GROVE_VERSION" || { echo "Failed to build grove: $?" >&2; exit 1; }
+	# build
+	$GO get -v -d . || { echo "Failed to go get dependencies: $?" >&2; exit 1; }
+	$GO build -v -ldflags "-X main.Version=$GROVE_VERSION" || { echo "Failed to build grove: $?" >&2; exit 1; }
 
-  # tar
-  tar -cvzf $RPMBUILD/SOURCES/grove-${GROVE_VERSION}.tgz grove conf/grove.cfg build/grove.init build/grove.logrotate || { echo "Failed to create archive for rpmbuild: $?" >&2; exit 1; }
+	# tar
+	tar -cvzf $RPMBUILD/SOURCES/grove-${GROVE_VERSION}.tgz grove conf/grove.cfg build/grove.init build/grove.logrotate || { echo "Failed to create archive for rpmbuild: $?" >&2; exit 1; }
 
-  # Work around bug in rpmbuild. Fixed in rpmbuild 4.13.
-  # See: https://github.com/rpm-software-management/rpm/commit/916d528b0bfcb33747e81a57021e01586aa82139
-  # Takes ownership of the spec file.
-  spec=build/grove.spec
-  spec_owner=$(stat -c%u $spec)
-  spec_group=$(stat -c%g $spec)
-  if ! id $spec_owner >/dev/null 2>&1; then
+	# Work around bug in rpmbuild. Fixed in rpmbuild 4.13.
+	# See: https://github.com/rpm-software-management/rpm/commit/916d528b0bfcb33747e81a57021e01586aa82139
+	# Takes ownership of the spec file.
+	spec=build/grove.spec
+	spec_owner=$(stat -c%u $spec)
+	spec_group=$(stat -c%g $spec)
+	if ! id $spec_owner >/dev/null 2>&1; then
 	  chown $(id -u):$(id -g) build/grove.spec
 
 	  function give_spec_back {
 		chown ${spec_owner}:${spec_group} build/grove.spec
 	  }
 	  trap give_spec_back EXIT
-  fi
+	fi
 
-  # build RPM
-  rpmbuild --define "_topdir $RPMBUILD" --define "version ${GROVE_VERSION}" --define "build_number ${BUILD_NUMBER}" -ba build/grove.spec || { echo "rpmbuild failed: $?" >&2; exit 1; }
+	# build RPM
+	rpmbuild --define "_topdir $RPMBUILD" --define "version ${GROVE_VERSION}" --define "build_number ${BUILD_NUMBER}" -ba build/grove.spec || { echo "rpmbuild failed: $?" >&2; exit 1; }
 
-  # copy build RPM to .
-  [ -e $DIST ] || mkdir -p $DIST
-  cp $RPMBUILD/RPMS/x86_64/${RPM} $DIST
+	# copy build RPM to .
+	[ -e $DIST ] || mkdir -p $DIST
+	cp $RPMBUILD/RPMS/x86_64/${RPM} $DIST
 }
 
 importFunctions

--- a/grove/grovetccfg/build/build_rpm.sh
+++ b/grove/grovetccfg/build/build_rpm.sh
@@ -14,9 +14,9 @@
 
 #----------------------------------------
 function importFunctions() {
-  TC_DIR=$(git rev-parse --show-toplevel)
-  [ ! -z "$TC_DIR" ] || { echo "Cannot find repository root." >&2 ; exit 1; }
-  export TC_DIR
+	TC_DIR=$(git rev-parse --show-toplevel)
+	[ ! -z "$TC_DIR" ] || { echo "Cannot find repository root." >&2 ; exit 1; }
+	export TC_DIR
 	functions_sh="$TC_DIR/build/functions.sh"
 	if [[ ! -r $functions_sh ]]; then
 		echo "Error: Can't find $functions_sh"
@@ -32,67 +32,74 @@ function checkGroveEnvironment() {
 	local scriptdir=$(dirname "$script")
 
 	export GROVETC_DIR=$(dirname "$scriptdir")
-  export GROVE_DIR=$(dirname "$GROVETC_DIR")
-  export GROVE_VERSION=`cat ${GROVE_DIR}/VERSION`
+	export GROVE_DIR=$(dirname "$GROVETC_DIR")
+	export GROVE_VERSION=`cat ${GROVE_DIR}/VERSION`
 	export PACKAGE="grovetccfg"
 	export BUILD_NUMBER=${BUILD_NUMBER:-$(getBuildNumber)}
 	export RPMBUILD="${GROVE_DIR}/rpmbuild"
 	export DIST="${TC_DIR}/dist"
 	export RPM="${PACKAGE}-${GROVE_VERSION}-${BUILD_NUMBER}.x86_64.rpm"
 
+	# grovetccfg needs to be built with go 1.11 or greater
+	verify_and_set_go_version
+	if [[ $? -ne 1 ]]; then
+		exit 0
+	fi
+
 	echo "=================================================="
-  echo "TC_DIR: $TC_DIR"
-  echo "PACKAGE: $PACKAGE"
-  echo "GROVE_DIR: $GROVE_DIR"
-  echo "GROVETC_DIR: $GROVETC_DIR"
+	echo "GO_VERSION: $GO_VERSION"
+	echo "TC_DIR: $TC_DIR"
+	echo "PACKAGE: $PACKAGE"
+	echo "GROVE_DIR: $GROVE_DIR"
+	echo "GROVETC_DIR: $GROVETC_DIR"
 	echo "GROVE_VERSION: $GROVE_VERSION"
 	echo "BUILD_NUMBER: $BUILD_NUMBER"
-  echo "DIST: $DIST"
+	echo "DIST: $DIST"
 	echo "RPM: $RPM"
-  echo "RPMBUILD: $RPMBUILD"
+	echo "RPMBUILD: $RPMBUILD"
 	echo "--------------------------------------------------"
 }
 
 # ---------------------------------------
 function initBuildArea() {
-  cd "$GROVETC_DIR"
+	cd "$GROVETC_DIR"
 
-  # prep build environment
-  [ -e $RPMBUILD ] && rm -rf $RPMBUILD
-  [ ! -e $RPMBUILD ] || { echo "Failed to clean up rpm build directory '$RPMBUILD': $?" >&2; exit 1; }
-  mkdir -p $RPMBUILD/{BUILD,RPMS,SOURCES} || { echo "Failed to create build directory '$RPMBUILD': $?" >&2; exit 1; }
+	# prep build environment
+	[ -e $RPMBUILD ] && rm -rf $RPMBUILD
+	[ ! -e $RPMBUILD ] || { echo "Failed to clean up rpm build directory '$RPMBUILD': $?" >&2; exit 1; }
+	mkdir -p $RPMBUILD/{BUILD,RPMS,SOURCES} || { echo "Failed to create build directory '$RPMBUILD': $?" >&2; exit 1; }
 }
 
 # ---------------------------------------
 function buildRpmGrove() {
-  # build
-  go get -v -d . || { echo "Failed to go get dependencies: $?" >&2; exit 1; }
-  go build -v -ldflags "-X main.Version=$GROVE_VERSION" || { echo "Failed to build $PACKAGE: $?" >&2; exit 1; }
+	# build
+	$GO get -v -d . || { echo "Failed to go get dependencies: $?" >&2; exit 1; }
+	$GO build -v -ldflags "-X main.Version=$GROVE_VERSION" || { echo "Failed to build $PACKAGE: $?" >&2; exit 1; }
 
-  # tar
-  tar -cvzf $RPMBUILD/SOURCES/${PACKAGE}-${GROVE_VERSION}.tgz ${PACKAGE}|| { echo "Failed to create archive for rpmbuild: $?" >&2; exit 1; }
+	# tar
+	tar -cvzf $RPMBUILD/SOURCES/${PACKAGE}-${GROVE_VERSION}.tgz ${PACKAGE}|| { echo "Failed to create archive for rpmbuild: $?" >&2; exit 1; }
 
-  # Work around bug in rpmbuild. Fixed in rpmbuild 4.13.
-  # See: https://github.com/rpm-software-management/rpm/commit/916d528b0bfcb33747e81a57021e01586aa82139
-  # Takes ownership of the spec file.
-  spec=build/${PACKAGE}.spec
-  spec_owner=$(stat -c%u $spec)
-  spec_group=$(stat -c%g $spec)
-  if ! id $spec_owner >/dev/null 2>&1; then
+	# Work around bug in rpmbuild. Fixed in rpmbuild 4.13.
+	# See: https://github.com/rpm-software-management/rpm/commit/916d528b0bfcb33747e81a57021e01586aa82139
+	# Takes ownership of the spec file.
+	spec=build/${PACKAGE}.spec
+	spec_owner=$(stat -c%u $spec)
+	spec_group=$(stat -c%g $spec)
+	if ! id $spec_owner >/dev/null 2>&1; then
 	  chown $(id -u):$(id -g) build/${PACKAGE}.spec
 
 	  function give_spec_back {
 		chown ${spec_owner}:${spec_group} build/${PACKAGE}.spec
 	  }
 	  trap give_spec_back EXIT
-  fi
+	fi
 
-  # build RPM
-  rpmbuild --define "_topdir $RPMBUILD" --define "version ${GROVE_VERSION}" --define "build_number ${BUILD_NUMBER}" -ba build/${PACKAGE}.spec || { echo "rpmbuild failed: $?" >&2; exit 1; }
+	# build RPM
+	rpmbuild --define "_topdir $RPMBUILD" --define "version ${GROVE_VERSION}" --define "build_number ${BUILD_NUMBER}" -ba build/${PACKAGE}.spec || { echo "rpmbuild failed: $?" >&2; exit 1; }
 
-  # copy build RPM to .
-  [ -e $DIST ] || mkdir -p $DIST
-  cp $RPMBUILD/RPMS/x86_64/${RPM} $DIST
+	# copy build RPM to .
+	[ -e $DIST ] || mkdir -p $DIST
+	cp $RPMBUILD/RPMS/x86_64/${RPM} $DIST
 }
 
 importFunctions

--- a/infrastructure/docker/build/Dockerfile-grove
+++ b/infrastructure/docker/build/Dockerfile-grove
@@ -32,9 +32,8 @@ RUN	yum -y install \
 	yum -y clean all
 
 ### grove specific requirements
-RUN	yum -y install \
-		golang-1.9.4 && \
-	yum -y clean all
+RUN	 curl https://dl.google.com/go/go1.11.linux-amd64.tar.gz -o /tmp/go1.11.linux-amd64.tar.gz && \
+  tar xzvf /tmp/go1.11.linux-amd64.tar.gz -C /usr/local
 ###
 
 ADD infrastructure/docker/build/clean_build.sh /

--- a/infrastructure/docker/build/Dockerfile-grovetccfg
+++ b/infrastructure/docker/build/Dockerfile-grovetccfg
@@ -31,10 +31,9 @@ RUN	yum -y install \
 		rpm-build && \
 	yum -y clean all
 
-### grove specific requirements
-RUN	yum -y install \
-		golang-1.9.4 && \
-	yum -y clean all
+### grovetccfg specific requirements
+RUN	 curl https://dl.google.com/go/go1.11.linux-amd64.tar.gz -o /tmp/go1.11.linux-amd64.tar.gz && \
+  tar xzvf /tmp/go1.11.linux-amd64.tar.gz -C /usr/local
 ###
 
 ADD infrastructure/docker/build/clean_build.sh /


### PR DESCRIPTION
Modifies the grove build scripts to insure grove is built using a go 1.11 or later compiler.  This addresses a performance problem with TLS requests using RSA certificates, Fixes #2780 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [X ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Build grove using the scripts provided

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



