### PR TITLE
Change Traffic Ops to 501 Not Implemented on unknown version reqs, and client to return a helpful message

### DIFF
--- a/traffic_ops/client/session.go
+++ b/traffic_ops/client/session.go
@@ -254,6 +254,11 @@ func (to *Session) ErrUnlessOK(resp *http.Response, remoteAddr net.Addr, err err
 	}
 
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotImplemented {
+		return nil, remoteAddr, errors.New("Traffic Ops Server returned 'Not Implemented', this client is probably newer than Traffic Ops, and you probably need to either upgrade Traffic Ops, or use a client whose version matches your Traffic Ops version.")
+	}
+
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
 		return nil, remoteAddr, readErr

--- a/traffic_ops/traffic_ops_golang/wrappers.go
+++ b/traffic_ops/traffic_ops_golang/wrappers.go
@@ -275,3 +275,11 @@ func (i *BodyInterceptor) RealWrite(b []byte) (int, error) {
 func (i *BodyInterceptor) Body() []byte {
 	return i.body
 }
+
+func NotImplementedHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(tc.ContentType, tc.ApplicationJson)
+		w.WriteHeader(http.StatusNotImplemented)
+		w.Write([]byte(`{"alerts":[{"level":"error","text":"The requested api version is not implemented by this server. If you are using a newer client with an older server, you will need to use an older client version or upgrade your server."}]}`))
+	})
+}


### PR DESCRIPTION
Change Traffic Ops to 501 Not Implemented on unknown version reqs, and client to return a helpful message

#### What does this PR do?

Change Traffic Ops to 501 Not Implemented on unknown version reqs, and client to return a helpful message

This is intended to mitigate the confusion for people running master, who try to use a newer client than their server, after a recent minor version increase.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Try to connect to a TO server since before a minor version bump (e.g. 1.3) with a client after the version increase. The client should return a helpful message.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



