### PR TITLE
Bugfix for self-signed SSL certs

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1628,8 +1628,7 @@ sub get_cookie {
 
 	my $url = $to_host . "/api/1.3/user/login";
 	my $json = qq/{ "u": "$u", "p": "$p"}/;
-	my $lwp = LWP::UserAgent->new;
-	my $response = $lwp->post($url, Content => $json);
+	my $response = $lwp_conn->post($url, Content => $json);
 
 	&check_lwp_response_code($response, $FATAL);
 


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

The get_cookie subroutine was not using the same connection as the rest of the ORT script. This fixes that. A side effect is that it also fixes self-signed certs to work again. I currently need self-signed certs to work because I use those for lab testing.

I do think that we should not make that the default, which the ORT script currently does. I think we should add an option to the ORT script for self-signed certs like curl's -k.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [x] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Best way to test: Run this ORT script against a TO that has a self-signed cert.

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



