### PR TITLE
Fixes missing deliveryservice data fields from the servers/deliveryservices endpoint.

### DIFF
--- a/lib/go-tc/deliveryservice_servers.go
+++ b/lib/go-tc/deliveryservice_servers.go
@@ -55,6 +55,7 @@ type DeliveryServiceServer struct {
 }
 
 type Filter int
+
 const (
 	Assigned Filter = iota
 	Unassigned
@@ -62,7 +63,7 @@ const (
 )
 
 type DSServersAttrResponse struct {
-	Response []DSServer 	`json:"response"`
+	Response []DSServer `json:"response"`
 }
 
 type DSServer struct {
@@ -109,64 +110,4 @@ type DSServer struct {
 	Type             string               `json:"type" db:"server_type"`
 	TypeID           *int                 `json:"typeId" db:"server_type_id"`
 	UpdPending       *bool                `json:"updPending" db:"upd_pending"`
-}
-
-// DSSDeliveryService is a representation of a deliveryservice that allows for all fields to be null
-type DSSDeliveryService struct {
-	// NOTE: the db: struct tags are used for testing to map to their equivalent database column (if there is one)
-	//
-	Active               *bool            `json:"active" db:"active"`
-	CacheURL             *string          `json:"cacheurl" db:"cacheurl"`
-	CCRDNSTTL            *int             `json:"ccrDnsTtl" db:"ccr_dns_ttl"`
-	CDNID                *int             `json:"cdnId" db:"cdn_id"`
-	CheckPath            *string          `json:"checkPath" db:"check_path"`
-	DeepCachingType      *DeepCachingType `json:"deepCachingType" db:"deep_caching_type"`
-	DisplayName          *string          `json:"displayName" db:"display_name"`
-	DNSBypassCNAME       *string          `json:"dnsBypassCname" db:"dns_bypass_cname"`
-	DNSBypassIP          *string          `json:"dnsBypassIp" db:"dns_bypass_ip"`
-	DNSBypassIP6         *string          `json:"dnsBypassIp6" db:"dns_bypass_ip6"`
-	DNSBypassTTL         *int             `json:"dnsBypassTtl" db:"dns_bypass_ttl"`
-	DSCP                 *int             `json:"dscp" db:"dscp"`
-	EdgeHeaderRewrite    *string          `json:"edgeHeaderRewrite" db:"edge_header_rewrite"`
-	FQPacingRate         *int             `json:"fqPacingRate" db:"fq_pacing_rate"`
-	GeoLimit             *int             `json:"geoLimit" db:"geo_limit"`
-	GeoLimitCountries    *string          `json:"geoLimitCountries" db:"geo_limit_countries"`
-	GeoLimitRedirectURL  *string          `json:"geoLimitRedirectURL" db:"geolimit_redirect_url"`
-	GeoProvider          *int             `json:"geoProvider" db:"geo_provider"`
-	GlobalMaxMBPS        *int             `json:"globalMaxMbps" db:"global_max_mbps"`
-	GlobalMaxTPS         *int             `json:"globalMaxTps" db:"global_max_tps"`
-	HTTPBypassFQDN       *string          `json:"httpBypassFqdn" db:"http_bypass_fqdn"`
-	ID                   *int             `json:"id" db:"id"`
-	InfoURL              *string          `json:"infoUrl" db:"info_url"`
-	InitialDispersion    *int             `json:"initialDispersion" db:"initial_dispersion"`
-	IPV6RoutingEnabled   *bool            `json:"ipv6RoutingEnabled" db:"ipv6_routing_enabled"`
-	LastUpdated          *TimeNoMod       `json:"lastUpdated" db:"last_updated"`
-	LogsEnabled          *bool            `json:"logsEnabled" db:"logs_enabled"`
-	LongDesc             *string          `json:"longDesc" db:"long_desc"`
-	LongDesc1            *string          `json:"longDesc1" db:"long_desc_1"`
-	LongDesc2            *string          `json:"longDesc2" db:"long_desc_2"`
-	MaxDNSAnswers        *int             `json:"maxDnsAnswers" db:"max_dns_answers"`
-	MidHeaderRewrite     *string          `json:"midHeaderRewrite" db:"mid_header_rewrite"`
-	MissLat              *float64         `json:"missLat" db:"miss_lat"`
-	MissLong             *float64         `json:"missLong" db:"miss_long"`
-	MultiSiteOrigin      *bool            `json:"multiSiteOrigin" db:"multi_site_origin"`
-	MultiSiteOriginAlgo  *int             `json:"multiSiteOriginAlgo" db:"multi_site_origin_algorithm"`
-	OriginShield         *string          `json:"originShield" db:"origin_shield"`
-	OrgServerFQDN        *string          `json:"orgServerFqdn" db:"org_server_fqdn"`
-	ProfileDesc          *string          `json:"profileDescription"`
-	ProfileID            *int             `json:"profileId" db:"profile"`
-	Protocol             *int             `json:"protocol" db:"protocol"`
-	QStringIgnore        *int             `json:"qstringIgnore" db:"qstring_ignore"`
-	RangeRequestHandling *int             `json:"rangeRequestHandling" db:"range_request_handling"`
-	RegexRemap           *string          `json:"regexRemap" db:"regex_remap"`
-	RegionalGeoBlocking  *bool            `json:"regionalGeoBlocking" db:"regional_geo_blocking"`
-	RemapText            *string          `json:"remapText" db:"remap_text"`
-	RoutingName          *string          `json:"routingName" db:"routing_name"`
-	SigningAlgorithm     *string          `json:"signingAlgorithm" db:"signing_algorithm"`
-	SSLKeyVersion        *int             `json:"sslKeyVersion" db:"ssl_key_version"`
-	TRRequestHeaders     *string          `json:"trRequestHeaders" db:"tr_request_headers"`
-	TRResponseHeaders    *string          `json:"trResponseHeaders" db:"tr_response_headers"`
-	TenantID             *int             `json:"tenantId" db:"tenant_id"`
-	TypeID               *int             `json:"typeId" db:"type"`
-	XMLID                *string          `json:"xmlId" db:"xml_id"`
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -518,7 +518,6 @@ func (dss *TODSSDeliveryService) Read() ([]interface{}, error, error, int) {
 	}
 	where += "ds.id in (SELECT deliveryService FROM deliveryservice_server where server = :server)"
 
-	log.Debugln("Tenancy is enabled")
 	tenantIDs, err := tenant.GetUserTenantIDListTx(tx, user.TenantID)
 	if err != nil {
 		log.Errorln("received error querying for user's tenants: " + err.Error())

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -491,6 +491,10 @@ func (dss *TODSSDeliveryService) Read() ([]interface{}, error, error, int) {
 	tx := dss.APIInfo().Tx.Tx
 	user := dss.APIInfo().User
 
+	if err := api.IsInt(params["id"]); err != nil {
+		return nil, errors.New("Resource not found."), nil, http.StatusNotFound //matches perl response
+	}
+
 	if _, ok := params["orderby"]; !ok {
 		params["orderby"] = "xml_id"
 	}
@@ -503,12 +507,7 @@ func (dss *TODSSDeliveryService) Read() ([]interface{}, error, error, int) {
 	}
 	where, orderBy, queryValues, errs := dbhelpers.BuildWhereAndOrderBy(params, queryParamsToSQLCols)
 	if len(errs) > 0 {
-		for _, err := range errs {
-			if err.Error() == `id cannot parse to integer` { // TODO create const for string
-				return nil, errors.New("Resource not found."), nil, http.StatusNotFound //matches perl response
-			}
-		}
-		return nil, nil, errors.New("reading dses: " + util.JoinErrsStr(errs)), http.StatusInternalServerError
+		return nil, nil, errors.New("reading server dses: " + util.JoinErrsStr(errs)), http.StatusInternalServerError
 	}
 
 	if where != "" {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -487,7 +487,7 @@ func TypeSingleton(reqInfo *api.APIInfo) api.Reader {
 // Read shows all of the delivery services associated with the specified server.
 func (dss *TODSSDeliveryService) Read() ([]interface{}, error, error, int) {
 	returnable := []interface{}{}
-	params := make(map[string]string)
+	params := dss.APIInfo().Params
 	tx := dss.APIInfo().Tx.Tx
 	user := dss.APIInfo().User
 
@@ -540,12 +540,7 @@ func (dss *TODSSDeliveryService) Read() ([]interface{}, error, error, int) {
 
 	dses, errs, _ := deliveryservice.GetDeliveryServices(query, queryValues, dss.APIInfo().Tx)
 	if len(errs) > 0 {
-		for _, err := range errs {
-			if err.Error() == `id cannot parse to integer` { // TODO create const for string
-				return nil, errors.New("Resource not found."), nil, http.StatusNotFound //matches perl response
-			}
-		}
-		return nil, nil, errors.New("reading dses: " + util.JoinErrsStr(errs)), http.StatusInternalServerError
+		return nil, nil, errors.New("reading server dses: " + util.JoinErrsStr(errs)), http.StatusInternalServerError
 	}
 
 	for _, ds := range dses {


### PR DESCRIPTION
This PR fixes /api/servers/{id}/deliveryservices endpoint.
The fix removes a duplicate deliveryservice struct and query.
The endpoint now uses the same DeliverServiceNullable struct in
tc-go and the query from deliverservice/deliveryservcesv13.go

Also added a tenancy check.

#### What does this PR do?
Fixes #2989

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [X] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



Fixes #2989