### PR TITLE
CIAB: Update X509 cert generation, add certs to TV, fix TR tomcat native.

### DIFF
--- a/infrastructure/cdn-in-a-box/edge/run.sh
+++ b/infrastructure/cdn-in-a-box/edge/run.sh
@@ -34,7 +34,7 @@ done
 source $X509_CA_ENV_FILE
 
 # Trust the CIAB-CA at the System level
-cp $X509_CA_CERT_FILE /etc/pki/ca-trust/source/anchors
+cp $X509_CA_CERT_FULL_CHAIN_FILE /etc/pki/ca-trust/source/anchors
 update-ca-trust extract
 
 while ! to-ping 2>/dev/null; do

--- a/infrastructure/cdn-in-a-box/enroller/run.sh
+++ b/infrastructure/cdn-in-a-box/enroller/run.sh
@@ -36,7 +36,7 @@ done
 source "$X509_CA_ENV_FILE"
  
 # Copy the CIAB-CA certificate to the traffic_router conf so it can be added to the trust store
-cp "$X509_CA_CERT_FILE" /usr/local/share/ca-certificates
+cp "$X509_CA_CERT_FULL_CHAIN_FILE" /usr/local/share/ca-certificates
 update-ca-certificates
 
 # Traffic Ops must be accepting connections before enroller can start

--- a/infrastructure/cdn-in-a-box/mid/run.sh
+++ b/infrastructure/cdn-in-a-box/mid/run.sh
@@ -34,7 +34,7 @@ done
 source $X509_CA_ENV_FILE
 
 # Trust the CIAB-CA at the System level
-cp $X509_CA_CERT_FILE /etc/pki/ca-trust/source/anchors
+cp $X509_CA_CERT_FULL_CHAIN_FILE /etc/pki/ca-trust/source/anchors
 update-ca-trust extract
 
 while ! to-ping 2>/dev/null; do

--- a/infrastructure/cdn-in-a-box/optional/vnc/run.sh
+++ b/infrastructure/cdn-in-a-box/optional/vnc/run.sh
@@ -28,7 +28,7 @@ done
 source $X509_CA_ENV_FILE
 
 # Trust the CIAB-CA at the System level
-cp $X509_CA_CERT_FILE /etc/pki/ca-trust/source/anchors
+cp $X509_CA_CERT_FULL_CHAIN_FILE /etc/pki/ca-trust/source/anchors
 update-ca-trust extract
 ################################################################################
 

--- a/infrastructure/cdn-in-a-box/origin/run.sh
+++ b/infrastructure/cdn-in-a-box/origin/run.sh
@@ -34,7 +34,7 @@ done
 source "$X509_CA_ENV_FILE"
 
 # Copy the CIAB-CA certificate to the traffic_router conf so it can be added to the trust store
-cp $X509_CA_CERT_FILE /usr/local/share/ca-certificates
+cp $X509_CA_CERT_FULL_CHAIN_FILE /usr/local/share/ca-certificates
 update-ca-certificates
 
 while ! to-ping 2>/dev/null; do

--- a/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
@@ -51,7 +51,7 @@ done
 source $X509_CA_ENV_FILE
 
 # Trust the CIAB-CA at the System level
-cp $X509_CA_CERT_FILE /etc/pki/ca-trust/source/anchors
+cp $X509_CA_CERT_FULL_CHAIN_FILE /etc/pki/ca-trust/source/anchors
 update-ca-trust extract
 
 # Enroll with traffic ops

--- a/infrastructure/cdn-in-a-box/traffic_ops/config.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/config.sh
@@ -50,7 +50,7 @@ done
 source "$X509_CA_ENV_FILE"
 
 # Add the CA certificate to sysem TLS trust store
-cp $X509_CA_CERT_FILE /etc/pki/ca-trust/source/anchors
+cp $X509_CA_CERT_FULL_CHAIN_FILE /etc/pki/ca-trust/source/anchors
 update-ca-trust extract
 
 crt="$X509_INFRA_CERT_FILE"

--- a/infrastructure/cdn-in-a-box/traffic_ops/generate-certs.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/generate-certs.sh
@@ -16,34 +16,26 @@
 # specific language governing permissions and limitations
 # under the License.
 
