### PR TITLE
Fix Traffic Ops GET statuses to allow null descriptions

### DIFF
--- a/lib/go-tc/statuses.go
+++ b/lib/go-tc/statuses.go
@@ -58,7 +58,7 @@ type Status struct {
 }
 
 type StatusNullable struct {
-	Description *string    `json:"description" db:"description"`
+	Description *string    `json:"description"`
 	ID          *int       `json:"id" db:"id"`
 	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
 	Name        *string    `json:"name" db:"name"`

--- a/traffic_ops/client/status.go
+++ b/traffic_ops/client/status.go
@@ -47,6 +47,24 @@ func (to *Session) CreateStatus(status tc.Status) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, nil
 }
 
+func (to *Session) CreateStatusNullable(status tc.StatusNullable) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(status)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_STATUSES, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
 // Update a Status by ID
 func (to *Session) UpdateStatusByID(id int, status tc.Status) (tc.Alerts, ReqInf, error) {
 

--- a/traffic_ops/testing/api/v14/statuses_test.go
+++ b/traffic_ops/testing/api/v14/statuses_test.go
@@ -32,7 +32,7 @@ func TestStatuses(t *testing.T) {
 func CreateTestStatuses(t *testing.T) {
 
 	for _, status := range testData.Statuses {
-		resp, _, err := TOSession.CreateStatus(status)
+		resp, _, err := TOSession.CreateStatusNullable(status)
 		log.Debugln("Response: ", resp)
 		if err != nil {
 			t.Errorf("could not CREATE types: %v\n", err)
@@ -44,8 +44,12 @@ func CreateTestStatuses(t *testing.T) {
 func UpdateTestStatuses(t *testing.T) {
 
 	firstStatus := testData.Statuses[0]
+	if firstStatus.Name == nil {
+		t.Fatalf("cannot update test statuses: first test data status must have a name\n")
+	}
+
 	// Retrieve the Status by name so we can get the id for the Update
-	resp, _, err := TOSession.GetStatusByName(firstStatus.Name)
+	resp, _, err := TOSession.GetStatusByName(*firstStatus.Name)
 	if err != nil {
 		t.Errorf("cannot GET Status by name: %v - %v\n", firstStatus.Name, err)
 	}
@@ -73,7 +77,10 @@ func UpdateTestStatuses(t *testing.T) {
 func GetTestStatuses(t *testing.T) {
 
 	for _, status := range testData.Statuses {
-		resp, _, err := TOSession.GetStatusByName(status.Name)
+		if status.Name == nil {
+			t.Fatalf("cannot get ftest statuses: test data statuses must have names\n")
+		}
+		resp, _, err := TOSession.GetStatusByName(*status.Name)
 		if err != nil {
 			t.Errorf("cannot GET Status by name: %v - %v\n", err, resp)
 		}
@@ -83,8 +90,12 @@ func GetTestStatuses(t *testing.T) {
 func DeleteTestStatuses(t *testing.T) {
 
 	for _, status := range testData.Statuses {
+		if status.Name == nil {
+			t.Fatalf("cannot get ftest statuses: test data statuses must have names\n")
+		}
+
 		// Retrieve the Status by name so we can get the id for the Update
-		resp, _, err := TOSession.GetStatusByName(status.Name)
+		resp, _, err := TOSession.GetStatusByName(*status.Name)
 		if err != nil {
 			t.Errorf("cannot GET Status by name: %v - %v\n", status.Name, err)
 		}
@@ -96,12 +107,12 @@ func DeleteTestStatuses(t *testing.T) {
 		}
 
 		// Retrieve the Status to see if it got deleted
-		types, _, err := TOSession.GetStatusByName(status.Name)
+		types, _, err := TOSession.GetStatusByName(*status.Name)
 		if err != nil {
 			t.Errorf("error deleting Status name: %s\n", err.Error())
 		}
 		if len(types) > 0 {
-			t.Errorf("expected Status name: %s to be deleted\n", status.Name)
+			t.Errorf("expected Status name: %s to be deleted\n", *status.Name)
 		}
 	}
 }

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -1680,6 +1680,9 @@
         {
             "description": "Pre Production. Not active in any configuration.",
             "name": "PRE_PROD"
+        },
+        {
+            "name": "TEST_NULL_DESCRIPTION"
         }
     ],
     "tenants": [

--- a/traffic_ops/testing/api/v14/traffic_control.go
+++ b/traffic_ops/testing/api/v14/traffic_control.go
@@ -38,7 +38,7 @@ type TrafficControl struct {
 	Regions                        []tc.Region                        `json:"regions"`
 	Roles                          []tc.Role                          `json:"roles"`
 	Servers                        []tc.Server                        `json:"servers"`
-	Statuses                       []tc.Status                        `json:"statuses"`
+	Statuses                       []tc.StatusNullable                `json:"statuses"`
 	StaticDNSEntries               []tc.StaticDNSEntry                `json:"staticdnsentries"`
 	Tenants                        []tc.Tenant                        `json:"tenants"`
 	Types                          []tc.Type                          `json:"types"`


### PR DESCRIPTION
#### What does this PR do?

Fix Traffic Ops GET statuses to allow null descriptions

Includes API Tests.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Run API tests. Create a status with a null description, and call `GET /statuses`.

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



