### PR TITLE
Backport #3066 - fix DS matchlist ordering to match the Perl

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
@@ -761,6 +761,7 @@ JOIN deliveryservice_regex as dsr ON dsr.regex = r.id
 JOIN deliveryservice as ds on ds.id = dsr.deliveryservice
 JOIN type as t ON r.type = t.id
 WHERE ds.xml_id = ANY($1)
+ORDER BY dsr.set_number
 `
 	rows, err := tx.Query(q, pq.Array(dses))
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13_test.go
@@ -25,7 +25,30 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+
+	"github.com/jmoiron/sqlx"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
+
+func TestGetDeliveryServicesMatchLists(t *testing.T) {
+	// test to make sure that the DS matchlists query orders by set_number
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .+ ORDER BY dsr.set_number")
+
+	GetDeliveryServicesMatchLists([]string{"foo"}, db.MustBegin().Tx)
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations were not met: %s", err)
+	}
+}
 
 func TestMakeExampleURLs(t *testing.T) {
 	expected := []string{


### PR DESCRIPTION
#### What does this PR do?

Backport #3066 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



