### PR TITLE
Prohibit content invalidation requests for no-origin DS types

### DIFF
--- a/traffic_ops/app/lib/API/Job.pm
+++ b/traffic_ops/app/lib/API/Job.pm
@@ -168,6 +168,10 @@ sub create_current_user_job {
 	if ( !defined($ds) ) {
 		return $self->not_found();
 	}
+	my $org_server_fqdn = UI::DeliveryService::compute_org_server_fqdn($self, $ds_id);
+	if ( !defined($org_server_fqdn) ) {
+		return $self->alert("cannot invalidate content: requested delivery service has no origin");
+	}
 
 	my $tenant_utils = Utils::Tenant->new($self);
 	my $tenants_data = $tenant_utils->create_tenants_data_from_db();


### PR DESCRIPTION
Prevent the submission of content invalidation requests against DS types
that don't have origins (e.g. CLIENT_STEERING).

(cherry picked from commit c06696a6d9ad5f72805aea6211ce3108a25a342d)



