### PR TITLE
Added pattern validation for truly valid xmlids

### DIFF
--- a/traffic_portal/app/src/common/modules/form/_form.scss
+++ b/traffic_portal/app/src/common/modules/form/_form.scss
@@ -28,6 +28,16 @@ form .control-label > span {
 	}
 }
 
+small.invalid-URL-error {
+	display: none;
+	visibility: hidden;
+}
+
+input[type="url"]:invalid ~ small.invalid-URL-error {
+	display: inline-block;
+	visibility: visible;
+}
+
 .dnssec-info-text {
   margin-bottom: 12px;
   font-size: medium;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -113,6 +113,11 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
         { value: false, label: 'false' }
     ];
 
+    $scope.activeInactive = [
+        { value: true, label: 'Active' },
+        { value: false, label: 'Not Active'}
+    ]
+
     $scope.signingAlgos = [
         { value: null, label: 'None' },
         { value: 'url_sig', label: 'URL Signature Keys' },
@@ -120,27 +125,27 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
     ];
 
     $scope.protocols = [
-        { value: 0, label: '0 - HTTP' },
-        { value: 1, label: '1 - HTTPS' },
-        { value: 2, label: '2 - HTTP AND HTTPS' },
-        { value: 3, label: '3 - HTTP TO HTTPS' }
+        { value: 0, label: 'HTTP' },
+        { value: 1, label: 'HTTPS' },
+        { value: 2, label: 'HTTP AND HTTPS' },
+        { value: 3, label: 'HTTP TO HTTPS' }
     ];
 
     $scope.qStrings = [
-        { value: 0, label: '0 - use qstring in cache key, and pass up' },
-        { value: 1, label: '1 - ignore in cache key, and pass up' },
-        { value: 2, label: '2 - drop at edge' }
+        { value: 0, label: 'Use query parameter strings in cache key and pass in upstream requests' },
+        { value: 1, label: 'Do not use query parameter strings in cache key, but do pass in upstream requests' },
+        { value: 2, label: 'Neither use query parameter strings in cache key, nor pass in upstream requests' }
     ];
 
     $scope.geoLimits = [
-        { value: 0, label: '0 - None' },
-        { value: 1, label: '1 - CZF only' },
-        { value: 2, label: '2 - CZF + Country Code(s)' }
+        { value: 0, label: 'None' },
+        { value: 1, label: 'Coverage Zone File only' },
+        { value: 2, label: 'Coverage Zone File and Country Code(s)' }
     ];
 
     $scope.geoProviders = [
-        { value: 0, label: '0 - Maxmind (Default)' },
-        { value: 1, label: '1 - Neustar' }
+        { value: 0, label: 'Maxmind' },
+        { value: 1, label: 'Neustar' }
     ];
 
     $scope.dscps = [
@@ -186,9 +191,9 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
     ];
 
     $scope.rrhs = [
-        { value: 0, label: "0 - Don't cache" },
-        { value: 1, label: "1 - Use background_fetch plugin" },
-        { value: 2, label: "2 - Use cache_range_requests plugin" }
+        { value: 0, label: "Don't cache Range Requests" },
+        { value: 1, label: "Use the background_fetch plugin" },
+        { value: 2, label: "Use the cache_range_requests plugin" }
     ];
 
     $scope.msoAlgos = [
@@ -282,11 +287,11 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
     $scope.manageUrlSigKeys = function() {
         $location.path($location.path() + '/url-sig-keys');
     };
-    
+
     $scope.manageUriSigningKeys = function() {
         $location.path($location.path() + '/uri-signing-keys');
     };
-    
+
     $scope.viewStaticDnsEntries = function() {
         $location.path($location.path() + '/static-dns-entries');
     };

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -100,10 +100,10 @@ under the License.
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z][a-z0-9\-]*" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
+                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
@@ -230,10 +230,10 @@ under the License.
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
-                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="^[a-z][a-z\-0-9]*$" required>
+                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="[a-z0-9]([a-z\-0-9]*[a-z0-9])?" required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
@@ -653,10 +653,10 @@ under the License.
             </div>
 
             <div class="modal-footer">
-                <button class="btn btn-link" ng-click="advancedShowing = !advancedShowing"><span ng-show="!advancedShowing">Show</span><span ng-show="advancedShowing">Hide</span> Advanced</button>
+                <button type="button" class="btn btn-link" ng-click="advancedShowing = !advancedShowing"><span ng-show="!advancedShowing">Show</span><span ng-show="advancedShowing">Hide</span> Advanced</button>
                 <button type="button" class="btn btn-danger" ng-if="!settings.isNew" ng-disabled="!deletable()" ng-click="confirmDelete(deliveryService)">{{settings.deleteLabel}}</button>
-                <button type="button" class="btn btn-success" ng-disabled="deliveryServiceForm.$pristine || deliveryServiceForm.$invalid || !saveable()" ng-click="save(deliveryService)">{{settings.saveLabel}}</button>
-                <button type="button" class="btn btn-primary" ng-if="settings.isRequest && fulfillable()" ng-disabled="deliveryServiceForm.$invalid" ng-click="fulfillRequest(deliveryService)">Fulfill Request</button>
+                <button class="btn btn-success" ng-disabled="deliveryServiceForm.$pristine || deliveryServiceForm.$invalid || !saveable()" ng-click="save(deliveryService)">{{settings.saveLabel}}</button>
+                <button class="btn btn-primary" ng-if="settings.isRequest && fulfillable()" ng-disabled="deliveryServiceForm.$invalid" ng-click="fulfillRequest(deliveryService)">Fulfill Request</button>
             </div>
         </form>
     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -98,10 +98,10 @@ under the License.
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" ng-required="true" ng-maxlength="48" ng-pattern="/^\S*$/" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')" autofocus>
+                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z][a-z0-9\-]*" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">No spaces</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -332,7 +332,6 @@ under the License.
                             <option ng-value="0" selected>Maxmind</option>
                             <option ng-value="1">Neustar</option>
                         </select>
-                        <small class="input-warning" ng-show="deliveryService.geoProvider == 1">Neustar support may have been dropped! Use with caution...</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -607,7 +607,7 @@ under the License.
                         <span uib-popover-html="label('remapText', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('remapText', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input id="remapText" name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" ng-maxlength="2048">
+                        <input id="remapText" name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.remapText, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.remapText)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -620,6 +620,7 @@ under the License.
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="infoUrl" name="infoUrl" type="url" class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
+                        <small class="input-error invalid-URL-error">Invalid URL</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -46,13 +46,13 @@ under the License.
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="viewCharts()">View Charts</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
                     <li role="menuitem"><a ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
                     <li role="menuitem"><a ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="viewOrigins()">View Origins</a></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
@@ -65,36 +65,38 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <form name="deliveryServiceForm" class="form-horizontal form-label-left" novalidate>
+        <form id="deliveryServiceForm" name="deliveryServiceForm" class="form-horizontal form-label-left">
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">
                     <span uib-popover-html="label('active', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('active', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="active" class="form-control" ng-model="deliveryService.active" ng-options="x.value as x.label for x in falseTrue" required>
-                        <option value="">Select...</option>
+                    <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required autofocus>
+                        <option disabled hidden value="">Select...</option>
+                        <option ng-value="true">Active</option>
+                        <option ng-value="false">Not Active</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.active, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active}} ]</small>
+                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">
                     <span uib-popover-html="label('typeId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('typeId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
-                        <option value="">Select...</option>
+                    <select id="type" name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
+                        <option selected disabled hidden value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.type, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
-                    <small ng-show="deliveryService.typeId"><a href="/#!/types/{{deliveryService.typeId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
+                    <small ng-show="deliveryService.typeId"><a href="/#!/types/{{deliveryService.typeId}}" rel="noopener noreferrer" referrerpolicy="no-referrer" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
@@ -108,11 +110,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">
                     <span uib-popover-html="label('displayName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('displayName', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" ng-maxlength="48" required autofocus>
+                    <input id="displayName" name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" maxlength="48" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'maxlength')">Too Long</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
@@ -121,12 +123,12 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">
                     <span uib-popover-html="label('tenantId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('tenantId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
-                        <option value="">Select...</option>
+                    <select id="tenantId" name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
+                        <option disabled hidden selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.tenantId, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
@@ -135,25 +137,25 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">
                     <span uib-popover-html="label('cdnId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cdnId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
-                        <option value="">Select...</option>
+                    <select id="cdn" name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
+                        <option disabled hidden selected value="">Select...</option>
                     </select>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdn, 'required')">Required</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdnId, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
                     <small ng-show="deliveryService.cdnId"><a href="/#!/cdns/{{deliveryService.cdnId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.orgServerFqdn), 'has-feedback': hasError(deliveryServiceForm.orgServerFqdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">
                     <span uib-popover-html="label('orgServerFqdn', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('orgServerFqdn', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="orgServerFqdn" type="text" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" ng-pattern="/^(https?:\/\/)([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d{1,5})?$/" required autofocus>
+                    <input id="orgServerFqdn" title="Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)" name="orgServerFqdn" type="url" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" pattern="https?://[a-z][a-z0-9\-]*(\.[a-z][a-z0-9\-]*)*(:\d+)?" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'pattern')">Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.orgServerFqdn != dsCurrent.orgServerFqdn">Current Value: [ {{dsCurrent.orgServerFqdn}} ]</small>
@@ -163,12 +165,16 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">
                     <span uib-popover-html="label('protocol', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('protocol', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="protocol" class="form-control" ng-model="deliveryService.protocol" ng-options="protocol.value as protocol.label for protocol in protocols" required>
-                        <option value="">Select...</option>
+                    <select id="protocol" name="protocol" class="form-control" ng-model="deliveryService.protocol" required>
+                        <option hidden disabled value="">Select...</option>
+                        <option ng-value="0">HTTP</option>
+                        <option ng-value="1">HTTPS</option>
+                        <option ng-value="2">HTTP and HTTPS</option>
+                        <option ng-value="3">HTTP to HTTPS</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.protocol, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
@@ -176,11 +182,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">
                     <span uib-popover-html="label('longDesc', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required autofocus></textarea>
