### PR TITLE
Traffic Monitor fix unnecessary structs

### DIFF
--- a/traffic_monitor/cache/astats.go
+++ b/traffic_monitor/cache/astats.go
@@ -49,3 +49,12 @@ func Unmarshal(body []byte) (Astats, error) {
 	err := json.Unmarshal(body, &aStats)
 	return aStats, err
 }
+
+type AStat struct {
+	InBytes   uint64
+	OutBytes  uint64
+	Status2xx uint64
+	Status3xx uint64
+	Status4xx uint64
+	Status5xx uint64
+}

--- a/traffic_monitor/cache/astats_test.go
+++ b/traffic_monitor/cache/astats_test.go
@@ -22,7 +22,12 @@ package cache
 import (
 	"fmt"
 	"io/ioutil"
+	"math/rand"
+	"strconv"
 	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_monitor/todata"
 )
 
 func TestAstats(t *testing.T) {
@@ -38,4 +43,97 @@ func TestAstats(t *testing.T) {
 		t.Log(err)
 	}
 	fmt.Printf("Found %v key/val pairs in ats\n", len(aStats.Ats))
+}
+
+func getMockTODataDSNameDirectMatches() map[tc.DeliveryServiceName]string {
+	return map[tc.DeliveryServiceName]string{
+		"ds0": "ds0.example.invalid",
+		"ds1": "ds1.example.invalid",
+	}
+}
+
+// ds, ok := toData.DeliveryServiceRegexes.DeliveryService(domain, subdomain, subsubdomain)
+func getMockTOData(dsNameFQDNs map[tc.DeliveryServiceName]string) todata.TOData {
+	tod := todata.New()
+	for dsName, dsDirectMatch := range dsNameFQDNs {
+		tod.DeliveryServiceRegexes.DirectMatches[dsDirectMatch] = dsName
+	}
+	return *tod
+}
+
+func getMockRawStats(cacheName string, dsNameFQDNs map[tc.DeliveryServiceName]string) map[string]interface{} {
+	st := map[string]interface{}{}
+	for _, dsFQDN := range dsNameFQDNs {
+		st["plugin.remap_stats."+dsFQDN+".in_bytes"] = float64(rand.Uint64())
+		st["plugin.remap_stats."+dsFQDN+".out_bytes"] = float64(rand.Uint64())
+		st["plugin.remap_stats."+dsFQDN+".status_2xx"] = float64(rand.Uint64())
+		st["plugin.remap_stats."+dsFQDN+".status_3xx"] = float64(rand.Uint64())
+		st["plugin.remap_stats."+dsFQDN+".status_4xx"] = float64(rand.Uint64())
+		st["plugin.remap_stats."+dsFQDN+".status_5xx"] = float64(rand.Uint64())
+	}
+	return st
+}
+
+func getMockSystem(infSpeed int, outBytes int) AstatsSystem {
+	infName := randStr()
+	return AstatsSystem{
+		InfName:           infName,
+		InfSpeed:          9876554433210,
+		ProcNetDev:        infName + ":12234567 8901234    1    2    3     4          5   12345 " + strconv.Itoa(outBytes) + " 923412341234    6    7    8     9       10          11",
+		ProcLoadavg:       "1.2 2.34 5.67 1/876 1234",
+		ConfigLoadRequest: rand.Int(),
+		LastReloadRequest: rand.Int(),
+		ConfigReloads:     rand.Int(),
+		LastReload:        rand.Int(),
+		AstatsLoad:        rand.Int(),
+		NotAvailable:      randBool(),
+	}
+
+}
+
+func TestAstatsPrecompute(t *testing.T) {
+	dsNameFQDNs := getMockTODataDSNameDirectMatches()
+	toData := getMockTOData(dsNameFQDNs)
+	cacheName := "cache0"
+	rawStats := getMockRawStats(cacheName, dsNameFQDNs)
+	outBytes := 987655443321
+	infSpeedMbps := 9876554433210
+	system := getMockSystem(infSpeedMbps, outBytes)
+
+	prc := astatsPrecompute(tc.CacheName(cacheName), toData, rawStats, system)
+
+	if len(prc.Errors) != 0 {
+		t.Fatalf("astatsPrecompute Errors expected 0, actual: %+v\n", prc.Errors)
+	}
+	if prc.OutBytes != int64(outBytes) {
+		t.Fatalf("astatsPrecompute OutBytes expected 987655443321, actual: %+v\n", prc.OutBytes)
+	}
+	if prc.MaxKbps != int64(infSpeedMbps*1000) {
+		t.Fatalf("astatsPrecompute MaxKbps expected 9876554433210000, actual: %+v\n", prc.MaxKbps)
+	}
+
+	for dsName, dsFQDN := range dsNameFQDNs {
+		dsStat, ok := prc.DeliveryServiceStats[dsName]
+		if !ok {
+			t.Fatalf("astatsPrecompute DeliveryServiceStats expected %+v, actual: missing\n", dsName)
+		}
+		if statName := "plugin.remap_stats." + dsFQDN + ".in_bytes"; dsStat.InBytes != uint64(rawStats[statName].(float64)) {
+			t.Fatalf("astatsPrecompute DeliveryServiceStats[%+v].InBytes expected %+v, actual: %+v\n", dsName, uint64(rawStats[statName].(float64)), dsStat.InBytes)
+		}
+		if statName := "plugin.remap_stats." + dsFQDN + ".out_bytes"; dsStat.OutBytes != uint64(rawStats[statName].(float64)) {
+			t.Fatalf("astatsPrecompute DeliveryServiceStats[%+v].OutBytes expected %+v, actual: %+v\n", dsName, uint64(rawStats[statName].(float64)), dsStat.OutBytes)
+		}
+		if statName := "plugin.remap_stats." + dsFQDN + ".status_2xx"; dsStat.Status2xx != uint64(rawStats[statName].(float64)) {
+			t.Fatalf("astatsPrecompute DeliveryServiceStats[%+v].Status2xx expected %+v, actual: %+v\n", dsName, uint64(rawStats[statName].(float64)), dsStat.Status2xx)
+		}
+		if statName := "plugin.remap_stats." + dsFQDN + ".status_3xx"; dsStat.Status3xx != uint64(rawStats[statName].(float64)) {
+			t.Fatalf("astatsPrecompute DeliveryServiceStats[%+v].Status3xx expected %+v, actual: %+v\n", dsName, uint64(rawStats[statName].(float64)), dsStat.Status3xx)
+		}
+		if statName := "plugin.remap_stats." + dsFQDN + ".status_4xx"; dsStat.Status4xx != uint64(rawStats[statName].(float64)) {
+			t.Fatalf("astatsPrecompute DeliveryServiceStats[%+v].Status4xx expected %+v, actual: %+v\n", dsName, uint64(rawStats[statName].(float64)), dsStat.Status4xx)
+		}
+		if statName := "plugin.remap_stats." + dsFQDN + ".status_5xx"; dsStat.Status5xx != uint64(rawStats[statName].(float64)) {
+			t.Fatalf("astatsPrecompute DeliveryServiceStats[%+v].Status5xx expected %+v, actual: %+v\n", dsName, uint64(rawStats[statName].(float64)), dsStat.Status5xx)
+		}
+	}
 }

