### PR TITLE
updated cachegroup api to include cachegroup fallbacks. updated docum…

### DIFF
--- a/docs/source/api/v12/cachegroup.rst
+++ b/docs/source/api/v12/cachegroup.rst
@@ -70,6 +70,8 @@ Cache Group
   +-----------------------------------+--------+--------------------------------------------------------------------------+
   | ``fallbackToClosest``             | bool   | Behaviour during non-availability/ failure of configured fallbacks       |
   +-----------------------------------+--------+--------------------------------------------------------------------------+
+  | ``fallbacks``                     | array  | Array of fallback cache group names associated with a cache group        |
+  +-----------------------------------+--------+--------------------------------------------------------------------------+
 
   **Response Example** ::
 
@@ -93,7 +95,12 @@ Cache Group
              "CZ",
              "GEO"
            ],
-           "fallbackToClosest":true
+           "fallbackToClosest":true,
+           "fallbacks": [
+             "cg_fallback_1",
+             "cg_fallback_2",
+             "cg_fallback_3"
+           ]
         },
         {
            "id": "22",
@@ -109,7 +116,8 @@ Cache Group
            "typeName": "MID_LOC",
            "typeId": "4",
            "localizationMethods": null,
-           "fallbackToClosest":false
+           "fallbackToClosest":false,
+           "fallbacks": []
         }
      ],
     }
@@ -184,6 +192,8 @@ Cache Group
   +-----------------------------------+--------+--------------------------------------------------------------------------+
   | ``fallbackToClosest``             | bool   | Behaviour during non-availability/ failure of configured fallbacks       |
   +-----------------------------------+--------+--------------------------------------------------------------------------+
+  | ``fallbacks``                     | array  | Array of fallback cache group names associated with a cache group        |
+  +-----------------------------------+--------+--------------------------------------------------------------------------+
 
   **Response Example** ::
 
@@ -207,7 +217,12 @@ Cache Group
            "shortName": "dcchi",
            "typeName": "MID_LOC",
            "typeId": "4",
-           "fallbackToClosest":true
+           "fallbackToClosest":true,
+           "fallbacks": [
+             "cg_fallback_1",
+             "cg_fallback_2",
+             "cg_fallback_3"
+           ]
         }
      ],
     }
@@ -474,6 +489,8 @@ Cache Group
   +---------------------------------+----------+-------------------------------------------------------------------+
   | ``fallbackToClosest``           | no       | Behaviour on configured fallbacks failure, true / false           |
   +---------------------------------+----------+-------------------------------------------------------------------+
+  | ``fallbacks``                   | no       | Array of fallback cache group names associated with a cache group |
+  +---------------------------------+----------+-------------------------------------------------------------------+
 
   **Request Example** ::
 
@@ -488,7 +505,12 @@ Cache Group
           "GEO"
         ],
         "typeId": 6,
-        "fallbackToClosest":true
+        "fallbackToClosest":true,
+        "fallbacks": [
+          "cg_fallback_1",
+          "cg_fallback_2",
+          "cg_fallback_3"
+        ]
     }
 
   **Response Properties**
@@ -522,6 +544,8 @@ Cache Group
   +------------------------------------+--------+-------------------------------------------------------------------+
   | ``lastUpdated``                    | string | The Time / Date this entry was last updated                       |
   +------------------------------------+--------+-------------------------------------------------------------------+
+  | ``fallbacks``                      | array  | Array of fallback cache group names associated with a cache group |
+  +------------------------------------+--------+-------------------------------------------------------------------+
   | ``alerts``                         | array  | A collection of alert messages.                                   |
   +------------------------------------+--------+-------------------------------------------------------------------+
   | ``>level``                         | string | Success, info, warning or error.                                  |
@@ -554,7 +578,12 @@ Cache Group
             "id" : "104",
             "parentCachegroupId" : "103",
             "secondaryParentCachegroupId" : null,
-            "fallbackToClosest":true
+            "fallbackToClosest":true,
+            "fallbacks": [
+              "cg_fallback_1",
+              "cg_fallback_2",
+              "cg_fallback_3"
+            ]
         }
     }
    
@@ -599,6 +628,8 @@ Cache Group
   +---------------------------------+----------+-------------------------------------------------------------------+
   | ``fallbackToClosest``           | no       | Behaviour on configured fallbacks failure, true / false           |
   +---------------------------------+----------+-------------------------------------------------------------------+
