### PR TITLE
TO API: reverts api 1.5 version to 1.4 as 1.5 wasn't needed yet

### DIFF
--- a/docs/source/api/consistenthash.rst
+++ b/docs/source/api/consistenthash.rst
@@ -37,7 +37,7 @@ Request Structure
 .. code-block:: http
 	:caption: Request Example
 
-	POST /api/1.5/consistenthash HTTP/1.1
+	POST /api/1.4/consistenthash HTTP/1.1
 	Host: trafficops.infra.ciab.test
 	User-Agent: curl/7.54.0
 	Accept: */*

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -64,12 +64,6 @@ sub define {
 	# Traffic Stats Extension 1.4
 	$self->traffic_stats_routes( $r, $version );
 
-	# 1.5 Routes
-	$version = "1.5";
-	$self->api_routes( $r, $version, $namespace );
-	# Traffic Stats Extension 1.5
-	$self->traffic_stats_routes( $r, $version );
-
 	$self->catch_all( $r, $namespace );
 }
 

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -416,7 +416,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?(\.json)?$`, api.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Pattern based consistent hashing endpoint
-		{1.5, http.MethodPost, `consistenthash/?$`, consistenthash.Post, auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.4, http.MethodPost, `consistenthash/?$`, consistenthash.Post, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		{1.4, http.MethodGet, `steering/?(\.json)?$`, steering.Get, auth.PrivLevelSteering, Authenticated, nil},
 	}

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -20,6 +20,7 @@ package status
  */
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -80,6 +81,7 @@ func TestReadStatuses(t *testing.T) {
 	obj := TOStatus{
 		api.APIInfoImpl{&reqInfo},
 		tc.StatusNullable{},
+		sql.NullString{},
 	}
 	statuses, userErr, sysErr, _ := obj.Read()
 	if userErr != nil || sysErr != nil {

--- a/traffic_portal/app/src/scripts/config.js
+++ b/traffic_portal/app/src/scripts/config.js
@@ -23,6 +23,6 @@
 
 angular.module('config', [])
 
-.constant('ENV', { api: { root:'/api/1.5/' } })
+.constant('ENV', { api: { root:'/api/1.4/' } })
 
 ;


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

TC 3.0.x has api 1.3 - https://github.com/apache/trafficcontrol/blob/3.0.x/traffic_ops/traffic_ops_golang/routes.go#L92 

After 3.0.x, changes were made to the api to warrant version 1.4. since we haven't had a release after 3.0.x, version 1.4 is the right version for the new consistenthash api endpoint.

Also, fixed a status unit test that would not build.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [x] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Run the API tests and ensure they all pass - https://github.com/apache/trafficcontrol/blob/master/traffic_ops/testing/api/README.md

Run the TO unit tests:

cd traffic_ops_golang
go test $(go list ./...)

Verify the consistent hash checker works in TP:

Navigate to a delivery service in TP and scroll to the bottom and click 'Test Regex'

![image](https://user-images.githubusercontent.com/251272/54618378-8d394a00-4a28-11e9-9fb9-030972c8a036.png)

If your environment has access to a traffic router, the endpoint should work fine.

## Check all that apply

- [x] This PR includes tests
- [x] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



