### PR TITLE
Traffic Monitor Disk Support

### DIFF
--- a/docs/source/development/traffic_monitor.rst
+++ b/docs/source/development/traffic_monitor.rst
@@ -192,6 +192,14 @@ Shared Data
 -----------
 Processed and aggregated data must be shared between the end of the stat and health processing pipelines, and HTTP requests. The CSP paradigm of idiomatic Go does not work efficiently with storing and sharing state. While not idiomatic Go, shared mutexed data structures are faster and simpler than CSP manager microthreads for each data object. Traffic Monitor has many thread-safe shared data types and objects. All shared data objects can be seen in ``manager/manager.go:Start()``, where they are created and passed to the various pipeline stage microthreads that need them. Their respective types all include the word ``Threadsafe``, and can be found in ``traffic_monitor/threadsafe/`` as well as, for dependency reasons, various appropriate directories. Currently, all thread-safe shared data types use mutexes. In the future, these could be changed to lock-free or wait-free structures, if the performance needs outweighed the readability and correctness costs. They could also easily be changed to internally be manager microthreads and channels, if being idiomatic were deemed more important than readability or performance.
 
+Disk Backup
+------------
+The traffic monitor config and CR config are both stored as backup files (tmconfig.backup and crconfig.backup or what ever you set the values to in the config file). This allows the monitor to come up and continue serving even if traffic ops 
+is down.  These files are updated any time a valid config is received from traffic ops, so if traffic ops goes down and the monitor is restarted it can still serve the previous data.  These files can also be manually edited and the changes 
+will be reloaded in to traffic monitor so that if traffic ops is down or unreachable for an extended period of time manual updates can be done. If on initial startup trafficops is unavailable then traffic monitor will continue through it's 
+exponential backoff until it hits the max retry interval, at that point it will create an un-authenticated trafficops session and use the data from disk. It will still poll trafficops for updates though and if it successfully gets through 
+then it will login at that point.
+
 Formatting Conventions
 ======================
 Go code should be formatted with ``gofmt``. See also ``CONTRIBUTING.md``.

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -41,9 +41,9 @@ const (
 	//StaticFileDir is the directory that contains static html and js files.
 	StaticFileDir = "/opt/traffic_monitor/static/"
 	//CrConfigBackupFile is the default file name to store the last crconfig
-	CrConfigBackupFile = "crconfig.backup"
+	CRConfigBackupFile = "crconfig.backup"
 	//TmConfigBackupFile is the default file name to store the last tmconfig
-	TmConfigBackupFile = "tmconfig.backup"
+	TMConfigBackupFile = "tmconfig.backup"
 )
 
 // Config is the configuration for the application. It includes myriad data, such as polling intervals and log locations.
@@ -71,8 +71,8 @@ type Config struct {
 	CRConfigHistoryCount         uint64        `json:"crconfig_history_count"`
 	TrafficOpsMinRetryInterval   time.Duration `json:"-"`
 	TrafficOpsMaxRetryInterval   time.Duration `json:"-"`
-	CrConfigBackupFile           string        `json:"crconfig_backup_file"`
-	TmConfigBackupFile           string        `json:"tmconfig_backup_file"`
+	CRConfigBackupFile           string        `json:"crconfig_backup_file"`
+	TMConfigBackupFile           string        `json:"tmconfig_backup_file"`
 	TrafficOpsDiskRetryMax       uint64        `json:"-"`
 }
 
@@ -107,8 +107,8 @@ var DefaultConfig = Config{
 	CRConfigHistoryCount:         20000,
 	TrafficOpsMinRetryInterval:   100 * time.Millisecond,
 	TrafficOpsMaxRetryInterval:   60000 * time.Millisecond,
-	CrConfigBackupFile:           CrConfigBackupFile,
-	TmConfigBackupFile:           TmConfigBackupFile,
+	CRConfigBackupFile:           CRConfigBackupFile,
+	TMConfigBackupFile:           TMConfigBackupFile,
 	TrafficOpsDiskRetryMax:       2,
 }
 
@@ -158,8 +158,8 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		TrafficOpsMinRetryIntervalMs   *uint64 `json:"traffic_ops_min_retry_interval_ms"`
 		TrafficOpsMaxRetryIntervalMs   *uint64 `json:"traffic_ops_max_retry_interval_ms"`
 		TrafficOpsDiskRetryMax         *uint64 `json:"traffic_ops_disk_retry_max"`
