### PR TITLE
Fix optional vnc container

### DIFF
--- a/docs/source/admin/quick_howto/ciab.rst
+++ b/docs/source/admin/quick_howto/ciab.rst
@@ -124,7 +124,7 @@ All components in Apache Traffic Control utilize SSL/TLS secure communications b
 
 Trusting the CA 
 ---------------
-For developer and testing use-cases, it may be necessary to have full x509 CA validation by HTTPS clients [5]_.  For x509 validation to work properly, the self-signed x509 CA certificate must be trusted either at the system leevel or by the client applicatoin itself. Procedures to import and trust the CA x.509 certifcate are outlined below for OSX, Windows, and two Linuxs below [6]_.  
+For developer and testing use-cases, it may be necessary to have full x509 CA validation by HTTPS clients [5]_.  For x509 validation to work properly, the self-signed x509 CA certificate must be trusted either at the system leevel or by the client applicatoin itself. Procedures to import and trust the CA x.509 certifcate are outlined below [6]_.
 
 Importing the CA Certificate on OSX
 -----------------------------------

--- a/docs/source/admin/quick_howto/ciab.rst
+++ b/docs/source/admin/quick_howto/ciab.rst
@@ -200,6 +200,28 @@ Multiple optional containers may be combined by using a shell alias:
 	mydc build
 	mydc up
 
+VNC Server 
+----------
+The tightvnc optional container provides a basic lightweight window manager (fluxbox), firefox browser, xterm, and a few other utilities within the CDN-In-A-Box tcnet bridge network. This can be very helpful for quick demonstrations of CDN-in-a-Box that require the use of real container network FQDNs and full X.509 validation.
+
+1. Download and install a VNC client. TightVNC client is preferred as it supports window resizing, host-to-vnc copy/pasting, and optimized frame buffer compression.
+2. Set your VNC console password by adding the ``VNC_PASSWD`` environment variable to ``infrastructure/cdn-in-a-box/varibles.env``. The password needs to be at least six characters long.  The default password is randomized for security.
+3. Start up CDN-in-a-Box stack using a custom bash alias
+
+.. code-block:: shell
+
+	# From infrastructure/cdn-in-a-box
+	alias mydc="docker-compose -f $PWD/docker-compose.yml -f $PWD/optional/docker-compose.vnc.yml"
+	docker volume prune -f
+	mydc build 
+	mydc kill 
+	mydc rm -fv 
+	mydc up
+
+4. Connect with a VNC client to localhost port 9080.  
+5. When Traffic Portal becomes available, the Firefox within the VNC instance will subsequently be started. 
+6. An xterm with bash shell is also automatically spawned and minimized for convenience. 
+
 Socks Proxy
 -----------
 Dantes socks proxy is an optional container that can be used to provide browsers and other clients the ability to resolve DNS queries and network connectivity directly on the tcnet bridged interface.  This is very helpful when running the CDN-In-A-Box stack on OSX/Windows docker host that lacks network bridge/ipforward support. Below is the basic procedure to enable the Socks Proxy support for CDN-in-a-Box:

--- a/infrastructure/cdn-in-a-box/dns/zone.ciab.test
+++ b/infrastructure/cdn-in-a-box/dns/zone.ciab.test
@@ -67,6 +67,9 @@ enroller          IN AAAA fc01:9400:1000:8::200
 client            IN A    172.16.239.250
 client            IN AAAA fc01:9400:1000:8::250
 
+vnc               IN A    172.16.239.251
+vnc               IN AAAA fc01:9400:1000:8::251
+
 dns               IN A    172.16.239.254
 dns               IN AAAA fc01:9400:1000:8::254
 

--- a/infrastructure/cdn-in-a-box/dns/zone.ciab.test
+++ b/infrastructure/cdn-in-a-box/dns/zone.ciab.test
@@ -64,6 +64,9 @@ origin            IN AAAA fc01:9400:1000:8::140
 enroller          IN A    172.16.239.200
 enroller          IN AAAA fc01:9400:1000:8::200
 
+socksproxy        IN A    172.16.239.233
+socksproxy        IN AAAA fc01:9400:1000:8::233
+
 client            IN A    172.16.239.250
 client            IN AAAA fc01:9400:1000:8::250
 

--- a/infrastructure/cdn-in-a-box/dns/zone.ip4.arpa
+++ b/infrastructure/cdn-in-a-box/dns/zone.ip4.arpa
@@ -36,6 +36,7 @@ $TTL 30 ; 30 seconds
 120           IN PTR   mid.infra.ciab.test.
 140           IN PTR   origin.infra.ciab.test.
 200           IN PTR   enroller.infra.ciab.test.
