### PR TITLE
Add Portal Test Docker Compose

### DIFF
--- a/infrastructure/cdn-in-a-box/docker-compose.traffic-portal-test.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.traffic-portal-test.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This compose file runs the traffic ops integration tests assuming
+# there is already a trafficops docker instance. When using docker,
+# make sure any container rpms you need are updated. Below is an
+# example of how to run the main compose with this file:
+# 
+# docker-compose up --build db trafficops-perl trafficops
+# docker-compose -f docker-compose.traffic-ops-test.yml up --build integration
+
+---
+version: '2.1'
+
+services:
+  portal-integration-test:
+    build:
+      context: ../..
+      dockerfile: infrastructure/cdn-in-a-box/traffic_portal_integration_test/Dockerfile
+    env_file:
+      - variables.env
+    hostname: portal-integration
+    domainname: infra.ciab.test
+    volumes:
+      - shared:/shared
+      - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
+      - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
+      - ../../junit:/junit
+
+volumes:
+  shared:
+    external: false
+  junit:

--- a/infrastructure/cdn-in-a-box/traffic_portal_integration_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_portal_integration_test/Dockerfile
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM centos:7
+
+COPY ./infrastructure/cdn-in-a-box/traffic_ops/to-access.sh /usr/local/sbin/
+COPY ./traffic_portal/ /lang/traffic_portal/
+
+WORKDIR /lang/traffic_portal/test/end_to_end
+RUN printf "\n\
+[google-chrome] \n\
+name=google-chrome \n\
+baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64 \n\
+enabled=1 \n\
+gpgcheck=1 \n\
+gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub \n\
+" > /etc/yum.repos.d/google-chrome.repo
+
+RUN yum update -y
+
+RUN yum install -y java-1.8.0-openjdk git google-chrome bind-utils
+
+RUN curl -LO https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-x64.tar.xz
+
+RUN ls -lah
+
+# Use bsdtar, because regular tar doesn't work with Docker
+RUN yum install -y bsdtar
+RUN bsdtar --strip-components 1 -xzvf node-v* -C /usr/local
+RUN npm install -g protractor
+RUN npm install --save-dev jasmine-reporters@^2.0.0
+
+RUN ls -lah /lang/traffic_portal/test/end_to_end
+
+RUN sed -i "s/baseUrl: 'https:\/\/localhost:4443/baseUrl: 'https:\/\/trafficportal.infra.ciab.test:443/" /lang/traffic_portal/test/end_to_end/conf.js
+RUN sed -i "s/baseUrl: 'https:\/\/localhost:4443/baseUrl: 'https:\/\/trafficportal.infra.ciab.test:443/" /lang/traffic_portal/test/end_to_end/login/conf.js
+
+RUN export junit_conf_jasmine=" \
+        onPrepare: function() { \
+            var jasmineReporters = require('jasmine-reporters'); \
+            jasmine.getEnv().addReporter( \
+                        new jasmineReporters.JUnitXmlReporter({savePath:'/portaltestresults', filePrefix: 'portaltestresults', consolidateAll:true}) \
+                    ); \
+        }, \
+" && perl -p -i -e 's/(\s*suites)/$ENV{junit_conf_jasmine}\1/g' conf.js
+
+RUN export junit_conf_chrome=", \
+                'chromeOptions': { \
+                      'args': ['--headless', '--disable-gpu', '--no-sandbox', '--ignore-certificate-errors'] \
+                    } \
+" && perl -p -i -e 's/(\s*'"'"'browserName'"'"':\s*'"'"'chrome'"'"')/\1\n$ENV{junit_conf_chrome}/g' conf.js
+
+# debug
+RUN cat conf.js
+RUN cat login/conf.js
+
+RUN webdriver-manager update
+
+COPY ./infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh /lang/traffic_portal/test/end_to_end/
+CMD ./run.sh

--- a/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+envvars=( DB_SERVER DB_PORT DB_ROOT_PASS DB_USER DB_USER_PASS ADMIN_USER ADMIN_PASS)
+for v in $envvars
+do
+	if [[ -z $$v ]]; then echo "$v is unset"; exit 1; fi
+done
+
+source to-access.sh
+
+set-dns.sh
+insert-self-into-dns.sh
+
+TO_URL="https://$TO_FQDN:$TO_PORT"
+while ! to-ping 2>/dev/null; do
+   echo "waiting for trafficops at '$TO_URL' fqdn '$TO_FQDN' host '$TO_HOST'"
+   sleep 3
+done
+
+nohup webdriver-manager start &
+
+selenium_port=4444
+selenium_fqdn="http://localhost:${selenium_port}"
+while ! curl -Lvsk "${selenium_fqdn}" 2>/dev/null >/dev/null; do
+   echo "waiting for selenium server to start on '${selenium_fqdn}'"
+   sleep 1
+done
+
+cat conf.js
+
+protractor conf.js --params.adminUser 'admin' --params.adminPassword 'twelve'
+rc=$?
+
+cp /portaltestresults/* /junit/
+
+exit $rc


### PR DESCRIPTION
#### What does this PR do?

Adds Traffic Portal CiaB Docker Compose Files, for running the Portal tests as part of a CiaB compose.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



