### PR TITLE
Prohibit content invalidation requests for no-origin DS types

### DIFF
--- a/traffic_ops/app/lib/API/Job.pm
+++ b/traffic_ops/app/lib/API/Job.pm
@@ -168,6 +168,10 @@ sub create_current_user_job {
 	if ( !defined($ds) ) {
 		return $self->not_found();
 	}
+	my $org_server_fqdn = UI::DeliveryService::compute_org_server_fqdn($self, $ds_id);
+	if ( !defined($org_server_fqdn) ) {
+		return $self->alert("cannot invalidate content: requested delivery service has no origin");
+	}
 
 	my $tenant_utils = Utils::Tenant->new($self);
 	my $tenants_data = $tenant_utils->create_tenants_data_from_db();


### PR DESCRIPTION
#### What does this PR do?
Prevent the submission of content invalidation requests against DS types
that don't have origins (e.g. CLIENT_STEERING).

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Submit a content invalidation job for a delivery service _with_ an origin and make sure the API allows it. Then submit a job for a delivery service _without_ an origin (like CLIENT_STEERING) and make sure the API prohibits it.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



