### PR TITLE
Fix nil pointer dereference in PUT /deliveryserivces/{id} endpoint

### DIFF
--- a/traffic_ops/testing/api/v14/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservices_test.go
@@ -17,10 +17,10 @@ package v14
 
 import (
 	"strconv"
+	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
-	"testing"
 )
 
 func TestDeliveryServices(t *testing.T) {
@@ -101,6 +101,7 @@ func UpdateTestDeliveryServices(t *testing.T) {
 	updatedMaxDNSAnswers := 164598
 	remoteDS.LongDesc = updatedLongDesc
 	remoteDS.MaxDNSAnswers = updatedMaxDNSAnswers
+	remoteDS.MatchList = nil // verify that this field is optional in a PUT request, doesn't cause nil dereference panic
 
 	if updateResp, err := TOSession.UpdateDeliveryService(strconv.Itoa(remoteDS.ID), &remoteDS); err != nil {
 		t.Errorf("cannot UPDATE DeliveryService by ID: %v - %v\n", err, updateResp)


### PR DESCRIPTION
If this endpoint receives a json request without a "matchList" array
(which is not a required field), the endpoint will panic on a nil
pointer dereference.

Load the delivery service matchList from the DB before dereferencing it.
As a side effect, this also prevents a user from passing in their own
"matchList" array which would potentially cause the wrong hostname to be
updated into the delivery service's ssl keys.

#### What does this PR do?

Fixes #3239 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Run the API integration tests and/or use curl to make a `PUT /api/x/deliveryservices/{id}` request with a json body that doesn't contain a `"matchList"` field.

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



