### PR TITLE
Add missing API calls to Python API client up to 1.3

### DIFF
--- a/traffic_control/clients/python/trafficops/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/trafficops/tosession.py
@@ -315,6 +315,7 @@ class TOSession(restapi.RestApiSession):
 
 	#
 	# ASN
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/asn.html#api-1-2-asns
 	#
 
 	# Implemented Direct API URL Endpoint Methods
@@ -323,13 +324,57 @@ class TOSession(restapi.RestApiSession):
 	def get_asns(self, query_params=None):
 		"""
 		Get ASNs.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/asn.html#api-1-2-asns
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	@restapi.api_request(u'get', u'asns/{asn_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_asn_by_id(self, asn_id=None):
+		"""
+		Get ASN by ID
+		:param asn_id: The ID of the ASN to retrieve
+		:type asn_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'asns/{asn_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_asn(self, asn_id=None, query_params=None):
+		"""
+		Update ASN
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/asn.html#api-1-2-asns
+		:param asn_id: The ID of the ASN to update
+		:type asn_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'asns', (u'1.1', u'1.2', u'1.3',))
+	def create_asn(self, data=None):
+		"""
+		Create ASN
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/asn.html#api-1-2-asns
+		:param data: The parameter data to use for cachegroup creation.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'asns/{asn_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_asn(self, asn_id=None):
+		"""
+		Delete ASN
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/asn.html#api-1-2-asns
+		:param asn_id: The ID of the ASN to delete
+		:type asn_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
 
 	#
 	# Cache
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cache.html#api-1-2-caches-stats
 	#
 
 	@restapi.api_request(u'get', u'caches/stats', (u'1.1', u'1.2', u'1.3',))
@@ -343,6 +388,7 @@ class TOSession(restapi.RestApiSession):
 
 	#
 	# Cache Group
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
 	#
 
 	@restapi.api_request(u'get', u'cachegroups', (u'1.1', u'1.2', u'1.3',))
@@ -463,6 +509,7 @@ class TOSession(restapi.RestApiSession):
 
 	#
 	# Cache Group Parameters
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup_parameter.html#cache-group-parameters
 	#
 
 	@restapi.api_request(u'post', u'cachegroupparameters', (u'1.2', u'1.3'))
@@ -489,7 +536,10 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	#
 	# Cache Group Fallback
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup_fallbacks.html#cache-group-fallback
+	#
 
 	@restapi.api_request(u'get', u'cachegroup_fallbacks', (u'1.2', u'1.3'))
 	def get_cache_group_fallbacks(self, query_params=None):
@@ -556,7 +606,7 @@ class TOSession(restapi.RestApiSession):
 
 	#
 	# CDN
-	#
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#cdn
 	#
 	
 	@restapi.api_request(u'get', u'cdns', (u'1.1', u'1.2', u'1.3',))
@@ -631,10 +681,179 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	#
+	# CDN Health
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#health
+	#
+
+	@restapi.api_request(u'get', u'cdns/health', (u'1.2', u'1.3',))
+	def get_cdns_health(self):
+		"""
+		Retrieves the health of all locations (cache groups) for all CDNs
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#health
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name:s}/health', (u'1.2', u'1.3',))
+	def get_cdn_health_by_name(self, cdn_name=None):
+		"""
+		Retrieves the health of all locations (cache groups) for a given CDN
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#health
+		:param cdn_name: The CDN name to find health for
+		:type cdn_name: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/usage', (u'1.2', u'1.3',))
+	def get_cdns_usage(self):
+		"""
+		Retrieves the high-level CDN usage metrics.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#health
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/capacity', (u'1.2', u'1.3',))
+	def get_cdns_capacity(self):
+		"""
+		Retrieves the aggregate capacity percentages of all locations (cache groups) for a given CDN.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#health
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# CDN Routing
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#routing
+	#
+
+	@restapi.api_request(u'get', u'cdns/routing', (u'1.2', u'1.3',))
+	def get_cdns_routing(self):
+		"""
+		Retrieves the aggregate routing percentages of all locations (cache groups) for a given CDN.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#routing
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# CDN Metrics
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#metrics
+	# These routes are currently not implemented TODO when completed
+	#
+
+	#
+	# CDN Domains
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#domains
+	#
+
+	@restapi.api_request(u'get', u'cdns/domains', (u'1.2', u'1.3',))
+	def get_cdns_domains(self):
+		"""
+		Retrieves the different CDN domains
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#domains
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# CDN Topology
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#topology
+	#
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name:s}/configs', (u'1.2', u'1.3',))
+	def get_cdn_config_info(self, cdn_name=None):
+		"""
+		Retrieves CDN config information
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#topology
+		:param cdn_name: The CDN name to find configs for
+		:type cdn_name: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name:s}/configs/monitoring', (u'1.2', u'1.3',))
+	def get_cdn_monitoring_info(self, cdn_name=None):
+		"""
+		Retrieves CDN monitoring information
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#topology
+		:param cdn_name: The CDN name to find configs for
+		:type cdn_name: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name:s}/configs/routing', (u'1.2', u'1.3',))
+	def get_cdn_routing_info(self, cdn_name=None):
+		"""
+		Retrieves CDN routing information
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#topology
+		:param cdn_name: The CDN name to find routing info for
+		:type cdn_name: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# CDN DNSSEC Keys
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#dnssec-keys
+	#
+
+	@restapi.api_request(u'get', u'cdns/name/{cdn_name:s}/dnsseckeys', (u'1.2', u'1.3',))
+	def get_cdn_dns_sec_keys(self, cdn_name=None):
+		"""
+		Gets a list of dnsseckeys for a CDN and all associated Delivery Services
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#dnssec-keys
+		:param cdn_name: The CDN name to find dnsseckeys info for
+		:type cdn_name: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/name/{cdn_name:s}/dnsseckeys/delete', (u'1.2', u'1.3',))
+	def delete_cdn_dns_sec_keys(self, cdn_name=None):
+		"""
+		Delete dnssec keys for a cdn and all associated delivery services
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#dnssec-keys
+		:param cdn_name: The CDN name to delete dnsseckeys info for
+		:type cdn_name: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'deliveryservices/dnsseckeys/generate', (u'1.2', u'1.3',))
+	def create_cdn_dns_sec_keys(self, data=None):
+		"""
+		Generates ZSK and KSK keypairs for a CDN and all associated Delivery Services
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#dnssec-keys
+		:param data: The parameter data to use for cachegroup creation.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# CDN SSL Keys
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#ssl-keys
+	#
+
+	@restapi.api_request(u'get', u'cdns/name/{cdn_name:s}/sslkeys', (u'1.2', u'1.3',))
+	def get_cdn_ssl_keys(self, cdn_name=None):
+		"""
+		Returns ssl certificates for all Delivery Services that are a part of the CDN.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cdn.html#ssl-keys
+		:param cdn_name: The CDN name to find ssl keys for
+		:type cdn_name: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
 
 	#
 	# Change Logs
-	#https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/changelog.html#change-logs
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/changelog.html#change-logs
 	#
 
 	@restapi.api_request(u'get', u'logs', (u'1.2', u'1.3',))
@@ -669,6 +888,57 @@ class TOSession(restapi.RestApiSession):
 	# Config Files and Config File Metadata
 	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/configfiles_ats.html#config-files-and-config-file-metadata
 	#
+
+	@restapi.api_request(u'get', u'servers/{host_name:s}/configfiles/ats', (u'1.2', u'1.3',))
+	def get_server_config_files(self, host_name=None, query_params=None):
+		"""
+		Get the configuiration files for a given host name
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/configfiles_ats.html#config-files-and-config
+		:param host_name: The host name to get config files for
+		:type host_name: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'servers/{host_name:s}/configfiles/ats/{config_file:s}', (u'1.2', u'1.3',))
+	def get_server_specific_config_file(self, host_name=None, config_file=None, query_params=None):
+		"""
+		Get the configuiration files for a given host name and config file
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/configfiles_ats.html#config-files-and-config
+		:param host_name: The host name to get config files for
+		:type host_name: String
+		:param config_file: The config file name to retrieve for host
+		:type config_file: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'profiles/{profile_name:s}/configfiles/ats/{config_file:s}', (u'1.2', u'1.3',))
+	def get_profile_specific_config_files(self, profile_name=None, config_file=None, query_params=None):
+		"""
+		Get the configuiration files for a given profile name and config file
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/configfiles_ats.html#config-files-and-config
+		:param profile_name: The profile name to get config files for
+		:type host_name: String
+		:param config_file: The config file name to retrieve for host
+		:type config_file: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name:s}/configfiles/ats/{config_file:s}', (u'1.2', u'1.3',))
+	def get_cdn_specific_config_file(self, cdn_name=None, config_file=None, query_params=None):
+		"""
+		Get the configuiration files for a given cdn name and config file
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/configfiles_ats.html#config-files-and-config
+		:param cdn_name: The cdn name to get config files for
+		:type cdn_name: String
+		:param config_file: The config file name to retrieve for host
+		:type config_file: String
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 
 	#
 	# Delivery Service
@@ -879,7 +1149,30 @@ class TOSession(restapi.RestApiSession):
 	#
 	# Delivery Service User
 	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#delivery-service-user
-	# (TODO: Add all calls)
+	# 
+
+	@restapi.api_request(u'post', u'deliveryservice_user', (u'1.2', u'1.3'))
+	def create_delivery_service_user_link(self, data=None):
+		"""
+		Create one or more user / delivery service assignments.
+		:param data: The parameter data to use for Delivery Service SSL key generation.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'deliveryservice_user/{delivery_service_id:d}/{user_id:d}', (u'1.2', u'1.3'))
+	def delete_delivery_service_user_link(self, delivery_service_id=None, user_id=None):
+		"""
+		Removes a delivery service from a user.
+		:param delivery_service_id: The delivery service id to dissasociate the user
+		:type delivery_service_id: int
+		:param user_id: The user id to dissassociate
+		:type user_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 
 	#
 	# Delivery Service SSL Keys
