### PR TITLE
TP adds table context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - To support reusing a single riak cluster connection, an optional parameter is added to riak.conf: "HealthCheckInterval". This options takes a 'Duration' value (ie: 10s, 5m) which affects how often the riak cluster is health checked.  Default is currently set to: "HealthCheckInterval": "5s".
 - Added a new Go db/admin binary to replace the Perl db/admin.pl script which is now deprecated and will be removed in a future release. The new db/admin binary is essentially a drop-in replacement for db/admin.pl since it supports all of the same commands and options; therefore, it should be used in place of db/admin.pl for all the same tasks.
 - Added an API 1.4 endpoint, /api/1.4/cdns/dnsseckeys/refresh, to perform necessary behavior previously served outside the API under `/internal`.
-- Adds the DS Record text to the cdn dnsseckeys endpoint in 1.4.
+- Added the DS Record text to the cdn dnsseckeys endpoint in 1.4.
 - Added monitoring.json snapshotting. This stores the monitoring json in the same table as the crconfig snapshot. Snapshotting is now required in order to push out monitoring changes.
 - To traffic_ops_ort.pl added the ability to handle ##OVERRIDE## delivery service ANY_MAP raw remap text to replace and comment out a base delivery service remap rules. THIS IS A TEMPORARY HACK until versioned delivery services are implemented.
 - Snapshotting the CRConfig now deletes HTTPS certificates in Riak for delivery services which have been deleted in Traffic Ops.
+- Added a context menu to the following tables in Traffic Portal: cache group tables, CDN tables, delivery service tables, parameter tables, profile tables, server tables.
 - Traffic Portal standalone Dockerfile
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added monitoring.json snapshotting. This stores the monitoring json in the same table as the crconfig snapshot. Snapshotting is now required in order to push out monitoring changes.
 - To traffic_ops_ort.pl added the ability to handle ##OVERRIDE## delivery service ANY_MAP raw remap text to replace and comment out a base delivery service remap rules. THIS IS A TEMPORARY HACK until versioned delivery services are implemented.
 - Snapshotting the CRConfig now deletes HTTPS certificates in Riak for delivery services which have been deleted in Traffic Ops.
-- Added a context menu to the following tables in Traffic Portal: cache group tables, CDN tables, delivery service tables, parameter tables, profile tables, server tables.
+- Added a context menu in place of the "Actions" column from the following tables in Traffic Portal: cache group tables, CDN tables, delivery service tables, parameter tables, profile tables, server tables.
 - Traffic Portal standalone Dockerfile
 
 ### Changed

--- a/licenses/MIT-angular_bootstrap_contextmenu
+++ b/licenses/MIT-angular_bootstrap_contextmenu
@@ -1,0 +1,30 @@
+/**
+ * angular-bootstrap-contextmenu v1.2.0
+ * https://github.com/Templarian/ui.bootstrap.contextMenu
+ * Copyright (c) 2014 Austin Andrews (@templarian)
+ * License: MIT
+ */
+
+https://github.com/Templarian/ui.bootstrap.contextMenu/blob/master/license.txt
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Austin Andrews (@templarian)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/traffic_portal/app/src/app.js
+++ b/traffic_portal/app/src/app.js
@@ -34,6 +34,7 @@ var trafficPortal = angular.module('trafficPortal', [
         'ngRoute',
         'ui.router',
         'ui.bootstrap',
+        'ui.bootstrap.contextMenu',
         'restangular',
         'app.templates',
         'angular-jwt',

--- a/traffic_portal/app/src/common/api/CDNService.js
+++ b/traffic_portal/app/src/common/api/CDNService.js
@@ -74,15 +74,20 @@ var CDNService = function($http, $q, Restangular, locationUtils, messageModel, E
     };
 
     this.deleteCDN = function(id) {
-        return Restangular.one("cdns", id).remove()
+        var request = $q.defer();
+
+        $http.delete(ENV.api['root'] + "cdns/" + id)
             .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'CDN deleted' } ], true);
+                function(result) {
+                    request.resolve(result.data);
                 },
                 function(fault) {
-                    messageModel.setMessages(fault.data.alerts, true);
+                    messageModel.setMessages(fault.data.alerts, false);
+                    request.reject(fault);
                 }
             );
