### PR TITLE
Fix Traffic Ops POST cachegroups/{id}/deliveryservices to return tenancy error instead of 500

### DIFF
--- a/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
@@ -52,45 +52,52 @@ func DSPostHandler(w http.ResponseWriter, r *http.Request) {
 	vals := map[string]interface{}{
 		"alerts": tc.CreateAlerts(tc.SuccessLevel, "Delivery services successfully assigned to all the servers of cache group "+strconv.Itoa(inf.IntParams["id"])+".").Alerts,
 	}
-	api.RespWriterVals(w, r, inf.Tx.Tx, vals)(postDSes(inf.Tx.Tx, inf.User, int64(inf.IntParams["id"]), req.DeliveryServices))
+
+	resp, userErr, sysErr, errCode := postDSes(inf.Tx.Tx, inf.User, int64(inf.IntParams["id"]), req.DeliveryServices)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	api.WriteRespVals(w, r, resp, vals)
 }
 
-func postDSes(tx *sql.Tx, user *auth.CurrentUser, cgID int64, dsIDs []int64) (tc.CacheGroupPostDSResp, error) {
+// postDSes returns the post response, any user error, any system error, and the HTTP status code to be returned in the event of an error.
+func postDSes(tx *sql.Tx, user *auth.CurrentUser, cgID int64, dsIDs []int64) (tc.CacheGroupPostDSResp, error, error, int) {
 	cdnName, err := getCachegroupCDN(tx, cgID)
 	if err != nil {
-		return tc.CacheGroupPostDSResp{}, errors.New("getting cachegroup CDN: " + err.Error())
+		return tc.CacheGroupPostDSResp{}, nil, errors.New("getting cachegroup CDN: " + err.Error()), http.StatusInternalServerError
 	}
 
 	tenantIDs, err := getDSTenants(tx, dsIDs)
 	if err != nil {
-		return tc.CacheGroupPostDSResp{}, errors.New("getting delivery service tennat IDs: " + err.Error())
+		return tc.CacheGroupPostDSResp{}, nil, errors.New("getting delivery service tennat IDs: " + err.Error()), http.StatusInternalServerError
 	}
 	for _, tenantID := range tenantIDs {
 		ok, err := tenant.IsResourceAuthorizedToUserTx(int(tenantID), user, tx)
 		if err != nil {
-			return tc.CacheGroupPostDSResp{}, errors.New("checking tenancy: " + err.Error())
+			return tc.CacheGroupPostDSResp{}, nil, errors.New("checking tenancy: " + err.Error()), http.StatusInternalServerError
 		}
 		if !ok {
-			return tc.CacheGroupPostDSResp{}, errors.New("not authorized for delivery service tenant " + strconv.FormatInt(tenantID, 10))
+			return tc.CacheGroupPostDSResp{}, errors.New("not authorized for delivery service tenant " + strconv.FormatInt(tenantID, 10)), nil, http.StatusForbidden
 		}
 	}
 
 	if err := verifyDSesCDN(tx, dsIDs, cdnName); err != nil {
-		return tc.CacheGroupPostDSResp{}, errors.New("verifying delivery service CDNs match cachegroup server CDNs: " + err.Error())
+		return tc.CacheGroupPostDSResp{}, nil, errors.New("verifying delivery service CDNs match cachegroup server CDNs: " + err.Error()), http.StatusInternalServerError
 	}
 	cgServers, err := getCachegroupServers(tx, cgID)
 	if err != nil {
-		return tc.CacheGroupPostDSResp{}, errors.New("getting cachegroup server names " + err.Error())
+		return tc.CacheGroupPostDSResp{}, nil, errors.New("getting cachegroup server names " + err.Error()), http.StatusInternalServerError
 	}
 	if err := insertCachegroupDSes(tx, cgID, dsIDs); err != nil {
-		return tc.CacheGroupPostDSResp{}, errors.New("inserting cachegroup delivery services: " + err.Error())
+		return tc.CacheGroupPostDSResp{}, nil, errors.New("inserting cachegroup delivery services: " + err.Error()), http.StatusInternalServerError
 	}
 
 	if err := updateParams(tx, dsIDs); err != nil {
-		return tc.CacheGroupPostDSResp{}, errors.New("updating delivery service parameters: " + err.Error())
+		return tc.CacheGroupPostDSResp{}, nil, errors.New("updating delivery service parameters: " + err.Error()), http.StatusInternalServerError
 	}
 	api.CreateChangeLogRawTx(api.ApiChange, fmt.Sprintf("assign servers in cache group %v to deliveryservices %v", cgID, dsIDs), user, tx)
-	return tc.CacheGroupPostDSResp{ID: util.JSONIntStr(cgID), ServerNames: cgServers, DeliveryServices: dsIDs}, nil
+	return tc.CacheGroupPostDSResp{ID: util.JSONIntStr(cgID), ServerNames: cgServers, DeliveryServices: dsIDs}, nil, nil, http.StatusOK
 }
 
 func insertCachegroupDSes(tx *sql.Tx, cgID int64, dsIDs []int64) error {


### PR DESCRIPTION
#### What does this PR do?

Fix Traffic Ops POST cachegroups/{id}/deliveryservices to return tenancy error instead of 500

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

`POST cachegroups/{id}/deliveryservices` to a delivery service your user's tenant isn't authorized for. Verify a `403 Forbidden` with message `not authorized for delivery service tenant x` is returned, not a 5xx with no message.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