@@ -968,12 +1261,40 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'post', u'deliveryservices/regexes', (u'1.1', u'1.2', u'1.3',))
-	def delete_deliveryservice_regexes(self, data=None):
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/regexes/{regex_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_deliveryservice_regexes_by_regex_id(self, delivery_service_id=None, regex_id=None):
 		"""
-		Delete RegExes.
-		:param data: The required data to delete delivery service regexes
+		Retrieves a regex for a specific delivery service.
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:param regex_id: The delivery service regex id
+		:type regex_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'deliveryservices/{delivery_service_id:d}/regexes', (u'1.1', u'1.2', u'1.3',))
+	def create_deliveryservice_regexes(self, delivery_service_id=None, data=None):
+		"""
+		Create a regex for a delivery service
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:param data: The required data to create delivery service regexes
 		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'deliveryservices/{delivery_service_id:d}/regexes/{regex_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_deliveryservice_regexes(self, delivery_service_id=None, regex_id=None, query_params=None):
+		"""
+		Update a regex for a delivery service
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:param regex_id: The delivery service regex id
+		:type regex_id: int
+		:param query_params: The required data to update delivery service regexes
+		:type query_params: Dict[Text, Any]
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
@@ -991,12 +1312,77 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-
-
-
+	#
 	# Delivery Service Statistics
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice_stats.html#delivery-service-statistics
+	#
 
+	@restapi.api_request(u'get', u'deliveryservice_stats.json', (u'1.1', u'1.2', u'1.3',))
+	def get_delivery_service_stats(self, query_params=None):
+		"""
+		Retrieves statistics on the delivery services.
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
 	# Divisions
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/division.html#divisions
+	#
+
+	@restapi.api_request(u'get', u'divisions', (u'1.1', u'1.2', u'1.3',))
+	def get_divisions(self):
+		"""
+		Get all divisions.
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'divisions/{division_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_division_by_id(self, division_id=None):
+		"""
+		Get a division by division id
+		:param division_id: The division id to retrieve
+		:type division_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'divisions/{division_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_division(self, division_id=None, query_params=None):
+		"""
+		Update a division by division id
+		:param division_id: The division id to update
+		:type division_id: int
+		:param query_params: The required data to update delivery service regexes
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'divisions', (u'1.1', u'1.2', u'1.3',))
+	def create_division(self, data=None):
+		"""
+		Create a division
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'divisions/{division_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_division(self, division_id=None, query_params=None):
+		"""
+		Delete a division by division id
+		:param division_id: The division id to delete
+		:type division_id: int
+		:param query_params: The required data to update delivery service regexes
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
 
 	# Federation
 
@@ -1010,26 +1396,64 @@ class TOSession(restapi.RestApiSession):
 
 	# Hardware Info
 
+	#
 	# ISO
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/iso.html#iso
+	#
 
-	# Jobs
-
-	# Parameter
-	@restapi.api_request(u'get', u'parameters', (u'1.1', u'1.2', u'1.3',))
-	def get_parameters(self):
+	@restapi.api_request(u'get', u'osversions', (u'1.2', u'1.3'))
+	def get_osversions(self):
 		"""
-		Get all Profile Parameters.
+		Get all OS versions for ISO generation and the directory where the kickstarter files are found. 
+		The values are retrieved from osversions.cfg found in either /var/www/files or in the location defined by the kickstart.files.location parameter (if defined).
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'post', u'parameters/validate', (u'1.1', u'1.2', u'1.3',))
-	def validate_parameter_exists(self, data=None):
+
+	@restapi.api_request(u'post', u'isos', (u'1.2', u'1.3',))
+	def generate_iso(self, data=None):
 		"""
-		Validate that a Parameter exists.
-		:param data: The parameter data to use for parameter validation.
+		Generate an ISO
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
 		:type data: Dict[Text, Any]
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Jobs
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/job.html#jobs
+	#
+
+	@restapi.api_request(u'get', u'jobs', (u'1.2', u'1.3'))
+	def get_jobs(self, query_params=None):
+		"""
+		Get all jobs (currently limited to invalidate content (PURGE) jobs) sorted by start time (descending).
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'jobs/{job_id:d}', (u'1.2', u'1.3'))
+	def get_job_by_id(self, job_id=None):
+		"""
+		Get a job by ID (currently limited to invalidate content (PURGE) jobs).
+		:param job_id: The job id to retrieve
+		:type job_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Parameter
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/parameter.html#parameter
+	#
+
+	@restapi.api_request(u'get', u'parameters', (u u'1.2', u'1.3',))
+	def get_parameters(self):
+		"""
+		Get all Profile Parameters.
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
@@ -1043,8 +1467,39 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	@restapi.api_request(u'get', u'parameters/{parameter_id:d}/profiles', (u'1.1', u'1.2', u'1.3',))
+	def get_associated_profiles_by_parameter_id(self, parameter_id=None):
+		"""
+		Get all Profiles associated to a Parameter by Id.
+		:param parameter_id: The parameter id
+		:type parameter_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'parameters/{parameter_id:d}/unassigned_profiles', (u'1.1', u'1.2', u'1.3',))
+	def get_unassigned_profiles_by_parameter_id(self, parameter_id=None):
+		"""
+		Retrieves all profiles NOT assigned to the parameter.
+		:param parameter_id: The parameter id
+		:type parameter_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
 	@restapi.api_request(u'get', u'profiles/{id:d}/parameters', (u'1.1', u'1.2', u'1.3',))
 	def get_parameters_by_profile_id(self, profile_id=None):
+		"""
+		Get all Parameters associated with a Profile by Id.
+		:param profile_id: The profile Id
+		:type profile_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'profiles/{id:d}/unassigned_parameters', (u'1.1', u'1.2', u'1.3',))
+	def get_unnassigned_parameters_by_profile_id(self, profile_id=None):
 		"""
 		Get all Parameters associated with a Profile by Id.
 		:param profile_id: The profile Id
@@ -1064,60 +1519,47 @@ class TOSession(restapi.RestApiSession):
 		"""
 
 	@restapi.api_request(u'post', u'parameters', (u'1.1', u'1.2', u'1.3',))
-	def create_parameters(self, data=None):
+	def create_parameter(self, data=None):
 		"""
