### PR TITLE
Fixed broken docs build with explicit Pygments version

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -15,3 +15,4 @@
 Sphinx>=1.4.3
 sphinx_rtd_theme>=0.4.0
 sphinx_autodoc_typehints>=1.3.0
+Pygments>=2.2.0


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?
Our public docs builds have been broken for a while, due to a known bug in Pygments that was fixed recently. This PR fixes issues that ReadTheDocs and others may have building the documentation by "forcing" them to use a Pygments version that includes the fix.

## Which TC components are affected by this PR?
- [x] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR?
Using requirements.txt to provide prerequisites, build the docs.


## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)