### PR TITLE
Fix code that checks the use_tenancy parameter

### DIFF
--- a/traffic_ops/app/lib/Utils/Tenant.pm
+++ b/traffic_ops/app/lib/Utils/Tenant.pm
@@ -71,9 +71,8 @@ sub new {
     #                                                                config_file => 'global', name => 'use_tenancy' } )
     #    ->get_column('value')->single();
 
-    my $use_tenancy_value = $dbh->resultset("Parameter")->search( { config_file => 'global', name => 'use_tenancy' } )
-        ->get_column('value')->single();
-    my $use_tenancy = defined($use_tenancy_value) ? $use_tenancy_value != '0' : 0;
+    # tenancy is always enabled
+    my $use_tenancy = 1;
 
     my $self = {
         dbh     => $dbh,
@@ -254,14 +253,8 @@ sub is_ds_resource_accessible_to_tenant {
 }
 
 sub use_tenancy {
-    # With tenancy, the DS/User mapping is no longer required for isolation.
-    # So we need a knob to turn of this mechanisem if/as-long it is not depraceted.
-    my $self = shift;
-    if ($self->{use_tenancy}) {
-        #mechanisem disabled
-        return 1;
-    }
-    return 0;
+    # tenancy is always enabled
+    return 1;
 }
 
 sub get_tenant_heirarchy_depth {

--- a/traffic_ops/testing/api/v14/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservices_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
 )
 
@@ -235,6 +236,7 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 		t.Error("tenant4user cannot GET deliveryservices")
 	}
 
+	// assert that tenant4user cannot read deliveryservices outside of its tenant
 	for _, ds := range dsesReadableByTenant4 {
 		if *ds.XMLID == "ds3" {
 			t.Error("expected tenant4 to be unable to read delivery services from tenant 3")
@@ -250,4 +252,12 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 	if _, err = tenant4TOClient.DeleteDeliveryService(string(*tenant3DS.ID)); err == nil {
 		t.Errorf("expected tenant4user to be unable to delete tenant3's deliveryservice (%s)", *tenant3DS.XMLID)
 	}
+
+	// assert that tenant4user cannot create a deliveryservice outside of its tenant
+	tenant3DS.XMLID = util.StrPtr("deliveryservicetenancytest")
+	tenant3DS.DisplayName = util.StrPtr("deliveryservicetenancytest")
+	if _, err = tenant4TOClient.CreateDeliveryServiceNullable(&tenant3DS); err == nil {
+		t.Errorf("expected tenant4user to be unable to create a deliveryservice outside of its tenant")
+	}
+
 }

--- a/traffic_ops/testing/api/v14/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservices_test.go
@@ -243,6 +243,11 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 
 	// assert that tenant4user cannot update tenant3user's deliveryservice
 	if _, err = tenant4TOClient.UpdateDeliveryServiceNullable(string(*tenant3DS.ID), &tenant3DS); err == nil {
-		t.Error("expected tenant4user to be unable to update tenant3's deliveryservice 'ds3'")
+		t.Errorf("expected tenant4user to be unable to update tenant3's deliveryservice (%s)", *tenant3DS.XMLID)
+	}
+
+	// assert that tenant4user cannot delete tenant3user's deliveryservice
+	if _, err = tenant4TOClient.DeleteDeliveryService(string(*tenant3DS.ID)); err == nil {
+		t.Errorf("expected tenant4user to be unable to delete tenant3's deliveryservice (%s)", *tenant3DS.XMLID)
 	}
 }

--- a/traffic_ops/testing/api/v14/origins_test.go
+++ b/traffic_ops/testing/api/v14/origins_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
 )
 
@@ -117,6 +118,7 @@ func OriginTenancyTest(t *testing.T) {
 		t.Error("tenant4user cannot GET origins")
 	}
 
