### PR TITLE
DS form tooltips now pure CSS hoverboxes

### DIFF
--- a/traffic_portal/app/src/common/modules/form/_form.scss
+++ b/traffic_portal/app/src/common/modules/form/_form.scss
@@ -1,5 +1,6 @@
-/*
+@charset "UTF-8";
 
+/*
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -16,15 +17,61 @@
 */
 
 .btn-link.request-status {
-  font-size: 20px;
-  color: #cd1323;
+	font-size: 20px;
+	color: #cd1323;
 }
 
-form .control-label > span {
-	text-decoration: underline dotted;
+.dnssec-info-text {
+	margin-bottom: 12px;
+	font-size: medium;
+}
 
-	&:hover {
-		cursor: help;
+/******* tooltip styling *******/
+form label.control-label {
+	text-decoration: underline dotted;
+	position: relative;
+	cursor: help;
+
+	div.helptooltip {
+		visibility: hidden;
+		text-decoration: none;
+		max-width: 276px;
+		position: absolute;
+		bottom: 2em;
+		padding-bottom: 1em;
+		z-index: 2;
+		color: default;
+		background-color: transparent;
+		transition: opacity 0.2s ease-in-out;
+		transition: bottom 0.2s cubic-bezier(0.075, 0.75, 0.875, 0.36);
+		color: #73879C;
+		text-align: left;
+
+		div.helptext {
+			background-color: white;
+			padding: 10px;
+			border-radius: 6px;
+			box-shadow: 0 5px 10px rgba(0,0,0,0.3);
+			width: max-content;
+			max-width: inherit;
+			cursor: auto;
+		}
+	}
+
+	&:hover div.helptooltip {
+		display: block;
+		visibility: visible;
+		opacity: 1;
+		bottom: 1em;
+	}
+
+	&:hover div.helptext::after {
+		content: " ";
+		position: absolute;
+		border-color: white transparent transparent;
+		border-style: solid;
+		border-width: 5px;
+		bottom: 3px;
 	}
 }
 
@@ -39,6 +86,58 @@ input[type="url"]:invalid ~ small.invalid-URL-error {
 }
 
 .dnssec-info-text {
-  margin-bottom: 12px;
-  font-size: medium;
+	margin-bottom: 12px;
+	font-size: medium;
 }
+
+@media (min-width: 768px) {
+	form label.control-label {
+		div.helptooltip {
+			left: calc(100% - 140px);
+		}
+
+		&:hover div.helptext::after {
+			left: 40%;
+		}
+	}
+}
+
+@media (max-width: 767px) {
+	form label.control-label {
+		div.helptooltip {
+			left: 0;
+		}
+
+		&:hover div.helptext::after {
+			left: 20px;
+		}
+	}
+}
+
+/********** tooltip warnings **********/
+div.helptext aside.warning {
+	h6 {
+		color: white;
+		width: 100%;
+		background-color: #f0b37e;
+		margin-bottom: 0;
+		padding: 2px 5px;
+
+		&::before {
+			font-family: "FontAwesome";
+			content: " ";
+		}
+	}
+
+	p {
+		background: #ffedcc;
+		padding: 5px;
+		margin-bottom: 0;
+	}
+}
+
+/********** bootstrap overriding user-agent styling.... **********/
+dl dd {
+	margin-left: 50px;
+}
+

--- a/traffic_portal/app/src/common/modules/form/_form.scss
+++ b/traffic_portal/app/src/common/modules/form/_form.scss
@@ -27,7 +27,7 @@
 }
 
 /******* tooltip styling *******/
-form label.control-label {
+form label.has-tooltip {
 	text-decoration: underline dotted;
 	position: relative;
 	cursor: help;
@@ -91,7 +91,7 @@ input[type="url"]:invalid ~ small.invalid-URL-error {
 }
 
 @media (min-width: 768px) {
-	form label.control-label {
+	form label.has-tooltip {
 		div.helptooltip {
 			left: calc(100% - 140px);
 		}
@@ -103,7 +103,7 @@ input[type="url"]:invalid ~ small.invalid-URL-error {
 }
 
 @media (max-width: 767px) {
-	form label.control-label {
+	form label.has-tooltip {
 		div.helptooltip {
 			left: 0;
 		}

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -67,7 +67,7 @@ under the License.
         <br>
         <form id="deliveryServiceForm" name="deliveryServiceForm" class="form-horizontal form-label-left">
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
                     <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
                 </div>
                 </label>
@@ -83,7 +83,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
                     <div class="helptext">
                         DNS is the standard routing type for most CDN services. HTTP Redirect is a specialty routing service that is primarily used for video and large file downloads where localization and latency are significant concerns. A "Live" routing type should be used for all live services.
                         <br>
@@ -103,7 +103,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
                     <div class="helptext">This id becomes a part of the CDN service domain in the form <samp>http://cdn.service-key.company.com/</samp>. Must be all lowercase, no spaces or special characters. May contain dashes.</div>
                 </div>
                 </label>
@@ -118,7 +118,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
                     <div class="helptext">Name of the service that appears in the Traffic portal. No character restrictions.</div>
                 </div>
                 </label>
@@ -132,7 +132,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
                     <div class="helptext">Name of company or division of company who owns account. Allows you to group your services and control access. Tenants are setup as a simple hierarchy where you may create parent / child accounts.</div>
                 </div>
                 </label>
@@ -147,7 +147,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
                     <div class="helptext">The CDN to which the Delivery Service belongs.</div>
                 </div>
                 </label>
@@ -162,7 +162,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.orgServerFqdn), 'has-feedback': hasError(deliveryServiceForm.orgServerFqdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">Origin Server Base URL *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">Origin Server Base URL *<div class="helptooltip">
                     <div class="helptext">The Origin Server’s base URL which includes the protocol (http or https). Example: <samp>http://movies.origin.com</samp>. Must be a domain only, no directories or IP addresses</div>
                 </div>
                 </label>
@@ -177,7 +177,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
                     <div class="helptext">
                         The protocol with which to serve this Delivery Service to the clients:
                         <br>
@@ -205,7 +205,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
                     <div class="helptext">Free text field that describes the purpose of the Delivery Service and will be displayed in the portal as a description field.</div>
                 </div>
                 </label>
@@ -218,7 +218,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
                     <div class="helptext">Free text field not currently used in configuration. For example, you can use this field to describe your customer type.</div>
                 </div>
                 </label>
@@ -230,7 +230,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
                     <div class="helptext">Free text field not currently used in configuration.</div>
                 </div>
                 </label>
@@ -251,7 +251,7 @@ under the License.
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
                         <div class="helptext">The routing name to use for the delivery <abbr title="Fully Qualified Domain Name">FQDN</abbr>, e.g. <samp>routing-name.deliveryservice.cdn-domain</samp>. It must be a valid hostname without periods.</div>
                     </div>
                     </label>
@@ -267,7 +267,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dscp), 'has-feedback': hasError(deliveryServiceForm.dscp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dscp">DSCP<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="dscp">DSCP<div class="helptooltip">
                         <div class="helptext">The <abbr title="Differentiated Services Code Point">DSCP *</abbr> value with which to mark IP packets outbound to the client.</div>
                     </div>
                     </label>
@@ -280,7 +280,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
                         <div class="helptext">Enabeld by default, disabling this allows you to turn off CDN responses to IPv6 requests</div>
                     </div>
                     </label>
@@ -295,7 +295,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.rangeRequestHandling), 'has-feedback': hasError(deliveryServiceForm.rangeRequestHandling)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">Range Request Handling *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">Range Request Handling *<div class="helptooltip">
                         <div class="helptext">
                             How to treat range requests.
                             <br>
@@ -320,7 +320,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.qstringIgnore), 'has-feedback': hasError(deliveryServiceForm.qstringIgnore)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">Query String Handling *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12">Query String Handling *<div class="helptooltip">
                         <div class="helptext">
                             How to treat query parameter strings in request URLs:
                             <br>
@@ -351,7 +351,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.multiSiteOrigin), 'has-feedback': hasError(deliveryServiceForm.multiSiteOrigin)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">Use Multi-Site Origin Feature *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">Use Multi-Site Origin Feature *<div class="helptooltip">
                         <div class="helptext">
                             Enables/disables the Multi-Site Origin feature for this Delivery Service.
                             <br>
@@ -371,7 +371,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
                         <div class="helptext">Allows you to turn on/off logging for this Delivery Service</div>
                     </div>
                     </label>
@@ -386,7 +386,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
                         <div class="helptext">Choose which Geolocation database provider - company that collects data on the location of IP addresses - to use.</div>
                     </div>
                     </label>
@@ -401,7 +401,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLat), 'has-feedback': hasError(deliveryServiceForm.missLat)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLat">Geo Miss Default Latitude *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="missLat">Geo Miss Default Latitude *<div class="helptooltip">
                         <div class="helptext">Default latitude for this Delivery Service. When client localization fails for both Coverage Zone and Geo Lookup, the client will be routed as if it was at this latitude.</div>
                     </div>
                     </label>
@@ -414,7 +414,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLong), 'has-feedback': hasError(deliveryServiceForm.missLong)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLong">Geo Miss Default Longitude *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="missLong">Geo Miss Default Longitude *<div class="helptooltip">
                         <div class="helptext">Default longitude for this Delivery Service. When client localization fails for both Coverage Zone and Geo Lookup, the client will be routed as if it was at this longitude.</div>
                     </div>
                     </label>
@@ -427,7 +427,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
                         <div class="helptext">
                             Some services are intended to be limited by geography. The possible settings are:
                             <br>
@@ -452,7 +452,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}" ng-show="deliveryService.geoLimit === 1 || deliveryService.geoLimit === 2">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
                         <div class="helptext">How (if at all) is this service to be limited by geography. Example Country Codes: <abbr title="Canada">CA</abbr>, <abbr title="India">IN</abbr>, <abbr title="Puerto Rico">PR</abbr>.</div>
                     </div>
                     </label>
@@ -465,7 +465,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
                         <div class="helptext">
                             Traffic Router will redirect to this URL when Geo Limit check fails.
                             <br>
@@ -482,7 +482,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.signingAlgorithm), 'has-feedback': hasError(deliveryServiceForm.signingAlgorithm)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">Signing Algorithm<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">Signing Algorithm<div class="helptooltip">
                         <div class="helptext">
                             Type of URL signing method to sign the URLs:
                             <br>
@@ -508,7 +508,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassIp), 'has-feedback': hasError(deliveryServiceForm.dnsBypassIp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIp">DNS Bypass IP<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIp">DNS Bypass IP<div class="helptooltip">
                         <div class="helptext">
                             IPv4 address to which to overflow requests when the Max Mbps or Max Tps for this Delivery Service are exceeded.
                         </div>
@@ -523,7 +523,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassIp6), 'has-feedback': hasError(deliveryServiceForm.dnsBypassIp6)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIp6">DNS Bypass IPv6<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIp6">DNS Bypass IPv6<div class="helptooltip">
                         <div class="helptext">
                             IPv6 address to which to overflow requests when the Max Mbps or Max Tps for this Delivery Service are exceeded.
                         </div>
@@ -538,7 +538,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassCname), 'has-feedback': hasError(deliveryServiceForm.dnsBypassCname)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassCname">DNS Bypass CNAME<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassCname">DNS Bypass CNAME<div class="helptooltip">
                         <div class="helptext">
                             Domain name to which to overflow requests when the Max Mbps or Max Tps for this Delivery Service are exceeded.
                         </div>
@@ -553,7 +553,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassTtl), 'has-feedback': hasError(deliveryServiceForm.dnsBypassTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassTtl">DNS Bypass TTL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassTtl">DNS Bypass TTL<div class="helptooltip">
                         <div class="helptext"><abbr title="Time To Live">TTL</abbr> for the DNS bypass domain or IP address when thresholds are exceeded.</div>
                     </div>
                     </label>
@@ -565,7 +565,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.maxDnsAnswers), 'has-feedback': hasError(deliveryServiceForm.maxDnsAnswers)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="maxDnsAnswers">Max DNS Answers<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="maxDnsAnswers">Max DNS Answers<div class="helptooltip">
                         <div class="helptext">
                             This is used to restrict the number of cache IP addresses that the Traffic Router will hand back to clients. A numeric value from 1 to 15 which determines how many caches your content will be spread across in a particular site. When a customer requests your content they will get 1 to 15 IP addresses back they can use. These are rotated in each response. Ideally the number will reflect the amount of traffic. 1 = trial account with very little traffic, 2 = small production service. Add 1 more server for every 20 Gbps of traffic you expect at peak. So 20 Gbps = 3, 40 Gbps = 4, 60 Gbps = 5
                         </div>
@@ -579,7 +579,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
                         <div class="helptext">The <abbr title="Time To Live">TTL</abbr> on the DNS record for the Traffic Router A and AAAA records. Setting too high or too low will result in poor caching performance.</div>
                     </div>
                     </label>
@@ -591,7 +591,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
                         <div class="helptext">Only used if a Delivery Service uses configurations that specifically require a profile. Example: Multi-Site Origin configurations would require a Delivery Service Profile to be used.</div>
                     </div>
                     </label>
@@ -605,7 +605,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxMbps), 'has-feedback': hasError(deliveryServiceForm.globalMaxMbps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">Global Max Mbps<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">Global Max Mbps<div class="helptooltip">
                         <div class="helptext">The maximum bits per second this Delivery Service can serve across all EDGE caches before traffic will be diverted to the bypass destination. For a DNS Delivery Service, the Bypass Ipv4 or Ipv6 will be used (depending on whether this was an A or AAAA request), and for HTTP Delivery Services the Bypass <abbr title="Fully Qualified Domain Name">FQDN</abbr> will be used.</div>
                     </div>
                     </label>
@@ -617,7 +617,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxTps), 'has-feedback': hasError(deliveryServiceForm.globalMaxTps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxTps">Global Max Tps<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxTps">Global Max Tps<div class="helptooltip">
                         <div class="helptext">The maximum transactions this Delivery Service can serve across all EDGE caches before traffic will be diverted to the bypass destination. For a DNS Delivery Service, the Bypass Ipv4 or Ipv6 will be used (depending on whether this was an A or AAAA request), and for HTTP Delivery Services the Bypass <abbr title="Fully Qualified Domain Name">FQDN</abbr> will be used.</div>
                     </div>
                     </label>
@@ -629,7 +629,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.fqPacingRate), 'has-feedback': hasError(deliveryServiceForm.fqPacingRate)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">Fair Queueing Pacing Rate Bps<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">Fair Queueing Pacing Rate Bps<div class="helptooltip">
                         <div class="helptext">The maximum bytes per second a cache will deliver on any single TCP connection. This uses the Linux kernel's Fair Queuing (<code>setsockopt(SO_MAX_PACING_RATE)</code>) to limit the rate of delivery.</div>
                     </div>
                     </label>
@@ -641,7 +641,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.edgeHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.edgeHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">Edge Header Rewrite Rules<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">Edge Header Rewrite Rules<div class="helptooltip">
                         <div class="helptext">
                             Headers can be added or altered at each layer of the CDN. You must tell us four things: the action, the header name, the header value, and the direction to apply. The action will tell us whether we are adding, removing, or replacing headers. The header name and header value will determine the full header text. The direction will determine whether we add it before we respond to a request or before we make a request further up the chain in the server hierarchy. Examples include:
                             <br>
@@ -666,7 +666,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.midHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.midHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">Mid Header Rewrite Rules<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">Mid Header Rewrite Rules<div class="helptooltip">
                         <div class="helptext">
                             Headers can be added or altered at each layer of the CDN. You must tell us four things: the action, the header name, the header value, and the direction to apply. The action will tell us whether we are adding, removing, or replacing headers. The header name and header value will determine the full header text. The direction will determine whether we add it before we respond to a request or before we make a request further up the chain in the server hierarchy. Examples include:
                             <ul>
@@ -690,7 +690,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">Traffic Router Additional Response Headers<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">Traffic Router Additional Response Headers<div class="helptooltip">
                         <div class="helptext">
                             List of header name:value pairs separated by <code>__RETURN__</code>. Listed pairs will be included in all Traffic Router HTTP(S) responses.
                         </div>
@@ -705,7 +705,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
                         <div class="helptext">
                             List of header keys separated by <code>__RETURN__</code>. Listed headers will be included in Traffic Router access log entries under the <samp>rh=</samp> token.
                         </div>
@@ -720,7 +720,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regexRemap), 'has-feedback': hasError(deliveryServiceForm.regexRemap)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regexRemap">Regex remap expression<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="regexRemap">Regex remap expression<div class="helptooltip">
                         <div class="helptext">
                             Allows remapping of incoming requests URL using regex pattern matching to search/replace text.
                             <br>
@@ -743,7 +743,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
                         <div class="helptext">
                             Allows you to manipulate the cache key of the incoming requests. Normally, the cache key is the origin domain. This can be changed so that multiple services can share a cache key, can also be used to preserve cached content if service origin is changed.
                             <br>
@@ -770,7 +770,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
                         <div class="helptext">For HTTP and DNS Delivery Services, this will get added to the end of the remap line verbatim on cache servers. For ANY_MAP Delivery Services this is the entire remap line.</div>
                     </div>
                     </label>
@@ -783,7 +783,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
                         <div class="helptext">Free text field used to enter a URL which provides information about the service.</div>
                     </div>
                     </label>
