### PR TITLE
Add Traffic Ops Golang panic logging

### DIFF
--- a/traffic_ops/traffic_ops_golang/routing.go
+++ b/traffic_ops/traffic_ops_golang/routing.go
@@ -66,7 +66,7 @@ type RawRoute struct {
 }
 
 func getDefaultMiddleware(secret string, requestTimeout time.Duration) []Middleware {
-	return []Middleware{getWrapAccessLog(secret), timeOutWrapper(requestTimeout), wrapHeaders}
+	return []Middleware{getWrapAccessLog(secret), timeOutWrapper(requestTimeout), wrapHeaders, wrapPanicRecover}
 }
 
 // ServerData ...


### PR DESCRIPTION
#### What does this PR do?

Adds TO Go panic logging. If an endpoint handler panics, it was previously unhandled. By default in Go, this meant the handler paniced, and a message like "panic: index out of range" was printed, with no stacktrace or other file, line, or function information.

This changes `traffic_ops_golang` to catch panics, and log panic message and the stacktrace.

Note I am creating this PR in response to a real panic bug in the app. We've observed a panic message in our logs, which is nigh-impossible to track down without the stacktrace.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Request any standard /api endpoint, to verify it works with the new wrapper. 

We don't actually have a designed panic in the code, if you feel the need to verify the stacktrace is logged, you will have to force a panic by modifying the code, e.g. adding `forcePanic := []int{}; thisPanics := forcePanic[1]` to a handler.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



