### PR TITLE
Ort headerrewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - traffic_ops/app/bin/checks/ToDnssecRefresh.pl now requires "user" and "pass" parameters of an operations-level user! Update your scripts accordingly! This was necessary to move to an API endpoint with proper authentication, which may be safely exposed.
 - Traffic Monitor UI updated to support HTTP or HTTPS traffic.
 - Modified Traffic Router logging format to include an additional field for DNS log entries, namely `rhi`. This defaults to '-' and is only used when EDNS0 client subnet extensions are enabled and a client subnet is present in the request. When enabled and a subnet is present, the subnet appears in the `chi` field and the resolver address is in the `rhi` field.
+- Changed traffic_ops_ort.pl so that hdr_rw-<ds>.config files are compared with strict ordering and line duplication when detecting configuration changes.
 
 ## [3.0.0] - 2018-10-30
 ### Added

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -398,7 +398,7 @@ sub process_cfg_file {
 	my $change_needed = ( join( '\0', @disk_file_lines ) ne join( '\0', @db_file_lines ) );
 
 	# if different, look deeper to see if we care about the diffs (e.g. different order)
-	if ( $change_needed && !( $cfg_file eq 'logs_xml.config' || $cfg_file =~ /\.cer$/ ) ) {
+	if ( $change_needed && !( $cfg_file eq 'logs_xml.config' || $cfg_file =~ m/\.cer$/ || $cfg_file =~ m/hdr\_rw\_(.*)\.config$/ ) ) {
 		my @return             = &diff_file_lines( $cfg_file, \@db_file_lines, \@disk_file_lines );
 		my @db_lines_missing   = @{ shift(@return) };
 		my @disk_lines_missing = @{ shift(@return) };


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

Changed traffic_ops_ort.pl so that hdr_rw-<ds>.config files are compared with
strict ordering and line duplication when detecting configuration changes.

Fixes #(replace_this_text_with_issue_number) 

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [x] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [ ] Other _________

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Using TP create (or modify) an active DS with Edge Header Rewrite Rule like the following, with appropriate __RETURN__ keywoards embedded:

```
cond %{SEND_RESPONSE_HDR_HOOK}
set-header Access-Control-Allow-Origin *
cond %{SEND_RESPONSE_HDR_HOOK}
set-header Content-Type "plain/text" [L]
```

Queue the appopriate CDN and pull the new config via traffic_ops_ort.pl syncds.  Verify the hdr_rw_<ds>.config has the above contents.

Remove one of the  
cond %{SEND_RESPONSE_HDR_HOOK}
lines, update and Queue.

Repeat with reordering the rules.

I also ran tests with the current ORT to verify that it incorrectly did not detect changes for these conditions.

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [x] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



