### PR TITLE
removes max-length from profile name

### DIFF
--- a/traffic_portal/app/src/common/modules/form/profile/form.profile.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/profile/form.profile.tpl.html
@@ -48,7 +48,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(profileForm.name), 'has-feedback': hasError(profileForm.name)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">Name *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="name" type="text" class="form-control" ng-model="profile.name" ng-maxlength="45" ng-pattern="/^\S*$/" required autofocus>
+                    <input name="name" type="text" class="form-control" ng-model="profile.name" ng-pattern="/^\S*$/" required autofocus>
                     <small class="input-error" ng-show="hasPropertyError(profileForm.name, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(profileForm.name, 'maxlength')">Too Long</small>
                     <small class="input-error" ng-show="hasPropertyError(profileForm.name, 'pattern')">No spaces</small>


### PR DESCRIPTION
#### What does this PR do?

Fixes #2830 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Open up TP and create a new profile. There is no max-length constraint on the `Name` anymore. 

Or try cloning a profile with a long name (45+ characters). There should be no problem anymore with the clone as indicated in #2830 .

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



