### PR TITLE
handle the situation where a cdn has no dnssec keys. i.e. before any …

### DIFF
--- a/traffic_portal/app/src/common/modules/form/cdnDnssecKeys/FormCdnDnssecKeysController.js
+++ b/traffic_portal/app/src/common/modules/form/cdnDnssecKeys/FormCdnDnssecKeysController.js
@@ -52,7 +52,7 @@ var FormCdnDnssecKeysController = function(cdn, dnssecKeys, $scope, $location, $
 	$scope.hasPropertyError = formUtils.hasPropertyError;
 
 	var init = function() {
-		if (dnssecKeys[cdn.name]) {
+		if (dnssecKeys && dnssecKeys[cdn.name]) {
 			$scope.ksk_new = _.find(dnssecKeys[cdn.name].ksk, function(ksk) { return ksk.status == 'new' });
 		}
 	};


### PR DESCRIPTION
…were generated.

#### What does this PR do?

Fixes #3145 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Open TP, create a new cdn. This cdn will obviously have no dnssec keys. then hit More > Manage DNSSEC Keys. The page should resolve correctly

https://tp.domain.com/#!/cdns/:id/dnssec-keys

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



