### PR TITLE
Fix Traffic Ops CDN DNSSEC generation when no delivery services exist

### DIFF
--- a/traffic_ops/traffic_ops_golang/cdn/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssec.go
@@ -259,7 +259,7 @@ type CDNDS struct {
 // getCDNDeliveryServices returns basic data for the delivery services on the given CDN, as well as the CDN name, or any error.
 func GetCDNDeliveryServices(tx *sql.Tx, cdn string) ([]CDNDS, error) {
 	q := `
-SELECT ds.xml_id, ds.protocol, t.name as type, ds.routing_name, cdn.domain_name as cdn_domain
+SELECT ds.xml_id, ds.protocol, t.name as type, ds.routing_name
 FROM deliveryservice as ds
 JOIN cdn ON ds.cdn_id = cdn.id
 JOIN type as t ON ds.type = t.id


### PR DESCRIPTION
Fixes an edge case of generating DNSSEC keys on a CDN when no delivery
services exist on that CDN (for example, if generating immediately
after creating the CDN). The edge case caused keys to be generated
with no domain name.

API Tests don't support Riak yet.

Manually tested, verified DNSSEC generation on a new CDN with no DSes works, and generates keys with the CDN's domain. Tested that DNSSEC generation and regeneration on a CDN with DSes still works.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Create a new CDN and generate DNSSEC keys. Verify the keys at `/api/1.2/cdns/name/your-new-cdn-name/dnsseckeys` have `name` of the cdn's domain name, and not `.`.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