+	// assert that tenant4user cannot read origins outside of its tenant
 	for _, origin := range originsReadableByTenant4 {
 		if *origin.FQDN == "origin.ds3.example.net" {
 			t.Error("expected tenant4 to be unable to read origins from tenant 3")
@@ -131,6 +133,12 @@ func OriginTenancyTest(t *testing.T) {
 	// assert that tenant4user cannot delete an origin outside of its tenant
 	if _, _, err = tenant4TOClient.DeleteOriginByID(*origins[0].ID); err == nil {
 		t.Errorf("expected tenant4user to be unable to delete an origin outside of its tenant (origin %s)", *origins[0].Name)
+	}
+
+	// assert that tenant4user cannot create origins outside of its tenant
+	tenant3Origin.FQDN = util.StrPtr("origin.tenancy.test.example.com")
+	if _, _, err = tenant4TOClient.CreateOrigin(tenant3Origin); err == nil {
+		t.Errorf("expected tenant4user to be unable to create an origin outside of its tenant")
 	}
 }
 

--- a/traffic_ops/testing/api/v14/origins_test.go
+++ b/traffic_ops/testing/api/v14/origins_test.go
@@ -17,12 +17,17 @@ package v14
 
 import (
 	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
 )
 
 func TestOrigins(t *testing.T) {
-	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, Coordinates, Origins}, func() {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, Users, DeliveryServices, Coordinates, Origins}, func() {
 		UpdateTestOrigins(t)
 		GetTestOrigins(t)
+		OriginTenancyTest(t)
 	})
 }
 
@@ -37,8 +42,13 @@ func CreateTestOrigins(t *testing.T) {
 }
 
 func GetTestOrigins(t *testing.T) {
+	_, _, err := TOSession.GetOrigins()
+	if err != nil {
+		t.Errorf("cannot GET origins: %v\n", err)
+	}
+
 	for _, origin := range testData.Origins {
-		resp, _, err := TOSession.GetServerByHostName(*origin.Name)
+		resp, _, err := TOSession.GetOriginByName(*origin.Name)
 		if err != nil {
 			t.Errorf("cannot GET Origin by name: %v - %v\n", err, resp)
 		}
@@ -76,6 +86,46 @@ func UpdateTestOrigins(t *testing.T) {
 	}
 	if *respOrigin.FQDN != updatedFQDN {
 		t.Errorf("results do not match actual: %s, expected: %s\n", *respOrigin.FQDN, updatedFQDN)
+	}
+}
+
+func OriginTenancyTest(t *testing.T) {
+	origins, _, err := TOSession.GetOrigins()
+	if err != nil {
+		t.Errorf("cannot GET origins: %v\n", err)
+	}
+	tenant3Origin := tc.Origin{}
+	foundTenant3Origin := false
+	for _, o := range origins {
+		if *o.FQDN == "origin.ds3.example.net" {
+			tenant3Origin = o
+			foundTenant3Origin = true
+		}
+	}
+	if !foundTenant3Origin {
+		t.Error("expected to find origin with tenant 'tenant3' and fqdn 'origin.ds3.example.net'")
+	}
+
+	toReqTimeout := time.Second * time.Duration(Config.Default.Session.TimeoutInSecs)
+	tenant4TOClient, _, err := toclient.LoginWithAgent(TOSession.URL, "tenant4user", "pa$$word", true, "to-api-v14-client-tests/tenant4user", true, toReqTimeout)
+	if err != nil {
+		t.Fatalf("failed to log in with tenant4user: %v", err.Error())
+	}
+
+	originsReadableByTenant4, _, err := tenant4TOClient.GetOrigins()
+	if err != nil {
+		t.Error("tenant4user cannot GET origins")
+	}
+
+	for _, origin := range originsReadableByTenant4 {
+		if *origin.FQDN == "origin.ds3.example.net" {
+			t.Error("expected tenant4 to be unable to read origins from tenant 3")
+		}
+	}
+
+	// assert that tenant4user cannot update tenant3user's origin
+	if _, _, err = tenant4TOClient.UpdateOriginByID(*tenant3Origin.ID, tenant3Origin); err == nil {
+		t.Error("expected tenant4user to be unable to update tenant3's origin")
 	}
 }
 

--- a/traffic_ops/testing/api/v14/origins_test.go
+++ b/traffic_ops/testing/api/v14/origins_test.go
@@ -127,6 +127,11 @@ func OriginTenancyTest(t *testing.T) {
 	if _, _, err = tenant4TOClient.UpdateOriginByID(*tenant3Origin.ID, tenant3Origin); err == nil {
 		t.Error("expected tenant4user to be unable to update tenant3's origin")
 	}
+
+	// assert that tenant4user cannot delete an origin outside of its tenant
+	if _, _, err = tenant4TOClient.DeleteOriginByID(*origins[0].ID); err == nil {
+		t.Errorf("expected tenant4user to be unable to delete an origin outside of its tenant (origin %s)", *origins[0].Name)
+	}
 }
 
 func DeleteTestOrigins(t *testing.T) {

--- a/traffic_ops/testing/api/v14/user_test.go
+++ b/traffic_ops/testing/api/v14/user_test.go
@@ -36,6 +36,7 @@ func TestUsers(t *testing.T) {
 		UserUpdateOwnRoleTest(t)
 		GetTestUsers(t)
 		GetTestUserCurrent(t)
+		UserTenancyTest(t)
 	})
 }
 
