### PR TITLE
Updated Python version in documentation builds

### DIFF
--- a/infrastructure/docker/build/Dockerfile-docs
+++ b/infrastructure/docker/build/Dockerfile-docs
@@ -34,9 +34,9 @@ RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 ### docs specific requirements
 ADD docs/source/requirements.txt /docs.requirements.txt
 RUN	yum -y install \
-		python34 \
-		python34-pip \
-        python34-psutil \
+		python36 \
+		python36-pip \
+		python36-psutil \
 		make && \
 	yum -y clean all && \
 	python3 -m pip install --upgrade setuptools && \


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #3466

Updates the Python version in the Dockerfile for building documentation from 3.4 -> 3.6

## Which Traffic Control components are affected by this PR?

- Documentation

## What is the best way to verify this PR?
Build the documentation using the Dockerfile (`sudo ./pkg -v docs`). Build systems have no tests.

## If this is a bug fix, what versions of Traffic Ops are affected?

- master (e047710a2a5b769bd011ef3b7e3827223e32fbb0)
- 3.0.0
- Basically every active branch

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)