@@ -797,7 +797,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
                         <div class="helptext">A path (e.g. <samp>/crossdomain.xml</samp>) with which to verify the connection to the origin server. This can be used by Check Extension scripts to do periodic health checks against the Delivery Service.</div>
                     </div>
                     </label>
@@ -810,7 +810,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.originShield), 'has-feedback': hasError(deliveryServiceForm.originShield)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="originShield">Origin Shield<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="originShield">Origin Shield<div class="helptooltip">
                         <div class="helptext">
                             Add another forward proxy upstream of the mid caches. Example: <samp>go_direct=true</samp> will allow the Mid to hit the origin directly instead of failing if the origin shield is down.
                             <aside class="warning">

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -67,8 +67,9 @@ under the License.
         <br>
         <form id="deliveryServiceForm" name="deliveryServiceForm" class="form-horizontal form-label-left">
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">
-                    <span uib-popover-html="label('active', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('active', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
+                    <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required autofocus>
@@ -77,96 +78,118 @@ under the License.
                         <option ng-value="false">Not Active</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.active, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">
-                    <span uib-popover-html="label('typeId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('typeId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
+                    <div class="helptext">
+                        DNS is the standard routing type for most CDN services. HTTP Redirect is a specialty routing service that is primarily used for video and large file downloads where localization and latency are significant concerns. A "Live" routing type should be used for all live services.
+                        <br>
+                        <br>
+                        <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#ds-types" target="_blank">See Delivery Service Types.</a>
+                    </div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="type" name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
                         <option selected disabled hidden value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.type, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
-                    <small ng-show="deliveryService.typeId"><a href="/#!/types/{{deliveryService.typeId}}" rel="noopener noreferrer" referrerpolicy="no-referrer" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
+                    <small ng-show="deliveryService.typeId"><a href="/#!/types/{{deliveryService.typeId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">
-                    <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
+                    <div class="helptext">This id becomes a part of the CDN service domain in the form <samp>http://cdn.service-key.company.com/</samp>. Must be all lowercase, no spaces or special characters. May contain dashes.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">
-                    <span uib-popover-html="label('displayName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('displayName', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
+                    <div class="helptext">Name of the service that appears in the Traffic portal. No character restrictions.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="displayName" name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" maxlength="48" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'maxlength')">Too Long</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.displayName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">
-                    <span uib-popover-html="label('tenantId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('tenantId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
+                    <div class="helptext">Name of company or division of company who owns account. Allows you to group your services and control access. Tenants are setup as a simple hierarchy where you may create parent / child accounts.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="tenantId" name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
                         <option disabled hidden selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.tenantId, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
                     <small ng-show="deliveryService.tenantId"><a href="/#!/tenants/{{deliveryService.tenantId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">
-                    <span uib-popover-html="label('cdnId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cdnId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
+                    <div class="helptext">The CDN to which the Delivery Service belongs.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="cdn" name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
-                        <option disabled hidden selected value="">Select...</option>
+                        <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdnId, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
                     <small ng-show="deliveryService.cdnId"><a href="/#!/cdns/{{deliveryService.cdnId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.orgServerFqdn), 'has-feedback': hasError(deliveryServiceForm.orgServerFqdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">
