### PR TITLE
fix builder Dockerfiles

### DIFF
--- a/infrastructure/docker/build/Dockerfile-docs
+++ b/infrastructure/docker/build/Dockerfile-docs
@@ -23,7 +23,9 @@ MAINTAINER Jonathan Gray
 VOLUME /trafficcontrol
 
 ### Common for all sub-component builds
-RUN	yum -y install \
+RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y update ca-certificates && \
+	yum -y install \
 		epel-release \
 		git \
 		rpm-build && \

--- a/infrastructure/docker/build/Dockerfile-grove
+++ b/infrastructure/docker/build/Dockerfile-grove
@@ -23,7 +23,9 @@ MAINTAINER Chris Lemmons
 VOLUME /trafficcontrol
 
 ### Common for all sub-component builds
-RUN	yum -y install \
+RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y update ca-certificates && \
+	yum -y install \
 		epel-release && \
 	yum -y clean all
 RUN	yum -y install \

--- a/infrastructure/docker/build/Dockerfile-grovetccfg
+++ b/infrastructure/docker/build/Dockerfile-grovetccfg
@@ -23,7 +23,9 @@ MAINTAINER John Rushford
 VOLUME /trafficcontrol
 
 ### Common for all sub-component builds
-RUN	yum -y install \
+RUN	yum -y update ca-certificates &&\
+ rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y install \
 		epel-release && \
 	yum -y clean all
 RUN	yum -y install \

--- a/infrastructure/docker/build/Dockerfile-source
+++ b/infrastructure/docker/build/Dockerfile-source
@@ -23,7 +23,9 @@ MAINTAINER Dan Kirkwood
 # docker run --volume /trafficcontrol:$(pwd) ...
 VOLUME /trafficcontrol
 
-RUN	yum -y install \
+RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y update ca-certificates && \
+	yum -y install \
 		git && \
 	yum -y clean all
 

--- a/infrastructure/docker/build/Dockerfile-traffic_monitor
+++ b/infrastructure/docker/build/Dockerfile-traffic_monitor
@@ -23,7 +23,9 @@ MAINTAINER Dan Kirkwood
 VOLUME /trafficcontrol
 
 ### Common for all sub-component builds
-RUN	yum -y install \
+RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y update ca-certificates && \
+	yum -y install \
 		epel-release \
 		git \
 		rpm-build && \

--- a/infrastructure/docker/build/Dockerfile-traffic_ops
+++ b/infrastructure/docker/build/Dockerfile-traffic_ops
@@ -23,7 +23,9 @@ MAINTAINER Dan Kirkwood
 VOLUME /trafficcontrol
 
 ### Common for all sub-component builds
-RUN	yum -y install \
+RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y update ca-certificates && \
+	yum -y install \
 		epel-release \
 		git \
 		rpm-build && \

--- a/infrastructure/docker/build/Dockerfile-traffic_portal
+++ b/infrastructure/docker/build/Dockerfile-traffic_portal
@@ -16,14 +16,16 @@
 # under the License.
 FROM centos:7
 
-MAINTAINER Dan Kirkwood
+MAINTAINER dev@trafficcontrol.apache.org
 
 # top level of trafficcontrol directory must be mounted as a volume:
 # docker run --volume /trafficcontrol:$(pwd) ...
 VOLUME /trafficcontrol
 
 ### Common for all sub-component builds
-RUN	yum -y install \
+RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y update ca-certificates && \
+	yum -y install \
 		epel-release \
 		git \
 		rpm-build && \
@@ -35,12 +37,20 @@ RUN	yum -y install \
 		libffi-devel \
 		make \
 		nodejs \
-		npm \
-		ruby-devel \
-		rubygems
+		npm
 
-RUN	gem update --system && \
-	gem install rb-inotify -v 0.9.10 && \
+# NOTE: error installing with default ruby 2.0.0.   This allows us to upgrade to 2.3
+RUN	yum -y install \
+		centos-release-scl \
+		openssl-devel && \
+	yum -y install \
+		rh-ruby23 \
+		rh-ruby23-ruby-devel \
+		rh-ruby23-runygems
+
+RUN	. /opt/rh/rh-ruby23/enable && \
+	gem update --system --no-document && \
+	gem install rb-inotify && \
 	gem install compass && \
 	npm -g install bower grunt-cli
 

--- a/infrastructure/docker/build/Dockerfile-traffic_router
+++ b/infrastructure/docker/build/Dockerfile-traffic_router
@@ -23,7 +23,9 @@ MAINTAINER Dan Kirkwood
 VOLUME /trafficcontrol
 
 ### Common for all sub-component builds
-RUN	yum -y install \
+RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y update ca-certificates && \
+	yum -y install \
 		epel-release \
 		git \
 		rpm-build && \

--- a/infrastructure/docker/build/Dockerfile-traffic_stats
+++ b/infrastructure/docker/build/Dockerfile-traffic_stats
@@ -23,7 +23,9 @@ MAINTAINER Dan Kirkwood
 VOLUME /trafficcontrol
 
 ### Common for all sub-component builds
-RUN	yum -y install \
+RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+	yum -y update ca-certificates && \
+	yum -y install \
 		epel-release \
 		git \
 		rpm-build && \


### PR DESCRIPTION
#### What does this PR do?
Fixes build errors in traffic_portal and traffic_ops both due to upstream repo changes.  Change is to use newer version of ruby for traffic_portal build and update ca-certificates for all builds.

Fixes #3150 
Fixes #3151

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [x] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [x] Traffic Router
- [x] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

See the Apache build passes.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



