### PR TITLE
Fix Traffic Ops auth failure returning 200, catastrophically breaking clients

### DIFF
--- a/traffic_ops/testing/api/v14/loginfail_test.go
+++ b/traffic_ops/testing/api/v14/loginfail_test.go
@@ -1,0 +1,75 @@
+package v14
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+	"time"
+
+	"golang.org/x/net/publicsuffix"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
+)
+
+func TestLoginFail(t *testing.T) {
+	log.Debugln("TestLoginFail")
+	// This specifically tests a previous bug: auth failure returning a 200, causing the client to think the request succeeded, and deserialize no matching fields successfully, and return an empty object.
+
+	userAgent := "to-api-v14-client-tests-loginfailtest"
+	uninitializedTOClient, err := getUninitializedTOClient(Config.TrafficOps.Users.Admin, Config.TrafficOps.UserPassword, Config.TrafficOps.URL, userAgent, time.Second*time.Duration(Config.Default.Session.TimeoutInSecs))
+	if err != nil {
+		t.Fatalf("getting uninitialized client: %+v\n", err)
+	}
+
+	if len(testData.CDNs) < 1 {
+		t.Fatalf("cannot test login: must have at least 1 test data cdn\n")
+	}
+	expectedCDN := testData.CDNs[0]
+	actualCDNs, _, err := uninitializedTOClient.GetCDNByName(expectedCDN.Name)
+	if err != nil {
+		t.Fatalf("GetCDNByName err expected nil, actual '%+v'\n", err)
+	}
+	if len(actualCDNs) < 1 {
+		t.Fatalf("uninitialized client should have retried login (possibly login failed with a 200, so it didn't try again, and the CDN request returned an auth failure with a 200, which the client reasonably thought was success, and deserialized with no matching keys, resulting in an empty object); len(actualCDNs) expected >1, actual 0")
+	}
+	actualCDN := actualCDNs[0]
+	if expectedCDN.Name != actualCDN.Name {
+		t.Fatalf("cdn.Name expected '%+v' actual '%+v'\n", expectedCDN.Name, actualCDN.Name)
+	}
+	log.Debugln("TestLoginFail PASSED")
+}
+
+func getUninitializedTOClient(user, pass, uri, agent string, reqTimeout time.Duration) (*toclient.Session, error) {
+	insecure := true
+	useCache := false
+	jar, err := cookiejar.New(&cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toclient.NewSession(user, pass, uri, agent, &http.Client{
+		Timeout: reqTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		},
+		Jar: jar,
+	}, useCache), nil
+}

--- a/traffic_ops/traffic_ops_golang/routing.go
+++ b/traffic_ops/traffic_ops_golang/routing.go
@@ -148,7 +148,7 @@ func getRouteMiddleware(middlewares []Middleware, authBase AuthBase, authenticat
 	}
 	if authenticated { // a privLevel of zero is an unauthenticated endpoint.
 		authWrapper := authBase.GetWrapper(privLevel)
-		middlewares = append([]Middleware{authWrapper}, middlewares...)
+		middlewares = append(middlewares, authWrapper)
 	}
 	return middlewares
 }


### PR DESCRIPTION
This specifically fixes a major bug, where auth failure returns a 200.

This causes a major bug in the TO Go client, (and likely other
clients) which assumes a 200 to be success, and then goes on to request
data, gets more auth failures with 200's, but thinks they're success,
and thinks the JSON is just missing all fields, which are defaulted
to 0/empty string/null.

This causes other bugs that just went unnoticed, like missing the
Access-Control headers, X-Server-Name, and gzipping.

Includes API Tests.

#### What does this PR do?

This specifically fixes a major bug, where auth failure returns a 200, breaking clients.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Run TO API Tests.

Run Traffic Ops and e.g. `curl -Lvsk https://your-traffic-ops.example.net/api/1.2/cdns`, you should get a `401`, along with `access-control` and `x-server-name` headers. 

Run `curl -Lvsk -H "Accept-Encoding: gzip" https://localhost/api/1.2/cdns | gunzip`, and verify a `content-encoding: gzip` header, and successful decoding by `gunzip`.

Go to `https://your-traffic-ops.example.net/api/1.2/cdns` in a web browser (which hasn't previously logged in, and therefore doesn't have an auth cookie), and verify the same results in a debug console (Readable error, `content-encoding: gzip`, `401` code).

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