-                    <span uib-popover-html="label('orgServerFqdn', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('orgServerFqdn', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">Origin Server Base URL *<div class="helptooltip">
+                    <div class="helptext">The Origin Server’s base URL which includes the protocol (http or https). Example: <samp>http://movies.origin.com</samp>. Must be a domain only, no directories or IP addresses</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="orgServerFqdn" title="Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)" name="orgServerFqdn" type="url" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" pattern="https?://[a-z][a-z0-9\-]*(\.[a-z][a-z0-9\-]*)*(:\d+)?" required>
+                    <input id="orgServerFqdn" name="orgServerFqdn" type="url" title="Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" pattern="https?://[a-z0-9][a-z0-9\-]*(\.[a-z0-9\-][a-z0-9\-]*)*(:\d{1,5})?" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'pattern')">Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.orgServerFqdn != dsCurrent.orgServerFqdn">Current Value: [ {{dsCurrent.orgServerFqdn}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.orgServerFqdn != dsCurrent.orgServerFqdn">Current Value: [ {{dsCurrent.orgServerFqdn}} ]</small>
                     <small ng-show="!settings.isNew && !settings.isRequest && deliveryService.orgServerFqdn"><a href="/#!/origins/{{origin.id}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                     <span ng-show="hasError(deliveryServiceForm.orgServerFqdn)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">
-                    <span uib-popover-html="label('protocol', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('protocol', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
+                    <div class="helptext">
+                        The protocol with which to serve this Delivery Service to the clients:
+                        <br>
+                        <br>
+                        <dl>
+                            <dt>HTTP</dt><dd>Deliver only HTTP traffic</dd>
+                            <dt>HTTPS</dt><dd>Deliver only HTTPS traffic</dd>
+                            <dt>HTTP AND HTTPS</dt><dd>Deliver both types of traffic</dd>
+                            <dt>HTTP TO HTTPS</dt><dd>Redirect HTTP traffic to use HTTPS</dd>
+                        </dl>
+                    </div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="protocol" name="protocol" class="form-control" ng-model="deliveryService.protocol" required>
@@ -177,40 +200,43 @@ under the License.
                         <option ng-value="3">HTTP to HTTPS</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.protocol, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">
-                    <span uib-popover-html="label('longDesc', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
+                    <div class="helptext">Free text field that describes the purpose of the Delivery Service and will be displayed in the portal as a description field.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc" name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" spellcheck="true" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.longDesc, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">
-                    <span uib-popover-html="label('longDesc1', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc1', 'title')}}</span>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
+                    <div class="helptext">Free text field not currently used in configuration. For example, you can use this field to describe your customer type.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc1" name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" spellcheck="true" rows="3"></textarea>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc1)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc2">
-                    <span uib-popover-html="label('longDesc2', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc2', 'title')}}</span>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
+                    <div class="helptext">Free text field not currently used in configuration.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc2" name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3" spellcheck="true"></textarea>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc2)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
@@ -225,8 +251,9 @@ under the License.
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">
-                        <span uib-popover-html="label('routingName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('routingName', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
+                        <div class="helptext">The routing name to use for the delivery <abbr title="Fully Qualified Domain Name">FQDN</abbr>, e.g. <samp>routing-name.deliveryservice.cdn-domain</samp>. It must be a valid hostname without periods.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
@@ -234,26 +261,28 @@ under the License.
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dscp), 'has-feedback': hasError(deliveryServiceForm.dscp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dscp">
-                        <span uib-popover-html="label('dscp', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dscp', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dscp">DSCP<div class="helptooltip">
+                        <div class="helptext">The <abbr title="Differentiated Services Code Point">DSCP *</abbr> value with which to mark IP packets outbound to the client.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="dscp" name="dscp" class="form-control" ng-model="deliveryService.dscp" ng-options="dcsp.value as dcsp.label for dcsp in dscps" required>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dscp, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dscp != dsCurrent.dscp">Current Value: [ {{magicNumberLabel(dscps, dsCurrent.dscp)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.dscp != dsCurrent.dscp">Current Value: [ {{magicNumberLabel(dscps, dsCurrent.dscp)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">
-                        <span uib-popover-html="label('ipv6RoutingEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ipv6RoutingEnabled', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
+                        <div class="helptext">Enabeld by default, disabling this allows you to turn off CDN responses to IPv6 requests</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="ipv6RoutingEnabled" name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" required>
@@ -261,13 +290,23 @@ under the License.
                             <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ipv6RoutingEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.rangeRequestHandling), 'has-feedback': hasError(deliveryServiceForm.rangeRequestHandling)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">
-                        <span uib-popover-html="label('rangeRequestHandling', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('rangeRequestHandling', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">Range Request Handling *<div class="helptooltip">
+                        <div class="helptext">
+                            How to treat range requests.
+                            <br>
+                            <br>
+                            <ul>
+                                <li>Do not cache (ranges requested from files that are already cached due to a non range request can still be served)</li>
+                                <li>Use the <a href="https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/background_fetch.en.html" target="_blank"><code>background_fetch</code> plugin.</a></li>
+                                <li>Use the <code>cache_range_requests</code> plugin.</li>
+                            </ul>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="rangeRequestHandling" name="rangeRequestHandling" class="form-control" ng-model="deliveryService.rangeRequestHandling" required>
@@ -276,13 +315,29 @@ under the License.
                             <option ng-value="2">Use the cache_range_requests plugin</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.rangeRequestHandling, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.rangeRequestHandling != dsCurrent.rangeRequestHandling">Current Value: [ {{magicNumberLabel(rrhs, dsCurrent.rangeRequestHandling)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.rangeRequestHandling != dsCurrent.rangeRequestHandling">Current Value: [ {{magicNumberLabel(rrhs, dsCurrent.rangeRequestHandling)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.qstringIgnore), 'has-feedback': hasError(deliveryServiceForm.qstringIgnore)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="qstringIgnore">
-                        <span uib-popover-html="label('qstringIgnore', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('qstringIgnore', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12">Query String Handling *<div class="helptooltip">
+                        <div class="helptext">
+                            How to treat query parameter strings in request URLs:
+                            <br>
+                            <br>
+                            <ul>
+                                <li>Use in cache key and hand up to origin: Each URL is considered unique if and only if the <em>entire</em> URL (i.e. including any query parameter string string) is unique.</li>
+                                <li>Do not use in cache key, but pass up to origin: Two URLs that are the same except for the query parameter string will match and cache HIT, while the origin still sees original query parameter string in the request.</li>
+                                <li>Drop at edge: Two URLs that are the same except for the query string will match and cache HIT, while the origin will not see original query string in the request.</li>
+                            </ul>
+                            <aside>
+                                <h6>Note:</h6>
+                                <p>Choosing to drop query parameter strings at the edge will preclude the use of a Regex Remap Expression. <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#regex-remap-expression" target="_blank">See Regex Remap Expression</a>
+                                <br>
+                                To set the qstring without the use of regex remap, or for further options, <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#qstring-handling" target="_blank">See Qstring Handling</a></p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="qstringIgnore" name="qstringIgnore" class="form-control" ng-model="deliveryService.qstringIgnore" required>
@@ -291,13 +346,19 @@ under the License.
                             <option ng-value="2">Neither use query parameter strings in cache key, nor pass in upstream requests</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.qstringIgnore, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.qstringIgnore != dsCurrent.qstringIgnore">Current Value: [ {{magicNumberLabel(qStrings, dsCurrent.qstringIgnore)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.qstringIgnore != dsCurrent.qstringIgnore">Current Value: [ {{magicNumberLabel(qStrings, dsCurrent.qstringIgnore)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.multiSiteOrigin), 'has-feedback': hasError(deliveryServiceForm.multiSiteOrigin)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">
-                        <span uib-popover-html="label('multiSiteOrigin', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('multiSiteOrigin', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">Use Multi-Site Origin Feature *<div class="helptooltip">
+                        <div class="helptext">
+                            Enables/disables the Multi-Site Origin feature for this Delivery Service.
+                            <br>
+                            <br>
+                            <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#multi-site-origin" target="_blank">See Multi-Site Origin.</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="multiSiteOrigin" name="multiSiteOrigin" class="form-control" ng-model="deliveryService.multiSiteOrigin" required>
@@ -305,13 +366,14 @@ under the License.
                             <option ng-value="true">Use Multi-Site Origin</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.multiSiteOrigin, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.multiSiteOrigin != dsCurrent.multiSiteOrigin">Current Value: [ {{dsCurrent.multiSiteOrigin ? 'Use Multi-Site Origin' : 'Do not use Multi-Site Origin'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.multiSiteOrigin != dsCurrent.multiSiteOrigin">Current Value: [ {{dsCurrent.multiSiteOrigin ? 'Use Multi-Site Origin' : 'Do not use Multi-Site Origin'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">
-                        <span uib-popover-html="label('logsEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('logsEnabled', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
+                        <div class="helptext">Allows you to turn on/off logging for this Delivery Service</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="logsEnabled" name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" required>
@@ -319,51 +381,64 @@ under the License.
                             <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.logsEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">
-                        <span uib-popover-html="label('geoProvider', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoProvider', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
+                        <div class="helptext">Choose which Geolocation database provider - company that collects data on the location of IP addresses - to use.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="geoProvider" name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" required>
-                            <option ng-value="0" selected>Maxmind</option>
+                            <option ng-value="0" selected>MaxMind</option>
                             <option ng-value="1">Neustar</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLat), 'has-feedback': hasError(deliveryServiceForm.missLat)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLat">
-                        <span uib-popover-html="label('missLat', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('missLat', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLat">Geo Miss Default Latitude *<div class="helptooltip">
+                        <div class="helptext">Default latitude for this Delivery Service. When client localization fails for both Coverage Zone and Geo Lookup, the client will be routed as if it was at this latitude.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input step="any" id="missLat" name="missLat" type="number" class="form-control" ng-model="deliveryService.missLat" required min="-90" max="90" title="Must be a valid latitude, in degrees."/>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.missLat, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.missLat != dsCurrent.missLat">Current Value: [ {{dsCurrent.missLat}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.missLat != dsCurrent.missLat">Current Value: [ {{dsCurrent.missLat}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.missLat)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLong), 'has-feedback': hasError(deliveryServiceForm.missLong)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLong">
-                        <span uib-popover-html="label('missLong', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('missLong', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLong">Geo Miss Default Longitude *<div class="helptooltip">
+                        <div class="helptext">Default longitude for this Delivery Service. When client localization fails for both Coverage Zone and Geo Lookup, the client will be routed as if it was at this longitude.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input step="any" id="missLong" name="missLong" type="number" class="form-control" ng-model="deliveryService.missLong" required min="-180" max="180" title="Must be a valid longitude, in degrees."/>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.missLong, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.missLong != dsCurrent.missLong">Current Value: [ {{dsCurrent.missLong}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.missLong != dsCurrent.missLong">Current Value: [ {{dsCurrent.missLong}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.missLong)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">
-                        <span uib-popover-html="label('geoLimit', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimit', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
+                        <div class="helptext">
+                            Some services are intended to be limited by geography. The possible settings are:
+                            <br>
+                            <br>
+                            <dl>
+                                <dt>None</dt><dd>Do not limit by geography.</dd>
+                                <dt>Coverage Zone File only</dt><dd>If the requesting IP is not in the Coverage Zone File, do not serve the request.</dd>
+                                <dt>Coverage Zone File and Country Code(s)</dt><dd>If the requesting IP is not in the Coverage Zone File or not in the United States, do not serve the request.</dd>
+                            </dl>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="geoLimit" name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" required>
@@ -372,36 +447,55 @@ under the License.
                             <option ng-value="2">Coverage Zone File and Country Code(s)</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimit, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}" ng-show="deliveryService.geoLimit === 1 || deliveryService.geoLimit === 2">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">
-                        <span uib-popover-html="label('geoLimitCountries', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitCountries', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
+                        <div class="helptext">How (if at all) is this service to be limited by geography. Example Country Codes: <abbr title="Canada">CA</abbr>, <abbr title="India">IN</abbr>, <abbr title="Puerto Rico">PR</abbr>.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255" pattern="[A-Z]+(,[A-Z]+)*">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitCountries, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitCountries)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">
-                        <span uib-popover-html="label('geoLimitRedirectURL', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitRedirectURL', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
+                        <div class="helptext">
+                            Traffic Router will redirect to this URL when Geo Limit check fails.
+                            <br>
+                            <br>
+                            See <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_router.html#tr-ngb" target="_blank">GeoLimit Failure Redirect</a> feature...
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="geoLimitRedirectURL" name="geoLimitRedirectURL" title="Must be a valid URL" type="url" class="form-control" ng-model="deliveryService.geoLimitRedirectURL">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitRedirectURL)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.signingAlgorithm), 'has-feedback': hasError(deliveryServiceForm.signingAlgorithm)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">
-                        <span uib-popover-html="label('signingAlgorithm', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('signingAlgorithm', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">Signing Algorithm<div class="helptooltip">
+                        <div class="helptext">
+                            Type of URL signing method to sign the URLs:
+                            <br>
+                            <dl>
+                                <dt>None</dt><dd>URLs will not be signed within this Delivery Service</dd>
+                                <dt>URL Signature Keys</dt><dd>URL Signature token-based authentication is enabled for this Delivery Service.</dd>
+                                <dt>URI Signing Keys</dt><dd>URI Signing token-based authentication is enabled for this Delivery Service.</dd>
+                            </dl>
+                            <br>
+                            <br>
+                            <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#signed-urls" target="_blank">See Token Based Authentication</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="signingAlgorithm" name="signingAlgorithm" class="form-control" ng-change="changeSigningAlgorithm(deliveryService.signingAlgorithm)" ng-model="deliveryService.signingAlgorithm">
@@ -409,243 +503,327 @@ under the License.
                             <option value="url_sig">URL Signature Keys</option>
                             <option value="uri_signing">URI Signing Keys</option>
                         </select>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.signingAlgorithm != dsCurrent.signingAlgorithm">Current Value: [ {{magicNumberLabel(signingAlgos, dsCurrent.signingAlgorithm)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.signingAlgorithm != dsCurrent.signingAlgorithm">Current Value: [ {{magicNumberLabel(signingAlgos, dsCurrent.signingAlgorithm)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassIp), 'has-feedback': hasError(deliveryServiceForm.dnsBypassIp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIp">
-                        <span uib-popover-html="label('dnsBypassIp', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassIp', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIp">DNS Bypass IP<div class="helptooltip">
+                        <div class="helptext">
+                            IPv4 address to which to overflow requests when the Max Mbps or Max Tps for this Delivery Service are exceeded.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="dnsBypassIp" name="dnsBypassIp" type="text" class="form-control" ng-model="deliveryService.dnsBypassIp" maxlength="255" pattern="\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dnsBypassIp, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassIp != dsCurrent.dnsBypassIp">Current Value: [ {{dsCurrent.dnsBypassIp}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.dnsBypassIp != dsCurrent.dnsBypassIp">Current Value: [ {{dsCurrent.dnsBypassIp}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassIp)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassIp6), 'has-feedback': hasError(deliveryServiceForm.dnsBypassIp6)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIP">
-                        <span uib-popover-html="label('dnsBypassIp6', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassIp6', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassIp6">DNS Bypass IPv6<div class="helptooltip">
+                        <div class="helptext">
+                            IPv6 address to which to overflow requests when the Max Mbps or Max Tps for this Delivery Service are exceeded.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="dnsBypassIp6" name="dnsBypassIp6" type="text" class="form-control" ng-model="deliveryService.dnsBypassIp6" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dnsBypassIp6, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassIp6 != dsCurrent.dnsBypassIp6">Current Value: [ {{dsCurrent.dnsBypassIp6}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.dnsBypassIp6 != dsCurrent.dnsBypassIp6">Current Value: [ {{dsCurrent.dnsBypassIp6}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassIp6)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassCname), 'has-feedback': hasError(deliveryServiceForm.dnsBypassCname)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassCname">
-                        <span uib-popover-html="label('dnsBypassCname', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassCname', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassCname">DNS Bypass CNAME<div class="helptooltip">
+                        <div class="helptext">
+                            Domain name to which to overflow requests when the Max Mbps or Max Tps for this Delivery Service are exceeded.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="dnsBypassCname" name="dnsBypassCname" type="text" class="form-control" ng-model="deliveryService.dnsBypassCname" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dnsBypassCname, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassCname != dsCurrent.dnsBypassCname">Current Value: [ {{dsCurrent.dnsBypassCname}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.dnsBypassCname != dsCurrent.dnsBypassCname">Current Value: [ {{dsCurrent.dnsBypassCname}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassCname)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassTtl), 'has-feedback': hasError(deliveryServiceForm.dnsBypassTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" label="dnsBypassTtl">
-                        <span uib-popover-html="label('dnsBypassTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassTtl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassTtl">DNS Bypass TTL<div class="helptooltip">
+                        <div class="helptext"><abbr title="Time To Live">TTL</abbr> for the DNS bypass domain or IP address when thresholds are exceeded.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="dnsBypassTtl" name="dnsBypassTtl" type="number" class="form-control" ng-model="deliveryService.dnsBypassTtl" step="1" min="0">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassTtl != dsCurrent.dnsBypassTtl">Current Value: [ {{dsCurrent.dnsBypassTtl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.dnsBypassTtl != dsCurrent.dnsBypassTtl">Current Value: [ {{dsCurrent.dnsBypassTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.maxDnsAnswers), 'has-feedback': hasError(deliveryServiceForm.maxDnsAnswers)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="maxDnsAnswers">
-                        <span uib-popover-html="label('maxDnsAnswers', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('maxDnsAnswers', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="maxDnsAnswers">Max DNS Answers<div class="helptooltip">
+                        <div class="helptext">
+                            This is used to restrict the number of cache IP addresses that the Traffic Router will hand back to clients. A numeric value from 1 to 15 which determines how many caches your content will be spread across in a particular site. When a customer requests your content they will get 1 to 15 IP addresses back they can use. These are rotated in each response. Ideally the number will reflect the amount of traffic. 1 = trial account with very little traffic, 2 = small production service. Add 1 more server for every 20 Gbps of traffic you expect at peak. So 20 Gbps = 3, 40 Gbps = 4, 60 Gbps = 5
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="maxDnsAnswers" name="maxDnsAnswers" type="number" class="form-control" placeholder="Max number of IP addresses in DNS answer (0 means all)" ng-model="deliveryService.maxDnsAnswers" step="1" min="0">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.maxDnsAnswers != dsCurrent.maxDnsAnswers">Current Value: [ {{dsCurrent.maxDnsAnswers}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.maxDnsAnswers != dsCurrent.maxDnsAnswers">Current Value: [ {{dsCurrent.maxDnsAnswers}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.maxDnsAnswers)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">
-                        <span uib-popover-html="label('ccrDnsTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ccrDnsTtl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
+                        <div class="helptext">The <abbr title="Time To Live">TTL</abbr> on the DNS record for the Traffic Router A and AAAA records. Setting too high or too low will result in poor caching performance.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="ccrDnsTtl" name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" step="1" min="0">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.ccrDnsTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">
-                        <span uib-popover-html="label('profileId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('profileId', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
+                        <div class="helptext">Only used if a Delivery Service uses configurations that specifically require a profile. Example: Multi-Site Origin configurations would require a Delivery Service Profile to be used.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="profile" name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
                             <option selected value="">None</option>
                         </select>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
                         <small ng-show="deliveryService.profileId"><a href="/#!/profiles/{{deliveryService.profileId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxMbps), 'has-feedback': hasError(deliveryServiceForm.globalMaxMbps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">
-                        <span uib-popover-html="label('globalMaxMbps', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('globalMaxMbps', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">Global Max Mbps<div class="helptooltip">
+                        <div class="helptext">The maximum bits per second this Delivery Service can serve across all EDGE caches before traffic will be diverted to the bypass destination. For a DNS Delivery Service, the Bypass Ipv4 or Ipv6 will be used (depending on whether this was an A or AAAA request), and for HTTP Delivery Services the Bypass <abbr title="Fully Qualified Domain Name">FQDN</abbr> will be used.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input id="globalMaxMbps" name="globalMaxMbps" type="number" class="form-control" placeholder="Max bits per second allowed globally" ng-model="deliveryService.globalMaxMbps" step="1" min="0">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.globalMaxMbps != dsCurrent.globalMaxMbps">Current Value: [ {{dsCurrent.globalMaxMbps}} ]</small>
+                        <input id="globalMaxMbps" name="globalMaxMbps" type="number" class="form-control" placeholder="Max megabits per second allowed globally" ng-model="deliveryService.globalMaxMbps" step="1" min="0">
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.globalMaxMbps != dsCurrent.globalMaxMbps">Current Value: [ {{dsCurrent.globalMaxMbps}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.globalMaxMbps)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxTps), 'has-feedback': hasError(deliveryServiceForm.globalMaxTps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globaMaxTps">
-                        <span uib-popover-html="label('globalMaxTps', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('globalMaxTps', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxTps">Global Max Tps<div class="helptooltip">
+                        <div class="helptext">The maximum transactions this Delivery Service can serve across all EDGE caches before traffic will be diverted to the bypass destination. For a DNS Delivery Service, the Bypass Ipv4 or Ipv6 will be used (depending on whether this was an A or AAAA request), and for HTTP Delivery Services the Bypass <abbr title="Fully Qualified Domain Name">FQDN</abbr> will be used.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="globalMaxTps" name="globalMaxTps" type="number" class="form-control" placeholder="Max transactions per second allowed globally" ng-model="deliveryService.globalMaxTps" step="1" min="0">
-                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.globalMaxTps, 'pattern')">Whole Number</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.globalMaxTps != dsCurrent.globalMaxTps">Current Value: [ {{dsCurrent.globalMaxTps}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.globalMaxTps != dsCurrent.globalMaxTps">Current Value: [ {{dsCurrent.globalMaxTps}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.globalMaxTps)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.fqPacingRate), 'has-feedback': hasError(deliveryServiceForm.fqPacingRate)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">
-                        <span uib-popover-html="label('fqPacingRate', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('fqPacingRate', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">Fair Queueing Pacing Rate Bps<div class="helptooltip">
+                        <div class="helptext">The maximum bytes per second a cache will deliver on any single TCP connection. This uses the Linux kernel's Fair Queuing (<code>setsockopt(SO_MAX_PACING_RATE)</code>) to limit the rate of delivery.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="fqPacingRate" name="fqPacingRate" type="number" class="form-control" placeholder="Rate-limit connections to this Bytes per second" ng-model="deliveryService.fqPacingRate" step="1" min="0">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.fqPacingRate != dsCurrent.fqPacingRate">Current Value: [ {{dsCurrent.fqPacingRate}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.fqPacingRate != dsCurrent.fqPacingRate">Current Value: [ {{dsCurrent.fqPacingRate}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.fqPacingRate)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.edgeHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.edgeHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">
-                        <span uib-popover-html="label('edgeHeaderRewrite', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('edgeHeaderRewrite', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">Edge Header Rewrite Rules<div class="helptooltip">
+                        <div class="helptext">
+                            Headers can be added or altered at each layer of the CDN. You must tell us four things: the action, the header name, the header value, and the direction to apply. The action will tell us whether we are adding, removing, or replacing headers. The header name and header value will determine the full header text. The direction will determine whether we add it before we respond to a request or before we make a request further up the chain in the server hierarchy. Examples include:
+                            <br>
+                            <br>
+                            <ul>
+                                <li>Action: Set</li>
+                                <li>Header Name: X-CDN</li>
+                                <li>Header Value: Foo</li>
+                                <li>Direction: Edge Response to Client</li>
+                            </ul>
+                            <br>
+                            <br>See <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#header-rewrite" target="_blank">Header Rewrite Options and DSCP.</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="edgeHeaderRewrite" name="edgeHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.edgeHeaderRewrite" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.edgeHeaderRewrite, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.edgeHeaderRewrite != dsCurrent.edgeHeaderRewrite">Current Value: [ {{dsCurrent.edgeHeaderRewrite}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.edgeHeaderRewrite != dsCurrent.edgeHeaderRewrite">Current Value: [ {{dsCurrent.edgeHeaderRewrite}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.edgeHeaderRewrite)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.midHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.midHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">
-                        <span uib-popover-html="label('midHeaderRewrite', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('midHeaderRewrite', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">Mid Header Rewrite Rules<div class="helptooltip">
+                        <div class="helptext">
+                            Headers can be added or altered at each layer of the CDN. You must tell us four things: the action, the header name, the header value, and the direction to apply. The action will tell us whether we are adding, removing, or replacing headers. The header name and header value will determine the full header text. The direction will determine whether we add it before we respond to a request or before we make a request further up the chain in the server hierarchy. Examples include:
+                            <ul>
+                                <li>Action: Set</li>
+                                <li>Header Name: Host</li>
+                                <li>Header Value: code_abc123</li>
+                                <li>Direction: Mid Request to Origin</li>
+                            </ul>
+                            <br>
+                            <br>
+                            See <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#header-rewrite" target="_blank">Header Rewrite Options and DSCP.</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="midHeaderRewrite" name="midHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.midHeaderRewrite" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.midHeaderRewrite, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.midHeaderRewrite != dsCurrent.midHeaderRewrite">Current Value: [ {{dsCurrent.midHeaderRewrite}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.midHeaderRewrite != dsCurrent.midHeaderRewrite">Current Value: [ {{dsCurrent.midHeaderRewrite}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.midHeaderRewrite)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">
-                        <span uib-popover-html="label('trResponseHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trResponseHeaders', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">Traffic Router Additional Response Headers<div class="helptooltip">
+                        <div class="helptext">
+                            List of header name:value pairs separated by <code>__RETURN__</code>. Listed pairs will be included in all Traffic Router HTTP(S) responses.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="trResponseHeaders" name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trResponseHeaders, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trResponseHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">
-                        <span uib-popover-html="label('trRequestHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trRequestHeaders', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
+                        <div class="helptext">
+                            List of header keys separated by <code>__RETURN__</code>. Listed headers will be included in Traffic Router access log entries under the <samp>rh=</samp> token.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="trRequestHeaders" name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trRequestHeaders, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trRequestHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regexRemap), 'has-feedback': hasError(deliveryServiceForm.regexRemap)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
-                        <span uib-popover-html="label('regexRemap', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('regexRemap', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regexRemap">Regex remap expression<div class="helptooltip">
+                        <div class="helptext">
+                            Allows remapping of incoming requests URL using regex pattern matching to search/replace text.
+                            <br>
+                            <br>
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regexRemap, 'maxlength')">Too Long</small>
+                            <br>
+                            <aside>
+                                <h6>Note</h6>
+                                <p>You will not be able to save a Regex Remap Expression if you have Query String Handling set to drop query strings at the edge. <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#regex-remap-expression" target="_blank">See Regex Remap Expression</a></p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input id="regexRemap" name="regexRemap" type="text" class="form-control" ng-model="deliveryService.regexRemap" ng-maxlength="1024">
+                        <input id="regexRemap" name="regexRemap" type="text" class="form-control" ng-model="deliveryService.regexRemap" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regexRemap, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regexRemap != dsCurrent.regexRemap">Current Value: [ {{dsCurrent.regexRemap}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.regexRemap != dsCurrent.regexRemap">Current Value: [ {{dsCurrent.regexRemap}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.regexRemap)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">
-                        <span uib-popover-html="label('cacheurl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cacheurl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
+                        <div class="helptext">
+                            Allows you to manipulate the cache key of the incoming requests. Normally, the cache key is the origin domain. This can be changed so that multiple services can share a cache key, can also be used to preserve cached content if service origin is changed.
+                            <br>
+                            <aside>
+                                <h6>Note</h6>
+                                <p>This only works with Edge-tier cache servers running <abbr title="Apache Traffic Server">ATS</abbr> version 6 and earlier. This <em>must</em> be empty if using <abbr title="Apache Traffic Server">ATS</abbr> 7 and / or the <a href="https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/cachekey.en.html" target="_blank">cachekey plugin.</a></p>
+                                <br>
+                                <br>
+                                See <a href="https://docs.trafficserver.apache.org/en/6.2.x/admin-guide/plugins/cacheurl.en.html" target="_blank">ATS documentation on cacheurl</a>
+                            </aside>
+                            <aside class="warning">
+                                <h6>Warning</h6>
+                                <p>This field is deprecated, and is subject to removal in upcoming releases. It is recommended that this be left blank.</p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="cacheurl" name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cacheurl, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.cacheurl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">
-                        <span uib-popover-html="label('remapText', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('remapText', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
+                        <div class="helptext">For HTTP and DNS Delivery Services, this will get added to the end of the remap line verbatim on cache servers. For ANY_MAP Delivery Services this is the entire remap line.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="remapText" name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.remapText, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.remapText)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">
-                        <span uib-popover-html="label('infoUrl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('infoUrl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
+                        <div class="helptext">Free text field used to enter a URL which provides information about the service.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input id="infoUrl" name="infoUrl" type="url" class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
+                        <input id="infoUrl" name="infoUrl" type="url" title="Must be a valid URL." class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
                         <small class="input-error invalid-URL-error">Invalid URL</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">
-                        <span uib-popover-html="label('checkPath', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('checkPath', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
+                        <div class="helptext">A path (e.g. <samp>/crossdomain.xml</samp>) with which to verify the connection to the origin server. This can be used by Check Extension scripts to do periodic health checks against the Delivery Service.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="checkPath" name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.checkPath, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.checkPath)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.originShield), 'has-feedback': hasError(deliveryServiceForm.originShield)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="originShield">
-                        <span uib-popover-html="label('originShield', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('originShield', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="originShield">Origin Shield<div class="helptooltip">
+                        <div class="helptext">
+                            Add another forward proxy upstream of the mid caches. Example: <samp>go_direct=true</samp> will allow the Mid to hit the origin directly instead of failing if the origin shield is down.
+                            <aside class="warning">
+                                <h6>Warning</h6>
+                                <p>This feature is experimental, use with caution!</p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="originShield" name="originShield" type="text" class="form-control" ng-model="deliveryService.originShield" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.originShield, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.originShield != dsCurrent.originShield">Current Value: [ {{dsCurrent.originShield}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.originShield != dsCurrent.originShield">Current Value: [ {{dsCurrent.originShield}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.originShield)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -68,7 +68,7 @@ under the License.
         <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
                     <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
                 </div>
                 </label>
@@ -84,7 +84,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
                     <div class="helptext">
                         DNS is the standard routing type for most CDN services. HTTP Redirect is a specialty routing service that is primarily used for video and large file downloads where localization and latency are significant concerns. A "Live" routing type should be used for all live services.
                         <br>
@@ -104,7 +104,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
                     <div class="helptext">This id becomes a part of the CDN service domain in the form <samp>http://cdn.service-key.company.com/</samp>. Must be all lowercase, no spaces or special characters. May contain dashes.</div>
                 </div>
                 </label>
@@ -119,7 +119,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
                     <div class="helptext">Name of the service that appears in the Traffic portal. No character restrictions.</div>
                 </div>
                 </label>
@@ -133,7 +133,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
                     <div class="helptext">Name of company or division of company who owns account. Allows you to group your services and control access. Tenants are setup as a simple hierarchy where you may create parent / child accounts.</div>
                 </div>
                 </label>
@@ -148,7 +148,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
                     <div class="helptext">The CDN to which the Delivery Service belongs.</div>
                 </div>
                 </label>
@@ -163,7 +163,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.orgServerFqdn), 'has-feedback': hasError(deliveryServiceForm.orgServerFqdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">Origin Server Base URL *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">Origin Server Base URL *<div class="helptooltip">
                     <div class="helptext">The Origin Server’s base URL which includes the protocol (http or https). Example: <samp>http://movies.origin.com</samp>. Must be a domain only, no directories or IP addresses</div>
                 </div>
                 </label>
@@ -178,7 +178,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
                     <div class="helptext">
                         The protocol with which to serve this Delivery Service to the clients:
                         <br>
@@ -206,7 +206,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
                     <div class="helptext">Free text field that describes the purpose of the Delivery Service and will be displayed in the portal as a description field.</div>
                 </div>
                 </label>
@@ -219,7 +219,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
                     <div class="helptext">Free text field not currently used in configuration. For example, you can use this field to describe your customer type.</div>
                 </div>
                 </label>
@@ -231,7 +231,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
                     <div class="helptext">Free text field not currently used in configuration.</div>
                 </div>
                 </label>
@@ -252,7 +252,7 @@ under the License.
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
                         <div class="helptext">The routing name to use for the delivery <abbr title="Fully Qualified Domain Name">FQDN</abbr>, e.g. <samp>routing-name.deliveryservice.cdn-domain</samp>. It must be a valid hostname without periods.</div>
                     </div>
                     </label>
@@ -268,7 +268,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.deepCachingType), 'has-feedback': hasError(deliveryServiceForm.deepCachingType)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="deepCachingType">Deep Caching *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="deepCachingType">Deep Caching *<div class="helptooltip">
                         <div class="helptext">
                             Enables clients to be routed to the closest possible deep edge caches on a per Delivery Service basis.
                             <br>
@@ -288,7 +288,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dscp), 'has-feedback': hasError(deliveryServiceForm.dscp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dscp">DSCP *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="dscp">DSCP *<div class="helptooltip">
                         <div class="helptext">The <abbr title="Differentiated Services Code Point">DSCP</abbr> value with which to mark IP packets outbound to the client.</div>
                     </div>
                     </label>
@@ -301,7 +301,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
                         <div class="helptext">Enabeld by default, disabling this allows you to turn off CDN responses to IPv6 requests</div>
                     </div>
                     </label>
@@ -316,7 +316,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.rangeRequestHandling), 'has-feedback': hasError(deliveryServiceForm.rangeRequestHandling)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">Range Request Handling *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">Range Request Handling *<div class="helptooltip">
                         <div class="helptext">
                             How to treat range requests.
                             <br>
@@ -341,7 +341,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.qstringIgnore), 'has-feedback': hasError(deliveryServiceForm.qstringIgnore)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">Query String Handling *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12">Query String Handling *<div class="helptooltip">
                         <div class="helptext">
                             How to treat query parameter strings in request URLs:
                             <br>
@@ -372,7 +372,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.multiSiteOrigin), 'has-feedback': hasError(deliveryServiceForm.multiSiteOrigin)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">Use Multi-Site Origin Feature *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">Use Multi-Site Origin Feature *<div class="helptooltip">
                         <div class="helptext">
                             Enables/disables the Multi-Site Origin feature for this Delivery Service.
                             <br>
@@ -392,7 +392,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
                         <div class="helptext">Allows you to turn on/off logging for this Delivery Service</div>
                     </div>
                     </label>
@@ -407,7 +407,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.initialDispersion), 'has-feedback': hasError(deliveryServiceForm.initialDispersion)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="initialDispersion">Initial Dispersion *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="initialDispersion">Initial Dispersion *<div class="helptooltip">
                         <div class="helptext">Determines number of machines content will be placed on within a cache group. Setting too high will result in poor caching performance. An initial dispersion of 1 is equivalent to "no dispersion".</div>
                     </div>
                     </label>
@@ -419,7 +419,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regionalGeoBlocking), 'has-feedback': hasError(deliveryServiceForm.regionalGeoBlocking)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">Regional Geoblocking *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">Regional Geoblocking *<div class="helptooltip">
                         <div class="helptext">
                             Define regional geo-blocking rules for Delivery Services in a JSON format and set this to 'Enabled' to use "Regional Geoblocking". <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/quick_howto/regionalgeo.html" target="_blank">See Regional Geo-blocking</a>
                         </div>
@@ -436,7 +436,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.anonymousBlockingEnabled), 'has-feedback': hasError(deliveryServiceForm.anonymousBlockingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="anonymousBlockingEnabled">Anonymous Blocking *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="anonymousBlockingEnabled">Anonymous Blocking *<div class="helptooltip">
                         <div class="helptext">
                             Enable this to block anonymized IP addresses (e.g. <abbr title="The Onion Ring">TOR</abbr> exit nodes) for this Delivery Service.
                             <br>
@@ -458,7 +458,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
                         <div class="helptext">Choose which Geolocation database provider - company that collects data on the location of IP addresses - to use.</div>
                     </div>
                     </label>
@@ -473,7 +473,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLat), 'has-feedback': hasError(deliveryServiceForm.missLat)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLat">Geo Miss Default Latitude *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="missLat">Geo Miss Default Latitude *<div class="helptooltip">
                         <div class="helptext">Default latitude for this Delivery Service. When client localization fails for both Coverage Zone and Geo Lookup, the client will be routed as if it was at this latitude.</div>
                     </div>
                     </label>
@@ -486,7 +486,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLong), 'has-feedback': hasError(deliveryServiceForm.missLong)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLong">Geo Miss Default Longitude *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="missLong">Geo Miss Default Longitude *<div class="helptooltip">
                         <div class="helptext">Default longitude for this Delivery Service. When client localization fails for both Coverage Zone and Geo Lookup, the client will be routed as if it was at this longitude.</div>
                     </div>
                     </label>
@@ -499,7 +499,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
                         <div class="helptext">
                             Some services are intended to be limited by geography. The possible settings are:
                             <br>
@@ -524,7 +524,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
                         <div class="helptext">How (if at all) is this service to be limited by geography. Example Country Codes: <abbr title="Canada">CA</abbr>, <abbr title="India">IN</abbr>, <abbr title="Puerto Rico">PR</abbr>.</div>
                     </div>
                     </label>
@@ -537,7 +537,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
                         <div class="helptext">
                             Traffic Router will redirect to this URL when Geo Limit check fails.
                             <br>
@@ -554,7 +554,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.signingAlgorithm), 'has-feedback': hasError(deliveryServiceForm.signingAlgorithm)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">Signing Algorithm<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">Signing Algorithm<div class="helptooltip">
                         <div class="helptext">
                             Type of URL signing method to sign the URLs:
                             <br>
@@ -580,7 +580,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.httpBypassFqdn), 'has-feedback': hasError(deliveryServiceForm.httpBypassFqdn)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="httpBypassFqdn">HTTP Bypass FQDN<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="httpBypassFqdn">HTTP Bypass FQDN<div class="helptooltip">
                         <div class="helptext">
                             Traffic Router will redirect to this <abbr title="Fully Qualified Domain Name">FQDN</abbr> (with the same path) when the Max Mbps or Max Tps for this Delivery Service are exceeded.
                         </div>
@@ -595,7 +595,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassTtl), 'has-feedback': hasError(deliveryServiceForm.dnsBypassTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassTtl">DNS Bypass TTL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassTtl">DNS Bypass TTL<div class="helptooltip">
                         <div class="helptext"><abbr title="Time To Live">TTL</abbr> for the DNS bypass domain or IP address when thresholds are exceeded.</div>
                     </div>
                     </label>
@@ -607,7 +607,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
                         <div class="helptext">The <abbr title="Time To Live">TTL</abbr> on the DNS record for the Traffic Router A and AAAA records. Setting too high or too low will result in poor caching performance.</div>
                     </div>
                     </label>
@@ -619,7 +619,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
                         <div class="helptext">Only used if a Delivery Service uses configurations that specifically require a profile. Example: Multi-Site Origin configurations would require a Delivery Service Profile to be used.</div>
                     </div>
                     </label>
@@ -633,7 +633,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxMbps), 'has-feedback': hasError(deliveryServiceForm.globalMaxMbps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">Global Max Mbps<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">Global Max Mbps<div class="helptooltip">
                         <div class="helptext">The maximum bits per second this Delivery Service can serve across all EDGE caches before traffic will be diverted to the bypass destination. For a DNS Delivery Service, the Bypass Ipv4 or Ipv6 will be used (depending on whether this was an A or AAAA request), and for HTTP Delivery Services the Bypass <abbr title="Fully Qualified Domain Name">FQDN</abbr> will be used.</div>
                     </div>
                     </label>
@@ -645,7 +645,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxTps), 'has-feedback': hasError(deliveryServiceForm.globalMaxTps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxTps">Global Max Tps<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxTps">Global Max Tps<div class="helptooltip">
                         <div class="helptext">The maximum transactions this Delivery Service can serve across all EDGE caches before traffic will be diverted to the bypass destination. For a DNS Delivery Service, the Bypass Ipv4 or Ipv6 will be used (depending on whether this was an A or AAAA request), and for HTTP Delivery Services the Bypass <abbr title="Fully Qualified Domain Name">FQDN</abbr> will be used.</div>
                     </div>
                     </label>
@@ -657,7 +657,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.fqPacingRate), 'has-feedback': hasError(deliveryServiceForm.fqPacingRate)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">Fair Queueing Pacing Rate Bps<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">Fair Queueing Pacing Rate Bps<div class="helptooltip">
                         <div class="helptext">The maximum bytes per second a cache will deliver on any single TCP connection. This uses the Linux kernel's Fair Queuing (<code>setsockopt(SO_MAX_PACING_RATE)</code>) to limit the rate of delivery.</div>
                     </div>
                     </label>
@@ -669,7 +669,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.edgeHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.edgeHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">Edge Header Rewrite Rules<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">Edge Header Rewrite Rules<div class="helptooltip">
                         <div class="helptext">
                             Headers can be added or altered at each layer of the CDN. You must tell us four things: the action, the header name, the header value, and the direction to apply. The action will tell us whether we are adding, removing, or replacing headers. The header name and header value will determine the full header text. The direction will determine whether we add it before we respond to a request or before we make a request further up the chain in the server hierarchy. Examples include:
                             <br>
@@ -694,7 +694,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.midHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.midHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">Mid Header Rewrite Rules<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">Mid Header Rewrite Rules<div class="helptooltip">
                         <div class="helptext">
                             Headers can be added or altered at each layer of the CDN. You must tell us four things: the action, the header name, the header value, and the direction to apply. The action will tell us whether we are adding, removing, or replacing headers. The header name and header value will determine the full header text. The direction will determine whether we add it before we respond to a request or before we make a request further up the chain in the server hierarchy. Examples include:
                             <ul>
@@ -718,7 +718,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">Traffic Router Additional Response Headers<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">Traffic Router Additional Response Headers<div class="helptooltip">
                         <div class="helptext">
                             List of header name:value pairs separated by <code>__RETURN__</code>. Listed pairs will be included in all Traffic Router HTTP(S) responses.
                         </div>
@@ -733,7 +733,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
                         <div class="helptext">
                             List of header keys separated by <code>__RETURN__</code>. Listed headers will be included in Traffic Router access log entries under the <samp>rh=</samp> token.
                         </div>
@@ -748,7 +748,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regexRemap), 'has-feedback': hasError(deliveryServiceForm.regexRemap)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regexRemap">Regex remap expression<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="regexRemap">Regex remap expression<div class="helptooltip">
                         <div class="helptext">
                             Allows remapping of incoming requests URL using regex pattern matching to search/replace text.
                             <br>
@@ -771,7 +771,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
                         <div class="helptext">
                             Allows you to manipulate the cache key of the incoming requests. Normally, the cache key is the origin domain. This can be changed so that multiple services can share a cache key, can also be used to preserve cached content if service origin is changed.
                             <br>
@@ -798,7 +798,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
                         <div class="helptext">For HTTP and DNS Delivery Services, this will get added to the end of the remap line verbatim on cache servers. For ANY_MAP Delivery Services this is the entire remap line.</div>
                     </div>
                     </label>
@@ -811,7 +811,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
                         <div class="helptext">Free text field used to enter a URL which provides information about the service.</div>
                     </div>
                     </label>
@@ -825,7 +825,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
                         <div class="helptext">A path (e.g. <samp>/crossdomain.xml</samp>) with which to verify the connection to the origin server. This can be used by Check Extension scripts to do periodic health checks against the Delivery Service.</div>
                     </div>
                     </label>
@@ -838,7 +838,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.originShield), 'has-feedback': hasError(deliveryServiceForm.originShield)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="originShield">Origin Shield<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="originShield">Origin Shield<div class="helptooltip">
                         <div class="helptext">
                             Add another forward proxy upstream of the mid caches. Example: <samp>go_direct=true</samp> will allow the Mid to hit the origin directly instead of failing if the origin shield is down.
                             <aside class="warning">
@@ -857,7 +857,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.consistentHashRegex), 'has-feedback': hasError(deliveryServiceForm.consistentHashRegex)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="consistentHashRegex">Consistent Hash Regex<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="consistentHashRegex">Consistent Hash Regex<div class="helptooltip">
                         <div class="helptext">
                             Regex used to extract parts of the request path using grouping in order to build a consistent request string to be used for cache selection. If this field is set on a steering delivery service, it will override the regex set on the target delivery services.
                             <br>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -68,106 +68,129 @@ under the License.
         <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">
