### PR TITLE
Fix TO CRConfig tm.url to be FQDN, not URI

### DIFF
--- a/traffic_ops/testing/api/v14/crconfig_test.go
+++ b/traffic_ops/testing/api/v14/crconfig_test.go
@@ -61,7 +61,7 @@ func UpdateTestCRConfigSnapshot(t *testing.T) {
 	cdn := testData.CDNs[0].Name
 
 	tmURLParamName := "tm.url"
-	tmURLExpected := "https://crconfig.tm.url.test.invalid"
+	tmURLExpected := "crconfig.tm.url.test.invalid"
 	_, _, err := TOSession.CreateParameter(tc.Parameter{
 		ConfigFile: "global",
 		Name:       tmURLParamName,

--- a/traffic_ops/traffic_ops_golang/crconfig/crconfig_test.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/crconfig_test.go
@@ -1,0 +1,77 @@
+package crconfig
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"testing"
+)
+
+func TestGetTMURLHost(t *testing.T) {
+	inputOutputs := [][]string{
+		{"a", "a"},
+		{"example.com", "example.com"},
+		{"example.com:42", "example.com:42"},
+		{"example.com:80", "example.com:80"},
+		{"example.com:443", "example.com:443"},
+		{"http://example.com:42", "example.com:42"},
+		{"https://example.com:42", "example.com:42"},
+		{"http://example.com:80", "example.com:80"},
+		{"https://example.com:80", "example.com:80"},
+		{"https://example.com:443", "example.com:443"},
+		{"http://example.com:443", "example.com:443"},
+		{"example.com:42/", "example.com:42"},
+		{"http://example.com:42/", "example.com:42"},
+		{"https://example.com:42/", "example.com:42"},
+		{"http://example.com:80/", "example.com:80"},
+		{"https://example.com:80/", "example.com:80"},
+		{"https://example.com:443/", "example.com:443"},
+		{"http://example.com:443/", "example.com:443"},
+		{"example.com:42/a/b", "example.com:42"},
+		{"http://example.com:42/a/b", "example.com:42"},
+		{"https://example.com:42/a/b", "example.com:42"},
+		{"http://example.com:80/a/b", "example.com:80"},
+		{"https://example.com:80/a/b", "example.com:80"},
+		{"https://example.com:443/a/b", "example.com:443"},
+		{"http://example.com:443/a/b", "example.com:443"},
+		{"example.com:42/a/b?c=42/d", "example.com:42"},
+		{"http://example.com:42/a/b?c=42/d", "example.com:42"},
+		{"https://example.com:42/a/b?c=42/d", "example.com:42"},
+		{"http://example.com:80/a/b?c=42/d", "example.com:80"},
+		{"https://example.com:80/a/b?c=42/d", "example.com:80"},
+		{"https://example.com:443/a/b?c=42/d", "example.com:443"},
+		{"http://example.com:443/a/b?c=42/d", "example.com:443"},
+		{"http://foo.example.com", "foo.example.com"},
+		{"https://foo.example.com", "foo.example.com"},
+		{"https://foo.example.com/bar", "foo.example.com"},
+		{"http://foo.example.com/bar", "foo.example.com"},
+		{"foo.example.com/bar", "foo.example.com"},
+		{"http:::foo.com$%^&*()__+/abc/def?42", "http:::foo.com$%^&*()__+"},
+		{"http:::foo.com$%^&*()__+/", "http:::foo.com$%^&*()__+"},
+		{"http:::foo.com$%^&*()__+", "http:::foo.com$%^&*()__+"},
+		{"asdf1345978fasf", "asdf1345978fasf"},
+	}
+	for _, inputOutput := range inputOutputs {
+		input := inputOutput[0]
+		expected := inputOutput[1]
+		if actual := getTMURLHost(input); expected != actual {
+			t.Errorf("getTMHostURL expected: '%+v', actual: '%+v'", expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
#### What does this PR do?

Fix TO CRConfig tm.url to be fdqn, not uri.

This fixes a regression introduced by https://github.com/apache/trafficcontrol/pull/3069 which itself fixes a bug from the CRConfig `tm_host` coming from the request Host header, not from TO.

The regression is that the `tm.url` is typically a URI, not an FQDN.

This fixes the CRConfig generation to work with either. If the `tm.url` parameter is an FQDN, it's returned as-is. If it's a URI, the Host part is returned.

Includes unit tests. Updates existing API Tests.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Snapshot the CRConfig with a global `tm.url` Parameter which is a URI, e.g. `https://example.invalid`, verify the CRConfig `stats` `tm_host` field is the FQDN of the URI, e.g. `example.invalid`.

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



