### PR TITLE
Fixed configuration file sanitization

### DIFF
--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/config_files.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/config_files.py
@@ -262,7 +262,7 @@ def sanitizeContents(raw:str) -> str:
 	# to use curly brace-enclosed text as a key into a dictonary of its arguments. They'll be
 	# rendered into single braces in the output of `.format`, leaving the string ultimately
 	# unchanged in that respect.
-	for line in raw.replace('{', "{{").replace('}', "}}").format(SERVER_INFO).splitlines():
+	for line in SERVER_INFO.sanitize(raw).splitlines():
 		tmp=(" ".join(line.split())).strip() #squeezes spaces and trims leading and trailing spaces
 		tmp=tmp.replace("&amp;", '&') #decodes HTML-encoded ampersands
 		tmp=tmp.replace("&gt;", '>') #decodes HTML-encoded greater-than symbols

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -94,7 +94,7 @@ class ServerInfo():
 		                       for a in dir(self)\
 		                       if not a.startswith('_')))
 
-	def __format__(self, fmt:str) -> str:
+	def sanitize(self, fmt:str) -> str:
 		"""
 		Implements ``str.format(self)``
 		"""


### PR DESCRIPTION
## What does this PR do?
Fixes a bug with the CIAB ORT package where replacement strings weren't getting properly substituted.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other: Python ORT package

## What is the best way to verify this PR?
Build CDN-in-a-Box and check that all of the files are devoid of replacement strings e.g. `__FULL_HOSTNAME__`

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



