### PR TITLE
Add CiaB expose-ports.yml, remove default expose

### DIFF
--- a/infrastructure/cdn-in-a-box/README.md
+++ b/infrastructure/cdn-in-a-box/README.md
@@ -154,7 +154,11 @@ show you the default UI for interacting with the CDN - Traffic Portal.
 > </div>
 >
 
+## Host Ports
 
+By default, `docker-compose.yml` does not expose ports to the host. This allows the host to be running other services on those ports, as well as allowing multiple CDN-in-a-Boxes to run on the same host, without port conflicts.
+
+To expose the ports of each service on the host, add the `docker-compose.expose-ports.yml` file. For example, `docker-compose -f docker-compose.yml -f docker-compose.expose-ports.yml up`.
 
 ## Common Pitfalls
 

--- a/infrastructure/cdn-in-a-box/docker-compose.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.expose-ports.yml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This compose file will expose the ports of each service on the host.
+#
+#      docker-compose -f docker-compose.yml -f docker-compose.expose-ports.yml up
+#
+
+---
+version: '2.1'
+
+services:
+  db:
+    ports:
+      - "5432:5432"
+  trafficops:
+    ports:
+      - "6443:443"
+  trafficops-perl:
+    ports:
+      - "60443:443"
+  trafficportal:
+    ports:
+      - "443:443"
+  trafficmonitor:
+    ports:
+      - "80:80"
+  trafficrouter:
+    ports:
+      - "3053:53"
+      - "3080:80"
+      - "3443:443"
+      - "3333:3333"
+  trafficvault:
+    ports:
+      - "8087:8087"
+      - "8098:8098"
+  edge:
+    ports:
+      - "9000:80"
+  mid:
+    ports:
+      - "9100:80"
+  origin:
+    ports:
+      - "9200:80"
+  dns:
+    ports:
+      - "9353:53"

--- a/infrastructure/cdn-in-a-box/docker-compose.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.yml
@@ -50,8 +50,6 @@ services:
     env_file:
       - variables.env
     # TODO: change to expose: "5432" to limit to containers
-    ports:
-      - "5432:5432"
 
   # trafficops runs only the Go version of Traffic Ops in a container.  All Traffic Ops API endpoints that have
   # been rewritten in Go will be handled here.  All that have not are passed to the trafficops-perl service
@@ -69,8 +67,6 @@ services:
       - variables.env
     hostname: trafficops
     image: trafficops-go
-    ports:
-      - "6443:443"
     volumes:
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
       - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
@@ -93,8 +89,6 @@ services:
     hostname: trafficops-perl
     image: trafficops-perl
     # TODO: change to expose: "60443" to limit to containers
-    ports:
-      - "60443:443"
     volumes:
       - ./traffic_ops/ca:/ca
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
@@ -118,8 +112,6 @@ services:
       - variables.env
     hostname: trafficportal
     image: trafficportal
-    ports:
-      - "443:443"
     volumes:
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
       - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
@@ -143,8 +135,6 @@ services:
       - variables.env
     hostname: trafficmonitor
     image: trafficmonitor
-    ports:
-      - "80:80"
 
   # trafficrouter routes clients to the most optimal cache
   trafficrouter:
@@ -160,11 +150,6 @@ services:
     env_file:
       - variables.env
     hostname: trafficrouter
-    ports:
-      - "3053:53"
-      - "3080:80"
-      - "3443:443"
-      - "3333:3333"
     volumes:
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
       - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
@@ -177,9 +162,6 @@ services:
       dockerfile: traffic_vault/Dockerfile
     depends_on:
       - enroller
-    ports:
-      - "8087:8087"
-      - "8098:8098"
     environment:
       - CLUSTER_NAME=trafficvault
     labels:
@@ -215,8 +197,6 @@ services:
     env_file:
       - variables.env
     hostname: edge
-    ports:
-      - "9000:80"
     volumes:
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
       - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
@@ -235,8 +215,6 @@ services:
     env_file:
       - variables.env
     hostname: mid
