### PR TITLE
updated so TCP port is configurable for Traffic Monitor

### DIFF
--- a/traffic_monitor/manager/monitorconfig.go
+++ b/traffic_monitor/manager/monitorconfig.go
@@ -22,6 +22,7 @@ package manager
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -267,8 +268,13 @@ func monitorConfigListen(
 				log.Infof("health.polling.type for '%v' is empty, using default '%v'", srv.HostName, pollType)
 			}
 
+			port := ""
+			if srv.Port != 0 {
+				port = ":" + strconv.Itoa(srv.Port)
+			}
+
 			r := strings.NewReplacer(
-				"${hostname}", srv.IP,
+				"${hostname}", srv.IP+port,
 				"${interface_name}", srv.InterfaceName,
 				"application=plugin.remap", "application=system",
 				"application=", "application=system",


### PR DESCRIPTION
(cherry picked from commit 02b071e6a4061678439a299ac31c2d91cf2a3cb9)

#### What does this PR do?

Fixes #3307 

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [X] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Verify that Traffic Monitor works currently. Update the TCP port of an edge server to anything except 80 and verify that it is picked up in Traffic Monitor. Change it back to its original port and verify that it is picked up in Traffic Monitor still.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



