### PR TITLE
Fix Traffic Ops Golang wrapper copying *http.Request, breaking status codes

### DIFF
--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -526,8 +526,8 @@ func GetUserFromReq(w http.ResponseWriter, r *http.Request, secret string) (auth
 	return user, nil, nil, http.StatusOK
 }
 
-func AddUserToReq(r *http.Request, u auth.CurrentUser) *http.Request {
+func AddUserToReq(r *http.Request, u auth.CurrentUser) {
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, auth.CurrentUserKey, u)
-	return r.WithContext(ctx)
+	*r = *r.WithContext(ctx)
 }

--- a/traffic_ops/traffic_ops_golang/wrappers.go
+++ b/traffic_ops/traffic_ops_golang/wrappers.go
@@ -63,7 +63,7 @@ func (a AuthBase) GetWrapper(privLevelRequired int) Middleware {
 			if user.PrivLevel < privLevelRequired {
 				api.HandleErr(w, r, nil, http.StatusForbidden, errors.New("Forbidden."), nil)
 			}
-			r = api.AddUserToReq(r, user)
+			api.AddUserToReq(r, user)
 			handlerFunc(w, r)
 		}
 	}


### PR DESCRIPTION
Fixed the Traffic Ops Golang Auth wrapper to not copy the Request.

Wrappers should never copy the Request, because it breaks the context,
set by other wrappers or the real handler (really, the whole reason
the context exists).

Right now, it was specifically breaking the response code context
key; but in the future, it could break anything. Wrappers should
never change the *http.Request pointer, always the value. That is,
`*req = *foo`, not `req = foo`.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



