### PR TITLE
Return a JSON response with a 200 for successful PUT snapshot

### DIFF
--- a/traffic_ops/traffic_ops_golang/crconfig/handler.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/handler.go
@@ -164,7 +164,7 @@ func SnapshotHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	api.CreateChangeLogRawTx(api.ApiChange, "Snapshot of CRConfig and Monitor performed for "+cdn, inf.User, inf.Tx.Tx)
-	w.WriteHeader(http.StatusOK) // TODO change to 204 No Content in new version
+	api.WriteResp(w, r, "SUCCESS")
 }
 
 // SnapshotGUIHandler creates the CRConfig JSON and writes it to the snapshot table in the database. The response emulates the old Perl UI function. This should go away when the old Perl UI ceases to exist.


### PR DESCRIPTION
This fixes the deviation from the Perl implementation which returned a
JSON response, fixing any clients that are currently broken due to
expecting a JSON response from this endpoint (e.g. the Python TO
client).

Fixes #3276.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?

Run the TO API tests which exercise this endpoint.

The Golang TO client doesn't decode a response from this endpoint, so I couldn't include a test that verified the JSON response without adding a new method to the Golang TO client. I don't think we should really add a new method for this, because it doesn't return any useful information anyways and should likely just be a `204` in the 2.0 API.

To verify the actual JSON response, you can try using the `TOSession.snapshot_crconfig(cdn_name="foo")` method in the Python TO client and verify that it works, or just curl /api/1.2/snapshot/<cdn_name> and verify the JSON response.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