-		Create Parameters
+		Create Parameter
 		:param data: The parameter(s) data to use for parameter creation.
 		:type data: Union[Dict[Text, Any], List[Dict[Text, Any]]]
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'parameters/{parameter_id:d}/profiles', (u'1.1', u'1.2', u'1.3',))
-	def get_associated_profiles_by_parameter_id(self, parameter_id=None):
+	@restapi.api_request(u'put', u'parameters/{parameter_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_parameter(self, parameter_id=None, query_params=None):
 		"""
-		Get all Profiles associated to a Parameter by Id.
-		:param parameter_id: The parameter id
+		Update Parameter
+		:param parameter_id: The parameter id to update
 		:type parameter_id: int
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'post', u'profiles/id/{profile_id:d}/parameters', (u'1.1', u'1.2', u'1.3',))
-	def associate_parameters_by_profile_id(self, profile_id=None, data=None):
-		"""
-		Associate Parameters to a Profile by Id.
-		:param profile_id: The profile id
-		:type profile_id: int
-		:param data: The parameter data to associate
-		:type data: Union[Dict[Text, Any], List[Dict[Text, Any]]]
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
 
-	@restapi.api_request(u'post', u'profiles/name/{profile_name}/parameters', (u'1.1', u'1.2', u'1.3',))
-	def associate_parameters_by_profile_name(self, profile_name=None, data=None):
+	@restapi.api_request(u'delete', u'parameters/{parameter_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_parameter(self, parameter_id=None):
 		"""
-		Associate Parameters to a Profile by Name.
-		:param profile_name: The profile name
-		:type profile_name: Text
-		:param data: The parameter data to associate
-		:type data: Union[Dict[Text, Any], List[Dict[Text, Any]]]
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'delete', u'profileparameters/{profile_id:d}/{parameter_id:d}', (u'1.1', u'1.2', u'1.3',))
-	def delete_profile_parameter_association_by_id(self, profile_id=None, parameter_id=None):
-		"""
-		Delete Parameter association by Id for a Profile by Id.
-		:param profile_id: The profile id
-		:type profile_id: int
-		:param parameter_id: The parameter id
+		Delete Parameter
+		:param parameter_id: The parameter id to delete
 		:type parameter_id: int
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
+
+
+	@restapi.api_request(u'post', u'parameters/validate', (u'1.1', u'1.2', u'1.3',))
+	def validate_parameter_exists(self, data=None):
+		"""
+		Validate that a Parameter exists.
+		:param data: The parameter data to use for parameter validation.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 
 	# Physical Location
 	@restapi.api_request(u'get', u'phys_locations', (u'1.1', u'1.2', u'1.3',))
@@ -1170,6 +1612,45 @@ class TOSession(restapi.RestApiSession):
 		"""
 
 	# Profile Parameters
+
+
+	@restapi.api_request(u'post', u'profiles/id/{profile_id:d}/parameters', (u'1.1', u'1.2', u'1.3',))
+	def associate_parameters_by_profile_id(self, profile_id=None, data=None):
+		"""
+		Associate Parameters to a Profile by Id.
+		:param profile_id: The profile id
+		:type profile_id: int
+		:param data: The parameter data to associate
+		:type data: Union[Dict[Text, Any], List[Dict[Text, Any]]]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'profiles/name/{profile_name}/parameters', (u'1.1', u'1.2', u'1.3',))
+	def associate_parameters_by_profile_name(self, profile_name=None, data=None):
+		"""
+		Associate Parameters to a Profile by Name.
+		:param profile_name: The profile name
+		:type profile_name: Text
+		:param data: The parameter data to associate
+		:type data: Union[Dict[Text, Any], List[Dict[Text, Any]]]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'profileparameters/{profile_id:d}/{parameter_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_profile_parameter_association_by_id(self, profile_id=None, parameter_id=None):
+		"""
+		Delete Parameter association by Id for a Profile by Id.
+		:param profile_id: The profile id
+		:type profile_id: int
+		:param parameter_id: The parameter id
+		:type parameter_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
 
 	#
 	# InfluxDB

--- a/traffic_control/clients/python/trafficops/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/trafficops/tosession.py
@@ -378,7 +378,7 @@ class TOSession(restapi.RestApiSession):
 	#
 
 	@restapi.api_request(u'get', u'caches/stats', (u'1.1', u'1.2', u'1.3',))
-	def get_cache_stats(self):
+	def get_traffic_monitor_cache_stats(self):
 		"""
 		Retrieves cache stats from Traffic Monitor. Also includes rows for aggregates
 		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cache.html#cache
@@ -1514,7 +1514,7 @@ class TOSession(restapi.RestApiSession):
 	#
 
 	@restapi.api_request(u'get', u'federations/{federation_id:d}/federation_resolvers', (u'1.2', u'1.3'))
-	def get_federation_resolvers(self, federation_id=None):
+	def get_federation_resolvers_by_id(self, federation_id=None):
 		"""
 		Retrieves federation resolvers assigned to a federation
 		:param federation_id: The federation id
@@ -2335,8 +2335,7 @@ class TOSession(restapi.RestApiSession):
 
 	@restapi.api_request(u'post', u'tenants', (u'1.1', u'1.2', u'1.3',))
 	def create_tenant(self, data=None):
-		"""
-		Create a tenant
+		"""Create a tenant
 		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/tenant.html#tenants
 		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
 		:type data: Dict[Text, Any]

--- a/traffic_control/clients/python/trafficops/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/trafficops/tosession.py
@@ -1240,7 +1240,7 @@ class TOSession(restapi.RestApiSession):
 
 	#
 	# Delivery Service Regexes
-	#
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice_regex.html#delivery-service-regexes
 	#
 
 	@restapi.api_request(u'get', u'deliveryservices_regexes', (u'1.1', u'1.2', u'1.3',))
@@ -1384,17 +1384,243 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	#
 	# Federation
+	#
+	#
 
+
+	@restapi.api_request(u'get', u'federations', (u'1.2', u'1.3'))
+	def get_federations(self):
+		"""
+		Retrieves a list of federation mappings (aka federation resolvers) for a the current user
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	@restapi.api_request(u'post', u'federations', (u'1.2', u'1.3'))
+	def create_federation(self, data=None):
+		"""
+		Allows a user to add federations for their delivery service(s). 
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name:s}/federations', (u'1.2', u'1.3'))
+	def get_federations_for_cdn(self, cdn_name=None):
+		"""
+		Retrieves a list of federations for a cdn.
+		:param cdn_name: The CDN name to find federation
+		:type cdn_name: String 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name:s}/federations/{federation_id:d}', (u'1.2', u'1.3'))
+	def get_federation_for_cdn_by_id(self, cdn_name=None, federation_id=None):
+		"""
+		Retrieves a federation for a cdn.
+		:param cdn_name: The CDN name to find federation
+		:type cdn_name: String 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	@restapi.api_request(u'post', u'cdns/{cdn_name:s}/federations', (u'1.2', u'1.3'))
+	def create_federation_in_cdn(self, cdn_name=None, data=None):
+		"""
+		Create a federation.
+		:param cdn_name: The CDN name to find federation
+		:type cdn_name: String 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'cdns/{cdn_name:s}/federations/{federation_id:d}', (u'1.2', u'1.3'))
+	def update_federation_in_cdn(self, cdn_name=None, federation_id=None, query_params=None):
+		"""
+		Update a federation.
+		:param cdn_name: The CDN name to find federation
+		:type cdn_name: String 
+		:param federation_id: The federation id
+		:type federation_id: int 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'cdns/{cdn_name:s}/federations/{federation_id:d}', (u'1.2', u'1.3'))
+	def delete_federation_in_cdn(self, cdn_name=None, federation_id=None):
+		"""
+		Delete a federation.
+		:param cdn_name: The CDN name to find federation
+		:type cdn_name: String 
+		:param federation_id: The federation id
+		:type federation_id: int 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
 	# Federation Delivery Service
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/federation_deliveryservice.html
+	#
 
+	@restapi.api_request(u'get', u'federations/{federation_id:d}/deliveryservices', (u'1.2', u'1.3'))
+	def get_federation_delivery_services(self, federation_id=None):
+		"""
+		Retrieves delivery services assigned to a federation
+		:param federation_id: The federation id
+		:type federation_id: int 
+		:param federation_id: The federation id
+		:type federation_id: int 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	@restapi.api_request(u'post', u'federations/{federation_id:d}/deliveryservices', (u'1.2', u'1.3'))
+	def assign_delivery_services_to_federations(self, federation_id=None, data=None):
+		"""
+		Create one or more federation / delivery service assignments. 
+		:param federation_id: The federation id
+		:type federation_id: int 
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'federation_resolvers/{federation_id:d}/deliveryservices/{delivery_service_id:d}', (u'1.2', u'1.3'))
+	def delete_federation_resolver(self, federation_resolver_id=None, delivery_service_id=None):
+		"""
+		Removes a delivery service from a federation. 
+		:param federation_id: The federation id
+		:type federation_id: int 
+		:param federation_id: The delivery service id
+		:type federation_id: int 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
 	# Federation Federation Resolver
+	#
+	#
 
+	@restapi.api_request(u'get', u'federations/{federation_id:d}/federation_resolvers', (u'1.2', u'1.3'))
+	def get_federation_resolvers(self, federation_id=None):
+		"""
+		Retrieves federation resolvers assigned to a federation
+		:param federation_id: The federation id
+		:type federation_id: int 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	@restapi.api_request(u'post', u'federations/{federation_id:d}/federation_resolvers', (u'1.2', u'1.3'))
+	def assign_federation_resolver_to_federations(self, federation_id=None, data=None):
+		"""
+		Create one or more federation / federation resolver assignments. 
+		:param federation_id: The federation id
+		:type federation_id: int 
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
 	# Federation Resolver
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/federation_resolver.html#federation-resolver
+	#
 
+	@restapi.api_request(u'get', u'federation_resolvers', (u'1.2', u'1.3'))
+	def get_federation_resolvers(self, query_params=None):
+		"""
+		Get federation resolvers. 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	@restapi.api_request(u'post', u'federation_resolvers', (u'1.2', u'1.3'))
+	def create_federation_resolver(self, data=None):
+		"""
+		Create a federation resolver. 
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'federation_resolvers/{federation_resolver_id:d}', (u'1.2', u'1.3'))
+	def delete_federation_resolver(self, federation_resolver_id=None):
+		"""
+		Delete a federation resolver. 
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	#
 	# Federation User
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/federation_user.html#federation-user
+	#
 
+	@restapi.api_request(u'get', u'federations/{federation_id:d}/users', (u'1.2', u'1.3'))
+	def get_federation_users(self, federation_id=None):
+		"""
+		Retrieves users assigned to a federation. 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'federations/{federation_id:d}/users', (u'1.2', u'1.3'))
+	def create_federation_user(self, federation_id=None, data=None):
+		"""
+		Create one or more federation / user assignments. 
+		:param federation_id: Federation ID
+		:type federation_id: int
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'federations/{federation_id:d}/users/{user_id:d}', (u'1.2', u'1.3'))
+	def delete_federation_user(self, federation_id=None, user_id=None):
+		"""
+		Delete one or more federation / user assignments. 
+		:param federation_id: Federation ID
+		:type federation_id: int
+		:param user_id: Federation User ID
+		:type user_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
 	# Hardware Info
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/hwinfo.html#hardware-info
+	#
+
+	@restapi.api_request(u'get', u'hwinfo.json', (u'1.2', u'1.3'))
+	def get_hwinfo(self):
+		"""
+		Get hwinfo for servers. 
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 
 	#
 	# ISO
