### PR TITLE
Improve handling of faulty CRConfig DS-server assignments in TR

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -620,6 +620,10 @@ public class ZoneManager extends Resolver {
 		for (final Cache c : data.getCacheMap().values()) {
 			for (final DeliveryServiceReference dsr : c.getDeliveryServices()) {
 				final DeliveryService ds = data.getDeliveryService(dsr.getDeliveryServiceId());
+				if (ds == null) {
+					LOGGER.warn("Content server " + c.getFqdn() + " has delivery service " + dsr.getDeliveryServiceId() + " assigned, but the delivery service was not found. Skipping.");
+					continue;
+				}
 				final String fqdn = dsr.getFqdn();
 				final String[] parts = fqdn.split("\\.", 2);
 				final String host = parts[0];


### PR DESCRIPTION
If a server has a reference to a delivery service but the delivery
service does not exist (i.e.
crconfig["contentServers"]["cache1"]["deliveryServices"] contains a DS
xml_id that doesn't have a matching delivery service in
crconfig["deliveryServices"]) Traffic Router should log a warning for
that error and continue rather than throwing a NullPointerException.

The bad generation of the CRConfig will be fixed separately.

#### What does this PR do?

Fixes #3315

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [x] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?
Create an ANY_MAP DS in Traffic Ops, assign it to some edges, snapshot, and check the Traffic Router logs to make sure it's not throwing NullPointerExceptions and starts up properly. The logs should display warnings of the format in this PR to indicate that it's skipping the missing delivery services.

#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



