### PR TITLE
Fixed containers sometimes sourcing an environment file which does not yet exist

### DIFF
--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -60,8 +60,8 @@ mid/traffic_ops_ort.rpm edge/traffic_ops_ort.rpm: ../../dist/traffic_ops_ort-$(S
 	cp -f $? $@
 traffic_portal/traffic_portal.rpm: ../../dist/traffic_portal-$(SPECIAL_SAUCE)
 	cp -f $? $@
-traffic_router/traffic_router.rpm: ../../dist/traffic_router-$(SPECIAL_SAUCE)
-	cp -f $? $@
+traffic_router/traffic_router.rpm: traffic_router/tomcat.rpm ../../dist/traffic_router-$(SPECIAL_SAUCE)
+	cp -f ../../dist/traffic_router-$(SPECIAL_SEASONING) $@
 traffic_router/tomcat.rpm: ../../dist/tomcat-$(SPECIAL_SEASONING)
 	cp -f $? $@
 

--- a/infrastructure/cdn-in-a-box/edge/run.sh
+++ b/infrastructure/cdn-in-a-box/edge/run.sh
@@ -24,7 +24,7 @@ set -m
 source /to-access.sh
 
 # Wait on SSL certificate generation
-until [ -f "$X509_CA_DONE_FILE" ]
+until [[ -f "$X509_CA_DONE_FILE" && -f "$x509_CA_ENV_FILE" ]]
 do
   echo "Waiting on Shared SSL certificate generation"
   sleep 3

--- a/infrastructure/cdn-in-a-box/enroller/run.sh
+++ b/infrastructure/cdn-in-a-box/enroller/run.sh
@@ -25,7 +25,7 @@ export TO_USER=$TO_ADMIN_USER
 export TO_PASSWORD=$TO_ADMIN_PASSWORD
 
 # Wait on SSL certificate generation
-until [ -f "$X509_CA_DONE_FILE" ] 
+until [[ -f "$X509_CA_DONE_FILE" && -f "$x509_CA_ENV_FILE" ]]
 do
      echo "Waiting on Shared SSL certificate generation"
      sleep 3
@@ -33,7 +33,7 @@ done
 
 # Source the CIAB-CA shared SSL environment
 source "$X509_CA_ENV_FILE"
- 
+
 # Copy the CIAB-CA certificate to the traffic_router conf so it can be added to the trust store
 cp "$X509_CA_CERT_FILE" /usr/local/share/ca-certificates
 update-ca-certificates

--- a/infrastructure/cdn-in-a-box/mid/run.sh
+++ b/infrastructure/cdn-in-a-box/mid/run.sh
@@ -24,7 +24,7 @@ set -m
 source /to-access.sh
 
 # Wait on SSL certificate generation
-until [ -f "$X509_CA_DONE_FILE" ]
+until [[ -f "$X509_CA_DONE_FILE" && -f "$x509_CA_ENV_FILE" ]]
 do
   echo "Waiting on Shared SSL certificate generation"
   sleep 3

--- a/infrastructure/cdn-in-a-box/origin/run.sh
+++ b/infrastructure/cdn-in-a-box/origin/run.sh
@@ -24,7 +24,7 @@ set -m
 source /to-access.sh
 
 # Wait on SSL certificate generation
-until [ -f "$X509_CA_DONE_FILE" ] 
+until [[ -f "$X509_CA_DONE_FILE" && -f "$x509_CA_ENV_FILE" ]]
 do
      echo "Waiting on Shared SSL certificate generation"
      sleep 3

--- a/infrastructure/cdn-in-a-box/testclient/run.sh
+++ b/infrastructure/cdn-in-a-box/testclient/run.sh
@@ -18,7 +18,7 @@
 
 ################################################################################
 # Wait on SSL certificate generation
-until [ -f "$X509_CA_DONE_FILE" ] 
+until [[ -f "$X509_CA_DONE_FILE" && -f "$x509_CA_ENV_FILE" ]]
 do
   echo "Waiting on Shared SSL certificate generation"
   sleep 3

--- a/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
@@ -41,7 +41,7 @@ done
 source /to-access.sh
 
 # Wait on SSL certificate generation
-until [ -f "$X509_CA_DONE_FILE" ] 
+until [[ -f "$X509_CA_DONE_FILE" && -f "$x509_CA_ENV_FILE" ]]
 do
   echo "Waiting on Shared SSL certificate generation"
   sleep 3
@@ -97,9 +97,9 @@ export TO_PASSWORD=$TO_ADMIN_PASSWORD
 touch /opt/traffic_monitor/var/log/traffic_monitor.log
 
 # Do not start until there is a valid CRConfig available
-until [ $(to-get '/CRConfig-Snapshots/CDN-in-a-Box/CRConfig.json' 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do 
-	echo "Waiting on valid CRConfig..."; 
-  	sleep 3; 
+until [ $(to-get '/CRConfig-Snapshots/CDN-in-a-Box/CRConfig.json' 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do
+	echo "Waiting on valid CRConfig...";
+  	sleep 3;
 done
 
 cd /opt/traffic_monitor

--- a/infrastructure/cdn-in-a-box/traffic_portal/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal/run.sh
@@ -30,7 +30,7 @@ SPIN_SLEEP_TIME="2000"
 source /to-access.sh
 
 # Wait on SSL certificate generation
-until [ -f "$X509_CA_DONE_FILE" ] 
+until [[ -f "$X509_CA_DONE_FILE" && -f "$x509_CA_ENV_FILE" ]]
 do
   echo "Waiting on Shared SSL certificate generation"
   sleep 3


### PR DESCRIPTION
## What does this PR do?

Fixes containers sometimes crashing because they attempt to read the non-existent `/shared/ssl/environment` file.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] CIAB

#### What is the best way to verify this PR?
Build and run CDN-in-a-Box

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