-    ports:
-      - "9100:80"
     volumes:
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
       - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
@@ -253,8 +231,6 @@ services:
     env_file:
       - variables.env
     hostname: origin
-    ports:
-      - "9200:80"
     volumes:
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
       - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
@@ -290,8 +266,6 @@ services:
       - shared:/shared
     hostname: dns
     domainname: infra.ciab.test
-    ports:
-      - "9353:53"
 
 volumes:
   schemas:

--- a/infrastructure/cdn-in-a-box/optional/README.md
+++ b/infrastructure/cdn-in-a-box/optional/README.md
@@ -19,25 +19,37 @@
 
 ## CDN-In-A-Box Optional Container(s)
 
-Create an alias to utilize these container(s) with the core CDN-In-A-Box stack
+Create an alias to utilize these container(s) with the core CDN-In-A-Box stack. Note, that the exposed port(s) have been moved to an optional docker-compose file to allow for concurrent CiaB instances.
 
 From the top-level directory of `cdn-in-a-box` create the following alias:
 
 ```
-alias mydc='docker-compose -f docker-compose.yml -f optional/docker-compose.$NAME1.yml -f optional/docker-compose.$NAME2.yml'
+alias mydc="docker-compose "` \
+        `"-f $PWD/docker-compose.yml "` \
+        `"-f $PWD/docker-compose.expose-ports.yml "` \
+        `"-f $PWD/optional/docker-compose.$NAME1.yml "` \
+        `"-f $PWD/optional/docker-compose.$NAME1.expose-ports.yml "` \
+        `"-f $PWD/optional/docker-compose.$NAME2.yml "` \
+        `"-f $PWD/optional/docker-compose.$NAME2.expose-ports.yml "
 ```
 
-For example, to use the vnc optional container, use the following alias:
+For example, to add the socksproxy and vnc optional container(s), use the following alias:
 
 
 ```
-alias mydc='docker-compose -f docker-compose.yml -f optional/docker-compose.vnc.yml'
-
+alias mydc="docker-compose "` \
+        `"-f $PWD/docker-compose.yml "` \
+        `"-f $PWD/docker-compose.expose-ports.yml "` \
+        `"-f $PWD/optional/docker-compose.socksproxy.yml "` \
+        `"-f $PWD/optional/docker-compose.socksproxy.expose-ports.yml "` \
+        `"-f $PWD/optional/docker-compose.vnc.yml "` \
+        `"-f $PWD/optional/docker-compose.vnc.expose-ports.yml "
 ```
 
 To start the CDN-In-A-Box stack:
 
 ```
 mydc build
+mydc rm -fv
 mydc up
 ```

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.socksproxy.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.socksproxy.expose-ports.yml
@@ -14,21 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# To use this compose you should first build Traffic Ops and then copy the RPM to :
 #
-# trafficcontrol/infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
+# Expose the SocksProxy container on the host on port 9080
 #
-#      cd trafficcontrol/infrastructure/cdn-in-a-box
+# From ./infrastructure/cdn-in-a-box
 #
-# Add six character password variable, VNC_PASSWD, to the settings in `variables.env`.
-#
-# To start up CiaB with VNC optional container:
-# 
 # alias mydc="docker-compose "` \
 #   `"-f $PWD/docker-compose.yml "` \
 #   `"-f $PWD/docker-compose.expose-ports.yml "` \
 #   `"-f $PWD/optional/docker-compose.socksproxy.yml "` \
-#   `"-f $PWD/optional/docker-compose.socksproxy.expose-ports.yml "
+#   `"-f $PWD/optional/docker-compose.socksproxy.expose-ports.yml"
 #
 # mydc rm -fv
 # mydc up
@@ -39,24 +34,6 @@
 version: '2.1'
 
 services:
-  # Optional Socks Proxy for docker hosts that have limited bridge/ipforwarding support.
   socksproxy:
