### PR TITLE
Change TO client CRConfig functions to use the api endpoints

### DIFF
--- a/traffic_ops/testing/api/v13/crconfig_test.go
+++ b/traffic_ops/testing/api/v13/crconfig_test.go
@@ -1,0 +1,77 @@
+package v13
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestCRConfig(t *testing.T) {
+	CreateTestCDNs(t)
+	CreateTestTypes(t)
+	CreateTestProfiles(t)
+	CreateTestStatuses(t)
+	CreateTestDivisions(t)
+	CreateTestRegions(t)
+	CreateTestPhysLocations(t)
+	CreateTestCacheGroups(t)
+	CreateTestServers(t)
+	CreateTestDeliveryServices(t)
+
+	UpdateTestCRConfigSnapshot(t)
+
+	DeleteTestDeliveryServices(t)
+	DeleteTestServers(t)
+	DeleteTestCacheGroups(t)
+	DeleteTestPhysLocations(t)
+	DeleteTestRegions(t)
+	DeleteTestDivisions(t)
+	DeleteTestStatuses(t)
+	DeleteTestProfiles(t)
+	DeleteTestTypes(t)
+	DeleteTestCDNs(t)
+}
+
+func UpdateTestCRConfigSnapshot(t *testing.T) {
+	log.Debugln("UpdateTestCRConfigSnapshot")
+
+	if len(testData.CDNs) < 1 {
+		t.Fatalf("no cdn test data")
+	}
+	cdn := testData.CDNs[0].Name
+	_, err := TOSession.SnapshotCRConfig(cdn)
+	if err != nil {
+		t.Fatalf("SnapshotCRConfig err expected nil, actual %+v", err)
+	}
+	crcBts, _, err := TOSession.GetCRConfig(cdn)
+	if err != nil {
+		t.Fatalf("GetCRConfig err expected nil, actual %+v", err)
+	}
+	crc := tc.CRConfig{}
+	if err := json.Unmarshal(crcBts, &crc); err != nil {
+		t.Fatalf("GetCRConfig bytes expected: valid tc.CRConfig, actual JSON unmarshal err: %+v", err)
+	}
+
+	if len(crc.DeliveryServices) == 0 {
+		t.Fatalf("GetCRConfig len(crc.DeliveryServices) expected: >0, actual: 0")
+	}
+
+	log.Debugln("UpdateTestCRConfigSnapshot() PASSED: ")
+}


### PR DESCRIPTION
#### What does this PR do?

Changes the Traffic Ops client CRConfig func to use the api endpoint, instead of the internal endpoint.

Also adds a Snapshot func, as necessitated by the API Test framework, and adds API Tests for creating and getting the snapshot.

This is specifically necessary to fix Traffic Monitor using the non-API endpoint (via the client). All non-API endpoints in TO are going away, so this is necessary for the Monitor to continue to work in the future.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

`go test`

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



