### PR TITLE
Removed main conflicting data from tc-fixtures.

### DIFF
--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -692,12 +692,6 @@
                     "value": "/etc/trafficserver/"
                 },
                 {
-                    "configFile": "remap.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/etc/trafficserver/"
-                },
-                {
                     "configFile": "storage.config",
                     "name": "location",
                     "secure": false,
@@ -714,24 +708,6 @@
                     "name": "CONFIG proxy.config.url_remap.remap_required",
                     "secure": false,
                     "value": "INT 0"
-                },
-                {
-                    "configFile": "rascal.properties",
-                    "name": "health.threshold.loadavg",
-                    "secure": false,
-                    "value": "25.0"
-                },
-                {
-                    "configFile": "rascal.properties",
-                    "name": "health.threshold.availableBandwidthInKbps",
-                    "secure": false,
-                    "value": ">1750000"
-                },
-                {
-                    "configFile": "rascal.properties",
-                    "name": "history.count",
-                    "secure": false,
-                    "value": "30"
                 },
                 {
                     "configFile": "rascal.properties",
@@ -762,12 +738,6 @@
                     "name": "trafficserver",
                     "secure": false,
                     "value": "0:off\t1:off\t2:on\t3:on\t4:on\t5:on\t6:off"
-                },
-                {
-                    "configFile": "plugin.config",
-                    "name": "regex_revalidate.so",
-                    "secure": false,
-                    "value": "--config regex_revalidate.config"
                 },
                 {
                     "configFile": "regex_revalidate.config",


### PR DESCRIPTION
#### What does this PR do?

A previous PR I had (#3100) added some tc-fixture data that added side effects, causing some tests to fail. I reverted the main conflicts. There aren't any conflicts left, but if someone wants to create a parameter that already exists there might be due to how the tests currently POST and DELETE fixture data.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Run the tests, make sure nothing fails related to profiles or parameters.
Right now the CRConfig test is failing for me, but I doubt that's related.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



