### PR TITLE
TO: Give a better error message when deleting an object being referenced

### DIFF
--- a/traffic_ops/testing/api/v14/divisions_test.go
+++ b/traffic_ops/testing/api/v14/divisions_test.go
@@ -33,7 +33,13 @@ func TestDivisions(t *testing.T) {
 
 func TryToDeleteDivision(t *testing.T) {
 	division := testData.Divisions[0]
-	_, _, err := TOSession.DeleteDivisionByName(division.Name)
+
+	resp, _, err := TOSession.GetDivisionByName(division.Name)
+	if err != nil {
+		t.Errorf("cannot GET Division by name: %v - %v\n", division.Name, err)
+	}
+	division = resp[0]
+	_, _, err = TOSession.DeleteDivisionByID(division.ID)
 
 	if err == nil {
 		t.Errorf("should not be able to delete a division prematurely")
@@ -45,7 +51,7 @@ func TryToDeleteDivision(t *testing.T) {
 		return
 	}
 
-	if strings.Contains(err.Error(), "This division is currently used by regions.") {
+	if strings.Contains(err.Error(), "cannot delete division because it is being used by a region") {
 		return
 	}
 

--- a/traffic_ops/testing/api/v14/divisions_test.go
+++ b/traffic_ops/testing/api/v14/divisions_test.go
@@ -16,6 +16,7 @@ package v14
 */
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
@@ -23,10 +24,32 @@ import (
 )
 
 func TestDivisions(t *testing.T) {
-	WithObjs(t, []TCObj{Parameters, Divisions}, func() {
+	WithObjs(t, []TCObj{Parameters, Divisions, Regions}, func() {
+		TryToDeleteDivision(t)
 		UpdateTestDivisions(t)
 		GetTestDivisions(t)
 	})
+}
+
+func TryToDeleteDivision(t *testing.T) {
+	division := testData.Divisions[0]
+	_, _, err := TOSession.DeleteDivisionByName(division.Name)
+
+	if err == nil {
+		t.Errorf("should not be able to delete a division prematurely")
+		return
+	}
+
+	if strings.Contains(err.Error(), "Resource not found.") {
+		t.Errorf("division with name %v does not exist", division.Name)
+		return
+	}
+
+	if strings.Contains(err.Error(), "This division is currently used by regions.") {
+		return
+	}
+
+	t.Errorf("unexpected error occured: %v", err)
 }
 
 func CreateTestDivisions(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/api/generic_crud.go
+++ b/traffic_ops/traffic_ops_golang/api/generic_crud.go
@@ -135,7 +135,7 @@ func GenericUpdate(val GenericUpdater) (error, error, int) {
 func GenericDelete(val GenericDeleter) (error, error, int) {
 	result, err := val.APIInfo().Tx.NamedExec(val.DeleteQuery(), val)
 	if err != nil {
-		return nil, errors.New("deleting " + val.GetType() + ": " + err.Error()), http.StatusInternalServerError
+		return ParseDBError(err)
 	}
 
 	if rowsAffected, err := result.RowsAffected(); err != nil {


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

Known Examples:
* deleting coordinate with a cachegroup
* deleting profile with a server (Fixes #3410)
* deleting division with assigned region (Fixes #2729)

Any endpoint that uses the generic cruder should be fixed (though, the disclaimer comment at the top of the function should also be read). An endpoint that doesn't use the generic cruder can use api.ParseDBError to get the same result.

## Which TC components are affected by this PR?

-  Traffic Ops

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

* Test the specific cases mentioned in the issues.
* Run the integration tests.
* Analyze the comment and understand the assumptions it makes.
If the current assumptions are not reasonable the logic can instead be handled outside `api.ParseDBError`, even being privatized to the generic delete function.

I made a test for the divisions-regions issue. Divisions use the generic delete, so the test pretty much tests the generic function.

## Check all that apply

- [x] This PR includes new tests
- [x] This PR does not need to include documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [x] This PR includes all required license headers
- [x] This PR does not include a database migration
- [x] This PR does not fix a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



