### PR TITLE
Fix lib/go-tc missing return

### DIFF
--- a/lib/go-tc/parameters.go
+++ b/lib/go-tc/parameters.go
@@ -105,7 +105,7 @@ type ProfileParametersByNamePost []ProfileParameterByNamePost
 func (pp *ProfileParametersByNamePost) UnmarshalJSON(bts []byte) error {
 	bts = bytes.TrimLeft(bts, " \n\t\r")
 	if len(bts) == 0 {
-		errors.New("no body")
+		return errors.New("no body")
 	}
 	if bts[0] == '[' {
 		ppArr := []ProfileParameterByNamePost{}


### PR DESCRIPTION
#### What does this PR do?

Fix lib/go-tc missing return, found by `go vet`.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



