### PR TITLE
Emit helpful error message when building traffic_monitor or traffic_stats rpm via pkg fails

### DIFF
--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -26,17 +26,6 @@ services:
     volumes:
       - ../../..:/trafficcontrol:z
 
-  # NOTE: Disabled java traffic_monitor in favor of golang version.
-  # The java version is to be renamed to traffic_monitor_legacy soon
-  # and eventually removed.
-  # traffic_monitor_legacy_build:
-  #   image: traffic_monitor_legacy_builder
-  #   build:
-  #     dockerfile: infrastructure/docker/build/Dockerfile-traffic_monitor_legacy
-  #     context: ../../..
-  #   volumes:
-  #     - ../../..:/trafficcontrol:z
-
   traffic_monitor_build:
     image: traffic_monitor_builder
     build:

--- a/traffic_monitor/build/build_rpm.sh
+++ b/traffic_monitor/build/build_rpm.sh
@@ -50,9 +50,17 @@ function initBuildArea() {
 	echo "The build area has been initialized."
 }
 
+function preBuildChecks() {
+	if [[ -e "$TM_DIR"/traffic_monitor ]]; then
+		echo "Found $TM_DIR/traffic_monitor, please remove before retrying to build"
+		exit 1
+	fi
+}
+
 # ---------------------------------------
 
 importFunctions
+preBuildChecks
 checkEnvironment go
 initBuildArea
 buildRpm traffic_monitor

--- a/traffic_stats/build/build_rpm.sh
+++ b/traffic_stats/build/build_rpm.sh
@@ -50,9 +50,17 @@ function initBuildArea() {
 	echo "The build area has been initialized."
 }
 
+function preBuildChecks() {
+    if [[ -e "$TS_DIR"/traffic_stats ]]; then
+        echo "Found $TS_DIR/traffic_stats, please remove before retrying to build"
+        exit 1
+    fi
+}
+
 # ---------------------------------------
 
 importFunctions
+preBuildChecks
 checkEnvironment go
 initBuildArea
 buildRpm traffic_stats


### PR DESCRIPTION
#### What does this PR do?

When building the traffic_monitor or traffic_stats rpm using the `pkg` script, it will
fail if there is a file at traffic_monitor/traffic_monitor or traffic_stats/traffic_stats, respectively (i.e. you
previously built the traffic_monitor and/or traffic_stats binary manually and left it there). This is the error you will currently get for the TM build (the TS error is basically the same):
```
cp: cannot overwrite non-directory '/tmp/trafficcontrol/rpmbuild/SOURCES/traffic_monitor-3.0.0/traffic_monitor' with directory '/tmp/trafficcontrol/traffic_monitor/'
Could not copy /tmp/trafficcontrol/traffic_monitor to /tmp/trafficcontrol/rpmbuild/SOURCES/traffic_monitor-3.0.0: 1
```

Provide a more helpful message that describes why the build will fail
and give the user a chance to save their traffic_monitor binary before removing it.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Without this PR, run `./pkg -v traffic_monitor_build traffic_stats_build` while there is a file at `traffic_monitor/traffic_monitor` and `traffic_stats/traffic_stats`. The build should fail but provides no helpful error message. With this PR, run the same thing and look for the more helpful error message in the output.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



