### PR TITLE
remove redundant debug: use `go test -v` instead

### DIFF
--- a/traffic_ops/testing/api/v14/cachegroups_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_test.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -33,41 +32,28 @@ func TestCacheGroups(t *testing.T) {
 }
 
 func CreateTestCacheGroups(t *testing.T) {
-	failed := false
-
 	for _, cg := range testData.CacheGroups {
 		_, _, err := TOSession.CreateCacheGroupNullable(cg)
 		if err != nil {
 			t.Errorf("could not CREATE cachegroups: %v, request: %v\n", err, cg)
-			failed = true
 		}
-	}
-	if !failed {
-		log.Debugln("CreateTestCacheGroups() PASSED: ")
 	}
 }
 
 func GetTestCacheGroups(t *testing.T) {
-	failed := false
 	for _, cg := range testData.CacheGroups {
 		resp, _, err := TOSession.GetCacheGroupNullableByName(*cg.Name)
 		if err != nil {
 			t.Errorf("cannot GET CacheGroup by name: %v - %v\n", err, resp)
-			failed = true
 		}
-	}
-	if !failed {
-		log.Debugln("GetTestCacheGroups() PASSED: ")
 	}
 }
 
 func UpdateTestCacheGroups(t *testing.T) {
-	failed := false
 	firstCG := testData.CacheGroups[0]
 	resp, _, err := TOSession.GetCacheGroupNullableByName(*firstCG.Name)
 	if err != nil {
 		t.Errorf("cannot GET CACHEGROUP by name: %v - %v\n", *firstCG.Name, err)
-		failed = true
 	}
 	cg := resp[0]
 	expectedShortName := "blah"
@@ -77,26 +63,22 @@ func UpdateTestCacheGroups(t *testing.T) {
 	typeResp, _, err := TOSession.GetTypeByID(*cg.TypeID)
 	if err != nil {
 		t.Error("could not lookup a typeID for this cachegroup")
-		failed = true
 	}
 	cg.TypeID = &typeResp[0].ID
 
 	updResp, _, err := TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
 	if err != nil {
 		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
-		failed = true
 	}
 
 	// Retrieve the CacheGroup to check CacheGroup name got updated
 	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
 	if err != nil {
 		t.Errorf("cannot GET CacheGroup by name: '%s', %v\n", *firstCG.Name, err)
-		failed = true
 	}
 	cg = resp[0]
 	if *cg.ShortName != expectedShortName {
 		t.Errorf("results do not match actual: %s, expected: %s\n", *cg.ShortName, expectedShortName)
-		failed = true
 	}
 
 	// test coordinate updates
@@ -107,22 +89,18 @@ func UpdateTestCacheGroups(t *testing.T) {
 	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
 	if err != nil {
 		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
-		failed = true
 	}
 
 	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
 	if err != nil {
 		t.Errorf("cannot GET CacheGroup by id: '%d', %v\n", *cg.ID, err)
-		failed = true
 	}
 	cg = resp[0]
 	if *cg.Latitude != expectedLat {
 		t.Errorf("failed to update latitude (expected = %f, actual = %f)\n", expectedLat, *cg.Latitude)
-		failed = true
 	}
 	if *cg.Longitude != expectedLong {
 		t.Errorf("failed to update longitude (expected = %f, actual = %f)\n", expectedLong, *cg.Longitude)
-		failed = true
 	}
 
 	// test localizationMethods
@@ -131,18 +109,15 @@ func UpdateTestCacheGroups(t *testing.T) {
 	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
 	if err != nil {
 		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
-		failed = true
 	}
 
 	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
 	if err != nil {
 		t.Errorf("cannot GET CacheGroup by id: '%d', %v\n", *cg.ID, err)
-		failed = true
 	}
 	cg = resp[0]
 	if !reflect.DeepEqual(expectedMethods, *cg.LocalizationMethods) {
 		t.Errorf("failed to update localizationMethods (expected = %v, actual = %v)\n", expectedMethods, *cg.LocalizationMethods)
-		failed = true
 	}
 
 	// test cachegroup fallbacks
@@ -152,12 +127,10 @@ func UpdateTestCacheGroups(t *testing.T) {
 	resp, _, err = TOSession.GetCacheGroupNullableByName(firstEdgeCGName)
 	if err != nil {
 		t.Errorf("cannot GET CacheGroup by name: '$%s', %v\n", firstEdgeCGName, err)
-		failed = true
 	}
 	cg = resp[0]
 	if *cg.Name != firstEdgeCGName {
 		t.Errorf("results do not match actual: %s, expected: %s\n", *cg.ShortName, firstEdgeCGName)
-		failed = true
 	}
 
 	// Test adding fallbacks when previously nil
@@ -166,18 +139,15 @@ func UpdateTestCacheGroups(t *testing.T) {
 	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
 	if err != nil {
 		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
-		failed = true
 	}
 
 	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
 	if err != nil {
 		t.Errorf("cannot GET CacheGroup by id: '%d', %v\n", *cg.ID, err)
-		failed = true
 	}
 	cg = resp[0]
 	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
 		t.Errorf("failed to update fallbacks (expected = %v, actual = %v)\n", expectedFallbacks, *cg.Fallbacks)
-		failed = true
 	}
 
 	// Test adding fallback to existing list
@@ -186,18 +156,15 @@ func UpdateTestCacheGroups(t *testing.T) {
 	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
 	if err != nil {
 		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v)\n", err, updResp)
-		failed = true
 	}
 
 	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
 	if err != nil {
 		t.Errorf("cannot GET CacheGroup by id: '%d', %v\n", *cg.ID, err)
-		failed = true
 	}
 	cg = resp[0]
 	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
 		t.Errorf("failed to update fallbacks (expected = %v, actual = %v)\n", expectedFallbacks, *cg.Fallbacks)
-		failed = true
 	}
 
 	// Test removing fallbacks
@@ -206,27 +173,19 @@ func UpdateTestCacheGroups(t *testing.T) {
 	updResp, _, err = TOSession.UpdateCacheGroupNullableByID(*cg.ID, cg)
 	if err != nil {
 		t.Errorf("cannot UPDATE CacheGroup by id: %v - %v\n", err, updResp)
-		failed = true
 	}
 
 	resp, _, err = TOSession.GetCacheGroupNullableByID(*cg.ID)
 	if err != nil {
 		t.Errorf("cannot GET CacheGroup by id: '%d', %v\n", *cg.ID, err)
-		failed = true
 	}
 	cg = resp[0]
 	if !reflect.DeepEqual(expectedFallbacks, *cg.Fallbacks) {
 		t.Errorf("failed to update fallbacks (expected = %v, actual = %v)\n", expectedFallbacks, *cg.Fallbacks)
-		failed = true
-	}
-
-	if !failed {
-		log.Debugln("UpdateTestCacheGroups() PASSED: ")
 	}
 }
 
 func DeleteTestCacheGroups(t *testing.T) {
-	failed := false
 	var mids []tc.CacheGroupNullable
 
 	// delete the edge caches.
@@ -235,7 +194,6 @@ func DeleteTestCacheGroups(t *testing.T) {
 		resp, _, err := TOSession.GetCacheGroupNullableByName(*cg.Name)
 		if err != nil {
 			t.Errorf("cannot GET CacheGroup by name: %v - %v\n", *cg.Name, err)
-			failed = true
 		}
 		// Mids are parents and need to be deleted only after the children
 		// cachegroups are deleted.
@@ -248,17 +206,14 @@ func DeleteTestCacheGroups(t *testing.T) {
 			_, _, err := TOSession.DeleteCacheGroupByID(*respCG.ID)
 			if err != nil {
 				t.Errorf("cannot DELETE CacheGroup by name: '%s' %v\n", *respCG.Name, err)
-				failed = true
 			}
 			// Retrieve the CacheGroup to see if it got deleted
 			cgs, _, err := TOSession.GetCacheGroupNullableByName(*cg.Name)
 			if err != nil {
 				t.Errorf("error deleting CacheGroup by name: %s\n", err.Error())
-				failed = true
 			}
 			if len(cgs) > 0 {
 				t.Errorf("expected CacheGroup name: %s to be deleted\n", *cg.Name)
-				failed = true
 			}
 		}
 	}
@@ -268,31 +223,23 @@ func DeleteTestCacheGroups(t *testing.T) {
 		resp, _, err := TOSession.GetCacheGroupNullableByName(*cg.Name)
 		if err != nil {
 			t.Errorf("cannot GET CacheGroup by name: %v - %v\n", *cg.Name, err)
-			failed = true
 		}
 		if len(resp) > 0 {
 			respCG := resp[0]
 			_, _, err := TOSession.DeleteCacheGroupByID(*respCG.ID)
 			if err != nil {
 				t.Errorf("cannot DELETE CacheGroup by name: '%s' %v\n", *respCG.Name, err)
-				failed = true
 			}
 
 			// Retrieve the CacheGroup to see if it got deleted
 			cgs, _, err := TOSession.GetCacheGroupNullableByName(*cg.Name)
 			if err != nil {
 				t.Errorf("error deleting CacheGroup name: %s\n", err.Error())
-				failed = true
 			}
 			if len(cgs) > 0 {
 				t.Errorf("expected CacheGroup name: %s to be deleted\n", *cg.Name)
-				failed = true
 			}
 		}
-	}
-
-	if !failed {
-		log.Debugln("DeleteTestCacheGroups() PASSED: ")
 	}
 }
 

--- a/traffic_ops/testing/api/v14/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/cachegroupsdeliveryservices_test.go
@@ -17,8 +17,6 @@ package v14
 
 import (
 	"testing"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func TestDeliveryServicesCachegroups(t *testing.T) {
@@ -31,8 +29,6 @@ func TestDeliveryServicesCachegroups(t *testing.T) {
 const TestEdgeServerCacheGroupName = "cachegroup1" // TODO this is the name hard-coded in the create servers test; change to be dynamic
 
 func CreateTestCachegroupsDeliveryServices(t *testing.T) {
-	log.Debugln("CreateTestCachegroupsDeliveryServices")
-
 	dss, _, err := TOSession.GetDeliveryServiceServers()
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServiceServers: %v\n", err)
@@ -108,8 +104,6 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 }
 
 func DeleteTestCachegroupsDeliveryServices(t *testing.T) {
-	log.Debugln("DeleteTestCachegroupsDeliveryServices")
-
 	dss, _, err := TOSession.GetDeliveryServiceServersN(1000000)
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServiceServers: %v\n", err)

--- a/traffic_ops/testing/api/v14/coordinates_test.go
+++ b/traffic_ops/testing/api/v14/coordinates_test.go
@@ -18,7 +18,6 @@ package v14
 import (
 	"testing"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -30,42 +29,29 @@ func TestCoordinates(t *testing.T) {
 }
 
 func CreateTestCoordinates(t *testing.T) {
-	failed := false
-
 	for _, coord := range testData.Coordinates {
 
 		_, _, err := TOSession.CreateCoordinate(coord)
 		if err != nil {
 			t.Errorf("could not CREATE coordinates: %v\n", err)
-			failed = true
 		}
-	}
-	if !failed {
-		log.Debugln("CreateTestCoordinates() PASSED: ")
 	}
 }
 
 func GetTestCoordinates(t *testing.T) {
-	failed := false
 	for _, coord := range testData.Coordinates {
 		resp, _, err := TOSession.GetCoordinateByName(coord.Name)
 		if err != nil {
 			t.Errorf("cannot GET Coordinate: %v - %v\n", err, resp)
-			failed = true
 		}
-	}
-	if !failed {
-		log.Debugln("GetTestCoordinates() PASSED: ")
 	}
 }
 
 func UpdateTestCoordinates(t *testing.T) {
-	failed := false
 	firstCoord := testData.Coordinates[0]
 	resp, _, err := TOSession.GetCoordinateByName(firstCoord.Name)
 	if err != nil {
 		t.Errorf("cannot GET Coordinate by name: %v - %v\n", firstCoord.Name, err)
-		failed = true
 	}
 	coord := resp[0]
 	expectedLat := 12.34
@@ -75,55 +61,40 @@ func UpdateTestCoordinates(t *testing.T) {
 	alert, _, err = TOSession.UpdateCoordinateByID(coord.ID, coord)
 	if err != nil {
 		t.Errorf("cannot UPDATE Coordinate by id: %v - %v\n", err, alert)
-		failed = true
 	}
 
 	// Retrieve the Coordinate to check Coordinate name got updated
 	resp, _, err = TOSession.GetCoordinateByID(coord.ID)
 	if err != nil {
 		t.Errorf("cannot GET Coordinate by name: '$%s', %v\n", firstCoord.Name, err)
-		failed = true
 	}
 	coord = resp[0]
 	if coord.Latitude != expectedLat {
 		t.Errorf("results do not match actual: %s, expected: %f\n", coord.Name, expectedLat)
 	}
-	if !failed {
-		log.Debugln("UpdateTestCoordinates() PASSED: ")
-	}
 }
 
 func DeleteTestCoordinates(t *testing.T) {
-	failed := false
-
 	for _, coord := range testData.Coordinates {
 		// Retrieve the Coordinate by name so we can get the id for the Update
 		resp, _, err := TOSession.GetCoordinateByName(coord.Name)
 		if err != nil {
 			t.Errorf("cannot GET Coordinate by name: %v - %v\n", coord.Name, err)
-			failed = true
 		}
 		if len(resp) > 0 {
 			respCoord := resp[0]
 			_, _, err := TOSession.DeleteCoordinateByID(respCoord.ID)
 			if err != nil {
 				t.Errorf("cannot DELETE Coordinate by name: '%s' %v\n", respCoord.Name, err)
-				failed = true
 			}
 			// Retrieve the Coordinate to see if it got deleted
 			coords, _, err := TOSession.GetCoordinateByName(coord.Name)
 			if err != nil {
 				t.Errorf("error deleting Coordinate name: %s\n", err.Error())
-				failed = true
 			}
 			if len(coords) > 0 {
 				t.Errorf("expected Coordinate name: %s to be deleted\n", coord.Name)
-				failed = true
 			}
 		}
-	}
-
-	if !failed {
-		log.Debugln("DeleteTestCoordinates() PASSED: ")
 	}
 }

--- a/traffic_ops/testing/api/v14/crconfig_test.go
+++ b/traffic_ops/testing/api/v14/crconfig_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -31,8 +30,6 @@ func TestCRConfig(t *testing.T) {
 }
 
 func UpdateTestCRConfigSnapshot(t *testing.T) {
-	log.Debugln("UpdateTestCRConfigSnapshot")
-
 	if len(testData.CDNs) < 1 {
 		t.Errorf("no cdn test data")
 	}
@@ -133,6 +130,4 @@ func UpdateTestCRConfigSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot DELETE Parameter by name: %v - %v\n", err, delResp)
 	}
-
-	log.Debugln("UpdateTestCRConfigSnapshot() PASSED: ")
 }

--- a/traffic_ops/testing/api/v14/deliveryservicematches_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservicematches_test.go
@@ -18,7 +18,6 @@ package v14
 import (
 	"testing"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -29,7 +28,6 @@ func TestDeliveryServiceMatches(t *testing.T) {
 }
 
 func GetTestDeliveryServiceMatches(t *testing.T) {
-	log.Debugln("GetTestDeliveryServiceMatches")
 	dsMatches, _, err := TOSession.GetDeliveryServiceMatches()
 	if err != nil {
 		t.Errorf("cannot GET DeliveryService matches: %v\n", err)

--- a/traffic_ops/testing/api/v14/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservices_test.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -32,8 +31,6 @@ func TestDeliveryServices(t *testing.T) {
 }
 
 func CreateTestDeliveryServices(t *testing.T) {
-	log.Debugln("CreateTestDeliveryServices")
-
 	pl := tc.Parameter{
 		ConfigFile: "remap.config",
 		Name:       "location",
@@ -52,11 +49,9 @@ func CreateTestDeliveryServices(t *testing.T) {
 }
 
 func GetTestDeliveryServices(t *testing.T) {
-	failed := false
 	actualDSes, _, err := TOSession.GetDeliveryServices()
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServices: %v - %v\n", err, actualDSes)
-		failed = true
 	}
 	actualDSMap := map[string]tc.DeliveryService{}
 	for _, ds := range actualDSes {
@@ -65,21 +60,15 @@ func GetTestDeliveryServices(t *testing.T) {
 	for _, ds := range testData.DeliveryServices {
 		if _, ok := actualDSMap[ds.XMLID]; !ok {
 			t.Errorf("GET DeliveryService missing: %v\n", ds.XMLID)
-			failed = true
 		}
-	}
-	if !failed {
-		log.Debugln("GetTestDeliveryServices() PASSED: ")
 	}
 }
 
 func UpdateTestDeliveryServices(t *testing.T) {
-	failed := false
 	firstDS := testData.DeliveryServices[0]
 
 	dses, _, err := TOSession.GetDeliveryServices()
 	if err != nil {
-		failed = true
 		t.Errorf("cannot GET Delivery Services: %v\n", err)
 	}
 
@@ -93,7 +82,6 @@ func UpdateTestDeliveryServices(t *testing.T) {
 		}
 	}
 	if !found {
-		failed = true
 		t.Errorf("GET Delivery Services missing: %v\n", firstDS.XMLID)
 	}
 
@@ -110,31 +98,23 @@ func UpdateTestDeliveryServices(t *testing.T) {
 	// Retrieve the server to check rack and interfaceName values were updated
 	resp, _, err := TOSession.GetDeliveryService(strconv.Itoa(remoteDS.ID))
 	if err != nil {
-		failed = true
 		t.Errorf("cannot GET Delivery Service by ID: %v - %v\n", remoteDS.XMLID, err)
 	}
 	if resp == nil {
-		failed = true
 		t.Errorf("cannot GET Delivery Service by ID: %v - nil\n", remoteDS.XMLID)
 	}
 
 	if resp.LongDesc != updatedLongDesc || resp.MaxDNSAnswers != updatedMaxDNSAnswers {
-		failed = true
 		t.Errorf("results do not match actual: %s, expected: %s\n", resp.LongDesc, updatedLongDesc)
 		t.Errorf("results do not match actual: %v, expected: %v\n", resp.MaxDNSAnswers, updatedMaxDNSAnswers)
-	}
-	if !failed {
-		log.Debugln("UpdatedTestDeliveryServices() PASSED: ")
 	}
 }
 
 func UpdateNullableTestDeliveryServices(t *testing.T) {
-	failed := false
 	firstDS := testData.DeliveryServices[0]
 
 	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
-		failed = true
 		t.Fatalf("cannot GET Delivery Services: %v\n", err)
 	}
 
@@ -151,7 +131,6 @@ func UpdateNullableTestDeliveryServices(t *testing.T) {
 		}
 	}
 	if !found {
-		failed = true
 		t.Fatalf("GET Delivery Services missing: %v\n", firstDS.XMLID)
 	}
 
@@ -167,35 +146,26 @@ func UpdateNullableTestDeliveryServices(t *testing.T) {
 	// Retrieve the server to check rack and interfaceName values were updated
 	resp, _, err := TOSession.GetDeliveryServiceNullable(strconv.Itoa(*remoteDS.ID))
 	if err != nil {
-		failed = true
 		t.Fatalf("cannot GET Delivery Service by ID: %v - %v\n", remoteDS.XMLID, err)
 	}
 	if resp == nil {
-		failed = true
 		t.Fatalf("cannot GET Delivery Service by ID: %v - nil\n", remoteDS.XMLID)
 	}
 
 	if resp.LongDesc == nil || resp.MaxDNSAnswers == nil {
-		failed = true
 		t.Errorf("results do not match actual: %v, expected: %s\n", resp.LongDesc, updatedLongDesc)
 		t.Fatalf("results do not match actual: %v, expected: %d\n", resp.MaxDNSAnswers, updatedMaxDNSAnswers)
 	}
 
 	if *resp.LongDesc != updatedLongDesc || *resp.MaxDNSAnswers != updatedMaxDNSAnswers {
-		failed = true
 		t.Errorf("results do not match actual: %s, expected: %s\n", *resp.LongDesc, updatedLongDesc)
 		t.Fatalf("results do not match actual: %d, expected: %d\n", *resp.MaxDNSAnswers, updatedMaxDNSAnswers)
-	}
-	if !failed {
-		log.Debugln("UpdateNullableTestDeliveryServices() PASSED: ")
 	}
 }
 
 func DeleteTestDeliveryServices(t *testing.T) {
 	dses, _, err := TOSession.GetDeliveryServices()
-	failed := false
 	if err != nil {
-		failed = true
 		t.Errorf("cannot GET Servers: %v\n", err)
 	}
 	for _, testDS := range testData.DeliveryServices {
@@ -209,20 +179,17 @@ func DeleteTestDeliveryServices(t *testing.T) {
 			}
 		}
 		if !found {
-			failed = true
 			t.Errorf("DeliveryService not found in Traffic Ops: %v\n", ds.XMLID)
 		}
 
 		delResp, err := TOSession.DeleteDeliveryService(strconv.Itoa(ds.ID))
 		if err != nil {
-			failed = true
 			t.Errorf("cannot DELETE DeliveryService by ID: %v - %v\n", err, delResp)
 		}
 
 		// Retrieve the Server to see if it got deleted
 		foundDS, err := TOSession.DeliveryService(strconv.Itoa(ds.ID))
 		if err == nil && foundDS != nil {
-			failed = true
 			t.Errorf("expected Delivery Service: %s to be deleted\n", ds.XMLID)
 		}
 	}
@@ -232,12 +199,7 @@ func DeleteTestDeliveryServices(t *testing.T) {
 	for _, param := range params {
 		deleted, _, err := TOSession.DeleteParameterByID(param.ID)
 		if err != nil {
-			failed = true
 			t.Errorf("cannot DELETE parameter by ID (%d): %v - %v\n", param.ID, err, deleted)
 		}
-	}
-
-	if !failed {
-		log.Debugln("DeleteTestDeliveryServices() PASSED: ")
 	}
 }

--- a/traffic_ops/testing/api/v14/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v14/deliveryserviceservers_test.go
@@ -17,8 +17,6 @@ package v14
 
 import (
 	"testing"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func TestDeliveryServiceServers(t *testing.T) {
@@ -28,8 +26,6 @@ func TestDeliveryServiceServers(t *testing.T) {
 }
 
 func DeleteTestDeliveryServiceServers(t *testing.T) {
-	log.Debugln("DeleteTestDeliveryServiceServers")
-
 	dses, _, err := TOSession.GetDeliveryServices()
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServices: %v\n", err)

--- a/traffic_ops/testing/api/v14/federations_test.go
+++ b/traffic_ops/testing/api/v14/federations_test.go
@@ -17,8 +17,6 @@ package v14
 
 import (
 	"testing"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func TestFederations(t *testing.T) {
@@ -29,8 +27,6 @@ func TestFederations(t *testing.T) {
 }
 
 func GetTestFederations(t *testing.T) {
-	log.Debugln("GetTestFederations")
-
 	if len(testData.Federations) == 0 {
 		t.Errorf("no federations test data")
 	}
@@ -78,12 +74,9 @@ func GetTestFederations(t *testing.T) {
 	if !matched {
 		t.Errorf("federation mapping expected to match test data, actual: cname %v not in test data", *mapping.CName)
 	}
-
-	log.Debugln("GetTestFederations PASSED")
 }
 
 func PostTestFederationsDeliveryServices(t *testing.T) {
-	log.Debugln("PostTestFederationsDeliveryServices")
 	dses, _, err := TOSession.GetDeliveryServices()
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServices: %v - %v\n", err, dses)
@@ -100,5 +93,4 @@ func PostTestFederationsDeliveryServices(t *testing.T) {
 	if _, err = TOSession.CreateFederationDeliveryServices(fedID, []int{ds.ID}, true); err != nil {
 		t.Errorf("creating federations delivery services: %v\n", err)
 	}
-	log.Debugln("PostTestFederationsDeliveryServices PASSED")
 }

--- a/traffic_ops/testing/api/v14/loginfail_test.go
+++ b/traffic_ops/testing/api/v14/loginfail_test.go
@@ -24,7 +24,6 @@ import (
 
 	"golang.org/x/net/publicsuffix"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
 	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
 )
 
@@ -35,7 +34,6 @@ func TestLoginFail(t *testing.T) {
 }
 
 func PostTestLoginFail(t *testing.T) {
-	log.Debugln("TestLoginFail")
 	// This specifically tests a previous bug: auth failure returning a 200, causing the client to think the request succeeded, and deserialize no matching fields successfully, and return an empty object.
 
 	userAgent := "to-api-v14-client-tests-loginfailtest"
@@ -59,7 +57,6 @@ func PostTestLoginFail(t *testing.T) {
 	if expectedCDN.Name != actualCDN.Name {
 		t.Fatalf("cdn.Name expected '%+v' actual '%+v'\n", expectedCDN.Name, actualCDN.Name)
 	}
-	log.Debugln("TestLoginFail PASSED")
 }
 
 func getUninitializedTOClient(user, pass, uri, agent string, reqTimeout time.Duration) (*toclient.Session, error) {

--- a/traffic_ops/testing/api/v14/origins_test.go
+++ b/traffic_ops/testing/api/v14/origins_test.go
@@ -17,8 +17,6 @@ package v14
 
 import (
 	"testing"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func TestOrigins(t *testing.T) {
@@ -29,48 +27,30 @@ func TestOrigins(t *testing.T) {
 }
 
 func CreateTestOrigins(t *testing.T) {
-	failed := false
-
 	// loop through origins, assign FKs and create
 	for _, origin := range testData.Origins {
 		_, _, err := TOSession.CreateOrigin(origin)
 		if err != nil {
 			t.Errorf("could not CREATE origins: %v\n", err)
-			failed = true
 		}
 	}
-
-	if !failed {
-		log.Debugln("CreateTestOrigins() PASSED")
-	}
-
 }
 
 func GetTestOrigins(t *testing.T) {
-	failed := false
-
 	for _, origin := range testData.Origins {
 		resp, _, err := TOSession.GetServerByHostName(*origin.Name)
 		if err != nil {
 			t.Errorf("cannot GET Origin by name: %v - %v\n", err, resp)
-			failed = true
 		}
-	}
-
-	if !failed {
-		log.Debugln("GetTestOrigins() PASSED")
 	}
 }
 
 func UpdateTestOrigins(t *testing.T) {
-	failed := false
-
 	firstOrigin := testData.Origins[0]
 	// Retrieve the origin by name so we can get the id for the Update
 	resp, _, err := TOSession.GetOriginByName(*firstOrigin.Name)
 	if err != nil {
 		t.Errorf("cannot GET origin by name: %v - %v\n", *firstOrigin.Name, err)
-		failed = true
 	}
 	remoteOrigin := resp[0]
 	updatedPort := 4321
@@ -82,36 +62,28 @@ func UpdateTestOrigins(t *testing.T) {
 	updResp, _, err := TOSession.UpdateOriginByID(*remoteOrigin.ID, remoteOrigin)
 	if err != nil {
 		t.Errorf("cannot UPDATE Origin by name: %v - %v\n", err, updResp.Alerts)
-		failed = true
 	}
 
 	// Retrieve the origin to check port and FQDN values were updated
 	resp, _, err = TOSession.GetOriginByID(*remoteOrigin.ID)
 	if err != nil {
 		t.Errorf("cannot GET Origin by ID: %v - %v\n", *remoteOrigin.Name, err)
-		failed = true
 	}
 
 	respOrigin := resp[0]
-	if *respOrigin.Port != updatedPort || *respOrigin.FQDN != updatedFQDN {
+	if *respOrigin.Port != updatedPort {
 		t.Errorf("results do not match actual: %d, expected: %d\n", *respOrigin.Port, updatedPort)
-		t.Errorf("results do not match actual: %s, expected: %s\n", *respOrigin.FQDN, updatedFQDN)
-		failed = true
 	}
-
-	if !failed {
-		log.Debugln("UpdateTestOrigins() PASSED")
+	if *respOrigin.FQDN != updatedFQDN {
+		t.Errorf("results do not match actual: %s, expected: %s\n", *respOrigin.FQDN, updatedFQDN)
 	}
 }
 
 func DeleteTestOrigins(t *testing.T) {
-	failed := false
-
 	for _, origin := range testData.Origins {
 		resp, _, err := TOSession.GetOriginByName(*origin.Name)
 		if err != nil {
 			t.Errorf("cannot GET Origin by name: %v - %v\n", *origin.Name, err)
-			failed = true
 		}
 		if len(resp) > 0 {
 			respOrigin := resp[0]
@@ -119,23 +91,16 @@ func DeleteTestOrigins(t *testing.T) {
 			delResp, _, err := TOSession.DeleteOriginByID(*respOrigin.ID)
 			if err != nil {
 				t.Errorf("cannot DELETE Origin by ID: %v - %v\n", err, delResp)
-				failed = true
 			}
 
 			// Retrieve the Origin to see if it got deleted
 			org, _, err := TOSession.GetOriginByName(*origin.Name)
 			if err != nil {
 				t.Errorf("error deleting Origin name: %s\n", err.Error())
-				failed = true
 			}
 			if len(org) > 0 {
 				t.Errorf("expected Origin name: %s to be deleted\n", *origin.Name)
-				failed = true
 			}
 		}
-	}
-
-	if !failed {
-		log.Debugln("DeleteTestOrigins() PASSED")
 	}
 }

--- a/traffic_ops/testing/api/v14/profiles_test.go
+++ b/traffic_ops/testing/api/v14/profiles_test.go
@@ -49,8 +49,6 @@ func CreateBadProfiles(t *testing.T) {
 
 		if err == nil {
 			t.Errorf("Creating bad profile succeeded: %+v\nResponse is %+v", pr, resp)
-		} else {
-			log.Debugf("bad profile creation failed appropriately")
 		}
 	}
 }

--- a/traffic_ops/testing/api/v14/regions_test.go
+++ b/traffic_ops/testing/api/v14/regions_test.go
@@ -87,7 +87,6 @@ func GetTestRegions(t *testing.T) {
 }
 
 func GetTestRegionsByNamePath(t *testing.T) {
-	log.Debugln("GetTestRegionsByNamePath")
 	for _, region := range testData.Regions {
 		_, _, err := TOSession.GetRegionByNamePath(region.Name)
 		if err != nil {

--- a/traffic_ops/testing/api/v14/roles_test.go
+++ b/traffic_ops/testing/api/v14/roles_test.go
@@ -55,10 +55,8 @@ func CreateTestRoles(t *testing.T) {
 }
 
 func UpdateTestRoles(t *testing.T) {
-	log.Debugln("entered test")
 	log.Debugf("testData.Roles contains: %++v\n", testData.Roles)
 	firstRole := testData.Roles[0]
-	log.Debugln("got first role from slice")
 	// Retrieve the Role by role so we can get the id for the Update
 	resp, _, status, err := TOSession.GetRoleByName(*firstRole.Name)
 	log.Debugln("Status Code: ", status)

--- a/traffic_ops/testing/api/v14/steering_test.go
+++ b/traffic_ops/testing/api/v14/steering_test.go
@@ -17,8 +17,6 @@ package v14
 
 import (
 	"testing"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func TestSteering(t *testing.T) {
@@ -28,8 +26,6 @@ func TestSteering(t *testing.T) {
 }
 
 func GetTestSteering(t *testing.T) {
-	log.Debugln("GetTestSteering")
-
 	if len(testData.SteeringTargets) < 1 {
 		t.Errorf("get steering: no steering target test data\n")
 	}
@@ -68,5 +64,4 @@ func GetTestSteering(t *testing.T) {
 	if steerings[0].Targets[0].Latitude != nil {
 		t.Errorf("steering get: Targets Order expected %v actual %+v\n", nil, *steerings[0].Targets[0].Latitude)
 	}
-	log.Debugln("GetTestSteering() PASSED")
 }

--- a/traffic_ops/testing/api/v14/steeringtargets_test.go
+++ b/traffic_ops/testing/api/v14/steeringtargets_test.go
@@ -30,7 +30,6 @@ func TestSteeringTargets(t *testing.T) {
 }
 
 func CreateTestSteeringTargets(t *testing.T) {
-	log.Debugln("CreateTestSteeringTargets")
 	for _, st := range testData.SteeringTargets {
 		if st.Type == nil {
 			t.Errorf("creating steering target: test data missing type\n")
@@ -78,12 +77,9 @@ func CreateTestSteeringTargets(t *testing.T) {
 			t.Errorf("creating steering target: %v\n", err)
 		}
 	}
-	log.Debugln("CreateTestSteeringTargets() PASSED")
 }
 
 func UpdateTestSteeringTargets(t *testing.T) {
-	log.Debugln("UpdateTestSteeringTargets")
-
 	if len(testData.SteeringTargets) < 1 {
 		t.Errorf("updating steering target: no steering target test data\n")
 	}
@@ -115,7 +111,7 @@ func UpdateTestSteeringTargets(t *testing.T) {
 
 	expected := util.JSONIntStr(-12345)
 	if st.Value != nil && *st.Value == expected {
-		expected += 1
+		expected++
 	}
 	st.Value = &expected
 
@@ -168,12 +164,9 @@ func UpdateTestSteeringTargets(t *testing.T) {
 	} else if *st.Value != *actual.Value {
 		t.Errorf("steering target update: value expected %v actual %v\n", *st.Value, actual.Value)
 	}
-	log.Debugln("UpdateTestSteeringTargets() PASSED")
 }
 
 func GetTestSteeringTargets(t *testing.T) {
-	log.Debugln("GetTestSteeringTargets")
-
 	if len(testData.SteeringTargets) < 1 {
 		t.Errorf("updating steering target: no steering target test data\n")
 	}
@@ -227,11 +220,9 @@ func GetTestSteeringTargets(t *testing.T) {
 	} else if *expected.Value != *actual.Value {
 		t.Errorf("steering target get: value expected %v actual %v\n", *expected.Value, *actual.Value)
 	}
-	log.Debugln("GetTestSteeringTargets() PASSED")
 }
 
 func DeleteTestSteeringTargets(t *testing.T) {
-	log.Debugln("DeleteTestSteeringTargets")
 	dsIDs := []uint64{}
 	for _, st := range testData.SteeringTargets {
 		if st.DeliveryService == nil {
@@ -276,5 +267,4 @@ func DeleteTestSteeringTargets(t *testing.T) {
 			t.Errorf("deleting steering targets: after delete, getting steering target: expected 0 actual %+v\n", len(sts))
 		}
 	}
-	log.Debugln("DeleteTestSteeringTargets() PASSED")
 }

--- a/traffic_ops/testing/api/v14/userdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v14/userdeliveryservices_test.go
@@ -16,7 +16,6 @@ package v14
 */
 
 import (
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"testing"
 )
 
@@ -29,8 +28,6 @@ func TestUserDeliveryServices(t *testing.T) {
 const TestUsersDeliveryServicesUser = "admin" // TODO make dynamic
 
 func CreateTestUsersDeliveryServices(t *testing.T) {
-	log.Debugln("CreateTestUsersDeliveryServices")
-
 	dses, _, err := TOSession.GetDeliveryServices()
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServices: %v - %v\n", err, dses)
@@ -93,8 +90,6 @@ func CreateTestUsersDeliveryServices(t *testing.T) {
 }
 
 func GetTestUsersDeliveryServices(t *testing.T) {
-	log.Debugln("GetTestUsersDeliveryServices")
-
 	dses, _, err := TOSession.GetDeliveryServices()
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServices: %v - %v\n", err, dses)
@@ -152,8 +147,6 @@ func GetTestUsersDeliveryServices(t *testing.T) {
 }
 
 func DeleteTestUsersDeliveryServices(t *testing.T) {
-	log.Debugln("DeleteTestUsersDeliveryServices")
-
 	users, _, err := TOSession.GetUsers()
 	if err != nil {
 		t.Errorf("cannot GET users: %v\n", err)


### PR DESCRIPTION

## What does this PR (Pull Request) do?

- [x] This PR fixes #3339

Removes debug statements from api tests that only indicate tests being run and PASSED.  Both of these are already done when tests run with `go test -v`.

## Which Traffic Control components are affected by this PR?

- Traffic Ops . (tests only)

## What is the best way to verify this PR?

Run traffic_ops API tests in `traffic_ops/testing/api/v14`.  Observe no messages saying "...PASSED...." are printed.

Only modifies tests.  No documentation, CHANGELOG, license headers needed.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [ x This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
