### PR TITLE
Fix Traffic Ops Tenancy and Activity Bugs, Fix TO API Test Framework to work with Tenancy

### DIFF
--- a/traffic_ops/client/asn.go
+++ b/traffic_ops/client/asn.go
@@ -17,11 +17,9 @@ package client
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -131,34 +129,4 @@ func (to *Session) DeleteASNByASN(asn int) (tc.Alerts, ReqInf, error) {
 	var alerts tc.Alerts
 	err = json.NewDecoder(resp.Body).Decode(&alerts)
 	return alerts, reqInf, nil
-}
-
-func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alerts, ReqInf, error) {
-	route := apiBase + `/deliveryservice_server/` + strconv.Itoa(dsID) + "/" + strconv.Itoa(serverID)
-	reqResp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
-	}
-	defer reqResp.Body.Close()
-	resp := tc.Alerts{}
-	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
-		return tc.Alerts{}, reqInf, errors.New("decoding response: " + err.Error())
-	}
-	return resp, reqInf, nil
-}
-
-func (to *Session) GetDeliveryServiceServers() (tc.DeliveryServiceServerResponse, ReqInf, error) {
-	route := apiBase + `/deliveryserviceserver`
-	reqResp, remoteAddr, err := to.request(http.MethodGet, route, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
-	}
-	defer reqResp.Body.Close()
-	resp := tc.DeliveryServiceServerResponse{}
-	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
-		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("decoding response: " + err.Error())
-	}
-	return resp, reqInf, nil
 }

--- a/traffic_ops/client/deliveryserviceserver.go
+++ b/traffic_ops/client/deliveryserviceserver.go
@@ -17,6 +17,9 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
@@ -41,4 +44,49 @@ func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, repla
 		return nil, err
 	}
 	return &resp.Response, nil
+}
+
+func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alerts, ReqInf, error) {
+	route := apiBase + `/deliveryservice_server/` + strconv.Itoa(dsID) + "/" + strconv.Itoa(serverID)
+	reqResp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
+	}
+	defer reqResp.Body.Close()
+	resp := tc.Alerts{}
+	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
+		return tc.Alerts{}, reqInf, errors.New("decoding response: " + err.Error())
+	}
+	return resp, reqInf, nil
+}
+
+func (to *Session) GetDeliveryServiceServers() (tc.DeliveryServiceServerResponse, ReqInf, error) {
+	route := apiBase + `/deliveryserviceserver`
+	reqResp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
+	}
+	defer reqResp.Body.Close()
+	resp := tc.DeliveryServiceServerResponse{}
+	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
+		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("decoding response: " + err.Error())
+	}
+	return resp, reqInf, nil
+}
+
+func (to *Session) GetDeliveryServiceServersN(n int) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+	route := apiBase + `/deliveryserviceserver` + `?limit=` + strconv.Itoa(n)
+	reqResp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
+	}
+	defer reqResp.Body.Close()
+	resp := tc.DeliveryServiceServerResponse{}
+	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
+		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("decoding response: " + err.Error())
+	}
+	return resp, reqInf, nil
 }

