### PR TITLE
Changing users route back to v14 until v11 exists

### DIFF
--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -162,10 +162,10 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		//User: CRUD
 		//Incrementing version for users because change to Nullable struct.
-		{1.1, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodGet, `users/{id}$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPut, `users/{id}$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
-		{1.1, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodGet, `users/?(\.json)?$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.4, http.MethodGet, `users/{id}$`, api.ReadHandler(user.GetTypeSingleton()), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.4, http.MethodPut, `users/{id}$`, api.UpdateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(user.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil},
 


### PR DESCRIPTION
#### What does this PR do?
There was a small misunderstanding about versioning. A v11 handler is needed to replace the perl, but the current handler should be v14, like when it was originally made (It was changed recently along with some bugfixes). The `confirmLocalPasswd` field was removed, causing the version to increment. A v11 handler should be made later, but at the moment we should stick to semantic versioning.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