+                    <textarea id="longDesc" name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" spellcheck="true" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.longDesc, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -188,58 +194,57 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">
                     <span uib-popover-html="label('longDesc1', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc1', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3" autofocus></textarea>
+                    <textarea id="longDesc1" name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" spellcheck="true" rows="3"></textarea>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc1)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc2">
                     <span uib-popover-html="label('longDesc2', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc2', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3" autofocus></textarea>
+                    <textarea id="longDesc2" name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3" spellcheck="true"></textarea>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc2)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-if="!settings.isNew && !settings.isRequest">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">Delivery Service URLs</label>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeFQDNs">Delivery Service URLs</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="edgeFQDNs" rows="4" cols="17" class="form-control readonly" readonly>{{edgeFQDNs(deliveryService)}}</textarea>
+                    <textarea id="edgeFQDNs" name="edgeFQDNs" rows="4" cols="17" class="form-control readonly" readonly>{{edgeFQDNs(deliveryService)}}</textarea>
                 </div>
             </div>
 
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">
                         <span uib-popover-html="label('routingName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('routingName', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
-                        <input name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" ng-maxlength="48" ng-pattern="/^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/" required autofocus>
+                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="^[a-z][a-z\-0-9]*$" required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Invalid. Must be a valid hostname without periods</small>
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dscp), 'has-feedback': hasError(deliveryServiceForm.dscp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dscp">
                         <span uib-popover-html="label('dscp', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dscp', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="dscp" class="form-control" ng-model="deliveryService.dscp" ng-options="dcsp.value as dcsp.label for dcsp in dscps" required>
-                            <option value="">Select...</option>
+                        <select id="dscp" name="dscp" class="form-control" ng-model="deliveryService.dscp" ng-options="dcsp.value as dcsp.label for dcsp in dscps" required>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dscp, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dscp != dsCurrent.dscp">Current Value: [ {{magicNumberLabel(dscps, dsCurrent.dscp)}} ]</small>
@@ -247,25 +252,28 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">
                         <span uib-popover-html="label('ipv6RoutingEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ipv6RoutingEnabled', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="ipv6RoutingEnabled" name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" required>
+                            <option ng-value="true">Enabled</option>
+                            <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ipv6RoutingEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.rangeRequestHandling), 'has-feedback': hasError(deliveryServiceForm.rangeRequestHandling)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">
                         <span uib-popover-html="label('rangeRequestHandling', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('rangeRequestHandling', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="rangeRequestHandling" class="form-control" ng-model="deliveryService.rangeRequestHandling" ng-options="rrh.value as rrh.label for rrh in rrhs" required>
-                            <option value="">Select...</option>
+                        <select id="rangeRequestHandling" name="rangeRequestHandling" class="form-control" ng-model="deliveryService.rangeRequestHandling" required>
+                            <option ng-value="0">Don't cache Range Requests</option>
+                            <option ng-value="1">Use the background_fetch plugin</option>
+                            <option ng-value="2">Use the cache_range_requests plugin</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.rangeRequestHandling, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.rangeRequestHandling != dsCurrent.rangeRequestHandling">Current Value: [ {{magicNumberLabel(rrhs, dsCurrent.rangeRequestHandling)}} ]</small>
@@ -273,12 +281,14 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.qstringIgnore), 'has-feedback': hasError(deliveryServiceForm.qstringIgnore)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="qstringIgnore">
                         <span uib-popover-html="label('qstringIgnore', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('qstringIgnore', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="qstringIgnore" class="form-control" ng-model="deliveryService.qstringIgnore" ng-options="qs.value as qs.label for qs in qStrings" required>
-                            <option value="">Select...</option>
+                        <select id="qstringIgnore" name="qstringIgnore" class="form-control" ng-model="deliveryService.qstringIgnore" required>
+                            <option ng-value="0" selected>Use query parameter strings in cache key and pass in upstream requests</option>
+                            <option ng-value="1">Do not use query parameter strings in cache key, but do pass in upstream requests</option>
+                            <option ng-value="2">Neither use query parameter strings in cache key, nor pass in upstream requests</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.qstringIgnore, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.qstringIgnore != dsCurrent.qstringIgnore">Current Value: [ {{magicNumberLabel(qStrings, dsCurrent.qstringIgnore)}} ]</small>
@@ -286,50 +296,54 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.multiSiteOrigin), 'has-feedback': hasError(deliveryServiceForm.multiSiteOrigin)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">
                         <span uib-popover-html="label('multiSiteOrigin', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('multiSiteOrigin', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="multiSiteOrigin" class="form-control" ng-model="deliveryService.multiSiteOrigin" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="multiSiteOrigin" name="multiSiteOrigin" class="form-control" ng-model="deliveryService.multiSiteOrigin" required>
+                            <option ng-value="false" selected>Do not use Multi-Site Origin</option>
+                            <option ng-value="true">Use Multi-Site Origin</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.multiSiteOrigin, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.multiSiteOrigin != dsCurrent.multiSiteOrigin">Current Value: [ {{dsCurrent.multiSiteOrigin}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.multiSiteOrigin != dsCurrent.multiSiteOrigin">Current Value: [ {{dsCurrent.multiSiteOrigin ? 'Use Multi-Site Origin' : 'Do not use Multi-Site Origin'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">
                         <span uib-popover-html="label('logsEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('logsEnabled', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="logsEnabled" name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" required>
+                            <option ng-value="true" selected>Enabled</option>
+                            <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.logsEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">
                         <span uib-popover-html="label('geoProvider', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoProvider', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" ng-options="gp.value as gp.label for gp in geoProviders" required>
-                            <option value="">Select...</option>
+                        <select id="geoProvider" name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" required>
+                            <option ng-value="0" selected>Maxmind</option>
+                            <option ng-value="1">Neustar</option>
                         </select>
+                        <small class="input-warning" ng-show="deliveryService.geoProvider == 1">Neustar support may have been dropped! Use with caution...</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLat), 'has-feedback': hasError(deliveryServiceForm.missLat)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLat">
                         <span uib-popover-html="label('missLat', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('missLat', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="missLat" type="number" class="form-control" ng-model="deliveryService.missLat" required autofocus>
+                        <input step="any" id="missLat" name="missLat" type="number" class="form-control" ng-model="deliveryService.missLat" required min="-90" max="90" title="Must be a valid latitude, in degrees."/>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.missLat, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.missLat != dsCurrent.missLat">Current Value: [ {{dsCurrent.missLat}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.missLat)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -337,11 +351,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLong), 'has-feedback': hasError(deliveryServiceForm.missLong)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLong">
                         <span uib-popover-html="label('missLong', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('missLong', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="missLong" type="number" class="form-control" ng-model="deliveryService.missLong" required autofocus>
+                        <input step="any" id="missLong" name="missLong" type="number" class="form-control" ng-model="deliveryService.missLong" required min="-180" max="180" title="Must be a valid longitude, in degrees."/>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.missLong, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.missLong != dsCurrent.missLong">Current Value: [ {{dsCurrent.missLong}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.missLong)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -349,24 +363,26 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">
                         <span uib-popover-html="label('geoLimit', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimit', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" ng-options="gl.value as gl.label for gl in geoLimits" required>
-                            <option value="">Select...</option>
+                        <select id="geoLimit" name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" required>
+                            <option ng-value="0" selected>None</option>
+                            <option ng-value="1">Coverage Zone File only</option>
+                            <option ng-value="2">Coverage Zone File and Country Code(s)</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimit, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
                     </div>
                 </div>
 
-                <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}" ng-show="deliveryService.geoLimit === 1 || deliveryService.geoLimit === 2">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">
                         <span uib-popover-html="label('geoLimitCountries', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitCountries', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" ng-maxlength="255" autofocus>
+                        <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255" pattern="[A-Z]+(,[A-Z]+)*">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitCountries, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitCountries)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -374,35 +390,36 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">
                         <span uib-popover-html="label('geoLimitRedirectURL', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitRedirectURL', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="geoLimitRedirectURL" type="text" class="form-control" ng-model="deliveryService.geoLimitRedirectURL" ng-pattern="/^(https?:\/\/)/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitRedirectURL, 'pattern')">Must start with http:// or https://</small>
+                        <input id="geoLimitRedirectURL" name="geoLimitRedirectURL" title="Must be a valid URL" type="url" class="form-control" ng-model="deliveryService.geoLimitRedirectURL">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitRedirectURL)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.signingAlgorithm), 'has-feedback': hasError(deliveryServiceForm.signingAlgorithm)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">
                         <span uib-popover-html="label('signingAlgorithm', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('signingAlgorithm', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="signingAlgorithm" class="form-control" ng-change="changeSigningAlgorithm(deliveryService.signingAlgorithm)" ng-model="deliveryService.signingAlgorithm" ng-options="sa.value as sa.label for sa in signingAlgos">
-                            <option value="">Select...</option>
+                        <select id="signingAlgorithm" name="signingAlgorithm" class="form-control" ng-change="changeSigningAlgorithm(deliveryService.signingAlgorithm)" ng-model="deliveryService.signingAlgorithm">
+                            <option ng-value="null">None</option>
+                            <option value="url_sig">URL Signature Keys</option>
+                            <option value="uri_signing">URI Signing Keys</option>
                         </select>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.signingAlgorithm != dsCurrent.signingAlgorithm">Current Value: [ {{magicNumberLabel(signingAlgos, dsCurrent.signingAlgorithm)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassIp), 'has-feedback': hasError(deliveryServiceForm.dnsBypassIp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIp">
                         <span uib-popover-html="label('dnsBypassIp', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassIp', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="dnsBypassIp" type="text" class="form-control" ng-model="deliveryService.dnsBypassIp" ng-maxlength="255" autofocus>
