### PR TITLE
TO Client: Changed post, put, and delete to pass on ReqInf

### DIFF
--- a/traffic_ops/client/deliveryservice.go
+++ b/traffic_ops/client/deliveryservice.go
@@ -92,7 +92,7 @@ func (to *Session) CreateDeliveryService(ds *tc.DeliveryService) (*tc.CreateDeli
 	if err != nil {
 		return nil, err
 	}
-	err = post(to, deliveryServicesEp(), jsonReq, &data)
+	_, err = post(to, deliveryServicesEp(), jsonReq, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (to *Session) UpdateDeliveryService(id string, ds *tc.DeliveryService) (*tc
 	if err != nil {
 		return nil, err
 	}
-	err = put(to, deliveryServiceEp(id), jsonReq, &data)
+	_, err = put(to, deliveryServiceEp(id), jsonReq, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (to *Session) UpdateDeliveryService(id string, ds *tc.DeliveryService) (*tc
 // DeleteDeliveryService deletes the DeliveryService matching the ID it's passed
 func (to *Session) DeleteDeliveryService(id string) (*tc.DeleteDeliveryServiceResponse, error) {
 	var data tc.DeleteDeliveryServiceResponse
-	err := del(to, deliveryServiceEp(id), &data)
+	_, err := del(to, deliveryServiceEp(id), &data)
 	if err != nil {
 		return nil, err
 	}

--- a/traffic_ops/client/deliveryserviceserver.go
+++ b/traffic_ops/client/deliveryserviceserver.go
@@ -37,7 +37,7 @@ func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, repla
 	resp := struct {
 		Response tc.DSServerIDs `json:"response"`
 	}{}
-	if err := post(to, path, jsonReq, &resp); err != nil {
+	if _, err := post(to, path, jsonReq, &resp); err != nil {
 		return nil, err
 	}
 	return &resp.Response, nil

--- a/traffic_ops/client/dsuser.go
+++ b/traffic_ops/client/dsuser.go
@@ -42,7 +42,7 @@ func (to *Session) SetDeliveryServiceUser(userID int, dses []int, replace bool) 
 		return nil, err
 	}
 	resp := tc.UserDeliveryServicePostResponse{}
-	err = post(to, uri, jsonReq, &resp)
+	_, err = post(to, uri, jsonReq, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (to *Session) SetDeliveryServiceUser(userID int, dses []int, replace bool) 
 func (to *Session) DeleteDeliveryServiceUser(userID int, dsID int) (*tc.UserDeliveryServiceDeleteResponse, error) {
 	uri := apiBase + `/deliveryservice_user/` + strconv.Itoa(dsID) + `/` + strconv.Itoa(userID)
 	resp := tc.UserDeliveryServiceDeleteResponse{}
-	if err := del(to, uri, &resp); err != nil {
+	if _, err := del(to, uri, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/traffic_ops/client/tenant.go
+++ b/traffic_ops/client/tenant.go
@@ -70,7 +70,7 @@ func (to *Session) CreateTenant(t *tc.Tenant) (*tc.TenantResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = post(to, tenantsEp(), jsonReq, &data)
+	_, err = post(to, tenantsEp(), jsonReq, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (to *Session) UpdateTenant(id string, t *tc.Tenant) (*tc.TenantResponse, er
 	if err != nil {
 		return nil, err
 	}
-	err = put(to, tenantEp(id), jsonReq, &data)
+	_, err = put(to, tenantEp(id), jsonReq, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (to *Session) UpdateTenant(id string, t *tc.Tenant) (*tc.TenantResponse, er
 // DeleteTenant deletes the Tenant matching the ID it's passed
 func (to *Session) DeleteTenant(id string) (*tc.DeleteTenantResponse, error) {
 	var data tc.DeleteTenantResponse
-	err := del(to, tenantEp(id), &data)
+	_, err := del(to, tenantEp(id), &data)
 	if err != nil {
 		return nil, err
 	}

--- a/traffic_ops/client/util.go
+++ b/traffic_ops/client/util.go
@@ -25,19 +25,16 @@ func get(to *Session, endpoint string, respStruct interface{}) (ReqInf, error) {
 	return makeReq(to, "GET", endpoint, nil, respStruct)
 }
 
-func post(to *Session, endpoint string, body []byte, respStruct interface{}) error {
-	_, err := makeReq(to, "POST", endpoint, body, respStruct)
-	return err
+func post(to *Session, endpoint string, body []byte, respStruct interface{}) (ReqInf, error) {
+	return makeReq(to, "POST", endpoint, body, respStruct)
 }
 
-func put(to *Session, endpoint string, body []byte, respStruct interface{}) error {
-	_, err := makeReq(to, "PUT", endpoint, body, respStruct)
-	return err
+func put(to *Session, endpoint string, body []byte, respStruct interface{}) (ReqInf, error) {
+	return makeReq(to, "PUT", endpoint, body, respStruct)
 }
 
-func del(to *Session, endpoint string, respStruct interface{}) error {
-	_, err := makeReq(to, "DELETE", endpoint, nil, respStruct)
-	return err
+func del(to *Session, endpoint string, respStruct interface{}) (ReqInf, error) {
+	return makeReq(to, "DELETE", endpoint, nil, respStruct)
 }
 
 func makeReq(to *Session, method, endpoint string, body []byte, respStruct interface{}) (ReqInf, error) {


### PR DESCRIPTION
#### What does this PR do?

This PR changes `post`, `put`, and `del` to pass on reqInf from `makeReq`.
Clients should be returning reqInf, regardless of what kind of request they are.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [X] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Just compiling the client or testing environment should suffice. I ran tests just in case and they are ok.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



