### PR TITLE
systemd: traffic_router.service is marked executable

### DIFF
--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -194,10 +194,9 @@
 								<mapping>
 									<directory>${env.STARTUP_SCRIPT_DIR}</directory>
 									<directoryIncluded>false</directoryIncluded>
-									<filemode>755</filemode>
+									<filemode>644</filemode>
 									<username>root</username>
 									<groupname>root</groupname>
-									<configuration>noreplace</configuration>
 									<sources>
 										<source>
 											<location>${env.STARTUP_SCRIPT_LOC}</location>

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -50,8 +50,8 @@ rm -rf ${RPM_BUILD_ROOT}/%{tomcat_home}/webapps/*
 rm -f ${RPM_BUILD_ROOT}/%{tomcat_home}/bin/*.bat
 
 # install sysd script
-install -d -m 755 ${RPM_BUILD_ROOT}%{_sysconfdir}/systemd/system
-install    -m 755 %_sourcedir/tomcat.service ${RPM_BUILD_ROOT}%{startup_script}
+install -d -m 644 ${RPM_BUILD_ROOT}%{_sysconfdir}/systemd/system
+install    -m 644 %_sourcedir/tomcat.service ${RPM_BUILD_ROOT}%{startup_script}
 
 %clean
 rm -rf ${RPM_BUILD_ROOT}


### PR DESCRIPTION
#### What does this PR do?

Fixes #3011
Fixes #3014 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [X] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

After installing Traffic Router, verify /var/log/messages to make sure this message doesn't appear:

```
systemd: Configuration file /etc/systemd/system/tomcat.service is marked executable. Please remove executable permission bits. Proceeding anyway.
```
Also, verify that traffic_server.service has proper permission (644)

```
]# ls -l /usr/lib/systemd/system/traffic_router.service
-rw-r--r-- 1 root root 1224 Nov 12 13:58 /usr/lib/systemd/system/traffic_router.service
```

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



