### PR TITLE
Fixes multiple things

### DIFF
--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -19,9 +19,9 @@ Summary:    Apache Tomcat Servlet/JSP Engine 8.5+, RI for Servlet 3.1/JSP 2.3 AP
 License:    Apache Software License
 URL:        https://github.com/apache/incubator-trafficcontrol/
 Source:     %{_sourcedir}/apache-tomcat-%{version}.tar.gz
-Requires:   java-1.8.0-openjdk >= 1.8, java-1.8.0-openjdk-devel >= 1.8
+Requires:   java >= 1.8
 
-%define startup_script %{_sysconfdir}/systemd/system/tomcat.service
+%define startup_script /lib/systemd/system/tomcat.service
 %define tomcat_home /opt/tomcat
 
 %description
@@ -50,8 +50,8 @@ rm -rf ${RPM_BUILD_ROOT}/%{tomcat_home}/webapps/*
 rm -f ${RPM_BUILD_ROOT}/%{tomcat_home}/bin/*.bat
 
 # install sysd script
-install -d -m 755 ${RPM_BUILD_ROOT}%{_sysconfdir}/systemd/system
-install    -m 755 %_sourcedir/tomcat.service ${RPM_BUILD_ROOT}%{startup_script}
+install -d -m 644 ${RPM_BUILD_ROOT}/lib/systemd/system
+install    -m 644 %_sourcedir/tomcat.service ${RPM_BUILD_ROOT}%{startup_script}
 
 %clean
 rm -rf ${RPM_BUILD_ROOT}
@@ -75,10 +75,6 @@ fi
 
 %post
 systemctl daemon-reload
-
-echo "Tomcat for Traffic Router installed successfully."
-echo ""
-echo "Start with 'systemctl start traffic_router'"
 
 %preun
 


### PR DESCRIPTION

#### What does this PR do?

Fixes #3020 
It also suppressed a message about how to start traffic router (wrong location)

Also includes:
- jdk/openjdk -> java
- Remove executable bits for systemd

Need to be merged after 3013, 3016 and 3017. Sorry about this, just found more stuff during testing.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [X] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



