### PR TITLE
genRoutesConfig explicitly requires the Python client package

### DIFF
--- a/docs/source/tools/compare.rst
+++ b/docs/source/tools/compare.rst
@@ -74,6 +74,7 @@ These can be overridden by command line switches as described above. If a userna
 
 genConfigRoutes.py
 ------------------
+.. note:: This script uses the :ref:`py-client`, and so that must be installed to use it.
 
 ``usage: genConfigRoutes.py [-h] [--refURL REFURL] [--testURL TESTURL]``
                           ``[--refUser REFUSER] [--refPasswd REFPASSWD]``

--- a/docs/source/tools/python_client.rst
+++ b/docs/source/tools/python_client.rst
@@ -13,6 +13,8 @@
 .. limitations under the License.
 ..
 
+.. _py-client:
+
 *****************************
 Apache-TrafficControl Package
 *****************************

--- a/traffic_ops/testing/compare/Dockerfile
+++ b/traffic_ops/testing/compare/Dockerfile
@@ -31,9 +31,9 @@ RUN mkdir -p /go/src/github.com/apache/trafficcontrol/traffic_control/clients/py
 
 RUN apk update
 RUN apk add python3 git
-RUN python3 -m ensurepip && python3 -m pip install --upgrade pip && python3 -m pip install requests munch
-
 ADD traffic_control/clients/python /go/src/github.com/apache/trafficcontrol/traffic_control/clients/python/
+RUN python3 -m ensurepip && python3 -m pip install --upgrade pip && python3 -m pip install /go/src/github.com/apache/trafficcontrol/traffic_control/clients/python/
+
 ADD lib /go/src/github.com/apache/trafficcontrol/lib
 ADD vendor /go/src/github.com/apache/trafficcontrol/vendor
 ADD traffic_ops/vendor/github.com/kelseyhightower /go/src/github.com/apache/trafficcontrol/traffic_ops/vendor/github.com/kelseyhightower

--- a/traffic_ops/testing/compare/README.md
+++ b/traffic_ops/testing/compare/README.md
@@ -69,6 +69,9 @@ These can be overridden by command line switches as described above. If a userna
 
 ### genConfigRoutes.py
 
+!!! note
+  This script requires the Apache-TrafficControl client package to be installed. See the [client README](../../../traffic_control/clients/python/README.rst) for installation instructions.
+
 usage: genConfigRoutes.py [-h] [--refURL REFURL] [--testURL TESTURL]
                           [--refUser REFUSER] [--refPasswd REFPASSWD]
                           [--testUser TESTUSER] [--testPasswd TESTPASSWD] [-k]

--- a/traffic_ops/testing/compare/genConfigRoutes.py
+++ b/traffic_ops/testing/compare/genConfigRoutes.py
@@ -19,6 +19,8 @@
 """
 This script is meant to generate a list of Traffic Ops API routes that point to configuration files
 for cache servers. It verifies that servers of the same name both exist and have the same routes.
+
+Note that the Python Apache-TrafficControl client package must be installed to use this script.
 """
 
 import argparse
@@ -29,18 +31,10 @@ import time
 import typing
 import sys
 
-random.seed(time.time())
-
-#: The repository root directory
-ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-
-#: An absolute path to the Traffic Ops python packages (This assumes that the script is run from
-#: within the repository's normal directory structure)
-TO_LIBS_PATH = os.path.join(ROOT, "traffic_control", "clients", "python") 
-
-sys.path.insert(0, TO_LIBS_PATH)
 from trafficops.tosession import TOSession
 from trafficops.restapi import LoginError, OperationError, InvalidJSONError
+
+random.seed(time.time())
 
 #: A format specifier for logging output. Propagates to all imported modules.
 LOG_FMT = "%(levelname)s: %(asctime)s line %(lineno)d in %(module)s.%(funcName)s: %(message)s"


### PR DESCRIPTION
#### What does this PR do?
Now that the Python client is a well-behaved package, genRoutesConfig.py can just directly require its prior installation, rather than doing a hack to relative import it.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] `traffic_ops/testing/compare/genRoutesConfig.py`

#### What is the best way to verify this PR?
Install the Python client, then verify that genRoutesConfig.py works properly.

#### Check all that apply
- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)