--- a/traffic_ops/testing/api/v14/cachegroups_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestCacheGroups(t *testing.T) {
-	WithObjs(t, []TCObj{Types, CacheGroups}, func() {
+	WithObjs(t, []TCObj{Types, Parameters, CacheGroups}, func() {
 		GetTestCacheGroups(t)
 		CheckCacheGroupsAuthentication(t)
 		UpdateTestCacheGroups(t)

--- a/traffic_ops/testing/api/v14/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/cachegroupsdeliveryservices_test.go
@@ -16,12 +16,13 @@ package v14
 */
 
 import (
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func TestDeliveryServicesCachegroups(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
 		CreateTestCachegroupsDeliveryServices(t)
 		DeleteTestCachegroupsDeliveryServices(t)
 	})
@@ -100,7 +101,7 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 func DeleteTestCachegroupsDeliveryServices(t *testing.T) {
 	log.Debugln("DeleteTestCachegroupsDeliveryServices")
 
-	dss, _, err := TOSession.GetDeliveryServiceServers()
+	dss, _, err := TOSession.GetDeliveryServiceServersN(1000000)
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServiceServers: %v\n", err)
 	}

--- a/traffic_ops/testing/api/v14/cdn_domains_test.go
+++ b/traffic_ops/testing/api/v14/cdn_domains_test.go
@@ -30,7 +30,7 @@ func GetTestDomains(t *testing.T) {
 }
 
 func TestDomains(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Profiles, Statuses}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Profiles, Statuses}, func() {
 		GetTestDomains(t)
 	})
 }

--- a/traffic_ops/testing/api/v14/cdnfederations_test.go
+++ b/traffic_ops/testing/api/v14/cdnfederations_test.go
@@ -25,7 +25,7 @@ import (
 var fedIDs []int
 
 func TestCDNFederations(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, DeliveryServices, CDNFederations}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Tenants, DeliveryServices, CDNFederations}, func() {
 		UpdateTestCDNFederations(t)
 		GetTestCDNFederations(t)
 	})

--- a/traffic_ops/testing/api/v14/cdns_test.go
+++ b/traffic_ops/testing/api/v14/cdns_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestCDNs(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs}, func() {
+	WithObjs(t, []TCObj{CDNs, Parameters}, func() {
 		UpdateTestCDNs(t)
 		GetTestCDNs(t)
 	})

--- a/traffic_ops/testing/api/v14/coordinates_test.go
+++ b/traffic_ops/testing/api/v14/coordinates_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestCoordinates(t *testing.T) {
-	WithObjs(t, []TCObj{Coordinates}, func() {
+	WithObjs(t, []TCObj{Parameters, Coordinates}, func() {
 		GetTestCoordinates(t)
 		UpdateTestCoordinates(t)
 	})

--- a/traffic_ops/testing/api/v14/crconfig_test.go
+++ b/traffic_ops/testing/api/v14/crconfig_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestCRConfig(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
 		UpdateTestCRConfigSnapshot(t)
 	})
 }

--- a/traffic_ops/testing/api/v14/deliveryservice_request_comments_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservice_request_comments_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDeliveryServiceRequestComments(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, DeliveryServiceRequests, DeliveryServiceRequestComments}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Tenants, DeliveryServiceRequests, DeliveryServiceRequestComments}, func() {
 		UpdateTestDeliveryServiceRequestComments(t)
 		GetTestDeliveryServiceRequestComments(t)
 	})

--- a/traffic_ops/testing/api/v14/deliveryservice_requests_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservice_requests_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 func TestDeliveryServiceRequests(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, DeliveryServiceRequests}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Tenants, DeliveryServiceRequests}, func() {
 		GetTestDeliveryServiceRequests(t)
 		UpdateTestDeliveryServiceRequests(t)
 	})
