### PR TITLE
Hint for form fields is now a help cursor instead of underline (which implies link)

### DIFF
--- a/traffic_portal/app/src/common/modules/form/_form.scss
+++ b/traffic_portal/app/src/common/modules/form/_form.scss
@@ -20,8 +20,12 @@
   color: #cd1323;
 }
 
-form .control-label > span:hover {
-  text-decoration: underline;
+form .control-label > span {
+	text-decoration: underline dotted;
+
+	&:hover {
+		cursor: help;
+	}
 }
 
 .dnssec-info-text {


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?
In Traffic Portal forms, when a help popover is available the UI indicates this by underlining the field label. This PR changes the hint to instead make the cursor appear as the system's default "help" cursor, indicating help on the topic available. The underline makes it seem like the text is a link, and clicking on it may navigate me away from the form.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
Build and start Traffic Portal and check that the field label text is no longer underlined on hover, but instead transforms the cursor into your system's "help" cursor (usually a question mark of some kind).


## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)