@@ -1560,8 +1786,11 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-
+	#
 	# Physical Location
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/phys_location.html#physical-location
+	#
+
 	@restapi.api_request(u'get', u'phys_locations', (u'1.1', u'1.2', u'1.3',))
 	def get_physical_locations(self, query_params=None):
 		"""
@@ -1570,11 +1799,71 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	@restapi.api_request(u'get', u'phys_locations/trimmed.json', (u'1.1', u'1.2', u'1.3',))
+	def get_trimmed_physical_locations(self):
+		"""
+		Get Physical Locations with name only
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'phys_locations/{physical_location_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_physical_location_by_id(self, physical_location_id=None):
+		"""
+		Get Physical Location by id
+		:param physical_location_id: The id to retrieve
+		:type physical_location_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'phys_locations/{physical_location_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_physical_location(self, physical_location_id=None, query_params=None):
+		"""
+		Update Physical Location by id
+		:param physical_location_id: The id to update
+		:type physical_location_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'regions/{region_name:s}/phys_locations', (u'1.1', u'1.2', u'1.3',))
+	def create_physical_location(self, region_name=None, query_params=None):
+		"""
+		Create physical location
+		:param region_name: the name of the region to create physical location into
+		:type region_name: String
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'phys_locations/{physical_location_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_physical_location(self, physical_location_id=None, query_params=None):
+		"""
+		Delete Physical Location by id
+		:param physical_location_id: The id to delete
+		:type physical_location_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
 	# Profiles
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/profile.html#profiles
+	#
+
 	@restapi.api_request(u'get', u'profiles', (u'1.1', u'1.2', u'1.3',))
 	def get_profiles(self, query_params=None):
 		"""
 		Get Profiles.
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'profiles/trimmed', (u'1.1', u'1.2', u'1.3',))
+	def get_trimmed_profiles(self):
+		"""
+		Get Profiles with names only
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
@@ -1586,6 +1875,30 @@ class TOSession(restapi.RestApiSession):
 		:param profile_id: The profile Id
 		:type profile_id: int
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'profiles', (u'1.1', u'1.2', u'1.3',))
+	def create_profile(self, data=None):
+		"""
+		Create a profile
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'profiles/name/{new_profile_name:s}/copy/{copy_profile_name:s}', (u'1.1', u'1.2', u'1.3',))
+	def copy_profile(self, new_profile_name=None, copy_profile_name=None, data=None):
+		"""
+		Copy profile to a new profile. The new profile name must not exist
+		:param new_profile_name: The name of profile to copy to
+		:type new_profile_name: String
+		:param copy_profile_name: The name of profile copy from
+		:type copy_profile_name: String
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
@@ -1611,7 +1924,18 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	#
 	# Profile Parameters
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/profile_parameter.html#api-1-2-profileparameters
+	#
+
+	@restapi.api_request(u'post', u'profileparameters', (u'1.1', u'1.2', u'1.3',))
+	def associate_paramater_to_profile(self, data=None):
+		"""
+		Associate parameter to profile.
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
 
 
 	@restapi.api_request(u'post', u'profiles/id/{profile_id:d}/parameters', (u'1.1', u'1.2', u'1.3',))
@@ -1625,6 +1949,27 @@ class TOSession(restapi.RestApiSession):
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
+
+	@restapi.api_request(u'post', u'profileparameter', (u'1.1', u'1.2', u'1.3',))
+	def assign_profile_to_parameter_ids(self, data=None):
+		"""
+		Create one or more profile / parameter assignments.
+		:param data: The data to assign
+		:type data: Union[Dict[Text, Any], List[Dict[Text, Any]]]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'parameterprofile', (u'1.1', u'1.2', u'1.3',))
+	def assign_parameter_to_profile_ids(self, data=None):
+		"""
+		Create one or more parameter / profile assignments.
+		:param data: The data to assign
+		:type data: Union[Dict[Text, Any], List[Dict[Text, Any]]]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 
 	@restapi.api_request(u'post', u'profiles/name/{profile_name}/parameters', (u'1.1', u'1.2', u'1.3',))
 	def associate_parameters_by_profile_name(self, profile_name=None, data=None):
@@ -1724,8 +2069,55 @@ class TOSession(restapi.RestApiSession):
 
 	#
 	# Server
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/server.html#server
 	#
-	#
+
+	@restapi.api_request(u'get', u'servers', (u'1.1', u'1.2',u'1.3',))
+	def get_servers(self, query_params=None):
+		"""
+		Get Servers.
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'servers/{server_id:d}', (u'1.1', u'1.2',u'1.3',))
+	def get_server_by_id(self, server_id=None:
+		"""
+		Get Server by Server ID
+		:param server_id: The server id to retrieve
+		:type server_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'servers/{server_id:d}/deliveryservices', (u'1.1', u'1.2',u'1.3',))
+	def get_server_delivery_services(self, server_id=None:
+		"""
+		Retrieves all delivery services assigned to the server
+		:param server_id: The server id to retrieve
+		:type server_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'servers/total', (u'1.1', u'1.2',u'1.3',))
+	def get_server_type_count(self:
+		"""
+		Retrieves a count of CDN servers by type
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'servers/status', (u'1.1', u'1.2',u'1.3',))
+	def get_server_status_count(self:
+		"""
+		Retrieves a count of CDN servers by status
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 	@restapi.api_request(u'get', u'servers/hostname/{name}/details', (u'1.1', u'1.2', u'1.3',))
 	def get_server_details(self, name=None):
 		"""
@@ -1737,12 +2129,12 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'servers', (u'1.1', u'1.2',u'1.3',))
-	def get_servers(self, query_params=None):
+	@restapi.api_request(u'post', u'servercheck', (u'1.1', u'1.2', u'1.3',))
+	def create_servercheck(self, data=None):
 		"""
-		Get Servers.
-		:param query_params: The optional url query parameters for the call
-		:type query_params: Dict[Text, Any]
+		Post a server check result to the serverchecks table.
+		:param data: The parameter data to use for server creation
+		:type data: Dict[Text, Any]
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""

--- a/traffic_control/clients/python/trafficops/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/trafficops/tosession.py
@@ -286,6 +286,37 @@ class TOSession(restapi.RestApiSession):
 
 		return result_set, response  # Note: Return last response object received
 
+# 
+# PUT ALL API DEFINITIONS BELOW AND UNDER ITS RESPECTIVE PAGE (whether it is 1.2 or 1.3, etc, if its a CDN put it under CDN header and corresponding calls)
+#
+
+	#
+	#	API Capabilities
+	#
+	@restapi.api_request(u'get', u'api_capabilities', (u'1.2', u'1.3',))
+	def get_api_capabilities(self, query_params=None):
+		"""
+		Get all API-capability mappings
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/api_capability.html#api-capabilities
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'api_capabilities/{id}', (u'1.2', u'1.3',))
+	def get_api_capabilities_by_id(self, id=None):
+		"""
+		Get an API-capability mapping by ID
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/api_capability.html#api-capabilities
+		:param id: The api-capabilities Id
+		:type id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# ASN
+	#
+
 	# Implemented Direct API URL Endpoint Methods
 	# See https://traffic-control-cdn.readthedocs.io/en/latest/api/index.html #api for detail
 	@restapi.api_request(u'get', u'asns', (u'1.1', u'1.2', u'1.3',))
@@ -296,10 +327,29 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+
+	#
+	# Cache
+	#
+
+	@restapi.api_request(u'get', u'caches/stats', (u'1.1', u'1.2', u'1.3',))
+	def get_cache_stats(self):
+		"""
+		Retrieves cache stats from Traffic Monitor. Also includes rows for aggregates
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cache.html#cache
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Cache Group
+	#
+
 	@restapi.api_request(u'get', u'cachegroups', (u'1.1', u'1.2', u'1.3',))
 	def get_cachegroups(self, query_params=None):
 		"""
 		Get Cache Groups.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
@@ -314,16 +364,322 @@ class TOSession(restapi.RestApiSession):
 	def get_cachegroup_by_id(self, cache_group_id=None):
 		"""
 		Get a Cache Group by Id.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
 		:param cache_group_id: The cache group Id
 		:type cache_group_id: int
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	@restapi.api_request(u'get', u'cachegroups/{cache_group_id:d}/parameters', (u'1.1', u'1.2', u'1.3',))
+	def get_cachegroup_parameters(self, cache_group_id=None):
+		"""
+		Get a cache groups parameters
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
+		:param cache_group_id: The cache group Id
+		:type cache_group_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cachegroups/{cache_group_id:d}/unassigned_parameters', (u'1.1', u'1.2', u'1.3',))
+	def get_cachegroup_unassigned_parameters(self, cache_group_id=None):
+		"""
+		Get a cache groups unassigned parameters
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
+		:param cache_group_id: The cache group Id
+		:type cache_group_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cachegroup/{parameter_id:d}/parameter', (u'1.1', u'1.2', u'1.3',))
+	def get_cachegroup_parameters_by_id(self, parameter_id=None):
+		"""
+		Get a cache groups parameter by its ID
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
+		:param parameter_id: The parameter Id
+		:type parameter_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cachegroupparameters', (u'1.1', u'1.2', u'1.3',))
+	def get_all_cachegroup_parameters(self):
+		"""
+		A collection of all cache group parameters.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'cachegroups', (u'1.1', u'1.2', u'1.3',))
+	def create_cachegroups(self, data=None):
+		"""
+		Create a Cache Group
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
+		:param data: The parameter data to use for cachegroup creation.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'cachegroups/{cache_group_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_cachegroups(self, cache_group_id=None, data=None):
+		"""
+		Update a cache group
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
+		:param cache_group_id: The cache group id to update
+		:type cache_group_id: Integer
+		:param data: The parameter data to use for cachegroup creation.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'cachegroups/{cache_group_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_cachegroups(self, cache_group_id=None):
+		"""
+		Delete a cache group
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
+		:param cache_group_id: The cache group id to update
+		:type cache_group_id: Integer
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'cachegroups/{cache_group_id:d}/queue_update', (u'1.1', u'1.2', u'1.3',))
+	def cachegroups_queue_update(self, cache_group_id=None, data=None):
+		"""
+		Queue Updates by Cache Group ID
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup.html#cache-group
+		:param cache_group_id: The Cache Group Id
+		:type cache_group_id: int
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Cache Group Parameters
+	#
+
+	@restapi.api_request(u'post', u'cachegroupparameters', (u'1.2', u'1.3'))
+	def assign_cache_group_parameters(self, data=None):
+		"""
+		Assign parameter(s) to cache group(s).
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup_parameter.html#cache-group-parameters
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'cachegroupparameters/{cache_group_id:d}/{parameter_id:d}', (u'1.2', u'1.3'))
+	def delete_cache_group_parameters(self, cache_group_id=None, parameter_id=None):
+		"""
+		Delete a cache group parameter association
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup_parameter.html#cache-group-parameters
+		:param cache_group_id: The cache group id in which the parameter will be deleted
+		:type cache_group_id: int
+		:param parameter_id: The parameter id which will be disassociated
+		:type parameter_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	# Cache Group Fallback
+
+	@restapi.api_request(u'get', u'cachegroup_fallbacks', (u'1.2', u'1.3'))
+	def get_cache_group_fallbacks(self, query_params=None):
+		"""
+		Retrieve fallback related configurations for a cache group
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup_fallbacks.html#api-1-2-cachegroup-fallbacks
+		:param query_params: Either cacheGroupId or fallbackId must be used or can be used simultaneously
+		:type query_params: Dict[Text, int]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'cachegroup_fallbacks', (u'1.2', u'1.3'))
+	def create_cache_group_fallbacks(self, data=None):
+		"""
+		Creates fallback configuration for the cache group. New fallbacks can be added only via POST.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup_fallbacks.html#api-1-2-cachegroup-fallbacks
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+ 		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'cachegroup_fallbacks', (u'1.2', u'1.3'))
+	def update_cache_group_fallbacks(self, data=None):
+		"""
+		Updates an existing fallback configuration for the cache group. 
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup_fallbacks.html#api-1-2-cachegroup-fallbacks
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'cachegroup_fallbacks', (u'1.2', u'1.3'))
+	def delete_cache_group_fallbacks(self, query_params=None):
+		"""
+		Deletes an existing fallback related configurations for a cache group
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cachegroup_fallbacks.html#api-1-2-cachegroup-fallbacks
+		:param query_params: Either cacheGroupId or fallbackId must be used or can be used simultaneously
+		:type query_params: Dict[Text, int]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Cache Statistics
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cache_stats.html#cache-statistics
+	#
+	@restapi.api_request(u'get', u'cache_stats', (u'1.2', u'1.3',))
+	def get_cache_stats(self, query_params=None):
+		"""
+		Retrieves statistics about the CDN.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/cache_stats.html#cache-statistics
+		:param query_params: See API page for more information on accepted params
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Capabilities - Not adding for vagueness
+	#
+
+	#
+	# CDN
+	#
+	#
+	
+	@restapi.api_request(u'get', u'cdns', (u'1.1', u'1.2', u'1.3',))
+	def get_cdns(self):
+		"""
+		Get all CDNs.
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/{cdn_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_cdn_by_id(self, cdn_id=None):
+		"""
+		Get a CDN by Id.
+		:param cdn_id: The CDN id
+		:type cdn_id: Text
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/name/{cdn_name}', (u'1.1', u'1.2', u'1.3',))
+	def get_cdn_by_name(self, cdn_name=None):
+		"""
+		Get a CDN by name.
+		:param cdn_name: The CDN name
+		:type cdn_name: Text
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'cdns', (u'1.1', u'1.2', u'1.3',))
+	def create_cdn(self, data=None):
+		"""
+		Create a new CDN.
+		:param data: The parameter data to use for cdn creation.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'cdns/{cdn_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_cdn_by_id(self, cdn_id=None, data=None):
+		"""
+		Update a CDN by Id.
+		:param cdn_id: The CDN id
+		:type cdn_id: int
+		:param data: The parameter data to use for cdn update.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'cdns/{cdn_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_cdn_by_id(self, cdn_id=None):
+		"""
+		Delete a CDN by Id.
+		:param cdn_id: The CDN id
+		:type cdn_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'cdns/{cdn_id:d}/queue_update', (u'1.1', u'1.2', u'1.3',))
+	def cdns_queue_update(self, cdn_id=None, data=None):
+		"""
+		Queue Updates by CDN Id.
+		:param cdn_id: The CDN Id
+		:type cdn_id: int
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+	#
+	# Change Logs
+	#https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/changelog.html#change-logs
+	#
+
+	@restapi.api_request(u'get', u'logs', (u'1.2', u'1.3',))
+	def get_change_logs(self):
+		"""
+		Retrieve all change logs from traffic ops
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/changelog.html#change-logs
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'logs/{days:d}/days', (u'1.2', u'1.3',))
+	def get_change_logs_for_days(self, days=None):
+		"""
+		Retrieve all change logs from Traffic Ops
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/changelog.html#change-logs
+		:param days: The number of days to retrieve change logs
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'logs/newcount', (u'1.2', u'1.3',))
+	def get_change_logs_newcount(self):
+		"""
+		Get amount of new logs from traffic ops
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/changelog.html#change-logs
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Config Files and Config File Metadata
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/configfiles_ats.html#config-files-and-config-file-metadata
+	#
+
+	#
+	# Delivery Service
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#delivery-service
+	#
+
 	@restapi.api_request(u'get', u'deliveryservices', (u'1.1', u'1.2', u'1.3',))
 	def get_deliveryservices(self, query_params=None):
 		"""
-		Get Delivery Services.
+		Retrieves all delivery services (if admin or ops) or all delivery services assigned to user.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
@@ -331,26 +687,53 @@ class TOSession(restapi.RestApiSession):
 	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}', (u'1.1', u'1.2', u'1.3',))
 	def get_deliveryservice_by_id(self, delivery_service_id=None):
 		"""
