### PR TITLE
Revert "Use JSONIntStr for user endpoint"

### DIFF
--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -1,7 +1,5 @@
 package tc
 
-import util "github.com/apache/trafficcontrol/lib/go-util"
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -56,24 +54,24 @@ type UserV13 struct {
 // commonUserFields is unexported, but its contents are still visible when it is embedded
 // LastUpdated is a new field for some structs
 type commonUserFields struct {
-	AddressLine1    *string          `json:"addressLine1" db:"address_line1"`
-	AddressLine2    *string          `json:"addressLine2" db:"address_line2"`
-	City            *string          `json:"city" db:"city"`
-	Company         *string          `json:"company" db:"company"`
-	Country         *string          `json:"country" db:"country"`
-	Email           *string          `json:"email" db:"email"`
-	FullName        *string          `json:"fullName" db:"full_name"`
-	GID             *int             `json:"gid"`
-	ID              *int             `json:"id" db:"id"`
-	NewUser         *bool            `json:"newUser" db:"new_user"`
-	PhoneNumber     *string          `json:"phoneNumber" db:"phone_number"`
-	PostalCode      *string          `json:"postalCode" db:"postal_code"`
-	PublicSSHKey    *string          `json:"publicSshKey" db:"public_ssh_key"`
-	Role            *util.JSONIntStr `json:"role" db:"role"`
-	StateOrProvince *string          `json:"stateOrProvince" db:"state_or_province"`
-	Tenant          *string          `json:"tenant"`
-	TenantID        *util.JSONIntStr `json:"tenantId" db:"tenant_id"`
-	UID             *int             `json:"uid"`
+	AddressLine1    *string `json:"addressLine1" db:"address_line1"`
+	AddressLine2    *string `json:"addressLine2" db:"address_line2"`
+	City            *string `json:"city" db:"city"`
+	Company         *string `json:"company" db:"company"`
+	Country         *string `json:"country" db:"country"`
+	Email           *string `json:"email" db:"email"`
+	FullName        *string `json:"fullName" db:"full_name"`
+	GID             *int    `json:"gid"`
+	ID              *int    `json:"id" db:"id"`
+	NewUser         *bool   `json:"newUser" db:"new_user"`
+	PhoneNumber     *string `json:"phoneNumber" db:"phone_number"`
+	PostalCode      *string `json:"postalCode" db:"postal_code"`
+	PublicSSHKey    *string `json:"publicSshKey" db:"public_ssh_key"`
+	Role            *int    `json:"role" db:"role"`
+	StateOrProvince *string `json:"stateOrProvince" db:"state_or_province"`
+	Tenant          *string `json:"tenant"`
+	TenantID        *int    `json:"tenantId" db:"tenant_id"`
+	UID             *int    `json:"uid"`
 	//Username        *string    `json:"username" db:"username"`  //not including major change due to naming incompatibility
 	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
-	util "github.com/apache/trafficcontrol/lib/go-util"
 )
 
 // Users gets an array of Users.
@@ -79,7 +78,6 @@ func (to *Session) GetUserCurrent() (*tc.UserCurrent, ReqInf, error) {
 
 // CreateUser creates a user
 func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, error) {
-
 	if user.TenantID == nil && user.Tenant != nil {
 		tenant, _, err := to.TenantByName(*user.Tenant)
 		if err != nil {
@@ -91,8 +89,7 @@ func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, er
 		if err != nil {
 			return nil, ReqInf{}, err
 		}
-		tmp := util.JSONIntStr(tenant.ID)
-		user.TenantID = &tmp
+		user.TenantID = &tenant.ID
 	}
 
 	if user.RoleName != nil && *user.RoleName != "" {
@@ -106,8 +103,7 @@ func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, er
 		if err != nil {
 			return nil, ReqInf{}, err
 		}
-		tmp := util.JSONIntStr(*roles[0].ID)
-		user.Role = &tmp
+		user.Role = roles[0].ID
 	}
 
 	var remoteAddr net.Addr

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -232,7 +232,7 @@ func (this *TOUser) Read() ([]interface{}, error, error, int) {
 }
 
 func (user *TOUser) privCheck() (error, error, int) {
-	requestedPrivLevel, _, err := dbhelpers.GetPrivLevelFromRoleID(user.ReqInfo.Tx.Tx, int(*user.Role))
+	requestedPrivLevel, _, err := dbhelpers.GetPrivLevelFromRoleID(user.ReqInfo.Tx.Tx, *user.Role)
 	if err != nil {
 		return nil, err, http.StatusInternalServerError
 	}
@@ -247,7 +247,7 @@ func (user *TOUser) privCheck() (error, error, int) {
 func (user *TOUser) Update() (error, error, int) {
 
 	// make sure current user cannot update their own role to a new value
-	if user.ReqInfo.User.ID == *user.ID && user.ReqInfo.User.Role != int(*user.Role) {
+	if user.ReqInfo.User.ID == *user.ID && user.ReqInfo.User.Role != *user.Role {
 		return fmt.Errorf("users cannot update their own role"), nil, http.StatusBadRequest
 	}
 
@@ -339,7 +339,7 @@ func (u *TOUser) IsTenantAuthorized(user *auth.CurrentUser) (bool, error) {
 	if u.TenantID != nil { // new tenant id (only on create or udpate)
 
 		//log.Debugf("%d with tenancy %d trying to access %d", user.ID, user.TenantID, *u.TenantID)
-		authorized, err := tenant.IsResourceAuthorizedToUserTx(int(*u.TenantID), user, tx)
+		authorized, err := tenant.IsResourceAuthorizedToUserTx(*u.TenantID, user, tx)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This reverts commit ccec233e2c7951e28b42bf370e5fc6b5c498df95.

In the conversion from perl to go, perl will accept strings or ints as
integers because it is a weakly typed language. The use of JSONIntStr
allowed the same to happen in golang (in this case for a single
endpoint).

The use of JSONIntStr would keep the functionaility from perl, however I
am reverting the change because keeping this behavior implies that we
want to maintain it in the future for all other endpoints.

When the original commit was made, there was not yet a consensus to keep the bug as is.
Here is a part of the discussion (the rest was in slack):
https://lists.apache.org/thread.html/f0624d4386f1de1f18b322436df6fa0402bf34314abd4b108edc5fde@%3Cdev.trafficcontrol.apache.org%3E

#### What does this PR do?

Fixes #(issue_number)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



