### PR TITLE
Bugfixes for users endpoint

### DIFF
--- a/docs/source/api/user_current.rst
+++ b/docs/source/api/user_current.rst
@@ -169,28 +169,6 @@ Request Structure
 
 Response Structure
 ------------------
-:addressLine1:     The user's address - including street name and number
-:addressLine2:     An additional address field for e.g. apartment number
-:city:             The name of the city wherein the user resides
-:company:          The name of the company for which the user works
-:country:          The name of the country wherein the user resides
-:email:            The user's email address
-:fullName:         The user's full name, e.g. "John Quincy Adams"
-:gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
-:id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
-:newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
-:phoneNumber:      The user's phone number
-:postalCode:       The postal code of the area in which the user resides
-:publicSshKey:     The user's public key used for the SSH protocol
-:registrationSent: If the user was created using the :ref:`to-api-users-register` endpoint, this will be the date and time at which the registration email was sent - otherwise it will be ``null``
-:role:             The integral, unique identifier of the highest-privilege role assigned to this user
-:rolename:         The name of the highest-privilege role assigned to this user
-:stateOrProvince:  The name of the state or province where this user resides
-:tenant:           The name of the tenant to which this user belongs
-:tenantId:         The integral, unique identifier of the tenant to which this user belongs
-:uid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX user ID of the user - now it is always ``null``
-:username:         The user's username
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/users.rst
+++ b/docs/source/api/users.rst
@@ -200,7 +200,7 @@ Response Structure
 :publicSshKey:     The user's public key used for the SSH protocol
 :registrationSent: If the user was created using the :ref:`to-api-users-register` endpoint, this will be the date and time at which the registration email was sent - otherwise it will be ``null``
 :role:             The integral, unique identifier of the highest-privilege role assigned to this user
-:rolename:         The name of the highest-privilege role assigned to this user
+:roleName:         The name of the highest-privilege role assigned to this user
 :stateOrProvince:  The name of the state or province where this user resides
 :tenant:           The name of the tenant to which this user belongs
 :tenantId:         The integral, unique identifier of the tenant to which this user belongs

--- a/docs/source/api/users.rst
+++ b/docs/source/api/users.rst
@@ -255,23 +255,3 @@ Response Structure
 		"postalCode": null,
 		"gid": null
 	}}
-
-``PUT``
-=======
-.. caution:: Due to a regular expression error, this method of this endpoint is unavailable at the moment. The bug is tracked by `GitHub Issue #3117 <https://github.com/apache/trafficcontrol/issues/3117>`_.
-
-.. warning:: Users that login via LDAP pass-back cannot be modified
-
-Modifies a user.
-
-:Auth. Required: Yes
-:Roles Required: "admin" or "operations"
-:Response Type:  Object
-
-Request Structure
------------------
-TBD
-
-Response Structure
-------------------
-TBD

--- a/docs/source/api/users_id.rst
+++ b/docs/source/api/users_id.rst
@@ -204,7 +204,7 @@ Response Structure
 :publicSshKey:     The user's public key used for the SSH protocol
 :registrationSent: If the user was created using the :ref:`to-api-users-register` endpoint, this will be the date and time at which the registration email was sent - otherwise it will be ``null``
 :role:             The integral, unique identifier of the highest-privilege role assigned to this user
-:rolename:         The name of the highest-privilege role assigned to this user
+:roleName:         The name of the highest-privilege role assigned to this user
 :stateOrProvince:  The name of the state or province where this user resides
 :tenant:           The name of the tenant to which this user belongs
 :tenantId:         The integral, unique identifier of the tenant to which this user belongs

--- a/docs/source/api/users_id.rst
+++ b/docs/source/api/users_id.rst
@@ -118,10 +118,6 @@ Response Structure
 
 ``PUT``
 =======
