### PR TITLE
ORT.py now implements all the same command line flags as the Perl script

### DIFF
--- a/infrastructure/cdn-in-a-box/edge/run.sh
+++ b/infrastructure/cdn-in-a-box/edge/run.sh
@@ -66,7 +66,7 @@ while [[ -z "$(testenrolled)" ]]; do
 done
 
 # Wait for SSL keys to exist
-until to-get "api/1.3/cdns/name/$CDN/sslkeys"; do
+until to-get "api/1.3/cdns/name/$CDN/sslkeys" && [[ "$(to-get api/1.3/cdns/name/$CDN/sslkeys)" != '{"response":[]}' ]]; do
 	echo 'waiting for SSL keys to exist'
 	sleep 3
 done

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-*/1 * * * * /usr/bin/traffic_ops_ort -k SYNCDS ALL https://$TO_FQDN $TO_ADMIN_USER:$TO_ADMIN_PASSWORD >> /var/log/ort.log 2>> /var/log/ort.log
+*/1 * * * * /usr/bin/traffic_ops_ort -k --dispersion 0 SYNCDS ALL https://$TO_FQDN $TO_ADMIN_USER:$TO_ADMIN_PASSWORD >> /var/log/ort.log 2>> /var/log/ort.log

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/config_files.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/config_files.py
@@ -27,7 +27,11 @@ import typing
 
 from base64 import b64decode
 
-from trafficops.restapi import OperationError, InvalidJSONError
+from trafficops.restapi import OperationError, InvalidJSONError, LoginError
+
+from .configuration import Configuration
+from .utils import getYesNoResponse as getYN
+
 
 #: Holds a set of service names that need reloaded configs, mapped to a boolean which indicates
 #: whether (:const:`True`) or not (:const:`False`) a full restart is required.
@@ -56,36 +60,37 @@ class ConfigFile():
 	contents = "" #: The full contents of the file - as configured in TO, not the on-disk contents
 	sanitizedContents = "" #: Will store the contents after sanitization
 
-	def __init__(self, raw:dict = None):
+	def __init__(self, raw:dict = None, toURL:str = "", tsroot:str = "/"):
 		"""
 		Constructs a :class:`ConfigFile` object from a raw API response
 
 		:param raw: A raw config file from an API response
+		:param toURL: The URL of a valid Traffic Ops host
+		:param tsroot: The absolute path to the root of an Apache Traffic Server installation
 		:raises ValueError: if ``raw`` does not faithfully represent a configuration file
 
-		>>> ConfigFile({"fnameOnDisk": "test",
-		...             "location": "/path/to",
-		...             "apiURI": "http://test",
-		...             "scope": "servers"}))
-		ConfigFile(path='/path/to/test', URI='http://test', scope='servers')
+		>>> a = ConfigFile({"fnameOnDisk": "test",
+		...                 "location": "/path/to",
+		...                 "apiURI":"/test",
+		...                 "scope": servers}, "http://example.com/")
+		>>> a
+		ConfigFile(path='/path/to/test', URI='http://example.com/test', scope='servers')
+		>>> a.SSLdir
+		"/etc/trafficserver/ssl"
 		"""
-		# TODO: pass these in as parameters? Configuration object?
-		from .configuration import TO_HOST, TO_PORT, TO_USE_SSL, TS_ROOT
-
 		if raw is not None:
 			try:
 				self.fname = raw["fnameOnDisk"]
 				self.location = raw["location"]
 				if "apiUri" in raw:
-					self.URI = "https://" if TO_USE_SSL else "http://"
-					self.URI = "%s%s:%d/%s" % (self.URI, TO_HOST, TO_PORT, raw["apiUri"].lstrip('/'))
+					self.URI = toURL + raw["apiUri"].lstrip('/')
 				else:
 					self.URI = raw["url"]
 				self.scope = raw["scope"]
 			except (KeyError, TypeError, IndexError) as e:
 				raise ValueError from e
 
-		self.SSLdir = os.path.join(TS_ROOT, "etc", "trafficserver", "ssl")
+		self.SSLdir = os.path.join(tsroot, "etc", "trafficserver", "ssl")
 
 	def __repr__(self) -> str:
 		"""
@@ -94,8 +99,8 @@ class ConfigFile():
 		>>> repr(ConfigFile({"fnameOnDisk": "test",
 		...                  "location": "/path/to",
 		...                  "apiURI": "http://test",
-		...                  "scope": "servers"}))
-		"ConfigFile(path='/path/to/test', URI='http://test', scope='servers')"
+		...                  "scope": "servers"}, "http://example.com/"))
+		"ConfigFile(path='/path/to/test', URI='http://example.com/test', scope='servers')"
 		"""
 		return "ConfigFile(path=%r, URI=%r, scope=%r)" %\
 		          (self.path, self.URI if self.URI else None, self.scope)
@@ -127,53 +132,49 @@ class ConfigFile():
 
 		logging.info("fetched")
 
-	def backup(self, contents:str):
+	def backup(self, contents:str, mode:Configuration.Modes):
 		"""
 		Creates a backup of this file under the :data:`BACKUP_DIR` directory
 
 		:param contents: The actual, on-disk contents from the original file
+		:param mode: The current run-mode of :program:`traffic_ops_ort`
 		:raises OSError: if the backup directory does not exist, or a backup of this file
 			could not be written into it.
 		"""
