### PR TITLE
fix grove and grovetccfg build from tarball

### DIFF
--- a/grove/build/build_rpm.sh
+++ b/grove/build/build_rpm.sh
@@ -14,7 +14,6 @@
 
 #----------------------------------------
 function importFunctions() {
-	TC_DIR=$(git rev-parse --show-toplevel)
 	[ ! -z "$TC_DIR" ] || { echo "Cannot find repository root." >&2 ; exit 1; }
 	export TC_DIR
 	functions_sh="$TC_DIR/build/functions.sh"

--- a/grove/grovetccfg/build/build_rpm.sh
+++ b/grove/grovetccfg/build/build_rpm.sh
@@ -14,7 +14,6 @@
 
 #----------------------------------------
 function importFunctions() {
-	TC_DIR=$(git rev-parse --show-toplevel)
 	[ ! -z "$TC_DIR" ] || { echo "Cannot find repository root." >&2 ; exit 1; }
 	export TC_DIR
 	functions_sh="$TC_DIR/build/functions.sh"


### PR DESCRIPTION
#### What does this PR do?

Allows ./pkg to build grove and grovetccfg from source using the tarball delivered as the source for a release.   That tarball has no git information,  so the build_rpm.sh script can't use git to determine the top-level directory.

Fixes #2981 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [x] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

```
./pkg -v source
cd /tmp; tar xzvf <trafficcontrol top-level dir>/dist/apache-trafficcontrol-3.0.0.tar.gz
cd apache-trafficcontrol-3.0.0
./pkg -v grove_build grovetccfg_build
```

The ./dist directory will now contain an rpm for each of grove and grovetccfg

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



