### PR TITLE
grovetccfg: use kernel host name if -host argument is not used on the command line.

### DIFF
--- a/grove/grovetccfg/grovetccfg.go
+++ b/grove/grovetccfg/grovetccfg.go
@@ -188,8 +188,14 @@ func main() {
 	flag.Parse()
 
 	if host == nil || *host == "" {
-		fmt.Println(time.Now().Format(time.RFC3339Nano) + " Error, a 'host' is required, use '-host'")
-		os.Exit(1)
+		// if the host was not specified on the command line, get it from the kernel
+		h, err := os.Hostname()
+		if err != nil {
+			fmt.Println(time.Now().Format(time.RFC3339Nano) + err.Error() + " and 'host' is required, use '-host'")
+			os.Exit(1)
+		}
+		sl := strings.Split(h, ".")
+		*host = sl[0]
 	}
 
 	useCache := false


### PR DESCRIPTION
If when using grovetccfg and the host is not specidied with -host on the command line, get and set the host from kernel.

#### What does this PR do?

helps with grove configuration by simplifying automated cron setup of grovetccfg.

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [X] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