+233           IN PTR   socksproxy.infra.ciab.test.
 250           IN PTR   client.infra.ciab.test.
 251           IN PTR   vnc.infra.ciab.test.
 254           IN PTR   dns.infra.ciab.test.

--- a/infrastructure/cdn-in-a-box/dns/zone.ip4.arpa
+++ b/infrastructure/cdn-in-a-box/dns/zone.ip4.arpa
@@ -37,4 +37,5 @@ $TTL 30 ; 30 seconds
 140           IN PTR   origin.infra.ciab.test.
 200           IN PTR   enroller.infra.ciab.test.
 250           IN PTR   client.infra.ciab.test.
+251           IN PTR   vnc.infra.ciab.test.
 254           IN PTR   dns.infra.ciab.test.

--- a/infrastructure/cdn-in-a-box/dns/zone.ip6.arpa
+++ b/infrastructure/cdn-in-a-box/dns/zone.ip6.arpa
@@ -36,6 +36,7 @@ $TTL 30 ; 30 seconds
 0.2.1         IN PTR   mid.infra.ciab.test.
 0.4.1         IN PTR   origin.infra.ciab.test.
 0.0.2         IN PTR   enroller.infra.ciab.test.
+3.3.2         IN PTR   socksproxy.infra.ciab.test.
 0.5.2         IN PTR   client.infra.ciab.test.
 1.5.2         IN PTR   vnc.infra.ciab.test.
 4.5.2         IN PTR   dns.infra.ciab.test.

--- a/infrastructure/cdn-in-a-box/dns/zone.ip6.arpa
+++ b/infrastructure/cdn-in-a-box/dns/zone.ip6.arpa
@@ -37,4 +37,5 @@ $TTL 30 ; 30 seconds
 0.4.1         IN PTR   origin.infra.ciab.test.
 0.0.2         IN PTR   enroller.infra.ciab.test.
 0.5.2         IN PTR   client.infra.ciab.test.
+1.5.2         IN PTR   vnc.infra.ciab.test.
 4.5.2         IN PTR   dns.infra.ciab.test.

--- a/infrastructure/cdn-in-a-box/docker-compose.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.yml
@@ -338,19 +338,6 @@ services:
     ports:
       - "9353:53"
 
-  client:
-    image: wernight/dante
-    hostname: client
-    domainname: infra.ciab.test
-    networks:
-      tcnet:
-        ipv4_address: 172.16.239.250
-        ipv6_address: "fc01:9400:1000:8::250"
-    ports:
-      - "9080:1080"
-    volumes:
-      - ./dns/container-resolv.conf:/etc/resolv.conf
-    
 volumes:
   schemas:
     external: false

--- a/infrastructure/cdn-in-a-box/optional/README.md
+++ b/infrastructure/cdn-in-a-box/optional/README.md
@@ -17,27 +17,27 @@
     under the License.
 -->
 
-# Private VNC/proxy testclient for ApacheConf Demo
+## CDN-In-A-Box Optional Container(s)
 
-## To start/install the VNC/proxy container
+Create an alias to utilize these container(s) with the core CDN-In-A-Box stack
+
+From the top-level directory of `cdn-in-a-box` create the following alias:
 
 ```
-alias vdc='docker-compose -f docker-compose.yml -f docker-compose.testclient.yml'
-vdc build 
-vdc kill && vdc rm -f 
-docker volume prune -f
-vdc up
+alias mydc='docker-compose -f docker-compose.yml -f optional/docker-compose.$NAME1.yml -f optional/docker-compose.$NAME2.yml'
 ```
 
-## Install a VNC client from the apple store or with brew
-- host/port `localhost:55900`
-- Password for VNC session is 'demo' or whatever $VNC_PASSWD is set to in Dockerfile
+For example, to use the vnc optional container, use the following alias:
 
-## URL locations within the VNC/proxy container:
-* Traffic Portal: https://trafficportal.infra.ciab.test
-* Traffic Monitor: http://trafficmonitor.infra.ciab.test
-* Demo1 Delivery Service: http://video.demo1.mycdn.ciab.test/index.html
 