+                        <input id="dnsBypassIp" name="dnsBypassIp" type="text" class="form-control" ng-model="deliveryService.dnsBypassIp" maxlength="255" pattern="\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dnsBypassIp, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassIp != dsCurrent.dnsBypassIp">Current Value: [ {{dsCurrent.dnsBypassIp}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassIp)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -410,11 +427,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassIp6), 'has-feedback': hasError(deliveryServiceForm.dnsBypassIp6)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIP">
                         <span uib-popover-html="label('dnsBypassIp6', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassIp6', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="dnsBypassIp6" type="text" class="form-control" ng-model="deliveryService.dnsBypassIp6" ng-maxlength="255" autofocus>
+                        <input id="dnsBypassIp6" name="dnsBypassIp6" type="text" class="form-control" ng-model="deliveryService.dnsBypassIp6" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dnsBypassIp6, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassIp6 != dsCurrent.dnsBypassIp6">Current Value: [ {{dsCurrent.dnsBypassIp6}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassIp6)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -422,11 +439,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassCname), 'has-feedback': hasError(deliveryServiceForm.dnsBypassCname)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassCname">
                         <span uib-popover-html="label('dnsBypassCname', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassCname', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="dnsBypassCname" type="text" class="form-control" ng-model="deliveryService.dnsBypassCname" ng-maxlength="255" autofocus>
+                        <input id="dnsBypassCname" name="dnsBypassCname" type="text" class="form-control" ng-model="deliveryService.dnsBypassCname" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dnsBypassCname, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassCname != dsCurrent.dnsBypassCname">Current Value: [ {{dsCurrent.dnsBypassCname}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassCname)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -434,48 +451,45 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassTtl), 'has-feedback': hasError(deliveryServiceForm.dnsBypassTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" label="dnsBypassTtl">
                         <span uib-popover-html="label('dnsBypassTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassTtl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="dnsBypassTtl" type="number" class="form-control" ng-model="deliveryService.dnsBypassTtl" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dnsBypassTtl, 'pattern')">Whole Number</small>
+                        <input id="dnsBypassTtl" name="dnsBypassTtl" type="number" class="form-control" ng-model="deliveryService.dnsBypassTtl" step="1" min="0">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassTtl != dsCurrent.dnsBypassTtl">Current Value: [ {{dsCurrent.dnsBypassTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.maxDnsAnswers), 'has-feedback': hasError(deliveryServiceForm.maxDnsAnswers)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="maxDnsAnswers">
                         <span uib-popover-html="label('maxDnsAnswers', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('maxDnsAnswers', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="maxDnsAnswers" type="number" class="form-control" placeholder="Max number of IP addresses in DNS answer (0 means all)" ng-model="deliveryService.maxDnsAnswers" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.maxDnsAnswers, 'pattern')">Whole Number</small>
+                        <input id="maxDnsAnswers" name="maxDnsAnswers" type="number" class="form-control" placeholder="Max number of IP addresses in DNS answer (0 means all)" ng-model="deliveryService.maxDnsAnswers" step="1" min="0">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.maxDnsAnswers != dsCurrent.maxDnsAnswers">Current Value: [ {{dsCurrent.maxDnsAnswers}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.maxDnsAnswers)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">
                         <span uib-popover-html="label('ccrDnsTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ccrDnsTtl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ccrDnsTtl, 'pattern')">Whole Number</small>
+                        <input id="ccrDnsTtl" name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" step="1" min="0">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.ccrDnsTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">
                         <span uib-popover-html="label('profileId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('profileId', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
-                            <option value="">Select...</option>
+                        <select id="profile" name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
+                            <option selected value="">None</option>
                         </select>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
                         <small ng-show="deliveryService.profileId"><a href="/#!/profiles/{{deliveryService.profileId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
@@ -483,23 +497,22 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxMbps), 'has-feedback': hasError(deliveryServiceForm.globalMaxMbps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">
                         <span uib-popover-html="label('globalMaxMbps', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('globalMaxMbps', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="globalMaxMbps" type="number" class="form-control" placeholder="Max bits per second allowed globally" ng-model="deliveryService.globalMaxMbps" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.globalMaxMbps, 'pattern')">Whole Number</small>
+                        <input id="globalMaxMbps" name="globalMaxMbps" type="number" class="form-control" placeholder="Max bits per second allowed globally" ng-model="deliveryService.globalMaxMbps" step="1" min="0">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.globalMaxMbps != dsCurrent.globalMaxMbps">Current Value: [ {{dsCurrent.globalMaxMbps}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.globalMaxMbps)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxTps), 'has-feedback': hasError(deliveryServiceForm.globalMaxTps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globaMaxTps">
                         <span uib-popover-html="label('globalMaxTps', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('globalMaxTps', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="globalMaxTps" type="number" class="form-control" placeholder="Max transactions per second allowed globally" ng-model="deliveryService.globalMaxTps" ng-pattern="/^\d+$/" autofocus>
+                        <input id="globalMaxTps" name="globalMaxTps" type="number" class="form-control" placeholder="Max transactions per second allowed globally" ng-model="deliveryService.globalMaxTps" step="1" min="0">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.globalMaxTps, 'pattern')">Whole Number</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.globalMaxTps != dsCurrent.globalMaxTps">Current Value: [ {{dsCurrent.globalMaxTps}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.globalMaxTps)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -507,23 +520,22 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.fqPacingRate), 'has-feedback': hasError(deliveryServiceForm.fqPacingRate)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">
                         <span uib-popover-html="label('fqPacingRate', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('fqPacingRate', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="fqPacingRate" type="number" class="form-control" placeholder="Rate-limit connections to this Bytes per second" ng-model="deliveryService.fqPacingRate" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.fqPacingRate, 'pattern')">Whole Number</small>
+                        <input id="fqPacingRate" name="fqPacingRate" type="number" class="form-control" placeholder="Rate-limit connections to this Bytes per second" ng-model="deliveryService.fqPacingRate" step="1" min="0">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.fqPacingRate != dsCurrent.fqPacingRate">Current Value: [ {{dsCurrent.fqPacingRate}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.fqPacingRate)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.edgeHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.edgeHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">
                         <span uib-popover-html="label('edgeHeaderRewrite', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('edgeHeaderRewrite', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="edgeHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.edgeHeaderRewrite" ng-maxlength="2048" autofocus>
+                        <input id="edgeHeaderRewrite" name="edgeHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.edgeHeaderRewrite" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.edgeHeaderRewrite, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.edgeHeaderRewrite != dsCurrent.edgeHeaderRewrite">Current Value: [ {{dsCurrent.edgeHeaderRewrite}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.edgeHeaderRewrite)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -531,11 +543,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.midHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.midHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">
                         <span uib-popover-html="label('midHeaderRewrite', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('midHeaderRewrite', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="midHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.midHeaderRewrite" ng-maxlength="2048" autofocus>
+                        <input id="midHeaderRewrite" name="midHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.midHeaderRewrite" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.midHeaderRewrite, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.midHeaderRewrite != dsCurrent.midHeaderRewrite">Current Value: [ {{dsCurrent.midHeaderRewrite}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.midHeaderRewrite)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -543,11 +555,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">
                         <span uib-popover-html="label('trResponseHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trResponseHeaders', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" ng-maxlength="1024" autofocus>
+                        <input id="trResponseHeaders" name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trResponseHeaders, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trResponseHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -555,11 +567,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">
                         <span uib-popover-html="label('trRequestHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trRequestHeaders', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" ng-maxlength="1024" autofocus>
+                        <input id="trRequestHeaders" name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trRequestHeaders, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trRequestHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -571,7 +583,7 @@ under the License.
                         <span uib-popover-html="label('regexRemap', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('regexRemap', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="regexRemap" type="text" class="form-control" ng-model="deliveryService.regexRemap" ng-maxlength="1024" autofocus>
+                        <input id="regexRemap" name="regexRemap" type="text" class="form-control" ng-model="deliveryService.regexRemap" ng-maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regexRemap, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regexRemap != dsCurrent.regexRemap">Current Value: [ {{dsCurrent.regexRemap}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.regexRemap)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -579,11 +591,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">
                         <span uib-popover-html="label('cacheurl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cacheurl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" ng-maxlength="1024" autofocus>
+                        <input id="cacheurl" name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cacheurl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.cacheurl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -591,11 +603,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">
                         <span uib-popover-html="label('remapText', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('remapText', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" ng-maxlength="2048" autofocus>
+                        <input id="remapText" name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" ng-maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.remapText, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.remapText)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -603,11 +615,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">
                         <span uib-popover-html="label('infoUrl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('infoUrl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="infoUrl" type="text" class="form-control" ng-model="deliveryService.infoUrl" ng-maxlength="255" autofocus>
+                        <input id="infoUrl" name="infoUrl" type="url" class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -615,11 +627,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">
                         <span uib-popover-html="label('checkPath', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('checkPath', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" ng-maxlength="255" autofocus>
+                        <input id="checkPath" name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.checkPath, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.checkPath)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -627,11 +639,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.originShield), 'has-feedback': hasError(deliveryServiceForm.originShield)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="originShield">
                         <span uib-popover-html="label('originShield', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('originShield', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="originShield" type="text" class="form-control" ng-model="deliveryService.originShield" ng-maxlength="1024" autofocus>
+                        <input id="originShield" name="originShield" type="text" class="form-control" ng-model="deliveryService.originShield" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.originShield, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.originShield != dsCurrent.originShield">Current Value: [ {{dsCurrent.originShield}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.originShield)" class="form-control-feedback"><i class="fa fa-times"></i></span>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -95,14 +95,14 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" ng-required="true" ng-maxlength="48" ng-pattern="/^\S*$/" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')" autofocus>
+                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z][a-z0-9\-]*" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">No spaces</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -639,6 +639,7 @@ under the License.
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="infoUrl" name="infoUrl" type="url" title="Must be a valid URL." class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
+                        <small class="input-error invalid-URL-error">Invalid URL</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -101,10 +101,10 @@ under the License.
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z][a-z0-9\-]*" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
+                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
@@ -231,10 +231,10 @@ under the License.
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
-                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="[a-z0-9][a-z0-9\-]*" required>
+                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?" required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
@@ -685,10 +685,10 @@ under the License.
             </div>
 
             <div class="modal-footer">
