### PR TITLE
CIAB: add net-tools to get insert-self-into-dns.sh to work again

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_portal_integration_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_portal_integration_test/Dockerfile
@@ -32,7 +32,7 @@ gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub \n\
 
 RUN yum update -y
 
-RUN yum install -y java-1.8.0-openjdk git google-chrome bind-utils
+RUN yum install -y java-1.8.0-openjdk git google-chrome bind-utils net-tools
 
 RUN curl -LO https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-x64.tar.xz
 


### PR DESCRIPTION
## Which issue is fixed by this PR? If not related to an existing issue, what does this PR do?

traffic_portal integration tests started failing in cdn-in-a-box because `insert-self-into-dns.sh` was changed to use `ifconfig` rather than `dig`,   and the former was not installed in the test image.  This fixes that issue.

## Which TC components are affected by this PR?

- [ ] Documentation
- [ ] Grove
- [ ] Traffic Analytics
- [ ] Traffic Monitor
- [ ] Traffic Ops
- [ ] Traffic Ops ORT
- [ ] Traffic Portal
- [ ] Traffic Router
- [ ] Traffic Stats
- [ ] Traffic Vault
- [x] Other cdn-in-a-box

## What is the best way to verify this PR? Please include manual steps or automated tests. 
### (If no tests are part of this PR, please provide explanation as to why no tests are included.)

```
cd infrastructure/cdn-in-a-box
docker-compose -f docker-compose.yml -f docker-compose.traffic-portal-test.yml up --build
```

watch above output for `ifconfig: command not found` or something similar.   if `dig` is able to find the address,  this patch is working..

## Check all that apply

- [ ] This PR includes tests
- [ ] This PR includes documentation updates
- [ ] This PR includes an update to CHANGELOG.md
- [ ] This PR includes all required license headers
- [ ] This PR includes a database migration (ensure that migration sequence is correct)
- [ ] This PR fixes a serious security flaw. Read more: [www.apache.org/security](http://www.apache.org/security/)

<!--
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-->



