### PR TITLE
v3.1.1 - now processes each route immediately as it is read

### DIFF
--- a/traffic_ops/testing/compare/compare.go
+++ b/traffic_ops/testing/compare/compare.go
@@ -36,7 +36,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 )
 
-const __version__ = "3.1.0"
+const __version__ = "3.1.1"
 const SHORT_HEADER = "# DO NOT EDIT"
 const LONG_HEADER = "# TRAFFIC OPS NOTE:"
 const LUA_HEADER = "-- DO NOT EDIT"
@@ -579,23 +579,18 @@ func main() {
 	}
 	wg.Wait()
 
-	var testRoutes []string
-
 	scanner := bufio.NewScanner(routesFile)
 	for scanner.Scan() {
-		testRoutes = append(testRoutes, scanner.Text())
+		wg.Add(1)
+		go func(r string) {
+			testRoute(tos, r)
+			wg.Done()
+		}(scanner.Text())
 	}
 
 	if err := scanner.Err(); err != nil {
 		log.Fatal(err)
 	}
 
-	wg.Add(len(testRoutes))
-	for _, route := range testRoutes {
-		go func(r string) {
-			testRoute(tos, r)
-			wg.Done()
-		}(route)
-	}
 	wg.Wait()
 }


### PR DESCRIPTION
## What does this PR do?
Fixes #3029 
`compare` will now immediately dispatch a goroutine to handle each route as it is read from the input file (or `STDIN`, as the case may be) which greatly improves the efficiency of piping the output of genConfigRoutes.py to `compare`

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other: The `compare` Tool

## What is the best way to verify this PR?
Build and test `compare` to be sure it works right, possibly piping in a slowly-populated list of routes to check the behaviour of comparing-as-you-go. See [the documentation](https://traffic-control-cdn.readthedocs.io/en/latest/tools/compare.html) for details.

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