+
+        return request.promise;
     };
 
     this.queueServerUpdates = function(id) {

--- a/traffic_portal/app/src/common/api/CacheGroupService.js
+++ b/traffic_portal/app/src/common/api/CacheGroupService.js
@@ -53,15 +53,20 @@ var CacheGroupService = function($http, $q, Restangular, locationUtils, messageM
     };
 
     this.deleteCacheGroup = function(id) {
-        return Restangular.one("cachegroups", id).remove()
+        var request = $q.defer();
+
+        $http.delete(ENV.api['root'] + "cachegroups/" + id)
             .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Cache group deleted' } ], true);
+                function(result) {
+                    request.resolve(result.data);
                 },
                 function(fault) {
-                    messageModel.setMessages(fault.data.alerts, true);
+                    messageModel.setMessages(fault.data.alerts, false);
+                    request.reject(fault);
                 }
             );
+
+        return request.promise;
     };
 
     this.queueServerUpdates = function(cgId, cdnId) {

--- a/traffic_portal/app/src/common/api/ParameterService.js
+++ b/traffic_portal/app/src/common/api/ParameterService.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var ParameterService = function(Restangular, locationUtils, messageModel) {
+var ParameterService = function(Restangular, $http, $q, locationUtils, messageModel, ENV) {
 
     this.getParameters = function(queryParams) {
         return Restangular.all('parameters').getList(queryParams);
@@ -53,16 +53,22 @@ var ParameterService = function(Restangular, locationUtils, messageModel) {
     };
 
     this.deleteParameter = function(id) {
-        return Restangular.one("parameters", id).remove()
+        var request = $q.defer();
+
+        $http.delete(ENV.api['root'] + "parameters/" + id)
             .then(
-            function() {
-                messageModel.setMessages([ { level: 'success', text: 'Parameter deleted' } ], true);
-            },
-            function(fault) {
-                messageModel.setMessages(fault.data.alerts, true);
-            }
-        );
+                function(result) {
+                    request.resolve(result.data);
+                },
+                function(fault) {
+                    messageModel.setMessages(fault.data.alerts, false);
+                    request.reject(fault);
+                }
+            );
+
+        return request.promise;
     };
+
 
     this.getProfileParameters = function(profileId) {
         return Restangular.one('profiles', profileId).getList('parameters');
@@ -78,5 +84,5 @@ var ParameterService = function(Restangular, locationUtils, messageModel) {
 
 };
 
-ParameterService.$inject = ['Restangular', 'locationUtils', 'messageModel'];
+ParameterService.$inject = ['Restangular', '$http', '$q', 'locationUtils', 'messageModel', 'ENV'];
 module.exports = ParameterService;

--- a/traffic_portal/app/src/common/api/ProfileService.js
+++ b/traffic_portal/app/src/common/api/ProfileService.js
@@ -53,15 +53,20 @@ var ProfileService = function(Restangular, $http, $q, locationUtils, messageMode
     };
 
     this.deleteProfile = function(id) {
-        return Restangular.one("profiles", id).remove()
+        var request = $q.defer();
+
+        $http.delete(ENV.api['root'] + "profiles/" + id)
             .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Profile deleted' } ], true);
+                function(result) {
+                    request.resolve(result.data);
                 },
                 function(fault) {
-                    messageModel.setMessages(fault.data.alerts, true);
+                    messageModel.setMessages(fault.data.alerts, false);
+                    request.reject(fault);
                 }
-        );
+            );
+
+        return request.promise;
     };
 
     this.getParameterProfiles = function(paramId) {

--- a/traffic_portal/app/src/common/api/ServerService.js
+++ b/traffic_portal/app/src/common/api/ServerService.js
@@ -53,15 +53,20 @@ var ServerService = function($http, $q, Restangular, locationUtils, messageModel
     };
 
     this.deleteServer = function(id) {
-        return Restangular.one("servers", id).remove()
+        var request = $q.defer();
+
+        $http.delete(ENV.api['root'] + "servers/" + id)
             .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Server deleted' } ], true);
+                function(result) {
+                    request.resolve(result.data);
                 },
                 function(fault) {
-                    messageModel.setMessages(fault.data.alerts, true);
+                    messageModel.setMessages(fault.data.alerts, false);
+                    request.reject(fault);
                 }
             );
+
+        return request.promise;
     };
 
     this.getServerConfigFiles = function(id) {

--- a/traffic_portal/app/src/common/modules/form/cacheGroup/edit/FormEditCacheGroupController.js
+++ b/traffic_portal/app/src/common/modules/form/cacheGroup/edit/FormEditCacheGroupController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var FormEditCacheGroupController = function(cacheGroup, types, cacheGroups, $scope, $controller, $uibModal, $anchorScroll, locationUtils, cacheGroupService) {
+var FormEditCacheGroupController = function(cacheGroup, types, cacheGroups, $scope, $controller, $uibModal, $anchorScroll, locationUtils, cacheGroupService, messageModel) {
 
     // extends the FormCacheGroupController to inherit common methods
     angular.extend(this, $controller('FormCacheGroupController', { cacheGroup: cacheGroup, types: types, cacheGroups: cacheGroups, $scope: $scope }));
@@ -31,7 +31,8 @@ var FormEditCacheGroupController = function(cacheGroup, types, cacheGroups, $sco
 
     var deleteCacheGroup = function(cacheGroup) {
         cacheGroupService.deleteCacheGroup(cacheGroup.id)
-            .then(function() {
+            .then(function(result) {
+                messageModel.setMessages(result.alerts, true);
                 locationUtils.navigateToPath('/cache-groups');
             });
     };
@@ -127,5 +128,5 @@ var FormEditCacheGroupController = function(cacheGroup, types, cacheGroups, $sco
 
 };
 
-FormEditCacheGroupController.$inject = ['cacheGroup', 'types', 'cacheGroups', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'cacheGroupService'];
+FormEditCacheGroupController.$inject = ['cacheGroup', 'types', 'cacheGroups', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'cacheGroupService', 'messageModel'];
 module.exports = FormEditCacheGroupController;

--- a/traffic_portal/app/src/common/modules/form/cdn/edit/FormEditCDNController.js
+++ b/traffic_portal/app/src/common/modules/form/cdn/edit/FormEditCDNController.js
@@ -17,14 +17,15 @@
  * under the License.
  */
 
-var FormEditCDNController = function(cdn, $scope, $controller, $uibModal, $anchorScroll, locationUtils, cdnService) {
+var FormEditCDNController = function(cdn, $scope, $controller, $uibModal, $anchorScroll, locationUtils, cdnService, messageModel) {
 
     // extends the FormCDNController to inherit common methods
     angular.extend(this, $controller('FormCDNController', { cdn: cdn, $scope: $scope }));
 
     var deleteCDN = function(cdn) {
         cdnService.deleteCDN(cdn.id)
-            .then(function() {
+            .then(function(result) {
+                messageModel.setMessages(result.alerts, true);
                 locationUtils.navigateToPath('/cdns');
             });
     };
@@ -68,5 +69,5 @@ var FormEditCDNController = function(cdn, $scope, $controller, $uibModal, $ancho
 
 };
 
-FormEditCDNController.$inject = ['cdn', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'cdnService'];
+FormEditCDNController.$inject = ['cdn', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'cdnService', 'messageModel'];
 module.exports = FormEditCDNController;

--- a/traffic_portal/app/src/common/modules/form/parameter/edit/FormEditParameterController.js
+++ b/traffic_portal/app/src/common/modules/form/parameter/edit/FormEditParameterController.js
@@ -17,14 +17,15 @@
  * under the License.
  */
 
-var FormEditParameterController = function(parameter, $scope, $controller, $uibModal, $anchorScroll, locationUtils, parameterService, profileService) {
+var FormEditParameterController = function(parameter, $scope, $controller, $uibModal, $anchorScroll, locationUtils, parameterService, profileService, messageModel) {
 
     // extends the FormParameterController to inherit common methods
     angular.extend(this, $controller('FormParameterController', { parameter: parameter, $scope: $scope }));
 
     var deleteParameter = function(parameter) {
         parameterService.deleteParameter(parameter.id)
-            .then(function() {
+            .then(function(result) {
+                messageModel.setMessages(result.alerts, true);
                 locationUtils.navigateToPath('/parameters');
             });
     };
@@ -124,5 +125,5 @@ var FormEditParameterController = function(parameter, $scope, $controller, $uibM
 
 };
 
-FormEditParameterController.$inject = ['parameter', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'parameterService', 'profileService'];
+FormEditParameterController.$inject = ['parameter', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'parameterService', 'profileService', 'messageModel'];
 module.exports = FormEditParameterController;

--- a/traffic_portal/app/src/common/modules/form/profile/edit/FormEditProfileController.js
+++ b/traffic_portal/app/src/common/modules/form/profile/edit/FormEditProfileController.js
@@ -17,14 +17,15 @@
  * under the License.
  */
 
-var FormEditProfileController = function(profile, $scope, $controller, $uibModal, $anchorScroll, locationUtils, profileService) {
+var FormEditProfileController = function(profile, $scope, $controller, $uibModal, $anchorScroll, locationUtils, profileService, messageModel) {
 
     // extends the FormProfileController to inherit common methods
     angular.extend(this, $controller('FormProfileController', { profile: profile, $scope: $scope }));
 
     var deleteProfile = function(profile) {
         profileService.deleteProfile(profile.id)
-            .then(function() {
+            .then(function(result) {
+                messageModel.setMessages(result.alerts, true);
                 locationUtils.navigateToPath('/profiles');
             });
     };
@@ -68,5 +69,5 @@ var FormEditProfileController = function(profile, $scope, $controller, $uibModal
 
 };
 
-FormEditProfileController.$inject = ['profile', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'profileService'];
+FormEditProfileController.$inject = ['profile', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'profileService', 'messageModel'];
 module.exports = FormEditProfileController;

--- a/traffic_portal/app/src/common/modules/form/server/edit/FormEditServerController.js
+++ b/traffic_portal/app/src/common/modules/form/server/edit/FormEditServerController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var FormEditServerController = function(server, $scope, $controller, $uibModal, locationUtils, serverService, statusService) {
+var FormEditServerController = function(server, $scope, $controller, $uibModal, locationUtils, serverService, statusService, messageModel) {
 
     // extends the FormServerController to inherit common methods
     angular.extend(this, $controller('FormServerController', { server: server, $scope: $scope }));
@@ -31,7 +31,8 @@ var FormEditServerController = function(server, $scope, $controller, $uibModal, 
 
     var deleteServer = function(server) {
         serverService.deleteServer(server.id)
-            .then(function() {
+            .then(function(result) {
+                messageModel.setMessages(result.alerts, true);
                 locationUtils.navigateToPath('/servers');
             });
     };
@@ -79,5 +80,5 @@ var FormEditServerController = function(server, $scope, $controller, $uibModal, 
 
 };
 
-FormEditServerController.$inject = ['server', '$scope', '$controller', '$uibModal', 'locationUtils', 'serverService', 'statusService'];
+FormEditServerController.$inject = ['server', '$scope', '$controller', '$uibModal', 'locationUtils', 'serverService', 'statusService', 'messageModel'];
 module.exports = FormEditServerController;

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParametersController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParametersController.js
@@ -17,11 +17,23 @@
  * under the License.
  */
 
-var TableCacheGroupParametersController = function(cacheGroup, cacheGroupParameters, $scope, $state, $uibModal, locationUtils, cacheGroupParameterService) {
+var TableCacheGroupParametersController = function(cacheGroup, parameters, $controller, $scope, $state, $uibModal, locationUtils, cacheGroupParameterService) {
+
+	// extends the TableParametersController to inherit common methods
+	angular.extend(this, $controller('TableParametersController', { parameters: parameters, $scope: $scope }));
 
 	$scope.cacheGroup = cacheGroup;
 
-	$scope.cacheGroupParameters = cacheGroupParameters;
+	// adds some items to the base parameters context menu
+	$scope.contextMenuItems.splice(2, 0,
+		{
+			text: 'Unlink Parameter from Cache Group',
+			click: function ($itemScope) {
+				$scope.removeParameter($itemScope.p.id);
+			}
+		},
+		null // Divider
+	);
 
 	$scope.removeParameter = function(paramId) {
 		cacheGroupParameterService.unlinkCacheGroupParameter(cacheGroup.id, paramId)
@@ -30,10 +42,6 @@ var TableCacheGroupParametersController = function(cacheGroup, cacheGroupParamet
 					$scope.refresh();
 				}
 			);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
 	};
 
 	$scope.selectParams = function() {
@@ -69,7 +77,7 @@ var TableCacheGroupParametersController = function(cacheGroup, cacheGroupParamet
 	$scope.navigateToPath = locationUtils.navigateToPath;
 
 	angular.element(document).ready(function () {
-		$('#parametersTable').dataTable({
+		$('#cacheGroupParametersTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
 			"columnDefs": [
@@ -81,5 +89,5 @@ var TableCacheGroupParametersController = function(cacheGroup, cacheGroupParamet
 
 };
 
-TableCacheGroupParametersController.$inject = ['cacheGroup', 'cacheGroupParameters', '$scope', '$state', '$uibModal', 'locationUtils', 'cacheGroupParameterService'];
+TableCacheGroupParametersController.$inject = ['cacheGroup', 'parameters', '$controller', '$scope', '$state', '$uibModal', 'locationUtils', 'cacheGroupParameterService'];
 module.exports = TableCacheGroupParametersController;

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParameters.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParameters.tpl.html
@@ -32,7 +32,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="parametersTable" class="table responsive-utilities jambo_table">
+        <table id="cacheGroupParametersTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>Name</th>
@@ -43,7 +43,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="p in ::cacheGroupParameters">
+            <tr ng-repeat="p in ::parameters" context-menu="contextMenuItems">
                 <td data-search="^{{::p.name}}$">{{::p.name}}</td>
                 <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
                 <td data-search="^{{::p.value}}$">{{::p.value}}</td>

--- a/traffic_portal/app/src/common/modules/table/cacheGroupServers/TableCacheGroupServersController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupServers/TableCacheGroupServersController.js
@@ -17,13 +17,14 @@
  * under the License.
  */
 
-var TableCacheGroupsServersController = function(cacheGroup, servers, $scope, $state, $uibModal, cacheGroupService, locationUtils, serverUtils, propertiesModel) {
+var TableCacheGroupsServersController = function(cacheGroup, servers, $controller, $scope, $state, $uibModal, cacheGroupService) {
+
+	// extends the TableServersController to inherit common methods
+	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
 
 	$scope.cacheGroup = cacheGroup;
 
-	$scope.servers = servers;
-
-	var queueServerUpdates = function(cacheGroup, cdnId) {
+	var queueCacheGroupServerUpdates = function(cacheGroup, cdnId) {
 		cacheGroupService.queueServerUpdates(cacheGroup.id, cdnId)
 			.then(
 				function() {
@@ -32,7 +33,7 @@ var TableCacheGroupsServersController = function(cacheGroup, servers, $scope, $s
 			);
 	};
 
-	var clearServerUpdates = function(cacheGroup, cdnId) {
+	var clearCacheGroupServerUpdates = function(cacheGroup, cdnId) {
 		cacheGroupService.clearServerUpdates(cacheGroup.id, cdnId)
 			.then(
 				function() {
@@ -41,15 +42,7 @@ var TableCacheGroupsServersController = function(cacheGroup, servers, $scope, $s
 			);
 	};
 
-	$scope.editServer = function(id) {
-		locationUtils.navigateToPath('/servers/' + id);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.confirmQueueServerUpdates = function(cacheGroup) {
+	$scope.confirmCacheGroupQueueServerUpdates = function(cacheGroup) {
 		var params = {
 			title: 'Queue Server Updates: ' + cacheGroup.name,
 			message: "Please select a CDN"
@@ -68,13 +61,13 @@ var TableCacheGroupsServersController = function(cacheGroup, servers, $scope, $s
 			}
 		});
 		modalInstance.result.then(function(cdn) {
-			queueServerUpdates(cacheGroup, cdn.id);
+			queueCacheGroupServerUpdates(cacheGroup, cdn.id);
 		}, function () {
 			// do nothing
 		});
 	};
 
-	$scope.confirmClearServerUpdates = function(cacheGroup) {
+	$scope.confirmCacheGroupClearServerUpdates = function(cacheGroup) {
 		var params = {
 			title: 'Clear Server Updates: ' + cacheGroup.name,
 			message: "Please select a CDN"
@@ -93,38 +86,21 @@ var TableCacheGroupsServersController = function(cacheGroup, servers, $scope, $s
 			}
 		});
 		modalInstance.result.then(function(cdn) {
-			clearServerUpdates(cacheGroup, cdn.id);
+			clearCacheGroupServerUpdates(cacheGroup, cdn.id);
 		}, function () {
 			// do nothing
 		});
 	};
 
-	$scope.showChartsButton = propertiesModel.properties.servers.charts.show;
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
-	$scope.ssh = serverUtils.ssh;
-
-	$scope.gotoMonitor = serverUtils.gotoMonitor;
-
-	$scope.openCharts = serverUtils.openCharts;
-
-	$scope.isOffline = serverUtils.isOffline;
-
-	$scope.offlineReason = serverUtils.offlineReason;
-
 	angular.element(document).ready(function () {
-		$('#serversTable').dataTable({
+		$('#cacheGroupServersTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
-			"columnDefs": [
-				{ 'orderable': false, 'targets': 12 }
-			],
 			"aaSorting": []
 		});
 	});
 
 };
 
-TableCacheGroupsServersController.$inject = ['cacheGroup', 'servers', '$scope', '$state', '$uibModal', 'cacheGroupService', 'locationUtils', 'serverUtils', 'propertiesModel'];
+TableCacheGroupsServersController.$inject = ['cacheGroup', 'servers', '$controller', '$scope', '$state', '$uibModal', 'cacheGroupService'];
 module.exports = TableCacheGroupsServersController;

--- a/traffic_portal/app/src/common/modules/table/cacheGroupServers/table.cacheGroupServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupServers/table.cacheGroupServers.tpl.html
@@ -31,8 +31,8 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-click="confirmQueueServerUpdates(cacheGroup)"><i class="fa fa-flag"></i>&nbsp;&nbsp;Queue {{::cacheGroup.name}} Server Updates</a></li>
-                    <li role="menuitem"><a ng-click="confirmClearServerUpdates(cacheGroup)"><i class="fa fa-ban"></i>&nbsp;&nbsp;Clear {{::cacheGroup.name}} Server Updates</a></li>
+                    <li role="menuitem"><a ng-click="confirmCacheGroupQueueServerUpdates(cacheGroup)"><i class="fa fa-flag"></i>&nbsp;&nbsp;Queue {{::cacheGroup.name}} Server Updates</a></li>
+                    <li role="menuitem"><a ng-click="confirmCacheGroupClearServerUpdates(cacheGroup)"><i class="fa fa-ban"></i>&nbsp;&nbsp;Clear {{::cacheGroup.name}} Server Updates</a></li>
                 </ul>
             </div>
             <button class="btn btn-default" title="Refresh" ng-click="refresh()"><i class="fa fa-refresh"></i></button>
@@ -41,7 +41,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="serversTable" class="table responsive-utilities jambo_table">
+        <table id="cacheGroupServersTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>UPD</th>
@@ -56,11 +56,10 @@ under the License.
                 <th>Cache Group</th>
                 <th>Phys Location</th>
                 <th>ILO</th>
-                <th style="text-align: right;">Actions</th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}">
+            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
                 <td data-order="{{::s.updPending}}" data-search="{{(s.updPending) ? 'UPD' : ''}}">
                     <i title="Updates Pending" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
                     <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
@@ -79,10 +78,6 @@ under the License.
                 <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
                 <td data-search="^{{::s.physLocation}}$">{{::s.physLocation}}</td>
                 <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
-                <td style="text-align: right;">
-                    <span ng-if="s.type == 'RASCAL'"><a class="link action-link" title="Go to" ng-click="gotoMonitor(s, $event)"><i class="fa fa-sm fa-external-link"></i>&nbsp;&nbsp;</a></span>
-                    <span ng-if="showChartsButton"><a class="link action-link" title="View Charts" ng-click="openCharts(s, $event)"><i class="fa fa-sm fa-bar-chart"></i></a></span>
-                </td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/cacheGroups/TableCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroups/TableCacheGroupsController.js
@@ -17,9 +17,151 @@
  * under the License.
  */
 
-var TableCacheGroupsController = function(cacheGroups, $scope, $state, locationUtils) {
+var TableCacheGroupsController = function(cacheGroups, $location, $scope, $state, $uibModal, $window, locationUtils, cacheGroupService, cdnService) {
+
+    var queueServerUpdates = function(cacheGroup, cdnId) {
+        cacheGroupService.queueServerUpdates(cacheGroup.id, cdnId);
+    };
+
+    var clearServerUpdates = function(cacheGroup, cdnId) {
+        cacheGroupService.clearServerUpdates(cacheGroup.id, cdnId);
+    };
+
+    var deleteCacheGroup = function(cacheGroup) {
+        cacheGroupService.deleteCacheGroup(cacheGroup.id)
+            .then(function() {
+                $scope.refresh();
+            });
+    };
+
+    var confirmQueueServerUpdates = function(cacheGroup) {
+        var params = {
+            title: 'Queue Server Updates: ' + cacheGroup.name,
+            message: "Please select a CDN"
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+            controller: 'DialogSelectController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                },
+                collection: function(cdnService) {
+                    return cdnService.getCDNs();
+                }
+            }
+        });
+        modalInstance.result.then(function(cdn) {
+            queueServerUpdates(cacheGroup, cdn.id);
+        }, function () {
+            // do nothing
+        });
+    };
+
+    var confirmClearServerUpdates = function(cacheGroup) {
+        var params = {
+            title: 'Clear Server Updates: ' + cacheGroup.name,
+            message: "Please select a CDN"
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+            controller: 'DialogSelectController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                },
+                collection: function(cdnService) {
+                    return cdnService.getCDNs();
+                }
+            }
+        });
+        modalInstance.result.then(function(cdn) {
+            clearServerUpdates(cacheGroup, cdn.id);
+        }, function () {
+            // do nothing
+        });
+    };
+
+    var confirmDelete = function(cacheGroup) {
+        var params = {
+            title: 'Delete Cache Group: ' + cacheGroup.name,
+            key: cacheGroup.name
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
+            controller: 'DialogDeleteController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                }
+            }
+        });
+        modalInstance.result.then(function() {
+            deleteCacheGroup(cacheGroup);
+        }, function () {
+            // do nothing
+        });
+    };
+
 
     $scope.cacheGroups = cacheGroups;
+
+    $scope.contextMenuItems = [
+        {
+            text: 'Open in New Tab',
+            click: function ($itemScope) {
+                $window.open('/#!/cache-groups/' + $itemScope.cg.id, '_blank');
+            }
+        },
+        null, // Dividier
+        {
+            text: 'Edit',
+            click: function ($itemScope) {
+                $scope.editCacheGroup($itemScope.cg.id);
+            }
+        },
+        {
+            text: 'Delete',
+            click: function ($itemScope) {
+                confirmDelete($itemScope.cg);
+            }
+        },
+        null, // Dividier
+        {
+            text: 'Queue Server Updates',
+            click: function ($itemScope) {
+                confirmQueueServerUpdates($itemScope.cg);
+            }
+        },
+        {
+            text: 'Clear Server Updates',
+            click: function ($itemScope) {
+                confirmClearServerUpdates($itemScope.cg);
+            }
+        },
+        null, // Dividier
+        {
+            text: 'Manage ASNs',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cache-groups/' + $itemScope.cg.id + '/asns');
+            }
+        },
+        {
+            text: 'Manage Parameters',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cache-groups/' + $itemScope.cg.id + '/parameters');
+            }
+        },
+        {
+            text: 'Manage Servers',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cache-groups/' + $itemScope.cg.id + '/servers');
+            }
+        }
+    ];
 
     $scope.editCacheGroup = function(id) {
         locationUtils.navigateToPath('/cache-groups/' + id);
@@ -43,5 +185,5 @@ var TableCacheGroupsController = function(cacheGroups, $scope, $state, locationU
 
 };
 
-TableCacheGroupsController.$inject = ['cacheGroups', '$scope', '$state', 'locationUtils'];
+TableCacheGroupsController.$inject = ['cacheGroups', '$location', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'cacheGroupService', 'cdnService'];
 module.exports = TableCacheGroupsController;

--- a/traffic_portal/app/src/common/modules/table/cacheGroups/TableCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroups/TableCacheGroupsController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var TableCacheGroupsController = function(cacheGroups, $location, $scope, $state, $uibModal, $window, locationUtils, cacheGroupService, cdnService) {
+var TableCacheGroupsController = function(cacheGroups, $location, $scope, $state, $uibModal, $window, locationUtils, cacheGroupService, cdnService, messageModel) {
 
     var queueServerUpdates = function(cacheGroup, cdnId) {
         cacheGroupService.queueServerUpdates(cacheGroup.id, cdnId);
@@ -29,7 +29,8 @@ var TableCacheGroupsController = function(cacheGroups, $location, $scope, $state
 
     var deleteCacheGroup = function(cacheGroup) {
         cacheGroupService.deleteCacheGroup(cacheGroup.id)
-            .then(function() {
+            .then(function(result) {
+                messageModel.setMessages(result.alerts, false);
                 $scope.refresh();
             });
     };
@@ -185,5 +186,5 @@ var TableCacheGroupsController = function(cacheGroups, $location, $scope, $state
 
 };
 
-TableCacheGroupsController.$inject = ['cacheGroups', '$location', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'cacheGroupService', 'cdnService'];
+TableCacheGroupsController.$inject = ['cacheGroups', '$location', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'cacheGroupService', 'cdnService', 'messageModel'];
 module.exports = TableCacheGroupsController;

--- a/traffic_portal/app/src/common/modules/table/cacheGroups/table.cacheGroups.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroups/table.cacheGroups.tpl.html
@@ -43,7 +43,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editCacheGroup(cg.id)" ng-repeat="cg in ::cacheGroups">
+            <tr ng-click="editCacheGroup(cg.id)" ng-repeat="cg in ::cacheGroups" context-menu="contextMenuItems">
                 <td data-search="^{{::cg.name}}$">{{::cg.name}}</td>
                 <td data-search="^{{::cg.shortName}}$">{{::cg.shortName}}</td>
                 <td data-search="^{{::cg.typeName}}$">{{::cg.typeName}}</td>

--- a/traffic_portal/app/src/common/modules/table/cdnDeliveryServices/TableCDNDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/cdnDeliveryServices/TableCDNDeliveryServicesController.js
@@ -17,42 +17,15 @@
  * under the License.
  */
 
-var TableCDNDeliveryServicesController = function(cdn, deliveryServices, $scope, $state, dateUtils, deliveryServiceUtils, locationUtils, propertiesModel) {
+var TableCDNDeliveryServicesController = function(cdn, deliveryServices, $controller, $scope) {
 
-	var protocols = deliveryServiceUtils.protocols;
-
-	var qstrings = deliveryServiceUtils.qstrings;
+	// extends the TableDeliveryServicesController to inherit common methods
+	angular.extend(this, $controller('TableDeliveryServicesController', { deliveryServices: deliveryServices, $scope: $scope }));
 
 	$scope.cdn = cdn;
 
-	$scope.deliveryServices = deliveryServices;
-
-	$scope.showChartsButton = propertiesModel.properties.deliveryServices.charts.customLink.show;
-
-	$scope.openCharts = deliveryServiceUtils.openCharts;
-
-	$scope.protocol = function(ds) {
-		return protocols[ds.protocol];
-	};
-
-	$scope.qstring = function(ds) {
-		return qstrings[ds.qstringIgnore];
-	};
-
-	$scope.getRelativeTime = dateUtils.getRelativeTime;
-
-	$scope.editDeliveryService = function(ds) {
-		locationUtils.navigateToPath('/delivery-services/' + ds.id + '?type=' + ds.type);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#deliveryServicesTable').dataTable({
+		$('#cdnDeliveryServicesTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
 			"columnDefs": [
@@ -64,5 +37,5 @@ var TableCDNDeliveryServicesController = function(cdn, deliveryServices, $scope,
 
 };
 
-TableCDNDeliveryServicesController.$inject = ['cdn', 'deliveryServices', '$scope', '$state', 'dateUtils', 'deliveryServiceUtils', 'locationUtils', 'propertiesModel'];
+TableCDNDeliveryServicesController.$inject = ['cdn', 'deliveryServices', '$controller', '$scope'];
 module.exports = TableCDNDeliveryServicesController;

--- a/traffic_portal/app/src/common/modules/table/cdnDeliveryServices/table.cdnDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdnDeliveryServices/table.cdnDeliveryServices.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="deliveryServicesTable" class="table responsive-utilities jambo_table">
+        <table id="cdnDeliveryServicesTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>Key (XML ID)</th>
@@ -50,7 +50,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices">
+            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices" context-menu="contextMenuItems">
                 <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
                 <td data-search="^{{::ds.tenant}}$">{{::ds.tenant}}</td>
                 <td data-search="^{{::ds.orgServerFqdn}}$">{{::ds.orgServerFqdn}}</td>

--- a/traffic_portal/app/src/common/modules/table/cdnProfiles/TableCDNProfilesController.js
+++ b/traffic_portal/app/src/common/modules/table/cdnProfiles/TableCDNProfilesController.js
@@ -17,24 +17,15 @@
  * under the License.
  */
 
-var TableCDNProfilesController = function(cdn, profiles, $scope, $state, locationUtils) {
+var TableCDNProfilesController = function(cdn, profiles, $controller, $scope) {
+
+	// extends the TableProfilesController to inherit common methods
+	angular.extend(this, $controller('TableProfilesController', { profiles: profiles, $scope: $scope }));
 
 	$scope.cdn = cdn;
 
-	$scope.profiles = profiles;
-
-	$scope.editProfile = function(id) {
-		locationUtils.navigateToPath('/profiles/' + id);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#profilesTable').dataTable({
+		$('#cdnProfilesTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
 			"aaSorting": []
@@ -43,5 +34,5 @@ var TableCDNProfilesController = function(cdn, profiles, $scope, $state, locatio
 
 };
 
-TableCDNProfilesController.$inject = ['cdn', 'profiles', '$scope', '$state', 'locationUtils'];
+TableCDNProfilesController.$inject = ['cdn', 'profiles', '$controller', '$scope'];
 module.exports = TableCDNProfilesController;

--- a/traffic_portal/app/src/common/modules/table/cdnProfiles/table.cdnProfiles.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdnProfiles/table.cdnProfiles.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="profilesTable" class="table responsive-utilities jambo_table">
+        <table id="cdnProfilesTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>Name</th>
@@ -40,7 +40,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editProfile(p.id)" ng-repeat="p in ::profiles">
+            <tr ng-click="editProfile(p.id)" ng-repeat="p in ::profiles" context-menu="contextMenuItems">
                 <td data-search="^{{::p.name}}$">{{::p.name}}</td>
                 <td data-search="^{{::p.description}}$">{{::p.description}}</td>
                 <td data-search="^{{::p.cdnName}}$">{{::p.cdnName}}</td>

--- a/traffic_portal/app/src/common/modules/table/cdnServers/TableCDNServersController.js
+++ b/traffic_portal/app/src/common/modules/table/cdnServers/TableCDNServersController.js
@@ -17,108 +17,22 @@
  * under the License.
  */
 
-var TableCDNServersController = function(cdn, servers, $scope, $state, $uibModal, locationUtils, serverUtils, cdnService, propertiesModel) {
+var TableCDNServersController = function(cdn, servers, $controller, $scope) {
 
-	var queueServerUpdates = function(cdn) {
-		cdnService.queueServerUpdates(cdn.id)
-			.then(
-				function() {
-					$scope.refresh();
-				}
-			);
-	};
-
-	var clearServerUpdates = function(cdn) {
-		cdnService.clearServerUpdates(cdn.id)
-			.then(
-				function() {
-					$scope.refresh();
-				}
-			);
-	};
+	// extends the TableServersController to inherit common methods
+	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
 
 	$scope.cdn = cdn;
 
-	$scope.servers = servers;
-
-	$scope.editServer = function(id) {
-		locationUtils.navigateToPath('/servers/' + id);
-	};
-
-	$scope.queueServerUpdates = function(cdn) {
-		var params = {
-			title: 'Queue Server Updates: ' + cdn.name,
-			message: 'Are you sure you want to queue server updates for all ' + cdn.name + ' servers?'
-		};
-		var modalInstance = $uibModal.open({
-			templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
-			controller: 'DialogConfirmController',
-			size: 'md',
-			resolve: {
-				params: function () {
-					return params;
-				}
-			}
-		});
-		modalInstance.result.then(function() {
-			queueServerUpdates(cdn);
-		}, function () {
-			// do nothing
-		});
-	};
-
-	$scope.clearServerUpdates = function(cdn) {
-		var params = {
-			title: 'Clear Server Updates: ' + cdn.name,
-			message: 'Are you sure you want to clear server updates for all ' + cdn.name + ' servers?'
-		};
-		var modalInstance = $uibModal.open({
-			templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
-			controller: 'DialogConfirmController',
-			size: 'md',
-			resolve: {
-				params: function () {
-					return params;
-				}
-			}
-		});
-		modalInstance.result.then(function() {
-			clearServerUpdates(cdn);
-		}, function () {
-			// do nothing
-		});
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.showChartsButton = propertiesModel.properties.servers.charts.show;
-
-	$scope.ssh = serverUtils.ssh;
-
-	$scope.gotoMonitor = serverUtils.gotoMonitor;
-
-	$scope.openCharts = serverUtils.openCharts;
-
-	$scope.isOffline = serverUtils.isOffline;
-
-	$scope.offlineReason = serverUtils.offlineReason;
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#serversTable').dataTable({
+		$('#cdnServersTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
-			"columnDefs": [
-				{ 'orderable': false, 'targets': 12 }
-			],
 			"aaSorting": []
 		});
 	});
 
 };
 
-TableCDNServersController.$inject = ['cdn', 'servers', '$scope', '$state', '$uibModal', 'locationUtils', 'serverUtils', 'cdnService', 'propertiesModel'];
+TableCDNServersController.$inject = ['cdn', 'servers', '$controller', '$scope'];
 module.exports = TableCDNServersController;

--- a/traffic_portal/app/src/common/modules/table/cdnServers/table.cdnServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdnServers/table.cdnServers.tpl.html
@@ -31,8 +31,8 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-click="queueServerUpdates(cdn)">Queue {{cdn.name}} Server Updates</a></li>
-                    <li role="menuitem"><a ng-click="clearServerUpdates(cdn)">Clear {{cdn.name}} Server Updates</a></li>
+                    <li role="menuitem"><a ng-click="confirmCDNQueueServerUpdates(cdn)">Queue {{cdn.name}} Server Updates</a></li>
+                    <li role="menuitem"><a ng-click="confirmCDNClearServerUpdates(cdn)">Clear {{cdn.name}} Server Updates</a></li>
                 </ul>
             </div>
             <button class="btn btn-default" title="Refresh" ng-click="refresh()"><i class="fa fa-refresh"></i></button>
@@ -41,7 +41,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="serversTable" class="table responsive-utilities jambo_table">
+        <table id="cdnServersTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>UPD</th>
@@ -56,11 +56,10 @@ under the License.
                 <th>Cache Group</th>
                 <th>Phys Location</th>
                 <th>ILO</th>
-                <th style="text-align: right;">Actions</th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}">
+            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
                 <td data-search="{{(s.updPending) ? 'UPD' : ''}}" data-order="{{::s.updPending}}">
                     <i title="Updates Pending" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
                     <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
@@ -79,10 +78,6 @@ under the License.
                 <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
                 <td data-search="^{{::s.physLocation}}$">{{::s.physLocation}}</td>
                 <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
-                <td style="text-align: right;">
-                    <span ng-if="s.type == 'RASCAL'"><a class="link action-link" title="Go to" ng-click="gotoMonitor(s, $event)"><i class="fa fa-sm fa-external-link"></i>&nbsp;&nbsp;</a></span>
-                    <span ng-if="showChartsButton"><a class="link action-link" title="View Charts" ng-click="openCharts(s, $event)"><i class="fa fa-sm fa-bar-chart"></i></a></span>
-                </td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/cdns/TableCDNsController.js
+++ b/traffic_portal/app/src/common/modules/table/cdns/TableCDNsController.js
@@ -17,9 +17,163 @@
  * under the License.
  */
 
-var TableCDNsController = function(cdns, $scope, $state, locationUtils) {
+var TableCDNsController = function(cdns, $location, $scope, $state, $uibModal, $window, locationUtils, cdnService) {
+
+    var queueServerUpdates = function(cdn) {
+        cdnService.queueServerUpdates(cdn.id);
+    };
+
+    var clearServerUpdates = function(cdn) {
+        cdnService.clearServerUpdates(cdn.id);
+    };
+
+    var deleteCDN = function(cdn) {
+        cdnService.deleteCDN(cdn.id)
+            .then(function() {
+                $scope.refresh();
+            });
+    };
+
+    var confirmQueueServerUpdates = function(cdn) {
+        var params = {
+            title: 'Queue Server Updates: ' + cdn.name,
+            message: 'Are you sure you want to queue server updates for all ' + cdn.name + ' servers?'
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
+            controller: 'DialogConfirmController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                }
+            }
+        });
+        modalInstance.result.then(function() {
+            queueServerUpdates(cdn);
+        }, function () {
+            // do nothing
+        });
+    };
+
+    var confirmClearServerUpdates = function(cdn) {
+        var params = {
+            title: 'Clear Server Updates: ' + cdn.name,
+            message: 'Are you sure you want to clear server updates for all ' + cdn.name + ' servers?'
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
+            controller: 'DialogConfirmController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                }
+            }
+        });
+        modalInstance.result.then(function() {
+            clearServerUpdates(cdn);
+        }, function () {
+            // do nothing
+        });
+    };
+
+    var confirmDelete = function(cdn) {
+        var params = {
+            title: 'Delete CDN: ' + cdn.name,
+            key: cdn.name
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
+            controller: 'DialogDeleteController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                }
+            }
+        });
+        modalInstance.result.then(function() {
+            deleteCDN(cdn);
+        }, function () {
+            // do nothing
+        });
+    };
 
     $scope.cdns = cdns;
+
+    $scope.contextMenuItems = [
+        {
+            text: 'Open in New Tab',
+            click: function ($itemScope) {
+                $window.open('/#!/cdns/' + $itemScope.cdn.id, '_blank');
+            }
+        },
+        null, // Dividier
+        {
+            text: 'Edit',
+            click: function ($itemScope) {
+                $scope.editCDN($itemScope.cdn.id);
+            }
+        },
+        {
+            text: 'Delete',
+            click: function ($itemScope) {
+                confirmDelete($itemScope.cdn);
+            }
+        },
+        null, // Dividier
+        {
+            text: 'Diff Snapshot',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cdns/' + $itemScope.cdn.id + '/config/changes');
+            }
+        },
+        null, // Dividier
+        {
+            text: 'Queue Server Updates',
+            click: function ($itemScope) {
+                confirmQueueServerUpdates($itemScope.cdn);
+            }
+        },
+        {
+            text: 'Clear Server Updates',
+            click: function ($itemScope) {
+                confirmClearServerUpdates($itemScope.cdn);
+            }
+        },
+        null, // Dividier
+        {
+            text: 'Manage DNSSEC Keys',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cdns/' + $itemScope.cdn.id + '/dnssec-keys');
+            }
+        },
+        {
+            text: 'Manage Federations',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cdns/' + $itemScope.cdn.id + '/federations');
+            }
+        },
+        {
+            text: 'Manage Delivery Services',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cdns/' + $itemScope.cdn.id + '/delivery-services');
+            }
+        },
+        {
+            text: 'Manage Profiles',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cdns/' + $itemScope.cdn.id + '/profiles');
+            }
+        },
+        {
+            text: 'Manage Servers',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/cdns/' + $itemScope.cdn.id + '/servers');
+            }
+        }
+    ];
 
     $scope.editCDN = function(id) {
         locationUtils.navigateToPath('/cdns/' + id);
@@ -43,5 +197,5 @@ var TableCDNsController = function(cdns, $scope, $state, locationUtils) {
 
 };
 
-TableCDNsController.$inject = ['cdns', '$scope', '$state', 'locationUtils'];
+TableCDNsController.$inject = ['cdns', '$location', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'cdnService'];
 module.exports = TableCDNsController;

--- a/traffic_portal/app/src/common/modules/table/cdns/TableCDNsController.js
+++ b/traffic_portal/app/src/common/modules/table/cdns/TableCDNsController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var TableCDNsController = function(cdns, $location, $scope, $state, $uibModal, $window, locationUtils, cdnService) {
+var TableCDNsController = function(cdns, $location, $scope, $state, $uibModal, $window, locationUtils, cdnService, messageModel) {
 
     var queueServerUpdates = function(cdn) {
         cdnService.queueServerUpdates(cdn.id);
@@ -29,7 +29,8 @@ var TableCDNsController = function(cdns, $location, $scope, $state, $uibModal, $
 
     var deleteCDN = function(cdn) {
         cdnService.deleteCDN(cdn.id)
-            .then(function() {
+            .then(function(result) {
+                messageModel.setMessages(result.alerts, false);
                 $scope.refresh();
             });
     };
@@ -197,5 +198,5 @@ var TableCDNsController = function(cdns, $location, $scope, $state, $uibModal, $
 
 };
 
-TableCDNsController.$inject = ['cdns', '$location', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'cdnService'];
+TableCDNsController.$inject = ['cdns', '$location', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'cdnService', 'messageModel'];
 module.exports = TableCDNsController;

--- a/traffic_portal/app/src/common/modules/table/cdns/table.cdns.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdns/table.cdns.tpl.html
@@ -39,7 +39,7 @@ under the License.
                 </tr>
             </thead>
             <tbody>
-                <tr ng-click="editCDN(cdn.id)" ng-repeat="cdn in ::cdns">
+                <tr ng-click="editCDN(cdn.id)" ng-repeat="cdn in ::cdns" context-menu="contextMenuItems">
                     <td name="name" data-search="^{{::cdn.name}}$">{{::cdn.name}}</td>
                     <td data-search="^{{::cdn.domainName}}$">{{::cdn.domainName}}</td>
                     <td data-search="^{{::cdn.dnssecEnabled}}$">{{::cdn.dnssecEnabled}}</td>

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceServers/TableDeliveryServiceServersController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceServers/TableDeliveryServiceServersController.js
@@ -17,7 +17,10 @@
  * under the License.
  */
 
-var TableDeliveryServiceServersController = function(deliveryService, servers, $scope, $state, $uibModal, locationUtils, serverUtils, deliveryServiceService, propertiesModel) {
+var TableDeliveryServiceServersController = function(deliveryService, servers, $controller, $scope, $uibModal, deliveryServiceService) {
+
+	// extends the TableServersController to inherit common methods
+	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
 
 	var removeServer = function(serverId) {
 		deliveryServiceService.deleteDeliveryServiceServer($scope.deliveryService.id, serverId)
@@ -30,15 +33,18 @@ var TableDeliveryServiceServersController = function(deliveryService, servers, $
 
 	$scope.deliveryService = deliveryService;
 
-	$scope.servers = servers;
-
-	$scope.editServer = function(id) {
-		locationUtils.navigateToPath('/servers/' + id);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
+	// adds some items to the base parameters context menu
+	$scope.contextMenuItems.splice(2, 0,
+		{
+			text: 'Unlink Server from Delivery Service',
+			hasTopDivider: function() {
+				return true;
+			},
+			click: function ($itemScope) {
+				$scope.confirmRemoveServer($itemScope.s);
+			}
+		}
+	);
 
 	$scope.selectServers = function() {
 		var modalInstance = $uibModal.open({
@@ -70,7 +76,9 @@ var TableDeliveryServiceServersController = function(deliveryService, servers, $
 	};
 
 	$scope.confirmRemoveServer = function(server, $event) {
-		$event.stopPropagation(); // this kills the click event so it doesn't trigger anything else
+		if ($event) {
+			$event.stopPropagation(); // this kills the click event so it doesn't trigger anything else
+		}
 
 		var params = {
 			title: 'Remove Server from Delivery Service?',
@@ -93,20 +101,8 @@ var TableDeliveryServiceServersController = function(deliveryService, servers, $
 		});
 	};
 
-	$scope.showChartsButton = propertiesModel.properties.servers.charts.show;
-
-	$scope.ssh = serverUtils.ssh;
-
-	$scope.openCharts = serverUtils.openCharts;
-
-	$scope.isOffline = serverUtils.isOffline;
-
-	$scope.offlineReason = serverUtils.offlineReason;
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#serversTable').dataTable({
+		$('#dsServersTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
 			"columnDefs": [
@@ -118,5 +114,5 @@ var TableDeliveryServiceServersController = function(deliveryService, servers, $
 
 };
 
-TableDeliveryServiceServersController.$inject = ['deliveryService', 'servers', '$scope', '$state', '$uibModal', 'locationUtils', 'serverUtils', 'deliveryServiceService', 'propertiesModel'];
+TableDeliveryServiceServersController.$inject = ['deliveryService', 'servers', '$controller', '$scope', '$uibModal', 'deliveryServiceService'];
 module.exports = TableDeliveryServiceServersController;

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceServers/TableDeliveryServiceServersController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceServers/TableDeliveryServiceServersController.js
@@ -33,7 +33,7 @@ var TableDeliveryServiceServersController = function(deliveryService, servers, $
 
 	$scope.deliveryService = deliveryService;
 
-	// adds some items to the base parameters context menu
+	// adds some items to the base servers context menu
 	$scope.contextMenuItems.splice(2, 0,
 		{
 			text: 'Unlink Server from Delivery Service',

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceServers/table.deliveryServiceServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceServers/table.deliveryServiceServers.tpl.html
@@ -32,7 +32,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="serversTable" class="table responsive-utilities jambo_table">
+        <table id="dsServersTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>UPD</th>
@@ -47,11 +47,11 @@ under the License.
                 <th>Cache Group</th>
                 <th>Phys Location</th>
                 <th>ILO</th>
-                <th style="text-align: right;">Actions</th>
+                <th></th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}">
+            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
                 <td data-search="{{(s.updPending) ? 'UPD' : ''}}" data-order="{{::s.updPending}}">
                     <i title="Updates Pending" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
                     <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
@@ -72,7 +72,6 @@ under the License.
                 <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
                 <td style="text-align: right;">
                     <a class="link action-link" title="Unlink Server from Delivery Service" ng-click="confirmRemoveServer(s, $event)"><i class="fa fa-sm fa-chain-broken"></i></a>
-                    <span ng-if="showChartsButton"><a class="link action-link" title="View Charts" ng-click="openCharts(s, $event)"><i class="fa fa-sm fa-bar-chart"></i></a></span>
                 </td>
             </tr>
             </tbody>

--- a/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
@@ -1,4 +1,4 @@
-    /*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
@@ -17,15 +17,181 @@
  * under the License.
  */
 
-var TableDeliveryServicesController = function(deliveryServices, $scope, $state, $location, $uibModal, dateUtils, deliveryServiceUtils, locationUtils, propertiesModel) {
+var TableDeliveryServicesController = function(deliveryServices, $anchorScroll, $scope, $state, $location, $uibModal, $window, deliveryServiceService, deliveryServiceRequestService, dateUtils, deliveryServiceUtils, locationUtils, messageModel, propertiesModel, userModel) {
 
     var protocols = deliveryServiceUtils.protocols;
 
     var qstrings = deliveryServiceUtils.qstrings;
 
+    var dsRequestsEnabled = propertiesModel.properties.dsRequests.enabled;
+
     var createDeliveryService = function(typeName) {
         var path = '/delivery-services/new?type=' + typeName;
         locationUtils.navigateToPath(path);
+    };
+
+    var clone = function(ds) {
+        var params = {
+            title: 'Clone Delivery Service: ' + ds.xmlId,
+            message: "Please select a content routing category for the clone"
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+            controller: 'DialogSelectController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                },
+                collection: function() {
+                    // the following represent the 4 categories of delivery services
+                    // the ids are arbitrary but the dialog.select dropdown needs them
+                    return [
+                        { id: 1, name: 'ANY_MAP' },
+                        { id: 2, name: 'DNS' },
+                        { id: 3, name: 'HTTP' },
+                        { id: 4, name: 'STEERING' }
+                    ];
+                }
+            }
+        });
+        modalInstance.result.then(function(type) {
+            locationUtils.navigateToPath('/delivery-services/' + ds.id + '/clone?type=' + type.name);
+        }, function () {
+            // do nothing
+        });
+    };
+
+    var confirmDelete = function(deliveryService) {
+        var params = {
+            title: 'Delete Delivery Service: ' + deliveryService.xmlId,
+            key: deliveryService.xmlId
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
+            controller: 'DialogDeleteController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                }
+            }
+        });
+        modalInstance.result.then(function() {
+            if (dsRequestsEnabled) {
+                createDeliveryServiceDeleteRequest(deliveryService);
+            } else {
+                deliveryServiceService.deleteDeliveryService(deliveryService)
+                    .then(
+                        function() {
+                            messageModel.setMessages([ { level: 'success', text: 'Delivery service [ ' + deliveryService.xmlId + ' ] deleted' } ], false);
+                            $scope.refresh();                        },
+                        function(fault) {
+                            $anchorScroll(); // scrolls window to top
+                            messageModel.setMessages(fault.data.alerts, false);
+                        }
+                    );
+            }
+        }, function () {
+            // do nothing
+        });
+    };
+
+    var createDeliveryServiceDeleteRequest = function(deliveryService) {
+        var params = {
+            title: "Delivery Service Delete Request",
+            message: 'All delivery service deletions must be reviewed.'
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/deliveryServiceRequest/dialog.deliveryServiceRequest.tpl.html',
+            controller: 'DialogDeliveryServiceRequestController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                },
+                statuses: function() {
+                    var statuses = [
+                        { id: $scope.DRAFT, name: 'Save Request as Draft' },
+                        { id: $scope.SUBMITTED, name: 'Submit Request for Review and Deployment' }
+                    ];
+                    if (userModel.user.roleName == propertiesModel.properties.dsRequests.roleNeededToSkip) {
+                        statuses.push({ id: $scope.COMPLETE, name: 'Fulfill Request Immediately' });
+                    }
+                    return statuses;
+                }
+            }
+        });
+        modalInstance.result.then(function(options) {
+            var status = 'draft';
+            if (options.status.id == $scope.SUBMITTED || options.status.id == $scope.COMPLETE) {
+                status = 'submitted';
+            };
+
+            var dsRequest = {
+                changeType: 'delete',
+                status: status,
+                deliveryService: deliveryService
+            };
+
+            // if the user chooses to complete/fulfill the delete request immediately, the ds will be deleted and behind the
+            // scenes a delivery service request will be created and marked as complete
+            if (options.status.id == $scope.COMPLETE) {
+                // first delete the ds
+                deliveryServiceService.deleteDeliveryService(deliveryService)
+                    .then(
+                        function() {
+                            // then create the ds request
+                            deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest).
+                            then(
+                                function(response) {
+                                    var comment = {
+                                        deliveryServiceRequestId: response.id,
+                                        value: options.comment
+                                    };
+                                    // then create the ds request comment
+                                    deliveryServiceRequestService.createDeliveryServiceRequestComment(comment).
+                                    then(
+                                        function() {
+                                            var promises = [];
+                                            // assign the ds request
+                                            promises.push(deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.id));
+                                            // set the status to 'complete'
+                                            promises.push(deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, 'complete'));
+                                            // and finally refresh the delivery services table
+                                            messageModel.setMessages([ { level: 'success', text: 'Delivery service [ ' + deliveryService.xmlId + ' ] deleted' } ], false);
+                                            $scope.refresh();
+                                        }
+                                    );
+                                }
+                            );
+                        },
+                        function(fault) {
+                            $anchorScroll(); // scrolls window to top
+                            messageModel.setMessages(fault.data.alerts, false);
+                        }
+                    );
+            } else {
+                deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest).
+                    then(
+                        function(response) {
+                            var comment = {
+                                deliveryServiceRequestId: response.id,
+                                value: options.comment
+                            };
+                            deliveryServiceRequestService.createDeliveryServiceRequestComment(comment).
+                                then(
+                                    function() {
+                                        messageModel.setMessages([ { level: 'success', text: 'Created request to ' + dsRequest.changeType + ' the ' + dsRequest.deliveryService.xmlId + ' delivery service' } ], true);
+                                        locationUtils.navigateToPath('/delivery-service-requests');
+                                    }
+                                );
+                        }
+                    );
+            }
+        }, function () {
+            // do nothing
+        });
     };
 
     $scope.deliveryServices = deliveryServices;
@@ -35,6 +201,113 @@ var TableDeliveryServicesController = function(deliveryServices, $scope, $state,
     $scope.openCharts = deliveryServiceUtils.openCharts;
 
     $scope.getRelativeTime = dateUtils.getRelativeTime;
+
+    $scope.navigateToPath = locationUtils.navigateToPath;
+
+    $scope.DRAFT = 0;
+    $scope.SUBMITTED = 1;
+    $scope.REJECTED = 2;
+    $scope.PENDING = 3;
+    $scope.COMPLETE = 4;
+
+    $scope.contextMenuItems = [
+        {
+            text: 'Open in New Tab',
+            click: function ($itemScope) {
+                $window.open('/#!/delivery-services/' + $itemScope.ds.id + '?type=' + $itemScope.ds.type, '_blank');
+            }
+        },
+        null, // Divider
+        {
+            text: 'Edit',
+            click: function ($itemScope) {
+                $scope.editDeliveryService($itemScope.ds);
+            }
+        },
+        {
+            text: 'Clone',
+            click: function ($itemScope) {
+                clone($itemScope.ds);
+            }
+        },
+        {
+            text: 'Delete',
+            click: function ($itemScope) {
+                confirmDelete($itemScope.ds);
+            }
+        },
+        null, // Divider
+        {
+            text: 'View Charts',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/charts?type=' + $itemScope.ds.type);
+            }
+        },
+        null, // Divider
+        {
+            text: 'Manage SSL Keys',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/ssl-keys?type=' + $itemScope.ds.type);
+            }
+        },
+        {
+            text: 'Manage URL Sig Keys',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/url-sig-keys?type=' + $itemScope.ds.type);
+            }
+        },
+        {
+            text: 'Manage URI Signing Keys',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/uri-signing-keys?type=' + $itemScope.ds.type);
+            }
+        },
+        null, // Divider
+        {
+            text: 'Manage Targets',
+            displayed: function ($itemScope) {
+                // only show for steering* delivery services
+                return $itemScope.ds.type.indexOf('STEERING') != -1;
+            },
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/targets?type=' + $itemScope.ds.type);
+            }
+        },
+        {
+            text: 'Manage Origins',
+            displayed: function ($itemScope) {
+                // only show for non-steering* delivery services
+                return $itemScope.ds.type.indexOf('STEERING') == -1;
+            },
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/origins?type=' + $itemScope.ds.type);
+            }
+        },
+        {
+            text: 'Manage Servers',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/servers?type=' + $itemScope.ds.type);
+            }
+        },
+        {
+            text: 'Manage Regexes',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/regexes?type=' + $itemScope.ds.type);
+            }
+        },
+        {
+            text: 'Manage Invalidation Requests',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/jobs?type=' + $itemScope.ds.type);
+            }
+        },
+        {
+            text: 'Manage Static DNS Entries',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/delivery-services/' + $itemScope.ds.id + '/static-dns-entries?type=' + $itemScope.ds.type);
+            }
+        }
+    ];
 
     $scope.editDeliveryService = function(ds) {
         var path = '/delivery-services/' + ds.id + '?type=' + ds.type;
@@ -124,5 +397,5 @@ var TableDeliveryServicesController = function(deliveryServices, $scope, $state,
 
 };
 
-TableDeliveryServicesController.$inject = ['deliveryServices', '$scope', '$state', '$location', '$uibModal', 'dateUtils', 'deliveryServiceUtils', 'locationUtils', 'propertiesModel'];
+TableDeliveryServicesController.$inject = ['deliveryServices', '$anchorScroll', '$scope', '$state', '$location', '$uibModal', '$window', 'deliveryServiceService', 'deliveryServiceRequestService', 'dateUtils', 'deliveryServiceUtils', 'locationUtils', 'messageModel', 'propertiesModel', 'userModel'];
 module.exports = TableDeliveryServicesController;

--- a/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
@@ -1,4 +1,4 @@
-/*
+    /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -57,8 +57,6 @@ var TableDeliveryServicesController = function(deliveryServices, $anchorScroll, 
         });
         modalInstance.result.then(function(type) {
             locationUtils.navigateToPath('/delivery-services/' + ds.id + '/clone?type=' + type.name);
-        }, function () {
-            // do nothing
         });
     };
 
@@ -189,8 +187,6 @@ var TableDeliveryServicesController = function(deliveryServices, $anchorScroll, 
                         }
                     );
             }
-        }, function () {
-            // do nothing
         });
     };
 

--- a/traffic_portal/app/src/common/modules/table/deliveryServices/table.deliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/deliveryServices/table.deliveryServices.tpl.html
@@ -58,7 +58,7 @@ under the License.
                 </tr>
             </thead>
             <tbody>
-                <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices">
+                <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices" context-menu="contextMenuItems">
                     <td name="xmlId" data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
                     <td data-search="^{{::ds.tenant}}$">{{::ds.tenant}}</td>
                     <td data-search="^{{::ds.orgServerFqdn}}$">{{::ds.orgServerFqdn}}</td>

--- a/traffic_portal/app/src/common/modules/table/parameterCacheGroups/TableParameterCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/parameterCacheGroups/TableParameterCacheGroupsController.js
@@ -17,11 +17,12 @@
  * under the License.
  */
 
-var TableParameterCacheGroupsController = function(parameter, cacheGroups, $scope, $state, locationUtils) {
+var TableParameterCacheGroupsController = function(parameter, cacheGroups, $controller, $scope, $state, locationUtils) {
+
+	// extends the TableCacheGroupsController to inherit common methods
+	angular.extend(this, $controller('TableCacheGroupsController', { cacheGroups: cacheGroups, $scope: $scope }));
 
 	$scope.parameter = parameter;
-
-	$scope.cacheGroups = cacheGroups;
 
 	$scope.addCacheGroup = function() {
 		alert('not hooked up yet: add cg to parameter');
@@ -31,21 +32,9 @@ var TableParameterCacheGroupsController = function(parameter, cacheGroups, $scop
 		alert('not hooked up yet: remove cg from parameter');
 	};
 
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
 	$scope.navigateToPath = locationUtils.navigateToPath;
-
-	angular.element(document).ready(function () {
-		$('#cacheGroupsTable').dataTable({
-			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
-			"iDisplayLength": 25,
-			"aaSorting": []
-		});
-	});
 
 };
 
-TableParameterCacheGroupsController.$inject = ['parameter', 'cacheGroups', '$scope', '$state', 'locationUtils'];
+TableParameterCacheGroupsController.$inject = ['parameter', 'cacheGroups', '$controller', '$scope', '$state', 'locationUtils'];
 module.exports = TableParameterCacheGroupsController;

--- a/traffic_portal/app/src/common/modules/table/parameterCacheGroups/table.parameterCacheGroups.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/parameterCacheGroups/table.parameterCacheGroups.tpl.html
@@ -38,16 +38,20 @@ under the License.
                 <th>Name</th>
                 <th>Short Name</th>
                 <th>Type</th>
+                <th>Parent</th>
+                <th>2nd Parent</th>
                 <th>Latitude</th>
                 <th>Longitude</th>
                 <th></th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="cg in ::cacheGroups">
+            <tr ng-repeat="cg in ::cacheGroups" context-menu="contextMenuItems">
                 <td data-search="^{{::cg.name}}$">{{::cg.name}}</td>
                 <td data-search="^{{::cg.shortName}}$">{{::cg.shortName}}</td>
                 <td data-search="^{{::cg.typeName}}$">{{::cg.typeName}}</td>
+                <td data-search="^{{::cg.parentCachegroupName}}$">{{::cg.parentCachegroupName}}</td>
+                <td data-search="^{{::cg.secondaryParentCachegroupName}}$">{{::cg.secondaryParentCachegroupName}}</td>
                 <td data-search="^{{::cg.latitude}}$">{{::cg.latitude}}</td>
                 <td data-search="^{{::cg.longitude}}$">{{::cg.longitude}}</td>
                 <td><button type="button" class="btn btn-link" title="Remove Cache Group" ng-click="removeCacheGroup()"><i class="fa fa-trash-o"></i></button></td>

--- a/traffic_portal/app/src/common/modules/table/parameterProfiles/TableParameterProfilesController.js
+++ b/traffic_portal/app/src/common/modules/table/parameterProfiles/TableParameterProfilesController.js
@@ -17,15 +17,10 @@
  * under the License.
  */
 
-var TableParameterProfilesController = function(parameter, parameterProfiles, $scope, $state, $uibModal, locationUtils, deliveryServiceService, profileParameterService, serverService) {
+var TableParameterProfilesController = function(parameter, profiles, $controller, $scope, $state, $uibModal, locationUtils, deliveryServiceService, profileParameterService, serverService) {
 
-	$scope.parameter = parameter;
-
-	$scope.parameterProfiles = parameterProfiles;
-
-	$scope.addProfile = function() {
-		alert('not hooked up yet: add profile to parameter');
-	};
+	// extends the TableProfilesController to inherit common methods
+	angular.extend(this, $controller('TableProfilesController', { profiles: profiles, $scope: $scope }));
 
 	var removeProfile = function(profileId) {
 		profileParameterService.unlinkProfileParameter(profileId, parameter.id)
@@ -36,7 +31,25 @@ var TableParameterProfilesController = function(parameter, parameterProfiles, $s
 			);
 	};
 
-	$scope.confirmRemoveProfile = function(profile) {
+	$scope.parameter = parameter;
+
+	// adds some items to the base profiles context menu
+	$scope.contextMenuItems.splice(2, 0,
+		{
+			text: 'Unlink Profile from Parameter',
+			hasBottomDivider: function() {
+				return true;
+			},
+			click: function ($itemScope) {
+				$scope.confirmRemoveProfile($itemScope.p);
+			}
+		}
+	);
+
+	$scope.confirmRemoveProfile = function(profile, $event) {
+		if ($event) {
+			$event.stopPropagation();
+		}
 		if (profile.type == 'DS_PROFILE') { // if this is a ds profile, then it is used by delivery service(s) so we'll fetch the ds count...
 			deliveryServiceService.getDeliveryServices({ profile: profile.id }).
 				then(function(result) {
@@ -86,11 +99,6 @@ var TableParameterProfilesController = function(parameter, parameterProfiles, $s
 		}
 	};
 
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
 	$scope.selectProfiles = function() {
 		var modalInstance = $uibModal.open({
 			templateUrl: 'common/modules/table/parameterProfiles/table.paramProfilesUnassigned.tpl.html',
@@ -104,7 +112,7 @@ var TableParameterProfilesController = function(parameter, parameterProfiles, $s
 					return profileService.getProfiles({ orderby: 'name' });
 				},
 				assignedProfiles: function() {
-					return parameterProfiles;
+					return profiles;
 				}
 			}
 		});
@@ -138,9 +146,6 @@ var TableParameterProfilesController = function(parameter, parameterProfiles, $s
 		});
 	};
 
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
 		$('#parameterProfilesTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
@@ -154,5 +159,5 @@ var TableParameterProfilesController = function(parameter, parameterProfiles, $s
 
 };
 
-TableParameterProfilesController.$inject = ['parameter', 'parameterProfiles', '$scope', '$state', '$uibModal', 'locationUtils', 'deliveryServiceService', 'profileParameterService', 'serverService'];
+TableParameterProfilesController.$inject = ['parameter', 'profiles', '$controller', '$scope', '$state', '$uibModal', 'locationUtils', 'deliveryServiceService', 'profileParameterService', 'serverService'];
 module.exports = TableParameterProfilesController;

--- a/traffic_portal/app/src/common/modules/table/parameterProfiles/table.parameterProfiles.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/parameterProfiles/table.parameterProfiles.tpl.html
@@ -44,9 +44,7 @@ under the License.
             <tr ng-click="editProfile(p.id)" ng-repeat="p in ::profiles" context-menu="contextMenuItems">
                 <td data-search="^{{::p.name}}$">{{::p.name}}</td>
                 <td data-search="^{{::p.name}}$">{{::p.description}}</td>
-                <td style="text-align: right;">
-                    <a class="link action-link" title="Unlink Profile from Parameter" ng-click="confirmRemoveProfile(p, $event)"><i class="fa fa-sm fa-chain-broken"></i></a>
-                </td>
+                <td><button type="button" class="btn btn-link" title="Unlink Profile from Parameter" ng-click="confirmRemoveProfile(p, $event)"><i class="fa fa-chain-broken"></i></button></td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/parameterProfiles/table.parameterProfiles.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/parameterProfiles/table.parameterProfiles.tpl.html
@@ -41,10 +41,12 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="pp in ::parameterProfiles">
-                <td data-search="^{{::pp.name}}$">{{::pp.name}}</td>
-                <td data-search="^{{::pp.name}}$">{{::pp.description}}</td>
-                <td><button type="button" class="btn btn-link" title="Unlink Profile from Parameter" ng-click="confirmRemoveProfile(pp)"><i class="fa fa-chain-broken"></i></button></td>
+            <tr ng-click="editProfile(p.id)" ng-repeat="p in ::profiles" context-menu="contextMenuItems">
+                <td data-search="^{{::p.name}}$">{{::p.name}}</td>
+                <td data-search="^{{::p.name}}$">{{::p.description}}</td>
+                <td style="text-align: right;">
+                    <a class="link action-link" title="Unlink Profile from Parameter" ng-click="confirmRemoveProfile(p, $event)"><i class="fa fa-sm fa-chain-broken"></i></a>
+                </td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/parameters/table.parameters.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/parameters/table.parameters.tpl.html
@@ -41,7 +41,7 @@ under the License.
                 </tr>
             </thead>
             <tbody>
-                <tr ng-click="editParameter(p.id)" ng-repeat="p in ::parameters">
+                <tr ng-click="editParameter(p.id)" ng-repeat="p in ::parameters" context-menu="contextMenuItems">
                     <td data-search="^{{::p.name}}$">{{::p.name}}</td>
                     <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
                     <td data-search="^{{::p.value}}$">{{::p.value}}</td>

--- a/traffic_portal/app/src/common/modules/table/physLocationServers/TablePhysLocationServersController.js
+++ b/traffic_portal/app/src/common/modules/table/physLocationServers/TablePhysLocationServersController.js
@@ -17,46 +17,22 @@
  * under the License.
  */
 
-var TablePhysLocationServersController = function(physLocation, servers, $scope, $state, locationUtils, serverUtils, propertiesModel) {
+var TablePhysLocationServersController = function(physLocation, servers, $controller, $scope) {
+
+	// extends the TableServersController to inherit common methods
+	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
 
 	$scope.physLocation = physLocation;
 
-	$scope.servers = servers;
-
-	$scope.editServer = function(id) {
-		locationUtils.navigateToPath('/servers/' + id);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.showChartsButton = propertiesModel.properties.servers.charts.show;
-
-	$scope.ssh = serverUtils.ssh;
-
-	$scope.gotoMonitor = serverUtils.gotoMonitor;
-
-	$scope.openCharts = serverUtils.openCharts;
-
-	$scope.isOffline = serverUtils.isOffline;
-
-	$scope.offlineReason = serverUtils.offlineReason;
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#serversTable').dataTable({
+		$('#physLocServersTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
-			"columnDefs": [
-				{ 'orderable': false, 'targets': 12 }
-			],
 			"aaSorting": []
 		});
 	});
 
 };
 
-TablePhysLocationServersController.$inject = ['physLocation', 'servers', '$scope', '$state', 'locationUtils', 'serverUtils', 'propertiesModel'];
+TablePhysLocationServersController.$inject = ['physLocation', 'servers', '$controller', '$scope'];
 module.exports = TablePhysLocationServersController;

--- a/traffic_portal/app/src/common/modules/table/physLocationServers/table.physLocationServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/physLocationServers/table.physLocationServers.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="serversTable" class="table responsive-utilities jambo_table">
+        <table id="physLocServersTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>UPD</th>
@@ -46,11 +46,10 @@ under the License.
                 <th>Cache Group</th>
                 <th>Phys Location</th>
                 <th>ILO</th>
-                <th style="text-align: right;">Actions</th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}">
+            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
                 <td data-search="{{(s.updPending) ? 'UPD' : ''}}" data-order="{{::s.updPending}}">
                     <i title="Updates Pending" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
                     <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
@@ -69,10 +68,6 @@ under the License.
                 <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
                 <td data-search="^{{::s.physLocation}}$">{{::s.physLocation}}</td>
                 <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
-                <td style="text-align: right;">
-                    <span ng-if="s.type == 'RASCAL'"><a class="link action-link" title="Go to" ng-click="gotoMonitor(s, $event)"><i class="fa fa-sm fa-external-link"></i>&nbsp;&nbsp;</a></span>
-                    <span ng-if="showChartsButton"><a class="link action-link" title="View Charts" ng-click="openCharts(s, $event)"><i class="fa fa-sm fa-bar-chart"></i></a></span>
-                </td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/profileDeliveryServices/TableProfileDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/profileDeliveryServices/TableProfileDeliveryServicesController.js
@@ -17,42 +17,15 @@
  * under the License.
  */
 
-var TableProfileDeliveryServicesController = function(profile, deliveryServices, $scope, $state, dateUtils, deliveryServiceUtils, locationUtils, propertiesModel) {
+var TableProfileDeliveryServicesController = function(profile, deliveryServices, $controller, $scope) {
 
-	var protocols = deliveryServiceUtils.protocols;
-
-	var qstrings = deliveryServiceUtils.qstrings;
+	// extends the TableDeliveryServicesController to inherit common methods
+	angular.extend(this, $controller('TableDeliveryServicesController', { deliveryServices: deliveryServices, $scope: $scope }));
 
 	$scope.profile = profile;
 
-	$scope.deliveryServices = deliveryServices;
-
-	$scope.showChartsButton = propertiesModel.properties.deliveryServices.charts.customLink.show;
-
-	$scope.openCharts = deliveryServiceUtils.openCharts;
-
-	$scope.protocol = function(ds) {
-		return protocols[ds.protocol];
-	};
-
-	$scope.qstring = function(ds) {
-		return qstrings[ds.qstringIgnore];
-	};
-
-	$scope.getRelativeTime = dateUtils.getRelativeTime;
-
-	$scope.editDeliveryService = function(ds) {
-		locationUtils.navigateToPath('/delivery-services/' + ds.id + '?type=' + ds.type);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#deliveryServicesTable').dataTable({
+		$('#profileDeliveryServicesTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
 			"columnDefs": [
@@ -64,5 +37,5 @@ var TableProfileDeliveryServicesController = function(profile, deliveryServices,
 
 };
 
-TableProfileDeliveryServicesController.$inject = ['profile', 'deliveryServices', '$scope', '$state', 'dateUtils', 'deliveryServiceUtils', 'locationUtils', 'propertiesModel'];
+TableProfileDeliveryServicesController.$inject = ['profile', 'deliveryServices', '$controller', '$scope'];
 module.exports = TableProfileDeliveryServicesController;

--- a/traffic_portal/app/src/common/modules/table/profileDeliveryServices/table.profileDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/profileDeliveryServices/table.profileDeliveryServices.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="deliveryServicesTable" class="table responsive-utilities jambo_table">
+        <table id="profileDeliveryServicesTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>Key (XML ID)</th>
@@ -50,7 +50,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices">
+            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices" context-menu="contextMenuItems">
                 <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
                 <td data-search="^{{::ds.tenant}}$">{{::ds.tenant}}</td>
                 <td data-search="^{{::ds.orgServerFqdn}}$">{{::ds.orgServerFqdn}}</td>

--- a/traffic_portal/app/src/common/modules/table/profileParameters/TableProfileParametersController.js
+++ b/traffic_portal/app/src/common/modules/table/profileParameters/TableProfileParametersController.js
@@ -17,11 +17,23 @@
  * under the License.
  */
 
-var TableProfileParametersController = function(profile, profileParameters, $scope, $state, $uibModal, locationUtils, deliveryServiceService, profileParameterService, serverService) {
+var TableProfileParametersController = function(profile, parameters, $controller, $scope, $state, $uibModal, locationUtils, deliveryServiceService, profileParameterService, serverService) {
+
+	// extends the TableParametersController to inherit common methods
+	angular.extend(this, $controller('TableParametersController', { parameters: parameters, $scope: $scope }));
 
 	$scope.profile = profile;
 
-	$scope.profileParameters = profileParameters;
+	// adds some items to the base parameters context menu
+	$scope.contextMenuItems.splice(2, 0,
+		{
+			text: 'Unlink Parameter from Profile',
+			click: function ($itemScope) {
+				$scope.confirmRemoveParam($itemScope.p);
+			}
+		},
+		null // Divider
+	);
 
 	var removeParameter = function(paramId) {
 		profileParameterService.unlinkProfileParameter(profile.id, paramId)
@@ -91,10 +103,6 @@ var TableProfileParametersController = function(profile, profileParameters, $sco
 		}
 	};
 
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
 	$scope.selectParams = function() {
 		var modalInstance = $uibModal.open({
 			templateUrl: 'common/modules/table/profileParameters/table.profileParamsUnassigned.tpl.html',
@@ -108,7 +116,7 @@ var TableProfileParametersController = function(profile, profileParameters, $sco
 					return parameterService.getParameters();
 				},
 				assignedParams: function() {
-					return profileParameters;
+					return parameters;
 				}
 			}
 		});
@@ -180,5 +188,5 @@ var TableProfileParametersController = function(profile, profileParameters, $sco
 
 };
 
-TableProfileParametersController.$inject = ['profile', 'profileParameters', '$scope', '$state', '$uibModal', 'locationUtils', 'deliveryServiceService', 'profileParameterService', 'serverService'];
+TableProfileParametersController.$inject = ['profile', 'parameters', '$controller', '$scope', '$state', '$uibModal', 'locationUtils', 'deliveryServiceService', 'profileParameterService', 'serverService'];
 module.exports = TableProfileParametersController;

--- a/traffic_portal/app/src/common/modules/table/profileParameters/table.profileParameters.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/profileParameters/table.profileParameters.tpl.html
@@ -43,12 +43,12 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="pp in ::profileParameters">
-                <td data-search="^{{::pp.name}}$">{{::pp.name}}</td>
-                <td data-search="^{{::pp.configFile}}$">{{::pp.configFile}}</td>
-                <td data-search="^{{::pp.value}}$">{{::pp.value}}</td>
-                <td data-search="^{{::pp.secure}}$">{{::pp.secure}}</td>
-                <td><button type="button" class="btn btn-link" title="Unlink Parameter from Profile" ng-click="confirmRemoveParam(pp)"><i class="fa fa-chain-broken"></i></button></td>
+            <tr ng-repeat="p in ::parameters" context-menu="contextMenuItems">
+                <td data-search="^{{::p.name}}$">{{::p.name}}</td>
+                <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
+                <td data-search="^{{::p.value}}$">{{::p.value}}</td>
+                <td data-search="^{{::p.secure}}$">{{::p.secure}}</td>
+                <td><button type="button" class="btn btn-link" title="Unlink Parameter from Profile" ng-click="confirmRemoveParam(p)"><i class="fa fa-chain-broken"></i></button></td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/profileServers/TableProfileServersController.js
+++ b/traffic_portal/app/src/common/modules/table/profileServers/TableProfileServersController.js
@@ -17,46 +17,22 @@
  * under the License.
  */
 
-var TableProfileServersController = function(profile, servers, $scope, $state, locationUtils, serverUtils, propertiesModel) {
+var TableProfileServersController = function(profile, servers, $controller, $scope) {
+
+	// extends the TableServersController to inherit common methods
+	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
 
 	$scope.profile = profile;
 
-	$scope.servers = servers;
-
-	$scope.editServer = function(id) {
-		locationUtils.navigateToPath('/servers/' + id);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.showChartsButton = propertiesModel.properties.servers.charts.show;
-
-	$scope.ssh = serverUtils.ssh;
-
-	$scope.gotoMonitor = serverUtils.gotoMonitor;
-
-	$scope.openCharts = serverUtils.openCharts;
-
-	$scope.isOffline = serverUtils.isOffline;
-
-	$scope.offlineReason = serverUtils.offlineReason;
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#serversTable').dataTable({
+		$('#profileServersTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
-			"columnDefs": [
-				{ 'orderable': false, 'targets': 12 }
-			],
 			"aaSorting": []
 		});
 	});
 
 };
 
-TableProfileServersController.$inject = ['profile', 'servers', '$scope', '$state', 'locationUtils', 'serverUtils', 'propertiesModel'];
+TableProfileServersController.$inject = ['profile', 'servers', '$controller', '$scope'];
 module.exports = TableProfileServersController;

--- a/traffic_portal/app/src/common/modules/table/profileServers/table.profileServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/profileServers/table.profileServers.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="serversTable" class="table responsive-utilities jambo_table">
+        <table id="profileServersTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>UPD</th>
@@ -46,11 +46,10 @@ under the License.
                 <th>Cache Group</th>
                 <th>Phys Location</th>
                 <th>ILO</th>
-                <th style="text-align: right;">Actions</th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}">
+            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
                 <td data-search="{{(s.updPending) ? 'UPD' : ''}}" data-order="{{::s.updPending}}">
                     <i title="Updates Pending" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
                     <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
@@ -69,10 +68,6 @@ under the License.
                 <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
                 <td data-search="^{{::s.physLocation}}$">{{::s.physLocation}}</td>
                 <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
-                <td style="text-align: right;">
-                    <span ng-if="s.type == 'RASCAL'"><a class="link action-link" title="Go to" ng-click="gotoMonitor(s, $event)"><i class="fa fa-sm fa-external-link"></i>&nbsp;&nbsp;</a></span>
-                    <span ng-if="showChartsButton"><a class="link action-link" title="View Charts" ng-click="openCharts(s, $event)"><i class="fa fa-sm fa-bar-chart"></i></a></span>
-                </td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/profiles/table.profiles.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/profiles/table.profiles.tpl.html
@@ -51,7 +51,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editProfile(p.id)" ng-repeat="p in ::profiles">
+            <tr ng-click="editProfile(p.id)" ng-repeat="p in ::profiles" context-menu="contextMenuItems">
                 <td data-search="^{{::p.name}}$">{{::p.name}}</td>
                 <td data-search="^{{::p.type}}$">{{::p.type}}</td>
                 <td data-search="^{{::p.routingDisabled}}$">{{::p.routingDisabled}}</td>

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.serverDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.serverDeliveryServices.tpl.html
@@ -41,7 +41,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="deliveryServicesTable" class="table responsive-utilities jambo_table">
+        <table id="serverDeliveryServicesTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>Key (XML ID)</th>
@@ -60,7 +60,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="ds in ::serverDeliveryServices">
+            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices" context-menu="contextMenuItems">
                 <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
                 <td data-search="^{{::ds.tenant}}$">{{::ds.tenant}}</td>
                 <td data-search="^{{::ds.orgServerFqdn}}$">{{::ds.orgServerFqdn}}</td>

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -17,11 +17,34 @@
  * under the License.
  */
 
-var TableServersController = function(servers, $scope, $state, $uibModal, locationUtils, serverUtils, cdnService, propertiesModel) {
+var TableServersController = function(servers, $scope, $state, $uibModal, $window, locationUtils, serverUtils, cdnService, serverService, statusService, propertiesModel, messageModel) {
 
-    $scope.servers = servers;
+    var getStatuses = function() {
+        statusService.getStatuses()
+            .then(function(result) {
+                $scope.statuses = result;
+            });
+    };
 
-    var queueServerUpdates = function(cdnId) {
+    var queueServerUpdates = function(server) {
+        serverService.queueServerUpdates(server.id)
+            .then(
+                function() {
+                    $scope.refresh();
+                }
+            );
+    };
+
+    var clearServerUpdates = function(server) {
+        serverService.clearServerUpdates(server.id)
+            .then(
+                function() {
+                    $scope.refresh();
+                }
+            );
+    };
+
+    var queueCDNServerUpdates = function(cdnId) {
         cdnService.queueServerUpdates(cdnId)
             .then(
                 function() {
@@ -30,7 +53,7 @@ var TableServersController = function(servers, $scope, $state, $uibModal, locati
             );
     };
 
-    var clearServerUpdates = function(cdnId) {
+    var clearCDNServerUpdates = function(cdnId) {
         cdnService.clearServerUpdates(cdnId)
             .then(
                 function() {
@@ -38,6 +61,153 @@ var TableServersController = function(servers, $scope, $state, $uibModal, locati
                 }
             );
     };
+
+    var confirmDelete = function(server) {
+        var params = {
+            title: 'Delete Server: ' + server.hostName,
+            key: server.hostName
+        };
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
+            controller: 'DialogDeleteController',
+            size: 'md',
+            resolve: {
+                params: function () {
+                    return params;
+                }
+            }
+        });
+        modalInstance.result.then(function() {
+            deleteServer(server);
+        }, function () {
+            // do nothing
+        });
+    };
+
+    var deleteServer = function(server) {
+        serverService.deleteServer(server.id)
+            .then(function(result) {
+                messageModel.setMessages(result.alerts, false);
+                $scope.refresh();
+            });
+    };
+
+    var confirmStatusUpdate = function(server) {
+        var modalInstance = $uibModal.open({
+            templateUrl: 'common/modules/dialog/select/status/dialog.select.status.tpl.html',
+            controller: 'DialogSelectStatusController',
+            size: 'md',
+            resolve: {
+                server: function() {
+                    return server;
+                },
+                statuses: function() {
+                    return $scope.statuses;
+                }
+            }
+        });
+        modalInstance.result.then(function(status) {
+            updateStatus(status, server);
+        }, function () {
+            // do nothing
+        });
+    };
+
+    var updateStatus = function(status, server) {
+        serverService.updateStatus(server.id, { status: status.id, offlineReason: status.offlineReason })
+            .then(
+                function(result) {
+                    messageModel.setMessages(result.data.alerts, false);
+                    $scope.refresh();
+                },
+                function(fault) {
+                    messageModel.setMessages(fault.data.alerts, false);
+                }
+            );
+    };
+
+    $scope.servers = servers;
+
+    $scope.contextMenuItems = [
+        {
+            text: 'Open Server Config in New Tab',
+            click: function ($itemScope) {
+                $window.open('/#!/servers/' + $itemScope.s.id, '_blank');
+            }
+        },
+        {
+            text: 'Navigate to Server FQDN',
+            click: function ($itemScope) {
+                $window.open('http://' + $itemScope.s.hostName + '.' + $itemScope.s.domainName, '_blank');
+            }
+        },
+        null, // Divider
+        {
+            text: 'Edit',
+            click: function ($itemScope) {
+                $scope.editServer($itemScope.s.id);
+            }
+        },
+        {
+            text: 'Delete',
+            click: function ($itemScope) {
+                confirmDelete($itemScope.s);
+            }
+        },
+        null, // Divider
+        {
+            text: 'Update Status',
+            click: function ($itemScope) {
+                confirmStatusUpdate($itemScope.s);
+            }
+        },
+        {
+            text: 'Queue Server Updates',
+            displayed: function ($itemScope) {
+                return serverUtils.isCache($itemScope.s) && !$itemScope.s.updPending;
+            },
+            click: function ($itemScope) {
+                queueServerUpdates($itemScope.s);
+            }
+        },
+        {
+            text: 'Clear Server Updates',
+            displayed: function ($itemScope) {
+                return serverUtils.isCache($itemScope.s) && $itemScope.s.updPending;
+            },
+            click: function ($itemScope) {
+                clearServerUpdates($itemScope.s);
+            }
+        },
+        null, // Divider
+        {
+            text: 'Show Charts',
+            displayed: function () {
+                return propertiesModel.properties.servers.charts.show;
+            },
+            hasBottomDivider: function () {
+                return true;
+            },
+            click: function ($itemScope) {
+                $window.open(propertiesModel.properties.servers.charts.baseUrl + $itemScope.s.hostName, '_blank');
+            }
+        },
+        {
+            text: 'Manage Delivery Services',
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/servers/' + $itemScope.s.id + '/delivery-services');
+            }
+        },
+        {
+            text: 'View Config Files',
+            displayed: function ($itemScope) {
+                return serverUtils.isCache($itemScope.s);
+            },
+            click: function ($itemScope) {
+                locationUtils.navigateToPath('/servers/' + $itemScope.s.id + '/config-files');
+            }
+        }
+    ];
 
     $scope.editServer = function(id) {
         locationUtils.navigateToPath('/servers/' + id);
@@ -47,84 +217,130 @@ var TableServersController = function(servers, $scope, $state, $uibModal, locati
         locationUtils.navigateToPath('/servers/new');
     };
 
-    $scope.confirmQueueServerUpdates = function() {
-        var params = {
-            title: 'Queue Server Updates',
-            message: "Please select a CDN"
-        };
-        var modalInstance = $uibModal.open({
-            templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
-            controller: 'DialogSelectController',
-            size: 'md',
-            resolve: {
-                params: function () {
-                    return params;
-                },
-                collection: function(cdnService) {
-                    return cdnService.getCDNs();
+    $scope.confirmCDNQueueServerUpdates = function(cdn) {
+        var params;
+        if (cdn) {
+            params = {
+                title: 'Queue Server Updates: ' + cdn.name,
+                message: 'Are you sure you want to queue server updates for all ' + cdn.name + ' servers?'
+            };
+            var modalInstance = $uibModal.open({
+                templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
+                controller: 'DialogConfirmController',
+                size: 'md',
+                resolve: {
+                    params: function () {
+                        return params;
+                    }
                 }
-            }
-        });
-        modalInstance.result.then(function(cdn) {
-            queueServerUpdates(cdn.id);
-        }, function () {
-            // do nothing
-        });
+            });
+            modalInstance.result.then(function() {
+                queueCDNServerUpdates(cdn.id);
+            }, function () {
+                // do nothing
+            });
+        } else {
+            params = {
+                title: 'Queue Server Updates',
+                message: "Please select a CDN"
+            };
+            var modalInstance = $uibModal.open({
+                templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+                controller: 'DialogSelectController',
+                size: 'md',
+                resolve: {
+                    params: function () {
+                        return params;
+                    },
+                    collection: function(cdnService) {
+                        return cdnService.getCDNs();
+                    }
+                }
+            });
+            modalInstance.result.then(function(cdn) {
+                queueCDNServerUpdates(cdn.id);
+            }, function () {
+                // do nothing
+            });
+        }
     };
 
-    $scope.confirmClearServerUpdates = function() {
-        var params = {
-            title: 'Clear Server Updates',
-            message: "Please select a CDN"
-        };
-        var modalInstance = $uibModal.open({
-            templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
-            controller: 'DialogSelectController',
-            size: 'md',
-            resolve: {
-                params: function () {
-                    return params;
-                },
-                collection: function(cdnService) {
-                    return cdnService.getCDNs();
+    $scope.confirmCDNClearServerUpdates = function(cdn) {
+        var params;
+        if (cdn) {
+            params = {
+                title: 'Clear Server Updates: ' + cdn.name,
+                message: 'Are you sure you want to clear server updates for all ' + cdn.name + ' servers?'
+            };
+            var modalInstance = $uibModal.open({
+                templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
+                controller: 'DialogConfirmController',
+                size: 'md',
+                resolve: {
+                    params: function () {
+                        return params;
+                    }
                 }
-            }
-        });
-        modalInstance.result.then(function(cdn) {
-            clearServerUpdates(cdn.id);
-        }, function () {
-            // do nothing
-        });
+            });
+            modalInstance.result.then(function() {
+                clearCDNServerUpdates(cdn.id);
+            }, function () {
+                // do nothing
+            });
+
+
+        } else {
+            params = {
+                title: 'Clear Server Updates',
+                message: "Please select a CDN"
+            };
+            var modalInstance = $uibModal.open({
+                templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+                controller: 'DialogSelectController',
+                size: 'md',
+                resolve: {
+                    params: function () {
+                        return params;
+                    },
+                    collection: function(cdnService) {
+                        return cdnService.getCDNs();
+                    }
+                }
+            });
+            modalInstance.result.then(function(cdn) {
+                clearCDNServerUpdates(cdn.id);
+            }, function () {
+                // do nothing
+            });
+        }
     };
 
     $scope.refresh = function() {
         $state.reload(); // reloads all the resolves for the view
     };
 
-    $scope.showChartsButton = propertiesModel.properties.servers.charts.show;
-
     $scope.ssh = serverUtils.ssh;
-
-    $scope.gotoMonitor = serverUtils.gotoMonitor;
-
-    $scope.openCharts = serverUtils.openCharts;
 
     $scope.isOffline = serverUtils.isOffline;
 
     $scope.offlineReason = serverUtils.offlineReason;
 
+    $scope.navigateToPath = locationUtils.navigateToPath;
+
+    var init = function () {
+        getStatuses();
+    };
+    init();
+
     angular.element(document).ready(function () {
         $('#serversTable').dataTable({
             "aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
             "iDisplayLength": 25,
-            "columnDefs": [
-                { 'orderable': false, 'targets': 12 }
-            ],
             "aaSorting": []
         });
     });
 
 };
 
-TableServersController.$inject = ['servers', '$scope', '$state', '$uibModal', 'locationUtils', 'serverUtils', 'cdnService', 'propertiesModel'];
+TableServersController.$inject = ['servers', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'serverUtils', 'cdnService', 'serverService', 'statusService', 'propertiesModel', 'messageModel'];
 module.exports = TableServersController;

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -130,11 +130,12 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 
     $scope.contextMenuItems = [
         {
-            text: 'Open Server Config in New Tab',
+            text: 'Open in New Tab',
             click: function ($itemScope) {
                 $window.open('/#!/servers/' + $itemScope.s.id, '_blank');
             }
         },
+        null, // Divider
         {
             text: 'Navigate to Server FQDN',
             click: function ($itemScope) {

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -31,8 +31,8 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-click="confirmQueueServerUpdates()">Queue Server Updates</a></li>
-                    <li role="menuitem"><a ng-click="confirmClearServerUpdates()">Clear Server Updates</a></li>
+                    <li role="menuitem"><a ng-click="confirmCDNQueueServerUpdates(null)">Queue CDN Server Updates</a></li>
+                    <li role="menuitem"><a ng-click="confirmCDNClearServerUpdates(null)">Clear CDN Server Updates</a></li>
                 </ul>
             </div>
         </div>
@@ -55,11 +55,10 @@ under the License.
                 <th>Cache Group</th>
                 <th>Phys Location</th>
                 <th>ILO</th>
-                <th style="text-align: right;">Actions</th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}">
+            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
                 <td data-search="{{(s.updPending) ? 'UPD' : ''}}" data-order="{{::s.updPending}}">
                     <i title="Updates Pending" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
                     <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
@@ -78,10 +77,6 @@ under the License.
                 <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
                 <td data-search="^{{::s.physLocation}}$">{{::s.physLocation}}</td>
                 <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
-                <td style="text-align: right;">
-                    <span ng-if="s.type == 'RASCAL'"><a class="link action-link" title="Go to" ng-click="gotoMonitor(s, $event)"><i class="fa fa-sm fa-external-link"></i>&nbsp;&nbsp;</a></span>
-                    <span ng-if="showChartsButton"><a class="link action-link" title="View Charts" ng-click="openCharts(s, $event)"><i class="fa fa-sm fa-bar-chart"></i></a></span>
-                </td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/statusServers/TableStatusServersController.js
+++ b/traffic_portal/app/src/common/modules/table/statusServers/TableStatusServersController.js
@@ -17,46 +17,22 @@
  * under the License.
  */
 
-var TableStatusServersController = function(status, servers, $scope, $state, locationUtils, serverUtils, propertiesModel) {
+var TableStatusServersController = function(status, servers, $controller, $scope) {
+
+	// extends the TableServersController to inherit common methods
+	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
 
 	$scope.status = status;
 
-	$scope.servers = servers;
-
-	$scope.editServer = function(id) {
-		locationUtils.navigateToPath('/servers/' + id);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.showChartsButton = propertiesModel.properties.servers.charts.show;
-
-	$scope.ssh = serverUtils.ssh;
-
-	$scope.gotoMonitor = serverUtils.gotoMonitor;
-
-	$scope.openCharts = serverUtils.openCharts;
-
-	$scope.isOffline = serverUtils.isOffline;
-
-	$scope.offlineReason = serverUtils.offlineReason;
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#serversTable').dataTable({
+		$('#statusServersTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
-			"columnDefs": [
-				{ 'orderable': false, 'targets': 12 }
-			],
 			"aaSorting": []
 		});
 	});
 
 };
 
-TableStatusServersController.$inject = ['status', 'servers', '$scope', '$state', 'locationUtils', 'serverUtils', 'propertiesModel'];
+TableStatusServersController.$inject = ['status', 'servers', '$controller', '$scope'];
 module.exports = TableStatusServersController;

--- a/traffic_portal/app/src/common/modules/table/statusServers/table.statusServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/statusServers/table.statusServers.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="serversTable" class="table responsive-utilities jambo_table">
+        <table id="statusServersTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>UPD</th>
@@ -46,11 +46,10 @@ under the License.
                 <th>Cache Group</th>
                 <th>Phys Location</th>
                 <th>ILO</th>
-                <th style="text-align: right;">Actions</th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}">
+            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
                 <td data-search="{{(s.updPending) ? 'UPD' : ''}}" data-order="{{::s.updPending}}">
                     <i title="Updates Pending" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
                     <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
@@ -69,10 +68,6 @@ under the License.
                 <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
                 <td data-search="^{{::s.physLocation}}$">{{::s.physLocation}}</td>
                 <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
-                <td style="text-align: right;">
-                    <span ng-if="s.type == 'RASCAL'"><a class="link action-link" title="Go to" ng-click="gotoMonitor(s, $event)"><i class="fa fa-sm fa-external-link"></i>&nbsp;&nbsp;</a></span>
-                    <span ng-if="showChartsButton"><a class="link action-link" title="View Charts" ng-click="openCharts(s, $event)"><i class="fa fa-sm fa-bar-chart"></i></a></span>
-                </td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/tenantDeliveryServices/TableTenantDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/tenantDeliveryServices/TableTenantDeliveryServicesController.js
@@ -17,39 +17,12 @@
  * under the License.
  */
 
-var TableTenantDeliveryServicesController = function(tenant, tenantDeliveryServices, $scope, $state, dateUtils, deliveryServiceUtils, locationUtils, propertiesModel) {
+var TableTenantDeliveryServicesController = function(tenant, deliveryServices, $controller, $scope) {
 
-	var protocols = deliveryServiceUtils.protocols;
-
-	var qstrings = deliveryServiceUtils.qstrings;
+	// extends the TableDeliveryServicesController to inherit common methods
+	angular.extend(this, $controller('TableDeliveryServicesController', { deliveryServices: deliveryServices, $scope: $scope }));
 
 	$scope.tenant = tenant;
-
-	$scope.tenantDeliveryServices = tenantDeliveryServices;
-
-	$scope.showChartsButton = propertiesModel.properties.deliveryServices.charts.customLink.show;
-
-	$scope.openCharts = deliveryServiceUtils.openCharts;
-
-	$scope.protocol = function(ds) {
-		return protocols[ds.protocol];
-	};
-
-	$scope.qstring = function(ds) {
-		return qstrings[ds.qstringIgnore];
-	};
-
-	$scope.getRelativeTime = dateUtils.getRelativeTime;
-
-	$scope.editDeliveryService = function(ds) {
-		locationUtils.navigateToPath('/delivery-services/' + ds.id + '?type=' + ds.type);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
 
 	angular.element(document).ready(function () {
 		$('#tenantDSsTable').dataTable({
@@ -64,5 +37,5 @@ var TableTenantDeliveryServicesController = function(tenant, tenantDeliveryServi
 
 };
 
-TableTenantDeliveryServicesController.$inject = ['tenant', 'tenantDeliveryServices', '$scope', '$state', 'dateUtils', 'deliveryServiceUtils', 'locationUtils', 'propertiesModel'];
+TableTenantDeliveryServicesController.$inject = ['tenant', 'deliveryServices', '$controller', '$scope'];
 module.exports = TableTenantDeliveryServicesController;

--- a/traffic_portal/app/src/common/modules/table/tenantDeliveryServices/table.tenantDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/tenantDeliveryServices/table.tenantDeliveryServices.tpl.html
@@ -50,7 +50,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::tenantDeliveryServices">
+            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices" context-menu="contextMenuItems">
                 <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
                 <td data-search="^{{::ds.tenant}}$">{{::ds.tenant}}</td>
                 <td data-search="^{{::ds.orgServerFqdn}}$">{{::ds.orgServerFqdn}}</td>

--- a/traffic_portal/app/src/common/modules/table/typeCacheGroups/TableTypeCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/typeCacheGroups/TableTypeCacheGroupsController.js
@@ -17,31 +17,16 @@
  * under the License.
  */
 
-var TableTypeCacheGroupsController = function(type, cacheGroups, $scope, $state, locationUtils) {
+var TableTypeCacheGroupsController = function(type, cacheGroups, $controller, $scope, $state, locationUtils) {
+
+	// extends the TableCacheGroupsController to inherit common methods
+	angular.extend(this, $controller('TableCacheGroupsController', { cacheGroups: cacheGroups, $scope: $scope }));
 
 	$scope.type = type;
 
-	$scope.cacheGroups = cacheGroups;
-
-	$scope.editCacheGroup = function(id) {
-		locationUtils.navigateToPath('/cache-groups/' + id);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
 	$scope.navigateToPath = locationUtils.navigateToPath;
-
-	angular.element(document).ready(function () {
-		$('#cacheGroupsTable').dataTable({
-			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
-			"iDisplayLength": 25,
-			"aaSorting": []
-		});
-	});
 
 };
 
-TableTypeCacheGroupsController.$inject = ['type', 'cacheGroups', '$scope', '$state', 'locationUtils'];
+TableTypeCacheGroupsController.$inject = ['type', 'cacheGroups', '$controller', '$scope', '$state', 'locationUtils'];
 module.exports = TableTypeCacheGroupsController;

--- a/traffic_portal/app/src/common/modules/table/typeCacheGroups/table.typeCacheGroups.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/typeCacheGroups/table.typeCacheGroups.tpl.html
@@ -37,15 +37,19 @@ under the License.
                 <th>Name</th>
                 <th>Short Name</th>
                 <th>Type</th>
+                <th>Parent</th>
+                <th>2nd Parent</th>
                 <th>Latitude</th>
                 <th>Longitude</th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editCacheGroup(cg.id)" ng-repeat="cg in ::cacheGroups">
+            <tr ng-click="editCacheGroup(cg.id)" ng-repeat="cg in ::cacheGroups" context-menu="contextMenuItems">
                 <td data-search="^{{::cg.name}}$">{{::cg.name}}</td>
                 <td data-search="^{{::cg.shortName}}$">{{::cg.shortName}}</td>
                 <td data-search="^{{::cg.typeName}}$">{{::cg.typeName}}</td>
+                <td data-search="^{{::cg.parentCachegroupName}}$">{{::cg.parentCachegroupName}}</td>
+                <td data-search="^{{::cg.secondaryParentCachegroupName}}$">{{::cg.secondaryParentCachegroupName}}</td>
                 <td data-search="^{{::cg.latitude}}$">{{::cg.latitude}}</td>
                 <td data-search="^{{::cg.longitude}}$">{{::cg.longitude}}</td>
             </tr>

--- a/traffic_portal/app/src/common/modules/table/typeDeliveryServices/TableTypeDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/typeDeliveryServices/TableTypeDeliveryServicesController.js
@@ -17,42 +17,15 @@
  * under the License.
  */
 
-var TableTypeDeliveryServicesController = function(type, deliveryServices, $scope, $state, dateUtils, deliveryServiceUtils, locationUtils, propertiesModel) {
+var TableTypeDeliveryServicesController = function(type, deliveryServices, $controller, $scope) {
 
-	var protocols = deliveryServiceUtils.protocols;
-
-	var qstrings = deliveryServiceUtils.qstrings;
+	// extends the TableDeliveryServicesController to inherit common methods
+	angular.extend(this, $controller('TableDeliveryServicesController', { deliveryServices: deliveryServices, $scope: $scope }));
 
 	$scope.type = type;
 
-	$scope.deliveryServices = deliveryServices;
-
-	$scope.showChartsButton = propertiesModel.properties.deliveryServices.charts.customLink.show;
-
-	$scope.openCharts = deliveryServiceUtils.openCharts;
-
-	$scope.protocol = function(ds) {
-		return protocols[ds.protocol];
-	};
-
-	$scope.qstring = function(ds) {
-		return qstrings[ds.qstringIgnore];
-	};
-
-	$scope.getRelativeTime = dateUtils.getRelativeTime;
-
-	$scope.editDeliveryService = function(ds) {
-		locationUtils.navigateToPath('/delivery-services/' + ds.id + '?type=' + ds.type);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#deliveryServicesTable').dataTable({
+		$('#typeDeliveryServicesTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
 			"columnDefs": [
@@ -64,5 +37,5 @@ var TableTypeDeliveryServicesController = function(type, deliveryServices, $scop
 
 };
 
-TableTypeDeliveryServicesController.$inject = ['type', 'deliveryServices', '$scope', '$state', 'dateUtils', 'deliveryServiceUtils', 'locationUtils', 'propertiesModel'];
+TableTypeDeliveryServicesController.$inject = ['type', 'deliveryServices', '$controller', '$scope'];
 module.exports = TableTypeDeliveryServicesController;

--- a/traffic_portal/app/src/common/modules/table/typeDeliveryServices/table.typeDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/typeDeliveryServices/table.typeDeliveryServices.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="deliveryServicesTable" class="table responsive-utilities jambo_table">
+        <table id="typeDeliveryServicesTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>Key (XML ID)</th>
@@ -50,7 +50,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices">
+            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices" context-menu="contextMenuItems">
                 <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
                 <td data-search="^{{::ds.tenant}}$">{{::ds.tenant}}</td>
                 <td data-search="^{{::ds.orgServerFqdn}}$">{{::ds.orgServerFqdn}}</td>

--- a/traffic_portal/app/src/common/modules/table/typeServers/TableTypeServersController.js
+++ b/traffic_portal/app/src/common/modules/table/typeServers/TableTypeServersController.js
@@ -17,46 +17,22 @@
  * under the License.
  */
 
-var TableTypeServersController = function(type, servers, $scope, $state, locationUtils, serverUtils, propertiesModel) {
+var TableTypeServersController = function(type, servers, $controller, $scope) {
+
+	// extends the TableServersController to inherit common methods
+	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
 
 	$scope.type = type;
 
-	$scope.servers = servers;
-
-	$scope.editServer = function(id) {
-		locationUtils.navigateToPath('/servers/' + id);
-	};
-
-	$scope.refresh = function() {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.showChartsButton = propertiesModel.properties.servers.charts.show;
-
-	$scope.ssh = serverUtils.ssh;
-
-	$scope.gotoMonitor = serverUtils.gotoMonitor;
-
-	$scope.openCharts = serverUtils.openCharts;
-
-	$scope.isOffline = serverUtils.isOffline;
-
-	$scope.offlineReason = serverUtils.offlineReason;
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#serversTable').dataTable({
+		$('#typeServersTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
-			"columnDefs": [
-				{ 'orderable': false, 'targets': 12 }
-			],
 			"aaSorting": []
 		});
 	});
 
 };
 
-TableTypeServersController.$inject = ['type', 'servers', '$scope', '$state', 'locationUtils', 'serverUtils', 'propertiesModel'];
+TableTypeServersController.$inject = ['type', 'servers', '$controller', '$scope'];
 module.exports = TableTypeServersController;

--- a/traffic_portal/app/src/common/modules/table/typeServers/table.typeServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/typeServers/table.typeServers.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="serversTable" class="table responsive-utilities jambo_table">
+        <table id="typeServersTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>UPD</th>
@@ -46,11 +46,10 @@ under the License.
                 <th>Cache Group</th>
                 <th>Phys Location</th>
                 <th>ILO</th>
-                <th style="text-align: right;">Actions</th>
             </tr>
             </thead>
             <tbody>
-            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}">
+            <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
                 <td data-search="{{(s.updPending) ? 'UPD' : ''}}" data-order="{{::s.updPending}}">
                     <i title="Updates Pending" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
                     <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
@@ -69,10 +68,6 @@ under the License.
                 <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
                 <td data-search="^{{::s.physLocation}}$">{{::s.physLocation}}</td>
                 <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
-                <td style="text-align: right;">
-                    <span ng-if="s.type == 'RASCAL'"><a class="link action-link" title="Go to" ng-click="gotoMonitor(s, $event)"><i class="fa fa-sm fa-external-link"></i>&nbsp;&nbsp;</a></span>
-                    <span ng-if="showChartsButton"><a class="link action-link" title="View Charts" ng-click="openCharts(s, $event)"><i class="fa fa-sm fa-bar-chart"></i></a></span>
-                </td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/app/src/common/modules/table/userDeliveryServices/TableUserDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/userDeliveryServices/TableUserDeliveryServicesController.js
@@ -17,38 +17,15 @@
  * under the License.
  */
 
-var TableUserDeliveryServicesController = function (user, userDeliveryServices, $scope, $state, $uibModal, dateUtils, deliveryServiceUtils, locationUtils, userService, propertiesModel) {
+var TableUserDeliveryServicesController = function (user, deliveryServices, $controller, $scope) {
 
-	var protocols = deliveryServiceUtils.protocols;
-
-	var qstrings = deliveryServiceUtils.qstrings;
+	// extends the TableDeliveryServicesController to inherit common methods
+	angular.extend(this, $controller('TableDeliveryServicesController', { deliveryServices: deliveryServices, $scope: $scope }));
 
 	$scope.user = user;
 
-	$scope.userDeliveryServices = userDeliveryServices;
-
-	$scope.showChartsButton = propertiesModel.properties.deliveryServices.charts.customLink.show;
-
-	$scope.openCharts = deliveryServiceUtils.openCharts;
-
-	$scope.protocol = function (ds) {
-		return protocols[ds.protocol];
-	};
-
-	$scope.qstring = function (ds) {
-		return qstrings[ds.qstringIgnore];
-	};
-
-	$scope.getRelativeTime = dateUtils.getRelativeTime;
-
-	$scope.refresh = function () {
-		$state.reload(); // reloads all the resolves for the view
-	};
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
-
 	angular.element(document).ready(function () {
-		$('#deliveryServicesTable').dataTable({
+		$('#userDeliveryServicesTable').dataTable({
 			"aLengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
 			"iDisplayLength": 25,
 			"aaSorting": []
@@ -57,5 +34,5 @@ var TableUserDeliveryServicesController = function (user, userDeliveryServices, 
 
 };
 
-TableUserDeliveryServicesController.$inject = ['user', 'userDeliveryServices', '$scope', '$state', '$uibModal', 'dateUtils', 'deliveryServiceUtils', 'locationUtils', 'userService', 'propertiesModel'];
+TableUserDeliveryServicesController.$inject = ['user', 'deliveryServices', '$controller', '$scope'];
 module.exports = TableUserDeliveryServicesController;

--- a/traffic_portal/app/src/common/modules/table/userDeliveryServices/table.userDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/userDeliveryServices/table.userDeliveryServices.tpl.html
@@ -31,7 +31,7 @@ under the License.
     </div>
     <div class="x_content">
         <br>
-        <table id="deliveryServicesTable" class="table responsive-utilities jambo_table">
+        <table id="userDeliveryServicesTable" class="table responsive-utilities jambo_table">
             <thead>
             <tr class="headings">
                 <th>Key (XML ID)</th>
@@ -50,7 +50,7 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="ds in ::userDeliveryServices">
+            <tr ng-click="editDeliveryService(ds)" ng-repeat="ds in ::deliveryServices" context-menu="contextMenuItems">
                 <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
                 <td data-search="^{{::ds.tenant}}$">{{::ds.tenant}}</td>
                 <td data-search="^{{::ds.orgServerFqdn}}$">{{::ds.orgServerFqdn}}</td>

--- a/traffic_portal/app/src/common/service/utils/ServerUtils.js
+++ b/traffic_portal/app/src/common/service/utils/ServerUtils.js
@@ -52,14 +52,6 @@ var ServerUtils = function($window, propertiesModel, userModel) {
 		);
 	};
 
-	this.gotoMonitor = function(server, $event) {
-		$event.stopPropagation(); // this kills the click event so it doesn't trigger anything else
-		$window.open(
-			'http://' + server.hostName + '.' + server.domainName,
-			'_blank'
-		);
-	};
-
 };
 
 ServerUtils.$inject = ['$window', 'propertiesModel', 'userModel'];

--- a/traffic_portal/app/src/modules/private/cacheGroups/parameters/index.js
+++ b/traffic_portal/app/src/modules/private/cacheGroups/parameters/index.js
@@ -30,7 +30,7 @@ module.exports = angular.module('trafficPortal.private.cacheGroups.parameters', 
 							cacheGroup: function($stateParams, cacheGroupService) {
 								return cacheGroupService.getCacheGroup($stateParams.cacheGroupId);
 							},
-							cacheGroupParameters: function($stateParams, cacheGroupParameterService) {
+							parameters: function($stateParams, cacheGroupParameterService) {
 								return cacheGroupParameterService.getCacheGroupParameters($stateParams.cacheGroupId);
 							}
 						}

--- a/traffic_portal/app/src/modules/private/parameters/profiles/index.js
+++ b/traffic_portal/app/src/modules/private/parameters/profiles/index.js
@@ -30,7 +30,7 @@ module.exports = angular.module('trafficPortal.private.parameters.profiles', [])
 							parameter: function($stateParams, parameterService) {
 								return parameterService.getParameter($stateParams.parameterId);
 							},
-							parameterProfiles: function($stateParams, profileService) {
+							profiles: function($stateParams, profileService) {
 								return profileService.getParameterProfiles($stateParams.parameterId);
 							}
 						}

--- a/traffic_portal/app/src/modules/private/profiles/parameters/index.js
+++ b/traffic_portal/app/src/modules/private/profiles/parameters/index.js
@@ -30,7 +30,7 @@ module.exports = angular.module('trafficPortal.private.profiles.parameters', [])
 							profile: function($stateParams, profileService) {
 								return profileService.getProfile($stateParams.profileId);
 							},
-							profileParameters: function($stateParams, parameterService) {
+							parameters: function($stateParams, parameterService) {
 								return parameterService.getProfileParameters($stateParams.profileId);
 							}
 						}

--- a/traffic_portal/app/src/modules/private/servers/deliveryServices/index.js
+++ b/traffic_portal/app/src/modules/private/servers/deliveryServices/index.js
@@ -30,7 +30,7 @@ module.exports = angular.module('trafficPortal.private.servers.deliveryServices'
 							server: function($stateParams, serverService) {
 								return serverService.getServer($stateParams.serverId);
 							},
-							serverDeliveryServices: function($stateParams, deliveryServiceService) {
+							deliveryServices: function($stateParams, deliveryServiceService) {
 								return deliveryServiceService.getServerDeliveryServices($stateParams.serverId);
 							}
 						}

--- a/traffic_portal/app/src/modules/private/tenants/deliveryServices/index.js
+++ b/traffic_portal/app/src/modules/private/tenants/deliveryServices/index.js
@@ -30,7 +30,7 @@ module.exports = angular.module('trafficPortal.private.tenants.deliveryServices'
 							tenant: function($stateParams, tenantService) {
 								return tenantService.getTenant($stateParams.tenantId);
 							},
-							tenantDeliveryServices: function(tenant, deliveryServiceService) {
+							deliveryServices: function(tenant, deliveryServiceService) {
 								return deliveryServiceService.getDeliveryServices({ tenant: tenant.id });
 							}
 						}

--- a/traffic_portal/app/src/modules/private/users/deliveryServices/index.js
+++ b/traffic_portal/app/src/modules/private/users/deliveryServices/index.js
@@ -30,7 +30,7 @@ module.exports = angular.module('trafficPortal.private.users.deliveryServices', 
 							user: function ($stateParams, userService) {
 								return userService.getUser($stateParams.userId);
 							},
-							userDeliveryServices: function ($stateParams, deliveryServiceService) {
+							deliveryServices: function ($stateParams, deliveryServiceService) {
 								return deliveryServiceService.getUserDeliveryServices($stateParams.userId);
 							}
 						}

--- a/traffic_portal/app/src/scripts/shared-libs.js
+++ b/traffic_portal/app/src/scripts/shared-libs.js
@@ -39,6 +39,9 @@ require('loading-bar');
 require('ui-bootstrap');
 require('ui-bootstrap-tpls');
 
+// angular bootstrap context menu
+require('contextMenu');
+
 // restangular
 require('restangular');
 

--- a/traffic_portal/app/src/styles/main.scss
+++ b/traffic_portal/app/src/styles/main.scss
@@ -54,9 +54,9 @@ $fa-font-path: "../assets/fonts";
   cursor: pointer;
 }
 
-html {
+html, body {
   position: relative;
-  min-height: 100%;
+  min-height: 100vh;
 }
 
 body {

--- a/traffic_portal/app/src/styles/theme.scss
+++ b/traffic_portal/app/src/styles/theme.scss
@@ -1292,8 +1292,6 @@ table.jambo_table thead {
 }
 table.jambo_table tbody tr:hover td {
   background: rgba(38, 185, 154, 0.07);
-  border-top: 1px solid rgba(38, 185, 154, 0.11);
-  border-bottom: 1px solid rgba(38, 185, 154, 0.11)
 }
 table.jambo_table tbody tr.selected {
   background: rgba(38, 185, 154, 0.16)

--- a/traffic_portal/bower.json
+++ b/traffic_portal/bower.json
@@ -7,7 +7,7 @@
         "angular-route": "1.6.4",
         "angular-sanitize": "1.6.4",
         "angular-bootstrap": "0.14.3",
-        "angular-bootstrap-contextmenu": "1.2.0",
+        "angular-bootstrap-contextmenu": "1.2.1",
         "angular-loading-bar": "0.8.0",
         "angular-ui-router": "0.4.2",
         "angular-jwt": "0.0.9",

--- a/traffic_portal/bower.json
+++ b/traffic_portal/bower.json
@@ -7,6 +7,7 @@
         "angular-route": "1.6.4",
         "angular-sanitize": "1.6.4",
         "angular-bootstrap": "0.14.3",
+        "angular-bootstrap-contextmenu": "1.2.0",
         "angular-loading-bar": "0.8.0",
         "angular-ui-router": "0.4.2",
         "angular-jwt": "0.0.9",

--- a/traffic_portal/grunt/browserify2.js
+++ b/traffic_portal/grunt/browserify2.js
@@ -30,6 +30,7 @@ module.exports = {
                             [
                                 'angular/angular.min.js',
                                 'angular-animate/angular-animate.min.js',
+                                'angular-bootstrap-contextmenu/contextMenu.js',
                                 'angular-bootstrap/ui-bootstrap.min.js',
                                 'angular-bootstrap/ui-bootstrap-tpls.min.js',
                                 'angular-jwt/dist/angular-jwt.min.js',
@@ -91,6 +92,7 @@ module.exports = {
                             [
                                 'angular/angular.js',
                                 'angular-animate/angular-animate.js',
+                                'angular-bootstrap-contextmenu/contextMenu.js',
                                 'angular-bootstrap/ui-bootstrap.js',
                                 'angular-bootstrap/ui-bootstrap-tpls.js',
                                 'angular-jwt/dist/angular-jwt.js',


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

This PR adds a context menu (right-click menu) to a handful of TP tables. For example, if you are looking at a table of delivery services, you can "right-click" on a delivery service to see a list of actions.

None of the functionality in the context menu is new. It is simply provided as a context menu rather than having to click on a delivery service and then perform one of these actions. So basically it saves you one mouse click (and saves one unnecessary api call). 

This PR also cleans up a lot of duplicate code by moving a lot of code into "base controllers" that can be extended.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [x] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Navigate to the following locations:

tp.domain.com/#!/cdns and right click on a cdn to see the following context menu:

![image](https://user-images.githubusercontent.com/251272/55748009-cdbe2f00-59fa-11e9-8f14-c78b029b0292.png)

tp.domain.com/#!/cache-groups and right click on a cache group to see the following context menu:

![image](https://user-images.githubusercontent.com/251272/55748048-e4fd1c80-59fa-11e9-8607-c5a077f740b0.png)

tp.domain.com/#!/parameters and right click on a parameter to see the following context menu:

![image](https://user-images.githubusercontent.com/251272/55748067-f2b2a200-59fa-11e9-802f-01e46bcf97f6.png)

tp.domain.com/#!/servers and right click on a server to see the following context menu:

![image](https://user-images.githubusercontent.com/251272/55748097-05c57200-59fb-11e9-97f4-5b4e91f77bd9.png)

tp.domain.com/#!/profiles and right click on a profile to see the following context menu:

![image](https://user-images.githubusercontent.com/251272/55748116-10800700-59fb-11e9-89fd-9df09c4d0518.png)

tp.domain.com/#!/delivery-services and right click on a delivery service to see the following context menu:

![image](https://user-images.githubusercontent.com/251272/55748138-1f66b980-59fb-11e9-99d7-6e3f00cd7ab4.png)

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [x] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