-		from .configuration import MODE, Modes
-		from .utils import getYesNoResponse
-
 		backupfile = os.path.join(BACKUP_DIR, self.fname)
 		willClobber = False
 		if os.path.isfile(backupfile):
 			willClobber = True
 
-		if MODE is Modes.INTERACTIVE:
+		if mode is Configuration.Modes.INTERACTIVE:
 			prmpt = ("Write backup file %s%%s?" % backupfile)
 			prmpt %= " - will clobber existing file by the same name - " if willClobber else ''
-			if not getYesNoResponse(prmpt, default='Y'):
+			if not getYN(prmpt, default='Y'):
 				return
 
 		elif willClobber:
 			logging.warning("Clobbering existing backup file '%s'!", backupfile)
 
-		if MODE is not Modes.REPORT:
+		if mode is not Configuration.Modes.REPORT:
 			with open(backupfile, 'w') as fp:
 				fp.write(contents)
 
 		logging.info("Backup File written")
 
 
-	def update(self, api:'to_api.API', cdn:str):
+	def update(self, conf:Configuration) -> bool:
 		"""
 		Updates the file if required, backing up as necessary
 
-		:param api: A valid, authenticated API session for use when interacting with Traffic Ops
-		:param cdn: The name of the CDN to which this server belongs (needed for SSL keys)
+		:param conf: An object that represents the configuration of :program:`traffic_ops_ort`
+		:returns: whether or not the file on disk actually changed
 		:raises OSError: when reading/writing files fails for some reason
 		"""
-		from . import utils
-		from .configuration import MODE, Modes, SERVER_INFO
 		from .services import NEEDED_RELOADS, FILES_THAT_REQUIRE_RELOADS
 
 		if not self.contents:
-			self.fetchContents(api)
-			finalContents = sanitizeContents(self.contents)
+			self.fetchContents(conf.api)
+			finalContents = sanitizeContents(self.contents, conf)
 		else:
 			finalContents = self.contents
 
@@ -184,83 +185,91 @@ class ConfigFile():
 		self.sanitizedContents = finalContents
 
 		if not os.path.isdir(self.location):
-			if MODE is Modes.INTERACTIVE and\
-			   not utils.getYesNoResponse("Create configuration directory %s?" % self.path, 'Y'):
+			if (conf.mode is Configuration.Modes.INTERACTIVE and
+			    not getYN("Create configuration directory %s?" % self.path, 'Y')):
 				logging.warning("%s will not be created - some services may not work properly!",
 				                self.path)
-				return
+				return False
 
 			logging.info("Directory %s will be created", self.location)
 			logging.info("File %s will be created", self.path)
 
-			if MODE is not Modes.REPORT:
+			if conf.mode is not Configuration.Modes.REPORT:
 				os.makedirs(self.location)
 				with open(self.path, 'x') as fp:
 					fp.write(finalContents)
-				return
+			return True
 
 		if not os.path.isfile(self.path):
-			if MODE is Modes.INTERACTIVE and\
-			   not utils.getYesNoResponse("Create configuration file %s?"%self.path, default='Y'):
+			if (conf.mode is Configuration.Modes.INTERACTIVE and\
+			    not getYN("Create configuration file %s?"%self.path, default='Y')):
 				logging.warning("%s will not be created - some services may not work properly!",
 				                self.path)
-				return
+				return False
 
 			logging.info("File %s will be created", self.path)
 
-			if MODE is not Modes.REPORT:
+			if conf.mode is not Configuration.Modes.REPORT:
 				with open(self.path, 'x') as fp:
 					fp.write(finalContents)
-				return
 
+			if self.fname == "ssl_multicert.config":
+				return self.advancedSSLProcessing(conf)
+			return True
+
+		written = False
 		with open(self.path, 'r+') as fp:
 			onDiskContents = fp.readlines()
 			if filesDiffer(finalContents.splitlines(), onDiskContents):
-				self.backup(''.join(onDiskContents))
-				if MODE is not Modes.REPORT:
+				self.backup(''.join(onDiskContents), conf.mode)
+				if conf.mode is not Configuration.Modes.REPORT:
 					fp.seek(0)
 					fp.truncate()
 
 
 					fp.write(finalContents)
-					if self.fname in FILES_THAT_REQUIRE_RELOADS:
-						NEEDED_RELOADS.add(FILES_THAT_REQUIRE_RELOADS[self.fname])
+
+				written = True
 				logging.info("File written to %s", self.path)
 			else:
 				logging.info("File doesn't differ from disk; nothing to do")
 
 		# Now we need to do some advanced processing to a couple specific filenames... unfortunately
 		if self.fname == "ssl_multicert.config":
-			self.advancedSSLProcessing(api, cdn)
+			return self.advancedSSLProcessing(conf) or written
 
