### PR TITLE
Adding backup file support for the crconfig and tmconfig files in Traffic Monitor

### DIFF
--- a/docs/source/development/traffic_monitor.rst
+++ b/docs/source/development/traffic_monitor.rst
@@ -192,6 +192,10 @@ Shared Data
 -----------
 Processed and aggregated data must be shared between the end of the stat and health processing pipelines, and HTTP requests. The CSP paradigm of idiomatic Go does not work efficiently with storing and sharing state. While not idiomatic Go, shared mutexed data structures are faster and simpler than CSP manager microthreads for each data object. Traffic Monitor has many thread-safe shared data types and objects. All shared data objects can be seen in ``manager/manager.go:Start()``, where they are created and passed to the various pipeline stage microthreads that need them. Their respective types all include the word ``Threadsafe``, and can be found in ``traffic_monitor/threadsafe/`` as well as, for dependency reasons, various appropriate directories. Currently, all thread-safe shared data types use mutexes. In the future, these could be changed to lock-free or wait-free structures, if the performance needs outweighed the readability and correctness costs. They could also easily be changed to internally be manager microthreads and channels, if being idiomatic were deemed more important than readability or performance.
 
+Disk Backup
+------------
+The traffic monitor config and CR config are both stored as backup files (tmconfig.backup and crconfig.backup or what ever you set the values to in the config file). This allows the monitor to come up and continue serving even if traffic ops is down.  These files are updated any time a valid config is received from traffic ops, so if traffic ops goes down and the monitor is restarted it can still serve the previous data.  These files can also be manually edited and the changes will be reloaded in to traffic monitor so that if traffic ops is down or unreachable for an extended period of time manual updates can be done.
+
 Formatting Conventions
 ======================
 Go code should be formatted with ``gofmt``. See also ``CONTRIBUTING.md``.

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -40,33 +40,41 @@ const (
 	LogLocationNull = "null"
 	//StaticFileDir is the directory that contains static html and js files.
 	StaticFileDir = "/opt/traffic_monitor/static/"
+	//CrConfigBackupFile is the default file name to store the last crconfig
+	CrConfigBackupFile = "crconfig.backup"
+	//TmConfigBackupFile is the default file name to store the last tmconfig
+	TmConfigBackupFile = "tmconfig.backup"
 )
 
 // Config is the configuration for the application. It includes myriad data, such as polling intervals and log locations.
 type Config struct {
-	CacheHealthPollingInterval   time.Duration `json:"-"`
-	CacheStatPollingInterval     time.Duration `json:"-"`
-	MonitorConfigPollingInterval time.Duration `json:"-"`
-	HTTPTimeout                  time.Duration `json:"-"`
-	PeerPollingInterval          time.Duration `json:"-"`
-	PeerOptimistic               bool          `json:"peer_optimistic"`
-	MaxEvents                    uint64        `json:"max_events"`
-	MaxStatHistory               uint64        `json:"max_stat_history"`
-	MaxHealthHistory             uint64        `json:"max_health_history"`
-	HealthFlushInterval          time.Duration `json:"-"`
-	StatFlushInterval            time.Duration `json:"-"`
-	LogLocationError             string        `json:"log_location_error"`
-	LogLocationWarning           string        `json:"log_location_warning"`
-	LogLocationInfo              string        `json:"log_location_info"`
-	LogLocationDebug             string        `json:"log_location_debug"`
-	LogLocationEvent             string        `json:"log_location_event"`
-	ServeReadTimeout             time.Duration `json:"-"`
-	ServeWriteTimeout            time.Duration `json:"-"`
-	HealthToStatRatio            uint64        `json:"health_to_stat_ratio"`
-	StaticFileDir                string        `json:"static_file_dir"`
-	CRConfigHistoryCount         uint64        `json:"crconfig_history_count"`
-	TrafficOpsMinRetryInterval   time.Duration `json:"-"`
-	TrafficOpsMaxRetryInterval   time.Duration `json:"-"`
+	CacheHealthPollingInterval    time.Duration `json:"-"`
+	CacheStatPollingInterval      time.Duration `json:"-"`
+	MonitorConfigPollingInterval  time.Duration `json:"-"`
+	HTTPTimeout                   time.Duration `json:"-"`
+	PeerPollingInterval           time.Duration `json:"-"`
+	PeerOptimistic                bool          `json:"peer_optimistic"`
+	MaxEvents                     uint64        `json:"max_events"`
+	MaxStatHistory                uint64        `json:"max_stat_history"`
+	MaxHealthHistory              uint64        `json:"max_health_history"`
+	HealthFlushInterval           time.Duration `json:"-"`
+	StatFlushInterval             time.Duration `json:"-"`
+	LogLocationError              string        `json:"log_location_error"`
+	LogLocationWarning            string        `json:"log_location_warning"`
+	LogLocationInfo               string        `json:"log_location_info"`
+	LogLocationDebug              string        `json:"log_location_debug"`
+	LogLocationEvent              string        `json:"log_location_event"`
+	ServeReadTimeout              time.Duration `json:"-"`
+	ServeWriteTimeout             time.Duration `json:"-"`
+	HealthToStatRatio             uint64        `json:"health_to_stat_ratio"`
+	StaticFileDir                 string        `json:"static_file_dir"`
+	CRConfigHistoryCount          uint64        `json:"crconfig_history_count"`
+	TrafficOpsMinRetryInterval    time.Duration `json:"-"`
+	TrafficOpsMaxRetryInterval    time.Duration `json:"-"`
+	CrConfigBackupFile            string        `json:"crconfig_backup_file"`
+	TmConfigBackupFile            string        `json:"tmconfig_backup_file"`
+	TrafficOpsFileFallbackRetries uint64        `json:"-"`
+	FileRetryTime                 time.Duration `json:"-"`
 }
 
 func (c Config) ErrorLog() log.LogLocation   { return log.LogLocation(c.LogLocationError) }