-## TODO:
-* On both linux/osx platforms, allow connectivity with docker daemon within the container
-* Generate a chopped up HLS movie
+```
+alias mydc='docker-compose -f docker-compose.yml -f optional/docker-compose.vnc.yml'
+
+```
+
+To start the CDN-In-A-Box stack:
+
+```
+mydc build
+mydc up
+```

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.socksproxy.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.socksproxy.yml
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# To use this compose you should first build Traffic Ops and then copy the RPM to :
+#
+# trafficcontrol/infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
+#
+#      cd trafficcontrol/infrastructure/cdn-in-a-box
+#
+# Adjust the settings in `variables.env` to suit your needs.
+#
+#      docker-compose up -d
+#
+# The Traffic Ops Go API will then be available on https://localhost:6443,
+# the Perl API on https://localhost:60443, and the postgres database on localhost 5432.
+#
+# Note that this setup is intended for testing and not for production use.
+
+---
+version: '2.1'
+
+networks:
+  tcnet:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.239.0/24
+        - subnet: "fc01:9400:1000:8::/64"
+
+services:
+  # Optional Socks Proxy for docker hosts that have limited bridge/ipforwarding support.
+  socksproxy:
+    image: wernight/dante
+    hostname: socksproxy
+    domainname: infra.ciab.test
+    networks:
+      tcnet:
+        ipv4_address: 172.16.239.233
+        ipv6_address: "fc01:9400:1000:8::233"
+    ports:
+      - "9080:1080"
+    volumes:
+      - ./dns/container-resolv.conf:/etc/resolv.conf
+    
+volumes:
+  schemas:
+    external: false
+  shared:
+    external: false
+  content:  
+    external: false
+  ca:
+    external: false 

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.yml
@@ -47,36 +47,38 @@ services:
   # TestClient is a VNC/Proxy container for development/testing CDN-In-A-Box 
   # This container should not be merged to the Apache TrafficServer REPO due to 
   # possible licence issues with video playback software and codecs
-  testclient:
+  vnc:
     build:
       context: .
-      dockerfile: testclient/Dockerfile
+      dockerfile: optional/vnc/Dockerfile
       args:
-        VNC_USER: "demo"
-        VNC_PASSWD: "demo"
+        VNC_BUILD_USER: "ciabuser"
+    depends_on:
+      - dns
     environment:
-      VNC_RESOLUTION: "1400x900"
+      VNC_USER: "ciabuser"
       VNC_DEPTH: 32
-      VNC_WM: "fluxbox"
+      VNC_RESOLUTION: "1400x900"
     env_file: 
       - variables.env
-    hostname: client
+    hostname: vnc
     domainname: infra.ciab.test
     networks:
       tcnet:
-        ipv4_address: 172.16.239.250
-        ipv6_address: "fc01:9400:1000:8::250"
+        ipv4_address: 172.16.239.251
+        ipv6_address: "fc01:9400:1000:8::251"
     ports:
-      - "50022:22"
-      - "55900:5900"
-      - "59090:9090"
+      - "5909:5909"
     volumes:
-      - shared:/shared
       - ./dns/container-resolv.conf:/etc/resolv.conf
-      - ~/Library/Containers/com.docker.docker/Data/docker.sock:/var/run/docker.sock
+      - shared:/shared
       
 volumes:
   schemas:
     external: false
-  enroller:
+  shared:
     external: false
+  content:  
+    external: false
+  ca:
+    external: false 

--- a/infrastructure/cdn-in-a-box/optional/socksproxy/README.md
+++ b/infrastructure/cdn-in-a-box/optional/socksproxy/README.md
@@ -1,0 +1,56 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Socksproxy Container for CDN-In-A-Box
+
+Dantes socks proxy is an optional container that can be used to provide browsers and other clients the ability 
+to resolve DNS queries and network connectivity directly to the tcnet bridged interface.  This is very helpful
+when running the CDN-In-A-Box stack on OSX/Windows docker host that lack network bridge/ipforward support.
+
+## Socks Container Lifecycle
+
+```
+# From infrastructure/cdn-in-a-box
+alias mydc="docker-compose -f $PWD/docker-compose.yml -f $PWD/optional/docker-compose.socksproxy.yml"
+docker volume prune -f
+mydc build 
+mydc kill 
+mydc rm -fv 
+mydc up
+```
+
+## Socks Connection Information
+
+- Docker Host/Port: localhost:9080
+- Container Host/Port: socksproxy.infra.ciab.test:1080
+
+## Socks Browser configuration
+
+- Install the Foxy Proxy browser plugin.
+- Add New Proxy, Manual Proxy Configuration, Host: localhost, Port: 9080, Check 'SOCKS Proxy', Select 'SOCKS v5'.
+- Enable 'pre-defined and patterns' mode.
+
+## Socks cmdline client environment
+ 
+Some network clients support connections via socks using the socks\_proxy environment variable
+
+```
+export http_proxy=socks://localhost:9080/
+export https_proxy=socks://localhost:9080/
+```