@@ -235,6 +236,65 @@ func GetTestUserCurrent(t *testing.T) {
 	}
 	if *user.UserName != SessionUserName {
 		t.Errorf("current user expected: %v actual: %v\n", SessionUserName, *user.UserName)
+	}
+}
+
+func UserTenancyTest(t *testing.T) {
+	users, _, err := TOSession.GetUsers()
+	if err != nil {
+		t.Errorf("cannot GET users: %v\n", err)
+	}
+	tenant3Found := false
+	tenant4Found := false
+	tenant3Username := "tenant3user"
+	tenant4Username := "tenant4user"
+	tenant3User := tc.User{}
+
+	// assert admin user can view tenant3user and tenant4user
+	for _, user := range users {
+		if *user.Username == tenant3Username {
+			tenant3Found = true
+			tenant3User = user
+		} else if *user.Username == tenant4Username {
+			tenant4Found = true
+		}
+		if tenant3Found && tenant4Found {
+			break
+		}
+	}
+	if !tenant3Found || !tenant4Found {
+		t.Error("expected admin to be able to view tenants: tenant3 and tenant4")
+	}
+
+	toReqTimeout := time.Second * time.Duration(Config.Default.Session.TimeoutInSecs)
+	tenant4TOClient, _, err := toclient.LoginWithAgent(TOSession.URL, "tenant4user", "pa$$word", true, "to-api-v14-client-tests/tenant4user", true, toReqTimeout)
+	if err != nil {
+		t.Fatalf("failed to log in with tenant4user: %v", err.Error())
+	}
+
+	usersReadableByTenant4, _, err := tenant4TOClient.GetUsers()
+	if err != nil {
+		t.Error("tenant4user cannot GET users")
+	}
+
+	tenant4canReadItself := false
+	for _, user := range usersReadableByTenant4 {
+		// assert that tenant4user cannot read tenant3user
+		if *user.Username == tenant3Username {
+			t.Error("expected tenant4user to be unable to read tenant3user")
+		}
+		// assert that tenant4user can read itself
+		if *user.Username == tenant4Username {
+			tenant4canReadItself = true
+		}
+	}
+	if !tenant4canReadItself {
+		t.Error("expected tenant4user to be able to read itself")
+	}
+
+	// assert that tenant4user cannot update tenant3user
+	if _, _, err = tenant4TOClient.UpdateUserByID(*tenant3User.ID, &tenant3User); err == nil {
+		t.Error("expected tenant4user to be unable to update tenant4user")
 	}
 }
 

