### PR TITLE
Backport: Escape $1 so that the regex populates correctly

### DIFF
--- a/traffic_ops/app/lib/UI/DeliveryService.pm
+++ b/traffic_ops/app/lib/UI/DeliveryService.pm
@@ -1432,7 +1432,7 @@ sub get_qstring_ignore_remap {
 	my $ats_major_version = shift;
 
 	if ($ats_major_version >= 6) {
-		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/^([^?]*)/$1/";
+		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/^([^?]*)/\$1/";
 	}
 	else {
 		return " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";


### PR DESCRIPTION
git cherry-pick a14a20fb1d3f3ac98b43479c47f656011cfa9a64

Backport of #2867
