### PR TITLE
Fix TO Go bad params to return 400 not 5xx

### DIFF
--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -223,7 +223,7 @@ func StripParamJSON(params map[string]string) map[string]string {
 func AllParams(req *http.Request, required []string, ints []string) (map[string]string, map[string]int, error, error, int) {
 	params, err := GetCombinedParams(req)
 	if err != nil {
-		return nil, nil, errors.New("getting combined URI parameters: " + err.Error()), nil, http.StatusBadRequest
+		return nil, nil, nil, errors.New("getting combined URI parameters: " + err.Error()), http.StatusInternalServerError
 	}
 	params = StripParamJSON(params)
 	if err := ParamsHaveRequired(params, required); err != nil {
@@ -231,7 +231,7 @@ func AllParams(req *http.Request, required []string, ints []string) (map[string]
 	}
 	intParams, err := IntParams(params, ints)
 	if err != nil {
-		return nil, nil, nil, errors.New("getting integer parameters: " + err.Error()), http.StatusInternalServerError
+		return nil, nil, errors.New("getting integer parameters: " + err.Error()), nil, http.StatusBadRequest
 	}
 	return params, intParams, nil, nil, 0
 }


### PR DESCRIPTION
#### What does this PR do?

Fix TO Go bad params to return 400 not 5xx

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Make a request to any API endpoint which takes an ID, and pass a string. Should get a 4xx with a message, not a 5xx.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