@@ -51,7 +51,7 @@ func CreateTestDeliveryServiceRequests(t *testing.T) {
 }
 
 func TestDeliveryServiceRequestRequired(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Tenants}, func() {
 		dsr := testData.DeliveryServiceRequests[dsrRequired]
 		alerts, _, err := TOSession.CreateDeliveryServiceRequest(dsr)
 		if err != nil {
@@ -65,7 +65,7 @@ func TestDeliveryServiceRequestRequired(t *testing.T) {
 }
 
 func TestDeliveryServiceRequestRules(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Tenants}, func() {
 		routingName := strings.Repeat("X", 1) + "." + strings.Repeat("X", 48)
 		// Test the xmlId length and form
 		XMLID := "X " + strings.Repeat("X", 46)
@@ -114,7 +114,7 @@ func TestDeliveryServiceRequestTypeFields(t *testing.T) {
 }
 
 func TestDeliveryServiceRequestBad(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Tenants}, func() {
 		// try to create non-draft/submitted
 		src := testData.DeliveryServiceRequests[dsrDraft]
 		s, err := tc.RequestStatusFromString("pending")
@@ -136,7 +136,7 @@ func TestDeliveryServiceRequestBad(t *testing.T) {
 
 // TestDeliveryServiceRequestWorkflow tests that transitions of Status are
 func TestDeliveryServiceRequestWorkflow(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Tenants}, func() {
 		// test empty request table
 		dsrs, _, err := TOSession.GetDeliveryServiceRequests()
 		if err != nil {

--- a/traffic_ops/testing/api/v14/deliveryservicematches_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservicematches_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDeliveryServiceMatches(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
 		GetTestDeliveryServiceMatches(t)
 	})
 }

--- a/traffic_ops/testing/api/v14/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservices_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestDeliveryServices(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
 		UpdateTestDeliveryServices(t)
 		UpdateNullableTestDeliveryServices(t)
 		GetTestDeliveryServices(t)

--- a/traffic_ops/testing/api/v14/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v14/deliveryserviceservers_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDeliveryServiceServers(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
 		DeleteTestDeliveryServiceServers(t)
 	})
 }

--- a/traffic_ops/testing/api/v14/deliveryservicesideligible_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservicesideligible_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestDeliveryServicesEligible(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
 		GetTestDeliveryServicesEligible(t)
 	})
 }

--- a/traffic_ops/testing/api/v14/divisions_test.go
+++ b/traffic_ops/testing/api/v14/divisions_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestDivisions(t *testing.T) {
-	WithObjs(t, []TCObj{Divisions}, func() {
+	WithObjs(t, []TCObj{Parameters, Divisions}, func() {
 		UpdateTestDivisions(t)
 		GetTestDivisions(t)
 	})

--- a/traffic_ops/testing/api/v14/federations_test.go
+++ b/traffic_ops/testing/api/v14/federations_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestFederations(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, UsersDeliveryServices, CDNFederations}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, UsersDeliveryServices, CDNFederations}, func() {
 		PostTestFederationsDeliveryServices(t)
 		GetTestFederations(t)
 	})

--- a/traffic_ops/testing/api/v14/origins_test.go
+++ b/traffic_ops/testing/api/v14/origins_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestOrigins(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, Coordinates, Origins}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, Coordinates, Origins}, func() {
 		UpdateTestOrigins(t)
 		GetTestOrigins(t)
 	})

--- a/traffic_ops/testing/api/v14/parameters_test.go
+++ b/traffic_ops/testing/api/v14/parameters_test.go
@@ -114,9 +114,15 @@ func DeleteTestParameter(t *testing.T, pl tc.Parameter) {
 	if err != nil {
 		t.Errorf("cannot GET Parameter by name: %v - %v\n", pl.Name, err)
 	}
-	if len(resp) > 0 {
-		respParameter := resp[0]
 
+	if len(resp) == 0 {
+		// TODO This fails for the ProfileParameters test; determine a way to check this, even for ProfileParameters
+		// t.Errorf("DeleteTestParameter got no params for %+v %+v\n", pl.Name, pl.ConfigFile)
+	} else if len(resp) > 1 {
+		// TODO figure out why this happens, and be more precise about deleting things where created.
+		// t.Errorf("DeleteTestParameter params for %+v %+v expected 1, actual %+v\n", pl.Name, pl.ConfigFile, len(resp))
+	}
+	for _, respParameter := range resp {
 		delResp, _, err := TOSession.DeleteParameterByID(respParameter.ID)
 		if err != nil {
 			t.Errorf("cannot DELETE Parameter by name: %v - %v\n", err, delResp)

--- a/traffic_ops/testing/api/v14/phys_locations_test.go
+++ b/traffic_ops/testing/api/v14/phys_locations_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestPhysLocations(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Divisions, Regions, PhysLocations}, func() {
+	WithObjs(t, []TCObj{CDNs, Parameters, Divisions, Regions, PhysLocations}, func() {
 		UpdateTestPhysLocations(t)
 		GetTestPhysLocations(t)
 	})

--- a/traffic_ops/testing/api/v14/regions_test.go
+++ b/traffic_ops/testing/api/v14/regions_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestRegions(t *testing.T) {
-	WithObjs(t, []TCObj{Divisions, Regions}, func() {
+	WithObjs(t, []TCObj{Parameters, Divisions, Regions}, func() {
 		UpdateTestRegions(t)
 		GetTestRegions(t)
 		GetTestRegionsByNamePath(t)

--- a/traffic_ops/testing/api/v14/roles_test.go
+++ b/traffic_ops/testing/api/v14/roles_test.go
@@ -31,7 +31,7 @@ const (
 )
 
 func TestRoles(t *testing.T) {
-	WithObjs(t, []TCObj{Roles}, func() {
+	WithObjs(t, []TCObj{Parameters, Roles}, func() {
 		UpdateTestRoles(t)
 		GetTestRoles(t)
 	})

--- a/traffic_ops/testing/api/v14/servers_test.go
+++ b/traffic_ops/testing/api/v14/servers_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestServers(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers}, func() {
 		UpdateTestServers(t)
 		GetTestServers(t)
 	})

--- a/traffic_ops/testing/api/v14/staticdnsentries_test.go
+++ b/traffic_ops/testing/api/v14/staticdnsentries_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestStaticDNSEntries(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, StaticDNSEntries}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, StaticDNSEntries}, func() {
 		GetTestStaticDNSEntries(t)
 		UpdateTestStaticDNSEntries(t)
 		UpdateTestStaticDNSEntriesInvalidAddress(t)

--- a/traffic_ops/testing/api/v14/statuses_test.go
+++ b/traffic_ops/testing/api/v14/statuses_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestStatuses(t *testing.T) {
-	WithObjs(t, []TCObj{Statuses}, func() {
+	WithObjs(t, []TCObj{Parameters, Statuses}, func() {
 		UpdateTestStatuses(t)
 		GetTestStatuses(t)
 	})

--- a/traffic_ops/testing/api/v14/steering_test.go
+++ b/traffic_ops/testing/api/v14/steering_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestSteering(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, SteeringTargets}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, SteeringTargets}, func() {
 		GetTestSteering(t)
 	})
 }

--- a/traffic_ops/testing/api/v14/steeringtargets_test.go
+++ b/traffic_ops/testing/api/v14/steeringtargets_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestSteeringTargets(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, SteeringTargets}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, SteeringTargets}, func() {
 		GetTestSteeringTargets(t)
 		UpdateTestSteeringTargets(t)
 	})

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -361,6 +361,73 @@
             "type": "HTTP_LIVE",
             "xmlId": "ds2",
             "anonymousBlockingEnabled": true
+        },
+        {
+            "active": true,
+            "cdnName": "cdn1",
+            "cacheurl": "cacheUrl3",
+            "ccrDnsTtl": 3600,
+            "cdnName": "cdn1",
+            "checkPath": "",
+            "deepCachingType": "NEVER",
+            "displayName": "d s 1",
+            "dnsBypassCname": null,
+            "dnsBypassIp": "",
+            "dnsBypassIp6": "",
+            "dnsBypassTtl": 30,
+            "dscp": 40,
+            "edgeHeaderRewrite": "edgeRewrite3",
+            "exampleURLs": [
+                "http://ccr.ds3.example.net",
+                "https://ccr.ds3x.example.net"
+            ],
+            "fqPacingRate": 0,
+            "geoLimit": 0,
+            "geoLimitCountries": "",
+            "geoLimitRedirectURL": null,
+            "geoProvider": 0,
+            "globalMaxMbps": 0,
+            "globalMaxTps": 0,
+            "httpBypassFqdn": "",
+            "infoUrl": "TBD",
+            "initialDispersion": 1,
+            "ipv6RoutingEnabled": true,
+            "lastUpdated": "2018-04-06 16:48:51+00",
+            "logsEnabled": false,
+            "longDesc": "d s 3",
+            "longDesc1": "ds3",
+            "longDesc2": "ds3",
+            "matchList": [
+                {
+                    "pattern": ".*\\.ds3\\..*",
+                    "setNumber": 0,
+                    "type": "HOST_REGEXP"
+                }
+            ],
+            "maxDnsAnswers": 0,
+            "midHeaderRewrite": "midRewrite3",
+            "missLat": 41.881944,
+            "missLong": -87.627778,
+            "multiSiteOrigin": false,
+            "orgServerFqdn": "http://origin.ds3.example.net",
+            "originShield": null,
+            "profileDescription": null,
+            "profileName": null,
+            "protocol": 2,
+            "qstringIgnore": 1,
+            "rangeRequestHandling": 0,
+            "regexRemap": "regexRemap3",
+            "regionalGeoBlocking": false,
+            "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/ds3plugin.lua",
+            "routingName": "ccr-ds3",
+            "signed": false,
+            "signingAlgorithm": "url_sig",
+            "sslKeyVersion": 2,
+            "tenant": "tenant3",
+            "tenantName": "tenant3",
+            "type": "HTTP_LIVE",
+            "xmlId": "ds3",
+            "anonymousBlockingEnabled": true
         }
     ],
     "divisions": [
@@ -1568,6 +1635,16 @@
             "active": false,
             "name": "tenant2",
             "parentName": "tenant1"
+        },
+        {
+            "active": true,
+            "name": "tenant3",
+            "parentName": "tenant2"
+        },
+        {
+            "active": true,
+            "name": "tenant4",
+            "parentName": "root"
         }
     ],
     "types": [
@@ -1829,6 +1906,48 @@
             "tenant": "tenant1",
             "uid": 0,
             "username": "readonlyuser"
+        },
+        {
+            "addressLine1": "address of admin",
+            "addressLine2": "",
+            "city": "Anywhere",
+            "company": "Comcast",
+            "country": "USA",
+            "email": "tenant3user@example.com",
+            "fullName": "Fred the admin",
+            "gid": 0,
+            "localPasswd": "pa$$word",
+            "confirmLocalPasswd": "pa$$word",
+            "newUser": false,
+            "phoneNumber": "810-555-9876",
+            "postalCode": "55443",
+            "publicSshKey": "",
+            "role": 4,
+            "stateOrProvince": "LA",
+            "tenant": "tenant3",
+            "uid": 0,
+            "username": "tenant3user"
+        },
+        {
+            "addressLine1": "address of admin",
+            "addressLine2": "",
+            "city": "Anywhere",
+            "company": "Comcast",
+            "country": "USA",
+            "email": "tenant4user@example.com",
+            "fullName": "Fred the admin",
+            "gid": 0,
+            "localPasswd": "pa$$word",
+            "confirmLocalPasswd": "pa$$word",
+            "newUser": false,
+            "phoneNumber": "810-555-9876",
+            "postalCode": "55443",
+            "publicSshKey": "",
+            "role": 4,
+            "stateOrProvince": "LA",
+            "tenant": "tenant4",
+            "uid": 0,
+            "username": "tenant4user"
         }
     ],
     "steeringTargets": [

--- a/traffic_ops/testing/api/v14/types_test.go
+++ b/traffic_ops/testing/api/v14/types_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestTypes(t *testing.T) {
-	WithObjs(t, []TCObj{Types}, func() {
+	WithObjs(t, []TCObj{Parameters, Types}, func() {
 		UpdateTestTypes(t)
 		GetTestTypes(t)
 	})

--- a/traffic_ops/testing/api/v14/user_test.go
+++ b/traffic_ops/testing/api/v14/user_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestUsers(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, Users}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, Users}, func() {
 		UpdateTestUsers(t)
 		GetTestUsers(t)
 		GetTestUserCurrent(t)
@@ -36,11 +36,10 @@ func CreateTestUsers(t *testing.T) {
 	for _, user := range testData.Users {
 
 		resp, _, err := TOSession.CreateUser(&user)
-		log.Debugln("Response: ", resp.Alerts)
-
 		if err != nil {
-			t.Errorf("could not CREATE user: %v\n", err)
+			t.Fatalf("could not CREATE user: %v\n", err)
 		}
+		log.Debugln("Response: ", resp.Alerts)
 	}
 }
 

--- a/traffic_ops/testing/api/v14/userdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/userdeliveryservices_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestUserDeliveryServices(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, UsersDeliveryServices}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, UsersDeliveryServices}, func() {
 		GetTestUsersDeliveryServices(t)
 	})
 }


### PR DESCRIPTION
This fixes major TO Tenancy bugs, as well as fixing the TO API framework to work with Tenancy enabled, and enabling it.

Unfortunately, all the tenancy issues, and the test framework, are intimately related, and there isn't a good way to separate them; so this PR is unfortunately large.

Specifically:

- Fix TO Tenancy checks to consider whether the user's tenant is active, not whether the resource's tenant is active.

- Fix TO Tenancy to prevent access when parent tenants (of the 
  user's tenant) are inactive.

- Add TO API Tests to verify tenancy, verify access is disabled when
  parents or self are inactive.

- Fix TO API Test user panic on test failure.

- Fix TO API Test tenants to automatically delete children before
  parents, rather than hard-coding.

- Fix TO API Test parameters race condition, fixed to delete all
  parameters not only first name+file.

- Fix TO API Tests to enable Tenancy on all tests (by creating
  Parameters, which creates the use_tenancy param).
  The TO API Tests were completely broken with tenancy, due
  to the above bugs. With the bugs fixed, the tests pass
  with tenancy enabled.

Fixes #2732 

#### What does this PR do?

Fixes #2732 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Run API tests. Run TO with Tenancy enabled, verify resources are accessible as expected.

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



