### PR TITLE
TO Go:  anchor `api/1.x` endpoints to start of path

### DIFF
--- a/traffic_ops/traffic_ops_golang/routing.go
+++ b/traffic_ops/traffic_ops_golang/routing.go
@@ -38,7 +38,7 @@ import (
 )
 
 // RoutePrefix ...
-const RoutePrefix = "api" // TODO config?
+const RoutePrefix = "^api" // TODO config?
 
 // Middleware ...
 type Middleware func(handlerFunc http.HandlerFunc) http.HandlerFunc

--- a/traffic_ops/traffic_ops_golang/routing_test.go
+++ b/traffic_ops/traffic_ops_golang/routing_test.go
@@ -170,42 +170,6 @@ func TestCompileRoutes(t *testing.T) {
 			t.Errorf("%s %s: expected params %v, got %v", rt.Method, rt.Path, rt.Params, params)
 		}
 	}
-
-	//t.Errorf("compiledRoutes: %++v", compiledRoutes)
-}
-
-func TestRegisterRoutes(t *testing.T) {
-	url, err := url.Parse("https://to.test")
-	if err != nil {
-		t.Error("error parsing test url")
-	}
-	cfg := config.Config{URL: url, Secrets: []string{"s3cr34$"}}
-	err = RegisterRoutes(ServerData{Config: cfg})
-	if err != nil {
-		t.Error("error registering routes")
-	}
-
-	d := http.DefaultServeMux
-
-	type testRoute struct {
-		method  string
-		route   string
-		pattern string
-	}
-	testRoutes := []testRoute{
-		{"GET", "api/1.3/about", "/api/1.3/about"},
-		{"GET", "/blorf/api/1.3/about", "/api/1.3/about"},
-	}
-
-	for _, tr := range testRoutes {
-		r, err := http.NewRequest(tr.method, tr.route, nil)
-		if err != nil {
-			t.Error("Error creating new request")
-		}
-		_, pattern := d.Handler(r)
-		fmt.Printf("handler for %s is %s -- expected %s\n", tr.route, pattern, tr.pattern)
-	}
-
 }
 
 func TestCreateRouteMap(t *testing.T) {


### PR DESCRIPTION
#### What does this PR do?

Fixes #3302 

Anchors `api/...` to start of URI path.  This eliminates accidentally matching paths with prefixes, e.g. `blah/api/1.2/cdns`.

Tests added.

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Try various endpoints against an installed TO:

- known legal endpoints on GET/POST/PUT/DELETE
- leading prefixes (e.g. `blah/api/1.2/cdns`)
- GET `internal/api/1.2/federations.json` should be proxied to the Perl endpoint and not handled by `api/1.x/federations`

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



