### PR TITLE
[Backport] Prevent Perl input record separator change in TO dbdump API

### DIFF
--- a/traffic_ops/app/lib/API/Database.pm
+++ b/traffic_ops/app/lib/API/Database.pm
@@ -40,7 +40,7 @@ sub dbdump {
 	}
 
 	# slurp it in..
-	undef $/;
+	local $/;
 	my $data = <$fh>;
 
 


### PR DESCRIPTION
Due to the way this code was previously written, the first call to the
dbdump API is successful, but subsequent calls are broken because the
chomp() function no longer strips trailing whitespace from the output of
the `hostname` command. This ends up breaking the response headers
because of the unexpected newline, causing traffic_ops_golang to emit
this error and return a 502:

    http: proxy error: net/http: HTTP/1.x transport connection broken:
    malformed MIME header line: -20181031125221.pg_dump"

By only locally declaring $/ (undefined), subsequent calls to `chomp()`
actually strip newlines because `$/ == "\n"` by default.

(cherry picked from commit 612bedd89c31e3e0187705411a1ffb281cf453bf)