### PR TITLE
Fix improper file slurping in Perl

### DIFF
--- a/traffic_ops/app/lib/API/Iso.pm
+++ b/traffic_ops/app/lib/API/Iso.pm
@@ -270,7 +270,7 @@ sub generate_iso {
 			}
 
 			# slurp it in..
-			undef $/;
+			local $/;
 			$data = <$fh>;
 
 			close $fh;

--- a/traffic_ops/app/lib/Extensions/TrafficStats/Helper/InfluxResponse.pm
+++ b/traffic_ops/app/lib/Extensions/TrafficStats/Helper/InfluxResponse.pm
@@ -36,7 +36,7 @@ sub parse_retention_period_in_seconds {
 	my $self             = shift;
 	my $retention_period = shift;
 
-	undef $/;
+	local $/;
 
 	my ( $hour, $minutes, $seconds ) = $retention_period =~ /(\d*)h(\d*)m(\d*)s/ms;
 

--- a/traffic_ops/app/lib/UI/GenDbDump.pm
+++ b/traffic_ops/app/lib/UI/GenDbDump.pm
@@ -40,7 +40,7 @@ sub dbdump {
 	}
 
 	# slurp it in..
-	undef $/;
+	local $/;
 	my $data = <$fh>;
 
 


### PR DESCRIPTION
#### What does this PR do?

The proper way to enable slurp mode is by doing `local $/;`. When you do
`undef $/` it is undefining the global `$/` input record separator which
is bad and can cause a multitude of problems. Using the `local` version
only nullifies the input record separator locally in order to enable
slurp mode in that particular function rather than changing it globally.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Hit the `POST /api/$version/isos?stream=yes` endpoint. This can be done in Traffic Portal, just make sure to set stream=yes in order to hit the changed code. I'm not sure how to really verify `parse_retention_period_in_seconds` since I can't find anywhere in the code that actually uses that function. The GenDbDump change isn't really verifiable anymore since it's a UI endpoint, but this should cover our bases in case it is being used in some obscure way by a non-UI endpoint.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



