### PR TITLE
Ort.py environment variables

### DIFF
--- a/docs/source/development/ort/traffic_ops_ort.configuration.rst
+++ b/docs/source/development/ort/traffic_ops_ort.configuration.rst
@@ -13,13 +13,10 @@
 .. limitations under the License.
 ..
 
+**************************************
 traffic\_ops\_ort.configuration module
-======================================
-
-.. autodata:: traffic_ops_ort.configuration.HOSTNAME
-	:annotation:
-
+**************************************
 .. automodule:: traffic_ops_ort.configuration
 	:members:
-    :undoc-members:
-    :show-inheritance:
+	:undoc-members:
+	:show-inheritance:

--- a/docs/source/development/ort/traffic_ops_ort.main_routines.rst
+++ b/docs/source/development/ort/traffic_ops_ort.main_routines.rst
@@ -13,10 +13,11 @@
 .. limitations under the License.
 ..
 
+***************************************
 traffic\_ops\_ort.main\_routines module
-=======================================
+***************************************
 
 .. automodule:: traffic_ops_ort.main_routines
-    :members:
-    :undoc-members:
-    :show-inheritance:
+	:members:
+	:undoc-members:
+	:show-inheritance:

--- a/docs/source/development/ort/traffic_ops_ort.packaging.rst
+++ b/docs/source/development/ort/traffic_ops_ort.packaging.rst
@@ -13,10 +13,10 @@
 .. limitations under the License.
 ..
 
+**********************************
 traffic\_ops\_ort.packaging module
-==================================
-
+**********************************
 .. automodule:: traffic_ops_ort.packaging
-    :members:
-    :undoc-members:
-    :show-inheritance:
+	:members:
+	:undoc-members:
+	:show-inheritance:

--- a/docs/source/development/ort/traffic_ops_ort.to_api.rst
+++ b/docs/source/development/ort/traffic_ops_ort.to_api.rst
@@ -13,9 +13,9 @@
 .. limitations under the License.
 ..
 
+********************************
 traffic\_ops\_ort.to\_api module
-================================
-
+********************************
 .. automodule:: traffic_ops_ort.to_api
     :members:
     :undoc-members:

--- a/docs/source/development/ort/traffic_ops_ort.utils.rst
+++ b/docs/source/development/ort/traffic_ops_ort.utils.rst
@@ -13,10 +13,10 @@
 .. limitations under the License.
 ..
 
+******************************
 traffic\_ops\_ort.utils module
-==============================
-
+******************************
 .. automodule:: traffic_ops_ort.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+	:members:
+	:undoc-members:
+	:show-inheritance:

