### PR TITLE
use golang package from centos vault temporarily

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -26,18 +26,20 @@ FROM centos:7
 RUN yum install -y epel-release && \
     yum install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm && \
     yum install -y \
-	    cpanminus \
-      bind-utils \
-      net-tools \
-	    gettext \
-	    nmap-ncat \
-	    openssl \
-	    perl \
-	    perl-Crypt-ScryptKDF \
-	    perl-Test-CPAN-Meta \
-      perl-JSON-PP \
-      git \
-      golang
+        cpanminus \
+        bind-utils \
+        net-tools \
+        gettext \
+        nmap-ncat \
+        openssl \
+        perl \
+        perl-Crypt-ScryptKDF \
+        perl-Test-CPAN-Meta \
+        perl-JSON-PP \
+        git && \
+    yum-config-manager --add-repo 'http://vault.centos.org/7.5.1804/os/x86_64/' && \
+    yum -y install --enablerepo=vault* golang-1.9.4 && \
+    yum -y clean all
 
 RUN yum install -y perl-DBIx-Connector
 

--- a/infrastructure/docker/build/Dockerfile-traffic_monitor
+++ b/infrastructure/docker/build/Dockerfile-traffic_monitor
@@ -30,8 +30,9 @@ RUN	yum -y install \
 	yum -y clean all
 
 ### traffic_monitor specific requirements
-RUN	yum -y install \
-		golang-1.9.4 && \
+# NOTE: temporary workaround for removal of golang packages from CentOS 7 base repo
+RUN yum-config-manager --add-repo 'http://vault.centos.org/7.5.1804/os/x86_64/' && \
+        yum -y install --enablerepo=vault* golang-1.9.4 && \
 	yum -y clean all
 ###
 

--- a/infrastructure/docker/build/Dockerfile-traffic_ops
+++ b/infrastructure/docker/build/Dockerfile-traffic_ops
@@ -30,15 +30,17 @@ RUN	yum -y install \
 	yum -y clean all
 
 ### traffic_ops specific requirements
+# NOTE: temporary workaround for removal of golang packages from CentOS 7 base repo
 RUN	yum -y install \
 		expat-devel \
 		gcc \
-		golang-1.9.4 \
 		libcurl-devel \
 		make \
 		openssl-devel \
 		perl-ExtUtils-MakeMaker \
 		tar && \
+        yum-config-manager --add-repo 'http://vault.centos.org/7.5.1804/os/x86_64/' && \
+        yum -y install --enablerepo=vault* golang-1.9.4 && \
 	yum -y clean all
 
 ADD infrastructure/docker/build/clean_build.sh /

--- a/infrastructure/docker/build/Dockerfile-traffic_stats
+++ b/infrastructure/docker/build/Dockerfile-traffic_stats
@@ -30,8 +30,9 @@ RUN	yum -y install \
 	yum -y clean all
 
 ### traffic_stats specific requirements
-RUN	yum -y install \
-		golang-1.9.4 && \
+# NOTE: temporary workaround for removal of golang packages from CentOS 7 base repo
+RUN yum-config-manager --add-repo 'http://vault.centos.org/7.5.1804/os/x86_64/' && \
+        yum -y install --enablerepo=vault* golang-1.9.4 && \
 	yum -y clean all
 ###
 


### PR DESCRIPTION
#### What does this PR do?

Gets golang packages from previous minor revision of CentOS.   This is a temporary provision to get the Go builds working again.   Getting from a new permanent location also means upgrading Go to 1.11.

Fixes #3087
#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [x] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [x] Traffic Stats
- [ ] Traffic Vault
- [x] Other cdn-in-a-box

#### What is the best way to verify this PR?

Build traffic_ops,  traffic_monitor, traffic_stats rpms.   Build cdn-in-a-box.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



