### PR TITLE
Udate the grove logrotate config to include the custom_ats_2.log

### DIFF
--- a/grove/build/grove.logrotate
+++ b/grove/build/grove.logrotate
@@ -45,3 +45,14 @@
         copytruncate
 }
 
+/opt/trafficserver/var/log/trafficserver/custom_ats_2.log {
+        hourly
+        dateext
+        dateformat -%Y%m%d%H
+        maxage 30
+        missingok
+        nomail
+        size 1G
+        rotate 10
+        copytruncate
+}


### PR DESCRIPTION
#### What does this PR do?
Adds the /opt/trafficserver/var/log/trafficserver/custom_ats_2.log to the grove.logrotate config file to insure that the file is properly rotated.
Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [X] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
On a grove edge the /opt/trafficserver/var/log/trafficserver/custom_ats_2.log should get rotated after it reaches 1G in size and only 5 rotated files are kept.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->