-	def advancedSSLProcessing(self, api:'to_api.API', cdn:str):
+		return written
+
+	def advancedSSLProcessing(self, conf:Configuration):
 		"""
 		Does advanced processing on ssl_multicert.config files
 
-		:param api: A valid, authenticated API session for use when interacting with Traffic Ops
-		:param cdn: The name of the CDN to which this server belongs (needed for SSL keys)
+		:param conf: An object that represents the configuration of :program:`traffic_ops_ort`
 		:raises OSError: when reading/writing files fails for some reason
 		"""
 		global SSL_KEY_REGEX
 
-		logging.info("Doing advanced SSL key processing for CDN '%s'", cdn)
+		logging.info("Doing advanced SSL key processing for CDN '%s'", conf.serverInfo.cdnName)
 
 		try:
-			r = api.get_cdn_ssl_keys(cdn_name=cdn)
+			r = conf.api.get_cdn_ssl_keys(cdn_name=conf.serverInfo.cdnName)
 
 			if r[1].status_code != 200 and r[1].status_code != 204:
-				raise ValueError("Bad response code: %d - raw response: %s" %
+				raise OSError("Bad response code: %d - raw response: %s" %
 				                               (r[1].status_code,    r[1].text))
-		except (OperationError, InvalidJSONError, ValueError) as e:
-			logging.error("Invalid values encountered when communicating with Traffic Ops!")
-			logging.debug("%r", e, stack_info=True, exc_info=True)
-			raise ValueError from e
+		except (OperationError, LoginError, InvalidJSONError, ValueError) as e:
+			raise OSError("Invalid values encountered when communicating with Traffic Ops!") from e
 
 		logging.debug("Raw response from Traffic Ops: %s", r[1].text)
 
+		written = False
 		for l in self.sanitizedContents.splitlines()[1:]:
 			logging.debug("advanced processing for line: %s", l)
+
+			# for some reason, pylint is detecting this regular expression as a string
+			#pylint: disable=E1101
 			m = SSL_KEY_REGEX.search(l)
+			#pylint: enable=E1101
 
 			if m is None:
 				continue
@@ -281,28 +290,31 @@ class ConfigFile():
 
 			for cert in r[0]:
 				if cert.hostname == full or cert.hostname == wildcard:
-					key = type(self)()
+					key = ConfigFile()
 					key.location = self.SSLdir
 					key.fname = m.group(2)
 					key.contents = b64decode(cert.certificate.key).decode()
 
 					logging.info("Processing private SSL key %s ...", key.fname)
-					key.update(api, cdn)
+					written = key.update(conf)
 					logging.info("Done.")
 
-					crt = type(self)()
+					crt = ConfigFile()
 					crt.location = self.SSLdir
 					crt.fname = m.group(1)
 					crt.contents = b64decode(cert.certificate.crt).decode()
 
 					logging.info("Processing SSL certificate %s ...", crt.fname)
-					crt.update(api, cdn)
+					written = crt.update(conf)
 					logging.info("Done.")
 					break
 			else:
 				logging.critical("Failed to find SSL key in %s for '%s' or by wildcard '%s'!",
-				                                           cdn,    full,            wildcard)
-				raise ValueError("No cert/key pair for ssl_multicert.config line '%s'" % l)
+				                         conf.serverInfo.cdnName,  full,            wildcard)
+				raise OSError("No cert/key pair for ssl_multicert.config line '%s'" % l)
+
+		# If even one key was written, we need to make ATS aware of the configuration changes
+		return written
 
 def filesDiffer(a:typing.List[str], b:typing.List[str]) -> bool:
 	"""
@@ -328,22 +340,22 @@ def filesDiffer(a:typing.List[str], b:typing.List[str]) -> bool:
 
 	return False
 
-def sanitizeContents(raw:str) -> str:
+def sanitizeContents(raw:str, conf:Configuration) -> str:
 	"""
 	Performs pre-processing on a raw configuration file
 
 	:param raw: The raw contents of the file as returned by a request to its URL
+	:param conf: An object that represents the configuration of :program:`traffic_ops_ort`
 	:returns: The same contents, but with special replacement strings parsed out and HTML-encoded
 		symbols decoded to their literal values
 	"""
-	from .configuration import SERVER_INFO
 	out = []
 
 	# These double curly braces escape the behaviour of Python's `str.format` method to attempt
 	# to use curly brace-enclosed text as a key into a dictonary of its arguments. They'll be
 	# rendered into single braces in the output of `.format`, leaving the string ultimately
 	# unchanged in that respect.
-	for line in SERVER_INFO.sanitize(raw).splitlines():
+	for line in conf.serverInfo.sanitize(raw, conf.hostname).splitlines():
 		tmp=(" ".join(line.split())).strip() #squeezes spaces and trims leading and trailing spaces
 		tmp=tmp.replace("&amp;", '&') #decodes HTML-encoded ampersands
 		tmp=tmp.replace("&gt;", '>') #decodes HTML-encoded greater-than symbols
@@ -352,20 +364,20 @@ def sanitizeContents(raw:str) -> str:
 
 	return '\n'.join(out)
 
-def initBackupDir():
+def initBackupDir(mode:Configuration.Modes):
 	"""
 	Initializes a backup directory as a subdirectory of the directory containing
 	this ORT script.
 
