### PR TITLE
CIAB: Add CDN_NAME environment variable

### DIFF
--- a/infrastructure/cdn-in-a-box/edge/run.sh
+++ b/infrastructure/cdn-in-a-box/edge/run.sh
@@ -45,8 +45,6 @@ while ! to-ping 2>/dev/null; do
 	sleep 5
 done
 
-CDN=CDN-in-a-Box
-
 export TO_USER=$TO_ADMIN_USER
 export TO_PASSWORD=$TO_ADMIN_PASSWORD
 
@@ -55,10 +53,10 @@ found=
 while [[ -z $found ]]; do
     echo 'waiting for enroller setup'
     sleep 3
-    found=$(to-get "api/1.3/cdns?name=$CDN" | jq -r '.response[].name')
+    found=$(to-get "api/1.3/cdns?name=$CDN_NAME" | jq -r '.response[].name')
 done
 
-to-enroll edge $CDN || (while true; do echo "enroll failed."; sleep 3 ; done)
+to-enroll edge $CDN_NAME || (while true; do echo "enroll failed."; sleep 3 ; done)
 
 while [[ -z "$(testenrolled)" ]]; do
 	echo "waiting on enrollment"
@@ -66,7 +64,7 @@ while [[ -z "$(testenrolled)" ]]; do
 done
 
 # Wait for SSL keys to exist
-until to-get "api/1.3/cdns/name/$CDN/sslkeys" && [[ "$(to-get api/1.3/cdns/name/$CDN/sslkeys)" != '{"response":[]}' ]]; do
+until to-get "api/1.3/cdns/name/$CDN_NAME/sslkeys" && [[ "$(to-get api/1.3/cdns/name/$CDN_NAME/sslkeys)" != '{"response":[]}' ]]; do
 	echo 'waiting for SSL keys to exist'
 	sleep 3
 done

--- a/infrastructure/cdn-in-a-box/mid/run.sh
+++ b/infrastructure/cdn-in-a-box/mid/run.sh
@@ -45,8 +45,6 @@ while ! to-ping 2>/dev/null; do
 	sleep 5
 done
 
-CDN=CDN-in-a-Box
-
 export TO_USER=$TO_ADMIN_USER
 export TO_PASSWORD=$TO_ADMIN_PASSWORD
 
@@ -55,10 +53,10 @@ found=
 while [[ -z $found ]]; do
     echo 'waiting for enroller setup'
     sleep 3
-    found=$(to-get api/1.3/cdns?name="$CDN" | jq -r '.response[].name')
+    found=$(to-get api/1.3/cdns?name="$CDN_NAME" | jq -r '.response[].name')
 done
 
-to-enroll mid $CDN "CDN_in_a_Box_Mid" || (while true; do echo "enroll failed."; sleep 3 ; done)
+to-enroll mid $CDN_NAME "CDN_in_a_Box_Mid" || (while true; do echo "enroll failed."; sleep 3 ; done)
 
 while [[ -z "$(testenrolled)" ]]; do
 	echo "waiting on enrollment"

--- a/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
@@ -58,9 +58,8 @@ cp $X509_CA_CERT_FULL_CHAIN_FILE /etc/pki/ca-trust/source/anchors
 update-ca-trust extract
 
 # Enroll with traffic ops
-CDN=CDN-in-a-Box
 TO_URL="https://$TO_FQDN:$TO_PORT"
-to-enroll tm $CDN || (while true; do echo "enroll failed."; sleep 3 ; done)
+to-enroll tm $CDN_NAME || (while true; do echo "enroll failed."; sleep 3 ; done)
 
 # Configure Traffic Monitor
 cat > /opt/traffic_monitor/conf/traffic_ops.cfg <<- ENDOFMESSAGE
@@ -69,7 +68,7 @@ cat > /opt/traffic_monitor/conf/traffic_ops.cfg <<- ENDOFMESSAGE
 	"password": "$TM_PASSWORD",
 	"url": "$TO_URL",
 	"insecure": true,