@@ -77,29 +85,33 @@ func (c Config) EventLog() log.LogLocation   { return log.LogLocation(c.LogLocat
 
 // DefaultConfig is the default configuration for the application, if no configuration file is given, or if a given config setting doesn't exist in the config file.
 var DefaultConfig = Config{
-	CacheHealthPollingInterval:   6 * time.Second,
-	CacheStatPollingInterval:     6 * time.Second,
-	MonitorConfigPollingInterval: 5 * time.Second,
-	HTTPTimeout:                  2 * time.Second,
-	PeerPollingInterval:          5 * time.Second,
-	PeerOptimistic:               true,
-	MaxEvents:                    200,
-	MaxStatHistory:               5,
-	MaxHealthHistory:             5,
-	HealthFlushInterval:          200 * time.Millisecond,
-	StatFlushInterval:            200 * time.Millisecond,
-	LogLocationError:             LogLocationStderr,
-	LogLocationWarning:           LogLocationStdout,
-	LogLocationInfo:              LogLocationNull,
-	LogLocationDebug:             LogLocationNull,
-	LogLocationEvent:             LogLocationStdout,
-	ServeReadTimeout:             10 * time.Second,
-	ServeWriteTimeout:            10 * time.Second,
-	HealthToStatRatio:            4,
-	StaticFileDir:                StaticFileDir,
-	CRConfigHistoryCount:         20000,
-	TrafficOpsMinRetryInterval:   100 * time.Millisecond,
-	TrafficOpsMaxRetryInterval:   60000 * time.Millisecond,
+	CacheHealthPollingInterval:    6 * time.Second,
+	CacheStatPollingInterval:      6 * time.Second,
+	MonitorConfigPollingInterval:  5 * time.Second,
+	HTTPTimeout:                   2 * time.Second,
+	PeerPollingInterval:           5 * time.Second,
+	PeerOptimistic:                true,
+	MaxEvents:                     200,
+	MaxStatHistory:                5,
+	MaxHealthHistory:              5,
+	HealthFlushInterval:           200 * time.Millisecond,
+	StatFlushInterval:             200 * time.Millisecond,
+	LogLocationError:              LogLocationStderr,
+	LogLocationWarning:            LogLocationStdout,
+	LogLocationInfo:               LogLocationNull,
+	LogLocationDebug:              LogLocationNull,
+	LogLocationEvent:              LogLocationStdout,
+	ServeReadTimeout:              10 * time.Second,
+	ServeWriteTimeout:             10 * time.Second,
+	HealthToStatRatio:             4,
+	StaticFileDir:                 StaticFileDir,
+	CRConfigHistoryCount:          20000,
+	TrafficOpsMinRetryInterval:    100 * time.Millisecond,
+	TrafficOpsMaxRetryInterval:    60000 * time.Millisecond,
+	CrConfigBackupFile:            CrConfigBackupFile,
+	TmConfigBackupFile:            TmConfigBackupFile,
+	TrafficOpsFileFallbackRetries: 7,
+	FileRetryTime:                 1 * time.Second,
 }
 
 // MarshalJSON marshals custom millisecond durations. Aliasing inspired by http://choly.ca/post/go-json-marshalling/
@@ -117,6 +129,7 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 		StatFlushIntervalMs            uint64 `json:"stat_flush_interval_ms"`
 		ServeReadTimeoutMs             uint64 `json:"serve_read_timeout_ms"`
 		ServeWriteTimeoutMs            uint64 `json:"serve_write_timeout_ms"`
+		FileRetryTimeMs                uint64 `json:"file_retry_timeout_ms"`
 		*Alias
 	}{
 		CacheHealthPollingIntervalMs:   uint64(c.CacheHealthPollingInterval / time.Millisecond),
@@ -127,6 +140,7 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 		PeerOptimistic:                 bool(true),
 		HealthFlushIntervalMs:          uint64(c.HealthFlushInterval / time.Millisecond),
 		StatFlushIntervalMs:            uint64(c.StatFlushInterval / time.Millisecond),
+		FileRetryTimeMs:                uint64(c.FileRetryTime / time.Millisecond),
 		Alias:                          (*Alias)(c),
 	})
 }