-                <button class="btn btn-link" ng-click="advancedShowing = !advancedShowing"><span ng-show="!advancedShowing">Show</span><span ng-show="advancedShowing">Hide</span> Advanced</button>
+                <button type="button" class="btn btn-link" ng-click="advancedShowing = !advancedShowing"><span ng-show="!advancedShowing">Show</span><span ng-show="advancedShowing">Hide</span> Advanced</button>
                 <button type="button" class="btn btn-danger" ng-if="!settings.isNew" ng-disabled="!deletable()" ng-click="confirmDelete(deliveryService)">{{settings.deleteLabel}}</button>
-                <button type="button" class="btn btn-success" ng-disabled="deliveryServiceForm.$pristine || deliveryServiceForm.$invalid || !saveable()" ng-click="save(deliveryService)">{{settings.saveLabel}}</button>
-                <button type="button" class="btn btn-primary" ng-if="settings.isRequest && fulfillable()" ng-disabled="deliveryServiceForm.$invalid" ng-click="fulfillRequest(deliveryService)">Fulfill Request</button>
+                <button class="btn btn-success" ng-disabled="deliveryServiceForm.$pristine || deliveryServiceForm.$invalid || !saveable()" ng-click="save(deliveryService)">{{settings.saveLabel}}</button>
+                <button class="btn btn-primary" ng-if="settings.isRequest && fulfillable()" ng-disabled="deliveryServiceForm.$invalid" ng-click="fulfillRequest(deliveryService)">Fulfill Request</button>
             </div>
         </form>
     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -387,7 +387,6 @@ under the License.
                             <option ng-value="0" selected>MaxMind</option>
                             <option ng-value="1">Neustar</option>
                         </select>
-                        <small class="input-warning" ng-show="deliveryService.geoProvider == 1">Neustar support may have been dropped! Use with caution...</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -46,13 +46,13 @@ under the License.
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="viewCharts()">View Charts</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
                     <li role="menuitem"><a ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
                     <li role="menuitem"><a ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="viewOrigins()">View Origins</a></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
@@ -65,28 +65,30 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <form name="deliveryServiceForm" class="form-horizontal form-label-left" novalidate>
+        <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">
                     <span uib-popover-html="label('active', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('active', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="active" class="form-control" ng-model="deliveryService.active" ng-options="x.value as x.label for x in falseTrue" required>
-                        <option value="">Select...</option>
+                    <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
+                        <option hidden disabled value="">Select...</option>
+                        <option ng-value="true">Active</option>
+                        <option ng-value="false">Not Active</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.active, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active}} ]</small>
+                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{ dsCurrent.active ? 'Active' : 'Not Active' }} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">
                     <span uib-popover-html="label('typeId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('typeId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
-                        <option value="">Select...</option>
+                    <select id="type" name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
+                        <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.type, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
@@ -109,11 +111,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">
                     <span uib-popover-html="label('displayName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('displayName', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" ng-maxlength="48" required autofocus>
+                    <input id="displayName" name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" maxlength="48" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'maxlength')">Too Long</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
@@ -122,12 +124,12 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">
                     <span uib-popover-html="label('tenantId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('tenantId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
-                        <option value="">Select...</option>
+                    <select id="tenantId" name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
+                        <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.tenantId, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
@@ -136,12 +138,12 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">
                     <span uib-popover-html="label('cdnId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cdnId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
-                        <option value="">Select...</option>
+                    <select id="cdn" name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
+                        <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdn, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
@@ -150,11 +152,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.orgServerFqdn), 'has-feedback': hasError(deliveryServiceForm.orgServerFqdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">
                     <span uib-popover-html="label('orgServerFqdn', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('orgServerFqdn', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="orgServerFqdn" type="text" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" ng-pattern="/^(https?:\/\/)([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d{1,5})?$/" required autofocus>
+                    <input id="orgServerFqdn" name="orgServerFqdn" type="url" title="Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" pattern="https?://[a-z0-9][a-z0-9\-]*(\.[a-z0-9\-][a-z0-9\-]*)*(:\d{1,5})?" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'pattern')">Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.orgServerFqdn != dsCurrent.orgServerFqdn">Current Value: [ {{dsCurrent.orgServerFqdn}} ]</small>
@@ -164,12 +166,16 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">
                     <span uib-popover-html="label('protocol', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('protocol', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="protocol" class="form-control" ng-model="deliveryService.protocol" ng-options="protocol.value as protocol.label for protocol in protocols" required>
-                        <option value="">Select...</option>
+                    <select id="protocol" name="protocol" class="form-control" ng-model="deliveryService.protocol" required>
+                        <option hidden disabled value="">Select...</option>
+                        <option ng-value="0">HTTP</option>
+                        <option ng-value="1">HTTPS</option>
+                        <option ng-value="2">HTTP and HTTPS</option>
+                        <option ng-value="3">HTTP to HTTPS</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.protocol, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
@@ -177,11 +183,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">
                     <span uib-popover-html="label('longDesc', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required autofocus></textarea>
+                    <textarea id="longDesc" name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.longDesc, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -189,11 +195,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">
                     <span uib-popover-html="label('longDesc1', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc1', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3" autofocus></textarea>
+                    <textarea id="longDesc1" name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3"></textarea>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc1)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
@@ -204,43 +210,45 @@ under the License.
                     <span uib-popover-html="label('longDesc2', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc2', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3" autofocus></textarea>
+                    <textarea id="longDesc2" name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3"></textarea>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc2)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-if="!settings.isNew && !settings.isRequest">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">Delivery Service URLs</label>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeFQDNs">Delivery Service URLs</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="edgeFQDNs" rows="4" cols="17" class="form-control readonly" readonly>{{edgeFQDNs(deliveryService)}}</textarea>
+                    <textarea id="edgeFQDNs" name="edgeFQDNs" rows="4" cols="17" class="form-control readonly" readonly>{{edgeFQDNs(deliveryService)}}</textarea>
                 </div>
             </div>
 
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">
                         <span uib-popover-html="label('routingName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('routingName', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
-                        <input name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" ng-maxlength="48" ng-pattern="/^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/" required autofocus>
+                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="[a-z0-9][a-z0-9\-]*" required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Invalid. Must be a valid hostname without periods</small>
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.deepCachingType), 'has-feedback': hasError(deliveryServiceForm.deepCachingType)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="deepCachingType">
                         <span uib-popover-html="label('deepCachingType', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('deepCachingType', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select id="deepCachingType" name="deepCachingType" class="form-control" ng-model="deliveryService.deepCachingType" ng-options="dct.value as dct.label for dct in deepCachingTypes" required>
-                            <option value="">Select...</option>
+                        <select id="deepCachingType" name="deepCachingType" class="form-control" ng-model="deliveryService.deepCachingType" required>
+                            <option hidden disabled value="">Select...</option>
+                            <option>ALWAYS</option>
+                            <option>NEVER</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.deepCachingType, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.deepCachingType != dsCurrent.deepCachingType">Current Value: [ {{dsCurrent.deepCachingType}} ]</small>
@@ -248,12 +256,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dscp), 'has-feedback': hasError(deliveryServiceForm.dscp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dscp">
                         <span uib-popover-html="label('dscp', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dscp', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="dscp" class="form-control" ng-model="deliveryService.dscp" ng-options="dcsp.value as dcsp.label for dcsp in dscps" required>
-                            <option value="">Select...</option>
+                        <select id="dscp" name="dscp" class="form-control" ng-model="deliveryService.dscp" ng-options="dcsp.value as dcsp.label for dcsp in dscps" required>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dscp, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dscp != dsCurrent.dscp">Current Value: [ {{magicNumberLabel(dscps, dsCurrent.dscp)}} ]</small>
@@ -261,25 +268,28 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">
                         <span uib-popover-html="label('ipv6RoutingEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ipv6RoutingEnabled', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="ipv6RoutingEnabled" name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" required>
+                            <option ng-value="true">Enabled</option>
+                            <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ipv6RoutingEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.rangeRequestHandling), 'has-feedback': hasError(deliveryServiceForm.rangeRequestHandling)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">
                         <span uib-popover-html="label('rangeRequestHandling', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('rangeRequestHandling', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="rangeRequestHandling" class="form-control" ng-model="deliveryService.rangeRequestHandling" ng-options="rrh.value as rrh.label for rrh in rrhs" required>
-                            <option value="">Select...</option>
+                        <select id="rangeRequestHandling" name="rangeRequestHandling" class="form-control" ng-model="deliveryService.rangeRequestHandling" required>
+                            <option ng-value="0">Don't cache Range Requests</option>
+                            <option ng-value="1">Use the background_fetch plugin</option>
+                            <option ng-value="2">Use the cache_range_requests plugin</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.rangeRequestHandling, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.rangeRequestHandling != dsCurrent.rangeRequestHandling">Current Value: [ {{magicNumberLabel(rrhs, dsCurrent.rangeRequestHandling)}} ]</small>
@@ -291,8 +301,10 @@ under the License.
                         <span uib-popover-html="label('qstringIgnore', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('qstringIgnore', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="qstringIgnore" class="form-control" ng-model="deliveryService.qstringIgnore" ng-options="qs.value as qs.label for qs in qStrings" required>
-                            <option value="">Select...</option>
+                        <select id="qstringIgnore" name="qstringIgnore" class="form-control" ng-model="deliveryService.qstringIgnore" required>
+                            <option ng-value="0" selected>Use query parameter strings in cache key and pass in upstream requests</option>
+                            <option ng-value="1">Do not use query parameter strings in cache key, but do pass in upstream requests</option>
+                            <option ng-value="2">Neither use query parameter strings in cache key, nor pass in upstream requests</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.qstringIgnore, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.qstringIgnore != dsCurrent.qstringIgnore">Current Value: [ {{magicNumberLabel(qStrings, dsCurrent.qstringIgnore)}} ]</small>
@@ -300,89 +312,93 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.multiSiteOrigin), 'has-feedback': hasError(deliveryServiceForm.multiSiteOrigin)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">
                         <span uib-popover-html="label('multiSiteOrigin', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('multiSiteOrigin', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="multiSiteOrigin" class="form-control" ng-model="deliveryService.multiSiteOrigin" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="multiSiteOrigin" name="multiSiteOrigin" class="form-control" ng-model="deliveryService.multiSiteOrigin" required>
