### PR TITLE
Add grovetccfg no-service-reload arg, document error codes.

### DIFF
--- a/grove/grovetccfg/README.md
+++ b/grove/grovetccfg/README.md
@@ -66,3 +66,12 @@ Flags:
 | `topass` | The Traffic Ops user password. |
 | `tourl` | The Traffic Ops URL, including the scheme and fully qualified domain name. |
 | `pretty` | Whether to pretty-print JSON |
+
+Exit Codes:
+
+| Code | Description |
+| --- | --- |
+| 0 | Success |
+| 1 | Error, see output for details |
+| 2 | Error reloading service |
+| 3 | Error clearing the server's update flag in Traffic Ops |


### PR DESCRIPTION
Add grovetccfg no-service-reload arg.

Also changes error codes to an enum, so code is self-documenting,
and adds readme documentation of error codes.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [x] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Run 
```
cd trafficcontrol/grove/grovetccfg
go build
mkdir testcertdir

./grovetccfg -tourl https://my-to-host.example.net -host edge-cache-hostname -touser myUser -topass myPass -ignore-update-flag -insecure -pretty -certdir testcertdir
```
On a machine with no Grove service running. Should fail with exit code 2, when it can't restart the service.

Run again with `-no-service-reload` argument, should succeed with exit code 0.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



