### PR TITLE
Fixed docs build but for real this time

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -15,3 +15,4 @@
 Sphinx>=1.4.3
 sphinx_rtd_theme>=0.4.0
 sphinx_autodoc_typehints>=1.3.0
+Pygments>=2.3.1


### PR DESCRIPTION
(cherry picked from commit 29fe74d58a1a5c18bfe7aa822888cf4bdc54172f)

## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?
Backports a change that pins Pygments to a version where a known bug that causes issues building our docs has been fixed

## Which TC components are affected by this PR?
- Documentation

## What is the best way to verify this PR? Please include manual steps or automated tests. 
Install the dependencies from `docs/source/requirements.txt` and build the documentation. e.g.

```bash
pushd docs

# You could also use `--user` to avoid `sudo -H`, or use a venv/pip env
sudo -H python3 -m pip install --upgrade -r source/requirements.txt
make
popd
```

## Check all that apply

- [ ] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)