-X509_CA_DEFAULT_NAME="ca"
-X509_CA_DEFAULT_COUNTRY="ZZ"
-X509_CA_DEFAULT_STATE="SomeState"
-X509_CA_DEFAULT_CITY="SomeCity"
-X509_CA_DEFAULT_COMPANY="SomeCompany"
-X509_CA_DEFAULT_ORG="SomeOrganization"
-X509_CA_DEFAULT_ORGUNIT="SomeOrgUnit"
-X509_CA_DEFAULT_EMAIL="no-reply@some.host.test"
-X509_CA_DEFAULT_DIGEST="sha256"
-X509_CA_DEFAULT_DURATION_DAYS="3650"
-X509_CA_DEFAULT_KEYTYPE="rsa"
-X509_CA_DEFAULT_KEYSIZE=4096
-X509_CA_DEFAULT_UMASK=0002
-X509_CA_DEFAULT_DIR="$PWD/ca-default"
-
-export X509_CA_INITIALIZED=0
+export X509_CA_DEFAULT_NAME="ca"
+export X509_CA_DEFAULT_COUNTRY="ZZ"
+export X509_CA_DEFAULT_STATE="SomeState"
+export X509_CA_DEFAULT_CITY="SomeCity"
+export X509_CA_DEFAULT_COMPANY="SomeCompany"
+export X509_CA_DEFAULT_ORG="SomeOrganization"
+export X509_CA_DEFAULT_ORGUNIT="SomeOrgUnit"
+export X509_CA_DEFAULT_EMAIL="no-reply@some.host.test"
+export X509_CA_DEFAULT_DIGEST="sha256"
+export X509_CA_DEFAULT_DURATION_DAYS="3650"
+export X509_CA_DEFAULT_KEYTYPE="rsa"
+export X509_CA_DEFAULT_KEYSIZE=4096
+export X509_CA_DEFAULT_UMASK=0002
+export X509_CA_DEFAULT_DIR="$PWD/ca-default"
 
 x509v3_init()
 {
-  if [[ $X509_CA_INITIALIZED -eq 1 ]] ; then
+  if [[ $X509_CA_INITIALIZED = true ]] ; then
     echo "ERROR: Already initialized."
     return 2
-  fi
-
-  # If no X509_CA directory exists, create it
-  if [ -d "$X509_CA_DIR" ] ; then
-    echo "ERROR: Previous X509v3 CA Directory Exists."
-    return 3
   fi
 
   export X509_CA_DIR="${X509_CA_DIR:-$X509_CA_DEFAULT_DIR}"
@@ -60,49 +52,68 @@ x509v3_init()
   export X509_CA_KEYTYPE="${X509_CA_KEYTYPE:-$X509_CA_DEFAULT_KEYTYPE}"
   export X509_CA_KEYSIZE="${X509_CA_KEYSIZE:-$X509_CA_DEFAULT_KEYSIZE}"
   export X509_CA_UMASK="${X509_CA_UMASK:-$X509_CA_DEFAULT_UMASK}"
+  export X509_CA_INITIALIZED=true
 
   # Runtime
-  export X509_CA_CERT_FILE="$X509_CA_DIR/${X509_CA_NAME}.crt"
-  export X509_CA_KEY_FILE="$X509_CA_DIR/${X509_CA_NAME}.key"
-  export X509_CA_CONFIG_FILE="$X509_CA_DIR/${X509_CA_NAME}.config"
-  export X509_CA_DB_FILE="$X509_CA_DIR/${X509_CA_NAME}.db"
-  export X509_CA_REVOKE_FILE="$X509_CA_DIR/${X509_CA_NAME}.crl"
-  export X509_CA_SERIAL_FILE="$X509_CA_DIR/${X509_CA_NAME}.serial"
+  export X509_CA_ROOT_CERT_FILE="$X509_CA_DIR/${X509_CA_NAME}-root.crt"
+  export X509_CA_ROOT_KEY_FILE="$X509_CA_DIR/${X509_CA_NAME}-root.key"
+  export X509_CA_ROOT_CONFIG_FILE="$X509_CA_DIR/${X509_CA_NAME}-root.config"
+  export X509_CA_ROOT_DB_FILE="$X509_CA_DIR/${X509_CA_NAME}-root.db"
+  export X509_CA_ROOT_REVOKE_FILE="$X509_CA_DIR/${X509_CA_NAME}-root.crl"
+  export X509_CA_ROOT_SERIAL_FILE="$X509_CA_DIR/${X509_CA_NAME}-root.serial"
+
+  export X509_CA_INTR_REQUEST_FILE="$X509_CA_DIR/${X509_CA_NAME}-intr.csr"
+  export X509_CA_INTR_CERT_FILE="$X509_CA_DIR/${X509_CA_NAME}-intr.crt"
+  export X509_CA_INTR_KEY_FILE="$X509_CA_DIR/${X509_CA_NAME}-intr.key"
+  export X509_CA_INTR_CONFIG_FILE="$X509_CA_DIR/${X509_CA_NAME}-intr.config"
+  export X509_CA_INTR_DB_FILE="$X509_CA_DIR/${X509_CA_NAME}-intr.db"
+  export X509_CA_INTR_REVOKE_FILE="$X509_CA_DIR/${X509_CA_NAME}-intr.crl"
+  export X509_CA_INTR_SERIAL_FILE="$X509_CA_DIR/${X509_CA_NAME}-intr.serial"
+
+  export X509_CA_CERT_FULL_CHAIN_FILE="$X509_CA_DIR/${X509_CA_NAME}-fullchain.crt"
   export X509_CA_ENV_FILE="$X509_CA_DIR/environment"
   export X509_CA_DONE_FILE="$X509_CA_DIR/completed"
+
+  # If no X509_CA directory exists, create it
+  if [ -d "$X509_CA_DIR" ] ; then
+    echo "ERROR: Previous X509v3 CA Directory Exists."
+    return 3
+  fi
 
   # Set the Umask
   umask $X509_CA_UMASK
 
   # Create CA Certificate
   mkdir -p "$X509_CA_DIR"
-  x509v3_create_ca
+  x509v3_create_root_ca
+  x509v3_create_intermediate_ca
+
+  # Create the CA environment file
+  x509v3_dump_env
 
   return $?
 }
 