-.. deprecated:: 1.4
-	Use the ``PUT`` method of the :ref:`to-api-users` endpoint instead.
-
-.. caution:: This endpoint doesn't work in API version 1.4 when attempting to modify the user that is currently logged-in. There's an error checking what fields the user has permissions to modify. The bug is tracked by `GitHub Issue #3118 <https://github.com/apache/trafficcontrol/issues/3118>`_. Note that a user can modify him or herself by calling the endpoint with an API version less than 1.4.
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -68,13 +68,12 @@ type commonUserFields struct {
 	PostalCode      *string `json:"postalCode" db:"postal_code"`
 	PublicSSHKey    *string `json:"publicSshKey" db:"public_ssh_key"`
 	Role            *int    `json:"role" db:"role"`
-	RoleName        *string `json:"rolename"`
 	StateOrProvince *string `json:"stateOrProvince" db:"state_or_province"`
 	Tenant          *string `json:"tenant"`
 	TenantID        *int    `json:"tenantId" db:"tenant_id"`
 	UID             *int    `json:"uid"`
 	//Username        *string    `json:"username" db:"username"`  //not including major change due to naming incompatibility
-	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"` //including minor change to add field
+	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }
 
 // User fields in v14 have been updated to be nullable. omitempty is used to protect password data
@@ -82,6 +81,17 @@ type User struct {
 	Username         *string    `json:"username" db:"username"`
 	RegistrationSent *TimeNoMod `json:"registrationSent" db:"registration_sent"`
 	LocalPassword    *string    `json:"localPasswd,omitempty" db:"local_passwd"`
+
+	// Expected behavior of role names:
+	// GET users/:id and users/   returns 'rolename'   'roleName' is nil
+	// POST and PUT users/        returns 'roleName'   'rolename' is nil
+	// The json the user enters for POST and PUT at the moment only uses the numerical id of 'role',
+	// so the name conflict does not occur on entry. However, the user should be careful when reading
+	// back those values. This is a bug that has been kept to maintain the version promise and prevent
+	// clients from breaking (see #3219).
+	// This is tracked by: apache/trafficcontrol/issues/3220
+	RoleNameGET *string `json:"rolename,omitempty"`
+	RoleName    *string `json:"roleName,omitempty" db:"rolename"`
 	commonUserFields
 }
 
