### PR TITLE
Fix Unit Test for PR (#3211) - ADDSSLKeys API - Remove mandatory SKI/AKI

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/keys_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/keys_test.go
@@ -227,7 +227,7 @@ func TestVerifyAndEncodeCertificate(t *testing.T) {
 
 	certs := strings.SplitAfter(dat, PemCertEndMarker)
 	length := len(certs) - 1
-	if length != 2 {
+	if length != 3 { // rootCA now included in certChain
 		t.Errorf("Test failure: expected 2 certs from verifyCertificate(), got: %d ", length)
 	}
 }


### PR DESCRIPTION
#### What does this PR do?

Fix Unit Test for PR (#3211) - ADDSSLKeys API - Remove mandatory SKI/AKI

Fixes PR #3211 Unit Test

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [X] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

1. Build and run unit tests for traffic_ops

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