+	:param mode: The current run-mode of :program:`traffic_ops_ort`
 	:raises OSError: if the backup directory initialization fails
 	"""
 	global BACKUP_DIR
-	from . import configuration as conf
 
 	logging.info("Initializing backup dir %s", BACKUP_DIR)
 
 	if not os.path.isdir(BACKUP_DIR):
-		if conf.MODE != conf.Modes.REPORT:
+		if mode is not Configuration.Modes.REPORT:
 			os.mkdir(BACKUP_DIR)
 		else:
 			logging.error("Cannot create non-existent backup dir in REPORT mode!")

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
@@ -22,11 +22,9 @@ and performs a variety of operations based on the run mode.
 
 import os
 import logging
-import requests
 
-from trafficops.restapi import LoginError, OperationError
-
-from . import to_api
+from .configuration import Configuration
+from .utils import getYesNoResponse as getYN
 
 #: A constant that holds the absolute path to the status file directory
 STATUS_FILE_DIR = "/opt/ort/status"
@@ -35,86 +33,74 @@ class ORTException(Exception):
 	"""Signifies an ORT related error"""
 	pass
 
-def syncDSState(api:to_api.API) -> bool:
+def syncDSState(conf:Configuration) -> bool:
 	"""
 	Queries Traffic Ops for the :term:`Delivery Service`'s sync state
 
-	:param api: A :class:`traffic_ops_ort.to_api.API` object to use when interacting with Traffic Ops
+	:param conf: The script's configuration
 
-	:raises ORTException: when something goes wrong
 	:returns: whether or not an update is needed
+	:raises ConnectionError: when something goes wrong communicating with Traffic Ops
 	"""
-	from . import configuration
 	logging.info("starting syncDS state fetch")
 
-	try:
-		updateStatus = api.getUpdateStatus(api.hostname)[0]
-	except (IndexError, ConnectionError, requests.exceptions.RequestException) as e:
-		logging.critical("Server configuration not found in Traffic Ops!")
-		raise ORTException from e
-	except PermissionError as e:
-		logging.critical("Failed to authenticate with the Traffic Ops server!")
-		raise ORTException from e
+	updateStatus = conf.api.getMyUpdateStatus()[0]
 
 	logging.debug("Retrieved raw update status: %r", updateStatus)
 
-	return 'upd_pending' in updateStatus and updateStatus['upd_pending']
+	if not 'upd_pending' in updateStatus and updateStatus['upd_pending']:
+		return False
 
-def revalidateState(api:to_api.API) -> bool:
+	disp = conf.dispersion
+	if conf.mode is Configuration.Modes.SYNCDS and disp:
+		import time
+		logging.info("Dispersion is set. Will sleep for %d seconds before continuing", disp)
+		time.sleep(disp)
+
+	return True
+
+def revalidateState(conf:Configuration) -> bool:
 	"""
 	Checks the revalidation status of this server in Traffic Ops
 
-	:param api: A :class:`traffic_ops_ort.to_api.API` object to use when interacting with Traffic Ops
+	:param conf: The script's configuration
 
 	:returns: whether or not this server has a revalidation pending
-	:raises ORTException:
+	:raises ConnectionError: when something goes wrong communicating with Traffic Ops
 	"""
-	from . import configuration as conf
 	logging.info("starting revalidation state fetch")
 
-	try:
-		updateStatus = api.getUpdateStatus(api.hostname)
-	except (IndexError, ConnectionError, requests.exceptions.RequestException) as e:
-		logging.critical("Server configuration not found in Traffic Ops!")
-		raise ORTException from e
-	except PermissionError as e:
-		logging.critical("Failed to authenticate with the Traffic Ops server!")
-		raise ORTException from e
+	updateStatus = conf.api.getMyUpdateStatus()[0]
 
 	logging.debug("Retrieved raw revalidation status: %r", updateStatus)
-	if conf.WAIT_FOR_PARENTS and\
-	   "parent_reval_pending" in updateStatus and\
-	   updateStatus["parent_reval_pending"]:
+	if (conf.wait_for_parents and
+		"parent_reval_pending" in updateStatus and
+	    updateStatus["parent_reval_pending"]):
 		logging.info("Parent revalidation is pending - waiting for parent")
 		return False
 
 	return "reval_pending" in updateStatus and updateStatus["reval_pending"]
 
-def deleteOldStatusFiles(myStatus:str, api:to_api.API):
+def deleteOldStatusFiles(myStatus:str, conf:Configuration):
 	"""
 	Attempts to delete any and all old status files
 
 	:param myStatus: the current status - files by this name will not be deleted
