### PR TITLE
Remove Centos6 references from docs

### DIFF
--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -24,7 +24,7 @@ Installing Traffic Monitor
 
 The following are hard requirements requirements for Traffic Monitor to operate:
 
-* CentOS 6+
+* CentOS 7+
 * Successful install of Traffic Ops (usually on a separate machine)
 * Administrative access to the Traffic Ops (usually on a separate machine)
 

--- a/docs/source/admin/traffic_ops/configuration.rst
+++ b/docs/source/admin/traffic_ops/configuration.rst
@@ -318,7 +318,7 @@ Create a ks.src file in the root of the selection location. See the example belo
 
 	mkdir newdir
 	cd newdir/
-	cp -r ../centos65/* .
+	cp -r ../centos74/* .
 	vim ks.src
 	vim isolinux/isolinux.cfg
 	cd vim osversions.cfg

--- a/docs/source/admin/traffic_ops/using.rst
+++ b/docs/source/admin/traffic_ops/using.rst
@@ -996,7 +996,7 @@ Tools
 
 Generate ISO
 ------------
-Generate ISO is a tool for building custom ISOs for building caches on remote hosts. Currently it only supports Centos 6, but if you're brave and pure of heart you MIGHT be able to get it to work with other unix-like OS's.
+Generate ISO is a tool for building custom ISOs for building caches on remote hosts. Currently it only supports Centos 7, but if you're brave and pure of heart you MIGHT be able to get it to work with other unix-like OS's.
 
 The interface is *mostly* self-explanatory as it's got hints.
 

--- a/docs/source/admin/traffic_portal/installation.rst
+++ b/docs/source/admin/traffic_portal/installation.rst
@@ -16,7 +16,7 @@
 *****************************
 Traffic Portal Administration
 *****************************
-Traffic Portal is only supported on CentOS Linux distributions - version 6.7 or higher (including 7.x). It runs on NodeJS and requires version 6.0 or higher.
+Traffic Portal is only supported on CentOS Linux distributions version 7.x. It runs on NodeJS and requires version 6.0 or higher.
 
 
 Installing Traffic Portal

--- a/docs/source/admin/traffic_portal/usingtrafficportal.rst
+++ b/docs/source/admin/traffic_portal/usingtrafficportal.rst
@@ -489,7 +489,7 @@ Invalidate content includes the ability to (where applicable):
 
 Generate ISO
 ------------
-Generates a boot-able system image for any of the servers in the Servers table (or any server for that matter). Currently it only supports CentOS 6 or 7, but if you're brave and pure of heart you MIGHT be able to get it to work with other Unix-like Operating Systems. The interface is *mostly* self-explanatory, but here is a short explanation of the fields in that form.
+Generates a boot-able system image for any of the servers in the Servers table (or any server for that matter). Currently it only supports CentOS 7, but if you're brave and pure of heart you MIGHT be able to get it to work with other Unix-like Operating Systems. The interface is *mostly* self-explanatory, but here is a short explanation of the fields in that form.
 
 Copy Server Attributes From
 	Optional. This option lets the user choose a server from the Traffic Ops database and will auto-fill the other fields as much as possible based on that server's properties


### PR DESCRIPTION
#### What does this PR do?
Cleans up remaining mentions of Centos 6 in the documents

#### Which TC components are affected by this PR?

- [x] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Read through the modified pages of the PR. 

#### Check all that apply

- [ ] This PR includes tests
- [X] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



