### PR TITLE
Flip DS 'signed' flag when signingAlgorithm is changed. fixes #2836

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -236,6 +236,14 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
         });
     };
 
+    $scope.changeSigningAlgorithm = function(signingAlgorithm) {
+        if (signingAlgorithm == null) {
+            deliveryService.signed = false;
+        } else {
+            deliveryService.signed = true;
+        }
+    };
+
     $scope.viewTargets = function() {
         $location.path($location.path() + '/targets');
     };

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -390,7 +390,7 @@ under the License.
                         <span uib-popover-html="label('signingAlgorithm', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('signingAlgorithm', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="signingAlgorithm" class="form-control" ng-model="deliveryService.signingAlgorithm" ng-options="sa.value as sa.label for sa in signingAlgos">
+                        <select name="signingAlgorithm" class="form-control" ng-change="changeSigningAlgorithm(deliveryService.signingAlgorithm)" ng-model="deliveryService.signingAlgorithm" ng-options="sa.value as sa.label for sa in signingAlgos">
                             <option value="">Select...</option>
                         </select>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.signingAlgorithm != dsCurrent.signingAlgorithm">Current Value: [ {{magicNumberLabel(signingAlgos, dsCurrent.signingAlgorithm)}} ]</small>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -443,7 +443,7 @@ under the License.
                         <span uib-popover-html="label('signingAlgorithm', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('signingAlgorithm', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="signingAlgorithm" class="form-control" ng-model="deliveryService.signingAlgorithm" ng-options="sa.value as sa.label for sa in signingAlgos">
+                        <select name="signingAlgorithm" class="form-control" ng-change="changeSigningAlgorithm(deliveryService.signingAlgorithm)" ng-model="deliveryService.signingAlgorithm" ng-options="sa.value as sa.label for sa in signingAlgos">
                             <option value="">Select...</option>
                         </select>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.signingAlgorithm != dsCurrent.signingAlgorithm">Current Value: [ {{magicNumberLabel(signingAlgos, dsCurrent.signingAlgorithm)}} ]</small>


### PR DESCRIPTION
#### What does this PR do?
Flips the 'signed' flag when Signing Algorithm is changed to/from None

Fixes #2836 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Update a DS from Signing Algorithm = URL Signature Keys to Signing Algorithm = None

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