--- a/traffic_ops/testing/api/v14/user_test.go
+++ b/traffic_ops/testing/api/v14/user_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
 )
 
@@ -295,6 +296,19 @@ func UserTenancyTest(t *testing.T) {
 	// assert that tenant4user cannot update tenant3user
 	if _, _, err = tenant4TOClient.UpdateUserByID(*tenant3User.ID, &tenant3User); err == nil {
 		t.Error("expected tenant4user to be unable to update tenant4user")
+	}
+
+	// assert that tenant4user cannot create a user outside of its tenant
+	rootTenant, _, err := TOSession.TenantByName("root")
+	if err != nil {
+		t.Error("expected to be able to GET the root tenant")
+	}
+	newUser := testData.Users[0]
+	newUser.Email = util.StrPtr("testusertenancy@example.com")
+	newUser.Username = util.StrPtr("testusertenancy")
+	newUser.TenantID = &rootTenant.ID
+	if _, _, err = tenant4TOClient.CreateUser(&newUser); err == nil {
+		t.Error("expected tenant4user to be unable to create a new user in the root tenant")
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant.go
@@ -124,20 +124,7 @@ func (tn *TOTenant) Create() (error, error, int) { return api.GenericCreate(tn) 
 
 func (ten *TOTenant) Read() ([]interface{}, error, error, int) {
 	if ten.APIInfo().User.TenantID == auth.TenantIDInvalid {
-		// NOTE: work around issue where user has no tenancy assigned.  If tenancy turned off, there
-		// should be no tenancy restrictions.  This should be removed once tenant_id NOT NULL constraints
-		// are in place
-		enabled, err := tenant.IsTenancyEnabledTx(ten.APIInfo().Tx.Tx)
-		if err != nil {
-			return nil, nil, errors.New("tenant checking tenancy: " + err.Error()), http.StatusInternalServerError
-		}
-
-		if enabled {
-			// tenancy enabled, but user doesn't belong to one -- return empty list
-			return nil, nil, nil, http.StatusOK
-		}
-		// give it the root tenant -- since tenancy turned off,  does not matter what it is
-		ten.APIInfo().User.TenantID = 1
+		return nil, nil, nil, http.StatusOK
 	}
 
 	tenants, userErr, sysErr, errCode := api.GenericRead(ten)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv12.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv12.go
@@ -72,7 +72,6 @@ func (ds *TODeliveryServiceV12) GetType() string {
 }
 
 // getDSTenantIDByID returns the tenant ID, whether the delivery service exists, and any error.
-// Note the id may be nil, even if true is returned, if the delivery service exists but its tenant_id field is null.
 func getDSTenantIDByID(tx *sql.Tx, id int) (*int, bool, error) {
 	tenantID := (*int)(nil)
 	if err := tx.QueryRow(`SELECT tenant_id FROM deliveryservice where id = $1`, id).Scan(&tenantID); err != nil {
@@ -85,7 +84,6 @@ func getDSTenantIDByID(tx *sql.Tx, id int) (*int, bool, error) {
 }
 
 // GetDSTenantIDByIDTx returns the tenant ID, whether the delivery service exists, and any error.
-// Note the id may be nil, even if true is returned, if the delivery service exists but its tenant_id field is null.
 func GetDSTenantIDByIDTx(tx *sql.Tx, id int) (*int, bool, error) {
 	tenantID := (*int)(nil)
 	if err := tx.QueryRow(`SELECT tenant_id FROM deliveryservice where id = $1`, id).Scan(&tenantID); err != nil {
@@ -98,7 +96,6 @@ func GetDSTenantIDByIDTx(tx *sql.Tx, id int) (*int, bool, error) {
 }
 
 // getDSTenantIDByName returns the tenant ID, whether the delivery service exists, and any error.
-// Note the id may be nil, even if true is returned, if the delivery service exists but its tenant_id field is null.
 func getDSTenantIDByName(tx *sql.Tx, name string) (*int, bool, error) {
 	tenantID := (*int)(nil)
 	if err := tx.QueryRow(`SELECT tenant_id FROM deliveryservice where xml_id = $1`, name).Scan(&tenantID); err != nil {
@@ -111,7 +108,6 @@ func getDSTenantIDByName(tx *sql.Tx, name string) (*int, bool, error) {
 }
 
 // GetDSTenantIDByNameTx returns the tenant ID, whether the delivery service exists, and any error.
-// Note the id may be nil, even if true is returned, if the delivery service exists but its tenant_id field is null.
 func GetDSTenantIDByNameTx(tx *sql.Tx, ds tc.DeliveryServiceName) (*int, bool, error) {
 	tenantID := (*int)(nil)
 	if err := tx.QueryRow(`SELECT tenant_id FROM deliveryservice where xml_id = $1`, ds).Scan(&tenantID); err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv13.go
@@ -559,21 +559,12 @@ func readGetDeliveryServices(params map[string]string, tx *sqlx.Tx, user *auth.C
 		return nil, errs, tc.DataConflictError
 	}
 
-	tenancyEnabled, err := tenant.IsTenancyEnabledTx(tx.Tx)
+	tenantIDs, err := tenant.GetUserTenantIDListTx(tx.Tx, user.TenantID)
 	if err != nil {
-		log.Errorln("checking if tenancy is enabled: " + err.Error())
+		log.Errorln("received error querying for user's tenants: " + err.Error())
 		return nil, []error{tc.DBError}, tc.SystemError
 	}
-
-	if tenancyEnabled {
-		log.Debugln("Tenancy is enabled")
-		tenantIDs, err := tenant.GetUserTenantIDListTx(tx.Tx, user.TenantID)
-		if err != nil {
-			log.Errorln("received error querying for user's tenants: " + err.Error())
-			return nil, []error{tc.DBError}, tc.SystemError
-		}
-		where, queryValues = dbhelpers.AddTenancyCheck(where, queryValues, "ds.tenant_id", tenantIDs)
-	}
+	where, queryValues = dbhelpers.AddTenancyCheck(where, queryValues, "ds.tenant_id", tenantIDs)
 	query := selectQuery() + where + orderBy
 
 	log.Debugln("generated deliveryServices query: " + query)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/matches.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/matches.go
@@ -56,20 +56,14 @@ JOIN regex as r ON r.id = dsr.regex
 WHERE ds.active = true
 `
 	qParams := []interface{}{}
-	tenancyEnabled, err := tenant.IsTenancyEnabledTx(tx)
+	tenantIDs, err := tenant.GetUserTenantIDListTx(tx, userTenantID)
 	if err != nil {
-		return nil, errors.New("checking tenancy enabled: " + err.Error())
+		return nil, errors.New("getting user tenant ID list: " + err.Error())
 	}
-	if tenancyEnabled {
-		tenantIDs, err := tenant.GetUserTenantIDListTx(tx, userTenantID)
-		if err != nil {
-			return nil, errors.New("getting user tenant ID list: " + err.Error())
-		}
-		q += `
+	q += `
 AND ds.tenant_id = ANY($1)
 `
-		qParams = append(qParams, pq.Array(tenantIDs))
-	}
+	qParams = append(qParams, pq.Array(tenantIDs))
 
 	q += `
 ORDER BY dsr.set_number


### PR DESCRIPTION
Tenancy is always enabled, so we no longer have to check the use_tenancy
parameter. This should allow us to delete the use_tenancy parameter now (can do in a follow-up PR that also fixes the patches.sql + seeds.sql).

#### What does this PR do?

Fixes #2695

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Run the TO API integration tests and TO unit tests.

#### Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



