### PR TITLE
Update logging.config generation to allow additional types and logging filters

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1459,8 +1459,8 @@ sub logging_dot_config {
 		my $log_filter_name = $data->{$log_filter_field . ".Name"} || "";
 		if ( length($log_filter_name) > 0) {
 			my $filter = $data->{$log_filter_field . ".Filter"};
-			$filter =~ s/"/\\\"/g;
-			$text .= $log_filter_name . " = filter." . $filter . "\n";
+			my $log_filter_type = $data->{$log_filter_field . ".Type"} || "accept";
+			$text .= $log_filter_name . " = filter." . $log_filter_type . "('" . $filter . "')\n";
 		}
 	}
 
@@ -1472,13 +1472,13 @@ sub logging_dot_config {
 
 		my $log_object_filename = $data->{$log_object_field . ".Filename"} || "";
 		if ( length($log_object_filename) > 0 ) {
-			my $log_object_type					= $data->{$log_object_field . ".Type"} || "ascii";
+			my $log_object_type                 = $data->{$log_object_field . ".Type"}               || "ascii";
 			my $log_object_format               = $data->{$log_object_field . ".Format"}             || "";
 			my $log_object_rolling_enabled      = $data->{$log_object_field . ".RollingEnabled"}     || "";
 			my $log_object_rolling_interval_sec = $data->{$log_object_field . ".RollingIntervalSec"} || "";
 			my $log_object_rolling_offset_hr    = $data->{$log_object_field . ".RollingOffsetHr"}    || "";
 			my $log_object_rolling_size_mb      = $data->{$log_object_field . ".RollingSizeMb"}      || "";
-			my $log_object_filters				= $data->{$log_object_field . ".Filters"} || "";
+			my $log_object_filters              = $data->{$log_object_field . ".Filters"}            || "";
 
 			$text .= "\nlog." . $log_object_type . " {\n";
 			$text .= "  Format = " . $log_object_format . ",\n";

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1459,6 +1459,8 @@ sub logging_dot_config {
 		my $log_filter_name = $data->{$log_filter_field . ".Name"} || "";
 		if ( length($log_filter_name) > 0) {
 			my $filter = $data->{$log_filter_field . ".Filter"};
+			$filter =~ s/'/\\'/g;
+			$filter =~ s/\\/\\\\/g;
 			my $log_filter_type = $data->{$log_filter_field . ".Type"} || "accept";
 			$text .= $log_filter_name . " = filter." . $log_filter_type . "('" . $filter . "')\n";
 		}

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1424,7 +1424,6 @@ sub drop_qstring_dot_config {
 sub logging_dot_config {
 	my $self        = shift;
 	my $profile_obj = shift;
-	my $filename    = shift;
 
 	my $data = $self->profile_param_data( $profile_obj->id, "logging.config" );
 
@@ -1435,14 +1434,13 @@ sub logging_dot_config {
 	$text .= " --\n";
 
 	my $max_log_objects = 10;
-	for ( my $i = 0; $i < $max_log_objects; $i = $i + 1 ) {
+
+	# Add formats and filters separately to the top of the file
+	for ( my $i = 0; $i < $max_log_objects; $i = $i + 1) {
 		my $log_format_field = "LogFormat";
-		my $log_object_field = "LogObject";
 		if ( $i > 0 ) {
 			$log_format_field = $log_format_field . "$i";
-			$log_object_field = $log_object_field . "$i";
 		}
-
 		my $log_format_name = $data->{$log_format_field . ".Name"} || "";
 		if ( length($log_format_name) > 0 ) {
 			my $format = $data->{$log_format_field . ".Format"};
@@ -1451,24 +1449,51 @@ sub logging_dot_config {
 			$text .= "	Format = '" . $format . " '\n";
 			$text .= "}\n";
 		}
+	}
+
+	for ( my $i = 0; $i < $max_log_objects; $i = $i + 1) {
+		my $log_filter_field = "LogFilter";
+		if ( $i > 0 ) {
+			$log_filter_field = $log_filter_field . "$i";
+		}
+		my $log_filter_name = $data->{$log_filter_field . ".Name"} || "";
+		if ( length($log_filter_name) > 0) {
+			my $filter = $data->{$log_filter_field . ".Filter"};
+			$filter =~ s/"/\\\"/g;
+			$text .= $log_filter_name . " = filter." . $filter . "\n";
+		}
+	}
+
+	for ( my $i = 0; $i < $max_log_objects; $i = $i + 1 ) {
+		my $log_object_field = "LogObject";
+		if ( $i > 0 ) {
+			$log_object_field = $log_object_field . "$i";
+		}
 
 		my $log_object_filename = $data->{$log_object_field . ".Filename"} || "";
 		if ( length($log_object_filename) > 0 ) {
+			my $log_object_type					= $data->{$log_object_field . ".Type"} || "ascii";
 			my $log_object_format               = $data->{$log_object_field . ".Format"}             || "";
 			my $log_object_rolling_enabled      = $data->{$log_object_field . ".RollingEnabled"}     || "";
 			my $log_object_rolling_interval_sec = $data->{$log_object_field . ".RollingIntervalSec"} || "";
 			my $log_object_rolling_offset_hr    = $data->{$log_object_field . ".RollingOffsetHr"}    || "";
 			my $log_object_rolling_size_mb      = $data->{$log_object_field . ".RollingSizeMb"}      || "";
-			my $log_object_header               = $data->{$log_object_field . ".Header"}             || "";
+			my $log_object_filters				= $data->{$log_object_field . ".Filters"} || "";
 
-			$text .= "\nlog.ascii {\n";
-			$text .= "  Format = " . $log_format_name . ",\n";
-			$text .= "  Filename = '" . $log_object_filename . "',\n";
-			$text .= "  RollingEnabled = " . $log_object_rolling_enabled . ",\n" unless defined();
-			$text .= "  RollingIntervalSec = " . $log_object_rolling_interval_sec . ",\n";
-			$text .= "  RollingOffsetHr = " . $log_object_rolling_offset_hr . ",\n";
-			$text .= "  RollingSizeMb = " . $log_object_rolling_size_mb . "\n";
-			$text .= "}\n";
+			$text .= "\nlog." . $log_object_type . " {\n";
+			$text .= "  Format = " . $log_object_format . ",\n";
+			$text .= "  Filename = '" . $log_object_filename . "'";
+			if ( $log_object_type ne "pipe") {
+				$text .= ",\n";
+				$text .= "  RollingEnabled = " . $log_object_rolling_enabled . ",\n";
+				$text .= "  RollingIntervalSec = " . $log_object_rolling_interval_sec . ",\n";
+				$text .= "  RollingOffsetHr = " . $log_object_rolling_offset_hr . ",\n";
+				$text .= "  RollingSizeMb = " . $log_object_rolling_size_mb;
+			}
+			if ( length($log_object_filters) > 0 ) {
+				$text .= ",\n  Filters = { " . $log_object_filters . " }";
+			}
+			$text .= "\n\}\n";
 		}
 	}
 

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1459,8 +1459,8 @@ sub logging_dot_config {
 		my $log_filter_name = $data->{$log_filter_field . ".Name"} || "";
 		if ( length($log_filter_name) > 0) {
 			my $filter = $data->{$log_filter_field . ".Filter"};
-			$filter =~ s/'/\\'/g;
 			$filter =~ s/\\/\\\\/g;
+			$filter =~ s/'/\\'/g;
 			my $log_filter_type = $data->{$log_filter_field . ".Type"} || "accept";
 			$text .= $log_filter_name . " = filter." . $log_filter_type . "('" . $filter . "')\n";
 		}


### PR DESCRIPTION
#### What does this PR do?

This PR expands the ApacheTrafficServer.pm configuration generation for the lua logging.config file to allow defining log filters and assign them to log objects (see [doc](https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/files/logging.config.en.html)).  In particular, new profile parameters LogFilter.Name, LogFilter.Filter, and LogObject.Filters are supported for logging.config file generation.  This PR also allows the use of the parameter LogObject.Type to enable binary and pipe ATS Log objects.  LogObject.Type defaults to "ascii" so no changes to existing profiles should be required.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [X] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

From Traffic Portal, generate a profile that uses the new LogFilter.Name, LogFilter.Filter, LogObject.Filters, and LogObject.Type parameters, and ensure that the resulting generated logging.config file looks as expected.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [X] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



