### PR TITLE
TO Go: add consistency test for Nullable vs non-Nullable on go-tc structs

### DIFF
--- a/lib/go-tc/nullable_test.go
+++ b/lib/go-tc/nullable_test.go
@@ -1,0 +1,115 @@
+// TODO: This comment with the `build nullable` tag must be removed when the structs are made consistent!!
+// skip this unless specifically testing for nullable vs non-nullable struct comparison
+
+// Run as `go test -tags nullable`
+// +build nullable
+
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNullStructs(t *testing.T) {
+	compareWithNullable(t, ASN{}, ASNNullable{})
+	compareWithNullable(t, CacheGroupFallback{}, CacheGroupFallbackNullable{})
+	compareWithNullable(t, CacheGroup{}, CacheGroupNullable{})
+	compareWithNullable(t, CDN{}, CDNNullable{})
+	compareWithNullable(t, Coordinate{}, CoordinateNullable{})
+	compareWithNullable(t, DeliveryServiceRequestComment{}, DeliveryServiceRequestCommentNullable{})
+	compareWithNullable(t, DeliveryServiceRequest{}, DeliveryServiceRequestNullable{})
+	compareWithNullable(t, DeliveryService{}, DeliveryServiceNullable{})
+	compareWithNullable(t, DeliveryServiceV12{}, DeliveryServiceNullableV12{})
+	compareWithNullable(t, DeliveryServiceV11{}, DeliveryServiceNullableV11{})
+	compareWithNullable(t, Division{}, DivisionNullable{})
+	compareWithNullable(t, Domain{}, DomainNullable{})
+	compareWithNullable(t, Parameter{}, ParameterNullable{})
+	compareWithNullable(t, PhysLocation{}, PhysLocationNullable{})
+	compareWithNullable(t, ProfileParameter{}, ProfileParameterNullable{})
+	compareWithNullable(t, Profile{}, ProfileNullable{})
+	compareWithNullable(t, Server{}, ServerNullable{})
+	compareWithNullable(t, StaticDNSEntry{}, StaticDNSEntryNullable{})
+	compareWithNullable(t, Status{}, StatusNullable{})
+	compareWithNullable(t, SteeringTarget{}, SteeringTargetNullable{})
+	compareWithNullable(t, Tenant{}, TenantNullable{})
+	compareWithNullable(t, Type{}, TypeNullable{})
+
+	// No Nullable version of these types
+	//compareWithNullable(t, Federation{}, FederationNullable{})
+	//compareWithNullable(t, ProfileParameters{}, ProfileParametersNullable{})
+}
+
+// compareFields checks that non-nullable and nullable versions have same fields
+func compareWithNullable(t *testing.T, obj interface{}, nullObj interface{}) {
+	ot := reflect.TypeOf(obj)
+	nt := reflect.TypeOf(nullObj)
+	if strings.Replace(nt.String(), "Nullable", "", 1) != ot.String() {
+		t.Errorf("expected type %s with nullable %s", ot, nt)
+	}
+
+	if ot.NumField() != nt.NumField() {
+		t.Errorf("%T has %d fields, but %T has %d", obj, ot.NumField(), nullObj, nt.NumField())
+	}
+
+	seen := make(map[string]struct{}, ot.NumField())
+
+	for i := 0; i < ot.NumField(); i++ {
+		oField := ot.Field(i)
+		if oField.Anonymous {
+			// embedded struct -- skip it
+			continue
+		}
+		nField, ok := nt.FieldByName(oField.Name)
+		if !ok {
+			t.Errorf("field %s found on %T but not %T", oField.Name, obj, nullObj)
+			continue
+		}
+
+		seen[nField.Name] = struct{}{}
+		oKind := oField.Type.Kind()
+		nKind := nField.Type.Kind()
+		//t.Logf("%T.%s is %s. %T.%s is %s", obj, oField.Name, oKind.String(), nullObj, nField.Name, nKind.String())
+		if oKind == nKind {
+			continue
+		}
+		if nKind == reflect.Ptr && nField.Type.Elem().Kind() != oKind {
+			t.Errorf("%T.%s (%s) and %T.%s (%s) have mismatched types", obj, oField.Name, oField.Type.String(), nullObj, nField.Name, nField.Type.String())
+		}
+	}
+
+	// check for fields in Nullable version not in non-Nullable
+	for i := 0; i < nt.NumField(); i++ {
+		nField := nt.Field(i)
+		if nField.Anonymous {
+			// embedded struct -- skip it
+			continue
+		}
+		if _, ok := seen[nField.Name]; ok {
+			// already accounted for
+			continue
+		}
+
+		t.Errorf("field %s found on %T but not %T", nField.Name, obj, nullObj)
+	}
+}


### PR DESCRIPTION
#### What does this PR do?

Tests for inconsistencies in `lib/go-tc` structs between Nullable and non-Nullable versions.  The test includes these checks:
 - same number of fields
 - same names of fields
 - same type (ptr for Nullable,  non-ptr of same type for non-Nullable)

Fixes #2893 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [x] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [x] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Ensure that this still passes:
```
cd lib/go-tc
go test
```

Ensure that this fails:
```
cd lib/go-tc
go test -tags nullable
```

These tests will not be run unless you specify the `-tags nullable` option on `go test`,  so will not cause the unit tests to fail.   This is to ensure we have a way to test as the errors are being corrected.


#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



