### PR TITLE
Add Traffic Ops API Test Docker Compose JUnit Output

### DIFF
--- a/infrastructure/cdn-in-a-box/docker-compose.traffic-ops-test.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.traffic-ops-test.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ../..
       dockerfile: infrastructure/cdn-in-a-box/traffic_ops_integration_test/Dockerfile
-    env_file: 
+    env_file:
       - variables.env
     hostname: integration
     domainname: infra.ciab.test
@@ -39,8 +39,9 @@ services:
       - shared:/shared
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
       - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
-
+      - ../../junit:/junit
 volumes:
+  junit:
   shared:
     external: false
  

--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/Dockerfile
@@ -32,6 +32,9 @@ WORKDIR /go/src/github.com/apache/trafficcontrol/traffic_ops/testing/api
 RUN go get -u golang.org/x/net/publicsuffix golang.org/x/crypto/scrypt
 RUN go test -c ./v1* -o traffic_ops_integration_test
 
+RUN go get -u github.com/jstemmer/go-junit-report
+RUN cd /go/src/github.com/jstemmer/go-junit-report && go build
+
 FROM debian:stretch
 RUN apt-get update && apt-get install -y netcat curl dnsutils net-tools vim && apt-get clean
 
@@ -49,6 +52,11 @@ COPY --from=integration-builder \
     /go/src/github.com/apache/trafficcontrol/traffic_ops/testing/api/traffic_ops_integration_test \
     /opt/integration/app/
 
+COPY --from=integration-builder \
+    /go/bin/go-junit-report \
+    /opt/integration/app/
+
+VOLUME ["/junit"]
+
 WORKDIR /opt/integration/app
 CMD ./run.sh
-

--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/config.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/config.sh
@@ -31,11 +31,11 @@ cat <<-EOF >/opt/integration/app/traffic-ops-test.conf
 {
     "default": {
         "logLocations": {
-            "debug": "stdout",
-            "error": "stdout",
-            "event": "stdout",
-            "info": "stdout",
-            "warning": "stdout"
+            "debug": "null",
+            "error": "null",
+            "event": "null",
+            "info": "null",
+            "warning": "null"
         },
         "session": {
             "timeoutInSecs": 60

--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/run.sh
@@ -38,5 +38,4 @@ done
 # if [[ -x ]]; then;./config.sh; done          traffic_ops/run-go.sh
 source config.sh
 
-./traffic_ops_integration_test -cfg=traffic-ops-test.conf
-exit $?
+./traffic_ops_integration_test -test.v -cfg=traffic-ops-test.conf 2>&1 | ./go-junit-report --package-name=golang.test.toapi --set-exit-code > /junit/golang.test.toapi.xml && chmod 777 -R /junit && cat /junit/golang.test.toapi.xml


### PR DESCRIPTION
#### What does this PR do?

Changes Traffic Ops API Test Docker Compose to output JUnit, instead of `go test` output.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