-                    <span uib-popover-html="label('active', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('active', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
+                    <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
+                    <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required autofocus>
                         <option hidden disabled value="">Select...</option>
                         <option ng-value="true">Active</option>
                         <option ng-value="false">Not Active</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.active, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{ dsCurrent.active ? 'Active' : 'Not Active' }} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.active != dsCurrent.active">Current Value: [ {{ dsCurrent.active ? 'Active' : 'Not Active' }} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">
-                    <span uib-popover-html="label('typeId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('typeId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
+                    <div class="helptext">
+                        DNS is the standard routing type for most CDN services. HTTP Redirect is a specialty routing service that is primarily used for video and large file downloads where localization and latency are significant concerns. A "Live" routing type should be used for all live services.
+                        <br>
+                        <br>
+                        <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#ds-types" target="_blank">See Delivery Service Types.</a>
+                    </div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="type" name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
                         <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.type, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
                     <small ng-show="deliveryService.typeId"><a href="/#!/types/{{deliveryService.typeId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">
-                    <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
+                    <div class="helptext">This id becomes a part of the CDN service domain in the form <samp>http://cdn.service-key.company.com/</samp>. Must be all lowercase, no spaces or special characters. May contain dashes.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">
-                    <span uib-popover-html="label('displayName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('displayName', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
+                    <div class="helptext">Name of the service that appears in the Traffic portal. No character restrictions.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="displayName" name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" maxlength="48" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'maxlength')">Too Long</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.displayName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">
-                    <span uib-popover-html="label('tenantId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('tenantId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
+                    <div class="helptext">Name of company or division of company who owns account. Allows you to group your services and control access. Tenants are setup as a simple hierarchy where you may create parent / child accounts.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="tenantId" name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
                         <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.tenantId, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
                     <small ng-show="deliveryService.tenantId"><a href="/#!/tenants/{{deliveryService.tenantId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">
-                    <span uib-popover-html="label('cdnId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cdnId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
+                    <div class="helptext">The CDN to which the Delivery Service belongs.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="cdn" name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
                         <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdn, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
                     <small ng-show="deliveryService.cdnId"><a href="/#!/cdns/{{deliveryService.cdnId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.orgServerFqdn), 'has-feedback': hasError(deliveryServiceForm.orgServerFqdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">
-                    <span uib-popover-html="label('orgServerFqdn', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('orgServerFqdn', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="orgServerFqdn">Origin Server Base URL *<div class="helptooltip">
+                    <div class="helptext">The Origin Server’s base URL which includes the protocol (http or https). Example: <samp>http://movies.origin.com</samp>. Must be a domain only, no directories or IP addresses</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="orgServerFqdn" name="orgServerFqdn" type="url" title="Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" pattern="https?://[a-z0-9][a-z0-9\-]*(\.[a-z0-9\-][a-z0-9\-]*)*(:\d{1,5})?" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'pattern')">Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.orgServerFqdn != dsCurrent.orgServerFqdn">Current Value: [ {{dsCurrent.orgServerFqdn}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.orgServerFqdn != dsCurrent.orgServerFqdn">Current Value: [ {{dsCurrent.orgServerFqdn}} ]</small>
                     <small ng-show="!settings.isNew && !settings.isRequest && deliveryService.orgServerFqdn"><a href="/#!/origins/{{origin.id}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                     <span ng-show="hasError(deliveryServiceForm.orgServerFqdn)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">
-                    <span uib-popover-html="label('protocol', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('protocol', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
+                    <div class="helptext">
+                        The protocol with which to serve this Delivery Service to the clients:
+                        <br>
+                        <br>
+                        <dl>
+                            <dt>HTTP</dt><dd>Deliver only HTTP traffic</dd>
+                            <dt>HTTPS</dt><dd>Deliver only HTTPS traffic</dd>
+                            <dt>HTTP AND HTTPS</dt><dd>Deliver both types of traffic</dd>
+                            <dt>HTTP TO HTTPS</dt><dd>Redirect HTTP traffic to use HTTPS</dd>
+                        </dl>
+                    </div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="protocol" name="protocol" class="form-control" ng-model="deliveryService.protocol" required>
@@ -178,40 +201,43 @@ under the License.
                         <option ng-value="3">HTTP to HTTPS</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.protocol, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">
