### PR TITLE
Fix Portal Tests

### DIFF
--- a/traffic_portal/test/end_to_end/CDNs/cdns-spec.js
+++ b/traffic_portal/test/end_to_end/CDNs/cdns-spec.js
@@ -18,10 +18,11 @@
  */
 
 var pd = require('./pageData.js');
+var cfunc = require('../common/commonFunctions.js');
 
 describe('Traffic Portal CDNs Test Suite', function() {
-
 	var pageData = new pd();
+  var commonFunctions = new cfunc();
 	var myNewCDN = 'pTestCDN';
 	var myDomainName = 'ptest.com';
 	var mydnssec = 'true';
@@ -29,25 +30,25 @@ describe('Traffic Portal CDNs Test Suite', function() {
 	it('should go to the CDNs page', function() {
 		console.log("Go to the CDNs page");
 		browser.get(browser.baseUrl + "/#!/cdns");
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/cdns");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/cdns");
 	});
 
     it('should open new CDN form page', function() {
     	console.log("Open new CDN form page");
 		browser.driver.findElement(by.name('createCdnButton')).click();
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/cdns/new");
+			expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/cdns/new");
     });
 
 	it('should fill out form, create button is enabled and submit', function () {
 		console.log("Filling out form, check create button is enabled and submit");
 		expect(pageData.createButton.isEnabled()).toBe(false);
-		pageData.name.sendKeys(myNewCDN);
-		pageData.domainName.sendKeys(myDomainName);
 		pageData.dnssecEnabled.click();
 		pageData.dnssecEnabled.sendKeys(mydnssec);
+		pageData.name.sendKeys(myNewCDN);
+		pageData.domainName.sendKeys(myDomainName);
 		expect(pageData.createButton.isEnabled()).toBe(true);
 		pageData.createButton.click();
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/cdns");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/cdns");
 	});
 
 	it('should verify the new CDN and then update CDN', function() {

--- a/traffic_portal/test/end_to_end/DeliveryServiceRequests/delivery-service-requests-spec.js
+++ b/traffic_portal/test/end_to_end/DeliveryServiceRequests/delivery-service-requests-spec.js
@@ -37,7 +37,7 @@ describe('Traffic Portal Delivery Service Requests', function() {
 	it('should open ds services page and click button to create a new one', function() {
 		console.log('Opening delivery service requests page');
 		browser.get(browser.baseUrl + "/#!/delivery-services");
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/delivery-services");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services");
 	});
 
 	it('should create and select type of ds from the dropdown and confirm', function() {
@@ -54,7 +54,7 @@ describe('Traffic Portal Delivery Service Requests', function() {
 	it('should populate and submit the ds form', function() {
 		console.log('Filling out form for ' + mockVals.xmlId);
 		browser.sleep(250);
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/delivery-services/new?type=" + mockVals.dsType[1]);
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services/new?type=" + mockVals.dsType[1]);
 		expect(pageData.createButton.isEnabled()).toBe(false);
 		pageData.active.click();
 		pageData.active.sendKeys(mockVals.active);
@@ -83,7 +83,7 @@ describe('Traffic Portal Delivery Service Requests', function() {
 
 	it('should redirect to delivery-service-requests page', function() {
 		console.log('Backing out and verifying ' + mockVals.xmlId + ' exists');
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/delivery-service-requests");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-service-requests");
 	});
 
 	it('should open up and update the ds', function() {
@@ -144,6 +144,6 @@ describe('Traffic Portal Delivery Service Requests', function() {
 		pageData.deleteButton.click();
 		pageData.confirmWithNameInput.sendKeys(mockVals.xmlId + ' request');
 		pageData.deletePermanentlyButton.click();
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/delivery-service-requests");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-service-requests");
 	});
 });

--- a/traffic_portal/test/end_to_end/DeliveryServices/delivery-services-spec.js
+++ b/traffic_portal/test/end_to_end/DeliveryServices/delivery-services-spec.js
@@ -36,7 +36,7 @@ describe('Traffic Portal Delivery Services Suite', function() {
 	it('should open ds page and click button to create a new one', function() {
 		console.log('Opening delivery services page');
 		browser.get(browser.baseUrl + "/#!/delivery-services");
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/delivery-services");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services");
 	});
 
 	it('should create and select type of ds from the dropdown and confirm', function() {
@@ -53,7 +53,7 @@ describe('Traffic Portal Delivery Services Suite', function() {
 	it('should populate and submit the ds form', function() {
 		console.log('Filling out form for ' + mockVals.xmlId);
 		browser.sleep(250);
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/delivery-services/new?type=" + mockVals.dsType[1]);
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services/new?type=" + mockVals.dsType[1]);
 		expect(pageData.createButton.isEnabled()).toBe(false);
 		pageData.active.click();
 		pageData.active.sendKeys(mockVals.active);
@@ -73,7 +73,7 @@ describe('Traffic Portal Delivery Services Suite', function() {
 	it('should back out to ds page and verify new ds and update it', function() {
 		console.log('Backing out and verifying ' + mockVals.xmlId + ' exists');
 		browser.get(browser.baseUrl + "/#!/delivery-services");
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/delivery-services");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services");
 
 	});
 
@@ -101,6 +101,6 @@ describe('Traffic Portal Delivery Services Suite', function() {
 		pageData.deleteButton.click();
 		pageData.confirmWithNameInput.sendKeys(mockVals.xmlId);
 		pageData.deletePermanentlyButton.click();
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/delivery-services");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services");
 	});
 });

--- a/traffic_portal/test/end_to_end/Servers/servers-spec.js
+++ b/traffic_portal/test/end_to_end/Servers/servers-spec.js
@@ -38,13 +38,13 @@ describe('Traffic Portal Servers Test Suite', function() {
 	it('should go to the Servers page', function() {
 		console.log('Looading Configure/Servers');
 		browser.get(browser.baseUrl + "/#!/servers");
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/servers");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/servers");
 	});
 
     it('should open new Servers form page', function() {
 		console.log('Clicking on Create new server ' + mockVals.hostName);
 		browser.driver.findElement(by.name('createServersButton')).click();
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/servers/new");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/servers/new");
     });
 
 	it('should fill out form, create button is enabled and submit', function () {
@@ -66,7 +66,7 @@ describe('Traffic Portal Servers Test Suite', function() {
 		commonFunctions.selectDropdownbyNum(pageData.physLocation, 1);
 		expect(pageData.createButton.isEnabled()).toBe(true);
 		pageData.createButton.click();
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/servers");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/servers");
 	});
 
 	it('should verify the new Server and then update Server', function() {

--- a/traffic_portal/test/end_to_end/common/commonFunctions.js
+++ b/traffic_portal/test/end_to_end/common/commonFunctions.js
@@ -27,4 +27,8 @@ module.exports = function() {
 				});
 		}
 	};
+
+	this.urlPath = function ( url ) {
+		return '/' + String(url).split('/').slice(3).join('/');
+	};
 };

--- a/traffic_portal/test/end_to_end/login/login-spec.js
+++ b/traffic_portal/test/end_to_end/login/login-spec.js
@@ -17,7 +17,10 @@
  * under the License.
  */
 
+var cfunc = require('../common/commonFunctions.js');
+
 describe('Traffic Portal Login Test Suite', function() {
+  var commonFunctions = new cfunc();
 
     beforeEach(function() {
         browser.get(browser.baseUrl);
@@ -37,11 +40,11 @@ describe('Traffic Portal Login Test Suite', function() {
     });
 
 	it('should successfully login to Traffic Portal', function() {
-		console.log('Logging in to Traffic Portal');
+		console.log('Logging in to Traffic Portal "' + browser.baseUrl + '" with user "' + browser.params.adminUser + '"');
 		browser.driver.findElement(by.name('loginUsername')).sendKeys(browser.params.adminUser);
 		browser.driver.findElement(by.name('loginPass')).sendKeys(browser.params.adminPassword);
 		browser.driver.findElement(by.name('loginSubmit')).click();
 		browser.debugger();
-		expect(browser.getCurrentUrl()).toEqual(browser.baseUrl+"/#!/");
+		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/");
 	});
 });


### PR DESCRIPTION
Fixes Portal tests for when the port is the default for the scheme
(http 80 or https 443).

Fixes Portal test creating a cdn, to defocus a dropdown. There appears
to be an issue with setting the dropdown last, and not defocusing it
to enable the create button.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



