### PR TITLE
lock TP dependency

### DIFF
--- a/infrastructure/docker/build/Dockerfile-traffic_portal
+++ b/infrastructure/docker/build/Dockerfile-traffic_portal
@@ -39,9 +39,10 @@ RUN	yum -y install \
 		ruby-devel \
 		rubygems
 
-RUN	gem update --system
-RUN	gem install compass
-RUN	npm -g install bower grunt-cli
+RUN	gem update --system && \
+	gem install rb-inotify -v 0.9.10 && \
+	gem install compass && \
+	npm -g install bower grunt-cli
 
 # bower will not run as root by default
 RUN	echo '{ "allow_root": true }' > /root/.bowerrc


### PR DESCRIPTION
#### What does this PR do?

Locks rb-inotify version to be compatible with Ruby version on centos 7.

Fixes #3131 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

```
./pkg -v traffic_portal_build
```

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



