### PR TITLE
CIAB: fix race issue where server not avail when server assignment done

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -36,7 +36,8 @@ RUN yum install -y epel-release && \
         perl-Crypt-ScryptKDF \
         perl-Test-CPAN-Meta \
         perl-JSON-PP \
-        git && \
+        git \
+        jq && \
     yum-config-manager --add-repo 'http://vault.centos.org/7.5.1804/os/x86_64/' && \
     yum -y install --enablerepo=vault* golang-1.9.4 && \
     yum -y clean all
@@ -86,4 +87,5 @@ ADD enroller/server_template.json \
 
 ADD traffic_ops_data /traffic_ops_data
 
+RUN chown -R trafops:trafops /opt/traffic_ops
 CMD /run.sh

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -75,23 +75,6 @@ TO_USER=$TO_ADMIN_USER TO_PASSWORD=$TO_ADMIN_PASSWORD to-enroll $(hostname -s) &
 
 to-enroll "to" ALL || (while true; do echo "enroll failed."; sleep 3 ; done)
 
-### Workaround: Start DeliveryService and Edge association
-while true; do
-  edge_name="$(to-get 'api/1.3/servers/hostname/edge/details' 2>/dev/null | jq -r -c '.response|.hostName')"
-  ds_name="$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[].xmlId')"
-
-  if [ -n "$edge_name" ] && [ "$ds_name" ] ; then
-    tmp_file=$(mktemp)
-    echo "{ \"xmlId\" : \"$ds_name\", \"serverNames\": [ \"$edge_name\" ] }" > $tmp_file
-    cp $tmp_file /shared/enroller/deliveryservice_servers/
-    break
-  else 
-    echo "Waiting for delivery service and edge to exist..."
-  fi
-
-  sleep 2
-done
-
 while true; do
   echo "Verifying that edge was associated to delivery service..."
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -142,12 +142,6 @@ to-enroll() {
 		sleep 2
 	done
 
-	while true; do
-		[ "$serverType" = "to" ] && break
-		[ -f "$ENROLLER_DIR/initial-load-done" ] && break
-		echo "Waiting for traffic-ops to do initial load ..."
-		sleep 2
-	done
 	if [[ ! -d ${ENROLLER_DIR}/servers ]]; then
 		echo "${ENROLLER_DIR}/servers not found -- contents:"
 		find ${ENROLLER_DIR} -ls

--- a/infrastructure/cdn-in-a-box/traffic_ops/trafficops-init.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/trafficops-init.sh
@@ -39,6 +39,38 @@ done
 endpoints="cdns types divisions regions phys_locations tenants users cachegroups deliveryservices profiles parameters servers deliveryservice_servers"
 vars=$(awk -F = '/^\w/ {printf "$%s ",$1}' /variables.env)
 
+waitfor() {
+    local endpoint="$1"
+    local field="$2"
+    local value="$3"
+
+    while true; do
+        v=$(to-get "api/1.4/$endpoint?$field=$value" | jq -r --arg field "$field" '.response[][$field]')
+        if [[ $v == $value ]]; then
+            break
+        fi
+        echo "waiting for $endpoint $field=$value"
+        sleep 3
+    done
+}
+
+# special cases -- any data type requiring specific data to already be available in TO should have an entry here.
+# e,g. deliveryservice_servers requires both deliveryservice and all servers to be available
+delayfor() {
+    local f="$1"
+    local d="${f%/*}"
+
+    case $d in
+        deliveryservice_servers)
+            ds=$( jq -r .xmlId <"$f" )
+            waitfor deliveryservices xmlId "$ds"
+            for s in $( jq -r .serverNames[] <"$f" ); do
+                waitfor servers hostName "$s"
+            done
+            ;;
+    esac
+}
+
 load_data_from() {
     local dir="$1"
     if [[ ! -d $dir ]] ; then
@@ -50,6 +82,7 @@ load_data_from() {
         [[ -d $d ]] || continue
         for f in "$d"/*.json; do 
             echo "Loading $f"
+            delayfor "$f"
             envsubst "$vars" <$f  > "$ENROLLER_DIR"/$f
         done
     done


### PR DESCRIPTION
#### What does this PR do?
on fresh cdn-in-a-box,  default dataset assigns the deliveryservice to the single edge server.  That server is not registered with traffic_ops at the time the assignment is done.

This is a stopgap measure until we improve synchronization between containers.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other cdn-in-a-box

#### What is the best way to verify this PR?
Build cdn-in-a-box from scratch:
```
cd infrastructure/cdn-in-a-box
docker-compose build
docker-compose up -d
```

set up access to traffic_ops:
```
. traffic_ops/to-access.sh
export TO_URL=https://localhost:6443 TO_USER=... TO_PASSWORD=...
to-get api/1.4/deliveryservices/1/servers | jq -S .response[].hostName
```

The hostName printed here should be "edge"..
