### PR TITLE
reuse single riak cluster connection, up riak heartbeat timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.1/deliveryservices/hostname/:hostname/sslkeys `GET`
   - /api/1.1/deliveryservices/sslkeys/add `POST`
   - /api/1.1/deliveryservices/xmlId/:xmlid/sslkeys/delete `GET`
+- To support reusing a single riak cluster connection, an optional parameter is added to riak.conf: "HealthCheckInterval". This options takes a 'Duration' value (ie: 10s, 5m) which affects how often the riak cluster is health checked.  Default is currently set to: "HealthCheckInterval": "5s".
   
 ### Changed
 - Issue 2821: Fixed "Traffic Router may choose wrong certificate when SNI names overlap"

--- a/traffic_ops/traffic_ops_golang/cdn/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssec.go
@@ -208,20 +208,15 @@ func DeleteDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 	}
 	defer inf.Close()
 
-	key := inf.Params["name"]
-
-	riakCluster, err := riaksvc.GetRiakClusterTx(inf.Tx.Tx, inf.Config.RiakAuthOptions)
+	cluster, err := riaksvc.GetPooledCluster(inf.Tx.Tx, inf.Config.RiakAuthOptions)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting riak cluster: "+err.Error()))
 		return
 	}
-	if err := riakCluster.Start(); err != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("starting riak cluster: "+err.Error()))
-		return
-	}
-	defer riaksvc.StopCluster(riakCluster)
 
-	if err := riaksvc.DeleteObject(key, CDNDNSSECKeyType, riakCluster); err != nil {
+	key := inf.Params["name"]
+
+	if err := riaksvc.DeleteObject(key, CDNDNSSECKeyType, cluster); err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deleting cdn dnssec keys: "+err.Error()))
 		return
 	}