@@ -89,6 +99,7 @@ type User struct {
 type UserCurrent struct {
 	UserName  *string `json:"username"`
 	LocalUser *bool   `json:"localUser"`
+	RoleName  *string `json:"roleName"`
 	commonUserFields
 }
 

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -76,22 +76,12 @@ type commonUserFields struct {
 	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }
 
-// User fields in v14 have been updated to be nullable. omitempty is used to protect password data
+// User fields in v14 have been updated to be nullable
 type User struct {
 	Username         *string    `json:"username" db:"username"`
 	RegistrationSent *TimeNoMod `json:"registrationSent" db:"registration_sent"`
 	LocalPassword    *string    `json:"localPasswd,omitempty" db:"local_passwd"`
-
-	// Expected behavior of role names:
-	// GET users/:id and users/   returns 'rolename'   'roleName' is nil
-	// POST and PUT users/        returns 'roleName'   'rolename' is nil
-	// The json the user enters for POST and PUT at the moment only uses the numerical id of 'role',
-	// so the name conflict does not occur on entry. However, the user should be careful when reading
-	// back those values. This is a bug that has been kept to maintain the version promise and prevent
-	// clients from breaking (see #3219).
-	// This is tracked by: apache/trafficcontrol/issues/3220
-	RoleNameGET *string `json:"rolename,omitempty"`
-	RoleName    *string `json:"roleName,omitempty" db:"rolename"`
+	RoleName         *string    `json:"roleName,omitempty" db:"-"`
 	commonUserFields
 }
 

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -1948,6 +1948,28 @@
             "tenant": "tenant4",
             "uid": 0,
             "username": "tenant4user"
+        },
+        {
+            "addressLine1": "address of ops",
+            "addressLine2": "place",
+            "city": "somewhere",
+            "company": "else",
+            "country": "UK",
+            "email": "ops@example.com",
+            "fullName": "Operations User",
+            "gid": 0,
+            "localPasswd": "pa$$word",
+            "confirmLocalPasswd": "pa$$word",
+            "newUser": false,
+            "phoneNumber": "",
+            "postalCode": "",
+            "publicSshKey": "",
+            "registrationSent": "",
+            "role": 3,
+            "stateOrProvince": "",
+            "tenant": "root",
+            "uid": 0,
+            "username": "opsuser"
         }
     ],
     "steeringTargets": [

--- a/traffic_ops/testing/api/v14/user_test.go
+++ b/traffic_ops/testing/api/v14/user_test.go
@@ -30,7 +30,7 @@ import (
 func TestUsers(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, Users}, func() {
 		UpdateTestUsers(t)
-		TestRolenameCapitalization(t)
+		RolenameCapitalizationTest(t)
 		OpsUpdateAdminTest(t)
 		UserSelfUpdateTest(t)
 		UserUpdateOwnRoleTest(t)
@@ -52,7 +52,7 @@ func CreateTestUsers(t *testing.T) {
 	}
 }
 
-func TestRolenameCapitalization(t *testing.T) {
+func RolenameCapitalizationTest(t *testing.T) {
 
 	roles, _, _, err := TOSession.GetRoles()
 	if err != nil {

--- a/traffic_ops/testing/api/v14/user_test.go
+++ b/traffic_ops/testing/api/v14/user_test.go
@@ -17,7 +17,6 @@ package v14
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -79,7 +78,7 @@ func RolenameCapitalizationTest(t *testing.T) {
 	}
 	jsonBytes, err = json.Marshal(resp)
 	if err != nil {
-		fmt.Printf("coult not marshal struct to bytes: %v\n", err)
+		t.Errorf("coult not marshal struct to bytes: %v\n", err)
 	}
 	if bytes.Contains(jsonBytes, []byte("rolename")) {
 		t.Errorf("incorrect json was returned for PUT")
@@ -91,7 +90,7 @@ func RolenameCapitalizationTest(t *testing.T) {
 	}
 	jsonBytes, err = json.Marshal(resp2)
 	if err != nil {
-		fmt.Printf("coult not marshal struct to bytes: %v\n", err)
+		t.Errorf("coult not marshal struct to bytes: %v\n", err)
 	}
 	if bytes.Contains(jsonBytes, []byte("roleName")) {
 		t.Errorf("incorrect json was returned for GET")

--- a/traffic_ops/testing/api/v14/user_test.go
+++ b/traffic_ops/testing/api/v14/user_test.go
@@ -60,7 +60,7 @@ func RolenameCapitalizationTest(t *testing.T) {
 	blob := []byte(`
 	{
 		"username": "test_user",
-		"email": "cooldude6@comcast.net",
+		"email": "cooldude6@example.com",
 		"fullName": "full name is required",
 		"localPasswd": "better_twelve",
 		"confirmLocalPasswd": "better_twelve",
@@ -80,7 +80,7 @@ func RolenameCapitalizationTest(t *testing.T) {
 	if err != nil {
 		t.Errorf("coult not marshal struct to bytes: %v\n", err)
 	}
-	if bytes.Contains(jsonBytes, []byte("rolename")) {
+	if !bytes.Contains(jsonBytes, []byte("roleName")) {
 		t.Errorf("incorrect json was returned for PUT")
 	}
 
@@ -92,7 +92,7 @@ func RolenameCapitalizationTest(t *testing.T) {
 	if err != nil {
 		t.Errorf("coult not marshal struct to bytes: %v\n", err)
 	}
-	if bytes.Contains(jsonBytes, []byte("roleName")) {
+	if !bytes.Contains(jsonBytes, []byte("rolename")) {
 		t.Errorf("incorrect json was returned for GET")
 	}
 
@@ -136,7 +136,7 @@ func UserSelfUpdateTest(t *testing.T) {
 	user := resp[0]
 
 	fullName := "Oops-man"
-	email := "operator@comcast.net"
+	email := "operator@example.com"
 	user.FullName = &fullName
 	user.Email = &email
 

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -117,6 +117,27 @@ func AddTenancyCheck(where string, queryValues map[string]interface{}, tenantCol
 	return where, queryValues
 }
 
+// GetPrivLevelFromRoleID returns the profile's name, whether a profile with ID exists, or any error.
+// This method exists on a temporary basis. After priv_level is fully deprecated and capabilities take over,
+// this method will not only no longer be needed, but the corresponding new privilege check should be done
+// via the primary database query for the users endpoint. The users json response will contain a list of
+// capabilities in the future, whereas now the users json response currently does not contain privLevel.
+// See the wiki page on the roles/capabilities as a system:
+// https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=68715910
+func GetPrivLevelFromRoleID(tx *sqlx.Tx, id int) (int, bool, error) {
+	var privLevel int
+	err := tx.QueryRow(`SELECT priv_level FROM role WHERE role.id = $1`, id).Scan(&privLevel)
+
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+
+	if err != nil {
+		return 0, false, fmt.Errorf("getting priv_level from role: %v", err)
+	}
+	return privLevel, true, nil
+}
+
 // GetDSNameFromID loads the DeliveryService's xml_id from the database, from the ID. Returns whether the delivery service was found, and any error.
 func GetDSNameFromID(tx *sql.Tx, id int) (tc.DeliveryServiceName, bool, error) {
 	name := tc.DeliveryServiceName("")

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -117,7 +117,7 @@ func AddTenancyCheck(where string, queryValues map[string]interface{}, tenantCol
 	return where, queryValues
 }
 
-// GetPrivLevelFromRoleID returns the profile's name, whether a profile with ID exists, or any error.
+// GetPrivLevelFromRoleID returns the priv_level associated with a role, whether it exists, and any error.
 // This method exists on a temporary basis. After priv_level is fully deprecated and capabilities take over,
 // this method will not only no longer be needed, but the corresponding new privilege check should be done
 // via the primary database query for the users endpoint. The users json response will contain a list of

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -159,17 +159,12 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `user/{id}/deliveryservices/available/?(\.json)?$`, user.GetAvailableDSes, auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodPost, `user/login/?$`, login.LoginHandler(d.DB, d.Config), 0, NoAuth, nil},
 
-		//User: CRUD (1.4 then 1.1)
+		//User: CRUD
 		//Incrementing version for users because change to Nullable struct.
 		{1.4, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.4, http.MethodGet, `users/{id}$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.4, http.MethodPut, `users/{id}$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 		{1.4, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-
-		{1.1, http.MethodGet, `users/?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
-		{1.1, http.MethodGet, `users/{id}$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
-		{1.1, http.MethodPut, `users/{id}$`, handlerToFunc(proxyHandler), auth.PrivLevelOperations, Authenticated, []Middleware{}},
-		{1.1, http.MethodPost, `users/?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelOperations, Authenticated, []Middleware{}},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil},
 

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -160,16 +160,15 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `user/login/?$`, login.LoginHandler(d.DB, d.Config), 0, NoAuth, nil},
 
 		//User: CRUD (1.4 then 1.1)
-		//Incrementing version for users because change to Nullable struct. Delete is completely new.
+		//Incrementing version for users because change to Nullable struct.
 		{1.4, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.4, http.MethodGet, `users/{id}$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.4, http.MethodPut, `users/{id}$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 		{1.4, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		//{1.4, http.MethodDelete, `users/{id}$`, api.DeleteHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodGet, `users/?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
-		{1.1, http.MethodGet, `users/{id}?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
-		{1.1, http.MethodPut, `users/{id}?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelOperations, Authenticated, []Middleware{}},
+		{1.1, http.MethodGet, `users/{id}$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
+		{1.1, http.MethodPut, `users/{id}$`, handlerToFunc(proxyHandler), auth.PrivLevelOperations, Authenticated, []Middleware{}},
 		{1.1, http.MethodPost, `users/?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelOperations, Authenticated, []Middleware{}},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -161,10 +161,10 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		//User: CRUD
 		//Incrementing version for users because change to Nullable struct.
-		{1.4, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.4, http.MethodGet, `users/{id}$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.4, http.MethodPut, `users/{id}$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.4, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `users/{id}$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPut, `users/{id}$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil},
 

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -162,15 +162,15 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		//User: CRUD (1.4 then 1.1)
 		//Incrementing version for users because change to Nullable struct. Delete is completely new.
 		{1.4, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.4, http.MethodGet, `users/{id}?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.4, http.MethodPut, `users/{id}?(\.json)?$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodGet, `users/{id}$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.4, http.MethodPut, `users/{id}$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 		{1.4, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		//{1.4, http.MethodDelete, `users/{id}?(\.json)?$`, api.DeleteHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		//{1.4, http.MethodDelete, `users/{id}$`, api.DeleteHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodGet, `users/?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
 		{1.1, http.MethodGet, `users/{id}?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
-		{1.1, http.MethodPut, `users/{id}?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
-		{1.1, http.MethodPost, `users/?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelReadOnly, Authenticated, []Middleware{}},
+		{1.1, http.MethodPut, `users/{id}?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelOperations, Authenticated, []Middleware{}},
+		{1.1, http.MethodPost, `users/?(\.json)?$`, handlerToFunc(proxyHandler), auth.PrivLevelOperations, Authenticated, []Middleware{}},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil},
 

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -236,9 +236,6 @@ func (user *TOUser) Read() ([]interface{}, error, error, int) {
 }
 
 func (user *TOUser) privCheck() (error, error, int) {
-	// if user Role does not exist the database constraint should catch it
-	//	untested so far
-	//	what do the other dbhelper GETters do?
 	privLevel, _, err := dbhelpers.GetPrivLevelFromRoleID(user.ReqInfo.Tx, *user.Role)
 	if err != nil {
 		return nil, err, http.StatusInternalServerError

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -221,6 +221,14 @@ func (user *TOUser) Read() ([]interface{}, error, error, int) {
 			return nil, nil, fmt.Errorf("parsing user rows: %v", err), http.StatusInternalServerError
 		}
 
+		// role is a required field for the endpoint, but not for an item in the database
+		// I doubt a nil check is needed, but I'm including it just in case
+		if user.RoleName == nil {
+			return nil, nil, fmt.Errorf("role name is nil", err), http.StatusInternalServerError
+		}
+		user.RoleNameGET = user.RoleName
+		user.RoleName = nil
+
 		users = append(users, *user)
 	}
 

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -21,6 +21,7 @@ package user
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -225,7 +226,7 @@ func (user *TOUser) Read() ([]interface{}, error, error, int) {
 		// role is a required field for the endpoint, but not for an item in the database
 		// I doubt a nil check is needed, but I'm including it just in case
 		if user.RoleName == nil {
-			return nil, nil, fmt.Errorf("role name is nil"), http.StatusInternalServerError
+			return nil, nil, errors.New("role name is nil"), http.StatusInternalServerError
 		}
 		user.RoleNameGET = user.RoleName
 		user.RoleName = nil

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -266,10 +266,10 @@ func (user *TOUser) Update() (error, error, int) {
 	}
 
 	resultRows, err := user.ReqInfo.Tx.NamedQuery(user.UpdateQuery(), user)
-	defer resultRows.Close()
 	if err != nil {
 		return api.ParseDBError(err)
 	}
+	defer resultRows.Close()
 
 	var lastUpdated tc.TimeNoMod
 	var tenant string
@@ -282,6 +282,7 @@ func (user *TOUser) Update() (error, error, int) {
 			return nil, fmt.Errorf("could not scan lastUpdated from insert: %s\n", err), http.StatusInternalServerError
 		}
 	}
+
 	user.LastUpdated = &lastUpdated
 	user.Tenant = &tenant
 	user.RoleName = &rolename


### PR DESCRIPTION
#### What does this PR do?

Fixes #3117
Fixes #3118
Fixes #3214
Fixes #3219 

This PR does not include documentation updates, so doc updates will follow.
_EDIT:_ Committed documentation updates

_EDIT 2:_ This PR is currently a WIP
There is a bugfix for #3219 that I want to address as well

_EDIT 3:_ Committed fix for #3219

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

#3117
Read the issue

#3118
   1) user can update themselves
   2) user cannot update their own role
   3) user cannot PUT or POST a user whos priv_level is higher than their own

I wrote integration tests for PUT. POST should work. I can add another test, but it has the same privilege check.

#3214 
I did not write an integration test for this. The commit is simple enough to see what the problem was, nor is it likely to change in the future.

#3219 
Post a user and make sure 'roleName' is in the json. Update the user and make sure 'roleName' is in the json, then GET the user and make sure 'rolename' is in the json. This should work for all minor versions 1.1 to 1.4

#### Check all that apply

- [x] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



