### PR TITLE
Fix trafficops python client installation

### DIFF
--- a/traffic_control/clients/python/setup.py
+++ b/traffic_control/clients/python/setup.py
@@ -22,14 +22,17 @@ Setuptools build/install script for the Python Traffic Control client
 import sys
 import os
 from setuptools import setup, find_packages
-from trafficops import __version__ as version
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+
+about = {}
+with open(os.path.join(HERE, 'trafficops', '__version__.py'), mode='r', encoding='utf-8') as f:
+	exec(f.read(), about)
 
 with open(os.path.join(HERE, "README.rst")) as fd:
 	setup(
 	       name="Apache-TrafficControl",
-	       version=version,
+	       version=about["__version__"],
 	       author="Apache Software Foundation",
 	       author_email="dev@trafficcontrol.apache.org",
 	       description="Python API Client for Traffic Control",

--- a/traffic_control/clients/python/trafficops/__version__.py
+++ b/traffic_control/clients/python/trafficops/__version__.py
@@ -14,15 +14,4 @@
 # limitations under the License.
 #
 
-from .__version__ import __version__
-
-# Import Local Modules into the 'trafficops' package namespace for convenience.
-from .tosession import TOSession
-from .restapi import InvalidJSONError, LoginError, OperationError, api_request, RestApiSession
-
-__all__ = [u'TOSession',
-           u'InvalidJSONError',
-           u'LoginError',
-           u'OperationError',
-           u'api_request',
-           u'RestApiSession']
+__version__ = '1.0.0'


### PR DESCRIPTION
#### What does this PR do?

Separate library metadata like `__version__` into `__version__.py` that
`setup.py` pulls from rather than importing version from the package itself.

This fixes an issue with installing this package caused by `setup.py`
importing from the package itself, which causes the package's imports to
run, leading to ModuleNotFoundError.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other: python trafficops client

#### What is the best way to verify this PR?
Create a python 3 virtualenv, activate it in your shell, and try installing both the current version of master and the version of this PR:
```
mkdir pyclient_test && cd pyclient_test
python3 -m virtualenv venv
source venv/bin/activate
# checkout the current version of TC master
pip install <location of your cloned TC repo>/traffic_control/clients/python # this will fail with ModuleNotFoundError
# checkout this PR and attempt to install again
pip install <location of your cloned TC repo>/traffic_control/clients/python # this should succeed
```

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