-x509v3_create_ca()
+x509v3_create_root_ca()
 {
   # Use today's epoch date for the first serial number
-  echo "$(date +%s)" > "$X509_CA_SERIAL_FILE"
+  echo "$(date +%s)" > "$X509_CA_ROOT_SERIAL_FILE"
 
   # Create the CA index file
-  touch "$X509_CA_DB_FILE"
+  touch "$X509_CA_ROOT_DB_FILE"
 
-  # Create the CA environment file
-  touch "$X509_CA_ENV_FILE"
-
-  local cn="$X509_CA_ORG Root CA (CA)"
+  local cn="$X509_CA_ORG Root CA"
+  local ca_name="$X509_CA_NAME-root"
 
   local ca_config=""`
   `"[ca]\n"`
-  `"default_ca = $X509_CA_NAME\n\n"`
-  `"[$X509_CA_NAME]\n"`
+  `"default_ca = $ca_name\n\n"`
+  `"[$ca_name]\n"`
   `"new_certs_dir = $X509_CA_DIR\n"`
-  `"certificate = $X509_CA_CERT_FILE\n"`
-  `"private_key = $X509_CA_KEY_FILE\n"`
-  `"serial = $X509_CA_SERIAL_FILE\n"`
-  `"database = $X509_CA_DB_FILE\n"`
+  `"certificate = $X509_CA_ROOT_CERT_FILE\n"`
+  `"private_key = $X509_CA_ROOT_KEY_FILE\n"`
+  `"serial = $X509_CA_ROOT_SERIAL_FILE\n"`
+  `"database = $X509_CA_ROOT_DB_FILE\n"`
   `"default_md = $X509_CA_DIGEST\n"`
   `"default_days = $X509_CA_DURATION_DAYS\n"`
   `"prompt = no\n"`
@@ -148,29 +159,144 @@ x509v3_create_ca()
   `"emailAddress_max = 64\n"`
   `"emailAddress_default = $X509_CA_EMAIL\n\n"`
   `"[v3_ca]\n"`
-  `"basicConstraints = CA:TRUE\n"`
   `"subjectKeyIdentifier = hash\n"`
-  `"keyUsage = cRLSign, keyCertSign\n"`
-  `"extendedKeyUsage = serverAuth, clientAuth\n\n"
+  `"authorityKeyIdentifier = keyid:always,issuer\n"`
+  `"basicConstraints = critical, CA:true\n"`
+  `"keyUsage = critical, digitalSignature, keyCertSign\n\n"`
+  `"[v3_intermediate_ca]\n"`
+  `"subjectKeyIdentifier = hash\n"`
+  `"authorityKeyIdentifier = keyid:always,issuer\n"`
+  `"basicConstraints = critical, CA:true, pathlen:0\n"`
+  `"keyUsage = critical, digitalSignature, keyCertSign\n"
 
-  echo "Writing CA openssl CA Config File"
-  echo -e "$ca_config" > "$X509_CA_CONFIG_FILE"
+  echo "Writing Root CA Config File"
+  echo -e "$ca_config" > "$X509_CA_ROOT_CONFIG_FILE"
 
-  echo "Creating CA certificate for [$X509_CA_NAME]."
+  echo "Creating Root CA certificate for [$ca_name]."
   # Create new CA Certificate and Key
   openssl req -x509 -nodes -extensions v3_ca \
-    -days "$((X509_CA_DURATION_DAYS+1))" \
-    -config "$X509_CA_CONFIG_FILE" \
+    -days "$((X509_CA_DURATION_DAYS*2))" \
+    -config "$X509_CA_ROOT_CONFIG_FILE" \
     -newkey "$X509_CA_KEYTYPE:$X509_CA_KEYSIZE" \
-    -keyout "$X509_CA_KEY_FILE" \
-    -out "$X509_CA_CERT_FILE" \
+    -keyout "$X509_CA_ROOT_KEY_FILE" \
+    -out "$X509_CA_ROOT_CERT_FILE" \
     -subj "/C=$X509_CA_COUNTRY/ST=$X509_CA_STATE/L=$X509_CA_CITY/O=$X509_CA_ORG/OU=$X509_CA_ORG/CN=$cn/emailAddress=$X509_CA_EMAIL/" \
-    > "$X509_CA_DIR/x509_create_ca.log" 2>&1
+    > "$X509_CA_DIR/x509_create_root_ca.log" 2>&1
 
   retcode=$?
 
-  echo "CreateX509 Cert RetCode=$retcode"
+  echo "CreateX509 Root CA RetCode=$retcode"
 
+  return $retcode
+}
+
+x509v3_create_intermediate_ca()
+{
+  # Use today's epoch date for the first serial number
+  echo "$(date +%s)" > "$X509_CA_INTR_SERIAL_FILE"
+
+  # Create the CA index file
+  touch "$X509_CA_INTR_DB_FILE"
+
+  local cn="$X509_CA_ORG Intermediate CA"
+  local ca_name="$X509_CA_NAME-intr"
+
+  local ca_config=""`
+  `"[ca]\n"`
+  `"default_ca = $ca_name\n\n"`
+  `"[$ca_name]\n"`
+  `"new_certs_dir = $X509_CA_DIR\n"`
+  `"certificate = $X509_CA_INTR_CERT_FILE\n"`
+  `"private_key = $X509_CA_INTR_KEY_FILE\n"`
+  `"serial = $X509_CA_INTR_SERIAL_FILE\n"`
+  `"database = $X509_CA_INTR_DB_FILE\n"`
+  `"default_md = $X509_CA_DIGEST\n"`
+  `"default_days = $X509_CA_DURATION_DAYS\n"`
+  `"prompt = no\n"`
+  `"preserve = no\n\n"`
+  `"[policy_match]\n"`
+  `"countryName = match\n"`
+  `"stateOrProvinceName = match\n"`
+  `"organizationName = match\n"`
+  `"organizationalUnitName = optional\n"`
+  `"commonName = supplied\n"`
+  `"emailAddress = optional\n\n"`
+  `"[policy_anything]\n"`
+  `"countryName = optional\n"`
+  `"stateOrProvinceName = optional\n"`
+  `"localityName = optional\n"`
+  `"organizationName = optional\n"`
+  `"organizationalUnitName = optional\n"`
+  `"commonName = supplied\n"`
+  `"emailAddress = optional\n\n"`
+  `"[req]\n"`
+  `"default_bits = $X509_CA_KEYSIZE\n"`
+  `"default_md = $X509_CA_DIGEST\n"`
+  `"default_days = $X509_CA_DURATION_DAYS\n"`
+  `"distinguished_name = req_dn\n"`
+  `"string_mask = nombstr\n"`
+  `"x509_extensions = v3_ca\n\n"`
+  `"[req_dn]\n"`
+  `"countryName = Country Name (2 letter code)\n"`
+  `"countryName_default = $X509_CA_COUNTRY\n"`
+  `"countryName_min = 2\n"`
+  `"countryName_max = 2\n"`
+  `"stateOrProvinceName = State or Province Name (full name)\n"`
+  `"stateOrProvinceName_default = $X509_CA_STATE\n"`
+  `"localityName = Locality Name (eg, city)\n"`
+  `"localityName_default = $X509_CA_CITY\n"`
+  `"0.organizationName = Organization Name (eg, company)\n"`
+  `"0.organizationName_default = $X509_CA_ORG\n"`
+  `"organizationalUnitName = Organizational Unit Name (eg, section)\n"`
+  `"organizationalUnitName_default = $X509_CA_ORGUNIT\n"`
+  `"commonName = Common Name (eg, YOUR name)\n"`
+  `"commonName_max = 64\n"`
+  `"emailAddress = Email Address\n"`
+  `"emailAddress_max = 64\n"`
+  `"emailAddress_default = $X509_CA_EMAIL\n\n"`
+  `"[v3_ca]\n"`
+  `"subjectKeyIdentifier = hash\n"`
+  `"authorityKeyIdentifier = keyid:always,issuer\n"`
+  `"basicConstraints = critical, CA:true\n"`
+  `"keyUsage = critical, digitalSignature, keyCertSign\n\n"`
+  `"[v3_intermediate_ca]\n"`
+  `"subjectKeyIdentifier = hash\n"`
+  `"authorityKeyIdentifier = keyid:always,issuer\n"`
+  `"basicConstraints = critical, CA:true, pathlen:0\n"`
+  `"keyUsage = critical, digitalSignature, keyCertSign\n"
+
+  echo "Writing Intemediate CA openssl CA Config File"
+  echo -e "$ca_config" > "$X509_CA_INTR_CONFIG_FILE"
+
+  echo "Creating Intermediate CA certificate request for [$ca_name]."
+  # Create new CA Certificate and Key
+  openssl req -new -nodes \
+    -days "$((X509_CA_DURATION_DAYS))" \
+    -config "$X509_CA_INTR_CONFIG_FILE" \
+    -newkey "$X509_CA_KEYTYPE:$X509_CA_KEYSIZE" \
+    -keyout "$X509_CA_INTR_KEY_FILE" \
+    -subj "/C=$X509_CA_COUNTRY/ST=$X509_CA_STATE/L=$X509_CA_CITY/O=$X509_CA_ORG/OU=$X509_CA_ORG/CN=$cn/emailAddress=$X509_CA_EMAIL/" \
+    -out "$X509_CA_INTR_REQUEST_FILE"
+    > "$X509_CA_DIR/x509_create_intermediate_csr.log" 2>&1
+  retcode=$?
+  echo "CreateX509 Intermediate CA RetCode=$retcode"
+
+  echo "Signing x509v3 Intermediate CA with Root CA Certificate..."
+  # Sign with the CA
+  openssl ca -config "$X509_CA_ROOT_CONFIG_FILE" \
+    -batch \
+    -extensions v3_intermediate_ca \
+    -policy policy_anything \
+    -out "$X509_CA_INTR_CERT_FILE" \
+    -infiles "$X509_CA_INTR_REQUEST_FILE" \
+    > "$X509_CA_DIR/x509_sign_intermediate_ca.log" 2>&1
+
+  retcode=$?
+  echo "Sign X509 Req RetCode=$retcode"
+
+  # Build X509 CA full chain 
+  cat $X509_CA_INTR_CERT_FILE $X509_CA_ROOT_CERT_FILE > $X509_CA_CERT_FULL_CHAIN_FILE
+  
   return $retcode
 }
 
@@ -224,24 +350,23 @@ x509v3_create_cert()
   `"prompt = no\n"`
   `"utf8 = yes\n"`
   `"default_md = $X509_CA_DIGEST\n"`
-  `"default_bits = $X509_CERT_KEYSIZE\n"`
+  `"default_bits = $X509_CA_KEYSIZE\n"`
   `"distinguished_name = dn\n"`
-  `"req_extensions = req_ext\n\n"`
   `"[dn]\n"`
   `"C = $X509_CA_COUNTRY\n"`
   `"ST = $X509_CA_STATE\n"`
   `"L = $X509_CA_CITY\n"`
   `"O  = $X509_CA_ORG\n"`
-  `"CN = $cn\n\n"`
-  `"[req_ext]\n"`
-  `"basicConstraints=CA:FALSE\n"`
-  `"subjectKeyIdentifier = hash\n"`
-  `"subjectAltName=@alt_names\n\n"
+  `"CN = $cn\n\n"
 
   local exten_config=""`
   `"[v3_ext]\n"`
-  `"basicConstraints=CA:FALSE\n"`
+  `"basicConstraints = CA:FALSE\n"`
+  `"nsCertType = server\n"`
   `"subjectKeyIdentifier = hash\n"`
+  `"authorityKeyIdentifier = keyid,issuer:always\n"`
+  `"keyUsage = critical, digitalSignature, keyEncipherment\n"`
+  `"extendedKeyUsage = serverAuth\n"`
   `"subjectAltName=@alt_names\n\n"
 
   echo "Creating x509v3 request for cn=$cn type $type..."
@@ -265,7 +390,7 @@ x509v3_create_cert()
   # Sign with the CA
   openssl ca -batch \
     -policy policy_anything \
-    -config "$X509_CA_CONFIG_FILE" \
+    -config "$X509_CA_INTR_CONFIG_FILE" \
     -out "$cert_file" \
     -extensions v3_ext \
     -extfile "$exten_file" \
@@ -282,8 +407,10 @@ x509v3_create_cert()
   echo "X509_${env_name}_REQUEST_FILE=\"$request_file\"" >> "$X509_CA_ENV_FILE"
 }
 
+
 x509v3_dump_env()
 {
+  touch "$X509_CA_ENV_FILE"
   tmp_file="$(mktemp)"
   cat "$X509_CA_ENV_FILE" > "$tmp_file"
   env | grep -E '^X509_' >> "$tmp_file"

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -90,6 +90,64 @@ while true; do
   sleep 2
 done
 
+### Add SSL keys for demo1 delivery service
+source "$X509_CA_ENV_FILE"
+demo1_sslkeys_verified=false
+demo1_version=1
+while [[ "$demo1_sslkeys_verified" = false ]]; do
+   while true; do
+     sslkeys_response=$(to-get "api/1.4/deliveryservices/xmlId/$ds_name/sslkeys?decode=true")
+     echo "CDN SSLKeys=$sslkeys_response"
+     [[ -n "$sslkeys_response" ]] && break
+     sleep 2
+   done
+   demo1_crt="$(sed -n -e '/-----BEGIN CERTIFICATE-----/,$p' $X509_DEMO1_CERT_FILE | jq -s -R '.')"
+   demo1_csr="$(sed -n -e '/-----BEGIN CERTIFICATE REQUEST-----/,$p' $X509_DEMO1_REQUEST_FILE | jq -s -R '.')"
+   demo1_key="$(sed -n -e '/-----BEGIN PRIVATE KEY-----/,$p' $X509_DEMO1_KEY_FILE | jq -s -R '.')"
+   demo1_json_request=$(jq -n \
+                           --arg     cdn        "CDN-in-a-Box" \
+                           --arg     hostname   "*.demo1.mycdn.ciab.test" \
+                           --arg     dsname     "$ds_name" \
+                           --argjson crt        "$demo1_crt" \
+                           --argjson csr        "$demo1_csr" \
+                           --argjson key        "$demo1_key" \
+                           --argjson version    $demo1_version \
+                          "{ cdn: \$cdn, 
+                             certificate: { 
+                               crt: \$crt, 
+                               csr: \$csr,
+                               key: \$key 
+                             },
+                             deliveryservice: \$dsname,
+                             hostname: \$hostname,
+                             key: \$dsname,
+                             version: $demo1_version 
+                          }")
+
+   demo1_json_response=$(to-post 'api/1.4/deliveryservices/sslkeys/add' "$demo1_json_request")
+
+   if [[ -n "$demo1_json_response" ]] ; then 
+      sleep 2
+      cdn_sslkeys_response=$(to-get 'api/1.3/cdns/name/CDN-in-a-Box/sslkeys.json' | jq '.response[] | length')
+      echo "cdn_sslkeys_response=$cdn_sslkeys_response"
+
+      if [ -n "$cdn_sslkeys_response" ] ; then 
+         if ((cdn_sslkeys_response==0)); then 
+           sleep 2 # Submit it again because the first time doesn't work !
+           demo1_json_response=$(to-post 'api/1.4/deliveryservices/sslkeys/add' "$demo1_json_request")
+ 
+           if [[ -n "$demo1_json_response" ]] ; then 
+              demo1_sslkeys_verified=true
+           fi
+        elif ((cdn_sslkeys_response>0)); then
+           demo1_sslkeys_verified=true
+        fi
+      fi
+   fi
+
+   ((demo_version+=1)) 
+done
+
 ### Automatic Queue/Snapshot ###
 while [[ "$AUTO_SNAPQUEUE_ENABLED" = true ]] ; do
   # AUTO_SNAPQUEUE_SERVERS should be a comma delimited list of expected docker service names to be enrolled - see varibles.env

--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -110,7 +110,7 @@ to-post() {
 		data="--data @$t"
 	fi
 	to-auth && \
-	    curl $CURLAUTH $CURLOPTS --cookie "$COOKIEJAR" -X POST $data "$TO_URL/$1"
+	    curl $CURLAUTH $CURLOPTS -H 'Content-Type: application/json;charset=UTF-8' --cookie "$COOKIEJAR" -X POST $data "$TO_URL/$1"
 	[[ -n $t ]] && rm -f "$t"
 }
 

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/010-ciab.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/010-ciab.json
@@ -2,7 +2,7 @@
     "xmlId": "demo1",
     "displayName": "Demo 1",
     "tenant": "root",
-    "protocol": 0,
+    "protocol": 2,
     "orgServerFqdn": "http://origin.infra.ciab.test",
     "cdnName": "CDN-in-a-Box",
     "type": "HTTP",

--- a/infrastructure/cdn-in-a-box/traffic_portal/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal/run.sh
@@ -40,7 +40,7 @@ done
 source $X509_CA_ENV_FILE
 
 # Trust the CIAB-CA at the System level
-cp $X509_CA_CERT_FILE /etc/pki/ca-trust/source/anchors
+cp $X509_CA_CERT_FULL_CHAIN_FILE /etc/pki/ca-trust/source/anchors
 update-ca-trust extract
 
 # Configuration of Traffic Portal

--- a/infrastructure/cdn-in-a-box/traffic_router/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_router/Dockerfile
@@ -38,6 +38,8 @@ ADD $TOMCAT_RPM /tomcat.rpm
 
 RUN yum -y install /traffic_router.rpm /tomcat.rpm
 
+RUN find /usr/lib* -name libtc\* -exec ln -sfv '{}' /opt/tomcat/lib \;
+
 ADD enroller/server_template.json \
     traffic_router/run.sh \
     traffic_ops/to-access.sh \

--- a/infrastructure/cdn-in-a-box/traffic_router/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_router/run.sh
@@ -28,7 +28,7 @@ CATALINA_PID="$CATALINA_BASE/temp/tomcat.pid"
 
 CATALINA_OPTS="\
   -server -Xms2g -Xmx8g \
-  -Djava.library.path=$CATALINA_HOME/lib \
+  -Djava.library.path=/usr/lib64:$CATALINA_BASE/lib:$CATALINA_HOME/lib \
   -Dlog4j.configuration=file://$CATALINA_BASE/conf/log4j.properties \
   -Dorg.apache.catalina.connector.Response.ENFORCE_ENCODING_IN_GET_WRITER=false \
   -XX:+UseG1GC \
@@ -37,6 +37,7 @@ CATALINA_OPTS="\
 
 JAVA_HOME=/opt/java
 JAVA_OPTS="\
+  -Djava.library.path=/usr/lib64 \
   -Dcache.config.json.refresh.period=5000 \
   -Djava.awt.headless=true \
   -Djava.security.egd=file:/dev/./urandom"
@@ -61,10 +62,10 @@ done
 source $X509_CA_ENV_FILE
 
 # Copy the CIAB-CA certificate to the traffic_router conf so it can be added to the trust store
-cp $X509_CA_CERT_FILE $CATALINA_BASE/conf
-cp $X509_CA_CERT_FILE /etc/pki/ca-trust/source/anchors
+cp $X509_CA_ROOT_CERT_FILE $CATALINA_BASE/conf
+cp $X509_CA_INTR_CERT_FILE $CATALINA_BASE/conf
+cp $X509_CA_CERT_FULL_CHAIN_FILE /etc/pki/ca-trust/source/anchors
 update-ca-trust extract
-
 
 # Add traffic 
 for crtfile in $(find $CATALINA_BASE/conf -name \*.crt -type f) 
@@ -102,6 +103,6 @@ until nc $TM_FQDN $TM_PORT </dev/null >/dev/null 2>&1; do
 done
 
 touch $LOGFILE $ACCESSLOG
-tail -F $CATALINA_OUT $CATALINA_LOG $LOGFILE $ACCESSLOG &  
+exec /opt/tomcat/bin/catalina.sh run &
 
-exec /opt/tomcat/bin/catalina.sh run 
+tail -F $CATALINA_OUT $CATALINA_LOG $LOGFILE $ACCESSLOG 

--- a/infrastructure/cdn-in-a-box/traffic_vault/prestart.d/00-config.sh
+++ b/infrastructure/cdn-in-a-box/traffic_vault/prestart.d/00-config.sh
@@ -30,7 +30,7 @@ done
 source "$X509_CA_ENV_FILE"
 
 # Copy the CIAB-CA certificate to the traffic_router conf so it can be added to the trust store
-cp $X509_CA_CERT_FILE /usr/local/share/ca-certificates
+cp $X509_CA_CERT_FULL_CHAIN_FILE /usr/local/share/ca-certificates
 update-ca-certificates
 
 # Grep out the existing SSL and Socket listener config


### PR DESCRIPTION
CIAB: Update X509 cert generation, add certs to TV, fix TR tomcat native.

#### What does this PR do?

* CIAB: Update X509 Certificate documentation
* CIAB: Fix Tomcat Native SSL support
* CIAB: Add demo1 SSL keys to trafficvault on startup
* CIAB: Generate x509 certificates with proper Subject/Authority Key Identifiers
* CIAB: Add X509 root/intermediate CA certs to java keystore
* CIAB: Update each container to install the X509 CA full chain file
* CIAB: Add Full Chain certificate file
* CIAB: Generate x509 certificates with proper certType, keyUsage, and extendedKeyUsage directives

#### Which TC components are affected by this PR?

- [X] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [X] Other __CDN-in-a-Box_______

#### What is the best way to verify this PR?

1. Rebuild all CIAB containers
```
# From infrastructure/cdn-in-a-box
docker-compose build
```
2. Remove all existing CIAB containers and shared volumes
```
# From infrastructure/cdn-in-a-box
docker-compose kill 
docker-compose rm -fv
docker volume prune -f 
```
3 Remove any existing CIAB X509 certificates from infrastructure/cdn-in-a-box/traffic_ops/ca
```
# From infrastructure/cdn-in-a-box
rm -rfv ./infrastructure/cdn-in-a-box/traffic_ops/ca
```
4. Start up CIAB
```
docker-compose up
```
6. Wait (3-4min) for CIAB to start by checking for availability of traffic router dns zone
```
# From infrastructure/cdn-in-a-box
t=0
while true
 do
   docker-compose exec trafficops host -t soa mycdn.ciab.test >/dev/null 2>&1
   if (($? == 0)) ; then 
      echo "CDN-in-a-Box is available ($t seconds)"
      break
    else
      echo "Waiting for CDN-in-a-Box to start ($t seconds)"
      sleep 3
      ((t+=3))
    fi
done
```
Expected output:
```
Waiting for CDN-in-a-Box to start (0 seconds)
Waiting for CDN-in-a-Box to start (3 seconds)
Waiting for CDN-in-a-Box to start (6 seconds)
Waiting for CDN-in-a-Box to start (9 seconds)
Waiting for CDN-in-a-Box to start (12 seconds)
Waiting for CDN-in-a-Box to start (15 seconds)
Waiting for CDN-in-a-Box to start (18 seconds)
Waiting for CDN-in-a-Box to start (21 seconds)
Waiting for CDN-in-a-Box to start (24 seconds)
Waiting for CDN-in-a-Box to start (27 seconds)
Waiting for CDN-in-a-Box to start (30 seconds)
Waiting for CDN-in-a-Box to start (33 seconds)
Waiting for CDN-in-a-Box to start (36 seconds)
Waiting for CDN-in-a-Box to start (39 seconds)
Waiting for CDN-in-a-Box to start (42 seconds)
Waiting for CDN-in-a-Box to start (45 seconds)
Waiting for CDN-in-a-Box to start (48 seconds)
Waiting for CDN-in-a-Box to start (51 seconds)
Waiting for CDN-in-a-Box to start (54 seconds)
Waiting for CDN-in-a-Box to start (57 seconds)
Waiting for CDN-in-a-Box to start (60 seconds)
Waiting for CDN-in-a-Box to start (63 seconds)
Waiting for CDN-in-a-Box to start (66 seconds)
Waiting for CDN-in-a-Box to start (69 seconds)
Waiting for CDN-in-a-Box to start (72 seconds)
Waiting for CDN-in-a-Box to start (75 seconds)
CDN-in-a-Box is available (78 seconds)
```
6. TEST 1 - Ping traffic router delivery service IP
```
# From infrastructure/cdn-in-a-box
docker-compose exec trafficops ping video.demo1.mycdn.ciab.test
```
Expected Output:
```
PING video.demo1.mycdn.ciab.test (172.16.239.60) 56(84) bytes of data.
64 bytes from trafficrouter.infra.ciab.test (172.16.239.60): icmp_seq=1 ttl=64 time=0.058 ms
64 bytes from trafficrouter.infra.ciab.test (172.16.239.60): icmp_seq=2 ttl=64 time=0.080 ms
64 bytes from trafficrouter.infra.ciab.test (172.16.239.60): icmp_seq=3 ttl=64 time=0.083 ms
64 bytes from trafficrouter.infra.ciab.test (172.16.239.60): icmp_seq=4 ttl=64 time=0.080 ms
64 bytes from trafficrouter.infra.ciab.test (172.16.239.60): icmp_seq=5 ttl=64 time=0.084 ms
64 bytes from trafficrouter.infra.ciab.test (172.16.239.60): icmp_seq=6 ttl=64 time=0.081 ms
64 bytes from trafficrouter.infra.ciab.test (172.16.239.60): icmp_seq=7 ttl=64 time=0.082 ms
```
7. TEST 2 - Test SSL capability of traffic router for demo1 delivery service. Correct response should be a 302 to the edge cache.
```
# From infrastructure/cdn-in-a-box
docker-compose exec trafficops curl -o /dev/null -v video.demo1.mycdn.ciab.test
```
Expected Output:
```
* Connected to video.demo1.mycdn.ciab.test (fc01:9400:1000:8::60) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* SSL connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate:
*       subject: CN=*.demo1.mycdn.ciab.test,O=CDN-in-a-Box,L=Denver,ST=Colorado,C=US
*       start date: Jan 03 00:55:00 2019 GMT
*       expire date: Jan 03 00:55:00 2020 GMT
*       common name: *.demo1.mycdn.ciab.test
*       issuer: E=no-reply@infra.ciab.test,CN=CDN-in-a-Box Intermediate CA,OU=CDN-in-a-Box,O=CDN-in-a-Box,L=Denver,ST=Colorado,C=US
> GET / HTTP/1.1
> User-Agent: curl/7.29.0
> Host: video.demo1.mycdn.ciab.test
> Accept: */*
> 
< HTTP/1.1 302 Found
< Location: https://edge.demo1.mycdn.ciab.test/
< Content-Length: 0
< Date: Tue, 08 Jan 2019 17:33:12 GMT
```
8. TEST 3 - Verify demo1 SSL cert has X509v3 Certificate has Subject/Authority Key Identifiers
```
# From infrastructure/cdn-in-a-box
docker-compose exec trafficops bash -c 'source $X509_CA_ENV_FILE ; openssl x509 -in $X509_DEMO1_CERT_FILE -noout -text | grep "X509v3 extensions" -A15'
```
Expected Output:
```
        X509v3 extensions:
            X509v3 Basic Constraints: 
                CA:FALSE
            Netscape Cert Type: 
                SSL Server
            X509v3 Subject Key Identifier: 
                9C:3B:61:5A:77:73:18:77:45:0B:29:8E:30:64:53:63:2A:80:06:EF
            X509v3 Authority Key Identifier: 
                keyid:5C:8B:4F:3A:33:D0:21:FB:09:81:97:D4:A9:53:9D:3D:E0:01:6C:8D
                DirName:/C=US/ST=Colorado/L=Denver/O=CDN-in-a-Box/OU=CDN-in-a-Box/CN=CDN-in-a-Box Root CA/emailAddress=no-reply@infra.ciab.test
                serial:15:46:47:68:96

            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication
```

Note: edge cache container still needs SSL certificates to be installed by ORT.  This functionality will be implemented in a future PR.

#### Check all that apply

- [ ] This PR includes tests
- [X] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



