### PR TITLE
Fix Test cg bad login expecting nil err

### DIFF
--- a/traffic_ops/testing/api/v14/cachegroups_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
-	"github.com/apache/trafficcontrol/traffic_ops/testing/api/utils"
 )
 
 func TestCacheGroups(t *testing.T) {
@@ -225,7 +224,6 @@ func DeleteTestCacheGroups(t *testing.T) {
 }
 
 func CheckCacheGroupsAuthentication(t *testing.T) {
-	failed := false
 	errFormat := "expected error from %s when unauthenticated"
 
 	cg := testData.CacheGroups[0]
@@ -233,38 +231,25 @@ func CheckCacheGroupsAuthentication(t *testing.T) {
 	resp, _, err := TOSession.GetCacheGroupNullableByName(*cg.Name)
 	if err != nil {
 		t.Errorf("cannot GET CacheGroup by name: %v - %v\n", *cg.Name, err)
-		failed = true
 	}
 	cg = resp[0]
 
-	errors := make([]utils.ErrorAndMessage, 0)
-
-	_, _, err = NoAuthTOSession.CreateCacheGroupNullable(cg)
-	errors = append(errors, utils.ErrorAndMessage{err, fmt.Sprintf(errFormat, "CreateCacheGroup")})
-
-	_, _, err = NoAuthTOSession.GetCacheGroupsNullable()
-	errors = append(errors, utils.ErrorAndMessage{err, fmt.Sprintf(errFormat, "GetCacheGroups")})
-
-	_, _, err = NoAuthTOSession.GetCacheGroupNullableByName(*cg.Name)
-	errors = append(errors, utils.ErrorAndMessage{err, fmt.Sprintf(errFormat, "GetCacheGroupByName")})
-
-	_, _, err = NoAuthTOSession.GetCacheGroupNullableByID(*cg.ID)
-	errors = append(errors, utils.ErrorAndMessage{err, fmt.Sprintf(errFormat, "GetCacheGroupByID")})
-
-	_, _, err = NoAuthTOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
-	errors = append(errors, utils.ErrorAndMessage{err, fmt.Sprintf(errFormat, "UpdateCacheGroupByID")})
-
-	_, _, err = NoAuthTOSession.DeleteCacheGroupByID(*cg.ID)
-	errors = append(errors, utils.ErrorAndMessage{err, fmt.Sprintf(errFormat, "DeleteCacheGroupByID")})
-
-	for _, err := range errors {
-		if err.Error != nil {
-			t.Error(err.Message)
-			failed = true
-		}
+	if _, _, err = NoAuthTOSession.CreateCacheGroupNullable(cg); err == nil {
+		t.Error(fmt.Errorf(errFormat, "CreateCacheGroup"))
 	}
-
-	if !failed {
-		log.Debugln("TestCacheGroupsAuthentication() PASSED: ")
+	if _, _, err = NoAuthTOSession.GetCacheGroupsNullable(); err == nil {
+		t.Error(fmt.Errorf(errFormat, "GetCacheGroups"))
+	}
+	if _, _, err = NoAuthTOSession.GetCacheGroupNullableByName(*cg.Name); err == nil {
+		t.Error(fmt.Errorf(errFormat, "GetCacheGroupByName"))
+	}
+	if _, _, err = NoAuthTOSession.GetCacheGroupNullableByID(*cg.ID); err == nil {
+		t.Error(fmt.Errorf(errFormat, "GetCacheGroupByID"))
+	}
+	if _, _, err = NoAuthTOSession.UpdateCacheGroupNullableByID(*cg.ID, cg); err == nil {
+		t.Error(fmt.Errorf(errFormat, "UpdateCacheGroupByID"))
+	}
+	if _, _, err = NoAuthTOSession.DeleteCacheGroupByID(*cg.ID); err == nil {
+		t.Error(fmt.Errorf(errFormat, "DeleteCacheGroupByID"))
 	}
 }


### PR DESCRIPTION
Test was backwards, testing a login failure was expecting a nil err,
needs to expect an error and not a nil for a bad login.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



