### PR TITLE
Change TO cdns/dnsseckeys to abstract versioning

### DIFF
--- a/lib/go-tc/deliveryservice_ssl_keys.go
+++ b/lib/go-tc/deliveryservice_ssl_keys.go
@@ -224,6 +224,25 @@ type DNSSECKeyDSRecordV11 struct {
 	Digest     string `json:"digest"`
 }
 
+func (keys *DNSSECKeys) ToV11() DNSSECKeysV11 {
+	v11 := DNSSECKeysV11{}
+	for keyName, keySet := range *keys {
+		v11[keyName] = keySet.ToV11()
+	}
+	return v11
+}
+
+func (set *DNSSECKeySet) ToV11() DNSSECKeySetV11 {
+	v11 := DNSSECKeySetV11{}
+	for _, zsk := range set.ZSK {
+		v11.ZSK = append(v11.ZSK, zsk.DNSSECKeyV11)
+	}
+	for _, ksk := range set.KSK {
+		v11.KSK = append(v11.KSK, ksk.DNSSECKeyV11)
+	}
+	return v11
+}
+
 // CDNDNSSECGenerateReqDate is the date accepted by CDNDNSSECGenerateReq.
 // This will unmarshal a UNIX epoch integer, a RFC3339 string, the old format string used by Perl '2018-08-21+14:26:06', and the old format string sent by the Portal '2018-08-21 14:14:42'.
 // This exists to fix a critical bug, see https://github.com/apache/trafficcontrol/issues/2723 - it SHOULD NOT be used by any other endpoint.


### PR DESCRIPTION
TechDebt. Changes the cdns/dnsseckeys api/1.1 and api/1.4+ endpoints
to use the same helper, so the 1.1 func is doing nothing but handling
and casting the latest obj to v11.

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



