### PR TITLE
Fixed broken ORT.py crontab

### DIFF
--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-*/1 * * * * . /to-access.sh; /usr/bin/traffic_ops_ort -kl ALL --dispersion 0 SYNCDS >> /var/log/ort.log 2>>&1
+*/1 * * * * /usr/bin/traffic_ops_ort -k --dispersion 0 SYNCDS ALL $TO_URL $TO_USER:$TO_PASSWORD >> /var/log/ort.log 2>&1


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?
In an earlier pull request I changed this crontab to use `to-access.sh` to source an environment and execute using the "new call signature" - that had a typo in it: `2>>&1` which can't actually be done. When fixing this, I found that since `cron` runs commands through `sh` (not `bash`) it can't actually do all of things in `to-access.sh` and that causes it to crash. So I reverted the crontab to use the "old call signature".

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [x] Traffic Ops ORT (Python)
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] CDN in a Box

## What is the best way to verify this PR? Please include manual steps or automated tests. 
Build and run [CDN in a Box](https://traffic-control-cdn.readthedocs.io/en/latest/admin/quick_howto/ciab.html), then use `docker exec -it cdninabox_edge_1 /bin/bash` to get into the edge container and watch the file `/var/log/ort.log` for changes. It should be being appended to with ORT.py output every minute.


## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