-                    <span uib-popover-html="label('longDesc', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
+                    <div class="helptext">Free text field that describes the purpose of the Delivery Service and will be displayed in the portal as a description field.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc" name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.longDesc, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">
-                    <span uib-popover-html="label('longDesc1', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc1', 'title')}}</span>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
+                    <div class="helptext">Free text field not currently used in configuration. For example, you can use this field to describe your customer type.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc1" name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3"></textarea>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc1)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">
-                    <span uib-popover-html="label('longDesc2', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc2', 'title')}}</span>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
+                    <div class="helptext">Free text field not currently used in configuration.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc2" name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3"></textarea>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc2)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
@@ -226,8 +252,9 @@ under the License.
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">
-                        <span uib-popover-html="label('routingName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('routingName', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
+                        <div class="helptext">The routing name to use for the delivery <abbr title="Fully Qualified Domain Name">FQDN</abbr>, e.g. <samp>routing-name.deliveryservice.cdn-domain</samp>. It must be a valid hostname without periods.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
@@ -235,14 +262,19 @@ under the License.
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.deepCachingType), 'has-feedback': hasError(deliveryServiceForm.deepCachingType)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="deepCachingType">
-                        <span uib-popover-html="label('deepCachingType', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('deepCachingType', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="deepCachingType">Deep Caching *<div class="helptooltip">
+                        <div class="helptext">
+                            Enables clients to be routed to the closest possible deep edge caches on a per Delivery Service basis.
+                            <br>
+                            <br>
+                            <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_router.html#deep-caching-deep-coverage-zone-topology" target="_blank">See Deep Caching</a></div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="deepCachingType" name="deepCachingType" class="form-control" ng-model="deliveryService.deepCachingType" required>
@@ -251,25 +283,27 @@ under the License.
                             <option>NEVER</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.deepCachingType, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.deepCachingType != dsCurrent.deepCachingType">Current Value: [ {{dsCurrent.deepCachingType}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.deepCachingType != dsCurrent.deepCachingType">Current Value: [ {{dsCurrent.deepCachingType}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dscp), 'has-feedback': hasError(deliveryServiceForm.dscp)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dscp">
-                        <span uib-popover-html="label('dscp', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dscp', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dscp">DSCP *<div class="helptooltip">
+                        <div class="helptext">The <abbr title="Differentiated Services Code Point">DSCP</abbr> value with which to mark IP packets outbound to the client.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="dscp" name="dscp" class="form-control" ng-model="deliveryService.dscp" ng-options="dcsp.value as dcsp.label for dcsp in dscps" required>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.dscp, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dscp != dsCurrent.dscp">Current Value: [ {{magicNumberLabel(dscps, dsCurrent.dscp)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.dscp != dsCurrent.dscp">Current Value: [ {{magicNumberLabel(dscps, dsCurrent.dscp)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">
-                        <span uib-popover-html="label('ipv6RoutingEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ipv6RoutingEnabled', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
+                        <div class="helptext">Enabeld by default, disabling this allows you to turn off CDN responses to IPv6 requests</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="ipv6RoutingEnabled" name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" required>
@@ -277,13 +311,23 @@ under the License.
                             <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ipv6RoutingEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show=" open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.rangeRequestHandling), 'has-feedback': hasError(deliveryServiceForm.rangeRequestHandling)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">
-                        <span uib-popover-html="label('rangeRequestHandling', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('rangeRequestHandling', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="rangeRequestHandling">Range Request Handling *<div class="helptooltip">
+                        <div class="helptext">
+                            How to treat range requests.
+                            <br>
+                            <br>
+                            <ul>
+                                <li>Do not cache (ranges requested from files that are already cached due to a non range request can still be served)</li>
+                                <li>Use the <a href="https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/background_fetch.en.html" target="_blank"><code>background_fetch</code> plugin.</a></li>
+                                <li>Use the <code>cache_range_requests</code> plugin.</li>
+                            </ul>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="rangeRequestHandling" name="rangeRequestHandling" class="form-control" ng-model="deliveryService.rangeRequestHandling" required>
@@ -292,13 +336,29 @@ under the License.
                             <option ng-value="2">Use the cache_range_requests plugin</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.rangeRequestHandling, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.rangeRequestHandling != dsCurrent.rangeRequestHandling">Current Value: [ {{magicNumberLabel(rrhs, dsCurrent.rangeRequestHandling)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.rangeRequestHandling != dsCurrent.rangeRequestHandling">Current Value: [ {{magicNumberLabel(rrhs, dsCurrent.rangeRequestHandling)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.qstringIgnore), 'has-feedback': hasError(deliveryServiceForm.qstringIgnore)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12">
-                        <span uib-popover-html="label('qstringIgnore', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('qstringIgnore', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12">Query String Handling *<div class="helptooltip">
+                        <div class="helptext">
+                            How to treat query parameter strings in request URLs:
+                            <br>
+                            <br>
+                            <ul>
+                                <li>Use in cache key and hand up to origin: Each URL is considered unique if and only if the <em>entire</em> URL (i.e. including any query parameter string string) is unique.</li>
+                                <li>Do not use in cache key, but pass up to origin: Two URLs that are the same except for the query parameter string will match and cache HIT, while the origin still sees original query parameter string in the request.</li>
+                                <li>Drop at edge: Two URLs that are the same except for the query string will match and cache HIT, while the origin will not see original query string in the request.</li>
+                            </ul>
+                            <aside>
+                                <h6>Note:</h6>
+                                <p>Choosing to drop query parameter strings at the edge will preclude the use of a Regex Remap Expression. <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#regex-remap-expression" target="_blank">See Regex Remap Expression</a>
+                                <br>
+                                To set the qstring without the use of regex remap, or for further options, <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#qstring-handling" target="_blank">See Qstring Handling</a></p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="qstringIgnore" name="qstringIgnore" class="form-control" ng-model="deliveryService.qstringIgnore" required>
@@ -307,13 +367,19 @@ under the License.
                             <option ng-value="2">Neither use query parameter strings in cache key, nor pass in upstream requests</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.qstringIgnore, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.qstringIgnore != dsCurrent.qstringIgnore">Current Value: [ {{magicNumberLabel(qStrings, dsCurrent.qstringIgnore)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.qstringIgnore != dsCurrent.qstringIgnore">Current Value: [ {{magicNumberLabel(qStrings, dsCurrent.qstringIgnore)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.multiSiteOrigin), 'has-feedback': hasError(deliveryServiceForm.multiSiteOrigin)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">
-                        <span uib-popover-html="label('multiSiteOrigin', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('multiSiteOrigin', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="multiSiteOrigin">Use Multi-Site Origin Feature *<div class="helptooltip">
+                        <div class="helptext">
+                            Enables/disables the Multi-Site Origin feature for this Delivery Service.
+                            <br>
+                            <br>
+                            <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#multi-site-origin" target="_blank">See Multi-Site Origin.</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="multiSiteOrigin" name="multiSiteOrigin" class="form-control" ng-model="deliveryService.multiSiteOrigin" required>
@@ -321,13 +387,14 @@ under the License.
                             <option ng-value="true">Use Multi-Site Origin</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.multiSiteOrigin, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.multiSiteOrigin != dsCurrent.multiSiteOrigin">Current Value: [ {{dsCurrent.multiSiteOrigin ? 'Use Multi-Site Origin' : 'Do not use Multi-Site Origin'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.multiSiteOrigin != dsCurrent.multiSiteOrigin">Current Value: [ {{dsCurrent.multiSiteOrigin ? 'Use Multi-Site Origin' : 'Do not use Multi-Site Origin'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">
-                        <span uib-popover-html="label('logsEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('logsEnabled', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
+                        <div class="helptext">Allows you to turn on/off logging for this Delivery Service</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="logsEnabled" name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" required>
@@ -335,24 +402,28 @@ under the License.
                             <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.logsEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.initialDispersion), 'has-feedback': hasError(deliveryServiceForm.initialDispersion)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="initialDispersion">
-                        <span uib-popover-html="label('initialDispersion', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('initialDispersion', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="initialDispersion">Initial Dispersion *<div class="helptooltip">
+                        <div class="helptext">Determines number of machines content will be placed on within a cache group. Setting too high will result in poor caching performance. An initial dispersion of 1 is equivalent to "no dispersion".</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input type="number" class="form-control" name="initialDispersion" id="initialDispersion" ng-model="deliveryService.initialDispersion" required min="1" max="10" step="1" value="1" title="The number of Edge-tier cache servers across which requests for a single resource will be spread. '1' is equivalent to 'No dispersion'." />
+                        <input type="number" class="form-control" name="initialDispersion" id="initialDispersion" ng-model="deliveryService.initialDispersion" required min="1" max="10" step="1" value="1" title="The number of Edge-tier cache servers across which requests for a single resource will be spread. '1' is equivalent to 'No dispersion'."/>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.initialDispersion, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.initialDispersion != dsCurrent.initialDispersion">Current Value: [ {{dsCurrent.initialDispersion}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="settings.isRequest && open() && deliveryService.initialDispersion != dsCurrent.initialDispersion">Current Value: [ {{dsCurrent.initialDispersion}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regionalGeoBlocking), 'has-feedback': hasError(deliveryServiceForm.regionalGeoBlocking)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">
-                        <span uib-popover-html="label('regionalGeoBlocking', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('regionalGeoBlocking', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">Regional Geoblocking *<div class="helptooltip">
+                        <div class="helptext">
+                            Define regional geo-blocking rules for Delivery Services in a JSON format and set this to 'Enabled' to use "Regional Geoblocking". <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/quick_howto/regionalgeo.html" target="_blank">See Regional Geo-blocking</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="regionalGeoBlocking" name="regionalGeoBlocking" class="form-control" ng-model="deliveryService.regionalGeoBlocking" required>
@@ -360,13 +431,21 @@ under the License.
                             <option ng-value="false" selected>Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regionalGeoBlocking, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">Current Value: [ {{dsCurrent.regionalGeoBlocking ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">Current Value: [ {{dsCurrent.regionalGeoBlocking ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.anonymousBlockingEnabled), 'has-feedback': hasError(deliveryServiceForm.anonymousBlockingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="anonymousBlockingEnabled">
-                        <span uib-popover-html="label('anonymousBlockingEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('anonymousBlockingEnabled', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="anonymousBlockingEnabled">Anonymous Blocking *<div class="helptooltip">
+                        <div class="helptext">
+                            Enable this to block anonymized IP addresses (e.g. <abbr title="The Onion Ring">TOR</abbr> exit nodes) for this Delivery Service.
+                            <br>
+                            <aside>
+                                <h6>Note:</h6>
+                                <p>Requires Geolocation provider's Anonymous IP database.</p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="anonymousBlockingEnabled" name="anonymousBlockingEnabled" class="form-control" ng-model="deliveryService.anonymousBlockingEnabled" required>
@@ -374,13 +453,14 @@ under the License.
                             <option ng-value="false" selected>Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.anonymousBlockingEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.anonymousBlockingEnabled != dsCurrent.anonymousBlockingEnabled">Current Value: [ {{dsCurrent.anonymousBlockingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.anonymousBlockingEnabled != dsCurrent.anonymousBlockingEnabled">Current Value: [ {{dsCurrent.anonymousBlockingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">
-                        <span uib-popover-html="label('geoProvider', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoProvider', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
+                        <div class="helptext">Choose which Geolocation database provider - company that collects data on the location of IP addresses - to use.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="geoProvider" name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" required>
@@ -388,37 +468,49 @@ under the License.
                             <option ng-value="1">Neustar</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLat), 'has-feedback': hasError(deliveryServiceForm.missLat)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLat">
-                        <span uib-popover-html="label('missLat', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('missLat', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLat">Geo Miss Default Latitude *<div class="helptooltip">
+                        <div class="helptext">Default latitude for this Delivery Service. When client localization fails for both Coverage Zone and Geo Lookup, the client will be routed as if it was at this latitude.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input step="any" id="missLat" name="missLat" type="number" class="form-control" ng-model="deliveryService.missLat" min="-90" max="90" title="Must be a valid latitude, in degrees." required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.missLat, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.missLat != dsCurrent.missLat">Current Value: [ {{dsCurrent.missLat}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.missLat != dsCurrent.missLat">Current Value: [ {{dsCurrent.missLat}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.missLat)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.missLong), 'has-feedback': hasError(deliveryServiceForm.missLong)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLong">
-                        <span uib-popover-html="label('missLong', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('missLong', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="missLong">Geo Miss Default Longitude *<div class="helptooltip">
+                        <div class="helptext">Default longitude for this Delivery Service. When client localization fails for both Coverage Zone and Geo Lookup, the client will be routed as if it was at this longitude.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input step="any" id="missLong" name="missLong" type="number" class="form-control" ng-model="deliveryService.missLong" min="-180" max="180" title="Must be a valid longitude, in degrees." required>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.missLong, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.missLong != dsCurrent.missLong">Current Value: [ {{dsCurrent.missLong}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.missLong != dsCurrent.missLong">Current Value: [ {{dsCurrent.missLong}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.missLong)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">
-                        <span uib-popover-html="label('geoLimit', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimit', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
+                        <div class="helptext">
+                            Some services are intended to be limited by geography. The possible settings are:
+                            <br>
+                            <br>
+                            <dl>
+                                <dt>None</dt><dd>Do not limit by geography.</dd>
+                                <dt>Coverage Zone File only</dt><dd>If the requesting IP is not in the Coverage Zone File, do not serve the request.</dd>
+                                <dt>Coverage Zone File and Country Code(s)</dt><dd>If the requesting IP is not in the Coverage Zone File or not in the United States, do not serve the request.</dd>
+                            </dl>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="geoLimit" name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" required>
@@ -427,36 +519,55 @@ under the License.
                             <option ng-value="2">Coverage Zone File and Country Code(s)</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimit, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">
-                        <span uib-popover-html="label('geoLimitCountries', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitCountries', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
+                        <div class="helptext">How (if at all) is this service to be limited by geography. Example Country Codes: <abbr title="Canada">CA</abbr>, <abbr title="India">IN</abbr>, <abbr title="Puerto Rico">PR</abbr>.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255">
+                        <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255" pattern="[A-Z]+(,[A-Z]+)*">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitCountries, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitCountries)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">
-                        <span uib-popover-html="label('geoLimitRedirectURL', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitRedirectURL', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
+                        <div class="helptext">
+                            Traffic Router will redirect to this URL when Geo Limit check fails.
+                            <br>
+                            <br>
+                            See <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_router.html#tr-ngb" target="_blank">GeoLimit Failure Redirect</a> feature...
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="geoLimitRedirectURL" name="geoLimitRedirectURL" type="url" class="form-control" ng-model="deliveryService.geoLimitRedirectURL" title="Must be a valid URL.">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitRedirectURL)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.signingAlgorithm), 'has-feedback': hasError(deliveryServiceForm.signingAlgorithm)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">
-                        <span uib-popover-html="label('signingAlgorithm', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('signingAlgorithm', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="signingAlgorithm">Signing Algorithm<div class="helptooltip">
+                        <div class="helptext">
+                            Type of URL signing method to sign the URLs:
+                            <br>
+                            <dl>
+                                <dt>None</dt><dd>URLs will not be signed within this Delivery Service</dd>
+                                <dt>URL Signature Keys</dt><dd>URL Signature token-based authentication is enabled for this Delivery Service.</dd>
+                                <dt>URI Signing Keys</dt><dd>URI Signing token-based authentication is enabled for this Delivery Service.</dd>
+                            </dl>
+                            <br>
+                            <br>
+                            <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#signed-urls" target="_blank">See Token Based Authentication</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="signingAlgorithm" name="signingAlgorithm" class="form-control" ng-change="changeSigningAlgorithm(deliveryService.signingAlgorithm)" ng-model="deliveryService.signingAlgorithm">
@@ -464,219 +575,301 @@ under the License.
                             <option value="url_sig">URL Signature Keys</option>
                             <option value="uri_signing">URI Signing Keys</option>
                         </select>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.signingAlgorithm != dsCurrent.signingAlgorithm">Current Value: [ {{magicNumberLabel(signingAlgos, dsCurrent.signingAlgorithm)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.signingAlgorithm != dsCurrent.signingAlgorithm">Current Value: [ {{magicNumberLabel(signingAlgos, dsCurrent.signingAlgorithm)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.httpBypassFqdn), 'has-feedback': hasError(deliveryServiceForm.httpBypassFqdn)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="httpBypassFqdn">
-                        <span uib-popover-html="label('httpBypassFqdn', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('httpBypassFqdn', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="httpBypassFqdn">HTTP Bypass FQDN<div class="helptooltip">
+                        <div class="helptext">
+                            Traffic Router will redirect to this <abbr title="Fully Qualified Domain Name">FQDN</abbr> (with the same path) when the Max Mbps or Max Tps for this Delivery Service are exceeded.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="httpBypassFqdn" name="httpBypassFqdn" type="text" class="form-control" ng-model="deliveryService.httpBypassFqdn" pattern="[A-z0-9][A-z0-9\-]*(\.[A-z0-9][A-z0-9\-]*)*">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.httpBypassFqdn, 'pattern')">Must be a valid <abbr title="Fully Qualified Domain Name">FQDN</abbr></small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.httpBypassFqdn != dsCurrent.httpBypassFqdn">Current Value: [ {{dsCurrent.httpBypassFqdn}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.httpBypassFqdn != dsCurrent.httpBypassFqdn">Current Value: [ {{dsCurrent.httpBypassFqdn}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.httpBypassFqdn)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.dnsBypassTtl), 'has-feedback': hasError(deliveryServiceForm.dnsBypassTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassTtl">
-                        <span uib-popover-html="label('dnsBypassTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('dnsBypassTtl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="dnsBypassTtl">DNS Bypass TTL<div class="helptooltip">
+                        <div class="helptext"><abbr title="Time To Live">TTL</abbr> for the DNS bypass domain or IP address when thresholds are exceeded.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="dnsBypassTtl" name="dnsBypassTtl" type="number" class="form-control" ng-model="deliveryService.dnsBypassTtl" min="0" step="1">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.dnsBypassTtl != dsCurrent.dnsBypassTtl">Current Value: [ {{dsCurrent.dnsBypassTtl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.dnsBypassTtl != dsCurrent.dnsBypassTtl">Current Value: [ {{dsCurrent.dnsBypassTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.dnsBypassTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">
-                        <span uib-popover-html="label('ccrDnsTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ccrDnsTtl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
+                        <div class="helptext">The <abbr title="Time To Live">TTL</abbr> on the DNS record for the Traffic Router A and AAAA records. Setting too high or too low will result in poor caching performance.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="ccrDnsTtl" name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" min="0" step="1">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.ccrDnsTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">
-                        <span uib-popover-html="label('profileId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('profileId', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
+                        <div class="helptext">Only used if a Delivery Service uses configurations that specifically require a profile. Example: Multi-Site Origin configurations would require a Delivery Service Profile to be used.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="profile" name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
                             <option selected value="">None</option>
                         </select>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
                         <small ng-show="deliveryService.profileId"><a href="/#!/profiles/{{deliveryService.profileId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxMbps), 'has-feedback': hasError(deliveryServiceForm.globalMaxMbps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">
-                        <span uib-popover-html="label('globalMaxMbps', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('globalMaxMbps', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxMbps">Global Max Mbps<div class="helptooltip">
+                        <div class="helptext">The maximum bits per second this Delivery Service can serve across all EDGE caches before traffic will be diverted to the bypass destination. For a DNS Delivery Service, the Bypass Ipv4 or Ipv6 will be used (depending on whether this was an A or AAAA request), and for HTTP Delivery Services the Bypass <abbr title="Fully Qualified Domain Name">FQDN</abbr> will be used.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input id="globalMaxMbps" name="globalMaxMbps" type="number" class="form-control" placeholder="Max bits per second allowed globally" ng-model="deliveryService.globalMaxMbps" min="0" step="1">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.globalMaxMbps != dsCurrent.globalMaxMbps">Current Value: [ {{dsCurrent.globalMaxMbps}} ]</small>
+                        <input id="globalMaxMbps" name="globalMaxMbps" type="number" class="form-control" placeholder="Max megabits per second allowed globally" ng-model="deliveryService.globalMaxMbps" min="0" step="1">
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.globalMaxMbps != dsCurrent.globalMaxMbps">Current Value: [ {{dsCurrent.globalMaxMbps}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.globalMaxMbps)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.globalMaxTps), 'has-feedback': hasError(deliveryServiceForm.globalMaxTps)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxTps">
-                        <span uib-popover-html="label('globalMaxTps', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('globalMaxTps', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="globalMaxTps">Global Max Tps<div class="helptooltip">
+                        <div class="helptext">The maximum transactions this Delivery Service can serve across all EDGE caches before traffic will be diverted to the bypass destination. For a DNS Delivery Service, the Bypass Ipv4 or Ipv6 will be used (depending on whether this was an A or AAAA request), and for HTTP Delivery Services the Bypass <abbr title="Fully Qualified Domain Name">FQDN</abbr> will be used.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="globalMaxTps" name="globalMaxTps" type="number" class="form-control" placeholder="Max transactions per second allowed globally" ng-model="deliveryService.globalMaxTps" min="0" step="1">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.globalMaxTps != dsCurrent.globalMaxTps">Current Value: [ {{dsCurrent.globalMaxTps}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.globalMaxTps != dsCurrent.globalMaxTps">Current Value: [ {{dsCurrent.globalMaxTps}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.globalMaxTps)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.fqPacingRate), 'has-feedback': hasError(deliveryServiceForm.fqPacingRate)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">
-                        <span uib-popover-html="label('fqPacingRate', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('fqPacingRate', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="fqPacingRate">Fair Queueing Pacing Rate Bps<div class="helptooltip">
+                        <div class="helptext">The maximum bytes per second a cache will deliver on any single TCP connection. This uses the Linux kernel's Fair Queuing (<code>setsockopt(SO_MAX_PACING_RATE)</code>) to limit the rate of delivery.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="fqPacingRate" name="fqPacingRate" type="number" class="form-control" placeholder="Rate-limit connections to this Bytes per second" ng-model="deliveryService.fqPacingRate" min="0" step="1">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.fqPacingRate != dsCurrent.fqPacingRate">Current Value: [ {{dsCurrent.fqPacingRate}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.fqPacingRate != dsCurrent.fqPacingRate">Current Value: [ {{dsCurrent.fqPacingRate}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.fqPacingRate)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.edgeHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.edgeHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">
-                        <span uib-popover-html="label('edgeHeaderRewrite', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('edgeHeaderRewrite', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="edgeHeaderRewrite">Edge Header Rewrite Rules<div class="helptooltip">
+                        <div class="helptext">
+                            Headers can be added or altered at each layer of the CDN. You must tell us four things: the action, the header name, the header value, and the direction to apply. The action will tell us whether we are adding, removing, or replacing headers. The header name and header value will determine the full header text. The direction will determine whether we add it before we respond to a request or before we make a request further up the chain in the server hierarchy. Examples include:
+                            <br>
+                            <br>
+                            <ul>
+                                <li>Action: Set</li>
+                                <li>Header Name: X-CDN</li>
+                                <li>Header Value: Foo</li>
+                                <li>Direction: Edge Response to Client</li>
+                            </ul>
+                            <br>
+                            <br>See <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#header-rewrite" target="_blank">Header Rewrite Options and DSCP.</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="edgeHeaderRewrite" name="edgeHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.edgeHeaderRewrite" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.edgeHeaderRewrite, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.edgeHeaderRewrite != dsCurrent.edgeHeaderRewrite">Current Value: [ {{dsCurrent.edgeHeaderRewrite}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.edgeHeaderRewrite != dsCurrent.edgeHeaderRewrite">Current Value: [ {{dsCurrent.edgeHeaderRewrite}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.edgeHeaderRewrite)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.midHeaderRewrite), 'has-feedback': hasError(deliveryServiceForm.midHeaderRewrite)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">
-                        <span uib-popover-html="label('midHeaderRewrite', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('midHeaderRewrite', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="midHeaderRewrite">Mid Header Rewrite Rules<div class="helptooltip">
+                        <div class="helptext">
+                            Headers can be added or altered at each layer of the CDN. You must tell us four things: the action, the header name, the header value, and the direction to apply. The action will tell us whether we are adding, removing, or replacing headers. The header name and header value will determine the full header text. The direction will determine whether we add it before we respond to a request or before we make a request further up the chain in the server hierarchy. Examples include:
+                            <ul>
+                                <li>Action: Set</li>
+                                <li>Header Name: Host</li>
+                                <li>Header Value: code_abc123</li>
+                                <li>Direction: Mid Request to Origin</li>
+                            </ul>
+                            <br>
+                            <br>
+                            See <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#header-rewrite" target="_blank">Header Rewrite Options and DSCP.</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="midHeaderRewrite" name="midHeaderRewrite" type="text" class="form-control" ng-model="deliveryService.midHeaderRewrite" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.midHeaderRewrite, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.midHeaderRewrite != dsCurrent.midHeaderRewrite">Current Value: [ {{dsCurrent.midHeaderRewrite}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.midHeaderRewrite != dsCurrent.midHeaderRewrite">Current Value: [ {{dsCurrent.midHeaderRewrite}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.midHeaderRewrite)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">
-                        <span uib-popover-html="label('trResponseHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trResponseHeaders', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">Traffic Router Additional Response Headers<div class="helptooltip">
+                        <div class="helptext">
+                            List of header name:value pairs separated by <code>__RETURN__</code>. Listed pairs will be included in all Traffic Router HTTP(S) responses.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="trResponseHeaders" name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trResponseHeaders, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trResponseHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">
-                        <span uib-popover-html="label('trRequestHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trRequestHeaders', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
+                        <div class="helptext">
+                            List of header keys separated by <code>__RETURN__</code>. Listed headers will be included in Traffic Router access log entries under the <samp>rh=</samp> token.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="trRequestHeaders" name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trRequestHeaders, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trRequestHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regexRemap), 'has-feedback': hasError(deliveryServiceForm.regexRemap)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regexRemap">
-                        <span uib-popover-html="label('regexRemap', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('regexRemap', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regexRemap">Regex remap expression<div class="helptooltip">
+                        <div class="helptext">
+                            Allows remapping of incoming requests URL using regex pattern matching to search/replace text.
+                            <br>
+                            <br>
+                            <a href="https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/regex_remap.en.html" target="_blank">See ATS documentation on regex remap</a>
+                            <br>
+                            <aside>
+                                <h6>Note</h6>
+                                <p>You will not be able to save a Regex Remap Expression if you have Query String Handling set to drop query strings at the edge. <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#regex-remap-expression" target="_blank">See Regex Remap Expression</a></p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="regexRemap" name="regexRemap" type="text" class="form-control" ng-model="deliveryService.regexRemap" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regexRemap, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regexRemap != dsCurrent.regexRemap">Current Value: [ {{dsCurrent.regexRemap}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.regexRemap != dsCurrent.regexRemap">Current Value: [ {{dsCurrent.regexRemap}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.regexRemap)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">
-                        <span uib-popover-html="label('cacheurl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cacheurl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
+                        <div class="helptext">
+                            Allows you to manipulate the cache key of the incoming requests. Normally, the cache key is the origin domain. This can be changed so that multiple services can share a cache key, can also be used to preserve cached content if service origin is changed.
+                            <br>
+                            <aside>
+                                <h6>Note</h6>
+                                <p>This only works with Edge-tier cache servers running <abbr title="Apache Traffic Server">ATS</abbr> version 6 and earlier. This <em>must</em> be empty if using <abbr title="Apache Traffic Server">ATS</abbr> 7 and / or the <a href="https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/cachekey.en.html" target="_blank">cachekey plugin.</a></p>
+                                <br>
+                                <br>
+                                See <a href="https://docs.trafficserver.apache.org/en/6.2.x/admin-guide/plugins/cacheurl.en.html" target="_blank">ATS documentation on cacheurl</a>
+                            </aside>
+                            <aside class="warning">
+                                <h6>Warning</h6>
+                                <p>This field is deprecated, and is subject to removal in upcoming releases. It is recommended that this be left blank.</p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="cacheurl" name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cacheurl, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.cacheurl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">
-                        <span uib-popover-html="label('remapText', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('remapText', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
+                        <div class="helptext">For HTTP and DNS Delivery Services, this will get added to the end of the remap line verbatim on cache servers. For ANY_MAP Delivery Services this is the entire remap line.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="remapText" name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.remapText, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.remapText)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">
-                        <span uib-popover-html="label('infoUrl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('infoUrl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
+                        <div class="helptext">Free text field used to enter a URL which provides information about the service.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="infoUrl" name="infoUrl" type="url" title="Must be a valid URL." class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
                         <small class="input-error invalid-URL-error">Invalid URL</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">
-                        <span uib-popover-html="label('checkPath', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('checkPath', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
+                        <div class="helptext">A path (e.g. <samp>/crossdomain.xml</samp>) with which to verify the connection to the origin server. This can be used by Check Extension scripts to do periodic health checks against the Delivery Service.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="checkPath" name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.checkPath, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.checkPath)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.originShield), 'has-feedback': hasError(deliveryServiceForm.originShield)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="originShield">
-                        <span uib-popover-html="label('originShield', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('originShield', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="originShield">Origin Shield<div class="helptooltip">
+                        <div class="helptext">
+                            Add another forward proxy upstream of the mid caches. Example: <samp>go_direct=true</samp> will allow the Mid to hit the origin directly instead of failing if the origin shield is down.
+                            <aside class="warning">
+                                <h6>Warning</h6>
+                                <p>This feature is experimental, use with caution!</p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="originShield" name="originShield" type="text" class="form-control" ng-model="deliveryService.originShield" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.originShield, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.originShield != dsCurrent.originShield">Current Value: [ {{dsCurrent.originShield}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.originShield != dsCurrent.originShield">Current Value: [ {{dsCurrent.originShield}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.originShield)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.consistentHashRegex), 'has-feedback': hasError(deliveryServiceForm.consistentHashRegex)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="consistentHashRegex">
-                        <span uib-popover-html="label('consistentHashRegex', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('consistentHashRegex', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="consistentHashRegex">Consistent Hash Regex<div class="helptooltip">
+                        <div class="helptext">
+                            Regex used to extract parts of the request path using grouping in order to build a consistent request string to be used for cache selection. If this field is set on a steering delivery service, it will override the regex set on the target delivery services.
+                            <br>
+                            <br>
+                            <a href="http://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_router.html#pattern-based-consistenthash" target="_blank">See Pattern-Based Consistent Hashing</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="consistentHashRegex" name="consistentHashRegex" type="text" class="form-control" ng-model="deliveryService.consistentHashRegex" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.consistentHashRegex, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.consistentHashRegex != dsCurrent.consistentHashRegex">Current Value: [ {{dsCurrent.consistentHashRegex}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.consistentHashRegex != dsCurrent.consistentHashRegex">Current Value: [ {{dsCurrent.consistentHashRegex}} ]</small>
                         <small><a ng-click="encodeRegex(deliveryService.consistentHashRegex)" href="/#!/delivery-services/{{deliveryService.id}}/consistent-hash?pattern={{encodedRegex}}" target="_blank">Test Regex&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                         <span ng-show="hasError(deliveryServiceForm.consistentHashRegex)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -65,92 +65,114 @@ under the License.
         <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">
-                    <span uib-popover-html="label('active', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('active', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
+                    <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select id="active" id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
+                    <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required autofocus>
                         <option hidden disabled value="">Select...</option>
                         <option ng-value="true">Active</option>
                         <option ng-value="false">Not Active</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.active, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">
-                    <span uib-popover-html="label('typeId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('typeId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
+                    <div class="helptext">
+                        DNS is the standard routing type for most CDN services. HTTP Redirect is a specialty routing service that is primarily used for video and large file downloads where localization and latency are significant concerns. A "Live" routing type should be used for all live services.
+                        <br>
+                        <br>
+                        <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#ds-types" target="_blank">See Delivery Service Types.</a>
+                    </div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="type" name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
                         <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.type, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
                     <small ng-show="deliveryService.typeId"><a href="/#!/types/{{deliveryService.typeId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">
-                    <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
+                    <div class="helptext">This id becomes a part of the CDN service domain in the form <samp>http://cdn.service-key.company.com/</samp>. Must be all lowercase, no spaces or special characters. May contain dashes.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z]([a-z0-9\-]*[a-z0-9])?" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">
-                    <span uib-popover-html="label('displayName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('displayName', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
+                    <div class="helptext">Name of the service that appears in the Traffic portal. No character restrictions.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="displayName" name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" maxlength="48" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'maxlength')">Too Long</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.displayName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">
-                    <span uib-popover-html="label('tenantId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('tenantId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
+                    <div class="helptext">Name of company or division of company who owns account. Allows you to group your services and control access. Tenants are setup as a simple hierarchy where you may create parent / child accounts.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="tenantId" name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
                         <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.tenantId, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
                     <small ng-show="deliveryService.tenantId"><a href="/#!/tenants/{{deliveryService.tenantId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">
-                    <span uib-popover-html="label('cdnId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cdnId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
+                    <div class="helptext">The CDN to which the Delivery Service belongs.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="cdn" name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
                         <option hidden disabled selected value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdn, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
                     <small ng-show="deliveryService.cdnId"><a href="/#!/cdns/{{deliveryService.cdnId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">
-                    <span uib-popover-html="label('protocol', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('protocol', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
+                    <div class="helptext">
+                        The protocol with which to serve this Delivery Service to the clients:
+                        <br>
+                        <br>
+                        <dl>
+                            <dt>HTTP</dt><dd>Deliver only HTTP traffic</dd>
+                            <dt>HTTPS</dt><dd>Deliver only HTTPS traffic</dd>
+                            <dt>HTTP AND HTTPS</dt><dd>Deliver both types of traffic</dd>
+                            <dt>HTTP TO HTTPS</dt><dd>Redirect HTTP traffic to use HTTPS</dd>
+                        </dl>
+                    </div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="protocol" name="protocol" class="form-control" ng-model="deliveryService.protocol" required>
@@ -161,40 +183,43 @@ under the License.
                         <option ng-value="3">HTTP to HTTPS</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.protocol, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.protocol != dsCurrent.protocol">Current Value: [ {{magicNumberLabel(protocols, dsCurrent.protocol)}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">
-                    <span uib-popover-html="label('longDesc', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
+                    <div class="helptext">Free text field that describes the purpose of the Delivery Service and will be displayed in the portal as a description field.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc" name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.longDesc, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">
-                    <span uib-popover-html="label('longDesc1', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc1', 'title')}}</span>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
+                    <div class="helptext">Free text field not currently used in configuration. For example, you can use this field to describe your customer type.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc1" name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3"></textarea>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc1)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc2">
-                    <span uib-popover-html="label('longDesc2', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc2', 'title')}}</span>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
+                    <div class="helptext">Free text field not currently used in configuration.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc2" name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3"></textarea>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc2)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
@@ -209,8 +234,9 @@ under the License.
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">
-                        <span uib-popover-html="label('routingName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('routingName', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
+                        <div class="helptext">The routing name to use for the delivery <abbr title="Fully Qualified Domain Name">FQDN</abbr>, e.g. <samp>routing-name.deliveryservice.cdn-domain</samp>. It must be a valid hostname without periods.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <small class="input-warning" ng-show="!settings.isNew && deliveryServiceForm.routingName.$dirty">Warning: Changing the routing name may require SSL certificates to be updated.</small>
@@ -218,14 +244,15 @@ under the License.
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'required')">Required</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'maxlength')">Too Long</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.routingName, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.routingName != dsCurrent.routingName">Current Value: [ {{dsCurrent.routingName}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.routingName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">
-                        <span uib-popover-html="label('ipv6RoutingEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ipv6RoutingEnabled', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
+                        <div class="helptext">Enabeld by default, disabling this allows you to turn off CDN responses to IPv6 requests</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="ipv6RoutingEnabled" name="ipv6RoutingEnabled" class="form-control" ng-model="deliveryService.ipv6RoutingEnabled" required>
@@ -233,13 +260,14 @@ under the License.
                             <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.ipv6RoutingEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.ipv6RoutingEnabled != dsCurrent.ipv6RoutingEnabled">Current Value: [ {{dsCurrent.ipv6RoutingEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">
-                        <span uib-popover-html="label('logsEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('logsEnabled', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
+                        <div class="helptext">Allows you to turn on/off logging for this Delivery Service</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="logsEnabled" name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" required>
@@ -247,27 +275,38 @@ under the License.
                             <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.logsEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">
-                        <span uib-popover-html="label('geoProvider', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoProvider', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
+                        <div class="helptext">Choose which Geolocation database provider - company that collects data on the location of IP addresses - to use.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="geoProvider" name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" required>
-                            <option ng-value="0" selected>Maxmind</option>
+                            <option ng-value="0" selected>MaxMind</option>
                             <option ng-value="1">Neustar</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">
-                        <span uib-popover-html="label('geoLimit', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimit', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
+                        <div class="helptext">
+                            Some services are intended to be limited by geography. The possible settings are:
+                            <br>
+                            <br>
+                            <dl>
+                                <dt>None</dt><dd>Do not limit by geography.</dd>
+                                <dt>Coverage Zone File only</dt><dd>If the requesting IP is not in the Coverage Zone File, do not serve the request.</dd>
+                                <dt>Coverage Zone File and Country Code(s)</dt><dd>If the requesting IP is not in the Coverage Zone File or not in the United States, do not serve the request.</dd>
+                            </dl>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="geoLimit" name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" required>
@@ -276,92 +315,106 @@ under the License.
                             <option ng-value="2">Coverage Zone File and Country Code(s)</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimit, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">
-                        <span uib-popover-html="label('geoLimitCountries', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitCountries', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
+                        <div class="helptext">How (if at all) is this service to be limited by geography. Example Country Codes: <abbr title="Canada">CA</abbr>, <abbr title="India">IN</abbr>, <abbr title="Puerto Rico">PR</abbr>.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitCountries, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitCountries)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">
-                        <span uib-popover-html="label('profileId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('profileId', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
+                        <div class="helptext">Only used if a Delivery Service uses configurations that specifically require a profile. Example: Multi-Site Origin configurations would require a Delivery Service Profile to be used.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="profile" name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
                             <option selected value="">None</option>
                         </select>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
                         <small ng-show="deliveryService.profileId"><a href="/#!/profiles/{{deliveryService.profileId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}"
                      ng-if="isClientSteering(deliveryService)">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">
-                        <span uib-popover-html="label('trResponseHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trResponseHeaders', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">Traffic Router Additional Response Headers<div class="helptooltip">
+                        <div class="helptext">
+                            List of header name:value pairs separated by <code>__RETURN__</code>. Listed pairs will be included in all Traffic Router HTTP(S) responses.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="trResponseHeaders" name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trResponseHeaders, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.trResponseHeaders != dsCurrent.trResponseHeaders">Current Value: [ {{dsCurrent.trResponseHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trResponseHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">
-                        <span uib-popover-html="label('ccrDnsTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ccrDnsTtl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
+                        <div class="helptext">The <abbr title="Time To Live">TTL</abbr> on the DNS record for the Traffic Router A and AAAA records. Setting too high or too low will result in poor caching performance.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="ccrDnsTtl" name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" min="0" step="1">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.ccrDnsTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">
-                        <span uib-popover-html="label('infoUrl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('infoUrl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
+                        <div class="helptext">Free text field used to enter a URL which provides information about the service.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="infoUrl" name="infoUrl" type="url" title="Must be a valid URL" class="form-control" ng-model="deliveryService.infoUrl" maxlength="255">
-                        <small class="input-error invalid-URL-error">Invalid URL</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
+                        <small class="input-error invalid-URL-error">Invalid URL</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">
-                        <span uib-popover-html="label('checkPath', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('checkPath', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
+                        <div class="helptext">A path (e.g. <samp>/crossdomain.xml</samp>) with which to verify the connection to the origin server. This can be used by Check Extension scripts to do periodic health checks against the Delivery Service.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="checkPath" name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.checkPath, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.checkPath)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.consistentHashRegex), 'has-feedback': hasError(deliveryServiceForm.consistentHashRegex)}">
-                    <label for="consistentHashRegex" class="control-label col-md-2 col-sm-2 col-xs-12">
-                        <span uib-popover-html="label('consistentHashRegex', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('consistentHashRegex', 'title')}}</span>
+                    <label for="consistentHashRegex" class="control-label col-md-2 col-sm-2 col-xs-12">Consistent Hash Regex<div class="helptooltip">
+                        <div class="helptext">
+                            Regex used to extract parts of the request path using grouping in order to build a consistent request string to be used for cache selection. If this field is set on a steering delivery service, it will override the regex set on the target delivery services.
+                            <br>
+                            <br>
+                            <a href="http://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_router.html#pattern-based-consistenthash" target="_blank">See Pattern-Based Consistent Hashing</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input name="consistentHashRegex" type="text" class="form-control" ng-model="deliveryService.consistentHashRegex" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.consistentHashRegex, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.consistentHashRegex != dsCurrent.consistentHashRegex">Current Value: [ {{dsCurrent.consistentHashRegex}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.consistentHashRegex != dsCurrent.consistentHashRegex">Current Value: [ {{dsCurrent.consistentHashRegex}} ]</small>
                         <small><a ng-click="encodeRegex(deliveryService.consistentHashRegex)" href="/#!/delivery-services/{{deliveryService.id}}/consistent-hash?pattern={{encodedRegex}}" target="_blank">Test Regex&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                         <span ng-show="hasError(deliveryServiceForm.consistentHashRegex)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -65,7 +65,7 @@ under the License.
         <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
                     <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
                 </div>
                 </label>
@@ -81,7 +81,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
                     <div class="helptext">
                         DNS is the standard routing type for most CDN services. HTTP Redirect is a specialty routing service that is primarily used for video and large file downloads where localization and latency are significant concerns. A "Live" routing type should be used for all live services.
                         <br>
@@ -101,7 +101,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
                     <div class="helptext">This id becomes a part of the CDN service domain in the form <samp>http://cdn.service-key.company.com/</samp>. Must be all lowercase, no spaces or special characters. May contain dashes.</div>
                 </div>
                 </label>
@@ -116,7 +116,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
                     <div class="helptext">Name of the service that appears in the Traffic portal. No character restrictions.</div>
                 </div>
                 </label>
@@ -130,7 +130,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
                     <div class="helptext">Name of company or division of company who owns account. Allows you to group your services and control access. Tenants are setup as a simple hierarchy where you may create parent / child accounts.</div>
                 </div>
                 </label>
@@ -145,7 +145,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
                     <div class="helptext">The CDN to which the Delivery Service belongs.</div>
                 </div>
                 </label>
@@ -160,7 +160,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.protocol), 'has-feedback': hasError(deliveryServiceForm.protocol)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="protocol">Protocol *<div class="helptooltip">
                     <div class="helptext">
                         The protocol with which to serve this Delivery Service to the clients:
                         <br>
@@ -188,7 +188,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
                     <div class="helptext">Free text field that describes the purpose of the Delivery Service and will be displayed in the portal as a description field.</div>
                 </div>
                 </label>
@@ -201,7 +201,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
                     <div class="helptext">Free text field not currently used in configuration. For example, you can use this field to describe your customer type.</div>
                 </div>
                 </label>
@@ -213,7 +213,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
                     <div class="helptext">Free text field not currently used in configuration.</div>
                 </div>
                 </label>
@@ -234,7 +234,7 @@ under the License.
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.routingName), 'has-feedback': hasError(deliveryServiceForm.routingName)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="routingName">Routing Name *<div class="helptooltip">
                         <div class="helptext">The routing name to use for the delivery <abbr title="Fully Qualified Domain Name">FQDN</abbr>, e.g. <samp>routing-name.deliveryservice.cdn-domain</samp>. It must be a valid hostname without periods.</div>
                     </div>
                     </label>
@@ -250,7 +250,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ipv6RoutingEnabled), 'has-feedback': hasError(deliveryServiceForm.ipv6RoutingEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="ipv6RoutingEnabled">IPv6 Routing Enabled *<div class="helptooltip">
                         <div class="helptext">Enabeld by default, disabling this allows you to turn off CDN responses to IPv6 requests</div>
                     </div>
                     </label>
@@ -265,7 +265,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
                         <div class="helptext">Allows you to turn on/off logging for this Delivery Service</div>
                     </div>
                     </label>
@@ -280,7 +280,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
                         <div class="helptext">Choose which Geolocation database provider - company that collects data on the location of IP addresses - to use.</div>
                     </div>
                     </label>
@@ -295,7 +295,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
                         <div class="helptext">
                             Some services are intended to be limited by geography. The possible settings are:
                             <br>
@@ -320,7 +320,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
                         <div class="helptext">How (if at all) is this service to be limited by geography. Example Country Codes: <abbr title="Canada">CA</abbr>, <abbr title="India">IN</abbr>, <abbr title="Puerto Rico">PR</abbr>.</div>
                     </div>
                     </label>
@@ -333,7 +333,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
                         <div class="helptext">Only used if a Delivery Service uses configurations that specifically require a profile. Example: Multi-Site Origin configurations would require a Delivery Service Profile to be used.</div>
                     </div>
                     </label>
@@ -346,9 +346,7 @@ under the License.
                     </div>
                 </div>
 
-                <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}"
-                     ng-if="isClientSteering(deliveryService)">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trResponseHeaders">Traffic Router Additional Response Headers<div class="helptooltip">
+
                         <div class="helptext">
                             List of header name:value pairs separated by <code>__RETURN__</code>. Listed pairs will be included in all Traffic Router HTTP(S) responses.
                         </div>
@@ -363,7 +361,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
                         <div class="helptext">The <abbr title="Time To Live">TTL</abbr> on the DNS record for the Traffic Router A and AAAA records. Setting too high or too low will result in poor caching performance.</div>
                     </div>
                     </label>
@@ -375,7 +373,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
                         <div class="helptext">Free text field used to enter a URL which provides information about the service.</div>
                     </div>
                     </label>
@@ -389,7 +387,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
                         <div class="helptext">A path (e.g. <samp>/crossdomain.xml</samp>) with which to verify the connection to the origin server. This can be used by Check Extension scripts to do periodic health checks against the Delivery Service.</div>
                     </div>
                     </label>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -63,7 +63,7 @@ under the License.
         <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
                     <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
                 </div>
                 </label>
@@ -79,7 +79,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
                     <div class="helptext">
                         DNS is the standard routing type for most CDN services. HTTP Redirect is a specialty routing service that is primarily used for video and large file downloads where localization and latency are significant concerns. A "Live" routing type should be used for all live services.
                         <br>
@@ -99,7 +99,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
                     <div class="helptext">This id becomes a part of the CDN service domain in the form <samp>http://cdn.service-key.company.com/</samp>. Must be all lowercase, no spaces or special characters. May contain dashes.</div>
                 </div>
                 </label>
@@ -114,7 +114,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
                     <div class="helptext">Name of the service that appears in the Traffic portal. No character restrictions.</div>
                 </div>
                 </label>
@@ -128,7 +128,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
                     <div class="helptext">Name of company or division of company who owns account. Allows you to group your services and control access. Tenants are setup as a simple hierarchy where you may create parent / child accounts.</div>
                 </div>
                 </label>
@@ -143,7 +143,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
                     <div class="helptext">The CDN to which the Delivery Service belongs.</div>
                 </div>
                 </label>
@@ -158,7 +158,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
                     <div class="helptext">Free text field that describes the purpose of the Delivery Service and will be displayed in the portal as a description field.</div>
                 </div>
                 </label>
@@ -171,7 +171,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
                     <div class="helptext">Free text field not currently used in configuration. For example, you can use this field to describe your customer type.</div>
                 </div>
                 </label>
@@ -183,7 +183,7 @@ under the License.
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
+                <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
                     <div class="helptext">Free text field not currently used in configuration.</div>
                 </div>
                 </label>
@@ -204,7 +204,7 @@ under the License.
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regionalGeoBlocking), 'has-feedback': hasError(deliveryServiceForm.regionalGeoBlocking)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">Regional Geoblocking *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">Regional Geoblocking *<div class="helptooltip">
                         <div class="helptext">
                             Define regional geo-blocking rules for Delivery Services in a JSON format and set this to 'Enabled' to use "Regional Geoblocking". <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/quick_howto/regionalgeo.html" target="_blank">See Regional Geo-blocking</a>
                         </div>
@@ -221,7 +221,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
                         <div class="helptext">Allows you to turn on/off logging for this Delivery Service</div>
                     </div>
                     </label>
@@ -236,7 +236,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
                         <div class="helptext">Choose which Geolocation database provider - company that collects data on the location of IP addresses - to use.</div>
                     </div>
                     </label>
@@ -251,7 +251,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
                         <div class="helptext">
                             Some services are intended to be limited by geography. The possible settings are:
                             <br>
@@ -276,7 +276,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
                         <div class="helptext">How (if at all) is this service to be limited by geography. Example Country Codes: <abbr title="Canada">CA</abbr>, <abbr title="India">IN</abbr>, <abbr title="Puerto Rico">PR</abbr>.</div>
                     </div>
                     </label>
@@ -289,7 +289,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
                         <div class="helptext">
                             Traffic Router will redirect to this URL when Geo Limit check fails.
                             <br>
@@ -306,7 +306,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
                         <div class="helptext">Only used if a Delivery Service uses configurations that specifically require a profile. Example: Multi-Site Origin configurations would require a Delivery Service Profile to be used.</div>
                     </div>
                     </label>
@@ -320,7 +320,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
                         <div class="helptext">
                             List of header keys separated by <code>__RETURN__</code>. Listed headers will be included in Traffic Router access log entries under the <samp>rh=</samp> token.
                         </div>
@@ -335,7 +335,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
                         <div class="helptext">
                             Allows you to manipulate the cache key of the incoming requests. Normally, the cache key is the origin domain. This can be changed so that multiple services can share a cache key, can also be used to preserve cached content if service origin is changed.
                             <br>
@@ -362,7 +362,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
                         <div class="helptext">The <abbr title="Time To Live">TTL</abbr> on the DNS record for the Traffic Router A and AAAA records. Setting too high or too low will result in poor caching performance.</div>
                     </div>
                     </label>
@@ -374,7 +374,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
                         <div class="helptext">For HTTP and DNS Delivery Services, this will get added to the end of the remap line verbatim on cache servers. For ANY_MAP Delivery Services this is the entire remap line.</div>
                     </div>
                     </label>
@@ -387,7 +387,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
                         <div class="helptext">Free text field used to enter a URL which provides information about the service.</div>
                     </div>
                     </label>
@@ -401,7 +401,7 @@ under the License.
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
+                    <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
                         <div class="helptext">A path (e.g. <samp>/crossdomain.xml</samp>) with which to verify the connection to the origin server. This can be used by Check Extension scripts to do periodic health checks against the Delivery Service.</div>
                     </div>
                     </label>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -63,8 +63,9 @@ under the License.
         <form name="deliveryServiceForm" class="form-horizontal form-label-left">
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.active), 'has-feedback': hasError(deliveryServiceForm.active)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">
-                    <span uib-popover-html="label('active', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('active', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
+                    <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required autofocus>
@@ -73,109 +74,122 @@ under the License.
                         <option ng-value="false">Not Active</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.active, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.active != dsCurrent.active">Current Value: [ {{dsCurrent.active ? 'Active' : 'Not Active'}} ]</small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.type), 'has-feedback': hasError(deliveryServiceForm.type)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">
-                    <span uib-popover-html="label('typeId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('typeId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="type">Content Routing Type *<div class="helptooltip">
+                    <div class="helptext">
+                        DNS is the standard routing type for most CDN services. HTTP Redirect is a specialty routing service that is primarily used for video and large file downloads where localization and latency are significant concerns. A "Live" routing type should be used for all live services.
+                        <br>
+                        <br>
+                        <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_ops/using.html#ds-types" target="_blank">See Delivery Service Types.</a>
+                    </div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="type" name="type" class="form-control" ng-model="deliveryService.typeId" ng-options="type.id as type.name for type in types" required>
                         <option disabled selected hidden value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.type, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.typeId != dsCurrent.typeId">Current Value: [ {{dsCurrent.type}} ]</small>
                     <small ng-show="deliveryService.typeId"><a href="/#!/types/{{deliveryService.typeId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
-           <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">
-                    <span uib-popover-html="label('xmlId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('xmlId', 'title')}}</span> *
+            <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.xmlId), 'has-feedback': hasError(deliveryServiceForm.xmlId)}">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="xmlId">XML_ID (Key) *<div class="helptooltip">
+                    <div class="helptext">This id becomes a part of the CDN service domain in the form <samp>http://cdn.service-key.company.com/</samp>. Must be all lowercase, no spaces or special characters. May contain dashes.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="xmlId" name="xmlId" type="text" class="form-control" placeholder="Unique id used for the delivery service" ng-model="deliveryService.xmlId" required maxlength="48" pattern="[a-z]([a-z0-9\-]*[a-z0-9])?" ng-readonly="(!settings.isRequest && !settings.isNew) || (settings.isRequest && changeType == 'update')">
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'maxlength')">Too Long</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.xmlId, 'pattern')">Must be a valid DNS label (no special characters, capital letters, periods, underscores, or spaces and cannot begin or end with a hyphen)</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.xmlId != dsCurrent.xmlId">Current Value: [ {{dsCurrent.xmlId}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.xmlId)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.displayName), 'has-feedback': hasError(deliveryServiceForm.displayName)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">
-                    <span uib-popover-html="label('displayName', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('displayName', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="displayName">Display Name *<div class="helptooltip">
+                    <div class="helptext">Name of the service that appears in the Traffic portal. No character restrictions.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="displayName" name="displayName" type="text" class="form-control" ng-model="deliveryService.displayName" maxlength="48" required>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.displayName, 'maxlength')">Too Long</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.displayName != dsCurrent.displayName">Current Value: [ {{dsCurrent.displayName}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.displayName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.tenantId), 'has-feedback': hasError(deliveryServiceForm.tenantId)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">
-                    <span uib-popover-html="label('tenantId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('tenantId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tenantId">Tenant *<div class="helptooltip">
+                    <div class="helptext">Name of company or division of company who owns account. Allows you to group your services and control access. Tenants are setup as a simple hierarchy where you may create parent / child accounts.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="tenantId" name="tenantId" class="form-control" ng-model="deliveryService.tenantId" ng-options="tenant.id as tenantLabel(tenant) for tenant in tenants" required>
                         <option disabled selected hidden value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.tenantId, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.tenantId != dsCurrent.tenantId">Current Value: [ {{dsCurrent.tenant}} ]</small>
                     <small ng-show="deliveryService.tenantId"><a href="/#!/tenants/{{deliveryService.tenantId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cdn), 'has-feedback': hasError(deliveryServiceForm.cdn)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">
-                    <span uib-popover-html="label('cdnId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cdnId', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cdn">CDN *<div class="helptooltip">
+                    <div class="helptext">The CDN to which the Delivery Service belongs.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select id="cdn" name="cdn" class="form-control" ng-model="deliveryService.cdnId" ng-options="cdn.id as cdn.name for cdn in cdns" required>
                         <option disabled selected hidden value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cdn, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.cdnId != dsCurrent.cdnId">Current Value: [ {{dsCurrent.cdnName}} ]</small>
                     <small ng-show="deliveryService.cdnId"><a href="/#!/cdns/{{deliveryService.cdnId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc), 'has-feedback': hasError(deliveryServiceForm.longDesc)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">
-                    <span uib-popover-html="label('longDesc', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc', 'title')}}</span> *
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc">Long Description *<div class="helptooltip">
+                    <div class="helptext">Free text field that describes the purpose of the Delivery Service and will be displayed in the portal as a description field.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc" name="longDesc" type="text" class="form-control" ng-model="deliveryService.longDesc" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.longDesc, 'required')">Required</small>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc != dsCurrent.longDesc">Current Value: [ {{dsCurrent.longDesc}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc1), 'has-feedback': hasError(deliveryServiceForm.longDesc1)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">
-                    <span uib-popover-html="label('longDesc1', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc1', 'title')}}</span>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc1">Long Description 2<div class="helptooltip">
+                    <div class="helptext">Free text field not currently used in configuration. For example, you can use this field to describe your customer type.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc1" name="longDesc1" type="text" class="form-control" ng-model="deliveryService.longDesc1" rows="3"></textarea>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc1 != dsCurrent.longDesc1">Current Value: [ {{dsCurrent.longDesc1}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc1)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
 
             <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.longDesc2), 'has-feedback': hasError(deliveryServiceForm.longDesc2)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12" for="longDesc2">
-                    <span uib-popover-html="label('longDesc2', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('longDesc2', 'title')}}</span>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Long Description 3<div class="helptooltip">
+                    <div class="helptext">Free text field not currently used in configuration.</div>
+                </div>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <textarea id="longDesc2" name="longDesc2" type="text" class="form-control" ng-model="deliveryService.longDesc2" rows="3"></textarea>
-                    <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
+                    <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.longDesc2 != dsCurrent.longDesc2">Current Value: [ {{dsCurrent.longDesc2}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.longDesc2)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
@@ -190,8 +204,11 @@ under the License.
             <div ng-show="advancedShowing">
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.regionalGeoBlocking), 'has-feedback': hasError(deliveryServiceForm.regionalGeoBlocking)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">
-                        <span uib-popover-html="label('regionalGeoBlocking', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('regionalGeoBlocking', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">Regional Geoblocking *<div class="helptooltip">
+                        <div class="helptext">
+                            Define regional geo-blocking rules for Delivery Services in a JSON format and set this to 'Enabled' to use "Regional Geoblocking". <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/quick_howto/regionalgeo.html" target="_blank">See Regional Geo-blocking</a>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="regionalGeoBlocking" name="regionalGeoBlocking" class="form-control" ng-model="deliveryService.regionalGeoBlocking" required>
@@ -199,13 +216,14 @@ under the License.
                             <option ng-value="false" selected>Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.regionalGeoBlocking, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">Current Value: [ {{dsCurrent.regionalGeoBlocking ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">Current Value: [ {{dsCurrent.regionalGeoBlocking ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.logsEnabled), 'has-feedback': hasError(deliveryServiceForm.logsEnabled)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">
-                        <span uib-popover-html="label('logsEnabled', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('logsEnabled', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="logsEnabled">Logs Enabled *<div class="helptooltip">
+                        <div class="helptext">Allows you to turn on/off logging for this Delivery Service</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="logsEnabled" name="logsEnabled" class="form-control" ng-model="deliveryService.logsEnabled" required>
@@ -213,13 +231,14 @@ under the License.
                             <option ng-value="false">Disabled</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.logsEnabled, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.logsEnabled != dsCurrent.logsEnabled">Current Value: [ {{dsCurrent.logsEnabled ? 'Enabled' : 'Disabled'}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoProvider), 'has-feedback': hasError(deliveryServiceForm.geoProvider)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">
-                        <span uib-popover-html="label('geoProvider', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoProvider', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoProvider">Geolocation Provider *<div class="helptooltip">
+                        <div class="helptext">Choose which Geolocation database provider - company that collects data on the location of IP addresses - to use.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="geoProvider" name="geoProvider" class="form-control" ng-model="deliveryService.geoProvider" required>
@@ -227,13 +246,23 @@ under the License.
                             <option ng-value="1">Neustar</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoProvider, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoProvider != dsCurrent.geoProvider">Current Value: [ {{magicNumberLabel(geoProviders, dsCurrent.geoProvider)}} ]</small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimit), 'has-feedback': hasError(deliveryServiceForm.geoLimit)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">
-                        <span uib-popover-html="label('geoLimit', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimit', 'title')}}</span> *
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimit">Geo Limit *<div class="helptooltip">
+                        <div class="helptext">
+                            Some services are intended to be limited by geography. The possible settings are:
+                            <br>
+                            <br>
+                            <dl>
+                                <dt>None</dt><dd>Do not limit by geography.</dd>
+                                <dt>Coverage Zone File only</dt><dd>If the requesting IP is not in the Coverage Zone File, do not serve the request.</dd>
+                                <dt>Coverage Zone File and Country Code(s)</dt><dd>If the requesting IP is not in the Coverage Zone File or not in the United States, do not serve the request.</dd>
+                            </dl>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="geoLimit" name="geoLimit" class="form-control" ng-model="deliveryService.geoLimit" required>
@@ -242,115 +271,144 @@ under the License.
                             <option ng-value="2">Coverage Zone File and Country Code(s)</option>
                         </select>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimit, 'required')">Required</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimit != dsCurrent.geoLimit">Current Value: [ {{magicNumberLabel(geoLimits, dsCurrent.geoLimit)}} ]</small>
                     </div>
                 </div>
 
-
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitCountries), 'has-feedback': hasError(deliveryServiceForm.geoLimitCountries)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">
-                        <span uib-popover-html="label('geoLimitCountries', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitCountries', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitCountries">Geo Limit Countries<div class="helptooltip">
+                        <div class="helptext">How (if at all) is this service to be limited by geography. Example Country Codes: <abbr title="Canada">CA</abbr>, <abbr title="India">IN</abbr>, <abbr title="Puerto Rico">PR</abbr>.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="geoLimitCountries" name="geoLimitCountries" type="text" class="form-control" ng-model="deliveryService.geoLimitCountries" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.geoLimitCountries, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimitCountries != dsCurrent.geoLimitCountries">Current Value: [ {{dsCurrent.geoLimitCountries}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitCountries)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.geoLimitRedirectURL), 'has-feedback': hasError(deliveryServiceForm.geoLimitRedirectURL)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">
-                        <span uib-popover-html="label('geoLimitRedirectURL', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('geoLimitRedirectURL', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="geoLimitRedirectURL">Geo Limit Redirect URL<div class="helptooltip">
+                        <div class="helptext">
+                            Traffic Router will redirect to this URL when Geo Limit check fails.
+                            <br>
+                            <br>
+                            See <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_router.html#tr-ngb" target="_blank">GeoLimit Failure Redirect</a> feature...
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="geoLimitRedirectURL" name="geoLimitRedirectURL" type="url" class="form-control" ng-model="deliveryService.geoLimitRedirectURL" title="Must be a valid URL.">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.geoLimitRedirectURL != dsCurrent.geoLimitRedirectURL">Current Value: [ {{dsCurrent.geoLimitRedirectURL}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.geoLimitRedirectURL)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.profile), 'has-feedback': hasError(deliveryServiceForm.profile)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">
-                        <span uib-popover-html="label('profileId', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('profileId', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="profile">Delivery Service Profile<div class="helptooltip">
+                        <div class="helptext">Only used if a Delivery Service uses configurations that specifically require a profile. Example: Multi-Site Origin configurations would require a Delivery Service Profile to be used.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <select id="profile" name="profile" class="form-control" ng-model="deliveryService.profileId" ng-options="profile.id as profile.name for profile in profiles">
                             <option selected value="">None</option>
                         </select>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.profileId != dsCurrent.profileId">Current Value: [ {{dsCurrent.profileName}} ]</small>
                         <small ng-show="deliveryService.profileId"><a href="/#!/profiles/{{deliveryService.profileId}}" target="_blank">View Details&nbsp;&nbsp;<i class="fa fs-xs fa-external-link"></i></a></small>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trRequestHeaders), 'has-feedback': hasError(deliveryServiceForm.trRequestHeaders)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">