--- a/traffic_monitor/cache/cache.go
+++ b/traffic_monitor/cache/cache.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
-	"github.com/apache/trafficcontrol/traffic_monitor/dsdata"
 	"github.com/apache/trafficcontrol/traffic_monitor/srvhttp"
 	"github.com/apache/trafficcontrol/traffic_monitor/todata"
 )
@@ -60,7 +59,7 @@ func (handler Handler) Precompute() bool {
 
 // PrecomputedData represents data parsed and pre-computed from the Result.
 type PrecomputedData struct {
-	DeliveryServiceStats map[tc.DeliveryServiceName]dsdata.Stat
+	DeliveryServiceStats map[tc.DeliveryServiceName]*AStat
 	OutBytes             int64
 	MaxKbps              int64
 	Errors               []error

--- a/traffic_monitor/cache/data_test.go
+++ b/traffic_monitor/cache/data_test.go
@@ -172,11 +172,22 @@ func randDsStat() dsdata.Stat {
 	}
 }
 
-func randDsStats() map[tc.DeliveryServiceName]dsdata.Stat {
+func randAStat() *AStat {
+	return &AStat{
+		InBytes:   rand.Uint64(),
+		OutBytes:  rand.Uint64(),
+		Status2xx: rand.Uint64(),
+		Status3xx: rand.Uint64(),
+		Status4xx: rand.Uint64(),
+		Status5xx: rand.Uint64(),
+	}
+}
+
+func randDsStats() map[tc.DeliveryServiceName]*AStat {
 	num := 5
-	a := map[tc.DeliveryServiceName]dsdata.Stat{}
+	a := map[tc.DeliveryServiceName]*AStat{}
 	for i := 0; i < num; i++ {
-		a[tc.DeliveryServiceName(randStr())] = randDsStat()
+		a[tc.DeliveryServiceName(randStr())] = randAStat()
 	}
 	return a
 }

--- a/traffic_monitor/cache/stats_type_noop.go
+++ b/traffic_monitor/cache/stats_type_noop.go
@@ -25,7 +25,6 @@ import (
 	"io"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
-	"github.com/apache/trafficcontrol/traffic_monitor/dsdata"
 	"github.com/apache/trafficcontrol/traffic_monitor/todata"
 )
 
@@ -46,5 +45,5 @@ func noopParse(cache tc.CacheName, r io.Reader) (error, map[string]interface{}, 
 }
 
 func noopPrecompute(cache tc.CacheName, toData todata.TOData, rawStats map[string]interface{}, system AstatsSystem) PrecomputedData {
-	return PrecomputedData{DeliveryServiceStats: map[tc.DeliveryServiceName]dsdata.Stat{}}
+	return PrecomputedData{DeliveryServiceStats: map[tc.DeliveryServiceName]*AStat{}}
 }


### PR DESCRIPTION
#### What does this PR do?

Fixes the Monitor using unnecessarily large structs, which cause unnecessary CPU from Garbage Collection.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [x] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Run monitor, verify it generally works. This is an internal change, the interface does not change.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



