### PR TITLE
Remove mandatory x509v3 Subject/Authority Key Identifiers in certificate(s) (#3181)

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
@@ -20,7 +20,6 @@ package deliveryservice
  */
 
 import (
-	"bytes"
 	"crypto/x509"
 	"database/sql"
 	"encoding/base64"
@@ -327,12 +326,14 @@ func verifyCertificate(certificate string, rootCA string) (string, bool, error) 
 	}
 	pemEncodedChain := ""
 	for _, link := range chain[0] {
-		// Only print non-self signed elements of the chain
-		if link.AuthorityKeyId != nil && !bytes.Equal(link.AuthorityKeyId, link.SubjectKeyId) {
-			block := &pem.Block{Type: "CERTIFICATE", Bytes: link.Raw}
-			pemEncodedChain += string(pem.EncodeToMemory(block))
-		}
+		// Include all certificates in the chain, since verification was successful.
+		block := &pem.Block{Type: "CERTIFICATE", Bytes: link.Raw}
+		pemEncodedChain += string(pem.EncodeToMemory(block))
 	}
+   
+  	if len(pemEncodedChain) < 1 {
+		return "", false, errors.New("Invalid empty certicate chain in request")
+  	}
 
 	return pemEncodedChain, false, nil
 }


### PR DESCRIPTION
Remove mandatory check for x509v3 Subject/Authority Key Identifiers in imported certificate(s)

#### What does this PR do?

Fixes #3181 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [X] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

1. Start up a Traffic Ops environment with at least one HTTP_and_HTTPS delivery service.
2. Import a self-signed CA and a certificate that is signed by this CA.  Make sure that the certificate does NOT contain the X509v3 Subject/Authority Identifer Key(s) extensions.
3. After importing the certs, view the certificate either via the API or in the DS sslkeys page of the Traffic Portal.  The certificate field should contain a valid certificate.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



