### PR TITLE
Fixes  an issue where traffic_monitor never completes startup if traffic_ops is unreachable

### DIFF
--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -182,7 +182,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	}
 	if aux.TrafficOpsRetryIntervalSec != nil {
 		if *aux.TrafficOpsRetryIntervalSec <= 0 {
-			log.Errorf("The 'traffic_ops_retry_interval_sec: %v' setting is incorrect, needs to be a positive number of seconds, using default of 3 seconds", aux.TrafficOpsRetryIntervalSec)
+			log.Errorf("The 'traffic_ops_retry_interval_sec: %v' setting is incorrect, needs to be a positive number of seconds, using default of 3 seconds", *aux.TrafficOpsRetryIntervalSec)
 			c.TrafficOpsRetryInterval = 3 * time.Second
 		} else {
 			c.TrafficOpsRetryInterval = time.Duration(*aux.TrafficOpsRetryIntervalSec) * time.Second


### PR DESCRIPTION
Fixes issues where when traffic monitor is starting up and is unable
to contact traffic_ops and obtain valid CRConfig data, traffic_monitor
will loop forever doing nothing useful.  This PR fixes the issue so
that during startup, traffic_monitor will continuously retry reaching
traffic_ops.  Upon successful login and a good CRConfig fetch,
traffic_monitor will resume its startup and begin polling caches
without intervention.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [x] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Shutdown the traffic_ops golang api server and then start traffic_monitor and you'll observe that it
continuously retries connecting to traffic_ops.  When traffic_ops is restored, traffic_monitor will then login to traffic_ops, fetch CRConfig data, complete its startup and then begin polling caches.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



