### PR TITLE
Fix: Steering Target form doesn't display 'Steering Delivery Service' value

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/form.deliveryServiceTarget.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/form.deliveryServiceTarget.tpl.html
@@ -33,7 +33,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(dsTargetForm.deliveryServiceId), 'has-feedback': hasError(dsTargetForm.deliveryServiceId)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">Steering Delivery Service</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="deliveryServiceId" class="form-control" ng-model="target.deliveryServiceId" ng-disabled="true" ng-options="ds.id as ds.xmlId for ds in deliveryServices"></select>
+                    <input name="deliveryServiceId" type="text" class="form-control" ng-model="deliveryService.xmlId" ng-disabled="true">
                 </div>
             </div>
             <div class="form-group" ng-class="{'has-error': hasError(dsTargetForm.targetId), 'has-feedback': hasError(dsTargetForm.targetId)}">


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

Fixes #3328

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)
Select a Target from a Steering Delivery Service and observe that "Steering Delivery Service" field is populated with the name (xmlId) of the Delivery Service.

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



