### PR TITLE
Added an optional configuration setting, 'DisableHTTP2' to the grove config.

### DIFF
--- a/grove/README.md
+++ b/grove/README.md
@@ -76,6 +76,7 @@ The config file has the following fields:
 | `rfc_compliant` | Whether to strictly adhere to RFC 7234. If false, client requests which can harm a parent, such as `no-cache` are ignored. |
 | `port` | The HTTP port to serve on. |
 | `https_port` | The HTTPS port to serve on. |
+| `disable_http2` | When set to true, HTTP2 support is disabled, the default is 'false' with HTTP2 enabled. changing this setting requires a restart of grove. |
 | `cache_size_bytes` | The maximum size of the memory cache, in bytes. This is a soft maximum, and the cache may temporarily exceed this size until older values can be purged. The cache uses a Least Recently Used algorithm, purging the oldest requested object when a request for an uncached object is received with a full cache. Also note the cache size calculation does not currently count headers. |
 | `remap_rules_file` | The file with remap rules. See [Remap Rules](#remap-rules). |
 | `concurrent_rule_requests` | The maximum number of simultaneous requests which will be issued to a parent for any rule. |

--- a/grove/config/config.go
+++ b/grove/config/config.go
@@ -28,8 +28,9 @@ type Config struct {
 	// RFCCompliant determines whether `Cache-Control: no-cache` requests are honored. The ability to ignore `no-cache` is necessary to protect origin servers from DDOS attacks. In general, CDNs and caching proxies with the goal of origin protection should set RFCComplaint false. Cache with other goals (performance, load balancing, etc) should set RFCCompliant true.
 	RFCCompliant bool `json:"rfc_compliant"`
 	// Port is the HTTP port to serve on
-	Port      int `json:"port"`
-	HTTPSPort int `json:"https_port"`
+	Port         int  `json:"port"`
+	HTTPSPort    int  `json:"https_port"`
+	DisableHTTP2 bool `json:"disable_http2"`
 	// CacheSizeBytes is the size of the memory cache, in bytes.
 	CacheSizeBytes int    `json:"cache_size_bytes"`
 	RemapRulesFile string `json:"remap_rules_file"`
@@ -89,6 +90,7 @@ const MSPerSec = 1000
 var DefaultConfig = Config{
 	RFCCompliant:           true,
 	Port:                   80,
+	DisableHTTP2:           false,
 	HTTPSPort:              443,
 	CacheSizeBytes:         bytesPerGibibyte,
 	RemapRulesFile:         "remap.config",

--- a/grove/web/listener.go
+++ b/grove/web/listener.go
@@ -67,9 +67,12 @@ func InterceptListen(network, laddr string) (net.Listener, *ConnMap, func(net.Co
 }
 
 // InterceptListenTLS is like InterceptListen but for serving HTTPS. It returns the tls.Config, which must be set on the http.Server using this listener for HTTP/2 to be set up.
-func InterceptListenTLS(network string, laddr string, certs []tls.Certificate) (net.Listener, *ConnMap, func(net.Conn, http.ConnState), *tls.Config, error) {
+func InterceptListenTLS(network string, laddr string, certs []tls.Certificate, h2Disabled bool) (net.Listener, *ConnMap, func(net.Conn, http.ConnState), *tls.Config, error) {
 	config := &tls.Config{}
-	config.NextProtos = []string{"h2"}
+	// HTTP2 is enabled if config.DisableHTTP2 is false
+	if !h2Disabled {
+		config.NextProtos = []string{"h2"}
+	}
 	config.Certificates = certs
 	config.BuildNameToCertificate()
 	l, err := net.Listen(network, laddr)


### PR DESCRIPTION
This PR adds a new config setting to grove that allows HTTP2 to be disabled.  By default the setting is with HTTP2 enabled.  To disable HTTP2, add "disable_http2: true" to the grove JSON config file.

will not negotiate and serve HTTP2.

#### What does this PR do?
Adds a new config setting that lets the operator disable HTTP2 in grove.
Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [X] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
By default, grove will negotiate and service HTTP2 with capable clients.  If the operator adds the config setting "disable_http2: true" to the grove config file, grove will not negotiate and service an HTTP2 connection.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->