+  | ``fallbacks``                   | no       | Array of fallback cache group names associated with a cache group |
+  +---------------------------------+----------+-------------------------------------------------------------------+
 
   **Request Example** ::
 
@@ -614,7 +645,12 @@ Cache Group
           "CZ",
           "GEO"
         ],
-        "fallbackToClosest":true
+        "fallbackToClosest":true,
+        "fallbacks": [
+          "cg_fallback_1",
+          "cg_fallback_2",
+          "cg_fallback_3"
+        ]
     }
 
   **Response Properties**
@@ -645,6 +681,8 @@ Cache Group
   | ``typeName``                       | string | The type of Cache Group entry, "EDGE_LOC", "MID_LOC" or "ORG_LOC" |
   +------------------------------------+--------+-------------------------------------------------------------------+
   | ``fallbackToClosest``              | bool   | Behaviour during non-availability/failure of configured fallbacks |
+  +------------------------------------+--------+-------------------------------------------------------------------+
+  | ``fallbacks``                      | array  | Array of fallback cache group names associated with a cache group |
   +------------------------------------+--------+-------------------------------------------------------------------+
   | ``lastUpdated``                    | string | The Time / Date this entry was last updated                       |
   +------------------------------------+--------+-------------------------------------------------------------------+
@@ -681,7 +719,12 @@ Cache Group
             "id" : "104",
             "parentCachegroupId" : "103",
             "secondaryParentCachegroupId" : null,
-            "fallbackToClosest":true
+            "fallbackToClosest":true,
+            "fallbacks": [
+              "cg_fallback_1",
+              "cg_fallback_2",
+              "cg_fallback_3"
+            ]
         }
     }
 

