### PR TITLE
Added docs dependencies needed for auto-documenting ATC Python modules

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -16,3 +16,7 @@ Sphinx>=1.4.3
 sphinx_rtd_theme>=0.4.0
 sphinx_autodoc_typehints>=1.3.0
 Pygments>=2.3.1
+munch>=2.1.1
+psutil
+future>=0.16.0
+distro

--- a/infrastructure/docker/build/Dockerfile-docs
+++ b/infrastructure/docker/build/Dockerfile-docs
@@ -36,6 +36,7 @@ ADD docs/source/requirements.txt /docs.requirements.txt
 RUN	yum -y install \
 		python34 \
 		python34-pip \
+        python34-psutil \
 		make && \
 	yum -y clean all && \
 	python3 -m pip install --upgrade setuptools && \


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?
Adds the dependencies of the Python client and ORT.py to `docs/sources/requirements.txt`. This is required for proper auto-documentation of those packages. To be clear, the regular documentation regard e.g. the Traffic Ops API can still be built without installing this full dependency stack, but the output will not include documentation of the Python client and ORT.py (which is, at the time of this writing, the case with our public ReadTheDocs hosting).

## Which TC components are affected by this PR?

- [x] Documentation

## What is the best way to verify this PR? Please include manual steps or automated tests. 
There are two ways to test this, one easier than the other.

### Docker
The easiest way to verify this is to build the docs using Docker. This can be done with simply `./pkg docs` from the repository root (may need elevated permissions). This will output a Gzipped tarball of the rendered documentation in `dist/`.

### Manually
To build the docs manually, first navigate to the documentation directory, then install the documentation dependencies from `docs/source/requirements.txt` and finally build the documentation with `make`.

E.g.
```bash
# Assuming we start in the repository root
cd docs

# If `pip` is not installed, it can be installed with `sudo python3 -m ensurepip`
sudo python3 -m pip install --upgrade -r source/requirements.txt

make
```
## Check all that apply
- [x] This PR includes documentation updates