### PR TITLE
modified the remap.RequestURI() function so that it deals with full request uris.

### DIFF
--- a/grove/remap/remap.go
+++ b/grove/remap/remap.go
@@ -141,10 +141,19 @@ var ErrNoMoreRetries = errors.New("retry num exceeded")
 
 // RequestURI returns the URI of the given request. This must be used, because Go does not populate the scheme of requests that come in from clients.
 func RequestURI(r *http.Request, scheme string) string {
-	return scheme + "://" + r.Host + r.RequestURI
+	newUrl,err := url.Parse(r.RequestURI)
+	if err != nil {
+		log.Errorf("parsing r.RequestURI: %v, error: %v", r.RequestURI, err)
+		return ""
+	}
+	newUrl.Scheme = scheme
+	newUrl.Host = r.Host
+	return newUrl.String()
 }
+
 func (hr simpleHTTPRequestRemapper) RemappingProducer(r *http.Request, scheme string) (*RemappingProducer, error) {
 	uri := RequestURI(r, scheme)
+	log.Debugf("remapped data r.Host: %v, r.RequestURI: %v, uri: %v", r.Host, r.RequestURI, uri)
 	rule, ok := hr.remapper.Remap(uri)
 	if !ok {
 		return nil, ErrRuleNotFound


### PR DESCRIPTION
Modifies remap.RequestURI() so that it parses full request uris containing schem and host.

#### What does this PR do?

Fixes #(issue_number)
#2864 
#### Which TC components are affected by this PR?

- [ ] Documentation
- [x] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
testing with curl -x or curl -proxy with the proxy fqdn and port should 


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



