### PR TITLE
[BACKPORT] Fix CRConfig generation to not include ANY_MAP DS-server assignments

### DIFF
--- a/traffic_ops/traffic_ops_golang/crconfig/servers.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/servers.go
@@ -22,6 +22,7 @@ package crconfig
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -190,10 +191,12 @@ select s.host_name, ds.xml_id
 from deliveryservice_server as dss
 inner join server as s on dss.server = s.id
 inner join deliveryservice as ds on ds.id = dss.deliveryservice
+inner join type as dt on dt.id = ds.type
 inner join profile as p on p.id = s.profile
 inner join status as st ON st.id = s.status
 where ds.cdn_id = (select id from cdn where name = $1)
-and ds.active = true
+and ds.active = true` +
+		fmt.Sprintf(" and dt.name != '%s' ", tc.DSTypeAnyMap) + `
 and p.routing_disabled = false
 and (st.name = 'REPORTED' or st.name = 'ONLINE' or st.name = 'ADMIN_DOWN')
 `
@@ -235,7 +238,8 @@ inner join deliveryservice_regex as dsr on dsr.regex = r.id
 inner join deliveryservice as ds on ds.id = dsr.deliveryservice
 inner join type as dt on dt.id = ds.type
 where ds.cdn_id = (select id from cdn where name = $1)
-and ds.active = true
+and ds.active = true` +
+		fmt.Sprintf(" and dt.name != '%s' ", tc.DSTypeAnyMap) + `
 and rt.name = 'HOST_REGEXP'
 order by dsr.set_number asc
 `


### PR DESCRIPTION
The CRConfig generation already filters ANY_MAP DSes out of the
"deliveryServices" data, but it should also filter them out of the
server-DS mappings as well.

(cherry picked from commit 89b7a918e9c29fd310e3c34956547b17883d3e0b)

#### Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

#### What is the best way to verify this PR?


#### Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



