### PR TITLE
CIAB: Fix Automatic snapshot/queue-updates on startup.

### DIFF
--- a/docs/source/admin/quick_howto/ciab.rst
+++ b/docs/source/admin/quick_howto/ciab.rst
@@ -171,6 +171,14 @@ The "enroller" provides an efficient way for Traffic Ops to be populated with da
 
 The enroller runs within CDN in a Box using the ``-dir <dir>`` switch which provides the above behavior. It can also be run using the ``-http :<port>`` switch to instead have it listen on the indicated port. In this case, it accepts only POST requests with the JSON provided using the POST JSON method, e.g. ``curl -X POST https://enroller/api/1.4/regions -d @newregion.json``.  CDN in a Box does not currently use this method, but may be modified in the future to avoid using the shared volume approach.
 
+Auto Snapshot/Queue-Updates
+---------------------------
+An automatic snapshot of the current Traffic Ops CDN configuration/toplogy will be performed once the "enroller" has finished loading all of the data and a minimum number of servers have been enrolled.  To enable this feature, set the boolean ``AUTO_SNAPQUEUE_ENABLED`` to ``true`` [7]_.  The snapshot and queue-updates actions will not be performed until all servers in ``AUTO_SNAPQUEUE_SERVERS`` (comma-delimited string) have been enrolled.  The current enrolled servers will be polled every ``AUTO_SNAPQUEUE_POLL_INTERVAL`` seconds, and each action (snapshot and queue-updates) will be delayed ``AUTO_SNAPQUEUE_ACTION_WAIT`` seconds [8]_.
+
+.. [7] Automatic Snapshot/Queue-Updates is enabled by default in ``infrastructure/cdn-in-a-box/variables.env``.
+.. [8] Server poll interval and delay action wait are defaulted to a value of 2 seconds.
+
+
 Mock Origin Service
 -------------------
 The default "origin" service container provides a basic static file HTTP server as the central respository for content. Additional files can be added to the origin root content directory located at ``infrastructure/cdn-in-a-box/origin/content``. To request content directly from the origin directly and bypass the CDN:

--- a/infrastructure/cdn-in-a-box/traffic_ops/config.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/config.sh
@@ -90,7 +90,8 @@ cat <<-EOF >/opt/traffic_ops/app/conf/cdn.conf
         "max_db_connections": 20,
         "backend_max_connections": {
             "mojolicious": 4
-        }
+        },
+        "crconfig_snapshot_use_client_request_host": true
     },
     "cors" : {
         "access_control_allow_origin" : "*"

--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -111,7 +111,7 @@ to-post() {
 	fi
 	to-auth && \
 	    curl $CURLAUTH $CURLOPTS --cookie "$COOKIEJAR" -X POST $data "$TO_URL/$1"
-	[[ -n $t ]] && rm "$t"
+	[[ -n $t ]] && rm -f "$t"
 }
 
 to-put() {

--- a/infrastructure/cdn-in-a-box/traffic_router/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_router/run.sh
@@ -92,14 +92,14 @@ echo "traffic_ops.password=$TO_ADMIN_PASSWORD" >> $TO_PROPERTIES
 echo "traffic_monitor.bootstrap.hosts=$TM_FQDN:$TM_PORT;" >> $TM_PROPERTIES
 echo "traffic_monitor.properties.reload.period=60000" >> $TM_PROPERTIES
 
+# Enroll Traffic Router
+to-enroll tr || (while true; do echo "enroll failed."; sleep 3 ; done)
+
 # Wait for traffic monitor
 until nc $TM_FQDN $TM_PORT </dev/null >/dev/null 2>&1; do
   echo "Waiting for Traffic Monitor to start..."
   sleep 3
 done
-
-# Enroll Traffic Router
-to-enroll tr || (while true; do echo "enroll failed."; sleep 3 ; done)
 
 touch $LOGFILE $ACCESSLOG
 tail -F $CATALINA_OUT $CATALINA_LOG $LOGFILE $ACCESSLOG &  

--- a/infrastructure/cdn-in-a-box/variables.env
+++ b/infrastructure/cdn-in-a-box/variables.env
@@ -83,3 +83,7 @@ TV_INT_PORT=8087
 TV_HTTP_PORT=8098
 TV_HTTPS_PORT=8088
 ENROLLER_DIR=/shared/enroller
+AUTO_SNAPQUEUE_ENABLED=true
+AUTO_SNAPQUEUE_SERVERS=trafficops,trafficops-perl,trafficmonitor,trafficrouter,trafficvault,edge,mid
+AUTO_SNAPQUEUE_POLL_INTERVAL=2
+AUTO_SNAPQUEUE_ACTION_WAIT=2


### PR DESCRIPTION
#### What does this PR do?

CIAB: Fix Automatic Snapshot and Queue Updates upon startup.

The "fixed" automatic snapshot/queue-updates procedure:

1) Poll servers from traffic ops with repeated requsets to 'api/1.x/servers'
2) Verify a minimum of servers have been enrolled.
3) Sleep for a configurable amount of seconds
4) Perform snapshot request via API
5) Sleep for a configuration amount of seconds
6) Perform queue-updates request via API

Documentation has been updated to reflect this "fixed" feature.

Traffic Router has been updated to enroll itself before waiting for the traffic monitor to start (chicken-egg problem)

Minor fix to to-enroll.sh to clean up temporary files.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

1) Build trafifcops-perl, trafficops, and trafficrouter containers

2) Start up the stack with "docker-compose up"

3) Monitor the "trafficops" container logs for the following:
AUTO-SNAPQUEUE - Expected Servers (7): edge,mid,trafficmonitor,trafficops,trafficops-perl,trafficrouter,trafficvault
AUTO-SNAPQUEUE - Current Servers (10): db,dns,edge,enroller,mid,trafficmonitor,trafficops,trafficportal,trafficrouter,trafficvault
AUTO-SNAPQUEUE - Remain Servers (1): trafficops-perl
AUTO-SNAPQUEUE - Expected Servers (7): edge,mid,trafficmonitor,trafficops,trafficops-perl,trafficrouter,trafficvault
AUTO-SNAPQUEUE - Current Servers (11): db,dns,edge,enroller,mid,trafficmonitor,trafficops,trafficops-perl,trafficportal,trafficrouter,trafficvault
AUTO-SNAPQUEUE - Remain Servers (0): 
AUTO-SNAPQUEUE - All expected servers enrolled.
AUTO-SNAPQUEUE - Do automatic snapshot...
AUTO-SNAPQUEUE - Do queue updates...

4) After queue updates has been performed it may take traffic monitor up to 30 seconds to see the new snapshot.

5) Login to traffic portal and verify that a snapshot diff  has no additional changes other than the timestamp.

6) The traffic router should start (ignore the SSL exception) within 15 seconds after traffic monitor has received new snapshot.

7) Should be able to ping the "demo1" delivery service URL once the traffic router has started.

#### Check all that apply

- [ ] This PR includes tests
- [X] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [X] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