--- a/infrastructure/cdn-in-a-box/optional/vnc/Dockerfile
+++ b/infrastructure/cdn-in-a-box/optional/vnc/Dockerfile
@@ -16,22 +16,14 @@
 # under the License.
 FROM docker.io/centos:7
 
-ARG BUILD_VNC_USER=demo
-ARG BUILD_VNC_PASSWD=demo
-
-ENV VNC_USER=$BUILD_VNC_USER
-ENV VNC_PASSWD=$BUILD_VNC_PASSWD
+ARG VNC_BUILD_USER
+ENV VNC_USER=$VNC_BUILD_USER
 
 RUN yum -y install https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm epel-release && \
     yum -y install xterm firefox git tigervnc-server sudo bind-utils net-tools which passwd which \
-                   fluxbox webcore-fonts terminus-fonts vnc mplayer wget openssl curl supervisor \
-                   tinyproxy openssh-clients openssh-server 
+                   fluxbox webcore-fonts terminus-fonts vnc mplayer wget openssl curl nc && \
+    yum -y clean all && rm -rf /var/cache/yum
 
-# Disabled Xfce (too large)
-#RUN yum -y groupinstall Xfce
-RUN yum clean all
-
-# Create testclient/vnc/proxy user(s)
 RUN useradd -m $VNC_USER && \
     echo "$VNC_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
@@ -43,31 +35,18 @@ RUN rm -rf /home/$VNC_USER/.vnc && \
     mkdir /home/$VNC_USER/.fluxbox && \
     fluxbox-generate_menu -k -g -B -su -t xterm -b firefox && \
     sed 's/{xterm}/{xterm -bg black -fg white +sb}/g' -i /home/$VNC_USER/.fluxbox/menu && \
-    echo "$VNC_USER" | vncpasswd -f > /home/$VNC_USER/.vnc/passwd && \
+    dd if=/dev/urandom of=/dev/stdout count=12 bs=1 | vncpasswd -f > /home/$VNC_USER/.vnc/passwd && \
     chmod 600 /home/$VNC_USER/.vnc/passwd
 
-ADD testclient/vnc_startup.sh /home/$VNC_USER/.vnc/xstartup 
+ADD optional/vnc/vnc_startup.sh /home/$VNC_USER/.vnc/xstartup 
 
 USER root
 
-ADD testclient/run.sh \
-    traffic_ops/to-access.sh \
-    /
+RUN systemd-machine-id-setup && \
+    chmod +x /home/$VNC_USER/.vnc/xstartup
 
-RUN chmod +x /home/$VNC_USER/.vnc/xstartup
+ADD optional/vnc/run.sh /
 
-VOLUME /ssl
-
-##########################
-# Ports 
-##########################
-# - 2200 - SSH 
-# - 5900 - VNC Port
-# - 7070 - Tinyproxy HTTP 
-# - 9090 - Socks5 Proxy
-##########################
-EXPOSE 2200/tcp 5900/tcp 7070/tcp 9090/tcp
-
-RUN yum --enablerepo=extras install -y docker-client-latest
+EXPOSE 5909/tcp
 
 CMD /run.sh

--- a/infrastructure/cdn-in-a-box/optional/vnc/README.md
+++ b/infrastructure/cdn-in-a-box/optional/vnc/README.md
@@ -1,0 +1,51 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# VNC Client Container for CDN-In-A-Box
+
+This container provides a basic lightweight window manager (fluxbox), firefox browser, xterm, and a few other utilities for the purpose of testing the traffic control components within the CDN-In-A-Box tcnet bridge network.  Additionally, the generated/supplied self-signed SSL CA certificate has been installed in the system trust store, which allows all applications and utilities to enjoy full SSL/TLS x509 certificate validation.
+
+## VNC Container Lifecycle
+
+```
+# From $SRC_ROOT/infrastructure/cdn-in-a-box
+alias vncdc='docker-compose -f docker-compose.yml -f optional/docker-compose.vnc.yml'
+vncdc build 
+vncdc kill && vncdc rm -fv 
+docker volume prune -f
+vncdc up
+```
+
+## VNC Connection Information
+- Docker Host/Port: localhost:5909
+- Container Host/Port: vnc.infra.ciab.test:5909
+- User: ciabuser
+- Password: must be set via $VNC_PASSWD (See below)
+
+## Environment Variables
+
+Environment variables that can be set prior to starting the vnc container.
+
+Defaults:
+```
+VNC_USER=ciabuser
+VNC_PASSWD=Random String (change in variables.env in top-level dir)
+VNC_DEPTH=32
+VNC_RESOLUTION=1440x900
+```