-	:param api: A :class:`traffic_ops_ort.to_api.API` object to use when interacting with Traffic Ops
-	:raises ConnectionError: if there's an issue retrieving a list of statuses from
-		Traffic Ops
+	:param conf: An object containing the configuration of :program:`traffic_ops_ort`
+	:raises ConnectionError: if there's an issue retrieving a list of statuses from Traffic Ops
 	:raises OSError: if a file cannot be deleted for any reason
 	"""
-	from .configuration import MODE, Modes
-	from . import utils
-
 	logging.info("Deleting old status files (those that are not %s)", myStatus)
 
-	doDeleteFiles = MODE is not Modes.REPORT
+	doDeleteFiles = conf.mode is not Configuration.Modes.REPORT
 
-	for status in api.get_statuses()[0]:
+	for status in conf.api.get_statuses()[0]:
 
 		# Only the status name matters
 		try:
 			status = status.name
 		except KeyError as e:
 			logging.debug("Bad status object: %r", status)
-			logging.debug("Original error: %s", e, exc_info=True, stack_info=True)
 			raise ConnectionError from e
 
 		if doDeleteFiles and status != myStatus:
@@ -124,52 +110,45 @@ def deleteOldStatusFiles(myStatus:str, api:to_api.API):
 			logging.info("File '%s' to be deleted", fname)
 
 			# check for user confirmation before deleting files in 'INTERACTIVE' mode
-			if MODE != Modes.INTERACTIVE or utils.getYesNoResponse("Delete file %s?" % fname):
+			if conf.mode is not Configuration.Modes.INTERACTIVE or getYN("Delete file %s?" % fname):
 				logging.warning("Deleting file '%s'!", fname)
 				os.remove(fname)
 
-def setStatusFile(api:to_api.API) -> bool:
+def setStatusFile(conf:Configuration) -> bool:
 	"""
 	Attempts to set the status file according to this server's reported status in Traffic Ops.
 
 	.. warning:: This will create the directory '/opt/ORTstatus' if it does not exist, and may
 		delete files there without warning!
 
-	:param api: A :class:`traffic_ops_ort.to_api.API` object to use when interacting with Traffic Ops
+	:param conf: An object that contains the configuration for :program:`traffic_ops_ort`
 	:returns: whether or not the status file could be set properly
 	"""
 	global STATUS_FILE_DIR
-	from .configuration import MODE, Modes
-	from . import utils
 	logging.info("Setting status file")
 
-	if not isinstance(MODE, Modes):
-		logging.error("MODE is not set to a valid Mode (from traffic_ops_ort.configuration.Modes)!")
-		return False
-
 	try:
-		myStatus = api.getMyStatus()
+		myStatus = conf.api.getMyStatus()
 	except ConnectionError as e:
 		logging.error("Failed to set status file - Traffic Ops connection failed")
 		return False
 
 	if not os.path.isdir(STATUS_FILE_DIR):
 		logging.warning("status directory does not exist, creating...")
-		doMakeDir = MODE is not Modes.REPORT
+		doMakeDir = conf.mode is not Configuration.Modes.REPORT
 
 		# Check for user confirmation if in 'INTERACTIVE' mode
-		if doMakeDir and (MODE is not Modes.INTERACTIVE or\
-		   utils.getYesNoResponse("Create status directory '%s'?" % STATUS_FILE_DIR, default='Y')):
+		if doMakeDir and (conf.mode is not Configuration.Modes.INTERACTIVE or
+		                  getYN("Create status directory '%s'?" % STATUS_FILE_DIR, default='Y')):
 			try:
 				os.makedirs(STATUS_FILE_DIR)
-				return False
 			except OSError as e:
 				logging.error("Failed to create status directory '%s' - %s", STATUS_FILE_DIR, e)
 				logging.debug("%s", e, exc_info=True, stack_info=True)
 				return False
 	else:
 		try:
-			deleteOldStatusFiles(myStatus, api)
+			deleteOldStatusFiles(myStatus, conf)
 		except ConnectionError as e:
 			logging.error("Failed to delete old status files - Traffic Ops connection failed.")
 			logging.debug("%s", e, exc_info=True, stack_info=True)
@@ -182,8 +161,8 @@ def setStatusFile(api:to_api.API) -> bool:
 	fname = os.path.join(STATUS_FILE_DIR, myStatus)
 	if not os.path.isfile(fname):
 		logging.info("File '%s' to be created", fname)
-		if MODE is not Modes.REPORT and\
-		  (MODE is not Modes.INTERACTIVE or utils.getYesNoResponse("Create file '%s'?", 'y')):
+		if conf.mode is not Configuration.Modes.REPORT and (
+		   conf.mode is not Configuration.Modes.INTERACTIVE or getYN("Create file '%s'?", 'y')):
 
 			try:
 				with open(fname, 'x'):
@@ -195,62 +174,68 @@ def setStatusFile(api:to_api.API) -> bool:
 
 	return True
 
-def processPackages(api:to_api.API) -> bool:
+def processPackages(conf:Configuration) -> bool:
 	"""
 	Manages the packages that Traffic Ops reports are required for this server.
 