+                            <option ng-value="false" selected>Do not use Multi-Site Origin</option>
+                            <option ng-value="true">Use Multi-Site Origin</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.multiSiteOrigin, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.multiSiteOrigin != dsCurrent.multiSiteOrigin">Current Value: [ {{dsCurrent.multiSiteOrigin}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.multiSiteOrigin != dsCurrent.multiSiteOrigin">Current Value: [ {{dsCurrent.multiSiteOrigin ? 'Use Multi-Site Origin' : 'Do not use Multi-Site Origin'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">
                         <span uib-popover-html="label('logsEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('logsEnabled', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="logsEnabled" name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" required>
+                            <option ng-value="true" selected>Enabled</option>
+                            <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.logsEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.initialDispersion), 'has-feedback': hasError(deliveryServiceForm.initialDispersion)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="initialDispersion">
                         <span uib-popover-html="label('initialDispersion', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('initialDispersion', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="initialDispersion" class="form-control" ng-model="deliveryService.initialDispersion" ng-options="disp.value as disp.label for disp in dispersions" required>
-                            <option value="">Select...</option>
-                        </select>
+                        <input type="number" class="form-control" name="initialDispersion" id="initialDispersion" ng-model="deliveryService.initialDispersion" required min="1" max="10" step="1" value="1" title="The number of Edge-tier cache servers across which requests for a single resource will be spread. '1' is equivalent to 'No dispersion'." />
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.initialDispersion, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.initialDispersion != dsCurrent.initialDispersion">Current Value: [ {{magicNumberLabel(dispersions, dsCurrent.initialDispersion)}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.initialDispersion != dsCurrent.initialDispersion">Current Value: [ {{dsCurrent.initialDispersion}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regionalGeoBlocking), 'has-feedback': hasError(deliveryServiceForm.regionalGeoBlocking)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">
                         <span uib-popover-html="label('regionalGeoBlocking', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('regionalGeoBlocking', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="regionalGeoBlocking" class="form-control" ng-model="deliveryService.regionalGeoBlocking" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="regionalGeoBlocking" name="regionalGeoBlocking" class="form-control" ng-model="deliveryService.regionalGeoBlocking" required>
+                            <option ng-value="true">Enabled</option>
+                            <option ng-value="false" selected>Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regionalGeoBlocking, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">Current Value: [ {{dsCurrent.regionalGeoBlocking}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">Current Value: [ {{dsCurrent.regionalGeoBlocking ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.anonymousBlockingEnabled), 'has-feedback': hasError(deliveryServiceForm.anonymousBlockingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="anonymousBlockingEnabled">
                         <span uib-popover-html="label('anonymousBlockingEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('anonymousBlockingEnabled', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="anonymousBlockingEnabled" class="form-control" ng-model="deliveryService.anonymousBlockingEnabled" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="anonymousBlockingEnabled" name="anonymousBlockingEnabled" class="form-control" ng-model="deliveryService.anonymousBlockingEnabled" required>
+                            <option ng-value="true">Enabled</option>
+                            <option ng-value="false" selected>Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.anonymousBlockingEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.anonymousBlockingEnabled != dsCurrent.anonymousBlockingEnabled">Current Value: [ {{dsCurrent.anonymousBlockingEnabled}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.anonymousBlockingEnabled != dsCurrent.anonymousBlockingEnabled">Current Value: [ {{dsCurrent.anonymousBlockingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">
                         <span uib-popover-html="label('geoProvider', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoProvider', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" ng-options="gp.value as gp.label for gp in geoProviders" required>
-                            <option value="">Select...</option>
+                        <select id="geoProvider" name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" required>
+                            <option ng-value="0" selected>MaxMind</option>
+                            <option ng-value="1">Neustar</option>
                         </select>
+                        <small class="input-warning" ng-show="deliveryService.geoProvider == 1">Neustar support may have been dropped! Use with caution...</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLat), 'has-feedback': hasError(deliveryServiceForm.missLat)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLat">
                         <span uib-popover-html="label('missLat', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('missLat', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="missLat" type="number" class="form-control" ng-model="deliveryService.missLat" required autofocus>
+                        <input step="any" id="missLat" name="missLat" type="number" class="form-control" ng-model="deliveryService.missLat" min="-90" max="90" title="Must be a valid latitude, in degrees." required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.missLat, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.missLat != dsCurrent.missLat">Current Value: [ {{dsCurrent.missLat}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.missLat)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -390,11 +406,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLong), 'has-feedback': hasError(deliveryServiceForm.missLong)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLong">
                         <span uib-popover-html="label('missLong', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('missLong', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="missLong" type="number" class="form-control" ng-model="deliveryService.missLong" required autofocus>
+                        <input step="any" id="missLong" name="missLong" type="number" class="form-control" ng-model="deliveryService.missLong" min="-180" max="180" title="Must be a valid longitude, in degrees." required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.missLong, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.missLong != dsCurrent.missLong">Current Value: [ {{dsCurrent.missLong}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.missLong)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -402,12 +418,14 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">
                         <span uib-popover-html="label('geoLimit', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimit', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" ng-options="gl.value as gl.label for gl in geoLimits" required>
-                            <option value="">Select...</option>
+                        <select id="geoLimit" name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" required>
+                            <option ng-value="0" selected>None</option>
+                            <option ng-value="1">Coverage Zone File only</option>
+                            <option ng-value="2">Coverage Zone File and Country Code(s)</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimit, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
@@ -415,11 +433,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">
                         <span uib-popover-html="label('geoLimitCountries', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitCountries', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" ng-maxlength="255" autofocus>
+                        <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitCountries, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitCountries)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -427,72 +445,71 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">
                         <span uib-popover-html="label('geoLimitRedirectURL', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitRedirectURL', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="geoLimitRedirectURL" type="text" class="form-control" ng-model="deliveryService.geoLimitRedirectURL" ng-pattern="/^(https?:\/\/)/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitRedirectURL, 'pattern')">Must start with http:// or https://</small>
+                        <input id="geoLimitRedirectURL" name="geoLimitRedirectURL" type="url" class="form-control" ng-model="deliveryService.geoLimitRedirectURL" title="Must be a valid URL.">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitRedirectURL)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.signingAlgorithm), 'has-feedback': hasError(deliveryServiceForm.signingAlgorithm)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">
                         <span uib-popover-html="label('signingAlgorithm', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('signingAlgorithm', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="signingAlgorithm" class="form-control" ng-change="changeSigningAlgorithm(deliveryService.signingAlgorithm)" ng-model="deliveryService.signingAlgorithm" ng-options="sa.value as sa.label for sa in signingAlgos">
-                            <option value="">Select...</option>
+                        <select id="signingAlgorithm" name="signingAlgorithm" class="form-control" ng-change="changeSigningAlgorithm(deliveryService.signingAlgorithm)" ng-model="deliveryService.signingAlgorithm">
+                            <option ng-value="null">None</option>
+                            <option value="url_sig">URL Signature Keys</option>
+                            <option value="uri_signing">URI Signing Keys</option>
                         </select>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.signingAlgorithm != dsCurrent.signingAlgorithm">Current Value: [ {{magicNumberLabel(signingAlgos, dsCurrent.signingAlgorithm)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.httpBypassFqdn), 'has-feedback': hasError(deliveryServiceForm.httpBypassFqdn)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="httpBypassFqdn">
                         <span uib-popover-html="label('httpBypassFqdn', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('httpBypassFqdn', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="httpBypassFqdn" type="text" class="form-control" ng-model="deliveryService.httpBypassFqdn" ng-pattern="/^([a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.httpBypassFqdn, 'pattern')">Must be a valid FQDN</small>
+                        <input id="httpBypassFqdn" name="httpBypassFqdn" type="text" class="form-control" ng-model="deliveryService.httpBypassFqdn" pattern="[A-z0-9][A-z0-9\-]*(\.[A-z0-9][A-z0-9\-]*)*">
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.httpBypassFqdn, 'pattern')">Must be a valid <abbr title="Fully Qualified Domain Name">FQDN</abbr></small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.httpBypassFqdn != dsCurrent.httpBypassFqdn">Current Value: [ {{dsCurrent.httpBypassFqdn}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.httpBypassFqdn)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassTtl), 'has-feedback': hasError(deliveryServiceForm.dnsBypassTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassTtl">
                         <span uib-popover-html="label('dnsBypassTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassTtl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="dnsBypassTtl" type="number" class="form-control" ng-model="deliveryService.dnsBypassTtl" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dnsBypassTtl, 'pattern')">Whole Number</small>
+                        <input id="dnsBypassTtl" name="dnsBypassTtl" type="number" class="form-control" ng-model="deliveryService.dnsBypassTtl" min="0" step="1">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassTtl != dsCurrent.dnsBypassTtl">Current Value: [ {{dsCurrent.dnsBypassTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">
                         <span uib-popover-html="label('ccrDnsTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ccrDnsTtl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ccrDnsTtl, 'pattern')">Whole Number</small>
+                        <input id="ccrDnsTtl" name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" min="0" step="1">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.ccrDnsTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">
                         <span uib-popover-html="label('profileId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('profileId', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
-                            <option value="">Select...</option>
+                        <select id="profile" name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
+                            <option selected value="">None</option>
                         </select>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
                         <small ng-show="deliveryService.profileId"><a href="/#!/profiles/{{deliveryService.profileId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
@@ -500,47 +517,44 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxMbps), 'has-feedback': hasError(deliveryServiceForm.globalMaxMbps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">
                         <span uib-popover-html="label('globalMaxMbps', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('globalMaxMbps', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="globalMaxMbps" type="number" class="form-control" placeholder="Max bits per second allowed globally" ng-model="deliveryService.globalMaxMbps" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.globalMaxMbps, 'pattern')">Whole Number</small>
+                        <input id="globalMaxMbps" name="globalMaxMbps" type="number" class="form-control" placeholder="Max bits per second allowed globally" ng-model="deliveryService.globalMaxMbps" min="0" step="1">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.globalMaxMbps != dsCurrent.globalMaxMbps">Current Value: [ {{dsCurrent.globalMaxMbps}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.globalMaxMbps)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxTps), 'has-feedback': hasError(deliveryServiceForm.globalMaxTps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxTps">
                         <span uib-popover-html="label('globalMaxTps', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('globalMaxTps', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="globalMaxTps" type="number" class="form-control" placeholder="Max transactions per second allowed globally" ng-model="deliveryService.globalMaxTps" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.globalMaxTps, 'pattern')">Whole Number</small>
+                        <input id="globalMaxTps" name="globalMaxTps" type="number" class="form-control" placeholder="Max transactions per second allowed globally" ng-model="deliveryService.globalMaxTps" min="0" step="1">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.globalMaxTps != dsCurrent.globalMaxTps">Current Value: [ {{dsCurrent.globalMaxTps}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.globalMaxTps)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
-        <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.fqPacingRate), 'has-feedback': hasError(deliveryServiceForm.fqPacingRate)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.fqPacingRate), 'has-feedback': hasError(deliveryServiceForm.fqPacingRate)}">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">
                         <span uib-popover-html="label('fqPacingRate', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('fqPacingRate', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="fqPacingRate" type="number" class="form-control" placeholder="Rate-limit connections to this Bytes per second" ng-model="deliveryService.fqPacingRate" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.fqPacingRate, 'pattern')">Whole Number</small>
+                        <input id="fqPacingRate" name="fqPacingRate" type="number" class="form-control" placeholder="Rate-limit connections to this Bytes per second" ng-model="deliveryService.fqPacingRate" min="0" step="1">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.fqPacingRate != dsCurrent.fqPacingRate">Current Value: [ {{dsCurrent.fqPacingRate}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.fqPacingRate)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.edgeHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.edgeHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">
                         <span uib-popover-html="label('edgeHeaderRewrite', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('edgeHeaderRewrite', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="edgeHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.edgeHeaderRewrite" ng-maxlength="2048" autofocus>
+                        <input id="edgeHeaderRewrite" name="edgeHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.edgeHeaderRewrite" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.edgeHeaderRewrite, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.edgeHeaderRewrite != dsCurrent.edgeHeaderRewrite">Current Value: [ {{dsCurrent.edgeHeaderRewrite}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.edgeHeaderRewrite)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -548,11 +562,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.midHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.midHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">
                         <span uib-popover-html="label('midHeaderRewrite', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('midHeaderRewrite', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="midHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.midHeaderRewrite" ng-maxlength="2048" autofocus>
+                        <input id="midHeaderRewrite" name="midHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.midHeaderRewrite" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.midHeaderRewrite, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.midHeaderRewrite != dsCurrent.midHeaderRewrite">Current Value: [ {{dsCurrent.midHeaderRewrite}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.midHeaderRewrite)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -560,11 +574,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">
                         <span uib-popover-html="label('trResponseHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trResponseHeaders', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" ng-maxlength="1024" autofocus>
+                        <input id="trResponseHeaders" name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trResponseHeaders, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trResponseHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -572,11 +586,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">
                         <span uib-popover-html="label('trRequestHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trRequestHeaders', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" ng-maxlength="1024" autofocus>
+                        <input id="trRequestHeaders" name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trRequestHeaders, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trRequestHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -584,11 +598,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regexRemap), 'has-feedback': hasError(deliveryServiceForm.regexRemap)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regexRemap">
                         <span uib-popover-html="label('regexRemap', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('regexRemap', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="regexRemap" type="text" class="form-control" ng-model="deliveryService.regexRemap" ng-maxlength="1024" autofocus>
+                        <input id="regexRemap" name="regexRemap" type="text" class="form-control" ng-model="deliveryService.regexRemap" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regexRemap, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regexRemap != dsCurrent.regexRemap">Current Value: [ {{dsCurrent.regexRemap}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.regexRemap)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -596,11 +610,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">
                         <span uib-popover-html="label('cacheurl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cacheurl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" ng-maxlength="1024" autofocus>
+                        <input id="cacheurl" name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cacheurl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.cacheurl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -608,11 +622,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">
                         <span uib-popover-html="label('remapText', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('remapText', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" ng-maxlength="2048" autofocus>
+                        <input id="remapText" name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.remapText, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.remapText)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -620,11 +634,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">
                         <span uib-popover-html="label('infoUrl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('infoUrl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="infoUrl" type="text" class="form-control" ng-model="deliveryService.infoUrl" ng-maxlength="255" autofocus>
