### PR TITLE
Fix TO POST cachegroups/id/deliveryservices failure when params exist

### DIFF
--- a/traffic_ops/testing/api/v14/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/cachegroupsdeliveryservices_test.go
@@ -69,6 +69,15 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 		t.Errorf("setting cachegroup delivery services returned success, but no servers set\n")
 	}
 
+	// Note this second post of the same cg-dses specifically tests a previous bug, where the query failed if any servers with location parameters were already assigned, due to an fk violation. See https://github.com/apache/trafficcontrol/pull/3199
+	resp, _, err = TOSession.SetCachegroupDeliveryServices(cgID, dsIDs)
+	if err != nil {
+		t.Errorf("setting cachegroup delivery services returned error: %v\n", err)
+	}
+	if len(resp.Response.ServerNames) == 0 {
+		t.Errorf("setting cachegroup delivery services returned success, but no servers set\n")
+	}
+
 	for _, serverName := range resp.Response.ServerNames {
 		servers, _, err := TOSession.GetServerByHostName(string(serverName))
 		if err != nil {

--- a/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
@@ -222,7 +222,7 @@ INSERT INTO parameter (name, config_file, value) (
     CONCAT('`+paramPrefix+`', xml_id, '.config'),
     (select v from ats_config_location)
   FROM deliveryservice WHERE id = ANY($1)
-) ON CONFLICT (name, config_file, value) DO UPDATE SET id = EXCLUDED.id RETURNING id
+) ON CONFLICT (name, config_file, value) DO UPDATE SET name = EXCLUDED.name RETURNING id
 `, pq.Array(dsIDs))
 	if err != nil {
 		return errors.New("inserting parameters: " + err.Error())


### PR DESCRIPTION
Fixes cachegroups/id/deliveryservices failing when one of the location
parameters being created on the newly-assigned servers already exists
(because a different server on the same profile was previously
assigned to the delivery service).

This causes the query "ON CONFLICT DO UPDATE SET id = EXCLUDED.id
RETURNING id" to fail, because changing the id creates a foreign
key conflict on the profile_parameters table.

The query doesn't actually need to update the id, Postgres just
requires _something_ be updated in order to return. This changes it to
set name=name, which is the same, and doesn't cause a query failure
from a fk conflict.

Includes API Tests.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