-		Get a Delivery Service by Id.
+		Retrieves a specific delivery service. If not admin / ops, delivery service must be assigned to user.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
 		:param delivery_service_id: The delivery service Id
 		:type delivery_service_id: int
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
-	@restapi.api_request(u'get', u'servers/hostname/{name}/details', (u'1.1', u'1.2', u'1.3',))
-	def get_server_details(self, name=None):
+
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/servers', (u'1.1', u'1.2', u'1.3',))
+	def get_deliveryservice_servers(self, delivery_service_id=None):
 		"""
-		#GET /api/1.2/servers/hostname/:name/details
-		Get server details from trafficOps
-		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/server.html
-		:param hostname: Server hostname
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		Retrieves properties of CDN EDGE or ORG servers assigned to a delivery service.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
+
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/servers/unassigned', (u'1.1', u'1.2', u'1.3',))
+	def get_deliveryservice_unassigned_servers(self, delivery_service_id=None):
+		"""
+		Retrieves properties of CDN EDGE or ORG servers not assigned to a delivery service. (Currently call does not work)
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/servers/eligible', (u'1.1', u'1.2', u'1.3',))
+	def get_deliveryservice_ineligible_servers(self, delivery_service_id=None):
+		"""
+		Retrieves properties of CDN EDGE or ORG servers not eligible for assignment to a delivery service.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
 	@restapi.api_request(u'post', u'deliveryservices', (u'1.1', u'1.2', u'1.3',))
 	def create_deliveryservice(self, data=None):
 		"""
-		Create a Delivery Service.
+		Allows user to create a delivery service.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
 		:param data: The request data structure for the API request
 		:type data: Dict[Text, Any]
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
@@ -361,6 +744,7 @@ class TOSession(restapi.RestApiSession):
 	def update_deliveryservice_by_id(self, delivery_service_id=None, data=None):
 		"""
 		Update a Delivery Service by Id.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
 		:param delivery_service_id: The delivery service Id
 		:type delivery_service_id: int
 		:param data: The request data structure for the API request
@@ -369,30 +753,89 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	@restapi.api_request(u'put', u'deliveryservices/{delivery_service_id:d}/safe', (u'1.1', u'1.2', u'1.3',))
+	def update_deliveryservice_safe(self, delivery_service_id=None, data=None):
+		"""
+		Allows a user to edit limited fields of an assigned delivery service.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:param data: The request data structure for the API request
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
 	@restapi.api_request(u'delete', u'deliveryservices/{delivery_service_id:d}', (u'1.1', u'1.2', u'1.3',))
 	def delete_deliveryservice_by_id(self, delivery_service_id=None):
 		"""
-		Delete a Delivery Service by Id.
+		Allows user to delete a delivery service.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#api-1-2-deliveryservices
 		:param delivery_service_id: The delivery service Id
 		:type delivery_service_id: int
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/servers', (u'1.1', u'1.2', u'1.3',))
-	def get_deliveryservices_servers(self, delivery_service_id=None):
+	# 
+	# Delivery Service Health
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#health
+	#
+
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/state', (u'1.1', u'1.2', u'1.3',))
+	def get_delivery_service_failover_state(self, delivery_service_id=None):
 		"""
-		Get all servers associated with a Delivery Service Id.
+		Retrieves the failover state for a delivery service. Delivery service must be assigned to user if user is not admin or operations.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#health
 		:param delivery_service_id: The delivery service Id
 		:type delivery_service_id: int
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/health', (u'1.1', u'1.2', u'1.3',))
+	def get_delivery_service_health(self, delivery_service_id=None):
+		"""
+		Retrieves the health of all locations (cache groups) for a delivery service. Delivery service must be assigned to user if user is not admin or operations.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#health
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/capacity', (u'1.1', u'1.2', u'1.3',))
+	def get_delivery_service_capacity(self, delivery_service_id=None):
+		"""
+		Retrieves the capacity percentages of a delivery service. Delivery service must be assigned to user if user is not admin or operations.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#health
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/routing', (u'1.1', u'1.2', u'1.3',))
+	def get_delivery_service_routing(self, delivery_service_id=None):
+		"""
+		Retrieves the routing method percentages of a delivery service. Delivery service must be assigned to user if user is not admin or operations.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#health
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Delivery Service Server
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#delivery-service-server
+	#
+
 	@restapi.api_request(u'get', u'deliveryserviceserver', (u'1.1', u'1.2', u'1.3',))
 	def get_deliveryserviceserver(self, query_params=None):
 		"""
-		Get Servers for all defined Delivery Services.
+		Retrieves delivery service / server assignments. (Allows pagination and limits)
 		:param query_params: The required url query parameters for the call
 		:type query_params: Dict[Text, Any]
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
@@ -412,7 +855,7 @@ class TOSession(restapi.RestApiSession):
 	@restapi.api_request(u'post', u'deliveryservices/{xml_id}/servers', (u'1.1', u'1.2', u'1.3',))
 	def assign_deliveryservice_servers_by_names(self, xml_id=None, data=None):
 		"""
-		Assign severs by name to a Delivery Service by xmlId. (Old Method)
+		Assign servers by name to a Delivery Service by xmlId. (Old Method)
 		:param xml_id: The XML Id of the delivery service
 		:type xml_id: Text
 		:param data: The required data to assign servers to a delivery service
@@ -421,46 +864,27 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'deliveryservices_regexes', (u'1.1', u'1.2', u'1.3',))
-	def get_deliveryservices_regexes(self):
+	@restapi.api_request(u'delete', u'deliveryservice_server/{delivery_service_id:d}/{server_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_deliveryservice_servers_by_id(self, delivery_service_id=None, server_id=None):
 		"""
