### PR TITLE
TO GO: Added missing struct fields to satisfy v11 definition of a user

### DIFF
--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -30,18 +30,28 @@ type UsersResponse struct {
 
 // User contains information about a given user in Traffic Ops.
 type User struct {
-	Username     string `json:"username,omitempty"`
-	PublicSSHKey string `json:"publicSshKey,omitempty"`
-	Role         int    `json:"role,omitempty"`
-	RoleName     string `json:"rolename,omitempty"`
-	ID           int    `json:"id,omitempty"`
-	UID          int    `json:"uid,omitempty"`
-	GID          int    `json:"gid,omitempty"`
-	Company      string `json:"company,omitempty"`
-	Email        string `json:"email,omitempty"`
-	FullName     string `json:"fullName,omitempty"`
-	NewUser      bool   `json:"newUser,omitempty"`
-	LastUpdated  string `json:"lastUpdated,omitempty"`
+	Username         string    `json:"username,omitempty"`
+	PublicSSHKey     string    `json:"publicSshKey,omitempty"`
+	Role             int       `json:"role,omitempty"`
+	RoleName         string    `json:"rolename,omitempty"`
+	ID               int       `json:"id,omitempty"`
+	UID              int       `json:"uid,omitempty"`
+	GID              int       `json:"gid,omitempty"`
+	Company          string    `json:"company,omitempty"`
+	Email            string    `json:"email,omitempty"`
+	FullName         string    `json:"fullName,omitempty"`
+	NewUser          bool      `json:"newUser,omitempty"`
+	LastUpdated      string    `json:"lastUpdated,omitempty"`
+	AddressLine1     string    `json:"addressLine1"`
+	AddressLine2     string    `json:"addressLine2"`
+	City             string    `json:"city"`
+	Country          string    `json:"country"`
+	PhoneNumber      string    `json:"phoneNumber"`
+	PostalCode       string    `json:"postalCode"`
+	RegistrationSent time.Time `json:"registrationSent"`
+	StateOrProvince  string    `json:"stateOrProvince"`
+	Tenant           string    `json:"tenant"`
+	TenantID         int       `json:"tenantId"`
 }
 
 // Credentials contains Traffic Ops login credentials

--- a/traffic_ops/testing/api/v13/user_test.go
+++ b/traffic_ops/testing/api/v13/user_test.go
@@ -15,9 +15,9 @@ package v13
 */
 
 import (
-	"testing"
-
+	"encoding/json"
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"testing"
 )
 
 func TestUsers(t *testing.T) {
@@ -29,13 +29,12 @@ func TestUsers(t *testing.T) {
 	CreateTestRegions(t)
 	CreateTestPhysLocations(t)
 	CreateTestCacheGroups(t)
-	CreateTestServers(t)
 	CreateTestDeliveryServices(t)
 
+	GetTestUsers(t)
 	GetTestUserCurrent(t)
 
 	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
 	DeleteTestCacheGroups(t)
 	DeleteTestPhysLocations(t)
 	DeleteTestRegions(t)
@@ -48,6 +47,23 @@ func TestUsers(t *testing.T) {
 }
 
 const SessionUserName = "admin" // TODO make dynamic?
+
+func GetTestUsers(t *testing.T) {
+
+	resp, _, err := TOSession.GetUsers()
+	if err != nil {
+		t.Fatalf("cannot GET users: %v\n", err)
+	}
+	if len(resp) == 0 {
+		t.Fatalf("no users, must have at least 1 user to test\n")
+	}
+
+	log.Debugf("Response: %s\n")
+	for _, user := range resp {
+		bytes, _ := json.Marshal(user)
+		log.Debugf("%s\n", bytes)
+	}
+}
 
 func GetTestUserCurrent(t *testing.T) {
 	log.Debugln("GetTestUserCurrent")

--- a/traffic_ops/testing/api/v13/userdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v13/userdeliveryservices_test.go
@@ -29,7 +29,6 @@ func TestUsersDeliveryServices(t *testing.T) {
 	CreateTestRegions(t)
 	CreateTestPhysLocations(t)
 	CreateTestCacheGroups(t)
-	CreateTestServers(t)
 	CreateTestDeliveryServices(t)
 
 	CreateTestUsersDeliveryServices(t)
@@ -37,7 +36,6 @@ func TestUsersDeliveryServices(t *testing.T) {
 	DeleteTestUsersDeliveryServices(t)
 
 	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
 	DeleteTestCacheGroups(t)
 	DeleteTestPhysLocations(t)
 	DeleteTestRegions(t)


### PR DESCRIPTION
#### What does this PR do?

This PR adds missing struct fields to the `User` struct. I'm putting it in a separate PR than my other work because this affects a different version.

I added a small test to verify that the correct struct fields existed, looking at the struct fields in the localhost is insufficient since the only place the `User` struct is used is in the client. (There is no golang handler currently)

Small note: Removed create and delete servers in the tests since the users test doesn't need it, and the server tests were failing at the time I wrote this.

Other Note: The struct I modified will eventually be deprecated because it isn't nullable, but in the meantime a User should still contain all of its fields.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Run the api tests from the command line. Using any localhost tests don't use the client code, the only place where the `User` struct is used.

#### Check all that apply

- [X] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->
