### PR TITLE
Fix Traffic Ops API Tests to delete on t.Fatal or panic

### DIFF
--- a/traffic_ops/testing/api/v14/cachegroups_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_test.go
@@ -25,13 +25,11 @@ import (
 )
 
 func TestCacheGroups(t *testing.T) {
-	CreateTestTypes(t)
-	CreateTestCacheGroups(t)
-	GetTestCacheGroups(t)
-	CheckCacheGroupsAuthentication(t)
-	UpdateTestCacheGroups(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestTypes(t)
+	WithObjs(t, []TCObj{Types, CacheGroups}, func() {
+		GetTestCacheGroups(t)
+		CheckCacheGroupsAuthentication(t)
+		UpdateTestCacheGroups(t)
+	})
 }
 
 func CreateTestCacheGroups(t *testing.T) {

--- a/traffic_ops/testing/api/v14/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/cachegroupsdeliveryservices_test.go
@@ -21,32 +21,10 @@ import (
 )
 
 func TestDeliveryServicesCachegroups(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-
-	CreateTestCachegroupsDeliveryServices(t)
-	DeleteTestCachegroupsDeliveryServices(t)
-
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		CreateTestCachegroupsDeliveryServices(t)
+		DeleteTestCachegroupsDeliveryServices(t)
+	})
 }
 
 const TestEdgeServerCacheGroupName = "cachegroup1" // TODO this is the name hard-coded in the create servers test; change to be dynamic

--- a/traffic_ops/testing/api/v14/cdn_domains_test.go
+++ b/traffic_ops/testing/api/v14/cdn_domains_test.go
@@ -30,13 +30,7 @@ func GetTestDomains(t *testing.T) {
 }
 
 func TestDomains(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	GetTestDomains(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Profiles, Statuses}, func() {
+		GetTestDomains(t)
+	})
 }

