### PR TITLE
Change Traffic Ops DNSSEC Generation to Lowercase FQDNs

### DIFF
--- a/traffic_ops/traffic_ops_golang/cdn/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssec.go
@@ -165,6 +165,7 @@ func generateStoreDNSSECKeys(
 	if !strings.HasSuffix(cdnDNSDomain, ".") {
 		cdnDNSDomain = cdnDNSDomain + "."
 	}
+	cdnDNSDomain = strings.ToLower(cdnDNSDomain)
 
 	inception := time.Now()
 	newCDNZSK, err := deliveryservice.GetDNSSECKeysV11(tc.DNSSECZSKType, cdnDNSDomain, ttl, inception, inception.Add(zExp), tc.DNSSECKeyStatusNew, time.Unix(effectiveDateUnix, 0), false)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
@@ -177,6 +177,7 @@ func GetDSDomainName(dsExampleURLs []string) (string, error) {
 		return "", errors.New("malformed example URL, nothing after first dot")
 	}
 	dsName = dsName[firstDot+1:]
+	dsName = strings.ToLower(dsName)
 	return dsName, nil
 }
 


### PR DESCRIPTION
#### What does this PR do?

Changes Traffic Ops DNSSEC Generation to Lowercase FQDNs

Based on #3205, recommend merging that first. Only actual changeset is https://github.com/apache/trafficcontrol/pull/3244/commits/af8dbbc120414234761a87e63a598016fb86d435

TO API Tests don't support Riak yet.

FYI I haven't tested this yet, because it takes so much time to test DNSSEC things.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



