### PR TITLE
[Backport - 3.0.x] Return a JSON response with a 200 for successful PUT snapshot

### DIFF
--- a/traffic_ops/traffic_ops_golang/crconfig/handler.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/handler.go
@@ -134,7 +134,7 @@ func SnapshotHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	api.CreateChangeLogRawTx(api.ApiChange, "Snapshot of CRConfig performed for "+cdn, inf.User, inf.Tx.Tx)
-	w.WriteHeader(http.StatusOK) // TODO change to 204 No Content in new version
+	api.WriteResp(w, r, "SUCCESS")
 }
 
 // SnapshotGUIHandler creates the CRConfig JSON and writes it to the snapshot table in the database. The response emulates the old Perl UI function. This should go away when the old Perl UI ceases to exist.


### PR DESCRIPTION
This fixes the deviation from the Perl implementation which returned a
JSON response, fixing any clients that are currently broken due to
expecting a JSON response from this endpoint (e.g. the Python TO
client).

Fixes #3276.

(cherry picked from commit 25d754656d23ca505fb25c6c39190c3f25de7673)

## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

Fixes #(replace_this_text_with_issue_number) 

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)


## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



