### PR TITLE
Fix typo in grove query string handling logic.

### DIFF
--- a/grove/grovetccfg/grovetccfg.go
+++ b/grove/grovetccfg/grovetccfg.go
@@ -832,7 +832,7 @@ func getQueryStringRule(dsQstringIgnore int) (remapdata.QueryStringRule, error) 
 	case DeliveryServiceQueryStringCacheAndRemap:
 		return remapdata.QueryStringRule{Remap: true, Cache: true}, nil
 	case DeliveryServiceQueryStringNoCacheRemap:
-		return remapdata.QueryStringRule{Remap: true, Cache: true}, nil
+		return remapdata.QueryStringRule{Remap: true, Cache: false}, nil
 	case DeliveryServiceQueryStringNoCacheNoRemap:
 		return remapdata.QueryStringRule{Remap: false, Cache: false}, nil
 	default:


### PR DESCRIPTION
A type of 1, "Ignore in cache key and pass up"
should have a value of 'false' for the 'Cache' field.

#### What does this PR do?
Fixes a problem with query string handling for a delivery service.
Fixes #(issue_number)
Fixes #3190
#### Which TC components are affected by this PR?

- [ ] Documentation
- [X] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



