### PR TITLE
moved 'main' packages that didn't need to be in 'main' into their own packages

### DIFF
--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -1,4 +1,4 @@
-package main
+package routing
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -69,6 +69,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/steeringtargets"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/systeminfo"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/types"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/urisigning"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/user"
 
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/origin"
@@ -304,10 +305,10 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.3, http.MethodDelete, `deliveryservice_request_comments/?$`, api.DeleteHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, Authenticated, nil},
 
 		//Delivery service uri signing keys: CRUD
-		{1.3, http.MethodGet, `deliveryservices/{xmlID}/urisignkeys$`, getURIsignkeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
-		{1.3, http.MethodPost, `deliveryservices/{xmlID}/urisignkeys$`, saveDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
-		{1.3, http.MethodPut, `deliveryservices/{xmlID}/urisignkeys$`, saveDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
-		{1.3, http.MethodDelete, `deliveryservices/{xmlID}/urisignkeys$`, removeDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
+		{1.3, http.MethodGet, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.GetURIsignkeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
+		{1.3, http.MethodPost, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.SaveDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
+		{1.3, http.MethodPut, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.SaveDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
+		{1.3, http.MethodDelete, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.RemoveDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, Authenticated, nil},
 
 		// Federations by CDN (the actual table for federation)
 		{1.1, http.MethodGet, `cdns/{name}/federations/?(\.json)?$`, api.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, Authenticated, nil},
@@ -427,7 +428,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 	return routes, rawRoutes, proxyHandler, nil
 }
 
-func memoryStatsHandler() http.HandlerFunc {
+func MemoryStatsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		handleErrs := tc.GetHandleErrorsFunc(w, r)
 		stats := runtime.MemStats{}
@@ -444,7 +445,7 @@ func memoryStatsHandler() http.HandlerFunc {
 	}
 }
 
-func dbStatsHandler(db *sqlx.DB) http.HandlerFunc {
+func DBStatsHandler(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		handleErrs := tc.GetHandleErrorsFunc(w, r)
 		stats := db.DB.Stats()

--- a/traffic_ops/traffic_ops_golang/routing/routing.go
+++ b/traffic_ops/traffic_ops_golang/routing/routing.go
@@ -1,4 +1,4 @@
-package main
+package routing
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/traffic_ops/traffic_ops_golang/routing/routing_test.go
+++ b/traffic_ops/traffic_ops_golang/routing/routing_test.go
@@ -1,4 +1,4 @@
-package main
+package routing
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/traffic_ops/traffic_ops_golang/routing/wrappers.go
+++ b/traffic_ops/traffic_ops_golang/routing/wrappers.go
@@ -1,4 +1,4 @@
-package main
+package routing
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/traffic_ops/traffic_ops_golang/routing/wrappers_test.go
+++ b/traffic_ops/traffic_ops_golang/routing/wrappers_test.go
@@ -1,4 +1,4 @@
-package main
+package routing
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/traffic_ops/traffic_ops_golang/traffic_ops_golang.go
+++ b/traffic_ops/traffic_ops_golang/traffic_ops_golang.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/plugin"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/routing"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
@@ -122,8 +123,8 @@ func main() {
 	pprofMux := http.DefaultServeMux
 	http.DefaultServeMux = http.NewServeMux() // this is so we don't serve pprof over 443.
 
-	pprofMux.Handle("/db-stats", dbStatsHandler(db))
-	pprofMux.Handle("/memory-stats", memoryStatsHandler())
+	pprofMux.Handle("/db-stats", routing.DBStatsHandler(db))
+	pprofMux.Handle("/memory-stats", routing.MemoryStatsHandler())
 	go func() {
 		debugServer := http.Server{
 			Addr:    "localhost:6060",
@@ -132,7 +133,7 @@ func main() {
 		log.Errorln(debugServer.ListenAndServe())
 	}()
 
-	if err := RegisterRoutes(ServerData{DB: db, Config: cfg, Profiling: &profiling, Plugins: plugins}); err != nil {
+	if err := routing.RegisterRoutes(routing.ServerData{DB: db, Config: cfg, Profiling: &profiling, Plugins: plugins}); err != nil {
 		log.Errorf("registering routes: %v\n", err)
 		return
 	}

--- a/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
+++ b/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
@@ -1,4 +1,4 @@
-package main
+package urisigning
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -45,7 +45,7 @@ type URISignerKeyset struct {
 }
 
 // endpoint handler for fetching uri signing keys from riak
-func getURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
+func GetURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
@@ -85,7 +85,7 @@ func getURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // removeDeliveryServiceURIKeysHandler is the HTTP DELETE handler used to remove urisigning keys assigned to a delivery service.
-func removeDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
+func RemoveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
@@ -129,7 +129,7 @@ func removeDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request)
 }
 
 // saveDeliveryServiceURIKeysHandler is the HTTP POST or PUT handler used to store urisigning keys to a delivery service.
-func saveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
+func SaveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/urisigning/urisigning_test.go
+++ b/traffic_ops/traffic_ops_golang/urisigning/urisigning_test.go
@@ -1,4 +1,4 @@
-package main
+package urisigning
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
## What does this PR do?
Moves `traffic_ops/traffic_ops_golang/route*.go` and `traffic_ops/traffic_ops_golang/wrappers*.go` into the new 'routing' package under `traffic_ops/traffic_ops_golang/routing/`, and similarly moves `traffic_ops/traffic_ops_golang/urisigning*.go` into the new 'urisigning' package under `traffic_ops/traffic_ops_golang/urisigning/`.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Build and test Traffic Ops

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