-	:param api: A :class:`traffic_ops_ort.to_api.API` object to use when interacting with Traffic Ops
+	:param conf: An object containing the configuration of :program:`traffic_ops_ort`
 	:returns: whether or not the package processing was successfully completed
 	"""
-	from .configuration import Modes, MODE
-
 	try:
-		myPackages = api.getMyPackages()
-	except (ConnectionError, PermissionError) as e:
-		logging.error("Failed to fetch package list from Traffic Ops - %s", e)
-		logging.debug("%s", e, exc_info=True, stack_info=True)
-		return False
-	except ValueError as e:
-		logging.error("Got malformed response from Traffic Ops! - %s", e)
+		myPackages = conf.api.getMyPackages()
+	except ConnectionError as e:
+		logging.error("Packages not found or API response malformed! - %s", e)
 		logging.debug("%s", e, exc_info=True, stack_info=True)
 		return False
 
 	for package in myPackages:
 		if package.install():
-			if MODE is not Modes.BADASS:
+			if conf.mode is not Configuration.Modes.BADASS:
 				return False
 			logging.warning("Failed to install %s, but we're BADASS, so moving on!", package)
 
 	return True
 
-def processServices(api:to_api.API) -> bool:
+def processServices(conf:Configuration) -> bool:
 	"""
 	Manages the running processes of the server, according to an ancient system known as 'chkconfig'
 
-	:param api: A :class:`traffic_ops_ort.to_api.API` object to use when interacting with Traffic Ops
+	:param conf: An object containing the configuration for :program:`traffic_ops_ort`
 	:returns: whether or not the service processing was completed successfully
 	"""
 	from . import services
 
-	for item in api.getMyChkconfig():
+	if not services.HAS_SYSTEMD:
+		logging.warning("This system doesn't have systemd, services cannot be enabled/disabled")
+		return True
+
+
+	try:
+		chkconfig = conf.api.getMyChkconfig()
+	except ConnectionError as e:
+		logging.error("Failed to fetch 'chkconfig' from Traffic Ops! (%s)", e)
+		logging.debug("%r", e, exc_info=True, stack_info=True)
+		return False
+
+	for item in chkconfig:
 		logging.debug("Processing item %r", item)
 
-		if not services.setServiceStatus(item):
+		if not services.setServiceStatus(item, conf.mode):
 			return False
 
 	return True
 
-def processConfigurationFiles(api:to_api.API) -> bool:
+def processConfigurationFiles(conf:Configuration) -> bool:
 	"""
 	Updates and backs up all of a server's configuration files.
 
-	:param api: A :class:`traffic_ops_ort.to_api.API` object to use when interacting with Traffic Ops
+	:param conf: An object containing the configuration for :program:`traffic_ops_ort`
 	:returns: whether or not the configuration changes were successful
 	"""
-	from . import config_files, configuration
+	from . import config_files, services
 
 	try:
-		config_files.initBackupDir()
+		config_files.initBackupDir(conf.mode)
 	except OSError as e:
 		logging.error("Couldn't create backup directory!")
 		logging.warning("%s", e)
@@ -258,28 +243,25 @@ def processConfigurationFiles(api:to_api.API) -> bool:
 		return False
 
 	try:
-		myFiles = api.getMyConfigFiles()
+		myFiles = conf.api.getMyConfigFiles(conf)
 	except ConnectionError as e:
-		logging.error("Failed to fetch configuration files - Traffic Ops connection failed! %s",e)
-		logging.debug("%s", e, exc_info=True, stack_info=True)
-		return False
-	except ValueError as e:
-		logging.error("Malformed configuration file response from Traffic Ops!")
+		logging.critical("Failed to fetch configuration files; Traffic Ops connection failed! %s",e)
 		logging.debug("%s", e, exc_info=True, stack_info=True)
 		return False
 
 	for file in myFiles:
 		try:
-			file = config_files.ConfigFile(file)
+			file = config_files.ConfigFile(file, conf.TOURL)
 			logging.info("\n============ Processing File: %s ============", file.fname)
-			file.update(api, configuration.SERVER_INFO.cdnName)
+			if file.update(conf) and file.fname in services.FILES_THAT_REQUIRE_RELOADS:
+				services.NEEDED_RELOADS.add(services.FILES_THAT_REQUIRE_RELOADS[file.fname])
 			logging.info("\n============================================\n")
 
 		# A bad object could just reflect an inconsistent reply structure from the API, so BADASSes
 		# will attempt to continue. However, an issue updating a valid configuration is not
 		# recoverable, even for BADASSes
-		except config_files.ConfigurationError as e:
-			logging.error("An error occurred while trying to update %s", file.name)
+		except OSError as e:
+			logging.error("An error occurred while trying to update %s", file.fname)
 			logging.debug("%s", e, exc_info=True, stack_info=True)
 			return False
 		except ValueError as e:
@@ -289,30 +271,24 @@ def processConfigurationFiles(api:to_api.API) -> bool:
 
 	return True
 
-def run() -> int:
+def run(conf:Configuration) -> int:
 	"""
 	This function is the entrypoint into the script's main flow from :func:`traffic_ops_ort.doMain`