--- a/traffic_ops/traffic_ops_golang/riaksvc/dsutil.go
+++ b/traffic_ops/traffic_ops_golang/riaksvc/dsutil.go
@@ -46,7 +46,7 @@ func MakeDSSSLKeyKey(dsName, version string) string {
 func GetDeliveryServiceSSLKeysObj(xmlID string, version string, tx *sql.Tx, authOpts *riak.AuthOptions) (tc.DeliveryServiceSSLKeys, bool, error) {
 	key := tc.DeliveryServiceSSLKeys{}
 	found := false
-	err := WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err := WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		// get the deliveryservice ssl keys by xmlID and version
 		ro, err := FetchObjectValues(MakeDSSSLKeyKey(xmlID, version), DeliveryServiceSSLKeysBucket, cluster)
 		if err != nil {
@@ -73,7 +73,7 @@ func PutDeliveryServiceSSLKeysObj(key tc.DeliveryServiceSSLKeys, tx *sql.Tx, aut
 	if err != nil {
 		return errors.New("marshalling key: " + err.Error())
 	}
-	err = WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err = WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		obj := &riak.Object{
 			ContentType:     "application/json",
 			Charset:         "utf-8",
@@ -99,7 +99,7 @@ func Ping(tx *sql.Tx, authOpts *riak.AuthOptions) (tc.RiakPingResp, error) {
 		return tc.RiakPingResp{}, errors.New("getting riak servers: " + err.Error())
 	}
 	for _, server := range servers {
-		cluster, err := RiakServersToCluster([]ServerAddr{server}, authOpts)
+		cluster, err := GetRiakStorageCluster([]ServerAddr{server}, authOpts)
 		if err != nil {
 			log.Errorf("RiakServersToCluster error for server %+v: %+v\n", server, err.Error())
 			continue // try another server
@@ -126,7 +126,7 @@ func Ping(tx *sql.Tx, authOpts *riak.AuthOptions) (tc.RiakPingResp, error) {
 func GetDNSSECKeys(cdnName string, tx *sql.Tx, authOpts *riak.AuthOptions) (tc.DNSSECKeys, bool, error) {
 	key := tc.DNSSECKeys{}
 	found := false
-	err := WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err := WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		ro, err := FetchObjectValues(cdnName, DNSSECKeysBucket, cluster)
 		if err != nil {
 			return err
@@ -151,7 +151,7 @@ func PutDNSSECKeys(keys tc.DNSSECKeys, cdnName string, tx *sql.Tx, authOpts *ria
 	if err != nil {
 		return errors.New("marshalling keys: " + err.Error())
 	}
-	err = WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err = WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		obj := &riak.Object{
 			ContentType:     "application/json",
 			Charset:         "utf-8",
@@ -170,7 +170,7 @@ func PutDNSSECKeys(keys tc.DNSSECKeys, cdnName string, tx *sql.Tx, authOpts *ria
 func GetBucketKey(tx *sql.Tx, authOpts *riak.AuthOptions, bucket string, key string) ([]byte, bool, error) {
 	val := []byte{}
 	found := false
-	err := WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err := WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		// get the deliveryservice ssl keys by xmlID and version
 		ro, err := FetchObjectValues(key, bucket, cluster)
 		if err != nil {
@@ -190,7 +190,7 @@ func GetBucketKey(tx *sql.Tx, authOpts *riak.AuthOptions, bucket string, key str
 }
 
 func DeleteDSSSLKeys(tx *sql.Tx, authOpts *riak.AuthOptions, xmlID string, version string) error {
-	err := WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err := WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		if err := DeleteObject(MakeDSSSLKeyKey(xmlID, version), DeliveryServiceSSLKeysBucket, cluster); err != nil {
 			return errors.New("deleting SSL keys: " + err.Error())
 		}
@@ -209,7 +209,7 @@ func GetURLSigKeys(tx *sql.Tx, authOpts *riak.AuthOptions, ds tc.DeliveryService
 	val := tc.URLSigKeys{}
 	found := false
 	key := GetURLSigConfigFileName(ds)
-	err := WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err := WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		ro, err := FetchObjectValues(key, URLSigKeysBucket, cluster)
 		if err != nil {
 			return err
@@ -234,7 +234,7 @@ func PutURLSigKeys(tx *sql.Tx, authOpts *riak.AuthOptions, ds tc.DeliveryService
 	if err != nil {
 		return errors.New("marshalling keys: " + err.Error())
 	}
-	err = WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err = WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		obj := &riak.Object{
 			ContentType:     "application/json",
 			Charset:         "utf-8",
@@ -255,7 +255,7 @@ const CDNSSLKeysLimit = 1000 // TODO: emulates Perl; reevaluate?
 
 func GetCDNSSLKeysObj(tx *sql.Tx, authOpts *riak.AuthOptions, cdnName string) ([]tc.CDNSSLKey, error) {
 	keys := []tc.CDNSSLKey{}
-	err := WithClusterTx(tx, authOpts, func(cluster StorageCluster) error {
+	err := WithCluster(tx, authOpts, func(cluster StorageCluster) error {
 		// get the deliveryservice ssl keys by xmlID and version
 		query := `cdn:` + cdnName
 		filterQuery := `_yz_rk:*latest`

--- a/traffic_ops/traffic_ops_golang/riaksvc/riak_services_test.go
+++ b/traffic_ops/traffic_ops_golang/riaksvc/riak_services_test.go
@@ -164,7 +164,7 @@ func TestGetRiakCluster(t *testing.T) {
 	}
 	defer tx.Commit()
 
-	if _, err := GetRiakClusterTx(tx, nil); err == nil {
+	if _, err := GetRiakCluster(tx, nil); err == nil {
 		t.Errorf("expected an error due to nil RiakAuthoptions in the config but, go no error.")
 	}
 
@@ -174,14 +174,22 @@ func TestGetRiakCluster(t *testing.T) {
 		TlsConfig: &tls.Config{},
 	}
 
-	if _, err := GetRiakClusterTx(tx, &authOptions); err != nil {
+	if _, err := GetRiakCluster(tx, &authOptions); err != nil {
+		t.Errorf("expected no errors, actual: %s.", err)
+	}
+
+	if _, err := GetPooledCluster(tx, &authOptions); err != nil {
 		t.Errorf("expected no errors, actual: %s.", err)
 	}
 
 	rows2 := sqlmock.NewRows([]string{"s.host_name", "s.domain_name"})
 	mock.ExpectQuery("SELECT").WillReturnRows(rows2)
 
-	if _, err := GetRiakClusterTx(tx, &authOptions); err == nil {
+	if _, err := GetRiakCluster(tx, &authOptions); err == nil {
+		t.Errorf("expected an error due to no available riak servers.")
+	}
+
+	if _, err := GetPooledCluster(tx, &authOptions); err == nil {
 		t.Errorf("expected an error due to no available riak servers.")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/urisigning.go
+++ b/traffic_ops/traffic_ops_golang/urisigning.go
@@ -65,12 +65,11 @@ func getURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cluster, err := riaksvc.StartCluster(inf.Tx.Tx, inf.Config.RiakAuthOptions)
+	cluster, err := riaksvc.GetPooledCluster(inf.Tx.Tx, inf.Config.RiakAuthOptions)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("starting riak cluster: "+err.Error()))
 		return
 	}
-	defer riaksvc.StopCluster(cluster)
 
 	ro, err := riaksvc.FetchObjectValues(xmlID, CDNURIKeysBucket, cluster)
 	if err != nil {
@@ -105,12 +104,11 @@ func removeDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	cluster, err := riaksvc.StartCluster(inf.Tx.Tx, inf.Config.RiakAuthOptions)
+	cluster, err := riaksvc.GetPooledCluster(inf.Tx.Tx, inf.Config.RiakAuthOptions)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("starting riak cluster: "+err.Error()))
 		return
 	}
-	defer riaksvc.StopCluster(cluster)
 
 	ro, err := riaksvc.FetchObjectValues(xmlID, CDNURIKeysBucket, cluster)
 	if err != nil {
@@ -165,12 +163,11 @@ func saveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cluster, err := riaksvc.StartCluster(inf.Tx.Tx, inf.Config.RiakAuthOptions)
+	cluster, err := riaksvc.GetPooledCluster(inf.Tx.Tx, inf.Config.RiakAuthOptions)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("starting riak cluster: "+err.Error()))
 		return
 	}
-	defer riaksvc.StopCluster(cluster)
 
 	obj := &riak.Object{
 		ContentType:     "text/json",


### PR DESCRIPTION
#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [x] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Generate and delete SSL keys via traffic portal.
Use curl against the sslkeys api: api/1.3/cdns/name/<cdnname>/sslkeys
Start and stop riak cluster nodes (need to wait for cluster to come online)

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [x] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