--- a/traffic_ops/testing/api/v14/cdnfederations_test.go
+++ b/traffic_ops/testing/api/v14/cdnfederations_test.go
@@ -25,18 +25,10 @@ import (
 var fedIDs []int
 
 func TestCDNFederations(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestDeliveryServices(t)
-	CreateTestCDNFederations(t)
-	UpdateTestCDNFederations(t)
-	GetTestCDNFederations(t)
-	DeleteTestCDNFederations(t)
-	DeleteTestDeliveryServices(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, DeliveryServices, CDNFederations}, func() {
+		UpdateTestCDNFederations(t)
+		GetTestCDNFederations(t)
+	})
 }
 
 func CreateTestCDNFederations(t *testing.T) {

--- a/traffic_ops/testing/api/v14/cdns_test.go
+++ b/traffic_ops/testing/api/v14/cdns_test.go
@@ -23,12 +23,10 @@ import (
 )
 
 func TestCDNs(t *testing.T) {
-
-	CreateTestCDNs(t)
-	UpdateTestCDNs(t)
-	GetTestCDNs(t)
-	DeleteTestCDNs(t)
-
+	WithObjs(t, []TCObj{CDNs}, func() {
+		UpdateTestCDNs(t)
+		GetTestCDNs(t)
+	})
 }
 
 func CreateTestCDNs(t *testing.T) {

--- a/traffic_ops/testing/api/v14/coordinates_test.go
+++ b/traffic_ops/testing/api/v14/coordinates_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 func TestCoordinates(t *testing.T) {
-	CreateTestCoordinates(t)
-	GetTestCoordinates(t)
-	UpdateTestCoordinates(t)
-	DeleteTestCoordinates(t)
+	WithObjs(t, []TCObj{Coordinates}, func() {
+		GetTestCoordinates(t)
+		UpdateTestCoordinates(t)
+	})
 }
 
 func CreateTestCoordinates(t *testing.T) {

--- a/traffic_ops/testing/api/v14/crconfig_test.go
+++ b/traffic_ops/testing/api/v14/crconfig_test.go
@@ -25,31 +25,9 @@ import (
 )
 
 func TestCRConfig(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-
-	UpdateTestCRConfigSnapshot(t)
-
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		UpdateTestCRConfigSnapshot(t)
+	})
 }
 
 func UpdateTestCRConfigSnapshot(t *testing.T) {

--- a/traffic_ops/testing/api/v14/deliveryservice_request_comments_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservice_request_comments_test.go
@@ -22,20 +22,10 @@ import (
 )
 
 func TestDeliveryServiceRequestComments(t *testing.T) {
-
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestDeliveryServiceRequests(t)
-	CreateTestDeliveryServiceRequestComments(t)
-	UpdateTestDeliveryServiceRequestComments(t)
-	GetTestDeliveryServiceRequestComments(t)
-	DeleteTestDeliveryServiceRequestComments(t)
-	DeleteTestDeliveryServiceRequests(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
-
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, DeliveryServiceRequests, DeliveryServiceRequestComments}, func() {
+		UpdateTestDeliveryServiceRequestComments(t)
+		GetTestDeliveryServiceRequestComments(t)
+	})
 }
 
 func CreateTestDeliveryServiceRequestComments(t *testing.T) {

--- a/traffic_ops/testing/api/v14/deliveryservicematches_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservicematches_test.go
@@ -22,31 +22,9 @@ import (
 )
 
 func TestDeliveryServiceMatches(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-
-	GetTestDeliveryServiceMatches(t)
-
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		GetTestDeliveryServiceMatches(t)
+	})
 }
 
 func GetTestDeliveryServiceMatches(t *testing.T) {

--- a/traffic_ops/testing/api/v14/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservices_test.go
@@ -24,31 +24,11 @@ import (
 )
 
 func TestDeliveryServices(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-	UpdateTestDeliveryServices(t)
-	UpdateNullableTestDeliveryServices(t)
-	GetTestDeliveryServices(t)
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		UpdateTestDeliveryServices(t)
+		UpdateNullableTestDeliveryServices(t)
+		GetTestDeliveryServices(t)
+	})
 }
 
 func CreateTestDeliveryServices(t *testing.T) {

--- a/traffic_ops/testing/api/v14/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v14/deliveryserviceservers_test.go
@@ -22,31 +22,9 @@ import (
 )
 
 func TestDeliveryServiceServers(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-
-	DeleteTestDeliveryServiceServers(t)
-
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		DeleteTestDeliveryServiceServers(t)
+	})
 }
 
 func DeleteTestDeliveryServiceServers(t *testing.T) {

--- a/traffic_ops/testing/api/v14/deliveryservicesideligible_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservicesideligible_test.go
@@ -20,31 +20,9 @@ import (
 )
 
 func TestDeliveryServicesEligible(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-
-	GetTestDeliveryServicesEligible(t)
-
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		GetTestDeliveryServicesEligible(t)
+	})
 }
 
 func GetTestDeliveryServicesEligible(t *testing.T) {

--- a/traffic_ops/testing/api/v14/divisions_test.go
+++ b/traffic_ops/testing/api/v14/divisions_test.go
@@ -23,12 +23,10 @@ import (
 )
 
 func TestDivisions(t *testing.T) {
-
-	CreateTestDivisions(t)
-	UpdateTestDivisions(t)
-	GetTestDivisions(t)
-	DeleteTestDivisions(t)
-
+	WithObjs(t, []TCObj{Divisions}, func() {
+		UpdateTestDivisions(t)
+		GetTestDivisions(t)
+	})
 }
 
 func CreateTestDivisions(t *testing.T) {

--- a/traffic_ops/testing/api/v14/federations_test.go
+++ b/traffic_ops/testing/api/v14/federations_test.go
@@ -22,34 +22,10 @@ import (
 )
 
 func TestFederations(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestDeliveryServices(t)
-	CreateTestUsersDeliveryServices(t)
-	CreateTestCDNFederations(t)
-
-	PostTestFederationsDeliveryServices(t)
-	GetTestFederations(t)
-
-	DeleteTestCDNFederations(t)
-	DeleteTestUsersDeliveryServices(t)
-	DeleteTestDeliveryServices(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, UsersDeliveryServices, CDNFederations}, func() {
+		PostTestFederationsDeliveryServices(t)
+		GetTestFederations(t)
+	})
 }
 
 func GetTestFederations(t *testing.T) {

--- a/traffic_ops/testing/api/v14/loginfail_test.go
+++ b/traffic_ops/testing/api/v14/loginfail_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 func TestLoginFail(t *testing.T) {
-	CreateTestCDNs(t)
-	PostTestLoginFail(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs}, func() {
+		PostTestLoginFail(t)
+	})
 }
 
 func PostTestLoginFail(t *testing.T) {

--- a/traffic_ops/testing/api/v14/origins_test.go
+++ b/traffic_ops/testing/api/v14/origins_test.go
@@ -22,35 +22,10 @@ import (
 )
 
 func TestOrigins(t *testing.T) {
-	CreateTestCDNs(t)
-	defer DeleteTestCDNs(t)
-	CreateTestTypes(t)
-	defer DeleteTestTypes(t)
-	CreateTestTenants(t)
-	defer DeleteTestTenants(t)
-	CreateTestProfiles(t)
-	defer DeleteTestProfiles(t)
-	CreateTestStatuses(t)
-	defer DeleteTestStatuses(t)
-	CreateTestDivisions(t)
-	defer DeleteTestDivisions(t)
-	CreateTestRegions(t)
-	defer DeleteTestRegions(t)
-	CreateTestPhysLocations(t)
-	defer DeleteTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	defer DeleteTestCacheGroups(t)
-	CreateTestServers(t)
-	defer DeleteTestServers(t)
-	CreateTestDeliveryServices(t)
-	defer DeleteTestDeliveryServices(t)
-	CreateTestCoordinates(t)
-	defer DeleteTestCoordinates(t)
-
-	CreateTestOrigins(t)
-	defer DeleteTestOrigins(t)
-	UpdateTestOrigins(t)
-	GetTestOrigins(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, Coordinates, Origins}, func() {
+		UpdateTestOrigins(t)
+		GetTestOrigins(t)
+	})
 }
 
 func CreateTestOrigins(t *testing.T) {

--- a/traffic_ops/testing/api/v14/parameters_test.go
+++ b/traffic_ops/testing/api/v14/parameters_test.go
@@ -28,11 +28,10 @@ func TestParameters(t *testing.T) {
 	//toReqTimeout := time.Second * time.Duration(Config.Default.Session.TimeoutInSecs)
 	//SwitchSession(toReqTimeout, Config.TrafficOps.URL, Config.TrafficOps.Users.Admin, Config.TrafficOps.UserPassword, Config.TrafficOps.Users.Portal, Config.TrafficOps.UserPassword)
 
-	CreateTestParameters(t)
-	UpdateTestParameters(t)
-	GetTestParameters(t)
-	DeleteTestParameters(t)
-
+	WithObjs(t, []TCObj{Parameters}, func() {
+		UpdateTestParameters(t)
+		GetTestParameters(t)
+	})
 }
 
 func CreateTestParameters(t *testing.T) {

--- a/traffic_ops/testing/api/v14/phys_locations_test.go
+++ b/traffic_ops/testing/api/v14/phys_locations_test.go
@@ -23,18 +23,10 @@ import (
 )
 
 func TestPhysLocations(t *testing.T) {
-
-	CreateTestCDNs(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	UpdateTestPhysLocations(t)
-	GetTestPhysLocations(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestCDNs(t)
-
+	WithObjs(t, []TCObj{CDNs, Divisions, Regions, PhysLocations}, func() {
+		UpdateTestPhysLocations(t)
+		GetTestPhysLocations(t)
+	})
 }
 
 func CreateTestPhysLocations(t *testing.T) {

--- a/traffic_ops/testing/api/v14/profile_parameters_test.go
+++ b/traffic_ops/testing/api/v14/profile_parameters_test.go
@@ -27,19 +27,9 @@ import (
 const queryParamFormat = "?profileId=%d&parameterId=%d"
 
 func TestProfileParameters(t *testing.T) {
-
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestParameters(t)
-	CreateTestProfiles(t)
-	CreateTestProfileParameters(t)
-	GetTestProfileParameters(t)
-	DeleteTestProfileParameters(t)
-	DeleteTestParameters(t)
-	DeleteTestProfiles(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
-
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Profiles, ProfileParameters}, func() {
+		GetTestProfileParameters(t)
+	})
 }
 
 func CreateTestProfileParameters(t *testing.T) {

--- a/traffic_ops/testing/api/v14/profiles_test.go
+++ b/traffic_ops/testing/api/v14/profiles_test.go
@@ -24,21 +24,12 @@ import (
 )
 
 func TestProfiles(t *testing.T) {
-
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-
-	// attempt to create profiles with missing info
-	CreateBadProfiles(t)
-	CreateTestProfiles(t)
-	CreateTestParameters(t)
-	UpdateTestProfiles(t)
-	GetTestProfiles(t)
-	GetTestProfilesWithParameters(t)
-	DeleteTestParameters(t)
-	DeleteTestProfiles(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Profiles, Parameters}, func() {
+		CreateBadProfiles(t)
+		UpdateTestProfiles(t)
+		GetTestProfiles(t)
+		GetTestProfilesWithParameters(t)
+	})
 }
 
 // CreateBadProfiles ensures that profiles can't be created with bad values

--- a/traffic_ops/testing/api/v14/readonlycannotmodify_test.go
+++ b/traffic_ops/testing/api/v14/readonlycannotmodify_test.go
@@ -25,31 +25,9 @@ import (
 )
 
 func TestReadOnlyCannotModify(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestDeliveryServices(t)
-	CreateTestUsers(t)
-
-	CreateTestCDNWithReadOnlyUser(t)
-
-	ForceDeleteTestUsers(t)
-	DeleteTestDeliveryServices(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, Users}, func() {
+		CreateTestCDNWithReadOnlyUser(t)
+	})
 }
 
 func CreateTestCDNWithReadOnlyUser(t *testing.T) {

--- a/traffic_ops/testing/api/v14/regions_test.go
+++ b/traffic_ops/testing/api/v14/regions_test.go
@@ -23,15 +23,11 @@ import (
 )
 
 func TestRegions(t *testing.T) {
-
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	UpdateTestRegions(t)
-	GetTestRegions(t)
-	GetTestRegionsByNamePath(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-
+	WithObjs(t, []TCObj{Divisions, Regions}, func() {
+		UpdateTestRegions(t)
+		GetTestRegions(t)
+		GetTestRegionsByNamePath(t)
+	})
 }
 
 func CreateTestRegions(t *testing.T) {

--- a/traffic_ops/testing/api/v14/roles_test.go
+++ b/traffic_ops/testing/api/v14/roles_test.go
@@ -31,14 +31,14 @@ const (
 )
 
 func TestRoles(t *testing.T) {
-	CreateTestRoles(t)
-	UpdateTestRoles(t)
-	GetTestRoles(t)
-	DeleteTestRoles(t)
+	WithObjs(t, []TCObj{Roles}, func() {
+		UpdateTestRoles(t)
+		GetTestRoles(t)
+	})
 }
 
 func CreateTestRoles(t *testing.T) {
-	expectedAlerts := []tc.Alerts{tc.Alerts{[]tc.Alert{tc.Alert{"role was created.","success"}}}, tc.Alerts{[]tc.Alert{tc.Alert{"can not add non-existent capabilities: [invalid-capability]","error"}}}}
+	expectedAlerts := []tc.Alerts{tc.Alerts{[]tc.Alert{tc.Alert{"role was created.", "success"}}}, tc.Alerts{[]tc.Alert{tc.Alert{"can not add non-existent capabilities: [invalid-capability]", "error"}}}}
 	for i, role := range testData.Roles {
 		var alerts tc.Alerts
 		alerts, _, status, err := TOSession.CreateRole(role)
@@ -56,7 +56,7 @@ func CreateTestRoles(t *testing.T) {
 
 func UpdateTestRoles(t *testing.T) {
 	log.Debugln("entered test")
-	log.Debugf("testData.Roles contains: %++v\n",testData.Roles)
+	log.Debugf("testData.Roles contains: %++v\n", testData.Roles)
 	firstRole := testData.Roles[0]
 	log.Debugln("got first role from slice")
 	// Retrieve the Role by role so we can get the id for the Update

--- a/traffic_ops/testing/api/v14/servers_test.go
+++ b/traffic_ops/testing/api/v14/servers_test.go
@@ -23,28 +23,10 @@ import (
 )
 
 func TestServers(t *testing.T) {
-
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	UpdateTestServers(t)
-	GetTestServers(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
-
+	WithObjs(t, []TCObj{CDNs, Types, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers}, func() {
+		UpdateTestServers(t)
+		GetTestServers(t)
+	})
 }
 
 func CreateTestServers(t *testing.T) {

--- a/traffic_ops/testing/api/v14/staticdnsentries_test.go
+++ b/traffic_ops/testing/api/v14/staticdnsentries_test.go
@@ -24,35 +24,11 @@ import (
 )
 
 func TestStaticDNSEntries(t *testing.T) {
-
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-	CreateTestStaticDNSEntries(t)
-	GetTestStaticDNSEntries(t)
-	UpdateTestStaticDNSEntries(t)
-	UpdateTestStaticDNSEntriesInvalidAddress(t)
-	DeleteTestStaticDNSEntries(t)
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
-
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, StaticDNSEntries}, func() {
+		GetTestStaticDNSEntries(t)
+		UpdateTestStaticDNSEntries(t)
+		UpdateTestStaticDNSEntriesInvalidAddress(t)
+	})
 }
 
 func CreateTestStaticDNSEntries(t *testing.T) {

--- a/traffic_ops/testing/api/v14/statuses_test.go
+++ b/traffic_ops/testing/api/v14/statuses_test.go
@@ -23,12 +23,10 @@ import (
 )
 
 func TestStatuses(t *testing.T) {
-
-	CreateTestStatuses(t)
-	UpdateTestStatuses(t)
-	GetTestStatuses(t)
-	DeleteTestStatuses(t)
-
+	WithObjs(t, []TCObj{Statuses}, func() {
+		UpdateTestStatuses(t)
+		GetTestStatuses(t)
+	})
 }
 
 func CreateTestStatuses(t *testing.T) {

--- a/traffic_ops/testing/api/v14/steering_test.go
+++ b/traffic_ops/testing/api/v14/steering_test.go
@@ -22,33 +22,9 @@ import (
 )
 
 func TestSteering(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-	CreateTestSteeringTargets(t)
-
-	GetTestSteering(t)
-
-	DeleteTestSteeringTargets(t)
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, SteeringTargets}, func() {
+		GetTestSteering(t)
+	})
 }
 
 func GetTestSteering(t *testing.T) {

--- a/traffic_ops/testing/api/v14/steeringtargets_test.go
+++ b/traffic_ops/testing/api/v14/steeringtargets_test.go
@@ -23,34 +23,10 @@ import (
 )
 
 func TestSteeringTargets(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestServers(t)
-	CreateTestDeliveryServices(t)
-
-	CreateTestSteeringTargets(t)
-	GetTestSteeringTargets(t)
-	UpdateTestSteeringTargets(t)
-	DeleteTestSteeringTargets(t)
-
-	DeleteTestDeliveryServices(t)
-	DeleteTestServers(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, SteeringTargets}, func() {
+		GetTestSteeringTargets(t)
+		UpdateTestSteeringTargets(t)
+	})
 }
 
 func CreateTestSteeringTargets(t *testing.T) {

--- a/traffic_ops/testing/api/v14/tenants_test.go
+++ b/traffic_ops/testing/api/v14/tenants_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 func TestTenants(t *testing.T) {
-	CreateTestTenants(t)
-	GetTestTenants(t)
-	UpdateTestTenants(t)
-	DeleteTestTenants(t)
+	WithObjs(t, []TCObj{Tenants}, func() {
+		GetTestTenants(t)
+		UpdateTestTenants(t)
+	})
 }
 
 func CreateTestTenants(t *testing.T) {

--- a/traffic_ops/testing/api/v14/types_test.go
+++ b/traffic_ops/testing/api/v14/types_test.go
@@ -23,12 +23,10 @@ import (
 )
 
 func TestTypes(t *testing.T) {
-
-	CreateTestTypes(t)
-	UpdateTestTypes(t)
-	GetTestTypes(t)
-	DeleteTestTypes(t)
-
+	WithObjs(t, []TCObj{Types}, func() {
+		UpdateTestTypes(t)
+		GetTestTypes(t)
+	})
 }
 
 func CreateTestTypes(t *testing.T) {

--- a/traffic_ops/testing/api/v14/user_test.go
+++ b/traffic_ops/testing/api/v14/user_test.go
@@ -23,36 +23,11 @@ import (
 )
 
 func TestUsers(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestDeliveryServices(t)
-
-	CreateTestUsers(t)
-	UpdateTestUsers(t)
-	GetTestUsers(t)
-	GetTestUserCurrent(t)
-	//Delete will be new functionality to 1.4, ignore for now
-	//DeleteTestUsers(t)
-	ForceDeleteTestUsers(t)
-
-	DeleteTestDeliveryServices(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
-
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, Users}, func() {
+		UpdateTestUsers(t)
+		GetTestUsers(t)
+		GetTestUserCurrent(t)
+	})
 }
 
 const SessionUserName = "admin" // TODO make dynamic?

--- a/traffic_ops/testing/api/v14/userdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/userdeliveryservices_test.go
@@ -21,31 +21,9 @@ import (
 )
 
 func TestUserDeliveryServices(t *testing.T) {
-	CreateTestCDNs(t)
-	CreateTestTypes(t)
-	CreateTestTenants(t)
-	CreateTestProfiles(t)
-	CreateTestStatuses(t)
-	CreateTestDivisions(t)
-	CreateTestRegions(t)
-	CreateTestPhysLocations(t)
-	CreateTestCacheGroups(t)
-	CreateTestDeliveryServices(t)
-
-	CreateTestUsersDeliveryServices(t)
-	GetTestUsersDeliveryServices(t)
-	DeleteTestUsersDeliveryServices(t)
-
-	DeleteTestDeliveryServices(t)
-	DeleteTestCacheGroups(t)
-	DeleteTestPhysLocations(t)
-	DeleteTestRegions(t)
-	DeleteTestDivisions(t)
-	DeleteTestStatuses(t)
-	DeleteTestProfiles(t)
-	DeleteTestTenants(t)
-	DeleteTestTypes(t)
-	DeleteTestCDNs(t)
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, UsersDeliveryServices}, func() {
+		GetTestUsersDeliveryServices(t)
+	})
 }
 
 const TestUsersDeliveryServicesUser = "admin" // TODO make dynamic

--- a/traffic_ops/testing/api/v14/withobjs.go
+++ b/traffic_ops/testing/api/v14/withobjs.go
@@ -1,0 +1,93 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v14
+
+import (
+	"testing"
+)
+
+// WithObjs creates the objs in order, runs f, and defers deleting the objs in the same order.
+//
+// Because deletion is deferred, using this ensures objects will be cleaned up if f panics or calls t.Fatal, as much as possible.
+//
+// Note that f itself may still create things which are not cleaned up properly, and likewise, the object creation and deletion tests themselves may fail.
+// All tests in the Traffic Ops API Testing framework use the same Traffic Ops instance, with persistent data. Because of this, when any test fails, all subsequent tests should be considered invalid, irrespective whether they pass or fail. Users are encouraged to use `go test -failfast`.
+func WithObjs(t *testing.T, objs []TCObj, f func()) {
+	for _, obj := range objs {
+		defer withFuncs[obj].Delete(t)
+		withFuncs[obj].Create(t)
+	}
+	f()
+}
+
+type TCObj int
+
+const (
+	CacheGroups TCObj = iota
+	CDNs
+	CDNFederations
+	Coordinates
+	DeliveryServices
+	DeliveryServiceRequests
+	DeliveryServiceRequestComments
+	Divisions
+	Origins
+	Parameters
+	PhysLocations
+	Profiles
+	ProfileParameters
+	Regions
+	Roles
+	Servers
+	Statuses
+	StaticDNSEntries
+	SteeringTargets
+	Tenants
+	Types
+	Users
+	UsersDeliveryServices
+)
+
+type TCObjFuncs struct {
+	Create func(t *testing.T)
+	Delete func(t *testing.T)
+}
+
+var withFuncs = map[TCObj]TCObjFuncs{
+	CacheGroups:                    {CreateTestCacheGroups, DeleteTestCacheGroups},
+	CDNs:                           {CreateTestCDNs, DeleteTestCDNs},
+	CDNFederations:                 {CreateTestCDNFederations, DeleteTestCDNFederations},
+	Coordinates:                    {CreateTestCoordinates, DeleteTestCoordinates},
+	DeliveryServices:               {CreateTestDeliveryServices, DeleteTestDeliveryServices},
+	DeliveryServiceRequests:        {CreateTestDeliveryServiceRequests, DeleteTestDeliveryServiceRequests},
+	DeliveryServiceRequestComments: {CreateTestDeliveryServiceRequestComments, DeleteTestDeliveryServiceRequestComments},
+	Divisions:                      {CreateTestDivisions, DeleteTestDivisions},
+	Origins:                        {CreateTestOrigins, DeleteTestOrigins},
+	Parameters:                     {CreateTestParameters, DeleteTestParameters},
+	PhysLocations:                  {CreateTestPhysLocations, DeleteTestPhysLocations},
+	Profiles:                       {CreateTestProfiles, DeleteTestProfiles},
+	ProfileParameters:              {CreateTestProfileParameters, DeleteTestProfileParameters},
+	Regions:                        {CreateTestRegions, DeleteTestRegions},
+	Roles:                          {CreateTestRoles, DeleteTestRoles},
+	Servers:                        {CreateTestServers, DeleteTestServers},
+	Statuses:                       {CreateTestStatuses, DeleteTestStatuses},
+	StaticDNSEntries:               {CreateTestStaticDNSEntries, DeleteTestStaticDNSEntries},
+	SteeringTargets:                {CreateTestSteeringTargets, DeleteTestSteeringTargets},
+	Tenants:                        {CreateTestTenants, DeleteTestTenants},
+	Types:                          {CreateTestTypes, DeleteTestTypes},
+	Users:                          {CreateTestUsers, ForceDeleteTestUsers},
+	UsersDeliveryServices: {CreateTestUsersDeliveryServices, DeleteTestUsersDeliveryServices},
+}


### PR DESCRIPTION
Fixes TO API Delete tests to run even if t.Fatal is called, or a
panic occurs.

It fixes it, by introducing a WithObjs abstraction, which also
reduces duplication, and is harder to get wrong than forgetting a
defer call.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



