### PR TITLE
Fix TM nil pointer panic

### DIFF
--- a/traffic_monitor/ds/stat_test.go
+++ b/traffic_monitor/ds/stat_test.go
@@ -398,3 +398,10 @@ func randStr() string {
 	}
 	return s
 }
+
+func TestAddLastStatsToStatCacheStatsNilVals(t *testing.T) {
+	// test that addLastStatsToStatCacheStats doesn't panic with nil values
+	addLastStatsToStatCacheStats(nil, nil)
+	addLastStatsToStatCacheStats(&dsdata.StatCacheStats{}, nil)
+	addLastStatsToStatCacheStats(nil, &dsdata.LastStatsData{})
+}


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

Fixes a Monitor nil pointer panic, from when a poll happened to not include any caches from a given cachegroup that was previously polled.

This is a race condition, but, as part of the fix, I added logging to see when the new (correct) default construction, and observed it getting hit after a few days. So I'm certain this fixes the race.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [x] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Verify Monitor runs as expected. This was a race condition, so it can't really be verified. You can run the Monitor with a large dataset for a few days, and see that it doesn't crash.

## Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



