### PR TITLE
Make SSL Cert lookup case-insensitive

### DIFF
--- a/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
+++ b/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
@@ -87,4 +87,9 @@ public class RouterNioEndpoint extends NioEndpoint {
             createSSLContext(sslHostConfig);
         }
     }
+
+    @Override
+    protected SSLHostConfig getSSLHostConfig(final String sniHostName) {
+        return super.getSSLHostConfig(sniHostName.toLowerCase());
+    }
 }

--- a/traffic_router/connector/src/test/java/secure/CertificateRegistryTest.java
+++ b/traffic_router/connector/src/test/java/secure/CertificateRegistryTest.java
@@ -50,6 +50,9 @@ public class CertificateRegistryTest {
 		certificateData1 = mock(CertificateData.class);
 		certificateData2 = mock(CertificateData.class);
 		certificateData3 = mock(CertificateData.class);
+		when(certificateData1.alias()).thenReturn("ds-1.some-cdn.example.com");
+		when(certificateData2.alias()).thenReturn("ds-2.some-cdn.example.com");
+		when(certificateData3.alias()).thenReturn("ds-3.some-cdn.example.com");
 
 		certificateDataList = Arrays.asList(certificateData1, certificateData2, certificateData3);
 

--- a/traffic_router/shared/src/main/java/com/comcast/cdn/traffic_control/traffic_router/shared/CertificateData.java
+++ b/traffic_router/shared/src/main/java/com/comcast/cdn/traffic_control/traffic_router/shared/CertificateData.java
@@ -49,8 +49,12 @@ public class CertificateData {
 		return hostname;
 	}
 
+	public String alias() {
+		return getHostname().replaceFirst("\\*\\.", "");
+	}
+
 	public void setHostname(final String hostname) {
-		this.hostname = hostname;
+		this.hostname = hostname.toLowerCase();
 	}
 
 	@SuppressWarnings("PMD.IfStmtsMustUseBraces")


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?
OpenSSL is performing an exact match between the requested SNI and the lookup keys associated with SSL Certificates. Since FQDNs are not case sensitive this is inappropriate and sometimes causes misses on the certificate lookup. TR incorrectly returns the default certificate in these cases.  This PR is a workaround for this issues by: 
1. When TR receives an HTTPS request it converts the requested SNI to lower case before passing it to OpenSSL. 
2. When configuring OpenSSL TR makes sure that all the lookup keys for the certs that it has received from Traffic Ops have been converted to lower case.  
Fixes #(replace_this_text_with_issue_number) 

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [X] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)
The easiest way to test this PR is to start up a local instance of TR by running TrafficRouterStart and configuring it to point at an existing Traffic Ops instance which is configured with at least one SSL Cert and a matching Delivery Service which is SSL enabled. Any existing non-production environment should do. Run a couple of 'curl' commands:
1. curl -kvs https://ccr.myds.mycdn.mycompany.com:8443/stuff --resolve ccr.myds.mycdn.mycompany.com:8443:127.0.0.1

should perform an SSL handshake and return a certificate for domain myds.mycdn.mycompany.com

2. curl -kvs https://ccr.MYDS.MYCDN.mycompany.com:8443/stuff --resolve ccr.myds.mycdn.mycompany.com:8443:127.0.0.1

should perform an SSL handshake and return the same certificate as in #1.

Of course you have to replace myds, mycdn and mycompany with the fqdn for your delivery service.

 


## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



