### PR TITLE
3.0.x docs build

### DIFF
--- a/infrastructure/docker/build/Dockerfile-docs
+++ b/infrastructure/docker/build/Dockerfile-docs
@@ -38,8 +38,8 @@ RUN	yum -y install \
 		python36-pip \
 		python36-psutil \
 		make && \
-	yum -y clean all && \
-	python3 -m pip install --upgrade setuptools && \
+	yum -y clean all
+RUN	python3 -m pip install --upgrade setuptools && \
 	python3 -m pip install -r /docs.requirements.txt
 ###
 

--- a/infrastructure/docker/build/Dockerfile-docs
+++ b/infrastructure/docker/build/Dockerfile-docs
@@ -34,8 +34,9 @@ RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 ### docs specific requirements
 ADD docs/source/requirements.txt /docs.requirements.txt
 RUN	yum -y install \
-		python34 \
-		python34-pip \
+		python36 \
+		python36-pip \
+		python36-psutil \
 		make && \
 	yum -y clean all && \
 	python3 -m pip install --upgrade setuptools && \


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fixes docs build in docker by upgrading python build and splitting up yum install from command that uses what was just installed (python3).  This avoids a spurious race condition in building docs in docker.

- [x] This PR fixes #3466 for the 3.0.x branch.

## Which Traffic Control components are affected by this PR?

- Documentation

## What is the best way to verify this PR?
```
./pkg -v docs
```

Test is documentation builds.  No CHANGELOG.md necessary.  No documentation change needed. 
## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