-	It runs the appropriate actions depending on the run mode
+	It runs the appropriate actions depending on the run mode.
+
+	:param conf: An object that holds the script's configuration
 
 	:returns: an exit code for the script
 	"""
-	from . import configuration, utils, services
-
-	try:
-		api = to_api.API(configuration.USERNAME, configuration.PASSWORD, configuration.TO_HOST,
-		                 configuration.HOSTNAME[0], configuration.TO_PORT, configuration.VERIFY,
-		                 configuration.TO_USE_SSL)
-	except (LoginError, OperationError) as e:
-		logging.critical("Failed to authenticate with Traffic Ops")
-		logging.error(e)
-		logging.debug("%r", e, exc_info=True, stack_info=True)
-		return 1
+	from . import services
 
 	# If this is just a revalidation, then we can exit if there's no revalidation pending
-	if configuration.MODE == configuration.Modes.REVALIDATE:
+	if conf.mode is Configuration.Modes.REVALIDATE:
 		try:
-			updateRequired = revalidateState(api)
-		except ORTException as e:
+			updateRequired = revalidateState(conf)
+		except ConnectionError as e:
+			logging.critical("Server configuration unreachable, or not found in Traffic Ops!")
+			logging.error(e)
 			logging.debug("%r", e, exc_info=True, stack_info=True)
 			return 2
 
@@ -326,30 +302,32 @@ def run() -> int:
 	# changes
 	else:
 		try:
-			updateRequired = syncDSState(api)
-		except ORTException as e:
+			updateRequired = syncDSState(conf)
+		except ConnectionError as e:
+			logging.critical("Server configuration unreachable, or not found in Traffic Ops!")
+			logging.error(e)
 			logging.debug("%r", e, exc_info=True, stack_info=True)
 			return 2
 
 		# Bail on failures - unless this script is BADASS!
-		if not setStatusFile(api):
-			if configuration.MODE is not configuration.Modes.BADASS:
+		if not setStatusFile(conf):
+			if conf.mode is not Configuration.Modes.BADASS:
 				logging.critical("Failed to set status as specified by Traffic Ops")
 				return 2
 			logging.warning("Failed to set status but we're BADASS, so moving on.")
 
 		logging.info("\nProcessing Packages...")
-		if not processPackages(api):
+		if not processPackages(conf):
 			logging.critical("Failed to process packages")
-			if configuration.MODE is not configuration.Modes.BADASS:
+			if conf.mode is not Configuration.Modes.BADASS:
 				return 2
 			logging.warning("Package processing failed but we're BADASS, so attempting to move on")
 		logging.info("Done.\n")
 
 		logging.info("\nProcessing Services...")
-		if not processServices(api):
+		if not processServices(conf):
 			logging.critical("Failed to process services.")
-			if configuration.MODE is not configuration.Modes.BADASS:
+			if conf.mode is not Configuration.Modes.BADASS:
 				return 2
 			logging.warning("Service processing failed but we're BADASS, so attempting to move on")
 		logging.info("Done.\n")
@@ -357,17 +335,17 @@ def run() -> int:
 
 	# All modes process configuration files
 	logging.info("\nProcessing Configuration Files...")
-	if not processConfigurationFiles(api):
+	if not processConfigurationFiles(conf):
 		logging.critical("Failed to process configuration files.")
 		return 2
 	logging.info("Done.\n")
 
 	if updateRequired:
-		if (configuration.MODE is not configuration.Modes.INTERACTIVE or
-		   utils.getYesNoResponse("Update Traffic Ops?", default='Y')):
+		if (conf.mode is not Configuration.Modes.INTERACTIVE or
+		    getYN("Update Traffic Ops?", default='Y')):
 
 			logging.info("\nUpdating Traffic Ops...")
-			api.updateTrafficOps()
+			conf.api.updateTrafficOps(conf.mode)
 			logging.info("Done.\n")
 		else:
 			logging.warning("Traffic Ops was not notified of changes. You should do this manually.")
@@ -375,7 +353,7 @@ def run() -> int:
 	else:
 		logging.info("Traffic Ops update not necessary")
 
-	if services.NEEDED_RELOADS and not services.doReloads():
+	if services.NEEDED_RELOADS and not services.doReloads(conf):
 		logging.critical("Failed to reload all configuration changes")
 		return 2
 

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
@@ -22,6 +22,8 @@ and performs a variety of operations based on the run mode.
 
 import os
 import logging
+import random
+import time
 
 from .configuration import Configuration
 from .utils import getYesNoResponse as getYN
@@ -51,9 +53,8 @@ def syncDSState(conf:Configuration) -> bool:
 	if not 'upd_pending' in updateStatus and updateStatus['upd_pending']:
 		return False
 
-	disp = conf.dispersion
-	if conf.mode is Configuration.Modes.SYNCDS and disp:
-		import time
+	if conf.mode is Configuration.Modes.SYNCDS and conf.dispersion:
+		disp = random.randint(0, conf.dispersion)
 		logging.info("Dispersion is set. Will sleep for %d seconds before continuing", disp)
 		time.sleep(disp)
 

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
@@ -50,7 +50,14 @@ def syncDSState(conf:Configuration) -> bool:
 
 	logging.debug("Retrieved raw update status: %r", updateStatus)
 
-	if not 'upd_pending' in updateStatus and updateStatus['upd_pending']:
+	if 'upd_pending' not in updateStatus:
+		raise ConnectionError("Malformed API response doesn't indicate if updates are pending!")
+
+	if not updateStatus['upd_pending']:
+		return False
+
+	if conf.wait_for_parents and 'parent_pending' in updateStatus and updateStatus["parent_pending"]:
+		logging.warning("One or more parents still have updates pending, waiting for parents.")
 		return False
 
 	if conf.mode is Configuration.Modes.SYNCDS and conf.dispersion:

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/main_routines.py
@@ -190,7 +190,7 @@ def processPackages(conf:Configuration) -> bool:
 		return False
 
 	for package in myPackages:
-		if package.install():
+		if package.install(conf):
 			if conf.mode is not Configuration.Modes.BADASS:
 				return False
 			logging.warning("Failed to install %s, but we're BADASS, so moving on!", package)

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/packaging.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/packaging.py
@@ -24,6 +24,9 @@ support a strict set of distributions with well-known package managers.
 import logging
 import subprocess
 
+from .configuration import Configuration
+from .utils import getYesNoResponse as getYN
+
 class _MetaPackage(type):
 	"""
 	This factory is responsible for constructing a :class:`Package` class which properly
