### PR TITLE
Added rat exclusions for charting libraries

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -73,3 +73,5 @@ bytefmt(?:                           Apache 2.0. Properly documented in LICENSE 
 siphash(?:                           CC0. Properly documented in LICENSE ){0}
 bbolt(?:                             MIT. Properly documented in LICENSE ){0}
 miekg(?:                             BSD 3-clause. Properly documented in LICENSE ){0}
+angular-chart(?:                     BSD 2-clause. Properly documented in LICENSE ){0}
+chartjs(?:                           MIT. Properly documented in LICENSE ){0}


### PR DESCRIPTION
#### What does this PR do?
Adds rat exclusions for charting libraries that were breaking the build.

Fixes #(issue_number)
Fixes #2984

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Run rat and verify these two files are no longer being reported at failing:
apache-trafficcontrol-3.0.0/traffic_portal/app/src/assets/js/chartjs/Chart.min_2.7.2.js
apache-trafficcontrol-3.0.0/traffic_portal/app/src/assets/js/chartjs/angular-chart.min_1.1.1.js

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



