### PR TITLE
fixed minor issue preventing package installation in Python2

### DIFF
--- a/docs/source/tools/python_client.rst
+++ b/docs/source/tools/python_client.rst
@@ -22,27 +22,16 @@ Apache-TrafficControl Package
 Package Contents
 ================
 .. automodule:: trafficops
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-TOSession
----------
-.. automodule:: trafficops.tosession
 	:members:
 	:undoc-members:
 	:show-inheritance:
 
-RestAPI
--------
-.. automodule:: trafficops.restapi
-	:members:
-	:undoc-members:
-	:show-inheritance:
-
-Utils
------
 .. automodule:: trafficops.utils
+	:members:
+	:undoc-members:
+	:show-inheritance:
+
+.. automodule:: trafficops.__version__
 	:members:
 	:undoc-members:
 	:show-inheritance:

--- a/traffic_control/clients/python/README.rst
+++ b/traffic_control/clients/python/README.rst
@@ -5,7 +5,7 @@ This is the Traffic Ops Python Client for Python 2.x and Python 3.x.
 
 .. attention:: Traffic Control version 3.0.0 officially deprecates Python 2.x support. Starting with Traffic Control version 4.0.0, Python 2.x support will be dropped, and only Python 3.x will be supported. Users and developers are encouraged to switch to Python 3 as soon as possible.
 
-.. note:: This client has only been tested against Python 2.7 and Python 3.6. Other versions may or may not work.
+.. note:: This client has only been tested against Python 2.7, 3.4, and 3.6. Other versions may or may not work.
 
 Installation
 ============
@@ -62,6 +62,8 @@ The local installation method requires ``pip`` and ``setuptools``. ``setuptools`
 Development Dependencies
 ------------------------
 To install the development dependencies, first ensure that your system has ``pip`` and ``setuptools`` then use ``pip`` to install the development environment.
+
+.. note:: Currently, the development environment only "requires" `Pylint <https://www.pylint.org/>`_, which is a simple linter for which a configuration file is provided at :file:`traffic_control/clients/python/pylint.rc`. This linter might be nice to catch common mistakes, but is in no way enforced by the project at this time. Once Python2 support is dropped with the release of the Apache-TrafficControl package 2.0, it will hopefully be refined and put to use. In the meantime, feel free to use it - or not.
 
 .. code-block:: shell
 	:caption: Development Dependencies Installation

--- a/traffic_control/clients/python/setup.py
+++ b/traffic_control/clients/python/setup.py
@@ -37,7 +37,7 @@ with open(os.path.join(HERE, "README.rst")) as fd:
 	       author="Apache Software Foundation",
 	       author_email="dev@trafficcontrol.apache.org",
 	       description="Python API Client for Traffic Control",
-	       long_description=fd.read(),
+	       long_description='\n'.join((fd.read(), about["__doc__"])),
 	       url="http://trafficcontrol.apache.org/",
 	       license="http://www.apache.org/licenses/LICENSE-2.0",
 	       classifiers=[
@@ -48,6 +48,8 @@ with open(os.path.join(HERE, "README.rst")) as fd:
 	           'Operating System :: OS Independent',
 	           'Programming Language :: Python :: 2.7',
 	           'Programming Language :: Python :: 3',
+	           'Programming Language :: Python :: 3.4',
+	           'Programming Language :: Python :: 3.5',
 	           'Programming Language :: Python :: 3.6',
 	           'Programming Language :: Python :: 3.7',
 	           'Programming Language :: Python :: 3.8',
@@ -64,13 +66,20 @@ with open(os.path.join(HERE, "README.rst")) as fd:
 	       ],
 	       extras_require={
 	           "dev": [
-	               "pylint"
+	               "pylint>=2.0,<3.0"
 	           ]
-	       }
+	       },
+	       # This will only be enforced by pip versions >=9.0 (18.1 being current at the time of
+	       # this writing) - i.e. not the pip installed as python34-pip from elrepo on CentOS
+	       python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
 	)
 
-if ((sys.version_info[0] == 2 and sys.version_info < (2, 7))
-   or (sys.version_info[0] == 3 and sys.version_info < (3, 6))):
-	MSG = ('WARNING: This library may not work properly with Python {0}, '
-		   'as it is untested for this version.')
-	print(MSG.format(sys.version.split(' ', 1)[0]))
+pyversion = sys.version_info
+if pyversion.major < 3:
+	sys.stderr.write(
+		"Python 2 is deprecated, and will not be supported in version 2 of this package (by 2020)\n"
+	)
+elif pyversion.major == 3 and (pyversion.minor < 4 or pyversion.minor > 6):
+	MSG = ('WARNING: This library may not work properly with Python {0.major}.{0.minor}.{0.micro}, '
+	       'as it is untested for this version. (3.4 <= version <=3.6 recommended)\n')
+	sys.stderr.write(MSG.format(pyversion))

