### PR TITLE
ORT.py now installs SSL certificates

### DIFF
--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -23,7 +23,7 @@ exactly like that legacy script, with the ability to set system configuration
 files and start, stop, and restart HTTP cache servers etc.
 """
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 __author__  = "Brennan Fieck"
 
 import argparse

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
@@ -272,7 +272,7 @@ def processConfigurationFiles(api:to_api.API) -> bool:
 		try:
 			file = config_files.ConfigFile(file)
 			logging.info("\n============ Processing File: %s ============", file.fname)
-			file.update(api)
+			file.update(api, configuration.SERVER_INFO.cdnName)
 			logging.info("\n============================================\n")
 
 		# A bad object could just reflect an inconsistent reply structure from the API, so BADASSes
@@ -283,11 +283,9 @@ def processConfigurationFiles(api:to_api.API) -> bool:
 			logging.debug("%s", e, exc_info=True, stack_info=True)
 			return False
 		except ValueError as e:
-			logging.error("%s does not appear to be a valid 'configfile' object!")
+			logging.error("%s does not appear to be a valid 'configfile' object, or has invalid contents!")
 			logging.debug("%s", e, exc_info=True, stack_info=True)
-			if configuration.MODE is not configuration.Modes.BADASS:
-				return False
-			logging.warning("Moving on because we're BADASS")
+			return False
 
 	return True
 

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
@@ -27,7 +27,7 @@
 			"configFile": "records.config",
 			"name": "CONFIG proxy.config.http.server_ports",
 			"secure": false,
-			"value": "STRING 80 80:ipv6"
+			"value": "STRING 80 80:ipv6 443:proto=http:ssl 443:ipv6:proto=http:ssl"
 		},
 		{
 			"configFile": "records.config",
@@ -294,6 +294,54 @@
 			"value": "/var/trafficserver/"
 		},
 		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.CA.cert.path",
+			"secure": false,
+			"value": "STRING /etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.CA.cert.path",
+			"secure": false,
+			"value": "STRING /etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.cert.path",
+			"secure": false,
+			"value": "STRING /etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.private_key.path",
+			"secure": false,
+			"value": "STRING /etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.ocsp.enabled",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.cert.path",
+			"secure": false,
+			"value": "STRING /etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.private_key.path",
+			"secure": false,
+			"value": "STRING /etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.ticket_key.filename",
+			"secure": false,
+			"value": "STRING NULL"
+		},
+		{
 			"configFile": "set_dscp_0.config",
 			"name": "location",
 			"value": "/etc/trafficserver/dscp"
@@ -397,6 +445,11 @@
 			"configFile": "set_dscp_37.config",
 			"name": "location",
 			"value": "/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "ssl_multicert.config",
+			"name": "location",
+			"value": "/etc/trafficserver"
 		}
 	]
 }

--- a/traffic_control/clients/python/trafficops/__version__.py
+++ b/traffic_control/clients/python/trafficops/__version__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/traffic_control/clients/python/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/tosession.py
@@ -765,7 +765,7 @@ class TOSession(RestApiSession):
 	#
 	# CDN SSL Keys
 	#
-	@api_request(u'get', u'cdns/name/{cdn_name:s}/sslkeys', (u'1.2', u'1.3',))
+	@api_request(u'get', u'cdns/name/{cdn_name:s}/sslkeys', (u'1.2', u'1.3', u'1.4'))
 	def get_cdn_ssl_keys(self, cdn_name=None):
 		"""
 		Returns ssl certificates for all Delivery Services that are a part of the CDN.


### PR DESCRIPTION
## What does this PR do?
The Python implementation of ORT will now install SSL certificates and keys just like the Perl version would.
Also fixes #3237 

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] CDN-in-a-Box
- [x] The Python trafficops client

## What is the best way to verify this PR?
Build CiaB and try to use the default DS with HTTPS. Someone who knows how should also verify that the installed certificates are valid.
A concern I have: right now I stop after the first SSL key match for an `ssl_multicert.config` line, but it's _possible_ to have more than one key I suppose. I can't think why, but if that's a real scenario I can fix it.

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



