### PR TITLE
Fixed bad parameter sets on CIAB cache profiles

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
@@ -93,7 +93,7 @@
 			"configFile": "records.config",
 			"name": "CONFIG proxy.config.reverse_proxy.enabled",
 			"secure": false,
-			"value": "INT 0"
+			"value": "INT 1"
 		},
 		{
 			"configFile": "records.config",

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/020-ATS_MID_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/020-ATS_MID_TIER_CACHE.json
@@ -93,7 +93,7 @@
 			"configFile": "records.config",
 			"name": "CONFIG proxy.config.reverse_proxy.enabled",
 			"secure": false,
-			"value": "INT 1"
+			"value": "INT 0"
 		},
 		{
 			"configFile": "records.config",


### PR DESCRIPTION
## What does this PR do?
Fixes parameters so that edge is a reverse proxy and mid a forward proxy, rather than the other way around.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other: CDN-in-a-Box

## What is the best way to verify this PR?
Build and test CDN-in-a-Box

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



