### PR TITLE
ORT.py now has a REVALIDATE mode that's totally compatible with the Perl version

### DIFF
--- a/docs/source/development/ort/traffic_ops_ort.rst
+++ b/docs/source/development/ort/traffic_ops_ort.rst
@@ -13,24 +13,20 @@
 .. limitations under the License.
 ..
 
+*************************
 traffic\_ops\_ort package
-=========================
+*************************
+.. automodule:: traffic_ops_ort
+	:members:
+	:undoc-members:
+	:show-inheritance:
 
 Submodules
 ----------
-
 .. toctree::
 
-   traffic_ops_ort.configuration
-   traffic_ops_ort.main_routines
-   traffic_ops_ort.packaging
-   traffic_ops_ort.to_api
-   traffic_ops_ort.utils
-
-Module contents
----------------
-
-.. automodule:: traffic_ops_ort
-    :members:
-    :undoc-members:
-    :show-inheritance:
+	traffic_ops_ort.configuration
+	traffic_ops_ort.main_routines
+	traffic_ops_ort.packaging
+	traffic_ops_ort.to_api
+	traffic_ops_ort.utils

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -21,6 +21,144 @@ Readiness Test - which was originally written in a single, chickenscratch
 Perl script. When the :func:`main` function is run, it acts (more or less)
 exactly like that legacy script, with the ability to set system configuration
 files and start, stop, and restart HTTP cache servers etc.
