### PR TITLE
Fix TO cdns/dnsseckeys to default if no ttl exists

### DIFF
--- a/traffic_ops/traffic_ops_golang/cdn/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssec.go
@@ -62,6 +62,15 @@ func CreateDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 	api.WriteResp(w, r, "Successfully created dnssec keys for "+cdnName)
 }
 
+// DefaultDSTTL is the default DS Record TTL to use, if no CDN Snapshot exists, or if no tld.ttls.DS parameter exists.
+// This MUST be the same value as Traffic Router's default. Currently:
+// traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/SignatureManager.java:476
+// `final Long dsTtl = ZoneUtils.getLong(config.get("ttls"), "DS", 60);`.
+// If Traffic Router and Traffic Ops differ, and a user is using the default, errors may occur!
+// Users are advised to set the tld.ttls.DS CRConfig.json Parameter, so the default is not used!
+// Traffic Ops functions SHOULD warn whenever this default is used.
+const DefaultDSTTL = 60 * time.Second
+
 func GetDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
@@ -85,8 +94,9 @@ func GetDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 
 	dsTTL, err := GetDSRecordTTL(inf.Tx.Tx, cdnName)
 	if err != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting DS Record TTL: "+err.Error()))
-		return
+		log.Errorln("Getting DNSSEC Keys: getting DS Record TTL from CRConfig Snapshot: " + err.Error())
+		log.Errorf("Getting DNSSEC Keys: getting DS Record TTL failed, using default %v. It is STRONGLY ADVISED to fix the error, and ensure a CRConfig Snapshot exists for the CDN, and a tld.ttls.DS CRConfig.json Parameter exists on a Router Profile on the CDN. Default DS Records may cause unexpected behavior or errors!\n", DefaultDSTTL)
+		dsTTL = DefaultDSTTL
 	}
 
 	keys, err := deliveryservice.MakeDNSSECKeysFromRiakKeys(riakKeys, dsTTL)


### PR DESCRIPTION
Fixes #3204

API Tests don't support Riak yet.
Manually Tested against a TO environment with Riak, with DNSSEC keys. Deleted the `tld.ttls.DS` and Snapshotted the CDN, verified an Internal Server Error without this fix, endpoint works as expected and logs errors with the fix.

#### What does this PR do?

Fixes #3204

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

On a TO deployment with DNSSEC and Riak, delete the `tld.ttls.DS` Parameter and Snapshot the CRConfig for the CDN. Without this PR, `/api/1.4/cdns/name/{cdn-name}/dnsseckeys` will return an `Internal Server Error`, with this PR, endpoint will succeed.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