@@ -147,6 +161,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		ServeWriteTimeoutMs            *uint64 `json:"serve_write_timeout_ms"`
 		TrafficOpsMinRetryIntervalMs   *uint64 `json:"traffic_ops_min_retry_interval_ms"`
 		TrafficOpsMaxRetryIntervalMs   *uint64 `json:"traffic_ops_max_retry_interval_ms"`
+		FileRetryTimeMs                *uint64 `json:"file_retry_timeout_ms"`
 		*Alias
 	}{
 		Alias: (*Alias)(c),
@@ -191,6 +206,9 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	}
 	if aux.TrafficOpsMaxRetryIntervalMs != nil {
 		c.TrafficOpsMaxRetryInterval = time.Duration(*aux.TrafficOpsMaxRetryIntervalMs) * time.Millisecond
+	}
+	if aux.FileRetryTimeMs != nil {
+		c.FileRetryTime = time.Duration(*aux.FileRetryTimeMs) * time.Millisecond
 	}
 	return nil
 }

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -327,6 +327,7 @@ func (s TrafficOpsSessionThreadsafe) trafficMonitorConfigMapRaw(cdn string) (*tc
 
 	if fileSession {
 		data, _ := ioutil.ReadFile(config.TmConfigBackupFile)
+		json := jsoniter.ConfigFastest
 		err := json.Unmarshal(data, &configMap)
 		if err != nil {
 			log.Errorf("Error unmarshaling TmConfigBackupFile, ", err)
@@ -334,6 +335,7 @@ func (s TrafficOpsSessionThreadsafe) trafficMonitorConfigMapRaw(cdn string) (*tc
 	} else {
 		configMap, _, err = ss.GetTrafficMonitorConfigMap(cdn)
 		if configMap != nil {
+			json := jsoniter.ConfigFastest
 			data, err := json.Marshal(*configMap)
 			if err == nil {
 				ioutil.WriteFile(config.TmConfigBackupFile, data, 0644)


### PR DESCRIPTION
Any time TM receives a valid cr or tm config file it gets written to a backup file on disk. A poller is started with a default of 1 sec (or using file_retry_timeout_ms in the

config file) that will poll the TO url every interval. If the url is unreachable and the backup files exist then TM will fall back to using those backup files for monitoring. The url will then be checked on the next interval and the next time
TO is available TM will switch back to the url usage.

Along with the file_retry_timeout_ms this also adds crconfig_backup_file and tmconfig_backup_file optional settings to specify backup file locations

On startup we continue to use the new backoff method however after we have reached TrafficOpsFileFallbackRetries amount we then test if the backup files exist and if they do we proceed to the disk based method. This way if TM starts up and TO
is down it will continue to work as long as it has a valid backup cr and tm config files.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [x] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Test with TO up and down and verify that TM still functions properly using the backup created on disk

#### Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