@@ -126,26 +129,25 @@ class Package(metaclass=_MetaPackage):
 				return True
 		return False
 
-	def install(self) -> int:
+	def install(self, conf:Configuration) -> int:
 		"""
 		Installs this package.
 
+		:param conf: An object containing the configuration for :program:`traffic_ops_ort`
+
 		:returns: the exit code of the install process
 		"""
-		from .configuration import MODE, Modes
-		from .utils import getYesNoResponse as getYN
-
 		if self.isInstalled():
 			logging.info("%s is already installed - nothing to do", self)
 			return 0
 
-		if MODE is Modes.INTERACTIVE and not getYN("Install %s?" % self, default='Y'):
+		if conf.mode is Configuration.Modes.INTERACTIVE and not getYN("Install %s?" % self, 'Y'):
 			logging.warning("%s will not be installed, dependencies may be unsatisfied!", self)
 			return 0
 
 		logging.info("Installing %s", self)
 
-		if MODE is Modes.REPORT:
+		if conf.mode is Configuration.Modes.REPORT:
 			return 0
 
 		try:
@@ -167,26 +169,23 @@ class Package(metaclass=_MetaPackage):
 
 		return sub.returncode
 
-	def uninstall(self) -> int:
+	def uninstall(self, conf:Configuration) -> int:
 		"""
-		Uninstalls this package
+		Uninstalls this package. I have no idea how one would make use of this from within ATC...
 
 		:returns: the exit code of the uninstall process
 		"""
-		from .configuration import MODE, Modes
-		from .utils import getYesNoResponse as getYN
-
 		if not self.isInstalled():
 			logging.info("%s is not installed - nothing to do", self)
 			return 0
 
-		if MODE is Modes.INTERACTIVE and not getYN("Uninstall %s?" % self, default='Y'):
+		if conf.mode is Configuration.Modes.INTERACTIVE and not getYN("Uninstall %s?" % self, 'Y'):
 			logging.warning("%s will not be installed, dependencies may be out of date!", self)
 			return 0
 
 		logging.info("Uninstalling %s", self)
 
-		if MODE is Modes.REPORT:
+		if conf.mode is Configuration.Modes.REPORT:
 			return 0
 
 		try:

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -53,6 +53,7 @@ class API(TOSession):
 
 		for r in conf.retries:
 			try:
+				logging.info("login attempt #%d", r)
 				self.login(conf.username, conf.password)
 				break
 			except LoginError, OperationError, InvalidJSONError as e:

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -50,7 +50,15 @@ class API(TOSession):
 		"""
 		super(API, self).__init__(host_ip=conf.toHost, api_version=self.VERSION,
 		                          host_port=conf.toPort, verify_cert=conf.verify, ssl=conf.useSSL)
-		self.login(conf.username, conf.password)
+
+		for r in conf.retries:
+			try:
+				self.login(conf.username, conf.password)
+				break
+			except LoginError, OperationError, InvalidJSONError as e:
+				logging.debug("login failure: %r", e, stack_info=True, exc_info=True)
+		else:
+			raise LoginError("Failed to log in to Traffic Ops, retries exceeded.")
 
 		self.hostname = conf.shortHostname
 


### PR DESCRIPTION
## What does this PR do?
Adds an implementation of the previously unused command-line parameters:

* `--rev_proxy_disable`
* `--dispersion DISP`
* `--login_dispersion DISP`
* `--wait_for_parents INT`
* `--retries RETRIES`

The default values are the same as the Perl script _in its usage output_. For example, the usage output of `traffic_ops_ort.pl` claims the default value for `--retries RETRIES` is 3, but it actually defaults to 5 - ORT.py honors the documented 3. Note that with the exception of `--rev_proxy_disable`, all arguments can be used the same way as with the Perl script; e.g. `--wait_for_parents=0` (although in the case of `--wait_for_parents` **any** integer that is not `0` will be considered a "Truth-y" value as opposed to the Perl behavior that required exactly `1`). Like the Perl script, the bypass of reverse proxies is disabled by default, but _unlike_ the Perl script, the mere presence of `--rev_proxy_disable` changes this behavior; no value is required, or indeed accepted.

## Which TC components are affected by this PR?

- [x] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [x] Traffic Ops ORT (Python)
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR?
For most of them, a CDN-in-a-Box will suffice. I honestly don't know how I'd go about testing the reverse proxy usage, but the code that implements it is straightforward enough that I'm confident it will work.

## Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)