### PR TITLE
CIAB: Dynamically choose the first mid server

### DIFF
--- a/infrastructure/cdn-in-a-box/mid/run.sh
+++ b/infrastructure/cdn-in-a-box/mid/run.sh
@@ -58,7 +58,13 @@ while [[ -z $found ]]; do
     found=$(to-get api/1.3/cdns?name="$CDN" | jq -r '.response[].name')
 done
 
-to-enroll mid $CDN "CDN_in_a_Box_Mid" || (while true; do echo "enroll failed."; sleep 3 ; done)
+cachegroup=
+while [[ -z $cachegroup ]] || [[ "$cachegroup" == "null" ]]; do
+    echo 'waiting for enroller server setup'
+    sleep 3
+    cachegroup=$(to-get api/1.3/servers | jq -r '.response[0].cachegroup')
+done
+to-enroll mid $CDN $cachegroup || (while true; do echo "enroll failed."; sleep 3 ; done)
 
 while [[ -z "$(testenrolled)" ]]; do
 	echo "waiting on enrollment"

--- a/infrastructure/cdn-in-a-box/mid/run.sh
+++ b/infrastructure/cdn-in-a-box/mid/run.sh
@@ -62,7 +62,7 @@ cachegroup=
 while [[ -z $cachegroup ]] || [[ "$cachegroup" == "null" ]]; do
     echo 'waiting for enroller server setup'
     sleep 3
-    cachegroup=$(to-get api/1.3/servers | jq -r '.response[0].cachegroup')
+    cachegroup=$(to-get api/1.3/servers?type=MID_LOC | jq -r -c '.response[0].cachegroup')
 done
 to-enroll mid $CDN $cachegroup || (while true; do echo "enroll failed."; sleep 3 ; done)
 


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

This PR would enable renaming the default Mid Server by removing the hard coded name `CDN_in_a_Box_Mid`. It now calls the API until a cachegroup exists. If there are more than one cachegroups, the first is selected.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] CDN in a Box

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Change the `name` in [060-ciabMid.json](infrastructure/cdn-in-a-box/traffic_ops_data/cachegroups/060-ciabMid.json), `parentCachegroupName` in [070-ciabEdge.json](infrastructure/cdn-in-a-box/traffic_ops_data/cachegroups/070-ciabEdge.json) and start CIAB. The default Mid server should have the new name.

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->