-		Get RegExes for all Delivery Services.
+		Removes a server (cache) from a delivery service.
+		:param delivery_service_id: The delivery service id 
+		:type delivery_service_id: int
+		:param server_id: The server id to remove from delivery service
+		:type server_id: int
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/regexes', (u'1.1', u'1.2', u'1.3',))
-	def get_deliveryservice_regexes_by_id(self, delivery_service_id=None):
-		"""
-		Get RegExes for a Delivery Service by Id.
-		:param delivery_service_id: The delivery service Id
-		:type delivery_service_id: int
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
+	#
+	# Delivery Service User
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#delivery-service-user
+	# (TODO: Add all calls)
 
-	@restapi.api_request(u'post', u'deliveryservices/regexes', (u'1.1', u'1.2', u'1.3',))
-	def delete_deliveryservice_regexes(self, data=None):
-		"""
-		Delete RegExes.
-		:param data: The required data to delete delivery service regexes
-		:type data: Dict[Text, Any]
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'delete', u'deliveryservices/{delivery_service_id:d}/regexes/{delivery_service_regex_id:d}',
-						 (u'1.1', u'1.2', u'1.3',))
-	def delete_deliveryservice_regex_by_regex_id(self, delivery_service_id=None, delivery_service_regex_id=None):
-		"""
-		Delete a RegEx by Id for a Delivery Service by Id.
-		:param delivery_service_id: The delivery service Id
-		:type delivery_service_id: int
-		:param delivery_service_regex_id: The delivery service regex Id
-		:type delivery_service_regex_id: int
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
+	#
+	# Delivery Service SSL Keys
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#ssl-keys
+	#
 
 	@restapi.api_request(u'get', u'deliveryservices/xmlId/{xml_id}/sslkeys', (u'1.1', u'1.2', u'1.3',))
 	def get_deliveryservice_ssl_keys_by_xml_id(self, xml_id=None, query_params=None):
@@ -506,6 +930,11 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	#
+	# Delivery Service URL Sig Keys
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/deliveryservice.html#url-sig-keys
+	#
+
 	@restapi.api_request(u'post', u'deliveryservices/xmlId/{xml_id}/urlkeys/generate', (u'1.1', u'1.2', u'1.3',))
 	def generate_deliveryservice_url_signature_keys(self, xml_id=None):
 		"""
@@ -516,151 +945,80 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'cdns', (u'1.1', u'1.2', u'1.3',))
-	def get_cdns(self):
+	#
+	# Delivery Service Regexes
+	#
+	#
+
+	@restapi.api_request(u'get', u'deliveryservices_regexes', (u'1.1', u'1.2', u'1.3',))
+	def get_deliveryservices_regexes(self):
 		"""
-		Get all CDNs.
+		Get RegExes for all Delivery Services.
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'post', u'cdns', (u'1.1', u'1.2', u'1.3',))
-	def create_cdn(self, data=None):
+	@restapi.api_request(u'get', u'deliveryservices/{delivery_service_id:d}/regexes', (u'1.1', u'1.2', u'1.3',))
+	def get_deliveryservice_regexes_by_id(self, delivery_service_id=None):
 		"""
-		Create a new CDN.
-		:param data: The parameter data to use for cdn creation.
-		:type data: Dict[Text, Any]
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-	@restapi.api_request(u'get', u'cdns/{cdn_id:d}', (u'1.1', u'1.2', u'1.3',))
-	def get_cdn_by_id(self, cdn_id=None):
-		"""
-		Get a CDN by Id.
-		:param cdn_id: The CDN id
-		:type cdn_id: Text
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		Get RegExes for a Delivery Service by Id.
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'cdns/name/{cdn_name}', (u'1.1', u'1.2', u'1.3',))
-	def get_cdn_by_name(self, cdn_name=None):
+	@restapi.api_request(u'post', u'deliveryservices/regexes', (u'1.1', u'1.2', u'1.3',))
+	def delete_deliveryservice_regexes(self, data=None):
 		"""
-		Get a CDN by name.
-		:param cdn_name: The CDN name
-		:type cdn_name: Text
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'put', u'cdns/{cdn_id:d}', (u'1.1', u'1.2', u'1.3',))
-	def update_cdn_by_id(self, cdn_id=None, data=None):
-		"""
-		Update a CDN by Id.
-		:param cdn_id: The CDN id
-		:type cdn_id: int
-		:param data: The parameter data to use for cdn update.
+		Delete RegExes.
+		:param data: The required data to delete delivery service regexes
 		:type data: Dict[Text, Any]
 		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'servers', (u'1.1', u'1.2',u'1.3',))
-	def get_servers(self, query_params=None):
+	@restapi.api_request(u'delete', u'deliveryservices/{delivery_service_id:d}/regexes/{delivery_service_regex_id:d}',
+						 (u'1.1', u'1.2', u'1.3',))
+	def delete_deliveryservice_regex_by_regex_id(self, delivery_service_id=None, delivery_service_regex_id=None):
 		"""
-		Get Servers.
-		:param query_params: The optional url query parameters for the call
-		:type query_params: Dict[Text, Any]
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		Delete a RegEx by Id for a Delivery Service by Id.
+		:param delivery_service_id: The delivery service Id
+		:type delivery_service_id: int
+		:param delivery_service_regex_id: The delivery service regex Id
+		:type delivery_service_regex_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'post', u'servers', (u'1.1', u'1.2', u'1.3',))
-	def create_server(self, data=None):
-		"""
-		Create a new Server.
-		:param data: The parameter data to use for server creation
-		:type data: Dict[Text, Any]
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
 
-	@restapi.api_request(u'put', u'servers/{server_id:d}', (u'1.1', u'1.2', u'1.3',))
-	def update_server_by_id(self, server_id=None, data=None):
-		"""
-		Update a Server by Id.
-		:param server_id: The server Id
-		:type server_id: int
-		:param data: The parameter data to edit
-		:type data: Dict[Text, Any]
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-	@restapi.api_request(u'put', u'servers/{server_id:d}/status', (u'1.1', u'1.2', u'1.3',))
-	def update_server_status_by_id(self, server_id=None, data=None):
-		"""
-		Update server_status by Id.
-		:param server_id: The server Id
-		:type server_id: int
-		:status: https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/server.html
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
 
-	@restapi.api_request(u'delete', u'servers/{server_id:d}', (u'1.1', u'1.2', u'1.3',))
-	def delete_server_by_id(self, server_id=None):
-		"""
-		Delete a Server by Id.
-		:param server_id: The server Id
-		:type server_id: int
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
 
+	# Delivery Service Statistics
+
+	# Divisions
+
+	# Federation
+
+	# Federation Delivery Service
+
+	# Federation Federation Resolver
+
+	# Federation Resolver
+
+	# Federation User
+
+	# Hardware Info
+
+	# ISO
+
+	# Jobs
+
+	# Parameter
 	@restapi.api_request(u'get', u'parameters', (u'1.1', u'1.2', u'1.3',))
 	def get_parameters(self):
 		"""
 		Get all Profile Parameters.
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'get', u'profiles', (u'1.1', u'1.2', u'1.3',))
-	def get_profiles(self, query_params=None):
-		"""
-		Get Profiles.
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'get', u'profiles/{profile_id:d}', (u'1.1', u'1.2', u'1.3',))
-	def get_profile_by_id(self, profile_id=None):
-		"""
-		Get Profile by Id.
-		:param profile_id: The profile Id
-		:type profile_id: int
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'put', u'profiles/{profile_id:d}', (u'1.1', u'1.2', u'1.3',))
-	def update_profile_by_id(self, profile_id=None, data=None):
-		"""
-		Update Profile by Id.
-		:param profile_id: The profile Id
-		:type profile_id: int
-		:param data: The parameter data to edit
-		:type data: Dict[Text, Any]
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'delete', u'profiles/{profile_id:d}', (u'1.1', u'1.2', u'1.3',))
-	def delete_profile_by_id(self, profile_id=None):
-		"""
-		Delete Profile by Id.
-		:param profile_id: The profile Id
-		:type profile_id: int
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
@@ -761,6 +1119,7 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	# Physical Location
 	@restapi.api_request(u'get', u'phys_locations', (u'1.1', u'1.2', u'1.3',))
 	def get_physical_locations(self, query_params=None):
 		"""
@@ -769,14 +1128,57 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'users', (u'1.1', u'1.2', u'1.3',))
-	def get_users(self):
+	# Profiles
+	@restapi.api_request(u'get', u'profiles', (u'1.1', u'1.2', u'1.3',))
+	def get_profiles(self, query_params=None):
 		"""
-		Get Users.
+		Get Profiles.
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
+	@restapi.api_request(u'get', u'profiles/{profile_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_profile_by_id(self, profile_id=None):
+		"""
+		Get Profile by Id.
+		:param profile_id: The profile Id
+		:type profile_id: int
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'profiles/{profile_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_profile_by_id(self, profile_id=None, data=None):
+		"""
+		Update Profile by Id.
+		:param profile_id: The profile Id
+		:type profile_id: int
+		:param data: The parameter data to edit
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'profiles/{profile_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_profile_by_id(self, profile_id=None):
+		"""
+		Delete Profile by Id.
+		:param profile_id: The profile Id
+		:type profile_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	# Profile Parameters
+
+	# InfluxDB
+
+	# Regions
+
+	#
+	# Roles
+	#
+	#
 	@restapi.api_request(u'get', u'roles', (u'1.1', u'1.2', u'1.3',))
 	def get_roles(self):
 		"""
@@ -785,39 +1187,70 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'statuses', (u'1.1', u'1.2', u'1.3',))
-	def get_statuses(self):
+	#
+	# Server
+	#
+	#
+	@restapi.api_request(u'get', u'servers/hostname/{name}/details', (u'1.1', u'1.2', u'1.3',))
+	def get_server_details(self, name=None):
 		"""
-		Get Statuses.
+		#GET /api/1.2/servers/hostname/:name/details
+		Get server details from trafficOps
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/server.html
+		:param hostname: Server hostname
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'types', (u'1.1', u'1.2', u'1.3',))
-	def get_types(self, query_params=None):
+	@restapi.api_request(u'get', u'servers', (u'1.1', u'1.2',u'1.3',))
+	def get_servers(self, query_params=None):
 		"""
-		Get Data Types.
+		Get Servers.
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'staticdnsentries', (u'1.1', u'1.2', u'1.3',))
-	def get_static_dns_entries(self):
+	@restapi.api_request(u'post', u'servers', (u'1.1', u'1.2', u'1.3',))
+	def create_server(self, data=None):
 		"""
