### PR TITLE
Fixes TO cdn/federations to return [] not null

### DIFF
--- a/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
+++ b/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
@@ -180,13 +180,13 @@ func (fed *TOCDNFederation) Read() ([]interface{}, error, error, int) {
 	}
 
 	if len(filteredFederations) == 0 {
-		if fed.ID == nil {
-			return nil, nil, nil, http.StatusNotFound
+		if fed.ID != nil {
+			return nil, errors.New("not found"), nil, http.StatusNotFound
 		}
 		if ok, err := dbhelpers.CDNExists(fed.APIInfo().Params["name"], fed.APIInfo().Tx); err != nil {
 			return nil, nil, errors.New("verifying CDN exists: " + err.Error()), http.StatusInternalServerError
 		} else if !ok {
-			return nil, nil, nil, http.StatusNotFound
+			return nil, errors.New("cdn not found"), nil, http.StatusNotFound
 		}
 	}
 	return filteredFederations, nil, nil, http.StatusOK


### PR DESCRIPTION
#### What does this PR do?

Fixes TO cdn/federations to return [] not null. Also fixes to return the correct error message if the CDN doesn't exist.

fixes #3076 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Hit `/api/1.2/cdns/mycdn/federations` for a CDN with no federations, should return `[]` not `null`.

Hit `/api/1.2/cdns/nocdn/federations` for a CDN that doesn't exist, should return a 404 not `null`.


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