--- a/traffic_control/clients/python/setup.py
+++ b/traffic_control/clients/python/setup.py
@@ -19,14 +19,15 @@
 Setuptools build/install script for the Python Traffic Control client
 """
 
-import sys
+import io
 import os
+import sys
 from setuptools import setup, find_packages
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 about = {}
-with open(os.path.join(HERE, 'trafficops', '__version__.py'), mode='r', encoding='utf-8') as f:
+with io.open(os.path.join(HERE, 'trafficops', '__version__.py'), mode='r', encoding='utf-8') as f:
 	exec(f.read(), about)
 
 with open(os.path.join(HERE, "README.rst")) as fd:

--- a/traffic_control/clients/python/trafficops/__version__.py
+++ b/traffic_control/clients/python/trafficops/__version__.py
@@ -18,13 +18,13 @@ Versioning
 The :mod:`trafficops.__version__` module contains only the :data:`__version__` "constant" which
 gives the version of this *Apache-TrafficControl package* and **not** the version of
 *Apache Traffic Control* for which it was made. The two are versioned separately, to allow the
-client to grow in a version-controlled manner despite the relatively slow release cadence of Apache
+client to grow in a version-controlled manner without being tied to the release cadence of Apache
 Traffic Control as a whole.
 
-We guarantee version 1.0 will work (in general) with Apache Traffic Control version 3.0 (release
-pending at the time of this writing). New functionality will be added as the :ref:`to-api` evolves,
-but changes to this client will remain non-breaking for existing code using it until the next major
-version is released.
+Version 1.0 is supported for use with Apache Traffic Control version 3.0 (release pending at the
+time of this writing). New functionality will be added as the :ref:`to-api` evolves, but changes to
+this client will remain non-breaking for existing code using it until the next major version is
+released.
 
 .. deprecated:: 1.0
 	The v1.0 release of this client deprecates support of Python2. Versions 2.0 and onward will

--- a/traffic_control/clients/python/trafficops/__version__.py
+++ b/traffic_control/clients/python/trafficops/__version__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,4 +12,4 @@
 # limitations under the License.
 #
 
-__version__ = '1.1.1'
+__version__ = '1.1.1-1'

--- a/traffic_control/clients/python/trafficops/__version__.py
+++ b/traffic_control/clients/python/trafficops/__version__.py
@@ -12,4 +12,26 @@
 # limitations under the License.
 #
 
-__version__ = '1.1.1-1'
+"""
+Versioning
+==========
+The :mod:`trafficops.__version__` module contains only the :data:`__version__` "constant" which
+gives the version of this *Apache-TrafficControl package* and **not** the version of
+*Apache Traffic Control* for which it was made. The two are versioned separately, to allow the
+client to grow in a version-controlled manner despite the relatively slow release cadence of Apache
+Traffic Control as a whole.
+
+We guarantee version 1.0 will work (in general) with Apache Traffic Control version 3.0 (release
+pending at the time of this writing). New functionality will be added as the :ref:`to-api` evolves,
+but changes to this client will remain non-breaking for existing code using it until the next major
+version is released.
+
+.. deprecated:: 1.0
+	The v1.0 release of this client deprecates support of Python2. Versions 2.0 and onward will
+	*only* support Python3 (v3.4+). Note that this release is expected either by the time Python2
+	reaches its end-of-life at the end of 2019, or with the release of Apache Traffic Control v4.0,
+	should that happen first. Users and developers are encouraged to switch to Python3 as soon as
+	possible.
+"""
+
+__version__ = '1.1.2'

--- a/traffic_control/clients/python/trafficops/utils.py
+++ b/traffic_control/clients/python/trafficops/utils.py
@@ -15,6 +15,8 @@
 #
 
 """
+utils
+=====
 Useful utility methods
 """
 


### PR DESCRIPTION
## What does this PR do?
Fixes an issue with the Python client `setup.py` not being Python2-compatible - related to getting the version number out of `__version__.py`.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] ATC Python client

## What is the best way to verify this PR?
Try to build/install the package for Python versions 2.7 and 3.4+ (I know the docs say we only support 3.6+, but 3.4 is the newest version available from elrepo so I think we ought to maintain compatibility with it)

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)