### PR TITLE
Changing `openjdk` to `java`

### DIFF
--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -219,8 +219,7 @@
 								</mapping>
 							</mappings>
 							<requires>
-								<require>java-1.8.0-openjdk &gt;= 1.8</require>
-								<require>java-1.8.0-openjdk-devel &gt;= 1.8</require>
+								<require>java &gt;= 1.8</require>
 								<require>tomcat = ${env.TOMCAT_VERSION}.${env.TOMCAT_RELEASE}-${env.BUILD_LOCK}</require>
 								<require>apr &gt;= 1.4.8</require>
 								<require>tomcat-native &gt;= 1.2.16</require>

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -19,7 +19,7 @@ Summary:    Apache Tomcat Servlet/JSP Engine 8.5+, RI for Servlet 3.1/JSP 2.3 AP
 License:    Apache Software License
 URL:        https://github.com/apache/incubator-trafficcontrol/
 Source:     %{_sourcedir}/apache-tomcat-%{version}.tar.gz
-Requires:   java-1.8.0-openjdk >= 1.8, java-1.8.0-openjdk-devel >= 1.8
+Requires:   java >= 1.8
 
 %define startup_script %{_sysconfdir}/systemd/system/tomcat.service
 %define tomcat_home /opt/tomcat


### PR DESCRIPTION
- This allows either JDK to be used

#### What does this PR do?

Fixes #3010 - Variance to be used for backport

When using the requirement `java`. If Oracle JDK is available, then it will use it, if not openjdk will be used. I removed the requirement for Tomcat for `java-1.8.0-openjdk-devel` as it seemed unnecessary. I would need a review on this.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [X] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Verify traffic router builds and install against Oracle JDK and OpenJDK.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