--- a/infrastructure/cdn-in-a-box/optional/vnc/README.md
+++ b/infrastructure/cdn-in-a-box/optional/vnc/README.md
@@ -24,13 +24,18 @@ This container provides a basic lightweight window manager (fluxbox), firefox br
 ## VNC Container Lifecycle
 
 ```
-# From $SRC_ROOT/infrastructure/cdn-in-a-box
-alias vncdc='docker-compose -f docker-compose.yml -f optional/docker-compose.vnc.yml'
-vncdc build 
-vncdc kill && vncdc rm -fv 
+# From infrastructure/cdn-in-a-box
+alias mydc="docker-compose -f $PWD/docker-compose.yml -f $PWD/optional/docker-compose.vnc.yml"
 docker volume prune -f
-vncdc up
+mydc rm -fv 
+mydc kill 
+mydc build 
+mydc up
 ```
+
+## VNC Clients
+- Tight VNC Client: https://www.tightvnc.com
+- Real VNC Client: https://www.realvnc.com
 
 ## VNC Connection Information
 - Docker Host/Port: localhost:5909

--- a/infrastructure/cdn-in-a-box/optional/vnc/run.sh
+++ b/infrastructure/cdn-in-a-box/optional/vnc/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -34,5 +34,18 @@ update-ca-trust extract
 
 VNC_DEPTH=${VNC_DEPTH:-32}
 VNC_RESOLUTION=${VNC_RESOLUTION:-1440x900}
+VNC_INSTANCE_NUM=9
 
-su -c "vncserver :0 -depth $VNC_DEPTH -geometry $VNC_RESOLUTION" - "$VNC_USER" && tail -F /home/dev/.vnc/vnc:0.log
+if [[ -z $VNC_PASSWD ]] ; then 
+   echo "WARNING: no \$VNC_PASSWD environment has been set."
+   sleep 10
+else 
+   echo "Changing vnc console password to: $VNC_PASSWD" 
+   echo -en "$VNC_PASSWD" | vncpasswd -f > /home/$VNC_USER/.vnc/passwd
+   sync 
+   sleep 1
+fi
+
+su -c "vncserver :$VNC_INSTANCE_NUM -depth $VNC_DEPTH -geometry $VNC_RESOLUTION" - "$VNC_USER" 
+
+tail -F '/home/ciabuser/.vnc/vnc.infra.ciab.test:9.log'

--- a/infrastructure/cdn-in-a-box/optional/vnc/vnc_startup.sh
+++ b/infrastructure/cdn-in-a-box/optional/vnc/vnc_startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,20 +18,17 @@
 
 VNC_DEPTH=${VNC_DEPTH:-32}
 VNC_RESOLUTION=${VNC_DEPTH:-1440x900}
-VNC_WM=${VNC_WM:-fluxbox}
+
+startfluxbox &
+
+sleep 3
 
 vncconfig -iconic &
-firefox &
 xterm -bg black -fg white +sb &
 
-case $VNC_WM in
-  "xfce")
-    startxfce4 &
-    ;;
-  "fluxbox")
-    startfluxbox &
-    ;;
-  *)
-    echo "No such Window Manager"
-  ;;
-esac
+until nc 'trafficportal.infra.ciab.test' 443 </dev/null >/dev/null 2>&1; do
+  echo "Waiting for Traffic Portal to start" 
+  sleep 2
+done
+
+firefox 'http://trafficportal.infra.ciab.test' &


### PR DESCRIPTION
#### What does this PR do?

This PR fixes a number of problems with the existing vnc `testclient` container:

Documentation updated. Depends on PR #3040

1) rename the container to `vnc` since that is its purpose
2) add `vnc.infra.ciab.test` hostname entry into the static dns server configuration.
3) move the vnc container under the `optional` containers directory for better organization
4) updates the shared volume required to get access to shared CA x509 SSL certificate
5) fixes to allow firefox to start up in a  container without dbus or systemd
6) default vnc password is now random by default. Override via environment at runtime.
7) Port changed to 5909 to avoid port collision

New proposed directory structure for optional containers: 
```
cdn-in-a-box/optional
cdn-in-a-box/optional/docker-compose.$NAME.yml
cdn-in-a-box/optional/$NAME/
```

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other _cdn-in-a-box________

#### What is the best way to verify this PR?

1) Add VNC_PASSWD with six alphanumeric password to variables.env
2) Start up the CIAB stack using the following alias:
```
alias vncdc='docker-compose -f docker-compose.yml -f optional/docker-compose.vnc.yml'
vncdc build 
vncdc kill && vncdc rm -fv 
docker volume prune -f
vncdc up
```
3) Connect with vnc client to localhost 5909 with $VNC_PASSWD
4) firefox should start as soon as the traffic portal is available.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



