### PR TITLE
Emit warning when adding self-signed certs using the API rather than prohibiting them

### DIFF
--- a/lib/go-tc/constants.go
+++ b/lib/go-tc/constants.go
@@ -42,7 +42,7 @@ const (
 	ErrorLevel
 )
 
-var alertLevels = [4]string{"success", "info", "warn", "error"}
+var alertLevels = [4]string{"success", "info", "warning", "error"}
 
 func (a AlertLevel) String() string {
 	return alertLevels[a]

--- a/traffic_ops/traffic_ops_golang/deliveryservice/keys_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/keys_test.go
@@ -27,7 +27,7 @@ import (
 const (
 	BadData = "This is bad data and it is not pem encoded"
 
-	SelfSigneCertOnly = `
+	SelfSignedCertOnly = `
 -----BEGIN CERTIFICATE-----
 MIIDkjCCAnoCCQCfwd219JKpUDANBgkqhkiG9w0BAQsFADCBijELMAkGA1UEBhMC
 VVMxETAPBgNVBAgMCENvbG9yYWRvMQ8wDQYDVQQHDAZEZW52ZXIxEDAOBgNVBAoM
@@ -199,19 +199,28 @@ OEUjfakK71+V/HbQt477zR4k7cRbiA==
 func TestVerifyAndEncodeCertificate(t *testing.T) {
 
 	// should fail bad base64 data
-	dat, err := verifyCertificate(BadData, "")
+	dat, _, err := verifyCertificate(BadData, "")
 	if err == nil {
 		t.Errorf("Unexpected result, there should have been a base64 decoding failure")
 	}
 
-	// should fail, can't verify self signed cert
-	dat, err = verifyCertificate(SelfSigneCertOnly, rootCA)
+	// should fail, can't verify self signed cert against this rootCA
+	dat, _, err = verifyCertificate(SelfSignedCertOnly, rootCA)
 	if err == nil {
 		t.Errorf("Unexpected result, a certificate verification error should have occured")
 	}
 
+	// should pass, unknown authority is just a warning not an error
+	dat, unknownAuth, err := verifyCertificate(GoodTLSKeys, "")
+	if err != nil {
+		t.Errorf("Test failure: %s", err)
+	}
+	if !unknownAuth {
+		t.Errorf("Unexpected result, certificate verification should have detected unknown authority")
+	}
+
 	// should pass
-	dat, err = verifyCertificate(GoodTLSKeys, rootCA)
+	dat, _, err = verifyCertificate(GoodTLSKeys, rootCA)
 	if err != nil {
 		t.Errorf("Test failure: %s", err)
 	}

--- a/traffic_portal/app/src/common/api/DeliveryServiceSslKeysService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceSslKeysService.js
@@ -60,7 +60,7 @@ var DeliveryServiceSslKeysService = function($http, $q, locationUtils, messageMo
         $http.post(ENV.api['root'] + "deliveryservices/sslkeys/add", sslKeys)
         .then(
             function(result) {
-            	messageModel.setMessages([ { level: 'success', text: 'SSL Keys updated for ' + deliveryService.xmlId } ], false);
+                messageModel.setMessages(result.data.alerts, false);
                 request.resolve(result.data.response);
             },
             function(fault) {


### PR DESCRIPTION
#### What does this PR do?

Rather than prohibit adding self-signed certs via the API, emit a
warning to indicate that self-signed certs were detected and might not
be completely valid.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Run the traffic_ops_golang unit tests.

In TP, generate self-signed certs for a DS. In the next view where the certs are shown, add a space to one of the input fields and remove it in order to use the "update keys" button. This will re-add your self-signed certificates using the API. You should see a message in a yellow box at the top that mentions the keys were added successfully but are signed by an unknown authority and might be invalid.

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



