### PR TITLE
Fixed old path spec in the egg section of remote pip installation instructions

### DIFF
--- a/traffic_control/clients/python/README.rst
+++ b/traffic_control/clients/python/README.rst
@@ -14,10 +14,10 @@ The official installation method is to use ``pip`` to install directly from from
 .. code-block:: shell
 	:caption: Install Using 'pip' From GitHub
 
-	pip install git+https://github.com/apache/trafficcontrol.git#"egg=trafficops&subdirectory=traffic_control/clients/python/trafficops"
+	pip install git+https://github.com/apache/trafficcontrol.git#"egg=trafficops&subdirectory=traffic_control/clients/python"
 
 	# or
-	# pip install git+ssh://git@github.com/apache/trafficcontrol.git#"egg=trafficops&subdirectory=traffic_control/clients/python/trafficops"
+	# pip install "git+ssh://git@github.com/apache/trafficcontrol.git#"egg=trafficops&subdirectory=traffic_control/clients/python"
 
 Local Installation
 ------------------


### PR DESCRIPTION
## What does this PR do?
The egg path in the Python client README refers to the old directory structure, this fixes it to work properly with the new layout.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Python Client

## What is the best way to verify this PR?
Try to copy/paste the installation commands so that it works properly.

## Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)