+                        <input id="infoUrl" name="infoUrl" type="url" title="Must be a valid URL." class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -632,11 +646,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">
                         <span uib-popover-html="label('checkPath', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('checkPath', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" ng-maxlength="255" autofocus>
+                        <input id="checkPath" name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.checkPath, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.checkPath)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -644,11 +658,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.originShield), 'has-feedback': hasError(deliveryServiceForm.originShield)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="originShield">
                         <span uib-popover-html="label('originShield', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('originShield', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="originShield" type="text" class="form-control" ng-model="deliveryService.originShield" ng-maxlength="1024" autofocus>
+                        <input id="originShield" name="originShield" type="text" class="form-control" ng-model="deliveryService.originShield" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.originShield, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.originShield != dsCurrent.originShield">Current Value: [ {{dsCurrent.originShield}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.originShield)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -656,11 +670,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.consistentHashRegex), 'has-feedback': hasError(deliveryServiceForm.consistentHashRegex)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="consistentHashRegex">
                         <span uib-popover-html="label('consistentHashRegex', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('consistentHashRegex', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="consistentHashRegex" type="text" class="form-control" ng-model="deliveryService.consistentHashRegex" ng-maxlength="1024" autofocus>
+                        <input id="consistentHashRegex" name="consistentHashRegex" type="text" class="form-control" ng-model="deliveryService.consistentHashRegex" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.consistentHashRegex, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.consistentHashRegex != dsCurrent.consistentHashRegex">Current Value: [ {{dsCurrent.consistentHashRegex}} ]</small>
                         <small><a ng-click="encodeRegex(deliveryService.consistentHashRegex)" href="/#!/delivery-services/{{deliveryService.id}}/consistent-hash?pattern={{encodedRegex}}" target="_blank">Test Regex&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -98,10 +98,10 @@ under the License.
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z][a-z0-9\-]*" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
+                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z]([a-z0-9\-]*[a-z0-9])?" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
@@ -214,10 +214,10 @@ under the License.
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
-                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="[a-z0-9][a-z0-9\-]*" required>
+                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?" required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
@@ -370,10 +370,10 @@ under the License.
             </div>
 
             <div class="modal-footer">
-                <button class="btn btn-link" ng-click="advancedShowing = !advancedShowing"><span ng-show="!advancedShowing">Show</span><span ng-show="advancedShowing">Hide</span> Advanced</button>
+                <button type="button" class="btn btn-link" ng-click="advancedShowing = !advancedShowing"><span ng-show="!advancedShowing">Show</span><span ng-show="advancedShowing">Hide</span> Advanced</button>
                 <button type="button" class="btn btn-danger" ng-if="!settings.isNew" ng-disabled="!deletable()" ng-click="confirmDelete(deliveryService)">{{settings.deleteLabel}}</button>
-                <button type="button" class="btn btn-success" ng-disabled="deliveryServiceForm.$pristine || deliveryServiceForm.$invalid || !saveable()" ng-click="save(deliveryService)">{{settings.saveLabel}}</button>
-                <button type="button" class="btn btn-primary" ng-if="settings.isRequest && fulfillable()" ng-disabled="deliveryServiceForm.$invalid" ng-click="fulfillRequest(deliveryService)">Fulfill Request</button>
+                <button class="btn btn-success" ng-disabled="deliveryServiceForm.$pristine || deliveryServiceForm.$invalid || !saveable()" ng-click="save(deliveryService)">{{settings.saveLabel}}</button>
+                <button class="btn btn-primary" ng-if="settings.isRequest && fulfillable()" ng-disabled="deliveryServiceForm.$invalid" ng-click="fulfillRequest(deliveryService)">Fulfill Request</button>
             </div>
         </form>
     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -260,7 +260,6 @@ under the License.
                             <option ng-value="0" selected>Maxmind</option>
                             <option ng-value="1">Neustar</option>
                         </select>
-                        <small class="input-warning" ng-show="deliveryService.geoProvider == 1">Neustar support may have been dropped! Use with caution...</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -46,11 +46,11 @@ under the License.
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="viewCharts()">View Charts</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="viewTargets()">View Targets</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
                     <li role="menuitem"><a ng-click="viewJobs()">View Invalidation Requests</a></li>
@@ -62,28 +62,30 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <form name="deliveryServiceForm" class="form-horizontal form-label-left" novalidate>
+        <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">
                     <span uib-popover-html="label('active', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('active', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="active" class="form-control" ng-model="deliveryService.active" ng-options="x.value as x.label for x in falseTrue" required>
-                        <option value="">Select...</option>
+                    <select id="active" id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
+                        <option hidden disabled value="">Select...</option>
+                        <option ng-value="true">Active</option>
+                        <option ng-value="false">Not Active</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.active, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active}} ]</small>
+                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">
                     <span uib-popover-html="label('typeId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('typeId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
-                        <option value="">Select...</option>
+                    <select id="type" name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
+                        <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.type, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
@@ -106,11 +108,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">
                     <span uib-popover-html="label('displayName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('displayName', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" ng-maxlength="48" required autofocus>
+                    <input id="displayName" name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" maxlength="48" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'maxlength')">Too Long</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
@@ -119,12 +121,12 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">
                     <span uib-popover-html="label('tenantId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('tenantId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
