### PR TITLE
fixes UI tests that broke due to PR#3361

### DIFF
--- a/traffic_portal/test/end_to_end/DeliveryServiceRequests/delivery-service-requests-spec.js
+++ b/traffic_portal/test/end_to_end/DeliveryServiceRequests/delivery-service-requests-spec.js
@@ -26,8 +26,8 @@ describe('Traffic Portal Delivery Service Requests', function() {
 	var commonFunctions = new cfunc();
 	var mockVals = {
 		dsType: ["ANY MAP", "DNS", "HTTP", "STEERING"],
-		active: "true",
-		xmlId: "thisIsOnlyADSTest",
+		active: "Active",
+		xmlId: "thisisonlyadstest",
 		displayName: "dsTest",
 		orgServerFqdn: "http://dstest.com",
 		longDesc: "This is only a test that should be disposed of by Automated UI Testing.",

--- a/traffic_portal/test/end_to_end/DeliveryServices/delivery-services-spec.js
+++ b/traffic_portal/test/end_to_end/DeliveryServices/delivery-services-spec.js
@@ -26,8 +26,8 @@ describe('Traffic Portal Delivery Services Suite', function() {
 	var commonFunctions = new cfunc();
 	var mockVals = {
 		dsType: ["ANY MAP", "DNS", "HTTP", "STEERING"],
-		active: "true",
-		xmlId: "thisIsOnlyATest",
+		active: "Active",
+		xmlId: "thisisonlyatest",
 		displayName: "dsTest",
 		orgServerFqdn: "http://dstest.com",
 		longDesc: "This is only a test that should be disposed of by Automated UI Testing."


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

This PR fixes a couple of UI tests that broke as a result of PR #3361 

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Run the UI tests. Make sure they pass. Here's how you do that: https://github.com/apache/trafficcontrol/tree/master/traffic_portal/test/end_to_end

## Check all that apply

- [x] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



