### PR TITLE
Update logrotate for grove and change some messaging from Error to Info level.

### DIFF
--- a/grove/build/grove.logrotate
+++ b/grove/build/grove.logrotate
@@ -34,3 +34,14 @@
         rotate 5
         copytruncate
 }
+
+/var/log/grove/error.log {
+        compress
+        maxage 30
+        missingok
+        nomail
+        size 100M
+        rotate 5
+        copytruncate
+}
+

--- a/grove/cache/handler.go
+++ b/grove/cache/handler.go
@@ -175,10 +175,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	conn := (*web.InterceptConn)(nil)
 	if realConn, ok := h.conns.Get(r.RemoteAddr); !ok {
-		log.Errorf("RemoteAddr '%v' not in Conns (reqid %v)\n", r.RemoteAddr, reqID)
+		log.Infof("RemoteAddr '%v' not in Conns (reqid %v)\n", r.RemoteAddr, reqID)
 	} else {
 		if conn, ok = realConn.(*web.InterceptConn); !ok {
-			log.Errorf("Could not get Conn info: Conn is not an InterceptConn: %T (reqid %v)\n", realConn, reqID)
+			log.Infof("Could not get Conn info: Conn is not an InterceptConn: %T (reqid %v)\n", realConn, reqID)
 		}
 	}
 
@@ -186,7 +186,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if err == nil { // if we failed to get a remapping, there's no DSCP to set.
 		if err := conn.SetDSCP(remappingProducer.DSCP()); err != nil {
-			log.Errorln(time.Now().Format(time.RFC3339Nano) + " " + r.RemoteAddr + " " + r.Method + " " + r.RequestURI + ": could not set DSCP: " + err.Error() + " (reqid " + strconv.FormatUint(reqID, 10) + ")")
+			log.Infoln(time.Now().Format(time.RFC3339Nano) + " " + r.RemoteAddr + " " + r.Method + " " + r.RequestURI + ": could not set DSCP: " + err.Error() + " (reqid " + strconv.FormatUint(reqID, 10) + ")")
 		}
 	}
 

--- a/grove/web/listener.go
+++ b/grove/web/listener.go
@@ -39,7 +39,7 @@ func getConnStateCallback(connMap *ConnMap) func(net.Conn, http.ConnState) {
 			fallthrough
 		case http.StateIdle:
 			if iconn, ok := conn.(*InterceptConn); !ok {
-				log.Errorf("ConnState callback: idle conn is not a InterceptConn: '%T'\n", conn)
+				log.Infof("ConnState callback: idle conn is not a InterceptConn: '%T'\n", conn)
 			} else {
 				// MUST be zeroed when the conn moves to Idle, because the Active callback happens _after_ some/all bytes have been read
 				iconn.bytesRead = 0
@@ -48,7 +48,7 @@ func getConnStateCallback(connMap *ConnMap) func(net.Conn, http.ConnState) {
 			connMap.Remove(conn.RemoteAddr().String())
 		case http.StateActive:
 			if iconn, ok := conn.(*InterceptConn); !ok {
-				log.Errorf("ConnState callback: active conn is not a InterceptConn: '%T'\n", conn)
+				log.Infof("ConnState callback: active conn is not a InterceptConn: '%T'\n", conn)
 			} else {
 				connMap.Add(iconn)
 			}


### PR DESCRIPTION
#### What does this PR do?

This changes some error messaging in grove to 'Info' log level as
these messages are more informative than they are errors and they are
filling up the error.logs.  Also updates logrotate to add in error.log
rotation.

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [x] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
/var/log/grove/error.log is rotated once it grows beyond 100m and no-longer logs messages about 'InterceptConn'.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



