### PR TITLE
TO Golang: Small CRUDer change to allow interface use for a single method type

### DIFF
--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -48,6 +48,8 @@ const ConfigContextKey = "context"
 const ReqIDContextKey = "reqid"
 const APIRespWrittenKey = "respwritten"
 
+type CRUDFactory func(reqInfo *APIInfo) CRUDer
+
 // WriteResp takes any object, serializes it as JSON, and writes that to w. Any errors are logged and written to w via tc.GetHandleErrorsFunc.
 // This is a helper for the common case; not using this in unusual cases is perfectly acceptable.
 func WriteResp(w http.ResponseWriter, r *http.Request, v interface{}) {

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -48,8 +48,6 @@ const ConfigContextKey = "context"
 const ReqIDContextKey = "reqid"
 const APIRespWrittenKey = "respwritten"
 
-type CRUDFactory func(reqInfo *APIInfo) CRUDer
-
 // WriteResp takes any object, serializes it as JSON, and writes that to w. Any errors are logged and written to w via tc.GetHandleErrorsFunc.
 // This is a helper for the common case; not using this in unusual cases is perfectly acceptable.
 func WriteResp(w http.ResponseWriter, r *http.Request, v interface{}) {

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -48,8 +48,6 @@ const ConfigContextKey = "context"
 const ReqIDContextKey = "reqid"
 const APIRespWrittenKey = "respwritten"
 
-type CRUDFactory func(reqInfo *APIInfo) CRUDer
-
 // WriteResp takes any object, serializes it as JSON, and writes that to w. Any errors are logged and written to w via tc.GetHandleErrorsFunc.
 // This is a helper for the common case; not using this in unusual cases is perfectly acceptable.
 func WriteResp(w http.ResponseWriter, r *http.Request, v interface{}) {
@@ -365,6 +363,19 @@ func (inf *APIInfo) Close() {
 	if err := inf.Tx.Tx.Commit(); err != nil && err != sql.ErrTxDone {
 		log.Errorln("committing transaction: " + err.Error())
 	}
+}
+
+// APIInfoImpl implements APIInfo via the APIInfoer interface
+type APIInfoImpl struct {
+	ReqInfo *APIInfo
+}
+
+func (val *APIInfoImpl) SetInfo(inf *APIInfo) {
+	val.ReqInfo = inf
+}
+
+func (val APIInfoImpl) APIInfo() *APIInfo {
+	return val.ReqInfo
 }
 
 // GetDB returns the database from the context. This should very rarely be needed, rather `NewInfo` should always be used to get a transaction, except in extenuating circumstances.

--- a/traffic_ops/traffic_ops_golang/api/change_log_test.go
+++ b/traffic_ops/traffic_ops_golang/api/change_log_test.go
@@ -30,14 +30,20 @@ import (
 )
 
 type testIdentifier struct {
+	ID int
 }
 
 func (i testIdentifier) GetKeyFieldsInfo() []KeyFieldInfo {
 	return []KeyFieldInfo{{"id", GetIntKey}}
 }
 
+func (i *testIdentifier) SetKeys(keys map[string]interface{}) {
+	id, _ := keys["id"].(int)
+	i.ID = id
+}
+
 func (i *testIdentifier) GetKeys() (map[string]interface{}, bool) {
-	return map[string]interface{}{"id": 1}, true
+	return map[string]interface{}{"id": i.ID}, true
 }
 
 func (i *testIdentifier) GetType() string {

--- a/traffic_ops/traffic_ops_golang/api/crud.go
+++ b/traffic_ops/traffic_ops_golang/api/crud.go
@@ -29,6 +29,34 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 )
 
+// APIInformer implements APIInfo via the APIInfoer struct
+// It is at this point I'd like to change the name of `APIInfo` so that it has a more
+// meaningful name. However, now is not the time it seems.
+type APIInformer struct {
+	ReqInfo *APIInfo
+}
+
+func (val *APIInformer) SetInfo(inf *APIInfo) {
+	val.ReqInfo = inf
+}
+
+func (val APIInformer) APIInfo() *APIInfo {
+	return val.ReqInfo
+}
+
+// Not sure if all need SetAPIInfo
+// Everything currently existing should implement SetAPIInfo
+// After re-write, look to see where SetAPIInfo was used
+// If it wasn't used for a particular GenericXxx, then delete it
+
+// Before I add SetAPIInfo though I want to make a default implementation for most other methods
+// See https://play.golang.org/p/eq95ilfwEnd
+
+// Update:
+// set api info will need to be a part of the main cruder
+// instead of what I was planning here
+// SetAPIInfo(i *api.APIInfo)
+
 type GenericCreator interface {
 	GetType() string
 	APIInfo() *APIInfo

--- a/traffic_ops/traffic_ops_golang/api/crud.go
+++ b/traffic_ops/traffic_ops_golang/api/crud.go
@@ -29,9 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 )
 
-// APIInformer implements APIInfo via the APIInfoer struct
-// It is at this point I'd like to change the name of `APIInfo` so that it has a more
-// meaningful name. However, now is not the time it seems.
+// APIInformer implements APIInfo via the APIInfoer interface
 type APIInformer struct {
 	ReqInfo *APIInfo
 }
@@ -43,19 +41,6 @@ func (val *APIInformer) SetInfo(inf *APIInfo) {
 func (val APIInformer) APIInfo() *APIInfo {
 	return val.ReqInfo
 }
-
-// Not sure if all need SetAPIInfo
-// Everything currently existing should implement SetAPIInfo
-// After re-write, look to see where SetAPIInfo was used
-// If it wasn't used for a particular GenericXxx, then delete it
-
-// Before I add SetAPIInfo though I want to make a default implementation for most other methods
-// See https://play.golang.org/p/eq95ilfwEnd
-
-// Update:
-// set api info will need to be a part of the main cruder
-// instead of what I was planning here
-// SetAPIInfo(i *api.APIInfo)
 
 type GenericCreator interface {
 	GetType() string

--- a/traffic_ops/traffic_ops_golang/api/crud.go
+++ b/traffic_ops/traffic_ops_golang/api/crud.go
@@ -29,16 +29,16 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 )
 
-// APIInformer implements APIInfo via the APIInfoer interface
-type APIInformer struct {
+// APIInfoImpl implements APIInfo via the APIInfoer interface
+type APIInfoImpl struct {
 	ReqInfo *APIInfo
 }
 
-func (val *APIInformer) SetInfo(inf *APIInfo) {
+func (val *APIInfoImpl) SetInfo(inf *APIInfo) {
 	val.ReqInfo = inf
 }
 
-func (val APIInformer) APIInfo() *APIInfo {
+func (val APIInfoImpl) APIInfo() *APIInfo {
 	return val.ReqInfo
 }
 

--- a/traffic_ops/traffic_ops_golang/api/generic_crud.go
+++ b/traffic_ops/traffic_ops_golang/api/generic_crud.go
@@ -29,19 +29,6 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 )
 
-// APIInfoImpl implements APIInfo via the APIInfoer interface
-type APIInfoImpl struct {
-	ReqInfo *APIInfo
-}
-
-func (val *APIInfoImpl) SetInfo(inf *APIInfo) {
-	val.ReqInfo = inf
-}
-
-func (val APIInfoImpl) APIInfo() *APIInfo {
-	return val.ReqInfo
-}
-
 type GenericCreator interface {
 	GetType() string
 	APIInfo() *APIInfo

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -142,8 +142,6 @@ func ReadHandler(obj Reader) http.HandlerFunc {
 //   *decoding and validating the struct
 //   *change log entry
 //   *forming and writing the body over the wire
-
-// Take an actual object here..
 func UpdateHandler(obj Updater) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
@@ -37,7 +37,7 @@ import (
 
 type tester struct {
 	ID          int
-	APIInformer `json:"-"`
+	APIInfoImpl `json:"-"`
 	userErr     error //only for testing
 	sysErr      error //only for testing
 	errCode     int   //only for testing

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
@@ -240,44 +240,45 @@ func TestUpdateHandler(t *testing.T) {
 }
 
 func TestDeleteHandler(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	w := httptest.NewRecorder()
-	r, err := http.NewRequest("", "", strings.NewReader(`{"ID":1}`))
-	if err != nil {
-		t.Error("Error creating new request")
-	}
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest("", "", strings.NewReader(`{"ID":1}`))
+		if err != nil {
+			t.Error("Error creating new request")
+		}
 
-	ctx := r.Context()
-	ctx = context.WithValue(ctx, auth.CurrentUserKey,
-		auth.CurrentUser{UserName: "username", ID: 1, PrivLevel: auth.PrivLevelAdmin})
-	ctx = context.WithValue(ctx, PathParamsKey, map[string]string{"id": "1"})
-	ctx = context.WithValue(ctx, DBContextKey, db)
-	ctx = context.WithValue(ctx, ConfigContextKey, &cfg)
-	ctx = context.WithValue(ctx, ReqIDContextKey, uint64(0))
-	// Add our context to the request
-	r = r.WithContext(ctx)
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, auth.CurrentUserKey,
+			auth.CurrentUser{UserName: "username", ID: 1, PrivLevel: auth.PrivLevelAdmin})
+		ctx = context.WithValue(ctx, PathParamsKey, map[string]string{"id": "1"})
+		ctx = context.WithValue(ctx, DBContextKey, db)
+		ctx = context.WithValue(ctx, ConfigContextKey, &cfg)
+		ctx = context.WithValue(ctx, ReqIDContextKey, uint64(0))
+		// Add our context to the request
+		r = r.WithContext(ctx)
 
-	typeRef := tester{ID: 1}
-	deleteFunc := DeleteHandler(GetTypeSingleton())
+		typeRef := tester{ID: 1}
+		deleteFunc := DeleteHandler(GetTypeSingleton())
 
-	//verifies we get the right changelog insertion
-	expectedMessage := Deleted + " " + typeRef.GetType() + ": " + typeRef.GetAuditName() + " keys: { id:1 }"
-	mock.ExpectBegin()
-	mock.ExpectExec("INSERT").WithArgs(ApiChange, expectedMessage, 1).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectCommit()
-	deleteFunc(w, r)
+		//verifies we get the right changelog insertion
+		expectedMessage := Deleted + " " + typeRef.GetType() + ": " + typeRef.GetAuditName() + " keys: { id:1 }"
+		mock.ExpectBegin()
+		mock.ExpectExec("INSERT").WithArgs(ApiChange, expectedMessage, 1).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+		deleteFunc(w, r)
 
-	//verifies the body is in the expected format
-	body := `{"alerts":[{"text":"tester was deleted.","level":"success"}]}`
-	if w.Body.String() != body {
-		t.Error("Expected body", body, "got", w.Body.String())
-	}
+		//verifies the body is in the expected format
+		body := `{"alerts":[{"text":"tester was deleted.","level":"success"}]}`
+		if w.Body.String() != body {
+			t.Error("Expected body", body, "got", w.Body.String())
+		}*/
 }

--- a/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
@@ -23,21 +23,12 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 )
 
-type CRUDer interface {
-	Creator
-	Reader
-	Updater
-	Deleter
-	Identifier
-	Validator
-}
+type CRUDFactory func(reqInfo *APIInfo) CRUDer
 
-type Updater interface {
-	// Update returns any user error, any system error, and the HTTP error code to be returned if there was an error.
-	Update() (error, error, int)
-}
+type CRUDer interface{}
 
 type Identifier interface {
+	SetKeys(map[string]interface{})
 	GetKeys() (map[string]interface{}, bool)
 	GetType() string
 	GetAuditName() string
@@ -47,12 +38,26 @@ type Identifier interface {
 type Creator interface {
 	// Create returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Create() (error, error, int)
-	SetKeys(map[string]interface{})
+	Identifier
+	Validator
+}
+
+type Reader interface {
+	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
+	Read() ([]interface{}, error, error, int)
+}
+
+type Updater interface {
+	// Update returns any user error, any system error, and the HTTP error code to be returned if there was an error.
+	Update() (error, error, int)
+	Identifier
+	Validator
 }
 
 type Deleter interface {
 	// Delete returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Delete() (error, error, int)
+	Identifier
 }
 
 type Validator interface {
@@ -61,9 +66,4 @@ type Validator interface {
 
 type Tenantable interface {
 	IsTenantAuthorized(user *auth.CurrentUser) (bool, error)
-}
-
-type Reader interface {
-	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
-	Read() ([]interface{}, error, error, int)
 }

--- a/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
@@ -23,36 +23,61 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 )
 
+// not sure if this will be needed after I'm done
 type CRUDer interface {
-	Creator
-	Reader
-	Updater
-	Deleter
+	Create() (error, error, int)
+	Read() ([]interface{}, error, error, int)
+	Update() (error, error, int)
+	Delete() (error, error, int)
+	APIInfoer
 	Identifier
 	Validator
 }
 
-type Updater interface {
-	// Update returns any user error, any system error, and the HTTP error code to be returned if there was an error.
-	Update() (error, error, int)
-}
-
 type Identifier interface {
+
+	// Getters and Setters for key data
+	// The current common case is a single numerical id
+	SetKeys(map[string]interface{})
 	GetKeys() (map[string]interface{}, bool)
+
+	// GetType gives the name of the implementing struct
 	GetType() string
+
+	// GetAuditName returns the name of an object instance. If no name is availible, the id should be returned. "unknown" is the final case
 	GetAuditName() string
+
+	// This should define the key getters and setters
 	GetKeyFieldsInfo() []KeyFieldInfo
 }
 
 type Creator interface {
 	// Create returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Create() (error, error, int)
-	SetKeys(map[string]interface{})
+	APIInfoer
+	Identifier
+	Validator
+}
+
+type Reader interface {
+	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
+	Read() ([]interface{}, error, error, int)
+	APIInfoer
+}
+
+type Updater interface {
+	// Update returns any user error, any system error, and the HTTP error code to be returned if there was an error.
+	Update() (error, error, int)
+	APIInfoer
+	Identifier
+	Validator
 }
 
 type Deleter interface {
 	// Delete returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Delete() (error, error, int)
+	APIInfoer
+	Identifier
 }
 
 type Validator interface {
@@ -63,7 +88,9 @@ type Tenantable interface {
 	IsTenantAuthorized(user *auth.CurrentUser) (bool, error)
 }
 
-type Reader interface {
-	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
-	Read() ([]interface{}, error, error, int)
+// APIInfoer is an interface that guarantees the existance of a variable through its setters and getters.
+// Every CRUD operation uses this login session context
+type APIInfoer interface {
+	SetInfo(*APIInfo)
+	APIInfo() *APIInfo
 }

--- a/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
@@ -23,7 +23,6 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 )
 
-// not sure if this will be needed after I'm done
 type CRUDer interface {
 	Create() (error, error, int)
 	Read() ([]interface{}, error, error, int)

--- a/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
@@ -23,12 +23,21 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 )
 
-type CRUDFactory func(reqInfo *APIInfo) CRUDer
+type CRUDer interface {
+	Creator
+	Reader
+	Updater
+	Deleter
+	Identifier
+	Validator
+}
 
-type CRUDer interface{}
+type Updater interface {
+	// Update returns any user error, any system error, and the HTTP error code to be returned if there was an error.
+	Update() (error, error, int)
+}
 
 type Identifier interface {
-	SetKeys(map[string]interface{})
 	GetKeys() (map[string]interface{}, bool)
 	GetType() string
 	GetAuditName() string
@@ -38,26 +47,12 @@ type Identifier interface {
 type Creator interface {
 	// Create returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Create() (error, error, int)
-	Identifier
-	Validator
-}
-
-type Reader interface {
-	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
-	Read() ([]interface{}, error, error, int)
-}
-
-type Updater interface {
-	// Update returns any user error, any system error, and the HTTP error code to be returned if there was an error.
-	Update() (error, error, int)
-	Identifier
-	Validator
+	SetKeys(map[string]interface{})
 }
 
 type Deleter interface {
 	// Delete returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Delete() (error, error, int)
-	Identifier
 }
 
 type Validator interface {
@@ -66,4 +61,9 @@ type Validator interface {
 
 type Tenantable interface {
 	IsTenantAuthorized(user *auth.CurrentUser) (bool, error)
+}
+
+type Reader interface {
+	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
+	Read() ([]interface{}, error, error, int)
 }

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant.go
@@ -42,11 +42,10 @@ import (
 
 // TOTenant provides a local type against which to define methods
 type TOTenant struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.TenantNullable
 }
 
-func (v *TOTenant) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOTenant) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOTenant) InsertQuery() string           { return insertQuery() }
 func (v *TOTenant) NewReadObj() interface{}       { return &tc.TenantNullable{} }
@@ -63,13 +62,6 @@ func (v *TOTenant) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 	}
 }
 func (v *TOTenant) UpdateQuery() string { return updateQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOTenant{reqInfo, tc.TenantNullable{}}
-		return &toReturn
-	}
-}
 
 // GetID wraps the ID member with null checking
 // Part of the Identifier interface

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant.go
@@ -42,7 +42,7 @@ import (
 
 // TOTenant provides a local type against which to define methods
 type TOTenant struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.TenantNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -37,7 +37,7 @@ const ASNsPrivLevel = 10
 
 //we need a type alias to define functions on
 type TOASNV11 struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.ASNNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -37,11 +37,10 @@ const ASNsPrivLevel = 10
 
 //we need a type alias to define functions on
 type TOASNV11 struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.ASNNullable
 }
 
-func (v *TOASNV11) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOASNV11) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOASNV11) InsertQuery() string           { return insertQuery() }
 func (v *TOASNV11) NewReadObj() interface{}       { return &tc.ASNNullable{} }
@@ -56,13 +55,6 @@ func (v *TOASNV11) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOASNV11) UpdateQuery() string { return updateQuery() }
 func (v *TOASNV11) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOASNV11{reqInfo, tc.ASNNullable{}}
-		return &toReturn
-	}
-}
 
 func (asn TOASNV11) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}
@@ -119,7 +111,10 @@ func V11ReadAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer inf.Close()
-	asns, userErr, sysErr, errCode := api.GenericRead(&TOASNV11{ReqInfo: inf})
+
+	asn := &TOASNV11{}
+	asn.SetInfo(inf)
+	asns, userErr, sysErr, errCode := api.GenericRead(asn)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -28,10 +28,8 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
 
 	"github.com/apache/trafficcontrol/lib/go-util"
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestASNs() []tc.ASNNullable {
@@ -55,41 +53,42 @@ func getTestASNs() []tc.ASNNullable {
 }
 
 func TestGetASNs(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testCase := getTestASNs()
-	cols := test.ColsFromStructByTag("db", tc.ASNNullable{})
-	rows := sqlmock.NewRows(cols)
+		testCase := getTestASNs()
+		cols := test.ColsFromStructByTag("db", tc.ASNNullable{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testCase {
-		rows = rows.AddRow(
-			*ts.ASN,
-			*ts.Cachegroup,
-			*ts.CachegroupID,
-			*ts.ID,
-			*ts.LastUpdated,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+		for _, ts := range testCase {
+			rows = rows.AddRow(
+				*ts.ASN,
+				*ts.Cachegroup,
+				*ts.CachegroupID,
+				*ts.ID,
+				*ts.LastUpdated,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
-	asns, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		asns, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(asns) != 2 {
-		t.Errorf("asn.Read expected: len(asns) == 2, actual: %v", len(asns))
-	}
+		if len(asns) != 2 {
+			t.Errorf("asn.Read expected: len(asns) == 2, actual: %v", len(asns))
+		}*/
 
 }
 

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -84,7 +84,7 @@ func TestGetASNs(t *testing.T) {
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOASNV11{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.ASNNullable{},
 	}
 	asns, userErr, sysErr, _ := obj.Read()
@@ -122,7 +122,7 @@ func TestInterfaces(t *testing.T) {
 func TestValidate(t *testing.T) {
 	i := -99
 	asn := TOASNV11{
-		api.APIInformer{nil},
+		api.APIInfoImpl{nil},
 		tc.ASNNullable{ASN: &i, CachegroupID: &i},
 	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(asn.Validate())))

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -40,15 +40,8 @@ import (
 )
 
 type TOCacheGroup struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.CacheGroupNullable
-}
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOCacheGroup{reqInfo, tc.CacheGroupNullable{}}
-		return &toReturn
-	}
 }
 
 func (cg TOCacheGroup) GetKeyFieldsInfo() []api.KeyFieldInfo {

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -40,7 +40,7 @@ import (
 )
 
 type TOCacheGroup struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.CacheGroupNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -211,17 +211,20 @@ func TestValidate(t *testing.T) {
 	ty := "EDGE_LOC"
 	ti := 6
 	lu := tc.TimeNoMod{Time: time.Now()}
-	c := TOCacheGroup{ReqInfo: &reqInfo, CacheGroupNullable: tc.CacheGroupNullable{
-		ID:                  &id,
-		Name:                &nm,
-		ShortName:           &sn,
-		Latitude:            &la,
-		Longitude:           &lo,
-		LocalizationMethods: &lm,
-		Type:                &ty,
-		TypeID:              &ti,
-		LastUpdated:         &lu,
-	}}
+	c := TOCacheGroup{
+		api.APIInformer{&reqInfo},
+		tc.CacheGroupNullable{
+			ID:                  &id,
+			Name:                &nm,
+			ShortName:           &sn,
+			Latitude:            &la,
+			Longitude:           &lo,
+			LocalizationMethods: &lm,
+			Type:                &ty,
+			TypeID:              &ti,
+			LastUpdated:         &lu,
+		},
+	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(c.Validate())))
 
 	expectedErrs := util.JoinErrsStr([]error{
@@ -245,17 +248,20 @@ func TestValidate(t *testing.T) {
 	la = 90.0
 	lo = 90.0
 	lm = []tc.LocalizationMethod{tc.LocalizationMethodGeo, tc.LocalizationMethodCZ, tc.LocalizationMethodDeepCZ}
-	c = TOCacheGroup{ReqInfo: &reqInfo, CacheGroupNullable: tc.CacheGroupNullable{
-		ID:                  &id,
-		Name:                &nm,
-		ShortName:           &sn,
-		Latitude:            &la,
-		Longitude:           &lo,
-		LocalizationMethods: &lm,
-		Type:                &ty,
-		TypeID:              &ti,
-		LastUpdated:         &lu,
-	}}
+	c = TOCacheGroup{
+		api.APIInformer{&reqInfo},
+		tc.CacheGroupNullable{
+			ID:                  &id,
+			Name:                &nm,
+			ShortName:           &sn,
+			Latitude:            &la,
+			Longitude:           &lo,
+			LocalizationMethods: &lm,
+			Type:                &ty,
+			TypeID:              &ti,
+			LastUpdated:         &lu,
+		},
+	}
 	err = c.Validate()
 	if err != nil {
 		t.Errorf("expected nil, got %s", err)

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -137,7 +137,12 @@ func TestReadCacheGroups(t *testing.T) {
 	mock.ExpectCommit()
 
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
-	cachegroups, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+	obj := TOCacheGroup{
+		api.APIInfoImpl{&reqInfo},
+		tc.CacheGroupNullable{},
+	}
+	cachegroups, userErr, sysErr, _ := obj.Read()
+
 	if userErr != nil || sysErr != nil {
 		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
 	}
@@ -212,7 +217,7 @@ func TestValidate(t *testing.T) {
 	ti := 6
 	lu := tc.TimeNoMod{Time: time.Now()}
 	c := TOCacheGroup{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.CacheGroupNullable{
 			ID:                  &id,
 			Name:                &nm,
@@ -249,7 +254,7 @@ func TestValidate(t *testing.T) {
 	lo = 90.0
 	lm = []tc.LocalizationMethod{tc.LocalizationMethodGeo, tc.LocalizationMethodCZ, tc.LocalizationMethodDeepCZ}
 	c = TOCacheGroup{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.CacheGroupNullable{
 			ID:                  &id,
 			Name:                &nm,

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -84,6 +84,7 @@ func getTestCacheGroups() []tc.CacheGroup {
 }
 
 func TestReadCacheGroups(t *testing.T) {
+
 	mockDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)

--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -35,7 +35,7 @@ import (
 
 //we need a type alias to define functions on
 type TOCDN struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.CDNNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -35,11 +35,10 @@ import (
 
 //we need a type alias to define functions on
 type TOCDN struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.CDNNullable
 }
 
-func (v *TOCDN) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOCDN) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOCDN) InsertQuery() string           { return insertQuery() }
 func (v *TOCDN) NewReadObj() interface{}       { return &tc.CDNNullable{} }
@@ -54,13 +53,6 @@ func (v *TOCDN) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOCDN) UpdateQuery() string { return updateQuery() }
 func (v *TOCDN) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOCDN{reqInfo, tc.CDNNullable{}}
-		return &toReturn
-	}
-}
 
 func (cdn TOCDN) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -30,9 +30,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestCDNs() []tc.CDN {
@@ -55,41 +52,42 @@ func getTestCDNs() []tc.CDN {
 }
 
 func TestReadCDNs(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testCDNs := getTestCDNs()
-	cols := test.ColsFromStructByTag("db", tc.CDN{})
-	rows := sqlmock.NewRows(cols)
+		testCDNs := getTestCDNs()
+		cols := test.ColsFromStructByTag("db", tc.CDN{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testCDNs {
-		rows = rows.AddRow(
-			ts.DNSSECEnabled,
-			ts.DomainName,
-			ts.ID,
-			ts.LastUpdated,
-			ts.Name,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testCDNs {
+			rows = rows.AddRow(
+				ts.DNSSECEnabled,
+				ts.DomainName,
+				ts.ID,
+				ts.LastUpdated,
+				ts.Name,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
-	cdns, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+		cdns, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(cdns) != 2 {
-		t.Errorf("cdn.Read expected: len(cdns) == 2, actual: %v", len(cdns))
-	}
+		if len(cdns) != 2 {
+			t.Errorf("cdn.Read expected: len(cdns) == 2, actual: %v", len(cdns))
+		}*/
 }
 
 func TestFuncs(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -83,7 +83,7 @@ func TestReadCDNs(t *testing.T) {
 
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TOCDN{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.CDNNullable{},
 	}
 	cdns, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestCDNs() []tc.CDN {
@@ -52,42 +54,46 @@ func getTestCDNs() []tc.CDN {
 }
 
 func TestReadCDNs(t *testing.T) {
-	/*
-		mockDB, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-		defer mockDB.Close()
 
-		db := sqlx.NewDb(mockDB, "sqlmock")
-		defer db.Close()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
 
-		testCDNs := getTestCDNs()
-		cols := test.ColsFromStructByTag("db", tc.CDN{})
-		rows := sqlmock.NewRows(cols)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
 
-		for _, ts := range testCDNs {
-			rows = rows.AddRow(
-				ts.DNSSECEnabled,
-				ts.DomainName,
-				ts.ID,
-				ts.LastUpdated,
-				ts.Name,
-			)
-		}
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT").WillReturnRows(rows)
-		mock.ExpectCommit()
+	testCDNs := getTestCDNs()
+	cols := test.ColsFromStructByTag("db", tc.CDN{})
+	rows := sqlmock.NewRows(cols)
 
-		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
-		cdns, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-		if userErr != nil || sysErr != nil {
-			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-		}
+	for _, ts := range testCDNs {
+		rows = rows.AddRow(
+			ts.DNSSECEnabled,
+			ts.DomainName,
+			ts.ID,
+			ts.LastUpdated,
+			ts.Name,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
 
-		if len(cdns) != 2 {
-			t.Errorf("cdn.Read expected: len(cdns) == 2, actual: %v", len(cdns))
-		}*/
+	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	obj := TOCDN{
+		api.APIInformer{&reqInfo},
+		tc.CDNNullable{},
+	}
+	cdns, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+
+	if len(cdns) != 2 {
+		t.Errorf("cdn.Read expected: len(cdns) == 2, actual: %v", len(cdns))
+	}
 }
 
 func TestFuncs(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
+++ b/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
@@ -38,7 +38,7 @@ import (
 
 // we need a type alias to define functions on
 type TOCDNFederation struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.CDNFederation
 	TenantID *int `json:"-" db:"tenant_id"`
 }

--- a/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
+++ b/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
@@ -38,12 +38,11 @@ import (
 
 // we need a type alias to define functions on
 type TOCDNFederation struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.CDNFederation
 	TenantID *int `json:"-" db:"tenant_id"`
 }
 
-func (v *TOCDNFederation) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOCDNFederation) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOCDNFederation) InsertQuery() string           { return insertQuery() }
 func (v *TOCDNFederation) NewReadObj() interface{}       { return &TOCDNFederation{} }
@@ -64,13 +63,6 @@ func (v *TOCDNFederation) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOCDNFederation) DeleteQuery() string { return deleteQuery() }
 func (v *TOCDNFederation) UpdateQuery() string { return updateQuery() }
-
-// Used for all CRUD routes
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		return &TOCDNFederation{reqInfo, tc.CDNFederation{}, nil}
-	}
-}
 
 // Fufills `Identifier' interface
 func (fed TOCDNFederation) GetKeyFieldsInfo() []api.KeyFieldInfo {

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
@@ -34,11 +34,10 @@ import (
 
 //we need a type alias to define functions on
 type TOCoordinate struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.CoordinateNullable
 }
 
-func (v *TOCoordinate) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOCoordinate) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOCoordinate) InsertQuery() string           { return insertQuery() }
 func (v *TOCoordinate) NewReadObj() interface{}       { return &tc.CoordinateNullable{} }
@@ -51,13 +50,6 @@ func (v *TOCoordinate) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOCoordinate) UpdateQuery() string { return updateQuery() }
 func (v *TOCoordinate) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOCoordinate{reqInfo, tc.CoordinateNullable{}}
-		return &toReturn
-	}
-}
 
 func (coordinate TOCoordinate) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
@@ -34,7 +34,7 @@ import (
 
 //we need a type alias to define functions on
 type TOCoordinate struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.CoordinateNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
@@ -87,7 +87,7 @@ func TestReadCoordinates(t *testing.T) {
 
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TOCoordinate{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.CoordinateNullable{},
 	}
 	coordinates, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
@@ -30,9 +30,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestCoordinates() []tc.Coordinate {
@@ -59,40 +56,41 @@ func getTestCoordinates() []tc.Coordinate {
 }
 
 func TestReadCoordinates(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testCoords := getTestCoordinates()
-	cols := test.ColsFromStructByTag("db", tc.Coordinate{})
-	rows := sqlmock.NewRows(cols)
+		testCoords := getTestCoordinates()
+		cols := test.ColsFromStructByTag("db", tc.Coordinate{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testCoords {
-		rows = rows.AddRow(
-			ts.ID,
-			ts.Name,
-			ts.Latitude,
-			ts.Longitude,
-			ts.LastUpdated,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testCoords {
+			rows = rows.AddRow(
+				ts.ID,
+				ts.Name,
+				ts.Latitude,
+				ts.Longitude,
+				ts.LastUpdated,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
-	coordinates, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
-	if len(coordinates) != 2 {
-		t.Errorf("coordinate.Read expected: len(coordinates) == 2, actual: %v", len(coordinates))
-	}
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
+		coordinates, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
+		if len(coordinates) != 2 {
+			t.Errorf("coordinate.Read expected: len(coordinates) == 2, actual: %v", len(coordinates))
+		}*/
 }
 
 func TestFuncs(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv12.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv12.go
@@ -36,20 +36,12 @@ import (
 )
 
 type TODeliveryServiceV12 struct {
-	ReqInfo *api.APIInfo
+	api.APIInformer
 	tc.DeliveryServiceNullableV12
 }
 
-func (v *TODeliveryServiceV12) APIInfo() *api.APIInfo { return v.ReqInfo }
 func (v *TODeliveryServiceV12) DeleteQuery() string {
 	return `DELETE FROM deliveryservice WHERE id = :id`
-}
-
-func GetTypeV12Factory() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TODeliveryServiceV12{reqInfo, tc.DeliveryServiceNullableV12{}}
-		return &toReturn
-	}
 }
 
 func (ds TODeliveryServiceV12) GetKeyFieldsInfo() []api.KeyFieldInfo {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv12.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv12.go
@@ -36,7 +36,7 @@ import (
 )
 
 type TODeliveryServiceV12 struct {
-	api.APIInformer
+	api.APIInfoImpl
 	tc.DeliveryServiceNullableV12
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
@@ -45,12 +45,15 @@ import (
 //we need a type alias to define functions on
 
 type TODeliveryServiceV13 struct {
-	ReqInfo *api.APIInfo
+	api.APIInformer
 	tc.DeliveryServiceNullable
 }
 
 func (ds *TODeliveryServiceV13) V12() *TODeliveryServiceV12 {
-	return &TODeliveryServiceV12{ReqInfo: ds.ReqInfo, DeliveryServiceNullableV12: ds.DeliveryServiceNullableV12}
+	v12 := &TODeliveryServiceV12{}
+	v12.DeliveryServiceNullableV12 = ds.DeliveryServiceNullableV12
+	v12.SetInfo(ds.ReqInfo)
+	return v12
 }
 
 func (ds TODeliveryServiceV13) MarshalJSON() ([]byte, error) {
@@ -61,13 +64,6 @@ func (ds *TODeliveryServiceV13) UnmarshalJSON(data []byte) error {
 }
 
 func (ds *TODeliveryServiceV13) APIInfo() *api.APIInfo { return ds.ReqInfo }
-
-func GetTypeV13Factory() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TODeliveryServiceV13{reqInfo, tc.DeliveryServiceNullable{}}
-		return &toReturn
-	}
-}
 
 func (ds TODeliveryServiceV13) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return ds.V12().GetKeyFieldsInfo()

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
@@ -45,7 +45,7 @@ import (
 //we need a type alias to define functions on
 
 type TODeliveryServiceV13 struct {
-	api.APIInformer
+	api.APIInfoImpl
 	tc.DeliveryServiceNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
@@ -35,11 +35,10 @@ import (
 
 //we need a type alias to define functions on
 type TODeliveryServiceRequestComment struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.DeliveryServiceRequestCommentNullable
 }
 
-func (v *TODeliveryServiceRequestComment) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TODeliveryServiceRequestComment) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TODeliveryServiceRequestComment) InsertQuery() string           { return insertQuery() }
 func (v *TODeliveryServiceRequestComment) NewReadObj() interface{} {
@@ -56,13 +55,6 @@ func (v *TODeliveryServiceRequestComment) ParamColumns() map[string]dbhelpers.Wh
 }
 func (v *TODeliveryServiceRequestComment) UpdateQuery() string { return updateQuery() }
 func (v *TODeliveryServiceRequestComment) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TODeliveryServiceRequestComment{reqInfo, tc.DeliveryServiceRequestCommentNullable{}}
-		return &toReturn
-	}
-}
 
 func (comment TODeliveryServiceRequestComment) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
@@ -35,7 +35,7 @@ import (
 
 //we need a type alias to define functions on
 type TODeliveryServiceRequestComment struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.DeliveryServiceRequestCommentNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
@@ -38,23 +38,15 @@ import (
 
 // TODeliveryServiceRequest is the type alias to define functions on
 type TODeliveryServiceRequest struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.DeliveryServiceRequestNullable
 }
 
-func (v *TODeliveryServiceRequest) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TODeliveryServiceRequest) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TODeliveryServiceRequest) InsertQuery() string           { return insertRequestQuery() }
 func (v *TODeliveryServiceRequest) UpdateQuery() string           { return updateRequestQuery() }
 func (v *TODeliveryServiceRequest) DeleteQuery() string {
 	return `DELETE FROM deliveryservice_request WHERE id = :id`
-}
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TODeliveryServiceRequest{reqInfo, tc.DeliveryServiceRequestNullable{}}
-		return &toReturn
-	}
 }
 
 func (req TODeliveryServiceRequest) GetKeyFieldsInfo() []api.KeyFieldInfo {
@@ -346,11 +338,8 @@ WHERE id=:id`
 ////////////////////////////////////////////////////////////////
 // Assignment change
 
-func GetAssignmentTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := deliveryServiceRequestAssignment{TODeliveryServiceRequest{reqInfo, tc.DeliveryServiceRequestNullable{}}}
-		return &toReturn
-	}
+func GetAssignmentSingleton() api.CRUDer {
+	return &deliveryServiceRequestAssignment{}
 }
 
 type deliveryServiceRequestAssignment struct {
@@ -417,16 +406,13 @@ func (req deliveryServiceRequestAssignment) ChangeLogMessage(action string) (str
 ////////////////////////////////////////////////////////////////
 // Status change
 
+func GetStatusSingleton() api.CRUDer {
+	return &deliveryServiceRequestStatus{}
+}
+
 // deliveryServiceRequestStatus implements interfaces needed to update the request status only
 type deliveryServiceRequestStatus struct {
 	TODeliveryServiceRequest
-}
-
-func GetStatusTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := deliveryServiceRequestStatus{TODeliveryServiceRequest{reqInfo, tc.DeliveryServiceRequestNullable{}}}
-		return &toReturn
-	}
 }
 
 func (req *deliveryServiceRequestStatus) Update() (error, error, int) {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
@@ -38,7 +38,7 @@ import (
 
 // TODeliveryServiceRequest is the type alias to define functions on
 type TODeliveryServiceRequest struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.DeliveryServiceRequestNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -44,7 +44,7 @@ import (
 
 // TODeliveryServiceRequest provides a type alias to define functions on
 type TODeliveryServiceServer struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.DeliveryServiceServer
 	TenantIDs pq.Int64Array `json:"-" db:"accessibleTenants"`
 }
@@ -492,7 +492,7 @@ func dssSelectQuery() string {
 }
 
 type TODSSDeliveryService struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.DeliveryServiceNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -44,14 +44,9 @@ import (
 
 // TODeliveryServiceRequest provides a type alias to define functions on
 type TODeliveryServiceServer struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.DeliveryServiceServer
 	TenantIDs pq.Int64Array `json:"-" db:"accessibleTenants"`
-}
-
-func GetRefType(inf *api.APIInfo) *TODeliveryServiceServer {
-	s := TODeliveryServiceServer{ReqInfo: inf}
-	return &s
 }
 
 func (dss TODeliveryServiceServer) GetKeyFieldsInfo() []api.KeyFieldInfo {
@@ -114,7 +109,9 @@ func ReadDSSHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer inf.Close()
 
-	results, err := GetRefType(inf).readDSS(inf.Tx, inf.User, inf.Params, inf.IntParams)
+	dss := TODeliveryServiceServer{}
+	dss.SetInfo(inf)
+	results, err := dss.readDSS(inf.Tx, inf.User, inf.Params, inf.IntParams)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
@@ -495,16 +492,8 @@ func dssSelectQuery() string {
 }
 
 type TODSSDeliveryService struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.DeliveryServiceNullable
-}
-
-func (dss *TODSSDeliveryService) APIInfo() *api.APIInfo {
-	return dss.ReqInfo
-}
-
-func TypeSingleton(reqInfo *api.APIInfo) api.Reader {
-	return &TODSSDeliveryService{reqInfo, tc.DeliveryServiceNullable{}}
 }
 
 // Read shows all of the delivery services associated with the specified server.

--- a/traffic_ops/traffic_ops_golang/division/divisions.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions.go
@@ -34,7 +34,7 @@ import (
 
 //we need a type alias to define functions on
 type TODivision struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.DivisionNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/division/divisions.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions.go
@@ -34,11 +34,10 @@ import (
 
 //we need a type alias to define functions on
 type TODivision struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.DivisionNullable
 }
 
-func (v *TODivision) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TODivision) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TODivision) InsertQuery() string           { return insertQuery() }
 func (v *TODivision) NewReadObj() interface{}       { return &tc.Division{} }
@@ -51,13 +50,6 @@ func (v *TODivision) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TODivision) UpdateQuery() string { return updateQuery() }
 func (v *TODivision) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TODivision{reqInfo, tc.DivisionNullable{}}
-		return &toReturn
-	}
-}
 
 func (division TODivision) GetAuditName() string {
 	if division.Name != nil {

--- a/traffic_ops/traffic_ops_golang/division/divisions_test.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestDivisions() []tc.Division {
@@ -46,39 +48,43 @@ func getTestDivisions() []tc.Division {
 }
 
 func TestGetDivisions(t *testing.T) {
-	/*
-		mockDB, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-		defer mockDB.Close()
 
-		db := sqlx.NewDb(mockDB, "sqlmock")
-		defer db.Close()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
 
-		testCase := getTestDivisions()
-		cols := test.ColsFromStructByTag("db", tc.Division{})
-		rows := sqlmock.NewRows(cols)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
 
-		for _, ts := range testCase {
-			rows = rows.AddRow(
-				ts.ID,
-				ts.LastUpdated,
-				ts.Name,
-			)
-		}
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT").WillReturnRows(rows)
-		mock.ExpectCommit()
+	testCase := getTestDivisions()
+	cols := test.ColsFromStructByTag("db", tc.Division{})
+	rows := sqlmock.NewRows(cols)
 
-		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
-		vals, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-		if userErr != nil || sysErr != nil {
-			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-		}
-		if len(vals) != 2 {
-			t.Errorf("read expected: len(vals) == 1, actual: %v", len(vals))
-		}*/
+	for _, ts := range testCase {
+		rows = rows.AddRow(
+			ts.ID,
+			ts.LastUpdated,
+			ts.Name,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
+
+	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	obj := TODivision{
+		api.APIInformer{&reqInfo},
+		tc.DivisionNullable{},
+	}
+	vals, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+	if len(vals) != 2 {
+		t.Errorf("read expected: len(vals) == 1, actual: %v", len(vals))
+	}
 
 }
 

--- a/traffic_ops/traffic_ops_golang/division/divisions_test.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions_test.go
@@ -75,7 +75,7 @@ func TestGetDivisions(t *testing.T) {
 
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TODivision{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.DivisionNullable{},
 	}
 	vals, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/division/divisions_test.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions_test.go
@@ -27,9 +27,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestDivisions() []tc.Division {
@@ -49,38 +46,39 @@ func getTestDivisions() []tc.Division {
 }
 
 func TestGetDivisions(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testCase := getTestDivisions()
-	cols := test.ColsFromStructByTag("db", tc.Division{})
-	rows := sqlmock.NewRows(cols)
+		testCase := getTestDivisions()
+		cols := test.ColsFromStructByTag("db", tc.Division{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testCase {
-		rows = rows.AddRow(
-			ts.ID,
-			ts.LastUpdated,
-			ts.Name,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testCase {
+			rows = rows.AddRow(
+				ts.ID,
+				ts.LastUpdated,
+				ts.Name,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
-	vals, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
-	if len(vals) != 2 {
-		t.Errorf("read expected: len(vals) == 1, actual: %v", len(vals))
-	}
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+		vals, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
+		if len(vals) != 2 {
+			t.Errorf("read expected: len(vals) == 1, actual: %v", len(vals))
+		}*/
 
 }
 

--- a/traffic_ops/traffic_ops_golang/origin/origins.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins.go
@@ -42,7 +42,7 @@ import (
 
 //we need a type alias to define functions on
 type TOOrigin struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.Origin
 }
 

--- a/traffic_ops/traffic_ops_golang/origin/origins.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins.go
@@ -42,15 +42,8 @@ import (
 
 //we need a type alias to define functions on
 type TOOrigin struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.Origin
-}
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOOrigin{reqInfo, tc.Origin{}}
-		return &toReturn
-	}
 }
 
 func (origin *TOOrigin) SetID(i int) {

--- a/traffic_ops/traffic_ops_golang/parameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters.go
@@ -48,7 +48,7 @@ var (
 
 //we need a type alias to define functions on
 type TOParameter struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.ParameterNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/parameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters.go
@@ -48,11 +48,10 @@ var (
 
 //we need a type alias to define functions on
 type TOParameter struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.ParameterNullable
 }
 
-func (v *TOParameter) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOParameter) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOParameter) InsertQuery() string           { return insertQuery() }
 func (v *TOParameter) NewReadObj() interface{}       { return &tc.ParameterNullable{} }
@@ -66,13 +65,6 @@ func (v *TOParameter) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOParameter) UpdateQuery() string { return updateQuery() }
 func (v *TOParameter) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOParameter{reqInfo, tc.ParameterNullable{}}
-		return &toReturn
-	}
-}
 
 func (param TOParameter) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{IDQueryParam, api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
@@ -25,13 +25,8 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
 
 	"encoding/json"
-
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestParameters() []tc.ParameterNullable {
@@ -66,47 +61,48 @@ func getTestParameters() []tc.ParameterNullable {
 }
 
 func TestGetParameters(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testParameters := getTestParameters()
-	cols := test.ColsFromStructByTag("db", tc.ParameterNullable{})
-	rows := sqlmock.NewRows(cols)
+		testParameters := getTestParameters()
+		cols := test.ColsFromStructByTag("db", tc.ParameterNullable{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testParameters {
-		rows = rows.AddRow(
-			ts.ConfigFile,
-			ts.ID,
-			ts.LastUpdated,
-			ts.Name,
-			ts.Profiles,
-			ts.Secure,
-			ts.Value,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testParameters {
+			rows = rows.AddRow(
+				ts.ConfigFile,
+				ts.ID,
+				ts.LastUpdated,
+				ts.Name,
+				ts.Profiles,
+				ts.Secure,
+				ts.Value,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{
-		Tx:    db.MustBegin(),
-		User:   &auth.CurrentUser{PrivLevel: 30},
-		Params: map[string]string{"name": "1"},
-	}
-	pps, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		reqInfo := api.APIInfo{
+			Tx:    db.MustBegin(),
+			User:   &auth.CurrentUser{PrivLevel: 30},
+			Params: map[string]string{"name": "1"},
+		}
+		pps, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(pps) != 2 {
-		t.Errorf("parameter.Read expected: len(pps) == 2, actual: %v", len(pps))
-	}
+		if len(pps) != 2 {
+			t.Errorf("parameter.Read expected: len(pps) == 2, actual: %v", len(pps))
+		}*/
 
 }
 

--- a/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
@@ -100,7 +100,7 @@ func TestGetParameters(t *testing.T) {
 		Params: map[string]string{"name": "1"},
 	}
 	obj := TOParameter{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.ParameterNullable{},
 	}
 	pps, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
@@ -25,6 +25,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	"encoding/json"
 )
@@ -61,48 +65,52 @@ func getTestParameters() []tc.ParameterNullable {
 }
 
 func TestGetParameters(t *testing.T) {
-	/*
-		mockDB, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-		defer mockDB.Close()
 
-		db := sqlx.NewDb(mockDB, "sqlmock")
-		defer db.Close()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
 
-		testParameters := getTestParameters()
-		cols := test.ColsFromStructByTag("db", tc.ParameterNullable{})
-		rows := sqlmock.NewRows(cols)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
 
-		for _, ts := range testParameters {
-			rows = rows.AddRow(
-				ts.ConfigFile,
-				ts.ID,
-				ts.LastUpdated,
-				ts.Name,
-				ts.Profiles,
-				ts.Secure,
-				ts.Value,
-			)
-		}
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT").WillReturnRows(rows)
-		mock.ExpectCommit()
+	testParameters := getTestParameters()
+	cols := test.ColsFromStructByTag("db", tc.ParameterNullable{})
+	rows := sqlmock.NewRows(cols)
 
-		reqInfo := api.APIInfo{
-			Tx:    db.MustBegin(),
-			User:   &auth.CurrentUser{PrivLevel: 30},
-			Params: map[string]string{"name": "1"},
-		}
-		pps, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-		if userErr != nil || sysErr != nil {
-			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-		}
+	for _, ts := range testParameters {
+		rows = rows.AddRow(
+			ts.ConfigFile,
+			ts.ID,
+			ts.LastUpdated,
+			ts.Name,
+			ts.Profiles,
+			ts.Secure,
+			ts.Value,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
 
-		if len(pps) != 2 {
-			t.Errorf("parameter.Read expected: len(pps) == 2, actual: %v", len(pps))
-		}*/
+	reqInfo := api.APIInfo{
+		Tx:     db.MustBegin(),
+		User:   &auth.CurrentUser{PrivLevel: 30},
+		Params: map[string]string{"name": "1"},
+	}
+	obj := TOParameter{
+		api.APIInformer{&reqInfo},
+		tc.ParameterNullable{},
+	}
+	pps, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+
+	if len(pps) != 2 {
+		t.Errorf("parameter.Read expected: len(pps) == 2, actual: %v", len(pps))
+	}
 
 }
 

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -33,11 +33,10 @@ import (
 
 //we need a type alias to define functions on
 type TOPhysLocation struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.PhysLocationNullable
 }
 
-func (v *TOPhysLocation) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOPhysLocation) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOPhysLocation) InsertQuery() string           { return insertQuery() }
 func (v *TOPhysLocation) NewReadObj() interface{}       { return &tc.PhysLocationNullable{} }
@@ -51,13 +50,6 @@ func (v *TOPhysLocation) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOPhysLocation) UpdateQuery() string { return updateQuery() }
 func (v *TOPhysLocation) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOPhysLocation{reqInfo, tc.PhysLocationNullable{}}
-		return &toReturn
-	}
-}
 
 func (pl TOPhysLocation) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -33,7 +33,7 @@ import (
 
 //we need a type alias to define functions on
 type TOPhysLocation struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.PhysLocationNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -98,7 +98,7 @@ func TestGetPhysLocations(t *testing.T) {
 
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TOPhysLocation{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.PhysLocationNullable{},
 	}
 	physLocations, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -29,9 +29,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestPhysLocations() []tc.PhysLocation {
@@ -61,50 +58,51 @@ func getTestPhysLocations() []tc.PhysLocation {
 }
 
 func TestGetPhysLocations(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testCase := getTestPhysLocations()
-	cols := test.ColsFromStructByTag("db", tc.PhysLocation{})
-	rows := sqlmock.NewRows(cols)
+		testCase := getTestPhysLocations()
+		cols := test.ColsFromStructByTag("db", tc.PhysLocation{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testCase {
-		rows = rows.AddRow(
-			ts.Address,
-			ts.City,
-			ts.Comments,
-			ts.Email,
-			ts.ID,
-			ts.LastUpdated,
-			ts.Name,
-			ts.Phone,
-			ts.POC,
-			ts.RegionID,
-			ts.RegionName,
-			ts.ShortName,
-			ts.State,
-			ts.Zip,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testCase {
+			rows = rows.AddRow(
+				ts.Address,
+				ts.City,
+				ts.Comments,
+				ts.Email,
+				ts.ID,
+				ts.LastUpdated,
+				ts.Name,
+				ts.Phone,
+				ts.POC,
+				ts.RegionID,
+				ts.RegionName,
+				ts.ShortName,
+				ts.State,
+				ts.Zip,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
-	physLocations, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+		physLocations, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(physLocations) != 2 {
-		t.Errorf("physLocation.Read expected: len(physLocations) == 2, actual: %v", len(physLocations))
-	}
+		if len(physLocations) != 2 {
+			t.Errorf("physLocation.Read expected: len(physLocations) == 2, actual: %v", len(physLocations))
+		}*/
 
 }
 

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestPhysLocations() []tc.PhysLocation {
@@ -58,51 +60,55 @@ func getTestPhysLocations() []tc.PhysLocation {
 }
 
 func TestGetPhysLocations(t *testing.T) {
-	/*
-		mockDB, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-		defer mockDB.Close()
 
-		db := sqlx.NewDb(mockDB, "sqlmock")
-		defer db.Close()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
 
-		testCase := getTestPhysLocations()
-		cols := test.ColsFromStructByTag("db", tc.PhysLocation{})
-		rows := sqlmock.NewRows(cols)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
 
-		for _, ts := range testCase {
-			rows = rows.AddRow(
-				ts.Address,
-				ts.City,
-				ts.Comments,
-				ts.Email,
-				ts.ID,
-				ts.LastUpdated,
-				ts.Name,
-				ts.Phone,
-				ts.POC,
-				ts.RegionID,
-				ts.RegionName,
-				ts.ShortName,
-				ts.State,
-				ts.Zip,
-			)
-		}
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT").WillReturnRows(rows)
-		mock.ExpectCommit()
+	testCase := getTestPhysLocations()
+	cols := test.ColsFromStructByTag("db", tc.PhysLocation{})
+	rows := sqlmock.NewRows(cols)
 
-		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
-		physLocations, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-		if userErr != nil || sysErr != nil {
-			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-		}
+	for _, ts := range testCase {
+		rows = rows.AddRow(
+			ts.Address,
+			ts.City,
+			ts.Comments,
+			ts.Email,
+			ts.ID,
+			ts.LastUpdated,
+			ts.Name,
+			ts.Phone,
+			ts.POC,
+			ts.RegionID,
+			ts.RegionName,
+			ts.ShortName,
+			ts.State,
+			ts.Zip,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
 
-		if len(physLocations) != 2 {
-			t.Errorf("physLocation.Read expected: len(physLocations) == 2, actual: %v", len(physLocations))
-		}*/
+	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	obj := TOPhysLocation{
+		api.APIInformer{&reqInfo},
+		tc.PhysLocationNullable{},
+	}
+	physLocations, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+
+	if len(physLocations) != 2 {
+		t.Errorf("physLocation.Read expected: len(physLocations) == 2, actual: %v", len(physLocations))
+	}
 
 }
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -48,22 +48,14 @@ const (
 
 //we need a type alias to define functions on
 type TOProfile struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.ProfileNullable
 }
 
-func (v *TOProfile) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOProfile) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOProfile) InsertQuery() string           { return insertQuery() }
 func (v *TOProfile) UpdateQuery() string           { return updateQuery() }
 func (v *TOProfile) DeleteQuery() string           { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOProfile{reqInfo, tc.ProfileNullable{}}
-		return &toReturn
-	}
-}
 
 func (prof TOProfile) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{IDQueryParam, api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -48,7 +48,7 @@ const (
 
 //we need a type alias to define functions on
 type TOProfile struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.ProfileNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -29,9 +29,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestProfiles() []tc.ProfileNullable {
@@ -68,44 +65,45 @@ func getTestProfiles() []tc.ProfileNullable {
 }
 
 func TestGetProfiles(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testCase := getTestProfiles()
-	cols := test.ColsFromStructByTag("db", tc.ProfileNullable{})
-	rows := sqlmock.NewRows(cols)
+		testCase := getTestProfiles()
+		cols := test.ColsFromStructByTag("db", tc.ProfileNullable{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testCase {
-		rows = rows.AddRow(
-			ts.ID,
-			ts.LastUpdated,
-			ts.Name,
-			ts.Description,
-			ts.CDNName,
-			ts.CDNID,
-			ts.RoutingDisabled,
-			ts.Type,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testCase {
+			rows = rows.AddRow(
+				ts.ID,
+				ts.LastUpdated,
+				ts.Name,
+				ts.Description,
+				ts.CDNName,
+				ts.CDNID,
+				ts.RoutingDisabled,
+				ts.Type,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
-	profiles, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
+		profiles, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(profiles) != 2 {
-		t.Errorf("profile.Read expected: len(profiles) == 2, actual: %v", len(profiles))
-	}
+		if len(profiles) != 2 {
+			t.Errorf("profile.Read expected: len(profiles) == 2, actual: %v", len(profiles))
+		}*/
 
 }
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -100,7 +100,7 @@ func TestGetProfiles(t *testing.T) {
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
 
 	obj := TOProfile{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.ProfileNullable{},
 	}
 	profiles, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestProfiles() []tc.ProfileNullable {
@@ -65,45 +67,50 @@ func getTestProfiles() []tc.ProfileNullable {
 }
 
 func TestGetProfiles(t *testing.T) {
-	/*
-		mockDB, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-		defer mockDB.Close()
 
-		db := sqlx.NewDb(mockDB, "sqlmock")
-		defer db.Close()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
 
-		testCase := getTestProfiles()
-		cols := test.ColsFromStructByTag("db", tc.ProfileNullable{})
-		rows := sqlmock.NewRows(cols)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
 
-		for _, ts := range testCase {
-			rows = rows.AddRow(
-				ts.ID,
-				ts.LastUpdated,
-				ts.Name,
-				ts.Description,
-				ts.CDNName,
-				ts.CDNID,
-				ts.RoutingDisabled,
-				ts.Type,
-			)
-		}
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT").WillReturnRows(rows)
-		mock.ExpectCommit()
+	testCase := getTestProfiles()
+	cols := test.ColsFromStructByTag("db", tc.ProfileNullable{})
+	rows := sqlmock.NewRows(cols)
 
-		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
-		profiles, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-		if userErr != nil || sysErr != nil {
-			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-		}
+	for _, ts := range testCase {
+		rows = rows.AddRow(
+			ts.ID,
+			ts.LastUpdated,
+			ts.Name,
+			ts.Description,
+			ts.CDNName,
+			ts.CDNID,
+			ts.RoutingDisabled,
+			ts.Type,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
 
-		if len(profiles) != 2 {
-			t.Errorf("profile.Read expected: len(profiles) == 2, actual: %v", len(profiles))
-		}*/
+	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
+
+	obj := TOProfile{
+		api.APIInformer{&reqInfo},
+		tc.ProfileNullable{},
+	}
+	profiles, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+
+	if len(profiles) != 2 {
+		t.Errorf("profile.Read expected: len(profiles) == 2, actual: %v", len(profiles))
+	}
 
 }
 

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -40,7 +40,7 @@ const (
 
 //we need a type alias to define functions on
 type TOProfileParameter struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.ProfileParameterNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -40,11 +40,10 @@ const (
 
 //we need a type alias to define functions on
 type TOProfileParameter struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.ProfileParameterNullable
 }
 
-func (v *TOProfileParameter) APIInfo() *api.APIInfo   { return v.ReqInfo }
 func (v *TOProfileParameter) NewReadObj() interface{} { return &tc.ProfileParametersNullable{} }
 func (v *TOProfileParameter) SelectQuery() string     { return selectQuery() }
 func (v *TOProfileParameter) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
@@ -55,13 +54,6 @@ func (v *TOProfileParameter) ParamColumns() map[string]dbhelpers.WhereColumnInfo
 	}
 }
 func (v *TOProfileParameter) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOProfileParameter{reqInfo, tc.ProfileParameterNullable{}}
-		return &toReturn
-	}
-}
 
 func (pp TOProfileParameter) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{ProfileIDQueryParam, api.GetIntKey}, {ParameterIDQueryParam, api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestProfileParameters() []tc.ProfileParameterNullable {
@@ -50,41 +53,45 @@ func getTestProfileParameters() []tc.ProfileParameterNullable {
 }
 
 func TestGetProfileParameters(t *testing.T) {
-	/*
-		mockDB, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-		defer mockDB.Close()
 
-		db := sqlx.NewDb(mockDB, "sqlmock")
-		defer db.Close()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
 
-		testPPs := getTestProfileParameters()
-		cols := test.ColsFromStructByTag("db", tc.ProfileParametersNullable{})
-		rows := sqlmock.NewRows(cols)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
 
-		for _, ts := range testPPs {
-			rows = rows.AddRow(
-				ts.LastUpdated,
-				ts.Profile,
-				ts.ParameterID,
-			)
-		}
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT").WillReturnRows(rows)
-		mock.ExpectCommit()
+	testPPs := getTestProfileParameters()
+	cols := test.ColsFromStructByTag("db", tc.ProfileParametersNullable{})
+	rows := sqlmock.NewRows(cols)
 
-		txx := db.MustBegin()
-		reqInfo := api.APIInfo{Tx: txx, Params: map[string]string{"profile": "1"}}
-		pps, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-		if userErr != nil || sysErr != nil {
-			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-		}
+	for _, ts := range testPPs {
+		rows = rows.AddRow(
+			ts.LastUpdated,
+			ts.Profile,
+			ts.ParameterID,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
 
-		if len(pps) != 2 {
-			t.Errorf("profileparameter.Read expected: len(pps) == 2, actual: %v", len(pps))
-		}*/
+	txx := db.MustBegin()
+	reqInfo := api.APIInfo{Tx: txx, Params: map[string]string{"profile": "1"}}
+	obj := TOProfileParameter{
+		api.APIInformer{&reqInfo},
+		tc.ProfileParameterNullable{},
+	}
+	pps, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+
+	if len(pps) != 2 {
+		t.Errorf("profileparameter.Read expected: len(pps) == 2, actual: %v", len(pps))
+	}
 
 }
 

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
@@ -25,10 +25,6 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestProfileParameters() []tc.ProfileParameterNullable {
@@ -54,40 +50,41 @@ func getTestProfileParameters() []tc.ProfileParameterNullable {
 }
 
 func TestGetProfileParameters(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testPPs := getTestProfileParameters()
-	cols := test.ColsFromStructByTag("db", tc.ProfileParametersNullable{})
-	rows := sqlmock.NewRows(cols)
+		testPPs := getTestProfileParameters()
+		cols := test.ColsFromStructByTag("db", tc.ProfileParametersNullable{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testPPs {
-		rows = rows.AddRow(
-			ts.LastUpdated,
-			ts.Profile,
-			ts.ParameterID,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testPPs {
+			rows = rows.AddRow(
+				ts.LastUpdated,
+				ts.Profile,
+				ts.ParameterID,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	txx := db.MustBegin()
-	reqInfo := api.APIInfo{Tx: txx, Params: map[string]string{"profile": "1"}}
-	pps, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		txx := db.MustBegin()
+		reqInfo := api.APIInfo{Tx: txx, Params: map[string]string{"profile": "1"}}
+		pps, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(pps) != 2 {
-		t.Errorf("profileparameter.Read expected: len(pps) == 2, actual: %v", len(pps))
-	}
+		if len(pps) != 2 {
+			t.Errorf("profileparameter.Read expected: len(pps) == 2, actual: %v", len(pps))
+		}*/
 
 }
 

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
@@ -81,7 +81,7 @@ func TestGetProfileParameters(t *testing.T) {
 	txx := db.MustBegin()
 	reqInfo := api.APIInfo{Tx: txx, Params: map[string]string{"profile": "1"}}
 	obj := TOProfileParameter{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.ProfileParameterNullable{},
 	}
 	pps, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -29,11 +29,10 @@ import (
 
 //we need a type alias to define functions on
 type TORegion struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.Region
 }
 
-func (v *TORegion) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TORegion) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = t }
 func (v *TORegion) InsertQuery() string           { return insertQuery() }
 func (v *TORegion) NewReadObj() interface{}       { return &tc.Region{} }
@@ -47,13 +46,6 @@ func (v *TORegion) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TORegion) UpdateQuery() string { return updateQuery() }
 func (v *TORegion) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TORegion{reqInfo, tc.Region{}}
-		return &toReturn
-	}
-}
 
 func (region TORegion) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -29,7 +29,7 @@ import (
 
 //we need a type alias to define functions on
 type TORegion struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.Region
 }
 

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -76,7 +76,7 @@ func TestReadRegions(t *testing.T) {
 
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TORegion{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.Region{},
 	}
 	regions, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestRegions() []tc.Region {
@@ -45,41 +48,45 @@ func getTestRegions() []tc.Region {
 }
 
 func TestReadRegions(t *testing.T) {
-	/*
-		mockDB, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-		defer mockDB.Close()
 
-		db := sqlx.NewDb(mockDB, "sqlmock")
-		defer db.Close()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
 
-		testRegions := getTestRegions()
-		cols := test.ColsFromStructByTag("db", tc.Region{})
-		rows := sqlmock.NewRows(cols)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
 
-		for _, ts := range testRegions {
-			rows = rows.AddRow(
-				ts.Division,
-				ts.ID,
-				ts.LastUpdated,
-				ts.Name,
-			)
-		}
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT").WillReturnRows(rows)
-		mock.ExpectCommit()
+	testRegions := getTestRegions()
+	cols := test.ColsFromStructByTag("db", tc.Region{})
+	rows := sqlmock.NewRows(cols)
 
-		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
-		regions, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-		if userErr != nil || sysErr != nil {
-			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-		}
+	for _, ts := range testRegions {
+		rows = rows.AddRow(
+			ts.Division,
+			ts.ID,
+			ts.LastUpdated,
+			ts.Name,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
 
-		if len(regions) != 2 {
-			t.Errorf("region.Read expected: len(regions) == 2, actual: %v", len(regions))
-		}*/
+	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
+	obj := TORegion{
+		api.APIInformer{&reqInfo},
+		tc.Region{},
+	}
+	regions, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+
+	if len(regions) != 2 {
+		t.Errorf("region.Read expected: len(regions) == 2, actual: %v", len(regions))
+	}
 }
 
 func TestInterfaces(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -25,10 +25,6 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestRegions() []tc.Region {
@@ -49,40 +45,41 @@ func getTestRegions() []tc.Region {
 }
 
 func TestReadRegions(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testRegions := getTestRegions()
-	cols := test.ColsFromStructByTag("db", tc.Region{})
-	rows := sqlmock.NewRows(cols)
+		testRegions := getTestRegions()
+		cols := test.ColsFromStructByTag("db", tc.Region{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testRegions {
-		rows = rows.AddRow(
-			ts.Division,
-			ts.ID,
-			ts.LastUpdated,
-			ts.Name,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testRegions {
+			rows = rows.AddRow(
+				ts.Division,
+				ts.ID,
+				ts.LastUpdated,
+				ts.Name,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
-	regions, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
+		regions, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(regions) != 2 {
-		t.Errorf("region.Read expected: len(regions) == 2, actual: %v", len(regions))
-	}
+		if len(regions) != 2 {
+			t.Errorf("region.Read expected: len(regions) == 2, actual: %v", len(regions))
+		}*/
 }
 
 func TestInterfaces(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -39,12 +39,11 @@ import (
 
 type TORole struct {
 	tc.Role
-	ReqInfo        *api.APIInfo    `json:"-"`
-	LastUpdated    *tc.TimeNoMod   `json:"-"`
-	PQCapabilities *pq.StringArray `json:"-" db:"capabilities"`
+	api.APIInformer `json:"-"`
+	LastUpdated     *tc.TimeNoMod   `json:"-"`
+	PQCapabilities  *pq.StringArray `json:"-" db:"capabilities"`
 }
 
-func (v *TORole) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TORole) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TORole) InsertQuery() string           { return insertQuery() }
 func (v *TORole) NewReadObj() interface{}       { return &TORole{} }
@@ -57,12 +56,6 @@ func (v *TORole) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TORole) UpdateQuery() string { return updateQuery() }
 func (v *TORole) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		return &TORole{ReqInfo: reqInfo}
-	}
-}
 
 func (role TORole) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -38,10 +38,10 @@ import (
 )
 
 type TORole struct {
-	tc.Role
 	api.APIInformer `json:"-"`
-	LastUpdated     *tc.TimeNoMod   `json:"-"`
-	PQCapabilities  *pq.StringArray `json:"-" db:"capabilities"`
+	tc.Role
+	LastUpdated    *tc.TimeNoMod   `json:"-"`
+	PQCapabilities *pq.StringArray `json:"-" db:"capabilities"`
 }
 
 func (v *TORole) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -38,7 +38,7 @@ import (
 )
 
 type TORole struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.Role
 	LastUpdated    *tc.TimeNoMod   `json:"-"`
 	PQCapabilities *pq.StringArray `json:"-" db:"capabilities"`

--- a/traffic_ops/traffic_ops_golang/role/roles_test.go
+++ b/traffic_ops/traffic_ops_golang/role/roles_test.go
@@ -98,7 +98,10 @@ func TestValidate(t *testing.T) {
 	// invalid name, empty domainname
 	n := "not_a_valid_role"
 	reqInfo := api.APIInfo{}
-	r := TORole{ReqInfo: &reqInfo, Role: tc.Role{Name: &n}}
+	r := TORole{
+		APIInformer: api.APIInformer{&reqInfo},
+		Role:        tc.Role{Name: &n},
+	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(r.Validate())))
 
 	expectedErrs := util.JoinErrsStr([]error{
@@ -111,7 +114,14 @@ func TestValidate(t *testing.T) {
 	}
 
 	//  name,  domainname both valid
-	r = TORole{ReqInfo: &reqInfo, Role: tc.Role{Name: stringAddr("this is a valid name"), Description: stringAddr("this is a description"), PrivLevel: intAddr(30)}}
+	r = TORole{
+		APIInformer: api.APIInformer{&reqInfo},
+		Role: tc.Role{
+			Name:        stringAddr("this is a valid name"),
+			Description: stringAddr("this is a description"),
+			PrivLevel:   intAddr(30),
+		},
+	}
 	err := r.Validate()
 	if err != nil {
 		t.Errorf("expected nil, got %s", err)

--- a/traffic_ops/traffic_ops_golang/role/roles_test.go
+++ b/traffic_ops/traffic_ops_golang/role/roles_test.go
@@ -99,7 +99,7 @@ func TestValidate(t *testing.T) {
 	n := "not_a_valid_role"
 	reqInfo := api.APIInfo{}
 	r := TORole{
-		APIInformer: api.APIInformer{&reqInfo},
+		APIInfoImpl: api.APIInfoImpl{&reqInfo},
 		Role:        tc.Role{Name: &n},
 	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(r.Validate())))
@@ -115,7 +115,7 @@ func TestValidate(t *testing.T) {
 
 	//  name,  domainname both valid
 	r = TORole{
-		APIInformer: api.APIInformer{&reqInfo},
+		APIInfoImpl: api.APIInfoImpl{&reqInfo},
 		Role: tc.Role{
 			Name:        stringAddr("this is a valid name"),
 			Description: stringAddr("this is a description"),

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -165,10 +165,10 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		//User: CRUD
 		//Incrementing version for users because change to Nullable struct.
-		{1.1, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `users/{id}$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `users/{id}$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `users/{id}$`, api.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `users/{id}$`, api.UpdateHandler(&user.TOUser{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(&user.TOUser{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil},
 

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -97,22 +97,22 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		// 1.3 routes exist only in a Go. There is NO equivalent Perl route. They should conform with the API guidelines (https://cwiki.apache.org/confluence/display/TC/API+Guidelines).
 
 		//ASN: CRUD
-		{1.2, http.MethodGet, `asns/?(\.json)?$`, api.ReadHandler(asn.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.2, http.MethodGet, `asns/?(\.json)?$`, api.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `asns/?(\.json)?$`, asn.V11ReadAll, auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `asns/{id}$`, api.ReadHandler(asn.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `asns/{id}$`, api.UpdateHandler(asn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `asns/?$`, api.CreateHandler(asn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `asns/{id}$`, api.DeleteHandler(asn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `asns/{id}$`, api.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `asns/{id}$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `asns/?$`, api.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `asns/{id}$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodGet, `caches/stats/?(\.json)?$`, cachesstats.Get, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//CacheGroup: CRUD
 		{1.1, http.MethodGet, `cachegroups/trimmed/?(\.json)?$`, cachegroup.GetTrimmed, auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `cachegroups/?(\.json)?$`, api.ReadHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `cachegroups/{id}$`, api.ReadHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `cachegroups/{id}$`, api.UpdateHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `cachegroups/?$`, api.CreateHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `cachegroups/{id}$`, api.DeleteHandler(cachegroup.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `cachegroups/?(\.json)?$`, api.ReadHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `cachegroups/{id}$`, api.ReadHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `cachegroups/{id}$`, api.UpdateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `cachegroups/?$`, api.CreateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `cachegroups/{id}$`, api.DeleteHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodPost, `cachegroups/{id}/queue_update$`, cachegroup.QueueUpdates, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `cachegroups/{id}/deliveryservices/?$`, cachegroup.DSPostHandler, auth.PrivLevelOperations, Authenticated, nil},
@@ -127,12 +127,12 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `cdns/routing$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
 
 		//CDN: CRUD
-		{1.1, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(cdn.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `cdns/{id}$`, api.ReadHandler(cdn.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `cdns/name/{name}/?(\.json)?$`, api.ReadHandler(cdn.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(cdn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `cdns/?$`, api.CreateHandler(cdn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(cdn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `cdns/{id}$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `cdns/name/{name}/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodDelete, `cdns/name/{name}$`, cdn.DeleteName, auth.PrivLevelOperations, Authenticated, nil},
 
 		//CDN: queue updates
@@ -148,12 +148,12 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `cdns/{cdn}/configs/monitoring(\.json)?$`, crconfig.SnapshotGetMonitoringHandler, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Division: CRUD
-		{1.1, http.MethodGet, `divisions/?(\.json)?$`, api.ReadHandler(division.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `divisions/{id}$`, api.ReadHandler(division.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `divisions/{id}$`, api.UpdateHandler(division.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `divisions/?$`, api.CreateHandler(division.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `divisions/{id}$`, api.DeleteHandler(division.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodGet, `divisions/name/{name}/?(\.json)?$`, api.ReadHandler(division.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `divisions/?(\.json)?$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `divisions/{id}$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `divisions/{id}$`, api.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `divisions/?$`, api.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `divisions/{id}$`, api.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `divisions/name/{name}/?(\.json)?$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//HWInfo
 		{1.1, http.MethodGet, `hwinfo-wip/?(\.json)?$`, hwinfo.Get, auth.PrivLevelReadOnly, Authenticated, nil},
@@ -173,19 +173,19 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Parameter: CRUD
-		{1.1, http.MethodGet, `parameters/?(\.json)?$`, api.ReadHandler(parameter.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `parameters/{id}$`, api.ReadHandler(parameter.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `parameters/{id}$`, api.UpdateHandler(parameter.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `parameters/?$`, api.CreateHandler(parameter.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `parameters/{id}$`, api.DeleteHandler(parameter.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `parameters/?(\.json)?$`, api.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `parameters/{id}$`, api.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `parameters/{id}$`, api.UpdateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `parameters/?$`, api.CreateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `parameters/{id}$`, api.DeleteHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Phys_Location: CRUD
-		{1.1, http.MethodGet, `phys_locations/?(\.json)?$`, api.ReadHandler(physlocation.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `phys_locations/?(\.json)?$`, api.ReadHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `phys_locations/trimmed/?(\.json)?$`, physlocation.GetTrimmed, auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `phys_locations/{id}$`, api.ReadHandler(physlocation.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `phys_locations/{id}$`, api.UpdateHandler(physlocation.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `phys_locations/?$`, api.CreateHandler(physlocation.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `phys_locations/{id}$`, api.DeleteHandler(physlocation.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `phys_locations/{id}$`, api.ReadHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `phys_locations/{id}$`, api.UpdateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `phys_locations/?$`, api.CreateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `phys_locations/{id}$`, api.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Ping
 		{1.1, http.MethodGet, `ping$`, ping.PingHandler(), 0, NoAuth, nil},
@@ -193,21 +193,21 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `keys/ping/?(\.json)?$`, ping.Keys, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Profile: CRUD
-		{1.1, http.MethodGet, `profiles/?(\.json)?$`, api.ReadHandler(profile.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `profiles/?(\.json)?$`, api.ReadHandler(&profile.TOProfile{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `profiles/trimmed/?(\.json)?$`, profile.Trimmed, auth.PrivLevelReadOnly, Authenticated, nil},
 
-		{1.1, http.MethodGet, `profiles/{id}$`, api.ReadHandler(profile.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `profiles/{id}$`, api.UpdateHandler(profile.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `profiles/?$`, api.CreateHandler(profile.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `profiles/{id}$`, api.DeleteHandler(profile.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `profiles/{id}$`, api.ReadHandler(&profile.TOProfile{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `profiles/{id}$`, api.UpdateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `profiles/?$`, api.CreateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `profiles/{id}$`, api.DeleteHandler(&profile.TOProfile{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Region: CRUDs
-		{1.1, http.MethodGet, `regions/?(\.json)?$`, api.ReadHandler(region.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `regions/{id}$`, api.ReadHandler(region.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `regions/?(\.json)?$`, api.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `regions/{id}$`, api.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `regions/name/{name}/?(\.json)?$`, region.GetName, auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `regions/{id}$`, api.UpdateHandler(region.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `regions/?$`, api.CreateHandler(region.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `regions/{id}$`, api.DeleteHandler(region.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPut, `regions/{id}$`, api.UpdateHandler(&region.TORegion{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `regions/?$`, api.CreateHandler(&region.TORegion{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `regions/{id}$`, api.DeleteHandler(&region.TORegion{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodDelete, `deliveryservice_server/{dsid}/{serverid}`, dsserver.Delete, auth.PrivLevelReadOnly, Authenticated, nil},
 
@@ -216,7 +216,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `deliveryserviceserver/?(\.json)?$`, dsserver.ReadDSSHandler, auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodPost, `deliveryserviceserver$`, dsserver.GetReplaceHandler, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `deliveryservices/{xml_id}/servers$`, dsserver.GetCreateHandler, auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodGet, `servers/{id}/deliveryservices$`, api.ReadOnlyHandler(dsserver.TypeSingleton), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `servers/{id}/deliveryservices$`, api.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `deliveryservices/{id}/servers$`, dsserver.GetReadAssigned, auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `deliveryservices/{id}/unassigned_servers$`, dsserver.GetReadUnassigned, auth.PrivLevelReadOnly, Authenticated, nil},
 		//{1.1, http.MethodGet, `deliveryservices/{id}/servers/eligible$`, dsserver.GetReadHandler(d.Tx, tc.Eligible),auth.PrivLevelReadOnly, Authenticated, nil},
@@ -233,38 +233,38 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.2, http.MethodGet, `servers/hostname/{hostName}/details/?(\.json)?$`, server.GetDetailHandler, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Server: CRUD
-		{1.1, http.MethodGet, `servers/?(\.json)?$`, api.ReadHandler(server.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `servers/{id}$`, api.ReadHandler(server.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `servers/{id}$`, api.UpdateHandler(server.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `servers/?$`, api.CreateHandler(server.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `servers/{id}$`, api.DeleteHandler(server.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `servers/?(\.json)?$`, api.ReadHandler(&server.TOServer{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `servers/{id}$`, api.ReadHandler(&server.TOServer{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `servers/{id}$`, api.UpdateHandler(&server.TOServer{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `servers/?$`, api.CreateHandler(&server.TOServer{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `servers/{id}$`, api.DeleteHandler(&server.TOServer{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Status: CRUD
-		{1.1, http.MethodGet, `statuses/?(\.json)?$`, api.ReadHandler(status.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `statuses/{id}$`, api.ReadHandler(status.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `statuses/{id}$`, api.UpdateHandler(status.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `statuses/?$`, api.CreateHandler(status.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `statuses/{id}$`, api.DeleteHandler(status.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `statuses/?(\.json)?$`, api.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `statuses/{id}$`, api.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `statuses/{id}$`, api.UpdateHandler(&status.TOStatus{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `statuses/?$`, api.CreateHandler(&status.TOStatus{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `statuses/{id}$`, api.DeleteHandler(&status.TOStatus{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//System
 		{1.1, http.MethodGet, `system/info/?(\.json)?$`, systeminfo.Get, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Type: CRUD
-		{1.1, http.MethodGet, `types/?(\.json)?$`, api.ReadHandler(types.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `types/{id}$`, api.ReadHandler(types.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `types/{id}$`, api.UpdateHandler(types.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `types/?$`, api.CreateHandler(types.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `types/{id}$`, api.DeleteHandler(types.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `types/?(\.json)?$`, api.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `types/{id}$`, api.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `types/{id}$`, api.UpdateHandler(&types.TOType{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `types/?$`, api.CreateHandler(&types.TOType{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `types/{id}$`, api.DeleteHandler(&types.TOType{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//About
 		{1.3, http.MethodGet, `about/?(\.json)?$`, about.Handler(), auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Coordinates
-		{1.3, http.MethodGet, `coordinates/?(\.json)?$`, api.ReadHandler(coordinate.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodGet, `coordinates/?$`, api.ReadHandler(coordinate.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodPut, `coordinates/?$`, api.UpdateHandler(coordinate.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodPost, `coordinates/?$`, api.CreateHandler(coordinate.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodDelete, `coordinates/?$`, api.DeleteHandler(coordinate.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodGet, `coordinates/?(\.json)?$`, api.ReadHandler(&coordinate.TOCoordinate{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodGet, `coordinates/?$`, api.ReadHandler(&coordinate.TOCoordinate{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodPut, `coordinates/?$`, api.UpdateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodPost, `coordinates/?$`, api.CreateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodDelete, `coordinates/?$`, api.DeleteHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Servers
 		// explicitly passed to legacy system until fully implemented.  Auth handled by legacy system.
@@ -274,34 +274,34 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.2, http.MethodGet, `servers/totals$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}},
 
 		//ASNs
-		{1.3, http.MethodGet, `asns/?(\.json)?$`, api.ReadHandler(asn.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodPut, `asns/?$`, api.UpdateHandler(asn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodPost, `asns/?$`, api.CreateHandler(asn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodDelete, `asns/?$`, api.DeleteHandler(asn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodGet, `asns/?(\.json)?$`, api.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodPut, `asns/?$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodPost, `asns/?$`, api.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodDelete, `asns/?$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//CDN generic handlers:
-		{1.3, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(cdn.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodGet, `cdns/{id}$`, api.ReadHandler(cdn.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(cdn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodPost, `cdns/?$`, api.CreateHandler(cdn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(cdn.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodGet, `cdns/{id}$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Delivery service requests
-		{1.3, http.MethodGet, `deliveryservice_requests/?(\.json)?$`, api.ReadHandler(dsrequest.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodGet, `deliveryservice_requests/?$`, api.ReadHandler(dsrequest.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodPut, `deliveryservice_requests/?$`, api.UpdateHandler(dsrequest.GetTypeSingleton()), auth.PrivLevelPortal, Authenticated, nil},
-		{1.3, http.MethodPost, `deliveryservice_requests/?$`, api.CreateHandler(dsrequest.GetTypeSingleton()), auth.PrivLevelPortal, Authenticated, nil},
-		{1.3, http.MethodDelete, `deliveryservice_requests/?$`, api.DeleteHandler(dsrequest.GetTypeSingleton()), auth.PrivLevelPortal, Authenticated, nil},
+		{1.3, http.MethodGet, `deliveryservice_requests/?(\.json)?$`, api.ReadHandler(&dsrequest.TODeliveryServiceRequest{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodGet, `deliveryservice_requests/?$`, api.ReadHandler(&dsrequest.TODeliveryServiceRequest{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodPut, `deliveryservice_requests/?$`, api.UpdateHandler(&dsrequest.TODeliveryServiceRequest{}), auth.PrivLevelPortal, Authenticated, nil},
+		{1.3, http.MethodPost, `deliveryservice_requests/?$`, api.CreateHandler(&dsrequest.TODeliveryServiceRequest{}), auth.PrivLevelPortal, Authenticated, nil},
+		{1.3, http.MethodDelete, `deliveryservice_requests/?$`, api.DeleteHandler(&dsrequest.TODeliveryServiceRequest{}), auth.PrivLevelPortal, Authenticated, nil},
 
 		//Delivery service request: Actions
-		{1.3, http.MethodPut, `deliveryservice_requests/{id}/assign$`, api.UpdateHandler(dsrequest.GetAssignmentTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodPut, `deliveryservice_requests/{id}/status$`, api.UpdateHandler(dsrequest.GetStatusTypeSingleton()), auth.PrivLevelPortal, Authenticated, nil},
+		{1.3, http.MethodPut, `deliveryservice_requests/{id}/assign$`, api.UpdateHandler(dsrequest.GetAssignmentSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodPut, `deliveryservice_requests/{id}/status$`, api.UpdateHandler(dsrequest.GetStatusSingleton()), auth.PrivLevelPortal, Authenticated, nil},
 
 		//Delivery service request comment: CRUD
-		{1.3, http.MethodGet, `deliveryservice_request_comments/?(\.json)?$`, api.ReadHandler(comment.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodPut, `deliveryservice_request_comments/?$`, api.UpdateHandler(comment.GetTypeSingleton()), auth.PrivLevelPortal, Authenticated, nil},
-		{1.3, http.MethodPost, `deliveryservice_request_comments/?$`, api.CreateHandler(comment.GetTypeSingleton()), auth.PrivLevelPortal, Authenticated, nil},
-		{1.3, http.MethodDelete, `deliveryservice_request_comments/?$`, api.DeleteHandler(comment.GetTypeSingleton()), auth.PrivLevelPortal, Authenticated, nil},
+		{1.3, http.MethodGet, `deliveryservice_request_comments/?(\.json)?$`, api.ReadHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodPut, `deliveryservice_request_comments/?$`, api.UpdateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, Authenticated, nil},
+		{1.3, http.MethodPost, `deliveryservice_request_comments/?$`, api.CreateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, Authenticated, nil},
+		{1.3, http.MethodDelete, `deliveryservice_request_comments/?$`, api.DeleteHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, Authenticated, nil},
 
 		//Delivery service uri signing keys: CRUD
 		{1.3, http.MethodGet, `deliveryservices/{xmlID}/urisignkeys$`, getURIsignkeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
@@ -310,26 +310,26 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.3, http.MethodDelete, `deliveryservices/{xmlID}/urisignkeys$`, removeDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
 
 		// Federations by CDN (the actual table for federation)
-		{1.1, http.MethodGet, `cdns/{name}/federations/?(\.json)?$`, api.ReadHandler(cdnfederation.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `cdns/{name}/federations/{id}$`, api.ReadHandler(cdnfederation.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPost, `cdns/{name}/federations/?(\.json)?$`, api.CreateHandler(cdnfederation.GetTypeSingleton()), auth.PrivLevelAdmin, Authenticated, nil},
-		{1.1, http.MethodPut, `cdns/{name}/federations/{id}$`, api.UpdateHandler(cdnfederation.GetTypeSingleton()), auth.PrivLevelAdmin, Authenticated, nil},
-		{1.1, http.MethodDelete, `cdns/{name}/federations/{id}$`, api.DeleteHandler(cdnfederation.GetTypeSingleton()), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.1, http.MethodGet, `cdns/{name}/federations/?(\.json)?$`, api.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `cdns/{name}/federations/{id}$`, api.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPost, `cdns/{name}/federations/?(\.json)?$`, api.CreateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.1, http.MethodPut, `cdns/{name}/federations/{id}$`, api.UpdateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.1, http.MethodDelete, `cdns/{name}/federations/{id}$`, api.DeleteHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, Authenticated, nil},
 
 		{1.4, http.MethodPost, `cdns/{name}/dnsseckeys/ksk/generate$`, cdn.GenerateKSK, auth.PrivLevelAdmin, Authenticated, nil},
 
 		//Origins
-		{1.3, http.MethodGet, `origins/?(\.json)?$`, api.ReadHandler(origin.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodGet, `origins/?$`, api.ReadHandler(origin.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodPut, `origins/?$`, api.UpdateHandler(origin.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodPost, `origins/?$`, api.CreateHandler(origin.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodDelete, `origins/?$`, api.DeleteHandler(origin.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodGet, `origins/?(\.json)?$`, api.ReadHandler(&origin.TOOrigin{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodGet, `origins/?$`, api.ReadHandler(&origin.TOOrigin{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodPut, `origins/?$`, api.UpdateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodPost, `origins/?$`, api.CreateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodDelete, `origins/?$`, api.DeleteHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Roles
-		{1.3, http.MethodGet, `roles/?(\.json)?$`, api.ReadHandler(role.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodPut, `roles/?$`, api.UpdateHandler(role.GetTypeSingleton()), auth.PrivLevelAdmin, Authenticated, nil},
-		{1.3, http.MethodPost, `roles/?$`, api.CreateHandler(role.GetTypeSingleton()), auth.PrivLevelAdmin, Authenticated, nil},
-		{1.3, http.MethodDelete, `roles/?$`, api.DeleteHandler(role.GetTypeSingleton()), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.3, http.MethodGet, `roles/?(\.json)?$`, api.ReadHandler(&role.TORole{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodPut, `roles/?$`, api.UpdateHandler(&role.TORole{}), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.3, http.MethodPost, `roles/?$`, api.CreateHandler(&role.TORole{}), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.3, http.MethodDelete, `roles/?$`, api.DeleteHandler(&role.TORole{}), auth.PrivLevelAdmin, Authenticated, nil},
 
 		//Delivery Services Regexes
 		{1.1, http.MethodGet, `deliveryservices_regexes/?(\.json)?$`, deliveryservicesregexes.Get, auth.PrivLevelReadOnly, Authenticated, nil},
@@ -344,11 +344,11 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.3, http.MethodGet, `servers/{host_name}/update_status$`, server.GetServerUpdateStatusHandler, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//StaticDNSEntries
-		{1.1, http.MethodGet, `staticdnsentries/?(\.json)?$`, api.ReadHandler(staticdnsentry.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodGet, `staticdnsentries/?$`, api.ReadHandler(staticdnsentry.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodPut, `staticdnsentries/?$`, api.UpdateHandler(staticdnsentry.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodPost, `staticdnsentries/?$`, api.CreateHandler(staticdnsentry.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodDelete, `staticdnsentries/?$`, api.DeleteHandler(staticdnsentry.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `staticdnsentries/?(\.json)?$`, api.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodGet, `staticdnsentries/?$`, api.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodPut, `staticdnsentries/?$`, api.UpdateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodPost, `staticdnsentries/?$`, api.CreateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodDelete, `staticdnsentries/?$`, api.DeleteHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//ProfileParameters
 		{1.1, http.MethodGet, `profiles/{id}/parameters/?(\.json)?$`, profileparameter.GetProfileID, auth.PrivLevelReadOnly, Authenticated, nil},
@@ -357,18 +357,18 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `parameters/profile/{name}/?(\.json)?$`, profileparameter.GetProfileName, auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodPost, `profiles/name/{name}/parameters/?$`, profileparameter.PostProfileParamsByName, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `profiles/{id}/parameters/?$`, profileparameter.PostProfileParamsByID, auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodGet, `profileparameters/?(\.json)?$`, api.ReadHandler(profileparameter.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPost, `profileparameters/?$`, api.CreateHandler(profileparameter.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `profileparameters/?(\.json)?$`, api.ReadHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPost, `profileparameters/?$`, api.CreateHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `profileparameter/?$`, profileparameter.PostProfileParam, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `parameterprofile/?$`, profileparameter.PostParamProfile, auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `profileparameters/{profileId}/{parameterId}$`, api.DeleteHandler(profileparameter.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `profileparameters/{profileId}/{parameterId}$`, api.DeleteHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Tenants
-		{1.1, http.MethodGet, `tenants/?(\.json)?$`, api.ReadHandler(apitenant.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `tenants/{id}$`, api.ReadHandler(apitenant.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `tenants/{id}$`, api.UpdateHandler(apitenant.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `tenants/?$`, api.CreateHandler(apitenant.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `tenants/{id}$`, api.DeleteHandler(apitenant.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `tenants/?(\.json)?$`, api.ReadHandler(&apitenant.TOTenant{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `tenants/{id}$`, api.ReadHandler(&apitenant.TOTenant{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `tenants/{id}$`, api.UpdateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `tenants/?$`, api.CreateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `tenants/{id}$`, api.DeleteHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//CRConfig
 		{1.1, http.MethodGet, `cdns/{cdn}/snapshot/?$`, crconfig.SnapshotGetHandler, auth.PrivLevelReadOnly, Authenticated, nil},
@@ -384,16 +384,16 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `federations/{id}/deliveryservices?(\.json)?$`, federations.PostDSes, auth.PrivLevelAdmin, Authenticated, nil},
 
 		////DeliveryServices
-		{1.3, http.MethodGet, `deliveryservices/?(\.json)?$`, api.ReadHandler(deliveryservice.GetTypeV13Factory()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `deliveryservices/?(\.json)?$`, api.ReadHandler(deliveryservice.GetTypeV12Factory()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.3, http.MethodGet, `deliveryservices/{id}/?(\.json)?$`, api.ReadHandler(deliveryservice.GetTypeV13Factory()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `deliveryservices/{id}/?(\.json)?$`, api.ReadHandler(deliveryservice.GetTypeV12Factory()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodGet, `deliveryservices/?(\.json)?$`, api.ReadHandler(&deliveryservice.TODeliveryServiceV13{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `deliveryservices/?(\.json)?$`, api.ReadHandler(&deliveryservice.TODeliveryServiceV12{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.3, http.MethodGet, `deliveryservices/{id}/?(\.json)?$`, api.ReadHandler(&deliveryservice.TODeliveryServiceV13{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `deliveryservices/{id}/?(\.json)?$`, api.ReadHandler(&deliveryservice.TODeliveryServiceV12{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.3, http.MethodPost, `deliveryservices/?(\.json)?$`, deliveryservice.CreateV13, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `deliveryservices/?(\.json)?$`, deliveryservice.CreateV12, auth.PrivLevelOperations, Authenticated, nil},
 		{1.3, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV13, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV12, auth.PrivLevelOperations, Authenticated, nil},
-		{1.3, http.MethodDelete, `deliveryservices/{id}/?(\.json)?$`, api.DeleteHandler(deliveryservice.GetTypeV13Factory()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `deliveryservices/{id}/?(\.json)?$`, api.DeleteHandler(deliveryservice.GetTypeV12Factory()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.3, http.MethodDelete, `deliveryservices/{id}/?(\.json)?$`, api.DeleteHandler(&deliveryservice.TODeliveryServiceV13{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `deliveryservices/{id}/?(\.json)?$`, api.DeleteHandler(&deliveryservice.TODeliveryServiceV12{}), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodGet, `deliveryservices/{id}/servers/eligible/?(\.json)?$`, deliveryservice.GetServersEligible, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		{1.1, http.MethodGet, `deliveryservices/xmlId/{xmlid}/sslkeys$`, deliveryservice.GetSSLKeysByXMLID, auth.PrivLevelAdmin, Authenticated, nil},
@@ -407,11 +407,11 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `deliveryservices/{id}/urlkeys/?(\.json)?$`, deliveryservice.GetURLKeysByID, auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `riak/bucket/{bucket}/key/{key}/values/?(\.json)?$`, apiriak.GetBucketKey, auth.PrivLevelAdmin, Authenticated, nil},
 
-		{1.1, http.MethodGet, `steering/{deliveryservice}/targets/?(\.json)?$`, api.ReadHandler(steeringtargets.TypeFactory), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `steering/{deliveryservice}/targets/{target}$`, api.ReadHandler(steeringtargets.TypeFactory), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPost, `steering/{deliveryservice}/targets/?(\.json)?$`, api.CreateHandler(steeringtargets.TypeFactory), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?(\.json)?$`, api.UpdateHandler(steeringtargets.TypeFactory), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?(\.json)?$`, api.DeleteHandler(steeringtargets.TypeFactory), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `steering/{deliveryservice}/targets/?(\.json)?$`, api.ReadHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `steering/{deliveryservice}/targets/{target}$`, api.ReadHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPost, `steering/{deliveryservice}/targets/?(\.json)?$`, api.CreateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?(\.json)?$`, api.UpdateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?(\.json)?$`, api.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.4, http.MethodGet, `steering/?(\.json)?$`, steering.Get, auth.PrivLevelSteering, Authenticated, nil},
 	}

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -43,7 +43,7 @@ import (
 
 //we need a type alias to define functions on
 type TOServer struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.ServerNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -43,22 +43,14 @@ import (
 
 //we need a type alias to define functions on
 type TOServer struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.ServerNullable
 }
 
-func (v *TOServer) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOServer) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOServer) InsertQuery() string           { return insertQuery() }
 func (v *TOServer) UpdateQuery() string           { return updateQuery() }
 func (v *TOServer) DeleteQuery() string           { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOServer{reqInfo, tc.ServerNullable{}}
-		return &toReturn
-	}
-}
 
 func (server TOServer) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
@@ -32,7 +32,7 @@ import (
 )
 
 type TOStaticDNSEntry struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.StaticDNSEntryNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
@@ -32,11 +32,10 @@ import (
 )
 
 type TOStaticDNSEntry struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.StaticDNSEntryNullable
 }
 
-func (v *TOStaticDNSEntry) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOStaticDNSEntry) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOStaticDNSEntry) InsertQuery() string           { return insertQuery() }
 func (v *TOStaticDNSEntry) NewReadObj() interface{}       { return &tc.StaticDNSEntryNullable{} }
@@ -57,13 +56,6 @@ func (v *TOStaticDNSEntry) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOStaticDNSEntry) UpdateQuery() string { return updateQuery() }
 func (v *TOStaticDNSEntry) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOStaticDNSEntry{reqInfo, tc.StaticDNSEntryNullable{}}
-		return &toReturn
-	}
-}
 
 func (staticDNSEntry TOStaticDNSEntry) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
@@ -88,7 +88,7 @@ func TestValidate(t *testing.T) {
 
 	reqInfo := api.APIInfo{Tx: tx}
 	// invalid name, empty domainname
-	ts := TOStaticDNSEntry{APIInformer: api.APIInformer{&reqInfo}}
+	ts := TOStaticDNSEntry{APIInfoImpl: api.APIInfoImpl{&reqInfo}}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(ts.Validate())))
 
 	expectedErrs := util.JoinErrsStr([]error{

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
@@ -88,7 +88,7 @@ func TestValidate(t *testing.T) {
 
 	reqInfo := api.APIInfo{Tx: tx}
 	// invalid name, empty domainname
-	ts := TOStaticDNSEntry{ReqInfo: &reqInfo}
+	ts := TOStaticDNSEntry{APIInformer: api.APIInformer{&reqInfo}}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(ts.Validate())))
 
 	expectedErrs := util.JoinErrsStr([]error{

--- a/traffic_ops/traffic_ops_golang/status/statuses.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses.go
@@ -33,11 +33,10 @@ import (
 
 //we need a type alias to define functions on
 type TOStatus struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.StatusNullable
 }
 
-func (v *TOStatus) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOStatus) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOStatus) InsertQuery() string           { return insertQuery() }
 func (v *TOStatus) NewReadObj() interface{}       { return &tc.Status{} }
@@ -51,13 +50,6 @@ func (v *TOStatus) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOStatus) UpdateQuery() string { return updateQuery() }
 func (v *TOStatus) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOStatus{reqInfo, tc.StatusNullable{}}
-		return &toReturn
-	}
-}
 
 func (status TOStatus) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/status/statuses.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses.go
@@ -33,7 +33,7 @@ import (
 
 //we need a type alias to define functions on
 type TOStatus struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.StatusNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -78,7 +78,7 @@ func TestReadStatuses(t *testing.T) {
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOStatus{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.StatusNullable{},
 	}
 	statuses, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -25,10 +25,6 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestStatuses() []tc.Status {
@@ -50,41 +46,42 @@ func getTestStatuses() []tc.Status {
 }
 
 func TestReadStatuses(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testStatuses := getTestStatuses()
-	cols := test.ColsFromStructByTag("db", tc.Status{})
-	rows := sqlmock.NewRows(cols)
+		testStatuses := getTestStatuses()
+		cols := test.ColsFromStructByTag("db", tc.Status{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testStatuses {
-		rows = rows.AddRow(
-			ts.Description,
-			ts.ID,
-			ts.LastUpdated,
-			ts.Name,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testStatuses {
+			rows = rows.AddRow(
+				ts.Description,
+				ts.ID,
+				ts.LastUpdated,
+				ts.Name,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
-	statuses, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		statuses, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(statuses) != 2 {
-		t.Errorf("status.Read expected: len(statuses) == 2, actual: %v", len(statuses))
-	}
+		if len(statuses) != 2 {
+			t.Errorf("status.Read expected: len(statuses) == 2, actual: %v", len(statuses))
+		}*/
 }
 
 func TestInterfaces(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestStatuses() []tc.Status {
@@ -46,42 +49,46 @@ func getTestStatuses() []tc.Status {
 }
 
 func TestReadStatuses(t *testing.T) {
-	/*
-		mockDB, mock, err := sqlmock.New()
-		if err != nil {
-			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-		}
-		defer mockDB.Close()
 
-		db := sqlx.NewDb(mockDB, "sqlmock")
-		defer db.Close()
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
 
-		testStatuses := getTestStatuses()
-		cols := test.ColsFromStructByTag("db", tc.Status{})
-		rows := sqlmock.NewRows(cols)
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
 
-		for _, ts := range testStatuses {
-			rows = rows.AddRow(
-				ts.Description,
-				ts.ID,
-				ts.LastUpdated,
-				ts.Name,
-			)
-		}
-		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT").WillReturnRows(rows)
-		mock.ExpectCommit()
+	testStatuses := getTestStatuses()
+	cols := test.ColsFromStructByTag("db", tc.Status{})
+	rows := sqlmock.NewRows(cols)
 
-		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	for _, ts := range testStatuses {
+		rows = rows.AddRow(
+			ts.Description,
+			ts.ID,
+			ts.LastUpdated,
+			ts.Name,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
 
-		statuses, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-		if userErr != nil || sysErr != nil {
-			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-		}
+	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
-		if len(statuses) != 2 {
-			t.Errorf("status.Read expected: len(statuses) == 2, actual: %v", len(statuses))
-		}*/
+	obj := TOStatus{
+		api.APIInformer{&reqInfo},
+		tc.StatusNullable{},
+	}
+	statuses, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+
+	if len(statuses) != 2 {
+		t.Errorf("status.Read expected: len(statuses) == 2, actual: %v", len(statuses))
+	}
 }
 
 func TestInterfaces(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
@@ -36,14 +36,10 @@ import (
 )
 
 type TOSteeringTargetV11 struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.SteeringTargetNullable
 	DSTenantID  *int          `json:"-" db:"tenant"`
 	LastUpdated *tc.TimeNoMod `json:"-" db:"last_updated"`
-}
-
-func TypeFactory(inf *api.APIInfo) api.CRUDer {
-	return &TOSteeringTargetV11{ReqInfo: inf}
 }
 
 func (st TOSteeringTargetV11) GetKeyFieldsInfo() []api.KeyFieldInfo {

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
@@ -36,7 +36,7 @@ import (
 )
 
 type TOSteeringTargetV11 struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.SteeringTargetNullable
 	DSTenantID  *int          `json:"-" db:"tenant"`
 	LastUpdated *tc.TimeNoMod `json:"-" db:"last_updated"`

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -33,7 +33,7 @@ import (
 
 //we need a type alias to define functions on
 type TOType struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.TypeNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -33,11 +33,10 @@ import (
 
 //we need a type alias to define functions on
 type TOType struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.TypeNullable
 }
 
-func (v *TOType) APIInfo() *api.APIInfo         { return v.ReqInfo }
 func (v *TOType) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
 func (v *TOType) InsertQuery() string           { return insertQuery() }
 func (v *TOType) NewReadObj() interface{}       { return &tc.TypeNullable{} }
@@ -51,13 +50,6 @@ func (v *TOType) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 func (v *TOType) UpdateQuery() string { return updateQuery() }
 func (v *TOType) DeleteQuery() string { return deleteQuery() }
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOType{reqInfo, tc.TypeNullable{}}
-		return &toReturn
-	}
-}
 
 func (typ TOType) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -29,9 +29,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func getTestTypes() []tc.TypeNullable {
@@ -59,41 +56,43 @@ func getTestTypes() []tc.TypeNullable {
 }
 
 func TestGetType(t *testing.T) {
-	mockDB, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer mockDB.Close()
+	/*
+		Will need to look how to remove this one differently
+		mockDB, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		defer mockDB.Close()
 
-	db := sqlx.NewDb(mockDB, "sqlmock")
-	defer db.Close()
+		db := sqlx.NewDb(mockDB, "sqlmock")
+		defer db.Close()
 
-	testCase := getTestTypes()
-	cols := test.ColsFromStructByTag("db", tc.TypeNullable{})
-	rows := sqlmock.NewRows(cols)
+		testCase := getTestTypes()
+		cols := test.ColsFromStructByTag("db", tc.TypeNullable{})
+		rows := sqlmock.NewRows(cols)
 
-	for _, ts := range testCase {
-		rows = rows.AddRow(
-			ts.ID,
-			ts.LastUpdated,
-			ts.Name,
-			ts.Description,
-			ts.UseInTable,
-		)
-	}
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
-	mock.ExpectCommit()
+		for _, ts := range testCase {
+			rows = rows.AddRow(
+				ts.ID,
+				ts.LastUpdated,
+				ts.Name,
+				ts.Description,
+				ts.UseInTable,
+			)
+		}
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT").WillReturnRows(rows)
+		mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
-	types, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
-	}
+		reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+		types, userErr, sysErr, _ := GetTypeSingleton()(&reqInfo).Read()
+		if userErr != nil || sysErr != nil {
+			t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+		}
 
-	if len(types) != 2 {
-		t.Errorf("type.Read expected: len(types) == 2, actual: %v", len(types))
-	}
+		if len(types) != 2 {
+			t.Errorf("type.Read expected: len(types) == 2, actual: %v", len(types))
+		}*/
 
 }
 

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -88,7 +88,7 @@ func TestGetType(t *testing.T) {
 	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOType{
-		api.APIInformer{&reqInfo},
+		api.APIInfoImpl{&reqInfo},
 		tc.TypeNullable{},
 	}
 	types, userErr, sysErr, _ := obj.Read()

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -38,15 +38,8 @@ import (
 )
 
 type TOUser struct {
-	ReqInfo *api.APIInfo `json:"-"`
+	api.APIInformer `json:"-"`
 	tc.User
-}
-
-func GetTypeSingleton() api.CRUDFactory {
-	return func(reqInfo *api.APIInfo) api.CRUDer {
-		toReturn := TOUser{reqInfo, tc.User{}}
-		return &toReturn
-	}
 }
 
 func (user TOUser) GetKeyFieldsInfo() []api.KeyFieldInfo {
@@ -77,10 +70,6 @@ func (user TOUser) GetType() string {
 func (user *TOUser) SetKeys(keys map[string]interface{}) {
 	i, _ := keys["id"].(int) // non-panicking type assertion
 	user.ID = &i
-}
-
-func (v *TOUser) APIInfo() *api.APIInfo {
-	return v.ReqInfo
 }
 
 func (user *TOUser) SetLastUpdated(t tc.TimeNoMod) {

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -286,11 +286,6 @@ func (user *TOUser) Update() (error, error, int) {
 	return nil, nil, http.StatusOK
 }
 
-// Delete is unimplemented, needed to satisfy CRUDer
-func (user *TOUser) Delete() (error, error, int) {
-	return nil, nil, http.StatusNotImplemented
-}
-
 func (u *TOUser) IsTenantAuthorized(user *auth.CurrentUser) (bool, error) {
 
 	// Delete: only id is given

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -38,7 +38,7 @@ import (
 )
 
 type TOUser struct {
-	api.APIInformer `json:"-"`
+	api.APIInfoImpl `json:"-"`
 	tc.User
 }
 


### PR DESCRIPTION
#### What does this PR do?

This should allow the CRUDer interfaces to work with just an updater, or just a creator, or some mix that doesn't include all CRUD operations.

#### Which TC components are affected by this PR?

Traffic Ops

#### What is the best way to verify this PR?

Commenting out one of the already existing handlers (I did the create for cdns), then
testing the endpoint with curl.
`curl -XPOST --cookie $mc -Lvsk 'https://localhost:6443/api/1.3/cdns' -d @cdn.json | jq`

This should yield an internal server error, which also logs an error.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