-    build:
-      context: .
-      dockerfile: optional/socksproxy/Dockerfile
-    hostname: socksproxy
-    domainname: infra.ciab.test
-    volumes:
-      - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
-      - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
-      - shared:/shared
-    
-volumes:
-  schemas:
-    external: false
-  shared:
-    external: false
-  content:
-    external: false
-  ca:
-    external: false
+    ports:
+      - "9080:1080"

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.expose-ports.yml
@@ -14,21 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# To use this compose you should first build Traffic Ops and then copy the RPM to :
 #
-# trafficcontrol/infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
+# Expose the VNC container on the host on port 5909
 #
-#      cd trafficcontrol/infrastructure/cdn-in-a-box
+# From ./infrastructure/cdn-in-a-box
 #
-# Add six character password variable, VNC_PASSWD, to the settings in `variables.env`.
-#
-# To start up CiaB with VNC optional container:
-# 
 # alias mydc="docker-compose "` \
 #   `"-f $PWD/docker-compose.yml "` \
 #   `"-f $PWD/docker-compose.expose-ports.yml "` \
-#   `"-f $PWD/optional/docker-compose.socksproxy.yml "` \
-#   `"-f $PWD/optional/docker-compose.socksproxy.expose-ports.yml "
+#   `"-f $PWD/optional/docker-compose.vnc.yml "` \
+#   `"-f $PWD/optional/docker-compose.vnc.expose-ports.yml"
 #
 # mydc rm -fv
 # mydc up
@@ -39,24 +34,6 @@
 version: '2.1'
 
 services:
-  # Optional Socks Proxy for docker hosts that have limited bridge/ipforwarding support.
-  socksproxy:
-    build:
-      context: .
-      dockerfile: optional/socksproxy/Dockerfile
-    hostname: socksproxy
-    domainname: infra.ciab.test
-    volumes:
-      - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
-      - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
-      - shared:/shared
-    
-volumes:
-  schemas:
-    external: false
-  shared:
-    external: false
-  content:
-    external: false
-  ca:
-    external: false
+  vnc:
+    ports:
+      - "5909:5909"

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.yml
@@ -21,15 +21,21 @@
 #
 #      cd trafficcontrol/infrastructure/cdn-in-a-box
 #
-# Adjust the settings in `variables.env` to suit your needs.
+# Add six character password variable, VNC_PASSWD, to the settings in `variables.env`.
 #
-#      docker-compose up -d
+# To start up CiaB with VNC optional container:
+# 
+# alias mydc="docker-compose "` \
+#   `"-f $PWD/docker-compose.yml "` \
+#   `"-f $PWD/docker-compose.expose-ports.yml "` \
+#   `"-f $PWD/optional/docker-compose.vnc.yml "` \
+#   `"-f $PWD/optional/docker-compose.vnc.expose-ports.yml "
 #
-# The Traffic Ops Go API will then be available on https://localhost:6443,
-# the Perl API on https://localhost:60443, and the postgres database on localhost 5432.
+# mydc rm -fv
+# mydc up
 #
 # Note that this setup is intended for testing and not for production use.
-
+#
 ---
 version: '2.1'
 
@@ -53,8 +59,6 @@ services:
       - variables.env
     hostname: vnc
     domainname: infra.ciab.test
-    ports:
-      - "5909:5909"
     volumes:
       - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
       - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh


### PR DESCRIPTION
Adds a separate docker-compose yml file to expose service ports,
and removes exposing ports from the default docker-compose.yml.

This allows multiple CiaB to run on the same host, as well as allowing
running a CiaB on a host already using a port, while allowing the
old behavior of exposing by chaining composes, via:

docker-compose -f docker-compose.yml -f docker-compose.expose-ports.yml up

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other CiaB

#### What is the best way to verify this PR?

Verify `docker-compose -f docker-compose.yml -f docker-compose.expose-ports.yml up` emulates old behavior, CiaB comes up, .`https://localhost` is served on the host.

Verify `docker-compose -f docker-compose.yml up` brings up a CiaB and `docker exec -it cdn-in-a-box_trafficvault_1 curl -Lvsk http://video.demo1.mycdn.ciab.test` returns the web page as expected, but `https://localhost` is not served on the host.

#### Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



