### PR TITLE
CIAB: update postgres version to 9.6.12

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-db
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-db
@@ -19,10 +19,10 @@
 # Dockerfile for trafficops db
 ############################################################
 
-FROM postgres:9.6.6
+FROM postgres:9.6-alpine
 
 ENV POSTGRES_PASSWORD=$POSTGRES_PASSWORD
-RUN apt-get update && apt-get install -y dnsutils net-tools
+RUN apk add bind-tools
 COPY traffic_ops/initdb.d /docker-entrypoint-initdb.d
 COPY traffic_ops/run-db.sh /
 ENTRYPOINT /run-db.sh


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

CIAB db can not be build anymore because its repository has been removed.
Check the following snapshot and this [path](http://cdn-fastly.deb.debian.org/debian/dists/) for details: 
![螢幕快照 2019-03-27 下午3 38 51](https://user-images.githubusercontent.com/5186176/55060546-af783b00-50ac-11e9-9ba9-740cb774a07a.png)

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other CIAB

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

1. build CIAB and start it
2. check if the demo page can be accessed

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



