### PR TITLE
makes link to TP documentation configurable

### DIFF
--- a/traffic_ops/app/conf/cdn.conf
+++ b/traffic_ops/app/conf/cdn.conf
@@ -43,6 +43,7 @@
     },
     "portal" : {
         "base_url" : "http://localhost:8080/!#/",
+        "docs_url" : "https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_portal/usingtrafficportal.html",
         "email_from" : "no-reply@traffic-portal-domain.com",
         "pass_reset_path" : "user",
         "user_register_path" : "user"

--- a/traffic_ops/app/templates/not_found.html.ep
+++ b/traffic_ops/app/templates/not_found.html.ep
@@ -27,7 +27,7 @@
 		  </div>
 
 			<div style="margin-top:20px;clear:both;">
-					If you are looking for a web page, the old Traffic Ops user interface was removed in Traffic Ops 4.0. Please use the <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_portal/usingtrafficportal.html#usingtrafficportal">Traffic Portal</a> instead.
+					If you are looking for a web page, the old Traffic Ops user interface was removed in Traffic Ops 4.0. Please use the <a href="<%= $config->{'portal'}{'docs_url'} %>"> Traffic Portal</a> instead.
 		  </div>
 	  </div>
 	</div>


### PR DESCRIPTION
#### What does this PR do?

Fixes #3050 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

In cdn.conf, change the value of portal->docs_url then navigate to the deprecated TO UI and click on the Traffic Portal link. It should take you to the value defined in portal->docs_url in cdn.conf.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



