### PR TITLE
Add TO deleting old DS certs on snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Adds the DS Record text to the cdn dnsseckeys endpoint in 1.4.
 - Added monitoring.json snapshotting. This stores the monitoring json in the same table as the crconfig snapshot. Snapshotting is now required in order to push out monitoring changes.
 - To traffic_ops_ort.pl added the ability to handle ##OVERRIDE## delivery service ANY_MAP raw remap text to replace and comment out a base delivery service remap rules. THIS IS A TEMPORARY HACK until versioned delivery services are implemented.
+- Snapshotting the CRConfig now deletes HTTPS certificates in Riak for delivery services which have been deleted in Traffic Ops.
 
 ### Changed
 - Traffic Ops Golang Endpoints

--- a/docs/source/admin/traffic_ops/using.rst
+++ b/docs/source/admin/traffic_ops/using.rst
@@ -1200,6 +1200,7 @@ To create a new snapshot, use the *Tools > Snapshot CRConfig* menu:
 	#. When the This will push out a new CRConfig.json. Are you sure? window opens, click **OK**.
 	#. The "Successfully wrote CRConfig.json!" window opens, click **OK**.
 
+.. Note:: Snapshotting the CDN also deletes all HTTPS certificates for every :term:`Delivery Service` which has been deleted since the last :term:`Snapshot`.
 
 .. index::
 	Invalidate Content

--- a/docs/source/api/cdns_id_snapshot.rst
+++ b/docs/source/api/cdns_id_snapshot.rst
@@ -25,6 +25,8 @@
 =======
 Performs a CDN snapshot. Effectively, this propagates the new *configuration* of the CDN to its *operating state*, which replaces the output of the :ref:`to-api-cdns-name-snapshot` endpoint with the output of the :ref:`to-api-cdns-name-snapshot-new` endpoint.
 
+.. Note:: Snapshotting the CDN also deletes all HTTPS certificates for every :term:`Delivery Service` which has been deleted since the last CDN :term:`Snapshot`.
+
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"
 :Response Type:  ``undefined``

--- a/docs/source/api/snapshot_name.rst
+++ b/docs/source/api/snapshot_name.rst
@@ -23,6 +23,8 @@
 =======
 Performs a CDN snapshot. Effectively, this propagates the new *configuration* of the CDN to its *operating state*, which replaces the output of the :ref:`to-api-cdns-name-snapshot` endpoint with the output of the :ref:`to-api-cdns-name-snapshot-new` endpoint.
 
+.. Note:: Snapshotting the CDN also deletes all HTTPS certificates for every :term:`Delivery Service` which has been deleted since the last :term:`Snapshot`.
+
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"
 :Response Type:  ``undefined``