-                        <option value="">Select...</option>
+                    <select id="tenantId" name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
+                        <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.tenantId, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
@@ -133,12 +135,12 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">
                     <span uib-popover-html="label('cdnId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cdnId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
-                        <option value="">Select...</option>
+                    <select id="cdn" name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
+                        <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdn, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
@@ -147,12 +149,16 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">
                     <span uib-popover-html="label('protocol', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('protocol', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="protocol" class="form-control" ng-model="deliveryService.protocol" ng-options="protocol.value as protocol.label for protocol in protocols" required>
-                        <option value="">Select...</option>
+                    <select id="protocol" name="protocol" class="form-control" ng-model="deliveryService.protocol" required>
+                        <option hidden disabled value="">Select...</option>
+                        <option ng-value="0">HTTP</option>
+                        <option ng-value="1">HTTPS</option>
+                        <option ng-value="2">HTTP and HTTPS</option>
+                        <option ng-value="3">HTTP to HTTPS</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.protocol, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
@@ -160,11 +166,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">
                     <span uib-popover-html="label('longDesc', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required autofocus></textarea>
+                    <textarea id="longDesc" name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.longDesc, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -172,97 +178,103 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">
                     <span uib-popover-html="label('longDesc1', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc1', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3" autofocus></textarea>
+                    <textarea id="longDesc1" name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3"></textarea>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc1)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc2">
                     <span uib-popover-html="label('longDesc2', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc2', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3" autofocus></textarea>
+                    <textarea id="longDesc2" name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3"></textarea>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc2)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-if="!settings.isNew && !settings.isRequest">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">Delivery Service URLs</label>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeFQDNs">Delivery Service URLs</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="edgeFQDNs" rows="4" cols="17" class="form-control readonly" readonly>{{edgeFQDNs(deliveryService)}}</textarea>
+                    <textarea id="edgeFQDNs" name="edgeFQDNs" rows="4" cols="17" class="form-control readonly" readonly>{{edgeFQDNs(deliveryService)}}</textarea>
                 </div>
             </div>
 
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">
                         <span uib-popover-html="label('routingName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('routingName', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
-                        <input name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" ng-maxlength="48" ng-pattern="/^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/" required autofocus>
+                        <input id="routingName" name="routingName" type="text" class="form-control" placeholder="Routing name used for the delivery service resulting in FQDN = <routing name>.<key>.<CDN domain>" ng-model="deliveryService.routingName" maxlength="48" pattern="[a-z0-9][a-z0-9\-]*" required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Invalid. Must be a valid hostname without periods</small>
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">
                         <span uib-popover-html="label('ipv6RoutingEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ipv6RoutingEnabled', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="ipv6RoutingEnabled" name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" required>
+                            <option ng-value="true">Enabled</option>
+                            <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ipv6RoutingEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">
                         <span uib-popover-html="label('logsEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('logsEnabled', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="logsEnabled" name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" required>
+                            <option ng-value="true" selected>Enabled</option>
+                            <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.logsEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">
                         <span uib-popover-html="label('geoProvider', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoProvider', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" ng-options="gp.value as gp.label for gp in geoProviders" required>
-                            <option value="">Select...</option>
+                        <select id="geoProvider" name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" required>
+                            <option ng-value="0" selected>Maxmind</option>
+                            <option ng-value="1">Neustar</option>
                         </select>
+                        <small class="input-warning" ng-show="deliveryService.geoProvider == 1">Neustar support may have been dropped! Use with caution...</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">
                         <span uib-popover-html="label('geoLimit', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimit', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" ng-options="gl.value as gl.label for gl in geoLimits" required>
-                            <option value="">Select...</option>
+                        <select id="geoLimit" name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" required>
+                            <option ng-value="0" selected>None</option>
+                            <option ng-value="1">Coverage Zone File only</option>
+                            <option ng-value="2">Coverage Zone File and Country Code(s)</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimit, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
@@ -270,11 +282,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">
                         <span uib-popover-html="label('geoLimitCountries', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitCountries', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" ng-maxlength="255" autofocus>
+                        <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitCountries, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitCountries)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -282,12 +294,12 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">
                         <span uib-popover-html="label('profileId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('profileId', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
-                            <option value="">Select...</option>
+                        <select id="profile" name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
+                            <option selected value="">None</option>
                         </select>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
                         <small ng-show="deliveryService.profileId"><a href="/#!/profiles/{{deliveryService.profileId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
@@ -296,11 +308,11 @@ under the License.
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}"
                      ng-if="isClientSteering(deliveryService)">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">
                         <span uib-popover-html="label('trResponseHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trResponseHeaders', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" ng-maxlength="1024" autofocus>
+                        <input id="trResponseHeaders" name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trResponseHeaders, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trResponseHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -308,23 +320,22 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">
                         <span uib-popover-html="label('ccrDnsTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ccrDnsTtl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ccrDnsTtl, 'pattern')">Whole Number</small>
+                        <input id="ccrDnsTtl" name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" min="0" step="1">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.ccrDnsTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">
                         <span uib-popover-html="label('infoUrl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('infoUrl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="infoUrl" type="text" class="form-control" ng-model="deliveryService.infoUrl" ng-maxlength="255" autofocus>
+                        <input id="infoUrl" name="infoUrl" type="url" title="Must be a valid URL" class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -332,11 +343,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">
                         <span uib-popover-html="label('checkPath', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('checkPath', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" ng-maxlength="255" autofocus>
+                        <input id="checkPath" name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.checkPath, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.checkPath)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -344,11 +355,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.consistentHashRegex), 'has-feedback': hasError(deliveryServiceForm.consistentHashRegex)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label for="consistentHashRegex" class="control-label col-md-2 col-sm-2 col-xs-12">
                         <span uib-popover-html="label('consistentHashRegex', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('consistentHashRegex', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="consistentHashRegex" type="text" class="form-control" ng-model="deliveryService.consistentHashRegex" ng-maxlength="1024" autofocus>
+                        <input name="consistentHashRegex" type="text" class="form-control" ng-model="deliveryService.consistentHashRegex" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.consistentHashRegex, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.consistentHashRegex != dsCurrent.consistentHashRegex">Current Value: [ {{dsCurrent.consistentHashRegex}} ]</small>
                         <small><a ng-click="encodeRegex(deliveryService.consistentHashRegex)" href="/#!/delivery-services/{{deliveryService.id}}/consistent-hash?pattern={{encodedRegex}}" target="_blank">Test Regex&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -336,6 +336,7 @@ under the License.
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="infoUrl" name="infoUrl" type="url" title="Must be a valid URL" class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
+                        <small class="input-error invalid-URL-error">Invalid URL</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -92,14 +92,14 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" ng-required="true" ng-maxlength="48" ng-pattern="/^\S*$/" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')" autofocus>
+                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z][a-z0-9\-]*" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">No spaces</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -226,7 +226,6 @@ under the License.
                             <option ng-value="0" selected>MaxMind</option>
                             <option ng-value="1">Neustar</option>
                         </select>
-                        <small class="input-warning" ng-show="deliveryService.geoProvider == 1">Neustar support may have been dropped! Use with caution...</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -96,10 +96,10 @@ under the License.
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z][a-z0-9\-]*" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
+                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z]([a-z0-9\-]*[a-z0-9])?" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
@@ -358,10 +358,10 @@ under the License.
             </div>
 
             <div class="modal-footer">
-                <button class="btn btn-link" ng-click="advancedShowing = !advancedShowing"><span ng-show="!advancedShowing">Show</span><span ng-show="advancedShowing">Hide</span> Advanced</button>
+                <button type="button" class="btn btn-link" ng-click="advancedShowing = !advancedShowing"><span ng-show="!advancedShowing">Show</span><span ng-show="advancedShowing">Hide</span> Advanced</button>
                 <button type="button" class="btn btn-danger" ng-if="!settings.isNew" ng-disabled="!deletable()" ng-click="confirmDelete(deliveryService)">{{settings.deleteLabel}}</button>
-                <button type="button" class="btn btn-success" ng-disabled="deliveryServiceForm.$pristine || deliveryServiceForm.$invalid || !saveable()" ng-click="save(deliveryService)">{{settings.saveLabel}}</button>
-                <button type="button" class="btn btn-primary" ng-if="settings.isRequest" ng-disabled="deliveryServiceForm.$invalid || !fulfillable()" ng-click="fulfillRequest(deliveryService)">Fulfill Request</button>
+                <button class="btn btn-success" ng-disabled="deliveryServiceForm.$pristine || deliveryServiceForm.$invalid || !saveable()" ng-click="save(deliveryService)">{{settings.saveLabel}}</button>
+                <button class="btn btn-primary" ng-if="settings.isRequest" ng-disabled="deliveryServiceForm.$invalid || !fulfillable()" ng-click="fulfillRequest(deliveryService)">Fulfill Request</button>
             </div>
         </form>
     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -337,6 +337,7 @@ under the License.
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="infoUrl" name="infoUrl" type="url" class="form-control" ng-model="deliveryService.infoUrl" title="Must be a valid URL." maxlength="255">
+                        <small class="input-error invalid-URL-error">Invalid URL</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -46,9 +46,9 @@ under the License.
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="viewCharts()">View Charts</a></li>
-                    <li class="divider"></li>
+                    <hr class="divider"/>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
                     <li role="menuitem"><a ng-click="viewJobs()">View Invalidation Requests</a></li>
@@ -60,28 +60,30 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <form name="deliveryServiceForm" class="form-horizontal form-label-left" novalidate>
+        <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">
                     <span uib-popover-html="label('active', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('active', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="active" class="form-control" ng-model="deliveryService.active" ng-options="x.value as x.label for x in falseTrue" required>
-                        <option value="">Select...</option>
+                    <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required autofocus>
+                        <option disabled hidden value="">Select...</option>
+                        <option ng-value="true">Active</option>
+                        <option ng-value="false">Not Active</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.active, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active}} ]</small>
+                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">
                     <span uib-popover-html="label('typeId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('typeId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
