### PR TITLE
All functionality for the admin program is now located in admin.go

### DIFF
--- a/traffic_ops/app/db/admin.go
+++ b/traffic_ops/app/db/admin.go
@@ -303,12 +303,13 @@ func loadSchema() {
 }
 
 func reverseSchema() {
-	fmt.Println("WARNING: the '" + CmdReverseSchema + "' command will be removed with Traffic Ops Perl because it will no longer be necessary")
-	cmd := exec.Command("db/admin.pl", "--env="+Environment, CmdReverseSchema)
+	fmt.Fprintf(os.Stderr, "WARNING: the '%s' command will be removed with Traffic Ops Perl because it will no longer be necessary\n", CmdReverseSchema)
+	cmd := exec.Command("db/reverse_schema.pl")
+	cmd.Env = append(os.Environ(), "MOJO_MODE="+Environment)
 	out, err := cmd.CombinedOutput()
 	fmt.Printf("%s", out)
 	if err != nil {
-		die("Can't run `db/admin.pl reverse_schema`: " + err.Error())
+		die("Can't run `db/reverse_schema.pl`: " + err.Error())
 	}
 }
 

--- a/traffic_ops/app/db/reverse_schema.pl
+++ b/traffic_ops/app/db/reverse_schema.pl
@@ -14,10 +14,20 @@
 # limitations under the License.
 #
 use strict;
-use File::Basename;
+use Schema;
+use DBIx::Class::Schema::Loader qw/make_schema_at/;
 
-STDERR->autoflush(1);
-print STDERR "WARNING: this script is deprecated, please use the db/admin binary instead.\n\n";
-my $args = join(" ", @ARGV);
-my $new_admin = dirname(__FILE__) . "/admin";
-exit(system("$new_admin " . $args));
+my $db_info = Schema->get_dbinfo();
+
+my $user    = $db_info->{user};
+my $pass    = $db_info->{password};
+my $dsn     = Schema->get_dsn();
+make_schema_at(
+	'Schema', {
+		debug                   => 1,
+		dump_directory          => './lib',
+		overwrite_modifications => 1,
+		exclude => 'goose_db_version',
+	},
+	[ $dsn, $user, $pass ],
+);


### PR DESCRIPTION
## What does this PR do?
Makes the deprecated `admin.pl` a small wrapper around the `admin` binary, so that new functionality need only be added in one place.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other: admin.pl

## What is the best way to verify this PR?
Run any and all tests for the `admin.pl` script

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)