### PR TITLE
CDN-in-a-box: fix python ORT to compare correctly

### DIFF
--- a/infrastructure/cdn-in-a-box/edge/traffic_ops_ort.py
+++ b/infrastructure/cdn-in-a-box/edge/traffic_ops_ort.py
@@ -1112,7 +1112,7 @@ def updateConfig(directory:str, fname:str, contents:str) -> bool:
 	                     if l and not l.startswith("# DO NOT EDIT")\
 	                     and not l.startswith("# TRAFFIC OPS NOTE:")])
 
-	if stripComments(diskContents.strip()) == stripComments(contents.strip()):
+	if stripComments(diskContents.strip()) == stripComments(importantContents.strip()):
 		logging.info("on-disk contents match Traffic Ops - nothing to do")
 		return True
 


### PR DESCRIPTION
#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other CDN-in-a-box

#### What is the best way to verify this PR?
```
cd infrastructure/cdn-in-a-box
docker-compose up --build
docker-compose logs edge
```

check that ORT logs don't show differences each minute.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