-	"cdnName": "$CDN",
+	"cdnName": "$CDN_NAME",
 	"httpListener": ":$TM_PORT"
 }
 ENDOFMESSAGE
@@ -100,7 +99,7 @@ export TO_PASSWORD=$TO_ADMIN_PASSWORD
 touch /opt/traffic_monitor/var/log/traffic_monitor.log
 
 # Do not start until there is a valid CRConfig available
-until [ $(to-get '/CRConfig-Snapshots/CDN-in-a-Box/CRConfig.json' 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do 
+until [ $(to-get "/CRConfig-Snapshots/$CDN_NAME/CRConfig.json" 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do
 	echo "Waiting on valid CRConfig..."; 
   	sleep 3; 
 done

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -82,8 +82,8 @@ while true; do
   echo "Verifying that edge was associated to delivery service..."
 
   edge_name="$(to-get 'api/1.3/servers/hostname/edge/details' 2>/dev/null | jq -r -c '.response|.hostName')"
-  ds_name="$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[].xmlId')"
-  ds_id="$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[].id')"
+  ds_name=$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[] | select(.cdnName == "'"$CDN_NAME"'").xmlId')
+  ds_id=$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[] | select(.cdnName == "'"$CDN_NAME"'").id')
   edge_verify=$(to-get "/api/1.2/deliveryservices/$ds_id/servers" | jq -r '.response[]|.hostName')
 
   if [[ $edge_verify = $edge_name ]] ; then
@@ -108,7 +108,7 @@ while [[ "$demo1_sslkeys_verified" = false ]]; do
    demo1_csr="$(sed -n -e '/-----BEGIN CERTIFICATE REQUEST-----/,$p' $X509_DEMO1_REQUEST_FILE | jq -s -R '.')"
    demo1_key="$(sed -n -e '/-----BEGIN PRIVATE KEY-----/,$p' $X509_DEMO1_KEY_FILE | jq -s -R '.')"
    demo1_json_request=$(jq -n \
-                           --arg     cdn        "CDN-in-a-Box" \
+                           --arg     cdn        "$CDN_NAME" \
                            --arg     hostname   "*.demo1.mycdn.ciab.test" \
                            --arg     dsname     "$ds_name" \
                            --argjson crt        "$demo1_crt" \
@@ -131,7 +131,7 @@ while [[ "$demo1_sslkeys_verified" = false ]]; do
 
    if [[ -n "$demo1_json_response" ]] ; then 
       sleep 2
-      cdn_sslkeys_response=$(to-get 'api/1.3/cdns/name/CDN-in-a-Box/sslkeys.json' | jq '.response[] | length')
+      cdn_sslkeys_response=$(to-get "api/1.3/cdns/name/$CDN_NAME/sslkeys.json" | jq '.response[] | length')
       echo "cdn_sslkeys_response=$cdn_sslkeys_response"
 
       if [ -n "$cdn_sslkeys_response" ] ; then 
@@ -162,11 +162,11 @@ while [[ "$AUTO_SNAPQUEUE_ENABLED" = true ]] ; do
   [ -z "$current_servers_json" ] && current_servers_json='[]'
   current_servers_list=$(jq -r -n --argjson current "$current_servers_json" '$current|join(",")')
   current_servers_total=$(jq -r -n --argjson current "$current_servers_json" '$current|length')
- 
+
   remain_servers_json=$(jq -n --argjson expected "$expected_servers_json" --argjson current "$current_servers_json" '$expected-$current')
   remain_servers_list=$(jq -r -n --argjson remain "$remain_servers_json" '$remain|join(",")')
   remain_servers_total=$(jq -r -n --argjson remain "$remain_servers_json" '$remain|length')
-    
+
   echo "AUTO-SNAPQUEUE - Expected Servers ($expected_servers_total): $expected_servers_list"
   echo "AUTO-SNAPQUEUE - Current Servers ($current_servers_total): $current_servers_list"
   echo "AUTO-SNAPQUEUE - Remain Servers ($remain_servers_total): $remain_servers_list"
@@ -180,7 +180,7 @@ while [[ "$AUTO_SNAPQUEUE_ENABLED" = true ]] ; do
      echo "AUTO-SNAPQUEUE - Do queue updates..."
      to-post 'api/1.3/cdns/2/queue_update' '{"action":"queue"}'
      break
-  fi 
+  fi
 
   sleep $AUTO_SNAPQUEUE_POLL_INTERVAL
 done

--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -170,7 +170,7 @@ to-enroll() {
 	if [[ ! -z "$2" ]]; then
 		export MY_CDN="$2"
 	else
-		export MY_CDN="CDN-in-a-Box"
+		export MY_CDN="$CDN_NAME"
 	fi
 	if [[ ! -z "$3" ]]; then
 		export MY_CACHE_GROUP="$3"

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/cdns/010-CDN-in-a-Box.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/cdns/010-CDN-in-a-Box.json
@@ -1,5 +1,5 @@
 {
 	"dnssecEnabled": false,
 	"domainName": "mycdn.ciab.test",
-	"name": "CDN-in-a-Box"
+	"name": "$CDN_NAME"
 }

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/010-ciab.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/010-ciab.json
@@ -4,7 +4,7 @@
     "tenant": "root",
     "protocol": 2,
     "orgServerFqdn": "http://origin.infra.ciab.test",
-    "cdnName": "CDN-in-a-Box",
+    "cdnName": "$CDN_NAME",
     "type": "HTTP",
     "active": true,
     "dscp": 0,

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
@@ -1,5 +1,5 @@
 {
-	"cdnName": "CDN-in-a-Box",
+	"cdnName": "$CDN_NAME",
 	"description": "Edge Cache - Apache Traffic Server",
 	"name": "ATS_EDGE_TIER_CACHE",
 	"routingDisabled": false,

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/020-ATS_MID_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/020-ATS_MID_TIER_CACHE.json
@@ -1,5 +1,5 @@
 {
-	"cdnName": "CDN-in-a-Box",
+	"cdnName": "$CDN_NAME",
 	"description": "Mid Cache - Apache Traffic Server",
 	"name": "ATS_MID_TIER_CACHE",
 	"routingDisabled": false,

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/040-CCR_CIAB.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/040-CCR_CIAB.json
@@ -1,5 +1,5 @@
 {
-  "cdnName": "CDN-in-a-Box",
+  "cdnName": "$CDN_NAME",
   "description": "Traffic Router for CDN-In-A-Box",
   "name": "CCR_CIAB",
   "routingDisabled": false,

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/070-RASCAL-Traffic_Monitor.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/070-RASCAL-Traffic_Monitor.json
@@ -1,5 +1,5 @@
 {
-  "cdnName": "CDN-in-a-Box",
+  "cdnName": "$CDN_NAME",
   "description": "Traffic Monitor for CDN-in-a-Box",
   "name": "RASCAL-Traffic_Monitor",
   "type": "TM_PROFILE",

--- a/infrastructure/cdn-in-a-box/variables.env
+++ b/infrastructure/cdn-in-a-box/variables.env
@@ -16,6 +16,7 @@
 # under the License.
 TLD_DOMAIN=ciab.test
 INFRA_SUBDOMAIN=infra
+CDN_NAME=CDN-in-a-Box
 CDN_SUBDOMAIN=mycdn
 DS_HOSTS=demo1 demo2 demo3
 X509_CA_NAME=CIAB-CA


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

Add a new environment variable: `CDN_NAME`
It's used to modify the CDN name in CIAB.

This commit also fix a `AUTO_SNAPQUEUE` issue.
If there are more than 1 deliveryservices in the folder `/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices`, the feature `AUTO_SNAPQUEUE` will be failed.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other CIAB

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

1. Modify the `CDN_NAME`. e.g. `TESTCDN`
2. Start CIAB
3. CIAB will work correctly and it's CDN name should be `TESTCDN`

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->
