### PR TITLE
CIAB: Dynamically detect server netmask

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops_data/servers/010-dns_server.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/servers/010-dns_server.json
@@ -3,7 +3,6 @@
   "domainName": "infra.ciab.test",
   "cachegroup": "CDN_in_a_Box_Edge",
   "interfaceName": "eth0",
-  "ipNetmask": "255.255.255.0",
   "interfaceMtu": 1500,
   "type": "BIND",
   "physLocation": "Apachecon North America 2018",

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/servers/020-db_server.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/servers/020-db_server.json
@@ -3,7 +3,6 @@
   "domainName": "infra.ciab.test",
   "cachegroup": "CDN_in_a_Box_Edge",
   "interfaceName": "eth0",
-  "ipNetmask": "255.255.255.0",
   "interfaceMtu": 1500,
   "type": "TRAFFIC_OPS_DB",
   "physLocation": "Apachecon North America 2018",

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/servers/030-enroller_server.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/servers/030-enroller_server.json
@@ -3,7 +3,6 @@
   "domainName": "infra.ciab.test",
   "cachegroup": "CDN_in_a_Box_Edge",
   "interfaceName": "eth0",
-  "ipNetmask": "255.255.255.0",
   "interfaceMtu": 1500,
   "type": "ENROLLER",
   "physLocation": "Apachecon North America 2018",


### PR DESCRIPTION
#### What does this PR do?

Since CIAB change to use Dynamic DNS, the netmask will also change.
Therefore, it should be dynamically detect.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other CIAB

#### What is the best way to verify this PR?

Start CIAB
Check the netmask of db, trafficvault, enroller, or dns.
Their netmask should be the real netmask (255.255.240.0)

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



