### PR TITLE
Adds support for single layer CDNs

### DIFF
--- a/docs/source/admin/quick_howto/multi_site.rst
+++ b/docs/source/admin/quick_howto/multi_site.rst
@@ -99,3 +99,6 @@ The following steps will take you through the procedure of setting up a Multi-Si
 	#) In the delivery service page, select the newly created DS_PROFILE and save the delivery service.
 
 #. Turn on parent_proxy_routing in the MID profile.
+
+.. Note:: Support for multisite configurations with single-layer CDNs is now available.  If a cachegroup's defined parents are either blank or of the type ORG_LOC, that cache's parent.config will be generated as a top layer cache, even if it is an edge.  In the past, parent.config generation was strictly determined by cache type. The new method examines the parent cachegroup definitions and generates the parent.config accordingly.
+


### PR DESCRIPTION
#### What does this PR do?
This PR adds support for single layer CDN environments.  Rather than use the server type to determine how the parent data is generated, the code determines if the cache has any parent caches assigned.  If no parent cachegroups are assigned, or if the parent cachegroups are origin cachegroups, parent configuration will be handled as though the cache in question was a mid, or more to the point, the top level of the CDN.

Fixes #(issue_number)
#2133 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [X] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Compare parent configuration files taken prior to the upgrade to the new versions.  There should be no change for standard multi-tier CDNs.  Single-layer CDNs should show an empty parent.config unless an MSO is present.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



