### PR TITLE
Configuration file route generation script now works with restructured ATC client

### DIFF
--- a/traffic_ops/testing/compare/genConfigRoutes.py
+++ b/traffic_ops/testing/compare/genConfigRoutes.py
@@ -36,17 +36,16 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")
 
 #: An absolute path to the Traffic Ops python packages (This assumes that the script is run from
 #: within the repository's normal directory structure)
-TO_LIBS_PATH = os.path.join(ROOT, "traffic_control", "clients", "python", "trafficops")
+TO_LIBS_PATH = os.path.join(ROOT, "traffic_control", "clients", "python") 
 
 sys.path.insert(0, TO_LIBS_PATH)
-sys.path.insert(0, os.path.join(TO_LIBS_PATH, "trafficops"))
 from trafficops.tosession import TOSession
-from common.restapi import LoginError, OperationError, InvalidJSONError
+from trafficops.restapi import LoginError, OperationError, InvalidJSONError
 
 #: A format specifier for logging output. Propagates to all imported modules.
 LOG_FMT = "%(levelname)s: %(asctime)s line %(lineno)d in %(module)s.%(funcName)s: %(message)s"
 
-__version__ = "2.0.0"
+__version__ = "2.0.0-1"
 
 def getConfigRoutesForServers(servers:typing.List[dict], inst:TOSession) \
                                                                -> typing.Generator[str, None, None]:
@@ -62,7 +61,7 @@ def getConfigRoutesForServers(servers:typing.List[dict], inst:TOSession) \
 	for server in servers:
 		try:
 			yield "/api/1.3/servers/%s/configfiles/ats" % server.hostName
-			for file in inst.getServerConfigFiles(servername=server.hostName)[0].configFiles:
+			for file in inst.get_server_config_files(host_name=server.hostName)[0].configFiles:
 				if "apiUri" in file:
 					yield file.apiUri
 				else:


### PR DESCRIPTION
## What does this PR do?
Recent changes to the ATC client broke the convoluted import mechanisms employed by the genRoutesConfig.py script. This fixes it.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] genRoutesConfig.py

## What is the best way to verify this PR?
Use `genRoutesConfig.py` to generate config file routes for two running traffic ops instances pointed at the same database (or using the same data). See [the documentation](https://traffic-control-cdn.readthedocs.io/en/latest/tools/compare.html#genconfigroutes-py) for details.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