-		Get Static DNS Entries.
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'post', u'cdns/{cdn_id:d}/queue_update', (u'1.1', u'1.2', u'1.3',))
-	def cdns_queue_update(self, cdn_id=None, data=None):
-		"""
-		Queue Updates by CDN Id.
-		:param cdn_id: The CDN Id
-		:type cdn_id: int
-		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		Create a new Server.
+		:param data: The parameter data to use for server creation
 		:type data: Dict[Text, Any]
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'servers/{server_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_server_by_id(self, server_id=None, data=None):
+		"""
+		Update a Server by Id.
+		:param server_id: The server Id
+		:type server_id: int
+		:param data: The parameter data to edit
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+	@restapi.api_request(u'put', u'servers/{server_id:d}/status', (u'1.1', u'1.2', u'1.3',))
+	def update_server_status_by_id(self, server_id=None, data=None):
+		"""
+		Update server_status by Id.
+		:param server_id: The server Id
+		:type server_id: int
+		:status: https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/server.html
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'servers/{server_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def delete_server_by_id(self, server_id=None):
+		"""
+		Delete a Server by Id.
+		:param server_id: The server Id
+		:type server_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
@@ -833,77 +1266,362 @@ class TOSession(restapi.RestApiSession):
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'put', u'snapshot/{cdn_name}', (u'1.1', u'1.2', u'1.3',))
-	def snapshot_crconfig(self, cdn_name=None):
+	#
+	# Static DNS Entries
+	#
+	#
+	@restapi.api_request(u'get', u'staticdnsentries', (u'1.1', u'1.2', ))
+	def get_static_dns_entries(self):
 		"""
-		Snapshot CRConfig by CDN Name.
-		:param cdn_name: The CDN name
-		:type cdn_name: Text
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		Get Static DNS Entries.
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
 
-	@restapi.api_request(u'get', u'cdns/{cdn_name}/snapshot', (u'1.2', u'1.3',))
-	def get_current_snapshot_crconfig(self, cdn_name=None):
+	@restapi.api_request(u'get', u'staticdnsentries', (u'1.1', u'1.2', u'1.3',))
+	def get_staticdnsentries(self, query_params=None):
 		"""
-		Retrieve the currently implemented CR Snapshot
-		:param cdn_name: The CDN name
-		:type cdn_name: Text
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-	@restapi.api_request(u'get', u'cdns/{cdn_name}/snapshot/new', (u'1.2', u'1.3',))
-	def get_pending_snapshot_crconfig(self, cdn_name=None):
-		"""
-		Retrieve the pending CR Snapshot
-		:param cdn_name: The CDN name
-		:type cdn_name: Text
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'get', u'logs', (u'1.2', u'1.3',))
-	def get_change_logs(self):
-		"""
-		Retrieve all change logs from traffic ops
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'get', u'logs/{days:d}/days', (u'1.2', u'1.3',))
-	def get_change_logs_for_days(self, days=None):
-		"""
-		Retrieve all change logs from Traffic Ops
-		:param days: The number of days to retrieve change logs
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	@restapi.api_request(u'get', u'logs/newcount', (u'1.2', u'1.3',))
-	def get_change_logs_newcount(self):
-		"""
-		Get amount of new logs from traffic ops
-		:rtype: Tuple[Dict[Text, Any], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
-
-	###                                                                              ###
-	###                                                                              ###
-	### add version 3 endpoints from here                                            ###
-	### ref: http://traffic-control-cdn.readthedocs.io/en/latest/api/v13/index.html  ###
-	###                                                                              ###
-	###                                                                              ###
-	###                                                                              ###
-
-	@restapi.api_request(u'get', u'coordinates', (u'1.3',))
-	def get_coordinates(self, query_params=None):
-		"""
-		Get all coordinates associated with the cdn
+		Get static DNS entries associated with the delivery service
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/staticdnsentry.html#api-1-3-staticdnsentries
 		:param query_params: The optional url query parameters for the call
 		:type query_params: Dict[Text, Any]
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
+
+	@restapi.api_request(u'post', u'staticdnsentries', (u'1.3',))
+	def create_staticdnsentries(self, data=None):
+		"""
+		Create static DNS entries associated with the delivery service
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/staticdnsentry.html#api-1-3-staticdnsentries
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'staticdnsentries', (u'1.3',))
+	def update_staticdnsentries(self, data=None, query_params=None):
+		"""
+		Update static DNS entries associated with the delivery service
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/staticdnsentry.html#api-1-3-staticdnsentries
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'staticdnsentries', (u'1.3',))
+	def delete_staticdnsentries(self, query_params=None):
+		"""
+		Delete static DNS entries associated with the delivery service
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/staticdnsentry.html#api-1-3-staticdnsentries
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Status
+	#
+	#
+	@restapi.api_request(u'get', u'statuses', (u'1.1', u'1.2', u'1.3',))
+	def get_statuses(self):
+		"""
+		Get Statuses.
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+	#
+	# System
+	#
+	#
+
+	#
+	# Tenants
+	#
+	#
+
+	#
+	# TO Extensions
+	#
+	#
+
+	#
+	# Types
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/type.html#api-1-2-types
+	#
+
+	@restapi.api_request(u'get', u'types', (u'1.1', u'1.2', u'1.3',))
+	def get_types(self, query_params=None):
+		"""
+		Get Data Types.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/type.html#api-1-2-types
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'types/trimmed', (u'1.1', u'1.2', u'1.3',))
+	def get_types_only_names(self):
+		"""
+		Get Data Types with only the Names
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/type.html#api-1-2-types
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'types/{type_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_type_by_id(self, type_id=None):
+		"""
+		Get Data Type with the given type id
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/type.html#api-1-2-types
+		:param type_id: The ID of the type to retrieve
+		:type type_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Users
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+	#
+
+	@restapi.api_request(u'get', u'users', (u'1.1', u'1.2', u'1.3',))
+	def get_users(self):
+		"""
+		Retrieves all users.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'users/{user_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_user_by_id(self, user_id=None):
+		"""
+		Retrieves user by ID.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+		:param user_id: The user to retrieve
+		:type user_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'users', (u'1.1', u'1.2', u'1.3',))
+	def create_user(self, data=None):
+		"""
+		Create a user.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'users/register', (u'1.1', u'1.2', u'1.3',))
+	def create_user_with_registration(self, data=None):
+		"""
+		Register a user and send registration email
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'users/{user_id:d}/deliveryservices', (u'1.1', u'1.2', u'1.3',))
+	def get_user_delivery_services(self, user_id=None):
+		"""
+		Retrieves all delivery services assigned to the user.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+		:param user_id: The user to retrieve
+		:type user_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'user/current', (u'1.1', u'1.2', u'1.3',))
+	def get_authenticated_user(self):
+		"""
+		Retrieves the profile for the authenticated user.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'user/current/jobs.json', (u'1.1', u'1.2', u'1.3',))
+	def get_authenticated_user_jobs(self):
+		"""
+		Retrieves the user’s list of jobs.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'user/current/jobs', (u'1.1', u'1.2', u'1.3',))
+	def create_invalidation_job(self, data=None):
+		"""
+		Invalidating content on the CDN is sometimes necessary when the origin was mis-configured and something is cached in the CDN that needs to be removed. 
+		Given the size of a typical Traffic Control CDN and the amount of content that can be cached in it, removing the content from all the caches may take a long time.
+		To speed up content invalidation, Traffic Ops will not try to remove the content from the caches, but it makes the content inaccessible using the regex_revalidate ATS plugin (https://docs.trafficserver.apache.org/en/latest/admin-guide/plugins/regex_revalidate.en.html). 
+		This forces a revalidation of the content, rather than a new get..
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/user.html#api-1-2-users
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Snapshot CRConfig
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/topology.html#snapshot-crconfig
+
+	#
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name}/snapshot', (u'1.2', u'1.3',))
+	def get_current_snapshot_crconfig(self, cdn_name=None):
+		"""
+		Retrieves the CURRENT snapshot for a CDN which doesn’t necessarily represent the current state of the CDN. 
+		The contents of this snapshot are currently used by Traffic Monitor and Traffic Router.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/topology.html#snapshot-crconfig
+		:param cdn_name: The CDN name
+		:type cdn_name: Text
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'cdns/{cdn_name}/snapshot/new', (u'1.2', u'1.3',))
+	def get_pending_snapshot_crconfig(self, cdn_name=None):
+		"""
+		Retrieves a PENDING snapshot for a CDN which represents the current state of the CDN. 
+		The contents of this snapshot are NOT currently used by Traffic Monitor and Traffic Router. 
+		Once a snapshot is performed, this snapshot will become the CURRENT snapshot and will be used by Traffic Monitor and Traffic Router.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/topology.html#snapshot-crconfig
+		:param cdn_name: The CDN name
+		:type cdn_name: Text
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'snapshot/{cdn_name}', (u'1.2', u'1.3',))
+	def snapshot_crconfig(self, cdn_name=None):
+		"""
+		Snapshot CRConfig by CDN Name.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/topology.html#snapshot-crconfig
+		:param cdn_name: The CDN name
+		:type cdn_name: Text
+		:rtype: Tuple[Dict[Text, Any], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+
+	#
+	# Coordinate
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/coordinate.html#coordinate
+	#
+
+	@restapi.api_request(u'get', u'coordinates', (u'1.3',))
+	def get_coordinates(self, query_params=None):
+		"""
+		Get all coordinates associated with the cdn
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/coordinate.html#coordinate
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'coordinates', (u'1.3'))
+	def create_coordinates(self, data=None):
+		"""
+		Create coordinates
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/coordinate.html#coordinate
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'coordinates', (u'1.3'))
+	def update_coordinates(self, query_params=None, data=None):
+		"""
+		Update coordinates
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/coordinate.html#coordinate
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'coordinates', (u'1.3'))
+	def delete_coordinates(self, query_params=None):
+		"""
+		Delete coordinates
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/coordinate.html#coordinate
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	#
+	# Origin
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/origin.html#api-1-3-origins
+	#
+
+	@restapi.api_request(u'get', u'origins', (u'1.3',))
+	def get_origins(self, query_params=None):
+		"""
+		Get origins associated with the delivery service
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/origin.html#api-1-3-origins
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'origins', (u'1.3',))
+	def create_origins(self, data=None):
+		"""
+		Creates origins associated with a delivery service
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/origin.html#api-1-3-origins
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'origins', (u'1.3',))
+	def update_origins(self, query_params=None):
+		"""
+		Updates origins associated with a delivery service
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/origin.html#api-1-3-origins
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'delete', u'origins', (u'1.3',))
+	def delete_origins(self, query_params=None):
+		"""
+		Updates origins associated with a delivery service
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v13/origin.html#api-1-3-origins
+		:param query_params: The optional url query parameters for the call
+		:type query_params: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	# Extra things here
 
 	@restapi.api_request("get", "servers/{servername:s}/configfiles/ats", ("1.3",))
 	def getServerConfigFiles(self, servername=None):
@@ -939,25 +1657,7 @@ class TOSession(restapi.RestApiSession):
 			logging.error("%s", exc_value)
 			logging.debug("%s", exc_type, stack_info=traceback)
 
-	@restapi.api_request(u'get', u'origins', (u'1.3',))
-	def get_origins(self, query_params=None):
-		"""
-		Get origins associated with the delivery service
-		:param query_params: The optional url query parameters for the call
-		:type query_params: Dict[Text, Any]
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
 