--- a/traffic_ops/traffic_ops_golang/cdn/dnssecrefresh.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssecrefresh.go
@@ -45,17 +45,21 @@ func RefreshDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 		noTx := (*sql.Tx)(nil) // make a variable instead of passing nil directly, to reduce copy-paste errors
 		if err != nil {
 			api.HandleErr(w, r, noTx, http.StatusInternalServerError, nil, errors.New("RefresHDNSSECKeys getting db from context: "+err.Error()))
+			unsetInDNSSECKeyRefresh()
 			return
 		}
 		cfg, err := api.GetConfig(r.Context())
 		if err != nil {
 			api.HandleErr(w, r, noTx, http.StatusInternalServerError, nil, errors.New("RefresHDNSSECKeys getting config from context: "+err.Error()))
+			unsetInDNSSECKeyRefresh()
 			return
 		}
 
 		tx, err := db.Begin()
 		if err != nil {
 			api.HandleErr(w, r, noTx, http.StatusInternalServerError, nil, errors.New("RefresHDNSSECKeys beginning tx: "+err.Error()))
+			unsetInDNSSECKeyRefresh()
+			return
 		}
 		go doDNSSECKeyRefresh(tx, cfg) // doDNSSECKeyRefresh takes ownership of tx and MUST close it.
 	} else {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deleteoldcerts.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deleteoldcerts.go
@@ -1,0 +1,197 @@
+package deliveryservice
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/riaksvc"
+
+	"github.com/basho/riak-go-client"
+)
+
+// DeleteOldCerts asynchronously deletes HTTPS certificates in Riak which have no corresponding delivery service in the database.
+//
+// Note the delivery service may still be in the CRConfig! Therefore, this should only be called immediately after a CRConfig Snapshot.
+//
+// This creates a goroutine, and immediately returns. It returns an error if there was an error preparing the delete routine, such as an error creating a db transaction.
+//
+// Note because it is asynchronous, this may return a nil error, but the asynchronous goroutine may error when fetching or deleting the certificates. If such an error occurs, it will be logged to the error log.
+//
+// If certificate deletion is already being processed by a goroutine, another delete will be queued, and this immediately returns nil. Only one delete will ever be queued.
+//
+func DeleteOldCerts(db *sql.DB, tx *sql.Tx, cfg *config.Config, cdn tc.CDNName) error {
+	if !cfg.RiakEnabled {
+		log.Infoln("deleting old delivery service certificates: Riak is not enabled, returning without cleaning up old certificates.")
+		return nil
+	}
+	if db == nil {
+		return errors.New("nil db")
+	}
+	if cfg == nil {
+		return errors.New("nil config")
+	}
+	startOldCertDeleter(db, tx, time.Duration(cfg.DBQueryTimeoutSeconds)*time.Second, cfg.RiakAuthOptions, cfg.RiakPort, cdn)
+	cleanupOldCertDeleters(tx)
+	return nil
+}
+
+// deleteOldDSCerts deletes the HTTPS certificates in Riak of delivery services which have been deleted in Traffic Ops.
+func deleteOldDSCerts(tx *sql.Tx, authOpts *riak.AuthOptions, riakPort *uint, cdn tc.CDNName) error {
+	dsKeys, err := riaksvc.GetCDNSSLKeysDSNames(tx, authOpts, riakPort, cdn)
+	if err != nil {
+		return errors.New("getting riak ds keys: " + err.Error())
+	}
+
+	dses, err := dbhelpers.GetCDNDSes(tx, cdn)
+	if err != nil {
+		return errors.New("getting ds names: " + err.Error())
+	}
+
+	successes := []string{}
+	failures := []string{}
+	for ds, riakKeys := range dsKeys {
+		if _, ok := dses[ds]; ok {
+			continue
+		}
+		for _, riakKey := range riakKeys {
+			err := riaksvc.DeleteDeliveryServicesSSLKey(tx, authOpts, riakPort, riakKey)
+			if err != nil {
+				log.Errorln("deleting Riak SSL keys for Delivery Service '" + string(ds) + "' key '" + riakKey + "': " + err.Error())
+				failures = append(failures, string(ds))
+			} else {
+				log.Infoln("Deleted Riak SSL keys for delivery service which has been deleted in the database '" + string(ds) + "' key '" + riakKey + "'")
+				successes = append(successes, string(ds))
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return errors.New("successfully deleted Riak SSL keys for deleted dses [" + strings.Join(successes, ", ") + "], but failed to delete Riak SSL keys for [" + strings.Join(failures, ", ") + "]; see the error log for details")
+	}
+	return nil
+}
+
+// deleteOldDSCertsDB takes a db, and creates a transaction to pass to deleteOldDSCerts.
+func deleteOldDSCertsDB(db *sql.DB, dbTimeout time.Duration, riakOpts *riak.AuthOptions, riakPort *uint, cdn tc.CDNName) {
+	dbCtx, cancelTx := context.WithTimeout(context.Background(), dbTimeout)
+	tx, err := db.BeginTx(dbCtx, nil)
+	if err != nil {
+		log.Errorln("Old Cert Deleter Job: beginning tx: " + err.Error())
+		return
+	}
+	defer cancelTx()
+	txCommit := false
+	defer dbhelpers.CommitIf(tx, &txCommit)
+	if err := deleteOldDSCerts(tx, riakOpts, riakPort, cdn); err != nil {
+		log.Errorln("deleting old DS certificates: " + err.Error())
+		return
+	}
+	txCommit = true
+}
+
+var oldCertDeleters = OldCertDeleters{D: map[tc.CDNName]*OldCertDeleter{}}
+
+type OldCertDeleters struct {
+	D map[tc.CDNName]*OldCertDeleter
+	M sync.Mutex
+}
+
+// startOldCertDeleter tells the old cert deleter goroutine to start another delete job, creating the goroutine if it doesn't exist.
+func startOldCertDeleter(db *sql.DB, tx *sql.Tx, dbTimeout time.Duration, riakOpts *riak.AuthOptions, riakPort *uint, cdn tc.CDNName) {
+	oldCertDeleter := getOrCreateOldCertDeleter(cdn)
+	oldCertDeleter.Once.Do(func() {
+		go doOldCertDeleter(oldCertDeleter.Start, oldCertDeleter.Die, db, dbTimeout, riakOpts, riakPort, cdn)
+	})
+
+	select {
+	case oldCertDeleter.Start <- struct{}{}:
+	default:
+	}
+}
+
+func getOrCreateOldCertDeleter(cdn tc.CDNName) *OldCertDeleter {
+	oldCertDeleters.M.Lock()
+	defer oldCertDeleters.M.Unlock()
+	oldCertDeleter, ok := oldCertDeleters.D[cdn]
+	if !ok {
+		oldCertDeleter = newOldCertDeleter()
+		oldCertDeleters.D[cdn] = oldCertDeleter
+	}
+	return oldCertDeleter
+}
+
+// cleanupOldCertDeleters stops all cert deleter goroutines for CDNs which have been deleted in the database.
+// Any error is logged, but not returned.
+// This is designed to be called when starting a new cert deleter job, to clean up any old cert deleters from deleted CDNs.
+// This should only be called immediately when snapshotting, and immediately after startOldCertDeleter, because otherwise a cert deleter may be removed before it can delete old certs for a given CDN.
+func cleanupOldCertDeleters(tx *sql.Tx) {
+	cdns, err := dbhelpers.GetCDNs(tx) // (map[tc.CDNName]struct{}, error) {
+	if err != nil {
+		log.Errorln("cleanupOldCertDeleters: getting cdns: " + err.Error())
+		return
+	}
+
+	oldCertDeleters.M.Lock()
+	defer oldCertDeleters.M.Unlock()
+
+	for cdn, oldCertDeleter := range oldCertDeleters.D {
+		if _, ok := cdns[cdn]; ok {
+			continue
+		}
+		delete(oldCertDeleters.D, cdn)
+		select {
+		case oldCertDeleter.Die <- struct{}{}:
+		default:
+		}
+	}
+}
+
+type OldCertDeleter struct {
+	Start chan struct{}
+	Die   chan struct{}
+	Once  sync.Once
+}
+
+func newOldCertDeleter() *OldCertDeleter {
+	return &OldCertDeleter{
+		Start: make(chan struct{}, 1),
+		Die:   make(chan struct{}, 1),
+	}
+}
+
+func doOldCertDeleter(do chan struct{}, die chan struct{}, db *sql.DB, dbTimeout time.Duration, riakOpts *riak.AuthOptions, riakPort *uint, cdn tc.CDNName) {
+	for {
+		select {
+		case <-do:
+			deleteOldDSCertsDB(db, dbTimeout, riakOpts, riakPort, cdn)
+		case <-die:
+			return
+		}
+	}
+}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deleteoldcerts.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deleteoldcerts.go
@@ -191,6 +191,12 @@ func doOldCertDeleter(do chan struct{}, die chan struct{}, db *sql.DB, dbTimeout
 		case <-do:
 			deleteOldDSCertsDB(db, dbTimeout, riakOpts, riakPort, cdn)
 		case <-die:
+			// Go selects aren't ordered, so double-check the do chan in case a race happened and a job came in at the same time as the die.
+			select {
+			case <-do:
+				deleteOldDSCertsDB(db, dbTimeout, riakOpts, riakPort, cdn)
+			default:
+			}
 			return
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
@@ -330,10 +330,10 @@ func verifyCertificate(certificate string, rootCA string) (string, bool, error) 
 		block := &pem.Block{Type: "CERTIFICATE", Bytes: link.Raw}
 		pemEncodedChain += string(pem.EncodeToMemory(block))
 	}
-   
-  	if len(pemEncodedChain) < 1 {
+
+	if len(pemEncodedChain) < 1 {
 		return "", false, errors.New("Invalid empty certicate chain in request")
-  	}
+	}
 
 	return pemEncodedChain, false, nil
 }


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

Fixes #882

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Riak endpoint, TO API tests don't support Riak yet.

To verify:
1. Enable info logging in Traffic Ops.
2. Delete an HTTPS delivery service with SSL keys. 
3. Snapshot the CRConfig on that DS's CDN.

Traffic Ops should log to the info log `Deleted Riak SSL keys for delivery service which has been deleted in the database 'your-ds' key 'your-ds-latest'.

The endpoint `/api/1.2/cdns/name/your-cdn-name/sslkeys` should no longer contain that delivery service.

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [x] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



