### PR TITLE
Genconfigroutes modes

### DIFF
--- a/docs/source/tools/compare.rst
+++ b/docs/source/tools/compare.rst
@@ -85,9 +85,9 @@ given pair of Traffic Ops instances. This, for the purpose of using the
 'compare' tool
 
 
--h, --help            show this help message and exit
---refURL REFURL       The full URL of the reference Traffic Ops instance (default: None)
---testURL TESTURL     The full URL of the testing Traffic Ops instance (default: None)
+-h, --help                           show this help message and exit
+--refURL REFURL                      The full URL of the reference Traffic Ops instance (default: None)
+--testURL TESTURL                    The full URL of the testing Traffic Ops instance (default: None)
 --refUser REFUSER                    A username for logging into the reference Traffic Ops instance. (default: None)
 --refPasswd REFPASSWD                A password for logging into the reference Traffic Ops instance (default: None)
 --testUser TESTUSER                  A username for logging into the testing Traffic Ops instance. If not given, the value for the reference instance will be used. (default: None)
@@ -96,6 +96,9 @@ given pair of Traffic Ops instances. This, for the purpose of using the
 -v, --version                        Print version information and exit
 -l LOG_LEVEL, --log_level LOG_LEVEL  Sets the Python log level, one of 'DEBUG', 'INFO', 'WARN', 'ERROR', or 'CRITICAL' (default: INFO)
 -q, --quiet                          Suppresses all logging output - even for critical errors (default: False)
+-s, --snapshot                       Produce snapshot routes in the output (CRConfig.json, snapshot/new etc.) (default: False)
+-C, --no-server-configs              Do not generate routes for server config files (default: False)
+
 
 .. note:: If you're using a CDN-in-a-Box environment for testing, it's likely that you'll need the ``-k``/``--insecure`` option if you're outside the Docker network
 
@@ -111,7 +114,11 @@ The genConfigRoutes.py script will output list of unique API routes (relative to
 
 Usage with Docker
 =================
-A Dockerfile is provided to run tests on a pair of instances given the configuration environment variables necessary. This will generate configuration file routes using ``genConfigRoutes.py``, and add them to whatever is already contained in ``traffic_ops/testing/compare/testroutes.txt``, then run the ``compare`` tool on the final API route list. Build artifacts (i.e. anything output files created by the `compare` tool) are placed in the `/artifacts/` directory on the container. To retrieve these results, the use of a volume is recommended. The build context *must* be at the root of the Traffic Control repository, as the tools have dependencies on the Traffic Control clients. In order to use the container, the following environment variables must be defined for the container at runtime:
+A Dockerfile is provided to run tests on a pair of instances given the configuration environment variables necessary. This will generate configuration file routes using ``genConfigRoutes.py``, and add them to whatever is already contained in ``traffic_ops/testing/compare/testroutes.txt``, then run the ``compare`` tool on the final API route list. Build artifacts (i.e. anything output files created by the `compare` tool) are placed in the `/artifacts/` directory on the container. To retrieve these results, the use of a volume is recommended. The build context *must* be at the root of the Traffic Control repository, as the tools have dependencies on the Traffic Control clients.
+
+Arguments can be passed to the genConfigRoutes.py script by defining the build-time argument ``MODE``. By default it expands to ``-s`` to allow the generation of CDN snapshot routes. It is not necessary to pass ``-k``/``--insecure``, as the Dockerfile will do that implicitly.
+
+In order to use the container, the following environment variables must be defined for the container at runtime:
 
 TO_URL
 	The URL of the reference Traffic Ops instance

--- a/traffic_ops/testing/compare/Dockerfile
+++ b/traffic_ops/testing/compare/Dockerfile
@@ -44,5 +44,8 @@ RUN go get -v ./...
 RUN go build .
 RUN cp testroutes.txt /artifacts/
 
-CMD ./genConfigRoutes.py -k --refURL=$TO_URL --testURL=$TEST_URL --refUser=$TO_USER --refPasswd=$TO_PASSWORD --testUser=$TEST_USER --testPasswd=$TEST_PASSWORD -l INFO 2>&1 >>/artifacts/testroutes.txt | tee /artifacts/genRoutesConfig.log &&\
+ARG MODE="-s"
+ENV mode=$MODE
+
+CMD ./genConfigRoutes.py $mode -k --refURL=$TO_URL --testURL=$TEST_URL --refUser=$TO_USER --refPasswd=$TO_PASSWORD --testUser=$TEST_USER --testPasswd=$TEST_PASSWORD -l INFO 2>&1 >>/artifacts/testroutes.txt | tee /artifacts/genRoutesConfig.log &&\
 	./compare --ref_url=$TO_URL --test_url=$TEST_URL --ref_user=$TO_USER --ref_passwd=$TO_PASSWORD --test_user=$TEST_USER --test_passwd=$TEST_PASSWORD -r /artifacts </artifacts/testroutes.txt

--- a/traffic_ops/testing/compare/README.md
+++ b/traffic_ops/testing/compare/README.md
@@ -104,6 +104,12 @@ optional arguments:
                         'WARN', 'ERROR', or 'CRITICAL' (default: INFO)
   -q, --quiet           Suppresses all logging output - even for critical
                         errors (default: False)
+  -s, --snapshot        Produce snapshot routes in the output (CRConfig.json,
+                        snapshot/new etc.) (default: False)
+  -C, --no-server-configs
+                        Do not generate routes for server config files
+                        (default: False)
+
 
 !!! note
 	This script will use the same environment variables as `compare`, which can be overridden by the above  command line parameters
@@ -113,7 +119,7 @@ optional arguments:
 
 The genConfigRoutes.py script will output list of unique API routes (relative to the desired Traffic Ops URL) that point to generated configuration files for a sample set of servers common to both Traffic Ops instances. The results are printed to stdout, making the output perfect for piping directly into `compare` like so:
 
-``` sourceCode
+```bash
 ./genConfigRoutes.py https://trafficopsA.example.test https://trafficopsB.example.test username:password | ./compare
 ```
 


### PR DESCRIPTION
## What does this PR do?
genConfigRoutes.py now has the -s option to enable generation of CDN snapshot routes, as well as the -C option to disable the generation of server configuration file routes. The dockerfile supports this change.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] The `compare` tool

## What is the best way to verify this PR?
Try to build and run the compare tool and route generator, both standalone and using the dockerfile in all 4 modes. Check the documentation for instructions (under "Tools").

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