-                        <option value="">Select...</option>
+                    <select id="type" name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
+                        <option disabled selected hidden value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.type, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
@@ -104,11 +106,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">
                     <span uib-popover-html="label('displayName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('displayName', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" ng-maxlength="48" required autofocus>
+                    <input id="displayName" name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" maxlength="48" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'maxlength')">Too Long</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
@@ -117,12 +119,12 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">
                     <span uib-popover-html="label('tenantId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('tenantId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
-                        <option value="">Select...</option>
+                    <select id="tenantId" name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
+                        <option disabled selected hidden value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.tenantId, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
@@ -131,12 +133,12 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">
                     <span uib-popover-html="label('cdnId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cdnId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
-                        <option value="">Select...</option>
+                    <select id="cdn" name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
+                        <option disabled selected hidden value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdn, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
@@ -145,11 +147,11 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">
                     <span uib-popover-html="label('longDesc', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required autofocus></textarea>
+                    <textarea id="longDesc" name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.longDesc, 'required')">Required</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -157,22 +159,22 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">
                     <span uib-popover-html="label('longDesc1', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc1', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3" autofocus></textarea>
+                    <textarea id="longDesc1" name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3"></textarea>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc1)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc2">
                     <span uib-popover-html="label('longDesc2', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc2', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3" autofocus></textarea>
+                    <textarea id="longDesc2" name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3"></textarea>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc2)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
@@ -181,68 +183,77 @@ under the License.
             <div class="form-group" ng-if="!settings.isNew && !settings.isRequest">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">Delivery Service URLs</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="edgeFQDNs" rows="4" cols="17" class="form-control readonly" readonly>{{edgeFQDNs(deliveryService)}}</textarea>
+                    <textarea id="edgeFQDNs" name="edgeFQDNs" rows="4" cols="17" class="form-control readonly" readonly>{{edgeFQDNs(deliveryService)}}</textarea>
                 </div>
             </div>
 
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regionalGeoBlocking), 'has-feedback': hasError(deliveryServiceForm.regionalGeoBlocking)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">
                         <span uib-popover-html="label('regionalGeoBlocking', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('regionalGeoBlocking', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="regionalGeoBlocking" class="form-control" ng-model="deliveryService.regionalGeoBlocking" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="regionalGeoBlocking" name="regionalGeoBlocking" class="form-control" ng-model="deliveryService.regionalGeoBlocking" required>
+                            <option ng-value="true">Enabled</option>
+                            <option ng-value="false" selected>Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regionalGeoBlocking, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">Current Value: [ {{dsCurrent.regionalGeoBlocking}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">Current Value: [ {{dsCurrent.regionalGeoBlocking ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">
                         <span uib-popover-html="label('logsEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('logsEnabled', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" ng-options="x.value as x.label for x in falseTrue" required>
-                            <option value="">Select...</option>
+                        <select id="logsEnabled" name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" required>
+                            <option ng-value="true" selected>Enabled</option>
+                            <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.logsEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled}} ]</small>
+                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">
                         <span uib-popover-html="label('geoProvider', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoProvider', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" ng-options="gp.value as gp.label for gp in geoProviders" required></select>
+                        <select id="geoProvider" name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" required>
+                            <option ng-value="0" selected>MaxMind</option>
+                            <option ng-value="1">Neustar</option>
+                        </select>
+                        <small class="input-warning" ng-show="deliveryService.geoProvider == 1">Neustar support may have been dropped! Use with caution...</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">
                         <span uib-popover-html="label('geoLimit', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimit', 'title')}}</span> *
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" ng-options="gl.value as gl.label for gl in geoLimits" required>
-                            <option value="">Select...</option>
+                        <select id="geoLimit" name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" required>
+                            <option ng-value="0" selected>None</option>
+                            <option ng-value="1">Coverage Zone File only</option>
+                            <option ng-value="2">Coverage Zone File and Country Code(s)</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimit, 'required')">Required</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
                     </div>
                 </div>
 
+
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">
                         <span uib-popover-html="label('geoLimitCountries', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitCountries', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" ng-maxlength="255" autofocus>
+                        <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitCountries, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitCountries)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -250,24 +261,23 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">
                         <span uib-popover-html="label('geoLimitRedirectURL', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitRedirectURL', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="geoLimitRedirectURL" type="text" class="form-control" ng-model="deliveryService.geoLimitRedirectURL" ng-pattern="/^(https?:\/\/)/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitRedirectURL, 'pattern')">Must start with http:// or https://</small>
+                        <input id="geoLimitRedirectURL" name="geoLimitRedirectURL" type="url" class="form-control" ng-model="deliveryService.geoLimitRedirectURL" title="Must be a valid URL.">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitRedirectURL)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">
                         <span uib-popover-html="label('profileId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('profileId', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <select name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
-                            <option value="">Select...</option>
+                        <select id="profile" name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
+                            <option selected value="">None</option>
                         </select>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
                         <small ng-show="deliveryService.profileId"><a href="/#!/profiles/{{deliveryService.profileId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
@@ -275,11 +285,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">
                         <span uib-popover-html="label('trRequestHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trRequestHeaders', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" ng-maxlength="1024" autofocus>
+                        <input id="trRequestHeaders" name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trRequestHeaders, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trRequestHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -287,11 +297,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">
                         <span uib-popover-html="label('cacheurl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cacheurl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" ng-maxlength="1024" autofocus>
+                        <input id="cacheurl" name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cacheurl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.cacheurl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -299,23 +309,22 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">
                         <span uib-popover-html="label('ccrDnsTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ccrDnsTtl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" ng-pattern="/^\d+$/" autofocus>
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ccrDnsTtl, 'pattern')">Whole Number</small>
+                        <input id="ccrDnsTtl" name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" min="0" step="1">
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.ccrDnsTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">
                         <span uib-popover-html="label('remapText', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('remapText', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" ng-maxlength="2048" autofocus>
+                        <input id="remapText" name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.remapText, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.remapText)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -323,11 +332,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">
                         <span uib-popover-html="label('infoUrl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('infoUrl', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="infoUrl" type="text" class="form-control" ng-model="deliveryService.infoUrl" ng-maxlength="255" autofocus>
+                        <input id="infoUrl" name="infoUrl" type="url" class="form-control" ng-model="deliveryService.infoUrl" title="Must be a valid URL." maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
@@ -335,11 +344,11 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">
                         <span uib-popover-html="label('checkPath', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('checkPath', 'title')}}</span>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" ng-maxlength="255" autofocus>
+                        <input id="checkPath" name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.checkPath, 'maxlength')">Too Long</small>
                         <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.checkPath)" class="form-control-feedback"><i class="fa fa-times"></i></span>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -89,15 +89,15 @@ under the License.
                 </div>
             </div>
 
-            <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
+           <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">
                     <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" ng-required="true" ng-maxlength="48" ng-pattern="/^\S*$/" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')" autofocus>
+                    <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z][a-z0-9\-]*" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">No spaces</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>

--- a/traffic_portal/app/src/styles/theme.scss
+++ b/traffic_portal/app/src/styles/theme.scss
@@ -2864,7 +2864,12 @@ ul.count2 li span {
 }
 .divider {
   border-bottom: 1px solid #ddd;
-  margin: 10px
+  margin: 10px;
+}
+hr.divider {
+  margin: 10px 0;
+  border: none;
+  background-color: #ddd;
 }
 .divider-dashed {
   border-top: 1px dashed #e7eaec;


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?
This PR partially addresses Issue #3312 by performing front-end validation on the XML_ID field of new, changed, or requested Delivery Services. Specifically, the validation checks for a whole-field match against the regular expression: `[a-z0-9][a-z0-9\-]*`. Input that doesn't match this *may still be submitted via the API and stored by the database*. The XML_ID is not always used as part of an <abbr title="Fully Qualified Domain Name">FQDN</abbr>, so such constraints on the server-side are better left until such a time that the future of the XML_ID - regarding whether it should be semantically distinct from a DNS label - is decided.

This PR also includes other quality-of-life improvements for Delivery Service forms.

* All `<label>`s now have an appropriate `for` attribute indicating which `<input>` (or `<select>`) it is actually labeling
* Changed many `ng-pattern` attributes to `pattern`, `ng-maxlength` attributes to `maxlength`.
* Form fields that allow the selection from among alternate `<options>` having a default, initial value of `Select...` will no longer include that value in the list of selectable options.
* ~Added a warning about hazy compatibility when attempting to set a new or existing Delivery Service's `geoProvider` to "Neustar".~ - this wound up being removed
* Fields that use enumerated names like e.g. `qstringIgnore` now have the integral value obscured, containing instead a human-readable description of the selected behavior. (They still pass the appropriate, integral value back to the API)
* Fields that previously allowed selecting either "True" or "False" now have more context-sensitive names - this removes a dependency on enumerating a hard-coded array (`[{"label": "false", "value": false}, {"label": "true", "value": true}]`) for every true/false field in the form. (Incoming PR to change those to checkboxes for sheer simplicity and effective communication of the represented idea)
* Fields that defined numbers and relied on `ng-pattern="/^\d+$/"` to ensure only natural numbers were entered now rely instead on the `min` and `step` attributes
* Latitude and Longitude fields now validate that the entered number is within the allowed range for each ([-90,90] and [-180,180], respectively)
* Fields that contained URLs have been updated to have `type="url"`
* `initalDispersion` is now an `<input type="number" min="1" max="10" step="1"/>` instead of a `<select>` iterating over a hard-coded Javascript array of those numbers.
* "More" menu delimiters are now `<hr/>`s instead of `<li class="divider"></li>`, as they are not actually items in the list but rather horizontal rules that separate them. (Incoming PR to change that `<ul>` to a `<menu>` and do the styling without classes on the `<hr/>` tags)

## Which TC components are affected by this PR?
- [x] Traffic Portal

## What is the best way to verify this PR? Please include manual steps or automated tests. 
Run the Traffic Portal UI tests, build and run Traffic Portal and check out the Delivery Service creation, modification and request forms.