### PR TITLE
Fixes issue 2804 by adding the GROVE_PROFILE_TYPE to the FormProfileController.js

### DIFF
--- a/traffic_portal/app/src/common/modules/form/profile/FormProfileController.js
+++ b/traffic_portal/app/src/common/modules/form/profile/FormProfileController.js
@@ -42,7 +42,8 @@ var FormProfileController = function(profile, Restangular, $scope, $location, $u
         { value: 'KAFKA_PROFILE' },
         { value: 'LOGSTASH_PROFILE' },
         { value: 'ES_PROFILE' },
-        { value: 'UNK_PROFILE' }
+        { value: 'UNK_PROFILE' },
+        { value: 'GROVE_PROFILE' }
     ];
 
     $scope.falseTrue = [


### PR DESCRIPTION
Fixes #2804 

#### What does this PR do?
It fixes an issue where when you view a grove profile type, the type displays 'select' instead of GROVE_PROFILE.

Fixes #2804 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ X] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Find a grove profile and view the details, you should see type is now GROVE_PROFILE

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



