### PR TITLE
Fix Traffic Ops /dnsseckeys/ksk/generate when no ksk exists

### DIFF
--- a/traffic_ops/traffic_ops_golang/cdn/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssec.go
@@ -62,6 +62,15 @@ func CreateDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 	api.WriteResp(w, r, "Successfully created dnssec keys for "+cdnName)
 }
 
+// DefaultDSTTL is the default DS Record TTL to use, if no CDN Snapshot exists, or if no tld.ttls.DS parameter exists.
+// This MUST be the same value as Traffic Router's default. Currently:
+// traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/SignatureManager.java:476
+// `final Long dsTtl = ZoneUtils.getLong(config.get("ttls"), "DS", 60);`.
+// If Traffic Router and Traffic Ops differ, and a user is using the default, errors may occur!
+// Users are advised to set the tld.ttls.DS CRConfig.json Parameter, so the default is not used!
+// Traffic Ops functions SHOULD warn whenever this default is used.
+const DefaultDSTTL = 60 * time.Second
+
 func GetDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
@@ -85,8 +94,9 @@ func GetDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 
 	dsTTL, err := GetDSRecordTTL(inf.Tx.Tx, cdnName)
 	if err != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting DS Record TTL: "+err.Error()))
-		return
+		log.Errorln("Getting DNSSEC Keys: getting DS Record TTL from CRConfig Snapshot: " + err.Error())
+		log.Errorf("Getting DNSSEC Keys: getting DS Record TTL failed, using default %v. It is STRONGLY ADVISED to fix the error, and ensure a CRConfig Snapshot exists for the CDN, and a tld.ttls.DS CRConfig.json Parameter exists on a Router Profile on the CDN. Default DS Records may cause unexpected behavior or errors!\n", DefaultDSTTL)
+		dsTTL = DefaultDSTTL
 	}
 
 	keys, err := deliveryservice.MakeDNSSECKeysFromRiakKeys(riakKeys, dsTTL)

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -174,3 +174,15 @@ func GetCDNNameFromID(tx *sql.Tx, id int64) (tc.CDNName, bool, error) {
 	}
 	return tc.CDNName(name), true, nil
 }
+
+// GetCDNDomainFromName returns the domain, whether the cdn exists, and any error.
+func GetCDNDomainFromName(tx *sql.Tx, cdnName tc.CDNName) (string, bool, error) {
+	domain := ""
+	if err := tx.QueryRow(`SELECT domain_name FROM cdn WHERE name = $1`, cdnName).Scan(&domain); err != nil {
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, errors.New("Error querying CDN name: " + err.Error())
+	}
+	return domain, true, nil
+}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
@@ -113,7 +113,7 @@ func GetDNSSECKeysV11(keyType string, dsName string, ttl time.Duration, inceptio
 func genKeys(dsName string, ksk bool, ttl time.Duration, tld bool) (string, string, *tc.DNSSECKeyDSRecordV11, error) {
 	bits := 1024
 	flags := 256
-	algorithm := dns.RSASHA256 // 8 - http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
+	algorithm := dns.RSASHA1 // 5 - http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
 	protocol := 3
 
 	if ksk {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
@@ -23,6 +23,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -151,7 +152,7 @@ func genKeys(dsName string, ksk bool, ttl time.Duration, tld bool) (string, stri
 	if ksk && tld {
 		dsRecord := dnskey.ToDS(digestType)
 		if dsRecord == nil {
-			return "", "", nil, errors.New("creating DS record from DNSKEY record: " + err.Error())
+			return "", "", nil, fmt.Errorf("creating DS record from DNSKEY record: converting dnskey %++v to DS failed", dnskey)
 		}
 		keyDS = &tc.DNSSECKeyDSRecordV11{Algorithm: int64(dsRecord.Algorithm), DigestType: int64(dsRecord.DigestType), Digest: dsRecord.Digest}
 	}


### PR DESCRIPTION
Fixes #3153

TO API Tests don't support Riak yet.
Manually tested against a TO with Riak. Creating a new CDN with DNSSEC enabled, then calling `/cdns/{name}/dnsseckeys/ksk/generate` works, and generates a new KSK as expected.

This also incidentally fixes `/cdns/dnsseckeys/generate` for a brand-new CDN.

Note for these endpoints to work with a newly created CDN, it will require a DS TTL on a Router Profile, without https://github.com/apache/trafficcontrol/pull/3206 .

#### What does this PR do?

Fixes #3153

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Create a new CDN, then call /cdns/{name}/dnsseckeys/ksk/generate . Verify keys were created by calling and inspecting `/api/1.4/cdns/name/{name}/dnsseckey`.

Note for these endpoints to work with a newly created CDN, it will require a DS TTL on a Router Profile, without https://github.com/apache/trafficcontrol/pull/3206 .

The easiest way to verify this, is to also apply https://github.com/apache/trafficcontrol/pull/3206 and then verify that a brand-new CDN can generate dnsseckeys and ksks.

Also verify /cdns/{name}/dnsseckeys/ksk/generate and /cdns/dnsseckeys/generate still work appropriately for existing CDNs: call those endpoints on an existing CDN with existing DNSSEC keys and KSKs, and verify existing keys are updated with new times correctly, and previous keys are changed to "expired" status.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



