### PR TITLE
change cdn-in-a-box integration tests to use dynamic dns

### DIFF
--- a/infrastructure/cdn-in-a-box/docker-compose.traffic-ops-test.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.traffic-ops-test.yml
@@ -26,16 +26,6 @@
 ---
 version: '2.1'
 
-networks:
-  tcnet:
-    driver: bridge
-    enable_ipv6: true
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.16.239.0/24
-        - subnet: "fc01:9400:1000:8::/64"
-
 services:
   integration:
     build:
@@ -45,11 +35,10 @@ services:
       - variables.env
     hostname: integration
     domainname: infra.ciab.test
-    networks:
-      tcnet:
     volumes:
       - shared:/shared
-      - ./dns/container-resolv.conf:/etc/resolv.conf
+      - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
+      - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
 
 volumes:
   shared:

--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/run.sh
@@ -25,6 +25,9 @@ done
 
 source to-access.sh
 
+set-dns.sh
+insert-self-into-dns.sh
+
 TO_URL="https://$TO_FQDN:$TO_PORT"
 while ! to-ping 2>/dev/null; do
    echo waiting for trafficops
@@ -37,4 +40,3 @@ source config.sh
 
 ./traffic_ops_integration_test -cfg=traffic-ops-test.conf
 exit $?
-


### PR DESCRIPTION
#### What does this PR do?

Changes integration tests in cdn-in-a-box to use the dynamic dns introduced in #3213 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other cdn-in-a-box;   testing

#### What is the best way to verify this PR?
```
cd infrastructure/cdn-in-a-box
docker-compose -f docker-compose.yml -f docker-compose.traffic-ops-test.yml build
docker-compose -f docker-compose.yml -f docker-compose.traffic-ops-test.yml up -d trafficops trafficops-perl integration
docker-compose -f docker-compose.yml -f docker-compose.traffic-ops-test.yml logs -f integration
```

should see integration tests run and `PASS` as the final line.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