+
+.. program:: traffic_ops_ort
+
+This package provides an executable script named :program:`traffic_ops_ort`
+
+Usage
+=====
+``traffic_ops_ort [-k] [--dispersion DISP] [--login_dispersion DISP] [--retries RETRIES] [--wait_for_parents] [--rev_proxy_disabled] [--ts-root PATH] MODE LOG_LEVEL TO_URL LOGIN``
+
+``traffic_ops_ort [-v]``
+
+``traffic_ops_ort [-h]``
+
+.. option:: -h, --help
+
+	Print usage information and exit
+
+.. option:: -v, --version
+
+	Print version information and exit
+
+.. option:: -k, --insecure
+
+	An optional flag which, when used, disables the checking of SSL certificates for validity
+
+.. option:: --dispersion DISP
+
+	Wait a random number between 0 and ``DISP`` seconds before starting. (Default: 300)
+
+	.. caution:: This option is not implemented yet; it has no effect and even the default is not
+		used.
+
+.. option:: --login_dispersion DISP
+
+	Wait a random number between 0 and ``DISP`` seconds before authenticating with Traffic Ops.
+	(Default: 0)
+
+	.. caution:: This option is not implemented yet; it has no effect.
+
+.. option:: --retries RETRIES
+
+	If connection to Traffic Ops fails, retry ``RETRIES`` times before giving up (Default: 3).
+
+	.. caution:: This option is not implemented yet; it has no effect and even the default is not
+		used.
+
+.. option:: --wait_for_parents
+
+	Do not apply updates if parents of this server have pending updates.
+
+	.. caution:: This option is not implemented yet; it has no effect and currently the default
+		behavior is to wait for parents regardless of the presence - or lack thereof - of this option
+
+.. option:: --rev_prox_disabled
+
+	Make requests directly to the Traffic Ops server, bypassing a reverse proxy if one exists.
+
+	.. caution:: This option is not implemented yet; :mod:`traffic_ops_ort` will make requests
+		directly to the provided :option:`TO_URL`
+
+.. option:: --ts_root PATH
+
+	An optional flag which, if present, specifies the absolute path to the install directory of
+	Apache Traffic Server. A common alternative to the default is ``/opt/trafficserver``.
+	(Default: ``/``)
+
+.. option:: MODE
+
+	Specifies :program:`traffic_ops_ort`'s mode of operation. Must be one of:
+
+	REPORT
+		Runs as though the mode was BADASS, but doesn't actually change anything on the system.
+
+		.. tip:: This is normally useful with a verbose :option:`LOG_LEVEL` to check the state of
+			the system
+
+	INTERACTIVE
+		Runs as though the mode was BADASS, but asks the user for confirmation before making changes
+	REVALIDATE
+		Will not restart Apache Traffic Server, install packages, or enable/disable system services
+		and will exit immediately if this server does not have revalidations pending. Otherwise, the
+		same as BADASS.
+	SYNCDS
+		Will not restart Apache Traffic Server, and will exit immediately if this server does not
+		have updates pending. Otherwise, the same as BADASS
+	BADASS
+		Applies all pending configuration in Traffic Ops, and attempts to solve encountered problems
+		when possible. This will install packages, enable/disable system services, and will start or
+		restart Apache Traffic Server as necessary.
+
+.. option:: LOG_LEVEL
+
+	Sets the verbosity of output provided by :program:`traffic_ops_ort`. Must be one of:
+
+	NONE
+		Will output nothing, not even fatal errors.
+	CRITICAL
+		Will only output error messages that indicate an unrecoverable error.
+	FATAL
+		A synonym for "CRITICAL"
+	ERROR
+		Will output more general errors about conditions that are causing problems of some kind.
+	WARN
+		In addition to error information, will output warnings about conditions that may cause
+		problems, or possible misconfiguration.
+	INFO
+		Outputs informational messages about what :program:`traffic_ops_ort` is doing as it
+		progresses.
+	DEBUG
+		Outputs detailed debug information, including stack traces.
+
+		.. note:: Not all stack traces indicate problems with :program:`traffic_ops_ort`. Stack
+			traces are printed whenever an exception is encountered, whether or not it could be
+			handled.
+
+	TRACE
+		A synonym for "DEBUG"
+	ALL
+		A synonym for "DEBUG"
+
+	.. note:: All logging is sent to STDERR. INTERACTIVE :option:`MODE` prompts are printed to STDOUT
+
+.. option:: TO_URL
+
+	This must be the full URL that refers to the Traffic Ops server, including schema and port
+	number (if needed). E.g. ``https://trafficops.infra.ciab.test:443``.
+
+.. option:: LOGIN
+
+	The information used to authenticate with Traffic Ops. This must consist of a username and a
+	password, delimited by a colon (``:``). E.g. ``admin:twelve``.
+
+	.. warning:: The first colon found in this string is considered the delimiter. There is no way
+		to escape the delimeter. This effectively means that usernames containing colons cannot be
+		used to authenticate with Traffic Ops, though passwords containing colons should be fine.
+
+Module Contents
+===============
 """
 
 __version__ = "0.0.4"
@@ -120,8 +258,7 @@ def main():
 	                    action="store_true")
 	parser.add_argument("--rev_proxy_disabled",
 	                    help="bypass the reverse proxy even if one has been configured.",
-	                    type=int,
-	                    default=0)
+	                    action="store_true")
 	parser.add_argument("--ts_root",
 	                    help="Specify the root directory at which Apache Traffic Server is installed"\
 	                         " (e.g. '/opt/trafficserver')",

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/config_files.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/config_files.py
@@ -249,8 +249,8 @@ class ConfigFile():
 			r = api.get_cdn_ssl_keys(cdn_name=cdn)
 
 			if r[1].status_code != 200 and r[1].status_code != 204:
-				raise ValueError("Bad response code: %d - raw response: %s",
-				                               r[1].status_code,    r[1].text)
+				raise ValueError("Bad response code: %d - raw response: %s" %
+				                               (r[1].status_code,    r[1].text))
 		except (OperationError, InvalidJSONError, ValueError) as e:
 			logging.error("Invalid values encountered when communicating with Traffic Ops!")
 			logging.debug("%r", e, stack_info=True, exc_info=True)

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
@@ -363,8 +363,8 @@ def run() -> int:
 	logging.info("Done.\n")
 
 	if updateRequired:
-		if configuration.MODE is not configuration.Modes.INTERACTIVE or\
-		   utils.getYesNoResponse("Update Traffic Ops?", default='Y'):
+		if (configuration.MODE is not configuration.Modes.INTERACTIVE or
+		   utils.getYesNoResponse("Update Traffic Ops?", default='Y')):
 
 			logging.info("\nUpdating Traffic Ops...")
 			api.updateTrafficOps()
@@ -372,9 +372,8 @@ def run() -> int:
 		else:
 			logging.warning("Traffic Ops was not notified of changes. You should do this manually.")
 
-		return 0
-
-	logging.info("Traffic Ops update not necessary")
+	else:
+		logging.info("Traffic Ops update not necessary")
 
 	if services.NEEDED_RELOADS and not services.doReloads():
 		logging.critical("Failed to reload all configuration changes")

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -121,7 +121,11 @@ class API(TOSession):
 		from . import configuration
 
 		logging.info("Fetching list of configuration files from Traffic Ops")
+
+		# The API function decorator confuses pylint into thinking this doesn't return
+		#pylint: disable=E1111
 		myFiles = self.get_server_config_files(host_name=self.hostname)
+		#pylint: enable=E1111
 
 		logging.debug("Raw response from Traffic Ops: %s", myFiles[1].text)
 		myFiles = myFiles[0]
@@ -199,7 +203,10 @@ class API(TOSession):
 		if host in self.CACHED_UPDATE_STATUS:
 			return self.CACHED_UPDATE_STATUS[host]
 
+		# The API function decorator confuses pylint into thinking this doesn't return
+		#pylint: disable=E1111
 		r = self.get_server_update_status(server_name=host)
+		#pylint: enable=E1111
 		logging.debug("Raw response from Traffic Ops: %s", r[1].text)
 
 		self.CACHED_UPDATE_STATUS[host] = r[0]
@@ -222,7 +229,10 @@ class API(TOSession):
 
 		logging.info("Fetching server status from Traffic Ops")
 
+		# The API function decorator confuses pylint into thinking this doesn't return
+		#pylint: disable=E1111
 		r = self.get_servers(query_params={"hostName": self.hostname})
+		#pylint: enable=E1111
 
 		logging.debug("Raw response from Traffic Ops: %s", r[1].text)
 


### PR DESCRIPTION
## What does this PR do?
Fixes some minor issues with REVALIDATE mode. Also adds some usage documentation to the package.

## Which TC components are affected by this PR?

- [x] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [x] Traffic Ops ORT (Python)
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR?
The easiest way is probably to just start up a CDN-in-a-Box and make sure everything's working fine. Then submit an invalidation request, wait a couple minutes, and make sure the configuration has changed as a appropriate.

To be totally sure, you'd probably need to check out the actual code paths to be sure REVALIDATE does what it says it does (and be sure that what it says it does is what it's supposed to do).

## Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)