### PR TITLE
Optimize regex_revalidate.config API endpoint

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1767,7 +1767,16 @@ sub regex_revalidate_dot_config {
 	my $max_hours = $max_days * 24;
 	my $min_hours = 1;
 
-	my $rs = $self->db->resultset('Job')->search( { start_time => \$interval }, { prefetch => 'job_deliveryservice' } );
+	my $date = Date::Manip::Date->new();
+
+	my $rs = $self->db->resultset('Job')->search(
+		{
+			start_time => \$interval,
+			"job_deliveryservice.cdn_id" => $cdn_obj->id,
+		},
+		{
+			prefetch => 'job_deliveryservice'
+		} );
 	while ( my $row = $rs->next ) {
 		next unless defined( $row->job_deliveryservice );
 
@@ -1787,7 +1796,6 @@ sub regex_revalidate_dot_config {
 			next;
 		}
 
-		my $date       = new Date::Manip::Date();
 		my $start_time = $row->start_time;
 		my $start_date = ParseDate($start_time);
 		my $end_date   = DateCalc( $start_date, ParseDateDelta( $ttl . ':00:00' ) );
@@ -1803,15 +1811,11 @@ sub regex_revalidate_dot_config {
 		}
 		my $asset_url = $row->asset_url;
 
-		my $job_cdn_id = $row->job_deliveryservice->cdn_id;
-		if ( $cdn_obj->id == $job_cdn_id ) {
-
-			# if there are multipe with same re, pick the longes lasting.
-			if ( !defined( $regex_time{ $row->asset_url } )
-				|| ( defined( $regex_time{ $row->asset_url } ) && $purge_end > $regex_time{ $row->asset_url } ) )
-			{
-				$regex_time{ $row->asset_url } = $purge_end;
-			}
+		# if there are multiple with same regex, pick the longest lasting.
+		if ( !defined( $regex_time{ $row->asset_url } )
+			|| ( defined( $regex_time{ $row->asset_url } ) && $purge_end > $regex_time{ $row->asset_url } ) )
+		{
+			$regex_time{ $row->asset_url } = $purge_end;
 		}
 	}
 


### PR DESCRIPTION
#### What does this PR do?

This endpoint can be unbearably slow and CPU-intensive with hundreds of
current invalidation jobs. Do some simple optimization to get this
endpoint more on par with other ATS config file endpoints.

Locally with ~600 current invalidation jobs, I'm seeing about 5-6x speed
improvement with these changes. Because of the added SQL filtering, the
endpoint now returns almost instantly for CDNs that have little or no
current invalidations. Previously, generating this file for ANY CDN
would require iterating over ALL current jobs across ALL CDNs, doing a
bunch of work before throwing away the results from other CDNs.

Fixes #3232

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
1. Create some invalidation jobs for a test DS and compare the before/after output of regex_revalidate.config (with/without this change)
2. Create 500 invalidation jobs and repeat step 1, compare request times

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