-                        <span uib-popover-html="label('trRequestHeaders', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('trRequestHeaders', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="trRequestHeaders">Traffic Router Log Request Headers<div class="helptooltip">
+                        <div class="helptext">
+                            List of header keys separated by <code>__RETURN__</code>. Listed headers will be included in Traffic Router access log entries under the <samp>rh=</samp> token.
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="trRequestHeaders" name="trRequestHeaders" type="text" class="form-control" ng-model="deliveryService.trRequestHeaders" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trRequestHeaders, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.trRequestHeaders != dsCurrent.trRequestHeaders">Current Value: [ {{dsCurrent.trRequestHeaders}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.trRequestHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.cacheurl), 'has-feedback': hasError(deliveryServiceForm.cacheurl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">
-                        <span uib-popover-html="label('cacheurl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('cacheurl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="cacheurl">Cache URL Expression<div class="helptooltip">
+                        <div class="helptext">
+                            Allows you to manipulate the cache key of the incoming requests. Normally, the cache key is the origin domain. This can be changed so that multiple services can share a cache key, can also be used to preserve cached content if service origin is changed.
+                            <br>
+                            <aside>
+                                <h6>Note</h6>
+                                <p>This only works with Edge-tier cache servers running <abbr title="Apache Traffic Server">ATS</abbr> version 6 and earlier. This <em>must</em> be empty if using <abbr title="Apache Traffic Server">ATS</abbr> 7 and / or the <a href="https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/cachekey.en.html" target="_blank">cachekey plugin.</a></p>
+                                <br>
+                                <br>
+                                See <a href="https://docs.trafficserver.apache.org/en/6.2.x/admin-guide/plugins/cacheurl.en.html" target="_blank">ATS documentation on cacheurl</a>
+                            </aside>
+                            <aside class="warning">
+                                <h6>Warning</h6>
+                                <p>This field is deprecated, and is subject to removal in upcoming releases. It is recommended that this be left blank.</p>
+                            </aside>
+                        </div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="cacheurl" name="cacheurl" type="text" class="form-control" ng-model="deliveryService.cacheurl" maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.cacheurl, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.cacheurl != dsCurrent.cacheurl">Current Value: [ {{dsCurrent.cacheurl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.cacheurl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">
-                        <span uib-popover-html="label('ccrDnsTtl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('ccrDnsTtl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="ccrDnsTtl">Delivery Service DNS TTL<div class="helptooltip">
+                        <div class="helptext">The <abbr title="Time To Live">TTL</abbr> on the DNS record for the Traffic Router A and AAAA records. Setting too high or too low will result in poor caching performance.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="ccrDnsTtl" name="ccrDnsTtl" type="number" class="form-control" ng-model="deliveryService.ccrDnsTtl" min="0" step="1">
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.ccrDnsTtl != dsCurrent.ccrDnsTtl">Current Value: [ {{dsCurrent.ccrDnsTtl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.ccrDnsTtl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.remapText), 'has-feedback': hasError(deliveryServiceForm.remapText)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">
-                        <span uib-popover-html="label('remapText', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('remapText', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="remapText">Raw remap text<div class="helptooltip">
+                        <div class="helptext">For HTTP and DNS Delivery Services, this will get added to the end of the remap line verbatim on cache servers. For ANY_MAP Delivery Services this is the entire remap line.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="remapText" name="remapText" type="text" class="form-control" ng-model="deliveryService.remapText" maxlength="2048">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.remapText, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.remapText != dsCurrent.remapText">Current Value: [ {{dsCurrent.remapText}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.remapText)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.infoUrl), 'has-feedback': hasError(deliveryServiceForm.infoUrl)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">
-                        <span uib-popover-html="label('infoUrl', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('infoUrl', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="infoUrl">Info URL<div class="helptooltip">
+                        <div class="helptext">Free text field used to enter a URL which provides information about the service.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input id="infoUrl" name="infoUrl" type="url" class="form-control" ng-model="deliveryService.infoUrl" title="Must be a valid URL." maxlength="255">
+                        <input id="infoUrl" name="infoUrl" type="url" class="form-control" ng-model="deliveryService.infoUrl" title="Must be a valid URL" maxlength="255">
                         <small class="input-error invalid-URL-error">Invalid URL</small>
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.infoUrl, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.infoUrl != dsCurrent.infoUrl">Current Value: [ {{dsCurrent.infoUrl}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.infoUrl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>
 
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.checkPath), 'has-feedback': hasError(deliveryServiceForm.checkPath)}">
-                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">
-                        <span uib-popover-html="label('checkPath', 'desc')" popover-trigger="click" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">{{label('checkPath', 'title')}}</span>
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12" for="checkPath">Check Path<div class="helptooltip">
+                        <div class="helptext">A path (e.g. <samp>/crossdomain.xml</samp>) with which to verify the connection to the origin server. This can be used by Check Extension scripts to do periodic health checks against the Delivery Service.</div>
+                    </div>
                     </label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
                         <input id="checkPath" name="checkPath" type="text" class="form-control" ng-model="deliveryService.checkPath" maxlength="255">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.checkPath, 'maxlength')">Too Long</small>
-                        <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
+                        <small class="input-diff" ng-if="settings.isRequest" ng-show="open() && deliveryService.checkPath != dsCurrent.checkPath">Current Value: [ {{dsCurrent.checkPath}} ]</small>
                         <span ng-show="hasError(deliveryServiceForm.checkPath)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>
                 </div>


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?
This PR changes the help tooltips displayed on Delivery Service forms from Javascript-based "popover" modals that triggered on click to pure CSS tooltips that appear on hover.

~Also changes errors about violated maximum length constraints (which you should never be able to see, honestly) and errors about unset required fields from Javascript to pure CSS (error text is also now part of presentation and not content)~ - jk this was a stupid idea

~Finally, this should fix forms so that when GeoLimit isn't set neither the GeoLimitURL field nor the GeoLimitCountries field will appear. Previously, only one of them would be hidden - I don't remember which.~ - removed

## Which TC components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR? Please include manual steps or automated tests. 
Build and run Traffic Portal and check out those tooltips. No tests because it's a UI change - theoretically the existing UI tests will handle it, though idk how those work.

## Check all that apply
- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)