--- a/lib/go-tc/cachegroups.go
+++ b/lib/go-tc/cachegroups.go
@@ -54,6 +54,7 @@ type CacheGroup struct {
 	Type                        string               `json:"typeName" db:"type_name"` // aliased to type_name to disambiguate struct scans due to join on 'type' table
 	TypeID                      int                  `json:"typeId" db:"type_id"`     // aliased to type_id to disambiguate struct scans due join on 'type' table
 	LastUpdated                 TimeNoMod            `json:"lastUpdated" db:"last_updated"`
+	Fallbacks                   []string             `json:"fallbacks" db:"fallbacks"`
 }
 
 type CacheGroupNullable struct {
@@ -71,6 +72,7 @@ type CacheGroupNullable struct {
 	Type                        *string               `json:"typeName" db:"type_name"` // aliased to type_name to disambiguate struct scans due to join on 'type' table
 	TypeID                      *int                  `json:"typeId" db:"type_id"`     // aliased to type_id to disambiguate struct scans due join on 'type' table
 	LastUpdated                 *TimeNoMod            `json:"lastUpdated" db:"last_updated"`
+	Fallbacks                   *[]string             `json:"fallbacks" db:"fallbacks"`
 }
 
 type CachegroupTrimmedName struct {

--- a/traffic_ops/testing/api/v14/cachegroups_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_test.go
@@ -92,7 +92,7 @@ func UpdateTestCacheGroups(t *testing.T) {
 	// Retrieve the CacheGroup to check CacheGroup name got updated
 	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
 	if err != nil {
-		t.Errorf("cannot GET CacheGroup by name: '$%s', %v\n", *firstCG.Name, err)
+		t.Errorf("cannot GET CacheGroup by name: '%s', %v\n", *firstCG.Name, err)
 		failed = true
 	}
 	cg = resp[0]
@@ -143,22 +143,22 @@ func UpdateTestCacheGroups(t *testing.T) {
 	}
 	cg = resp[0]
 	if !reflect.DeepEqual(expectedMethods, *cg.LocalizationMethods) {
-		t.Errorf("failed to update localizationMethods (expected = %v, actual = %v\n", expectedMethods, *cg.LocalizationMethods)
+		t.Errorf("failed to update localizationMethods (expected = %v, actual = %v)\n", expectedMethods, *cg.LocalizationMethods)
 		failed = true
 	}
 
 	// test cachegroup fallbacks
 
 	// Retrieve the CacheGroup to check CacheGroup name got updated
-	firstEdgeCG := testData.CacheGroups[3]
-	resp, _, err = TOSession.GetCacheGroupNullableByName(*firstEdgeCG.Name)
+	firstEdgeCGName := "cachegroup1"
+	resp, _, err = TOSession.GetCacheGroupNullableByName(firstEdgeCGName)
 	if err != nil {
-		t.Errorf("cannot GET CacheGroup by name: '$%s', %v\n", *firstEdgeCG.Name, err)
+		t.Errorf("cannot GET CacheGroup by name: '$%s', %v\n", firstEdgeCGName, err)
 		failed = true
 	}
 	cg = resp[0]
-	if *cg.Name != *firstEdgeCG.Name {
-		t.Errorf("results do not match actual: %s, expected: %s\n", *cg.ShortName, *firstEdgeCG.Name)
+	if *cg.Name != firstEdgeCGName {
+		t.Errorf("results do not match actual: %s, expected: %s\n", *cg.ShortName, firstEdgeCGName)
 		failed = true
 	}
 
@@ -178,7 +178,7 @@ func UpdateTestCacheGroups(t *testing.T) {
 	}
 	cg = resp[0]
 	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
-		t.Errorf("failed to update fallbacks (expected = %v, actual = %v\n", expectedFallbacks, *cg.Fallbacks)
+		t.Errorf("failed to update fallbacks (expected = %v, actual = %v)\n", expectedFallbacks, *cg.Fallbacks)
 		failed = true
 	}
 
@@ -187,7 +187,7 @@ func UpdateTestCacheGroups(t *testing.T) {
 	cg.Fallbacks = &expectedFallbacks
 	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
 	if err != nil {
-		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
+		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v)\n", err, updResp)
 		failed = true
 	}
 
@@ -198,7 +198,7 @@ func UpdateTestCacheGroups(t *testing.T) {
 	}
 	cg = resp[0]
 	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
-		t.Errorf("failed to update fallbacks (expected = %v, actual = %v\n", expectedFallbacks, *cg.Fallbacks)
+		t.Errorf("failed to update fallbacks (expected = %v, actual = %v)\n", expectedFallbacks, *cg.Fallbacks)
 		failed = true
 	}
 
@@ -218,7 +218,7 @@ func UpdateTestCacheGroups(t *testing.T) {
 	}
 	cg = resp[0]
 	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
-		t.Errorf("failed to update fallbacks (expected = %v, actual = %v\n", expectedFallbacks, *cg.Fallbacks)
+		t.Errorf("failed to update fallbacks (expected = %v, actual = %v)\n", expectedFallbacks, *cg.Fallbacks)
 		failed = true
 	}
 

--- a/traffic_ops/testing/api/v14/cachegroups_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_test.go
@@ -147,6 +147,81 @@ func UpdateTestCacheGroups(t *testing.T) {
 		failed = true
 	}
 
+	// test cachegroup fallbacks
+
+	// Retrieve the CacheGroup to check CacheGroup name got updated
+	firstEdgeCG := testData.CacheGroups[3]
+	resp, _, err = TOSession.GetCacheGroupNullableByName(*firstEdgeCG.Name)
+	if err != nil {
+		t.Errorf("cannot GET CacheGroup by name: '$%s', %v\n", *firstEdgeCG.Name, err)
+		failed = true
+	}
+	cg = resp[0]
+	if *cg.Name != *firstEdgeCG.Name {
+		t.Errorf("results do not match actual: %s, expected: %s\n", *cg.ShortName, *firstEdgeCG.Name)
+		failed = true
+	}
+
+	// Test adding fallbacks when previously nil
+	expectedFallbacks := []string{"fallback1", "fallback2"}
+	cg.Fallbacks = &expectedFallbacks
+	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
+	if err != nil {
+		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
+		failed = true
+	}
+
+	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
+	if err != nil {
+		t.Errorf("cannot GET CacheGroup by id: '%d', %v\n", *cg.ID, err)
+		failed = true
+	}
+	cg = resp[0]
+	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
+		t.Errorf("failed to update fallbacks (expected = %v, actual = %v\n", expectedFallbacks, *cg.Fallbacks)
+		failed = true
+	}
+
+	// Test adding fallback to existing list
+	expectedFallbacks = []string{"fallback1", "fallback2", "fallback3"}
+	cg.Fallbacks = &expectedFallbacks
+	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
+	if err != nil {
+		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
+		failed = true
+	}
+
+	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
+	if err != nil {
+		t.Errorf("cannot GET CacheGroup by id: '%d', %v\n", *cg.ID, err)
+		failed = true
+	}
+	cg = resp[0]
+	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
+		t.Errorf("failed to update fallbacks (expected = %v, actual = %v\n", expectedFallbacks, *cg.Fallbacks)
+		failed = true
+	}
+
+	// Test removing fallbacks
+	expectedFallbacks = []string{}
+	cg.Fallbacks = &expectedFallbacks
+	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
+	if err != nil {
+		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
+		failed = true
+	}
+
+	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
+	if err != nil {
+		t.Errorf("cannot GET CacheGroup by id: '%d', %v\n", *cg.ID, err)
+		failed = true
+	}
+	cg = resp[0]
+	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
+		t.Errorf("failed to update fallbacks (expected = %v, actual = %v\n", expectedFallbacks, *cg.Fallbacks)
+		failed = true
+	}
+
 	if !failed {
 		log.Debugln("UpdateTestCacheGroups() PASSED: ")
 	}

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -46,13 +46,60 @@
             "typeName": "EDGE_LOC"
         },
         {
+            "latitude": 0,
+            "longitude": 0,
+            "name": "fallback1",
+            "parentCachegroupName": "parentCachegroup",
+            "secondaryParentCachegroupName": "secondaryCachegroup",
+            "shortName": "fb1",
+            "localizationMethods": [
+                "CZ",
+                "DEEP_CZ",
+                "GEO"
+            ],
+            "typeName": "EDGE_LOC"
+        },
+        {
+            "latitude": 0,
+            "longitude": 0,
+            "name": "fallback2",
+            "parentCachegroupName": "parentCachegroup",
+            "secondaryParentCachegroupName": "secondaryCachegroup",
+            "shortName": "fb2",
+            "localizationMethods": [
+                "CZ",
+                "DEEP_CZ",
+                "GEO"
+            ],
+            "typeName": "EDGE_LOC"
+        },
+        {
+            "latitude": 0,
+            "longitude": 0,
+            "name": "fallback3",
+            "parentCachegroupName": "parentCachegroup",
+            "secondaryParentCachegroupName": "secondaryCachegroup",
+            "shortName": "fb3",
+            "localizationMethods": [
+                "CZ",
+                "DEEP_CZ",
+                "GEO"
+            ],
+            "typeName": "EDGE_LOC"
+        },
+        {
             "latitude": 24.1234,
             "longitude": -121.1234,
             "name": "cachegroup2",
             "parentCachegroupName": "parentCachegroup",
             "secondaryParentCachegroupName": "secondaryCachegroup",
             "shortName": "cg2",
-            "typeName": "EDGE_LOC"
+            "typeName": "EDGE_LOC",
+            "fallbacks": [
+                "fallback1",
+                "fallback2",
+                "fallback3"
+            ]
         }
     ],
     "cdns": [

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -171,8 +171,7 @@ func (cg TOCacheGroup) Validate() error {
 			}
 
 			if !isValid {
-				log.Errorf("the cache group " + fallback + "is not valid as a fallback.  It must exist as a cache group and be of type EDGE_LOC.")
-				return errors.New("the cache group " + fallback + "is not valid as a fallback.  It must exist as a cache group and be of type EDGE_LOC.")
+				return errors.New("the cache group " + fallback + " is not valid as a fallback.  It must exist as a cache group and be of type EDGE_LOC.")
 			}
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -53,6 +53,10 @@ func getTestCacheGroups() []tc.CacheGroup {
 		Type:        "EDGE_LOC",
 		TypeID:      6,
 		LastUpdated: tc.TimeNoMod{Time: time.Now()},
+		Fallbacks: []string{
+			"cachegroup2",
+			"cachegroup3",
+		},
 	}
 	cgs = append(cgs, testCG1)
 
@@ -103,6 +107,7 @@ func TestReadCacheGroups(t *testing.T) {
 		"type_name",
 		"type_id",
 		"last_updated",
+		"fallbacks",
 	})
 
 	for _, ts := range testCGs {
@@ -120,6 +125,7 @@ func TestReadCacheGroups(t *testing.T) {
 			ts.Type,
 			ts.TypeID,
 			ts.LastUpdated,
+			[]byte("{cachegroup2,cachegroup3}"),
 		)
 	}
 	mock.ExpectBegin()


### PR DESCRIPTION
…entation

#### What does this PR do?

Updates cachegroups API in traffic_ops_golang to include cachegroup fallbacks.  Updates corresponding test and documentation

#### Which TC components are affected by this PR?

- [X] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [X] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Post/Put/Read/Delete using cachegroup API including the new fallbacks field

#### Check all that apply

- [X] This PR includes tests
- [X] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



