### PR TITLE
Fixes internal server error for `cachegroups/:id/queue_update` blank field

### DIFF
--- a/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
@@ -49,10 +49,14 @@ func QueueUpdates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if reqObj.CDN == nil && reqObj.CDNID == nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("cdn does not exist"), nil)
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("cdn is a required field"), nil)
 		return
 	}
-	if reqObj.CDN == nil || *reqObj.CDN == "" {
+	if *reqObj.CDN == "" {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("cdn cannot be blank"), nil)
+		return
+	}
+	if reqObj.CDNID != nil && reqObj.CDN == nil || *reqObj.CDN == "" {
 		cdn, ok, err := dbhelpers.GetCDNNameFromID(inf.Tx.Tx, int64(*reqObj.CDNID))
 		if err != nil {
 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting CDN name from ID '"+strconv.Itoa(int(*reqObj.CDNID))+"': "+err.Error()))

--- a/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
@@ -48,15 +48,11 @@ func QueueUpdates(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("action must be 'queue' or 'dequeue'"), nil)
 		return
 	}
-	if reqObj.CDN == nil && reqObj.CDNID == nil {
+	if reqObj.CDNID == nil && (reqObj.CDN == nil || *reqObj.CDN == "") {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("cdn is a required field"), nil)
 		return
 	}
-	if *reqObj.CDN == "" {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("cdn cannot be blank"), nil)
-		return
-	}
-	if reqObj.CDNID != nil && reqObj.CDN == nil || *reqObj.CDN == "" {
+	if reqObj.CDNID != nil && (reqObj.CDN == nil || *reqObj.CDN == "") {
 		cdn, ok, err := dbhelpers.GetCDNNameFromID(inf.Tx.Tx, int64(*reqObj.CDNID))
 		if err != nil {
 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting CDN name from ID '"+strconv.Itoa(int(*reqObj.CDNID))+"': "+err.Error()))


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

Fixes #2933 
Also adds error message for when cdn is blank, preventing an internal server error that is caused by a panic.

## Which TC components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

Post to the endpoint using a blank cdn and then with no cdn (as it is mentioned in the issue)
`curl --cookie $mc -d '{"action": "queue", "cdn": ""}' -Lvsk "https://localhost:6443/api/1.1/cachegroups/7/queue_update"`

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [x] This PR does not include a database migration
- [x] This PR does not fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