-		CrConfigBackupFile             *string `json:"crconfig_backup_file"`
-		TmConfigBackupFile             *string `json:"tmconfig_backup_file"`
+		CRConfigBackupFile             *string `json:"crconfig_backup_file"`
+		TMConfigBackupFile             *string `json:"tmconfig_backup_file"`
 		*Alias
 	}{
 		Alias: (*Alias)(c),
@@ -208,11 +208,11 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	if aux.TrafficOpsDiskRetryMax != nil {
 		c.TrafficOpsDiskRetryMax = *aux.TrafficOpsDiskRetryMax
 	}
-	if aux.CrConfigBackupFile != nil {
-		c.CrConfigBackupFile = *aux.CrConfigBackupFile
+	if aux.CRConfigBackupFile != nil {
+		c.CRConfigBackupFile = *aux.CRConfigBackupFile
 	}
-	if aux.TmConfigBackupFile != nil {
-		c.TmConfigBackupFile = *aux.TmConfigBackupFile
+	if aux.TMConfigBackupFile != nil {
+		c.TMConfigBackupFile = *aux.TMConfigBackupFile
 	}
 	return nil
 }

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -41,9 +41,9 @@ const (
 	//StaticFileDir is the directory that contains static html and js files.
 	StaticFileDir = "/opt/traffic_monitor/static/"
 	//CrConfigBackupFile is the default file name to store the last crconfig
-	CRConfigBackupFile = "crconfig.backup"
+	CRConfigBackupFile = "/opt/traffic_monitor/crconfig.backup"
 	//TmConfigBackupFile is the default file name to store the last tmconfig
-	TMConfigBackupFile = "tmconfig.backup"
+	TMConfigBackupFile = "/opt/traffic_monitor/tmconfig.backup"
 )
 
 // Config is the configuration for the application. It includes myriad data, such as polling intervals and log locations.

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -40,6 +40,10 @@ const (
 	LogLocationNull = "null"
 	//StaticFileDir is the directory that contains static html and js files.
 	StaticFileDir = "/opt/traffic_monitor/static/"
+	//CrConfigBackupFile is the default file name to store the last crconfig
+	CrConfigBackupFile = "crconfig.backup"
+	//TmConfigBackupFile is the default file name to store the last tmconfig
+	TmConfigBackupFile = "tmconfig.backup"
 )
 
 // Config is the configuration for the application. It includes myriad data, such as polling intervals and log locations.
@@ -67,6 +71,9 @@ type Config struct {
 	CRConfigHistoryCount         uint64        `json:"crconfig_history_count"`
 	TrafficOpsMinRetryInterval   time.Duration `json:"-"`
 	TrafficOpsMaxRetryInterval   time.Duration `json:"-"`
+	CrConfigBackupFile           string        `json:"crconfig_backup_file"`
+	TmConfigBackupFile           string        `json:"tmconfig_backup_file"`
+	TrafficOpsDiskRetryMax       uint64        `json:"-"`
 }
 
 func (c Config) ErrorLog() log.LogLocation   { return log.LogLocation(c.LogLocationError) }
@@ -100,6 +107,9 @@ var DefaultConfig = Config{
 	CRConfigHistoryCount:         20000,
 	TrafficOpsMinRetryInterval:   100 * time.Millisecond,
 	TrafficOpsMaxRetryInterval:   60000 * time.Millisecond,
+	CrConfigBackupFile:           CrConfigBackupFile,
+	TmConfigBackupFile:           TmConfigBackupFile,
+	TrafficOpsDiskRetryMax:       2,
 }
 
 // MarshalJSON marshals custom millisecond durations. Aliasing inspired by http://choly.ca/post/go-json-marshalling/
@@ -147,6 +157,9 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		ServeWriteTimeoutMs            *uint64 `json:"serve_write_timeout_ms"`
 		TrafficOpsMinRetryIntervalMs   *uint64 `json:"traffic_ops_min_retry_interval_ms"`
 		TrafficOpsMaxRetryIntervalMs   *uint64 `json:"traffic_ops_max_retry_interval_ms"`
+		TrafficOpsDiskRetryMax         *uint64 `json:"traffic_ops_disk_retry_max"`
+		CrConfigBackupFile             *string `json:"crconfig_backup_file"`
+		TmConfigBackupFile             *string `json:"tmconfig_backup_file"`
 		*Alias
 	}{
 		Alias: (*Alias)(c),
@@ -191,6 +204,15 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	}
 	if aux.TrafficOpsMaxRetryIntervalMs != nil {
 		c.TrafficOpsMaxRetryInterval = time.Duration(*aux.TrafficOpsMaxRetryIntervalMs) * time.Millisecond
+	}
+	if aux.TrafficOpsDiskRetryMax != nil {
+		c.TrafficOpsDiskRetryMax = *aux.TrafficOpsDiskRetryMax
+	}
+	if aux.CrConfigBackupFile != nil {
+		c.CrConfigBackupFile = *aux.CrConfigBackupFile
+	}
+	if aux.TmConfigBackupFile != nil {
+		c.TmConfigBackupFile = *aux.TmConfigBackupFile
 	}
 	return nil
 }

--- a/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/manager/manager.go
@@ -43,7 +43,7 @@ import (
 // Start starts the poller and handler goroutines
 //
 func Start(opsConfigFile string, cfg config.Config, appData config.StaticAppData, trafficMonitorConfigFileName string) error {
-	toSession := towrap.ITrafficOpsSession(towrap.NewTrafficOpsSessionThreadsafe(nil, cfg.CRConfigHistoryCount))
+	toSession := towrap.ITrafficOpsSession(towrap.NewTrafficOpsSessionThreadsafe(nil, cfg.CRConfigHistoryCount, cfg))
 
 	localStates := peer.NewCRStatesThreadsafe() // this is the local state as discoverer by this traffic_monitor
 	fetchCount := threadsafe.NewUint()          // note this is the number of individual caches fetched from, not the number of times all the caches were polled.

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -331,8 +331,8 @@ func (s TrafficOpsSessionThreadsafe) trafficMonitorConfigMapRaw(cdn string) (*tc
 
 		log.Errorln("Error getting configMap from traffic_ops, backup file exists, reading from file")
 		json := jsoniter.ConfigFastest
-		if err = json.Unmarshal(b, &configMap); err != nil {
-			log.Errorln("Error unmarshaling JSON from TMConfigBackupFile")
+		if err := json.Unmarshal(b, &configMap); err != nil {
+			return nil, errors.New("unmarhsalling backup file monitoring.json: " + err.Error())
 		}
 		return configMap, err
 	}


### PR DESCRIPTION
With these changes traffic monitor will create TM and CR backup files on disk. If TO is unreachable and these files exist then it will pull its data from these files. Any time a new valid one is available it will write them back to disk. On startup TM will still follow its exponential backoff scheme but once it hits the max it will create a non-authenticated TO session so that we can use the disk files. If at any point TO comes back up then TM will attempt to authenticate and continue as normal

This depends on #3045 

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [x] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



