### PR TITLE
Fix TM unnecessary self-assignment

### DIFF
--- a/traffic_monitor/tools/testcaches/testcaches.go
+++ b/traffic_monitor/tools/testcaches/testcaches.go
@@ -53,12 +53,11 @@ func main() {
 	}
 
 	remaps := makeFakeRemaps(*numRemaps)
-	servers, err := fakesrvr.News(*portStart, *numPorts, remaps)
+	_, err := fakesrvr.News(*portStart, *numPorts, remaps)
 	if err != nil {
 		fmt.Println("Error making FakeServers: " + err.Error())
 		return
 	}
-	servers = servers // debug
 	for {
 		// TODO handle sighup to die
 		time.Sleep(time.Hour)


### PR DESCRIPTION
#### What does this PR do?

Fix TM unnecessary self-assignment.

Labelling "bug" because it triggers `go vet`. Not actually a bug, but unnecessary, and prevents a clean `go vet`. 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



