### PR TITLE
CDN in a Box Documentation

### DIFF
--- a/docs/source/admin/quick_howto/ciab.rst
+++ b/docs/source/admin/quick_howto/ciab.rst
@@ -1,0 +1,117 @@
+..
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _ciab:
+
+************
+CDN in a Box
+************
+"CDN in a Box" is a name given to the time-honored tradition of new Traffic Control developers/potential users attempting to set up their own miniature CDN to just see how it all fits together. Historically, this has been a nightmare of digging through leftover ``virsh`` scripts and manually configuring pretty hefty networking changes (don't even get me started on DNS) and just generally having a bad time. For a few years now, different people had made it to various stages of merging the project into Docker for ease of networking, but certain constraints hampered progress - until now. The project has finally reached a working state, and now getting a mock/test CDN running can be a very simple task (albeit rather time-consuming).
+
+Getting Started
+===============
+Because it runs in Docker, the only true prerequisites are:
+
+* Docker version >= 17.05.0-ce
+* Docker Compose\ [1]_ version >= 1.9.0
+
+Building
+--------
+The CDN in a Box directory is found within the Traffic Control repository at ``infrastructure/cdn-in-a-box/``. CDN in a Box relies on the presence of pre-built RPM files for the following Traffic Control components:
+
+* Traffic Monitor - at ``infrastructure/cdn-in-a-box/traffic_monitor/traffic_monitor.rpm``
+* Traffic Ops - at ``infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm``
+* Traffic Portal - at ``infrastructure/cdn-in-a-box/traffic_portal/traffic_portal.rpm``
+* Traffic Router - at ``infrastructure/cdn-in-a-box/traffic_router/traffic_router.rpm`` - also requires an Apache Tomcat RPM at ``infrastructure/cdn-in-a-box/traffic_router/tomcat.rpm``
+
+.. note:: These can also be specified via the ``RPM`` variable to a direct Docker build of the component - with the exception of Traffic Router, which instead accepts ``JDK8_RPM`` to specify a Java Development Kit RPM,  ``TRAFFIC_ROUTER_RPM`` to specify a Traffic Router RPM, and  ``TOMCAT_RPM`` to specify an Apache Tomcat RPM.
+
+These can all be supplied manually via the steps in :ref:`dev-building` (for Traffic Control component RPMs) or via some external source. Alternatively, the ``infrastructure/cdn-in-a-box/Makefile`` file contains recipes to build all of these - simply run ``make``\ [2]_ from the ``infrastructure/cdn-in-a-box/`` directory.
+Once all RPM dependencies have been satisfied, run ``docker-compose build`` from the ``infrastructure/cdn-in-a-box/`` directory to construct the images needed to run CDN in a Box.
+
+Usage
+-----
+In a typical scenario, if the steps in `Building`_ have been followed, all that's required to start the CDN in a Box is to run ``docker-compose up`` - optionally with ``-d``  to run without binding to the terminal - from the ``infrastructure/cdn-in-a-box/`` directory. This will start up the entire stack and should take care of any needed initial configuration. The services within the containers are exposed locally to the host on specific ports. These are configured within the ``infrastructure/cdn-in-a-box/docker-compose.yml`` file, but the default ports are shown in :ref:`ciab-service-info`. Some services have credentials associated, which are totally configurable in `variables.env`_.
+
+.. _ciab-service-info:
+.. table:: Service Info
+
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Service                         | Ports exposed and their usage                                | Username                              | Password                                  |
+	+=================================+==============================================================+=======================================+===========================================+
+	| DNS                             | DNS name resolution on 9353                                  | N/A                                   | N/A                                       |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Edge Tier Cache                 | Apache Trafficserver HTTP caching reverse proxy on port 9000 | N/A                                   | N/A                                       |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Mid Tier Cache                  | Apache Trafficserver HTTP caching forward proxy on port 9100 | N/A                                   | N/A                                       |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Mock Origin Server              | Example web page served on port 9200                         | N/A                                   | N/A                                       |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Traffic Monitor                 | Web interface and API on port 80                             | N/A                                   | N/A                                       |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Traffic Ops                     | Main API endpoints on port 6443, with a direct route to the  | ``TO_ADMIN_USER`` in `variables.env`_ | ``TO_ADMIN_PASSWORD`` in `variables.env`_ |
+	|                                 | Perl API on port 60443\ [3]_                                 |                                       |                                           |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Traffic Ops PostgresQL Database | PostgresQL connections accepted on port 5432 (database name: | ``DB_USER`` in `variables.env`_       | ``DB_USER_PASS`` in `variables.env`_      |
+	|                                 | ``DB_NAME`` in `variables.env`_)                             |                                       |                                           |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Traffic Portal                  | Web interface on 443 (Javascript required)                   | ``TO_ADMIN_USER`` in `variables.env`_ | ``TO_ADMIN_PASSWORD`` in `variables.env`_ |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Traffic Router                  | Web interfaces on ports 3080 (HTTP) and 3443 (HTTPS), with a | N/A                                   | N/A                                       |
+	|                                 | DNS service on 53 and an API on 3333                         |                                       |                                           |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+	| Traffic Vault                   | Riak key-value store on port 8010                            | ``TV_ADMIN_USER`` in `variables.env`_ | ``TV_ADMIN_PASSWORD`` in `variables.env`_ |
+	+---------------------------------+--------------------------------------------------------------+---------------------------------------+-------------------------------------------+
+
+.. seealso:: :ref:`tr-api` and :ref:`tm-api`
+
+While the components may be interacted with by the host using these ports, the true operation of the CDN can only truly be seen from within the Docker network. To see the CDN in action, connect to a container within the CDN in a Box project and use cURL to request the URL ``http://video.demo1.mycdn.ciab.test`` which will be resolved by the DNS container to the IP of the Traffic Router, which will provide a ``302 FOUND`` response pointing to the Edge-Tier cache. A typical choice for this is the "enroller" service, which has a very nuanced purpose not discussed here but already has the ``curl`` command line tool installed. For a more user-friendly interface into the CDN network, see `The Test Client`_.
+
+.. code-block:: shell
+	:caption: Example Command to See the CDN in Action
+
+	sudo docker-compose exec enroller /usr/bin/curl -L "http://video.demo1.mycdn.ciab.test"
+
+When the CDN is to be shut down, it is often best to do so using ``sudo docker-compose down -v`` due to the use of shared volumes in the system which might interfere with a proper initialization upon the next run.
+
+variables.env
+"""""""""""""
+.. include:: ../../../../infrastructure/cdn-in-a-box/variables.env
+	:code: shell
+	:start-line: 16
+	:tab-width: 4
+
+.. note:: While these port settings can be changed without hampering the function of the CDN in a Box system, note that changing a port without also changing the matching port-mapping in ``infrastructure/cdn-in-a-box/docker-compose.yml`` for the affected service *will* make it unreachable from the host.
+
+.. [1] It is perfectly possible to build and run all containers without Docker Compose, but it's not recommended and not covered in this guide.
+.. [2] Consider ``make -j`` to build quickly, if your computer can handle multiple builds at once.
+.. [3] Please do NOT use the Perl endpoints directly. The CDN will only work properly if everything hits the Go API, which will proxy to the Perl endpoints as needed.
+
+Advanced Usage
+==============
+This section will be amended as functionality is added to the CDN in a Box project.
+
+The Test Client
+---------------
+The "testclient" service is an optional extension to CDN in a Box which provides several more user-friendly interfaces to the CDN network. Specifically it contains:
+
+* A small HTTP proxy on port 7070
+* An SSH server listening on port 2200
+* A VNC server on port 5900
+* A Socks5 Proxy on port 9090
+
+Using this, the CDN can be directly utilized using the network's internal name resolution and a web browser. To use the test client, pass ``-f docker-compose.testclient.yml`` either to the same ``docker-compose`` command, or to a separate ``docker-compose`` command run after the CDN in a Box has already started. If the former is done, note that it is also necessary to pass ``-f docker-compose.yml`` to properly build the entire system along with the test client.
+
+.. seealso:: `The official Docker Compose documentation CLI reference <https://docs.docker.com/compose/reference/>`_ for complete instructions on how to pass service definition files to the ``docker-compose`` executable.

--- a/docs/source/admin/quick_howto/index.rst
+++ b/docs/source/admin/quick_howto/index.rst
@@ -18,21 +18,13 @@ Quick How To Guides
 *******************
 Traffic Control is a complicated system, and documenting it is not trivial. Sometimes a picture says more than a thousand words, so here are some screen shot based tutorials on how to use some of the more involved features.
 
-Traffic Ops
-===========
-
 .. toctree::
 
-	multi_site.rst
-	federations.rst
-	regionalgeo.rst
-	anonymous_blocking.rst
-
-Traffic Portal
-==============
-
-.. toctree::
-
-	dnssec.rst
-	ds_requests.rst
-	steering.rst
+	multi_site
+	federations
+	regionalgeo
+	anonymous_blocking
+	dnssec
+	ds_requests
+	steering
+	ciab

--- a/infrastructure/cdn-in-a-box/README.md
+++ b/infrastructure/cdn-in-a-box/README.md
@@ -22,17 +22,12 @@ This is intended to simplify the process of creating a "CDN in a box", easing
 the barrier to entry for newcomers as well as providing a way to spin up a
 minimal CDN for full system testing.
 
-## Implemented Components
-As of the time of this writing, Traffic Ops, Traffic Monitor, Traffic Portal and a
-database server for Traffic Ops are all fully implemented. An edge-tier cache,
-mid-tier cache and simple origin are also all implemented, although with limited
-functionality (caches do not respond to update queues/routing, and origin serves
-static HTTP content - likely subject to change in favor of proper video streaming in
-the future). Other components will follow as well as details on specific parts of the
-implementation.
+> **note**
+>
+> For a more in-depth discussion of the CDN in a Box system, please see [the official documentation](https://traffic-control-cdn.readthedocs.io/en/latest/admin/quick_howto/ciab.html).
 
 ## Setup
-The containers run on docker, and require Docker (tested v17.05.0-ce) and Docker
+The containers run on Docker, and require Docker (tested v17.05.0-ce) and Docker
 Compose (tested v1.9.0) to build and run. On most 'nix systems these can be installed
 via the distribution's package manager under the names `docker-ce` and
 `docker-compose`, respectively (e.g. `sudo yum install docker-ce`).
@@ -73,72 +68,92 @@ show you the default UI for interacting with the CDN - Traffic Portal.
 > warnings may be safely ignored via the e.g. `Add Exception` button (possibly hidden
 > behind e.g. `Advanced Options`).
 
+> <table>
+> <colgroup>
+> <col width="18%" />
+> <col width="34%" />
+> <col width="22%" />
+> <col width="24%" />
+> </colgroup>
+> <thead>
+> <tr class="header">
+> <th align="left">Service</th>
+> <th align="left">Ports exposed and their usage</th>
+> <th align="left">Username</th>
+> <th align="left">Password</th>
+> </tr>
+> </thead>
+> <tbody>
+> <tr class="odd">
+> <td align="left">DNS</td>
+> <td align="left">DNS name resolution on 9353</td>
+> <td align="left">N/A</td>
+> <td align="left">N/A</td>
+> </tr>
+> <tr class="even">
+> <td align="left">Edge Tier Cache</td>
+> <td align="left">Apache Trafficserver HTTP caching reverse proxy on port 9000</td>
+> <td align="left">N/A</td>
+> <td align="left">N/A</td>
+> </tr>
+> <tr class="odd">
+> <td align="left">Mid Tier Cache</td>
+> <td align="left">Apache Trafficserver HTTP caching forward proxy on port 9100</td>
+> <td align="left">N/A</td>
+> <td align="left">N/A</td>
+> </tr>
+> <tr class="even">
+> <td align="left">Mock Origin Server</td>
+> <td align="left">Example web page served on port 9200</td>
+> <td align="left">N/A</td>
+> <td align="left">N/A</td>
+> </tr>
+> <tr class="odd">
+> <td align="left">Traffic Monitor</td>
+> <td align="left">Web interface and API on port 80</td>
+> <td align="left">N/A</td>
+> <td align="left">N/A</td>
+> </tr>
+> <tr class="even">
+> <td align="left">Traffic Ops</td>
+> <td align="left">Main API endpoints on port 6443, with a direct route to the Perl API on port 60443<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a></td>
+> <td align="left"><code>TO_ADMIN_USER</code> in variables.env</td>
+> <td align="left"><code>TO_ADMIN_PASSWORD</code> in variables.env</td>
+> </tr>
+> <tr class="odd">
+> <td align="left">Traffic Ops PostgresQL Database</td>
+> <td align="left">PostgresQL connections accepted on port 5432 (database name: <code>DB_NAME</code> in variables.env)</td>
+> <td align="left"><code>DB_USER</code> in variables.env</td>
+> <td align="left"><code>DB_USER_PASS</code> in variables.env</td>
+> </tr>
+> <tr class="even">
+> <td align="left">Traffic Portal</td>
+> <td align="left">Web interface on 443 (Javascript required)</td>
+> <td align="left"><code>TO_ADMIN_USER</code> in variables.env</td>
+> <td align="left"><code>TO_ADMIN_PASSWORD</code> in variables.env</td>
+> </tr>
+> <tr class="odd">
+> <td align="left">Traffic Router</td>
+> <td align="left">Web interfaces on ports 3080 (HTTP) and 3443 (HTTPS), with a DNS service on 53 and an API on 3333</td>
+> <td align="left">N/A</td>
+> <td align="left">N/A</td>
+> </tr>
+> <tr class="even">
+> <td align="left">Traffic Vault</td>
+> <td align="left">Riak key-value store on port 8010</td>
+> <td align="left"><code>TV_ADMIN_USER</code> in variables.env</td>
+> <td align="left"><code>TV_ADMIN_PASSWORD</code> in variables.env</td>
+> </tr>
+> </tbody>
+> </table>
+> <div class="footnotes">
+> <hr />
+> <ol>
+> <li id="fn1"><p>Please do NOT use the Perl endpoints directly. The CDN will only work properly if everything hits the Go API, which will proxy to the Perl endpoints as needed.<a href="#fnref1">↩</a></p></li>
+> </ol>
+> </div>
+>
 
-
-### Traffic Ops
-The API and legacy UI for the CDN
-* URLs:
-	* New Go endpoints: [`https://localhost:6443`](https://localhost:6443)
-	* Limited, Legacy Perl endpoints: [`https://localhost:60443`](https://localhost:60443)
-* Login Credentials:
-	* Username: Defined by `TO_ADMIN_USER` in [`variables.env`](./variables.env)
-	* Password: Defined by `TO_ADMIN_PASSWORD` in [`variables.env`](./variables.env)
-
-Login credentials will work for both sets of endpoints.
-Note that the recommended way to access the Traffic Ops API is through the new Go endpoints.
-Not all endpoints have been implemented in Go, but the Go server will proxy requests it cannot
-service back to the legacy API.
-
-### Traffic Portal
-The modern UI for the CDN
-* URL: [`https://localhost`](https://localhost)
-* Login Credentials:
-	* Username: Defined by `TO_ADMIN_USER` in [`variables.env`](./variables.env)
-	* Password: Defined by `TO_ADMIN_PASSWORD` in [`variables.env`](./variables.env)
-
-### Traffic Ops PostgreSQL Database
-This holds the configuration information for the entire CDN. It is normally accessed
-directly only by Traffic Ops.
-* URL: [`postgres://traffic_ops:twelve@localhost:5432/traffic_ops`](postgres://traffic_ops:twelve@localhost:5432/traffic_ops)
-* Login Credentials:
-	* Username: Defined by `DB_USER` in [`variables.env`](./variables.env)
-	* Password: Defined by `DB_USER_PASS` in [`variables.env`](./variables.env)
-* Port: 5432
-* Database: Defined by `DB_NAME` in [`variables.env`](./variables.env)
-
-### Traffic Vault
-A secure storage server for private keys used by Traffic Ops
-* Port: 8010
-
-### Traffic Monitor
-Traffic Monitor is responsible for monitoring and reporting the "health" of edge- and
-mid-tier caches (See [the documentation](http://traffic-control-cdn.readthedocs.io/en//latest/overview/traffic_monitor.html) for details).
-
-* URL: [`http://localhost`](http://localhost)
-
-### Edge-Tier Cache
-An edge-tier cache sits at the outermost extremity of the CDN, typically serving content
-directly to the user from either its cache, or a parent cache group. The management port
-is not exposed locally - however the main content port is.
-
-* URL: [`http://localhost:8080`](http://localhost:8080)
-
-### Mid-Tier Cache
-A mid-tier cache serves content internally - within the CDN. Typically, requests are
-made from an edge-tier cache and the mid serves content from its own cache, a parent
-mid-tier cache or directly from the origin. The management port is not exposed locally -
-however the main content port is.
-
-* URL: [`http://localhost:9080`](http://localhost:8081)
-
-### Origin Server
-An origin server simply serves HTTP(S) content. The CDN-in-a-box origin server serves up
-a very simple page sporting the Traffic Control logo.
-
-* URL: [`http://localhost:8081`](http://localhost:9080)
-
-The process creates containers for each component with ports exposed on the host.  The
-following should be available once the system is running:
 
 
 ## Common Pitfalls

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -27,8 +27,8 @@ RUN yum install -y epel-release && \
     yum install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm && \
     yum install -y \
 	    cpanminus \
-      bind-utils \ 
-      net-tools \ 
+      bind-utils \
+      net-tools \
 	    gettext \
 	    nmap-ncat \
 	    openssl \
@@ -36,8 +36,8 @@ RUN yum install -y epel-release && \
 	    perl-Crypt-ScryptKDF \
 	    perl-Test-CPAN-Meta \
       perl-JSON-PP \
-      git \ 
-      golang 
+      git \
+      golang
 
 RUN yum install -y perl-DBIx-Connector
 

--- a/infrastructure/cdn-in-a-box/traffic_router/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_router/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ############################################################
-# Dockerfile to build Traffic Router 3.0 
+# Dockerfile to build Traffic Router 3.0
 # Based on CentOS 7.x
 ############################################################
 
@@ -25,12 +25,12 @@ MAINTAINER Dan Kirkwood
 # Default values for TMCAT RPM and RPM -- override with `docker build --build-arg JDK=...'
 ARG JDK8_RPM=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.rpm
 ARG TRAFFIC_ROUTER_RPM=traffic_router/traffic_router.rpm
-ARG TOMCAT_RPM=traffic_router/tomcat.rpm 
+ARG TOMCAT_RPM=traffic_router/tomcat.rpm
 
 ### Common for all sub-component builds
 RUN	yum -y install epel-release git rpm-build net-tools iproute nc wget tar unzip \
           perl-JSON perl-WWWCurl which make autoconf automake gcc gcc-c++ apr apr-devel \
-					openssl openssl-devel bind-utils net-tools perl-JSON-PP gettext && \ 
+					openssl openssl-devel bind-utils net-tools perl-JSON-PP gettext && \
     yum -y clean all
 
 ADD $TRAFFIC_ROUTER_RPM /traffic_router.rpm
@@ -41,19 +41,19 @@ RUN curl -kvsL -o /jdk8.rpm -H  'Cookie: oraclelicense=accept-securebackup-cooki
     rpm -ivh /jdk8.rpm && \
     ln -sfv $(find /usr/java -mindepth 1 -maxdepth 1 -type d -name jdk\*)   /opt/java
 
-# Install Tomcat and Tomcat Native 
+# Install Tomcat and Tomcat Native
 RUN cd / && rpm2cpio /traffic_router.rpm | cpio -ivd && \
-    rpm2cpio /tomcat.rpm | cpio -ivd && \ 
+    rpm2cpio /tomcat.rpm | cpio -ivd && \
  		tar -C /opt -xvpf /opt/tomcat/bin/tomcat-native.tar.gz
 
 # Compile and install Tomcat-native
 RUN	cd $(find /opt -maxdepth 1 -type d | grep tomcat-native )/native && \
     ./configure --prefix=/opt/tomcat --with-apr=`which apr-1-config` --with-java-home=/opt/java --with-ssl && \
 		make install
-     
-ADD enroller/server_template.json \ 
-    traffic_router/run.sh \ 
-    traffic_ops/to-access.sh \ 
+
+ADD enroller/server_template.json \
+    traffic_router/run.sh \
+    traffic_ops/to-access.sh \
     /
 
 EXPOSE 53 80 3333


### PR DESCRIPTION
#### What does this PR do?

Adds documentation for the CDN in a Box project, updates `infrastructure/cdn-in-a-box/README.md` and minor fixes to a Dockerfile in ciab as well as removing now-unused recipes from the ciab Makefile

#### Which TC components are affected by this PR?

- [x] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] CDN in a Box

#### What is the best way to verify this PR?
Build RPMs with the cdn-in-a-box makefile, build the docs, and read them and the README to make sure everything makes sense.

#### Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