-	@restapi.api_request(u'get', u'staticdnsentries', (u'1.3',))
-	def get_staticdnsentries(self, query_params=None):
-		"""
-		Get static DNS entries associated with the delivery service
-		:param query_params: The optional url query parameters for the call
-		:type query_params: Dict[Text, Any]
-		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
-		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
-		"""
 
 
 if __name__ == u'__main__':

--- a/traffic_control/clients/python/trafficops/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/trafficops/tosession.py
@@ -1171,7 +1171,10 @@ class TOSession(restapi.RestApiSession):
 
 	# Profile Parameters
 
+	#
 	# InfluxDB
+	# Documentation is unknown and call will not be documented
+	#
 
 	#
 	# Regions
@@ -1400,6 +1403,11 @@ class TOSession(restapi.RestApiSession):
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
+
+	#
+	# Steering Targets
+	# 
+	#
 
 	#
 	# System

--- a/traffic_control/clients/python/trafficops/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/trafficops/tosession.py
@@ -1173,12 +1173,63 @@ class TOSession(restapi.RestApiSession):
 
 	# InfluxDB
 
+	#
 	# Regions
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/region.html#regions
+	#
+
+	@restapi.api_request(u'get', u'regions', (u'1.1', u'1.2', u'1.3',))
+	def get_regions(self):
+		"""
+		Get Regions.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/region.html#regions
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'regions/{region_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_region_by_id(self, region_id=None):
+		"""
+		Get Region by ID
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/region.html#regions
+		:param region_id: The region id of the region to retrieve
+		:type region_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'regions/{region_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_region(self, region_id=None):
+		"""
+		Update a region
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/tenant.html#tenants
+		:parma region_id: The region to update
+		:type region_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'divisions/{division_name:s}/regions', (u'1.1', u'1.2', u'1.3',))
+	def create_region(self, division_name=None, data=None):
+		"""
+		Create a region
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/tenant.html#tenants
+		:param division_name: The Division name in which region will reside
+		:type division_name: String
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+
+
 
 	#
 	# Roles
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/role.html#roles
 	#
-	#
+
 	@restapi.api_request(u'get', u'roles', (u'1.1', u'1.2', u'1.3',))
 	def get_roles(self):
 		"""
@@ -1268,8 +1319,9 @@ class TOSession(restapi.RestApiSession):
 
 	#
 	# Static DNS Entries
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/static_dns.html#api-1-2-staticdnsentries
 	#
-	#
+
 	@restapi.api_request(u'get', u'staticdnsentries', (u'1.1', u'1.2', ))
 	def get_static_dns_entries(self):
 		"""
@@ -1326,29 +1378,127 @@ class TOSession(restapi.RestApiSession):
 
 	#
 	# Status
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/status.html#api-1-2-statuses
 	#
-	#
+
 	@restapi.api_request(u'get', u'statuses', (u'1.1', u'1.2', u'1.3',))
 	def get_statuses(self):
 		"""
-		Get Statuses.
+		Retrieves a list of the server status codes available.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/status.html#api-1-2-statuses
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
 		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
 		"""
+
+	@restapi.api_request(u'get', u'statuses/{status_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_statuses_by_id(self, status_id=None):
+		"""
+		Retrieves a server status by ID.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/status.html#api-1-2-statuses
+		:param status_id: The status id to retrieve
+		:type status_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 	#
 	# System
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/system.html#api-1-1-system
 	#
-	#
+
+	@restapi.api_request(u'get', u'system/info.json', (u'1.1', u'1.2', u'1.3',))
+	def get_system_info(self):
+		"""
+		Get information on the traffic ops system.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/system.html#api-1-1-system
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 
 	#
 	# Tenants
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/tenant.html#tenants
 	#
-	#
+
+	@restapi.api_request(u'get', u'tenants', (u'1.1', u'1.2', u'1.3',))
+	def get_tenants(self):
+		"""
+		Get all tenants.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/tenant.html#tenants
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'get', u'tenants/{tenant_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def get_tenant_by_id(self, tenant_id=None):
+		"""
+		Get a tenant by ID.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/tenant.html#tenants
+		:param tenant_id: The tenant to retrieve
+		:type tenant_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'put', u'tenants/{tenant_id:d}', (u'1.1', u'1.2', u'1.3',))
+	def update_tenant(self, tenant_id=None):
+		"""
+		Update a tenant
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/tenant.html#tenants
+		:param tenant_id: The tenant to update
+		:type tenant_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'tenants', (u'1.1', u'1.2', u'1.3',))
+	def create_tenant(self, data=None):
+		"""
+		Create a tenant
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/tenant.html#tenants
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
 
 	#
 	# TO Extensions
+	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/to_extension.html#to-extensions
 	#
-	#
+	
+	@restapi.api_request(u'get', u'to_extensions.json', (u'1.1', u'1.2', u'1.3',))
+	def get_to_extensions(self):
+		"""
+		Retrieves the list of extensions.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/to_extension.html#to-extensions
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'to_extensions', (u'1.1', u'1.2', u'1.3',))
+	def create_to_extension(self, data=None):
+		"""
+		Creates a Traffic Ops extension.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/to_extension.html#to-extensions
+		:param data: The update action. QueueUpdateRequest() can be used for this argument also.
+		:type data: Dict[Text, Any]
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
+
+	@restapi.api_request(u'post', u'to_extensions/{extension_id:d}/delete', (u'1.1', u'1.2', u'1.3',))
+	def delete_to_extension(self, extension_id=None):
+		"""
+		Deletes a Traffic Ops extension.
+		https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/to_extension.html#to-extensions
+		:param extension_id: The extension id to delete
+		:type extension_id: int
+		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
+		:raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+		"""
 
 	#
 	# Types
@@ -1478,7 +1628,6 @@ class TOSession(restapi.RestApiSession):
 	#
 	# Snapshot CRConfig
 	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/topology.html#snapshot-crconfig
-
 	#
 
 	@restapi.api_request(u'get', u'cdns/{cdn_name}/snapshot', (u'1.2', u'1.3',))

--- a/traffic_control/clients/python/trafficops/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/trafficops/tosession.py
@@ -1675,7 +1675,7 @@ class TOSession(restapi.RestApiSession):
 	# https://traffic-control-cdn.readthedocs.io/en/latest/api/v12/parameter.html#parameter
 	#
 
-	@restapi.api_request(u'get', u'parameters', (u u'1.2', u'1.3',))
+	@restapi.api_request(u'get', u'parameters', (u'1.2', u'1.3',))
 	def get_parameters(self):
 		"""
 		Get all Profile Parameters.
@@ -2083,7 +2083,7 @@ class TOSession(restapi.RestApiSession):
 		"""
 
 	@restapi.api_request(u'get', u'servers/{server_id:d}', (u'1.1', u'1.2',u'1.3',))
-	def get_server_by_id(self, server_id=None:
+	def get_server_by_id(self, server_id=None):
 		"""
 		Get Server by Server ID
 		:param server_id: The server id to retrieve
@@ -2093,7 +2093,7 @@ class TOSession(restapi.RestApiSession):
 		"""
 
 	@restapi.api_request(u'get', u'servers/{server_id:d}/deliveryservices', (u'1.1', u'1.2',u'1.3',))
-	def get_server_delivery_services(self, server_id=None:
+	def get_server_delivery_services(self, server_id=None):
 		"""
 		Retrieves all delivery services assigned to the server
 		:param server_id: The server id to retrieve
@@ -2103,7 +2103,7 @@ class TOSession(restapi.RestApiSession):
 		"""
 
 	@restapi.api_request(u'get', u'servers/total', (u'1.1', u'1.2',u'1.3',))
-	def get_server_type_count(self:
+	def get_server_type_count(self):
 		"""
 		Retrieves a count of CDN servers by type
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]
@@ -2111,7 +2111,7 @@ class TOSession(restapi.RestApiSession):
 		"""
 
 	@restapi.api_request(u'get', u'servers/status', (u'1.1', u'1.2',u'1.3',))
-	def get_server_status_count(self:
+	def get_server_status_count(self):
 		"""
 		Retrieves a count of CDN servers by status
 		:rtype: Tuple[Union[Dict[Text, Any], List[Dict[Text, Any]]], requests.Response]


### PR DESCRIPTION
#### What does this PR do?

Adds most API calls from the API documentation pages

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ X] Other Python API

#### What is the best way to verify this PR?

Install python api and run existing scripts (existing calls were not changed at all, just added new ones)


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