--- a/infrastructure/cdn-in-a-box/edge/run.sh
+++ b/infrastructure/cdn-in-a-box/edge/run.sh
@@ -72,7 +72,7 @@ until to-get "api/1.3/cdns/name/$CDN/sslkeys" && [[ "$(to-get api/1.3/cdns/name/
 done
 
 # Leaves the container hanging open in the event of a failure for debugging purposes
-traffic_ops_ort -k BADASS ALL "https://$TO_FQDN:$TO_PORT" "$TO_ADMIN_USER:$TO_ADMIN_PASSWORD" || { echo "Failed"; }
+traffic_ops_ort -kl ALL BADASS || { echo "Failed"; }
 
 envsubst < "/etc/cron.d/traffic_ops_ort-cron-template" > "/var/spool/cron/root" && rm -f "/etc/cron.d/traffic_ops_ort-cron-template"
 crontab "/var/spool/cron/root"

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-*/1 * * * * [[ -f /to-access.sh ]] && . /to-access.sh; /usr/bin/traffic_ops_ort -l ALL --dispersion 0 SYNCDS >> /var/log/ort.log 2>> /var/log/ort.log
+*/1 * * * * . /to-access.sh; /usr/bin/traffic_ops_ort -l ALL --dispersion 0 SYNCDS >> /var/log/ort.log 2>>&1

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-*/1 * * * * . /to-access.sh; /usr/bin/traffic_ops_ort -l ALL --dispersion 0 SYNCDS >> /var/log/ort.log 2>>&1
+*/1 * * * * . /to-access.sh; /usr/bin/traffic_ops_ort -kl ALL --dispersion 0 SYNCDS >> /var/log/ort.log 2>>&1

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-*/1 * * * * /usr/bin/traffic_ops_ort -k --dispersion 0 SYNCDS ALL https://$TO_FQDN $TO_ADMIN_USER:$TO_ADMIN_PASSWORD >> /var/log/ort.log 2>> /var/log/ort.log
+*/1 * * * * [[ -f /to-access.sh ]] && . /to-access.sh; /usr/bin/traffic_ops_ort -l ALL --dispersion 0 SYNCDS >> /var/log/ort.log 2>> /var/log/ort.log

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -28,11 +28,35 @@ This package provides an executable script named :program:`traffic_ops_ort`
 
 Usage
 =====
-``traffic_ops_ort [-k] [--dispersion DISP] [--login_dispersion DISP] [--retries RETRIES] [--wait_for_parents INT] [--rev_proxy_disable] [--ts-root PATH] MODE LOG_LEVEL TO_URL LOGIN``
+There are two main ways to invoke :program:`traffic_ops_ort`. The first method uses what's referred
+to as the "legacy call signature" and is meant to match the Perl command line arguments.
 
-``traffic_ops_ort [-v]``
+.. code-block:: text
+	:caption: Legacy Call Signature
 
-``traffic_ops_ort [-h]``
+	traffic_ops_ort [-k] [-h] [-v] [--dispersion DISP] [--login_dispersion DISP]
+	         [--retries RETRIES] [--wait_for_parents INT] [--rev_proxy_disable]
+	         [--ts_root PATH] MODE LOG_LEVEL TO_URL LOGIN``
+
+The second method - called the "new call signature" - aims to reduce the complexity of the
+:term:`ORT` command line. Rather than require a URL and "login string" for connecting and
+authenticating with the Traffic Ops server, these pieces of information are optional and may be
+provided by the :option:`--to_url`, :option:`-u`/:option:`--to_user`, and
+:option:`-p`/:option:`--password` options, respectively. If they are NOT provided, then their values
+will be obtained from the :envvar:`TO_URL`, :envvar:`TO_USER`, and :envvar:`TO_PASSWORD` environment
+variables, respectively. Note that :program:`traffic_ops_ort` cannot be run using the new call
+signature without providing a definition for each of these, either on the command line or in the
+execution environment.
+
+.. code-block:: text
+	:caption: New call signature
+
+	traffic_ops_ort [-k] [-h] [-v] [--dispersion DISP] [--login_dispersion DISP]
+	     [--retries RETRIES] [--wait_for_parents INT] [--rev_proxy_disable]
+	     [--ts_root PATH] [-l LOG_LEVEL] [-u USER] [-p PASSWORD] [--to_url URL] MODE
+
+These two call signatures should not be mixed, and :program:`traffic_ops_ort` will exit with an
+error if they are.
 
 Arguments and Flags
 -------------------
@@ -101,9 +125,11 @@ Arguments and Flags
 		when possible. This will install packages, enable/disable system services, and will start or
 		restart Apache Traffic Server as necessary.
 
-.. option:: LOG_LEVEL
+.. option:: LOG_LEVEL, -l LOG_LEVEL, --log_level LOG_LEVEL
 
-	Sets the verbosity of output provided by :program:`traffic_ops_ort`. Must be one of:
+	Sets the verbosity of output provided by :program:`traffic_ops_ort`. This argument is positional
+	in the legacy call signature, but optional in the new call signature, wherein it has a default
+	value of "WARN". Must be one of (case-insensitive):
 
 	NONE
 		Will output nothing, not even fatal errors.
@@ -133,19 +159,50 @@ Arguments and Flags
 
 	.. note:: All logging is sent to STDERR. INTERACTIVE :option:`MODE` prompts are printed to STDOUT
 
-.. option:: TO_URL
+.. option:: TO_URL, --to_url TO_URL
 
-	This must be the full URL that refers to the Traffic Ops server, including schema and port
-	number (if needed). E.g. ``https://trafficops.infra.ciab.test:443``.
+	This must be at minimum an :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the
+	Traffic Ops server, but may optionally include the schema and/or port number. E.g.
+	``https://trafficops.infra.ciab.test:443``, ``https://trafficops.infra.ciab.test``,
+	``trafficops.infra.ciab.test:443``, and ``trafficops.infra.ciab.test`` are all acceptable, and
+	in fact are all equivalent. When given a value without a schema, HTTPS will be the assumed
+	protocol, and when a port number is not present, 443 will be assumed except in the case that
+	the schema *is* provided and is ``http://`` (case-insensitive) in which case 80 will be assumed.
+
+	This argument is positional in the legacy call signature, but is optional in the new call
+	signature. When the new call signature is used and this option is not present on the command
+	line, its value will be obtained from :envvar:`TO_URL`. Note that :program:`traffic_ops_ort`
+	cannot be run using the new call signature unless this value is defined, either on the command
+	line or in the execution environment.
 
 .. option:: LOGIN
 
 	The information used to authenticate with Traffic Ops. This must consist of a username and a
-	password, delimited by a colon (``:``). E.g. ``admin:twelve``.
+	password, delimited by a colon (``:``). E.g. ``admin:twelve``. This argument is not used in the
+	new call signature, instead :option:`-u`/:option:`--to_user` and
+	:option:`-p`/:option:`--to_password` are used to separately set the authentication user and
+	password, respectively.
 
 	.. warning:: The first colon found in this string is considered the delimiter. There is no way
 		to escape the delimeter. This effectively means that usernames containing colons cannot be
 		used to authenticate with Traffic Ops, though passwords containing colons should be fine.
+
+.. option:: -u USER, --to_user USER
+
+	Specifies the username of the user as whom to authenticate when connecting to Traffic Ops. This
+	option is only available using the new call signature. If not provided when using said new call
+	signature, the value will be obtained from the :envvar:`TO_USER` environment variable. Note that
+	:program:`traffic_ops_ort` cannot be run using the new call signature unless this value is
+	defined, either on the command line or in the execution environment.
+
+.. option:: -p PASSWORD, --password PASSWORD
+
+	Specifies the password of the user identified by :envvar:`TO_USER` (or
+	:option:`-u`/:option:`--to_user` if overridden) to use when authenticating to Traffic Ops. This
+	option is only available using the new call signature. If not provided when using said new call
+	signature, the value will be obtained from the :envvar:`TO_PASSWORD`  environment variable. Note
+	that :program:`traffic_ops_ort` cannot be run using the new call signature unless this value is
+	defined, either on the command line or in the execution environment.
 
 Environment Variables
 ---------------------
@@ -155,15 +212,23 @@ Environment Variables
 	:abbr:`FQDN (Fully Qualified Domain Name)` will do just as well. It may also omit the port
 	number on which the Traffic Ops server listens for incoming connections - port 443 will be
 	assumed unless :envvar:`TO_URL` is prefixed by ``http://`` (case-insensitive), in which case
-	port 80 will be assumed.
+	port 80 will be assumed. The value of this environment variable will only be considered if
+	:program:`traffic_ops_ort` was invoked using the new call signature, which allows it to be
+	overridden on the command line by the value of :option:`--to_url`.
 
 .. envvar:: TO_USER
 
-	The username to use when authenticating to the Traffic Ops server.
+	The username to use when authenticating to the Traffic Ops server. The value of this environment
+	variable will only be considered if :program:`traffic_ops_ort` was invoked using the new call
+	signature, which allows it to be overridden on the command line by the value of
+	:option:`-u`/:option:`--to_user`.
 
 .. envvar:: TO_PASSWORD
 
-	The password to use when authenticating to the Traffic Ops server.
+	The password to use when authenticating to the Traffic Ops server. The value of this environment
+	variable will only be considered if :program:`traffic_ops_ort` was invoked using the new call
+	signature, which allows it to be overridden on the command line by the value of
+	:option:`-p`/:option:`--to_password`.
 
 Module Contents
 ===============
@@ -216,12 +281,27 @@ def doMain(args:argparse.Namespace) -> int:
 		logging.debug("%r", e, exc_info=True, stack_info=True)
 		return 1
 
+_EPILOG = """traffic_ops_ort supports two calling conventions, one is intended to be fully
+compatible with the Perl implementation, while the other is intended to be an improvement over the
+former. Essentially this means that either the `Log_Level`, `Traffic_Ops_URL` and
+`Traffic_Ops_Login`` must all be given, or none of them. If none of them are given, the log level
+will be determined by the `-l`/`--log_level` option, the Traffic Ops server URL will be constructed
+from the information available in the `TO_URL` environment and/or the `--to_url` option, the
+Traffic Ops user will be determined from the information available in the `TO_USER` environment
+variable and/or the `-u`/`--to_user` option, and the Traffic Ops user's password will be determined
+from the information available in the `TO_PASSWORD` environment variable and/or the
+`-p`/`--to_password` option.
+""".replace('\n', ' ') + "\n\n" + ("Note that passing a negative integer to options that expect "
+                                   "integers will instead set them zero.")
+
 def main() -> int:
 	"""
 	The ORT entrypoint, parses argv before handing it off to :func:`doMain`.
 
 	:returns: An exit code for :program:`traffic_ops_ort`
 	"""
+	global _EPILOG
+
 	# I have no idea why, but the old ORT script does this on every run.
 	print(datetime.datetime.utcnow().strftime("%a %b %d %H:%M:%S UTC %Y"))
 
@@ -232,8 +312,7 @@ def main() -> int:
 	logLevelsAllowed = {str(x) for x in LogLevels}.union({str(x).lower() for x in LogLevels})
 
 	parser = argparse.ArgumentParser(description="A Python-based TO_ORT implementation",
-	                                 epilog=("Note that passing a negative integer to options that "
-	                                         "expect integers will instead set them to zero."),
+	                                 epilog=_EPILOG,
 	                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 	parser.add_argument("Mode",

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -221,6 +221,12 @@ def main():
 	# I have no idea why, but the old ORT script does this on every run.
 	print(datetime.datetime.utcnow().strftime("%a %b %d %H:%M:%S UTC %Y"))
 
+	from .configuration import LogLevels
+	from .configuration.Configuration import Modes
+
+	runModesAllowed = {str(x) for x in Modes}.union({str(x).lower() for x in Modes})
+	logLevelsAllowed = {str(x) for x in LogLevels}.union({str(x).lower() for x in LogLevels})
+
 	parser = argparse.ArgumentParser(description="A Python-based TO_ORT implementation",
 	                                 epilog=("Note that passing a negative integer to options that "
 	                                         "expect integers will instead set them to zero."),
@@ -228,22 +234,26 @@ def main():
 
 	parser.add_argument("Mode",
 	                    help="REPORT: Do nothing, but print what would be done\n"\
-	                         "REPORT, INTERACTIVE, REVALIDATE, SYNCDS, BADASS")
-	parser.add_argument("Log_Level",
+	                         "REPORT, INTERACTIVE, REVALIDATE, SYNCDS, BADASS",
+	                    choices=runModesAllowed,
+	                    type=str)
+	parser.add_argument("legacy",
 	                    help="ALL/TRACE, DEBUG, INFO, WARN, ERROR, FATAL/CRITICAL, NONE",
-	                    dest="legacyArgs",
-	                    nargs="?",
+	                    metavar="Log_Level",
+	                    nargs="*",
 	                    action="append",
+	                    choices=logLevelsAllowed,
 	                    type=str)
 	parser.add_argument("-l", "--log_level",
 	                    help=("Sets the logging level. Should be one of (in order of increasing "
 	                          "verbosity) NONE, CRITICAL, ERROR, WARN, INFO, DEBUG"),
 	                    type=str,
+	                    choices=logLevelsAllowed,
 	                    default="WARN")
-	parser.add_argument("Traffic_Ops_URL",
+	parser.add_argument("legacy",
 	                    help="URL to Traffic Ops host. Example: https://trafficops.company.net",
-	                    dest="legacyArgs",
-	                    nargs="?",
+	                    metavar="Traffic_Ops_URL",
+	                    nargs="*",
 	                    action="append",
 	                    type=str)
 	parser.add_argument("--to_url",
@@ -252,9 +262,9 @@ def main():
 	                          " `https://trafficops.infra.ciab.test:443`. This overrides the TO_URL"
 	                          " environment variable"),
 	                    type=str)
-	parser.add_argument("Traffic_Ops_Login",
+	parser.add_argument("legacy",
 	                    help="Example: 'username:password'",
-	                    dest="legacyArgs",
+	                    metavar="Traffic_Ops_Login",
 	                    nargs="?",
 	                    action="append",
 	                    type=str)

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -196,7 +196,7 @@ Arguments and Flags
 	:program:`traffic_ops_ort` cannot be run using the new call signature unless this value is
 	defined, either on the command line or in the execution environment.
 
-.. option:: -p PASSWORD, --password PASSWORD
+.. option:: -p PASSWORD, --to_password PASSWORD
 
 	Specifies the password of the user identified by :envvar:`TO_USER` (or
 	:option:`-u`/:option:`--to_user` if overridden) to use when authenticating to Traffic Ops. This

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -251,8 +251,7 @@ def main() -> int:
 	parser.add_argument("-l", "--log_level",
 	                    help="Sets the logging level. (Default: WARN)",
 	                    type=str,
-	                    choices=logLevelsAllowed,
-	                    default="WARN")
+	                    choices=logLevelsAllowed)
 	parser.add_argument("legacy",
 	                    help="URL to Traffic Ops host. Example: https://trafficops.company.net",
 	                    metavar="Traffic_Ops_URL",

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -177,6 +177,7 @@ def doMain(args:argparse.Namespace) -> int:
 	except ValueError as e:
 		logging.critical(e)
 		logging.debug("%r", e, exc_info=True, stack_info=True)
+<<<<<<< c8d6ef9157e1d078478be6aec2827a52c3d7fb59
 		return 1
 
 	if conf.login_dispersion:
@@ -194,6 +195,25 @@ def doMain(args:argparse.Namespace) -> int:
 		logging.debug("%r", e, exc_info=True, stack_info=True)
 		return 1
 
+=======
+		return 1
+
+	if conf.login_dispersion:
+		disp = random.randint(0, conf.login_dispersion)
+		logging.info("Login dispersion is active - sleeping for %d seconds before continuing", disp)
+		time.sleep(disp)
+
+	try:
+		with to_api.API(conf) as api:
+			conf.api = api
+			return main_routines.run(conf)
+	except (LoginError, OperationError, InvalidJSONError, RequestException) as e:
+		logging.critical("Failed to connect and authenticate with the Traffic Ops server")
+		logging.error(e)
+		logging.debug("%r", e, exc_info=True, stack_info=True)
+		return 1
+
+>>>>>>> ORT.py now implements all the same command line flags as the Perl script
 def main():
 	"""
 	The ORT entrypoint, parses argv before handing it off to :func:`doMain`.
@@ -231,8 +251,12 @@ def main():
 	                    default=3)
 	parser.add_argument("--wait_for_parents",
 	                    help="do not update if parent_pending = 1 in the update json.",
+<<<<<<< c8d6ef9157e1d078478be6aec2827a52c3d7fb59
 	                    type=int,
 	                    default=1)
+=======
+	                    action="store_true")
+>>>>>>> ORT.py now implements all the same command line flags as the Perl script
 	parser.add_argument("--rev_proxy_disable",
 	                    help="bypass the reverse proxy even if one has been configured.",
 	                    action="store_true")

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -74,7 +74,8 @@ Arguments and Flags
 
 .. option:: --dispersion DISP
 
-	Wait a random number between 0 and ``DISP`` seconds before starting. (Default: 300)
+	Wait a random number between 0 and ``DISP`` seconds before starting. This option *only* has any
+	effect if :option:`MODE` is ``SYNCDS``. (Default: 300)
 
 .. option:: --login_dispersion DISP
 
@@ -234,7 +235,7 @@ Module Contents
 ===============
 """
 
-__version__ = "0.0.5"
+__version__ = "0.1.0"
 __author__  = "Brennan Fieck"
 
 import argparse

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -221,10 +221,10 @@ def main():
 	# I have no idea why, but the old ORT script does this on every run.
 	print(datetime.datetime.utcnow().strftime("%a %b %d %H:%M:%S UTC %Y"))
 
-	from .configuration import LogLevels
-	from .configuration.Configuration import Modes
+	from .configuration import LogLevels, Configuration
 
-	runModesAllowed = {str(x) for x in Modes}.union({str(x).lower() for x in Modes})
+	runModesAllowed = {str(x) for x in Configuration.Modes}.union(
+	                  {str(x).lower() for x in Configuration.Modes})
 	logLevelsAllowed = {str(x) for x in LogLevels}.union({str(x).lower() for x in LogLevels})
 
 	parser = argparse.ArgumentParser(description="A Python-based TO_ORT implementation",

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -197,7 +197,6 @@ def doMain(args:argparse.Namespace) -> int:
 	except ValueError as e:
 		logging.critical(e)
 		logging.debug("%r", e, exc_info=True, stack_info=True)
-<<<<<<< c8d6ef9157e1d078478be6aec2827a52c3d7fb59
 		return 1
 
 	if conf.login_dispersion:
@@ -215,25 +214,6 @@ def doMain(args:argparse.Namespace) -> int:
 		logging.debug("%r", e, exc_info=True, stack_info=True)
 		return 1
 
-=======
-		return 1
-
-	if conf.login_dispersion:
-		disp = random.randint(0, conf.login_dispersion)
-		logging.info("Login dispersion is active - sleeping for %d seconds before continuing", disp)
-		time.sleep(disp)
-
-	try:
-		with to_api.API(conf) as api:
-			conf.api = api
-			return main_routines.run(conf)
-	except (LoginError, OperationError, InvalidJSONError, RequestException) as e:
-		logging.critical("Failed to connect and authenticate with the Traffic Ops server")
-		logging.error(e)
-		logging.debug("%r", e, exc_info=True, stack_info=True)
-		return 1
-
->>>>>>> ORT.py now implements all the same command line flags as the Perl script
 def main():
 	"""
 	The ORT entrypoint, parses argv before handing it off to :func:`doMain`.

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -240,7 +240,7 @@ def main():
 	parser.add_argument("legacy",
 	                    help="ALL/TRACE, DEBUG, INFO, WARN, ERROR, FATAL/CRITICAL, NONE",
 	                    metavar="Log_Level",
-	                    nargs="*",
+	                    nargs="?",
 	                    action="append",
 	                    choices=logLevelsAllowed,
 	                    type=str)
@@ -253,7 +253,7 @@ def main():
 	parser.add_argument("legacy",
 	                    help="URL to Traffic Ops host. Example: https://trafficops.company.net",
 	                    metavar="Traffic_Ops_URL",
-	                    nargs="*",
+	                    nargs="?",
 	                    action="append",
 	                    type=str)
 	parser.add_argument("--to_url",

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -251,12 +251,8 @@ def main():
 	                    default=3)
 	parser.add_argument("--wait_for_parents",
 	                    help="do not update if parent_pending = 1 in the update json.",
-<<<<<<< c8d6ef9157e1d078478be6aec2827a52c3d7fb59
 	                    type=int,
 	                    default=1)
-=======
-	                    action="store_true")
->>>>>>> ORT.py now implements all the same command line flags as the Perl script
 	parser.add_argument("--rev_proxy_disable",
 	                    help="bypass the reverse proxy even if one has been configured.",
 	                    action="store_true")

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -34,6 +34,8 @@ Usage
 
 ``traffic_ops_ort [-h]``
 
+Arguments and Flags
+-------------------
 .. option:: -h, --help
 
 	Print usage information and exit
@@ -144,6 +146,24 @@ Usage
 	.. warning:: The first colon found in this string is considered the delimiter. There is no way
 		to escape the delimeter. This effectively means that usernames containing colons cannot be
 		used to authenticate with Traffic Ops, though passwords containing colons should be fine.
+
+Environment Variables
+---------------------
+.. envvar:: TO_URL
+
+	Should be set to the URL of a Traffic Ops server. This doesn't need to be a full URL, an
+	:abbr:`FQDN (Fully Qualified Domain Name)` will do just as well. It may also omit the port
+	number on which the Traffic Ops server listens for incoming connections - port 443 will be
+	assumed unless :envvar:`TO_URL` is prefixed by ``http://`` (case-insensitive), in which case
+	port 80 will be assumed.
+
+.. envvar:: TO_USER
+
+	The username to use when authenticating to the Traffic Ops server.
+
+.. envvar:: TO_PASSWORD
+
+	The password to use when authenticating to the Traffic Ops server.
 
 Module Contents
 ===============

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -231,12 +231,41 @@ def main():
 	                         "REPORT, INTERACTIVE, REVALIDATE, SYNCDS, BADASS")
 	parser.add_argument("Log_Level",
 	                    help="ALL/TRACE, DEBUG, INFO, WARN, ERROR, FATAL/CRITICAL, NONE",
+	                    dest="legacyArgs",
+	                    nargs="?",
+	                    action="append",
 	                    type=str)
+	parser.add_argument("-l", "--log_level",
+	                    help=("Sets the logging level. Should be one of (in order of increasing "
+	                          "verbosity) NONE, CRITICAL, ERROR, WARN, INFO, DEBUG"),
+	                    type=str,
+	                    default="WARN")
 	parser.add_argument("Traffic_Ops_URL",
 	                    help="URL to Traffic Ops host. Example: https://trafficops.company.net",
+	                    dest="legacyArgs",
+	                    nargs="?",
+	                    action="append",
+	                    type=str)
+	parser.add_argument("--to_url",
+	                    help=("A URL or hostname - optionally with a port specification - that "
+	                          "points to a Traffic Ops server. e.g. `trafficops.infra.ciab.test` or"
+	                          " `https://trafficops.infra.ciab.test:443`. This overrides the TO_URL"
+	                          " environment variable"),
 	                    type=str)
 	parser.add_argument("Traffic_Ops_Login",
-	                    help="Example: 'username:password'")
+	                    help="Example: 'username:password'",
+	                    dest="legacyArgs",
+	                    nargs="?",
+	                    action="append",
+	                    type=str)
+	parser.add_argument("-u", "--to_user",
+	                    help=("The username to use when authenticating to the Traffic Ops server. "
+	                          "This overrides the TO_USER environment variable."),
+	                    type=str)
+	parser.add_argument("-p", "--to_password",
+	                    help=("The password to use when authenticating to the Traffic Ops server. "
+	                          "This overrides the TO_PASSWORD environment variable."),
+	                    type=str)
 	parser.add_argument("--dispersion",
 	                    help="wait a random number between 0 and <dispersion> before starting.",
 	                    type=int,

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/configuration.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/configuration.py
@@ -113,7 +113,7 @@ class Configuration():
 		self.rev_proxy_disable = args.rev_proxy_disable
 		self.verify = not args.insecure
 
-		setLogLevel(args.Log_Level)
+		setLogLevel(args.log_level)
 
 		logging.info("Distribution detected as: '%s'", DISTRO)
 
@@ -128,12 +128,8 @@ class Configuration():
 		self.tsroot = parseTSRoot(args.ts_root)
 		logging.info("ATS root installation directory set to '%s'", self.tsroot)
 
-		self.useSSL, self.toHost, self.toPort = parseTOURL(args.Traffic_Ops_URL, self.verify)
-
-		try:
-			self.username, self.password = args.Traffic_Ops_Login.split(':')
-		except ValueError as e:
-			raise ValueError("Invalid login information, should be like 'username:password'.") from e
+		self.useSSL, self.toHost, self.toPort = parseTOURL(args.to_url, self.verify)
+		self.username, self.password = args.to_user, args.to_password
 
 
 	@property

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -23,8 +23,12 @@ It extends the class provided by the official Apache Traffic Control Client.
 import typing
 import logging
 
+<<<<<<< cae82dff75ed7d5a93b334961fe84993e703d1c3
 from requests.exceptions import RequestException
 from requests.compat import urljoin
+=======
+import requests
+>>>>>>> ORT.py now implements all the same command line flags as the Perl script
 from trafficops.tosession import TOSession
 from trafficops.restapi import LoginError, OperationError, InvalidJSONError
 

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -23,12 +23,9 @@ It extends the class provided by the official Apache Traffic Control Client.
 import typing
 import logging
 
-<<<<<<< cae82dff75ed7d5a93b334961fe84993e703d1c3
 from requests.exceptions import RequestException
 from requests.compat import urljoin
-=======
-import requests
->>>>>>> ORT.py now implements all the same command line flags as the Perl script
+
 from trafficops.tosession import TOSession
 from trafficops.restapi import LoginError, OperationError, InvalidJSONError
 

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -23,8 +23,8 @@ It extends the class provided by the official Apache Traffic Control Client.
 import typing
 import logging
 
-from requests.exceptions import RequestException
 from requests.compat import urljoin
+from requests.exceptions import RequestException
 
 from trafficops.tosession import TOSession
 from trafficops.restapi import LoginError, OperationError, InvalidJSONError


### PR DESCRIPTION
## What does this PR do?
The Python implementation of ORT will now use the semi-standard environment variables:

TO_URL
    Specifies the URL/hostname of the Traffic Ops server, optionally with a port (must match `(?i:https?://)?\w+(\.\w+)*(:\d+)?` )
TO_USER
   Specifies the name of the user as whom to authenticate with Traffic Ops
TO_PASSWORD
    Specifies the password of the user as whom to authenticate with Traffic Ops

This PR adds a new call signature to ORT.py - in addition to the old, Perl-compatible(ish) call signature - wherein specification of these pieces of information is optional when these environment variables are defined. They can also be overridden when they **are** defined by using the new `--to_url`, `-u`/`--to_user`, and `-p`/`--to_password` options, respectively. This new call signature also makes the log level optional (provided by the `-l`/`--log_level` option), and it will now default to `WARN`.

## Which TC components are affected by this PR?

- [x] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [x] Traffic Ops ORT (Python)
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR?
Define those environment variables and verify that

1. When using the old call signature, they are ignored and operations proceed normally
2. When using the new call signature, they are used and operations proceed normally
3. When using the new call signature, they can be overridden by command-line options and operations proceed normally.

This PR also includes updates to the documentation that should go into greater detail regarding the command line options allowed, so feel free to build and look at that if you need more information

## Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)