### PR TITLE
Add additional routeResult URL instead of overwriting existing URL li…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Modified Traffic Router logging format to include an additional field for DNS log entries, namely `rhi`. This defaults to '-' and is only used when EDNS0 client subnet extensions are enabled and a client subnet is present in the request. When enabled and a subnet is present, the subnet appears in the `chi` field and the resolver address is in the `rhi` field.
 - Changed traffic_ops_ort.pl so that hdr_rw-<ds>.config files are compared with strict ordering and line duplication when detecting configuration changes.
 - Traffic Ops (golang), Traffic Monitor, Traffic Stats are now compiled using Go version 1.11. Grove was already being compiled with this version which improves performance for TLS when RSA certificates are used.
+- Issue 3476: Traffic Router returns partial result for CLIENT_STEERING Delivery Services when Regional Geoblocking or Anonymous Blocking is enabled.
+
 
 ## [3.0.0] - 2018-10-30
 ### Added

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AnonymousIp.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AnonymousIp.java
@@ -245,7 +245,7 @@ public final class AnonymousIp {
 			routeResult.setResponseCode(AnonymousIp.BLOCK_CODE);
 			track.setResult(ResultType.ANON_BLOCK);
 			if (AnonymousIp.getCurrentConfig().redirectUrl != null) {
-				routeResult.setUrl(new URL(AnonymousIp.getCurrentConfig().redirectUrl));
+				routeResult.addUrl(new URL(AnonymousIp.getCurrentConfig().redirectUrl));
 			}
 		}
 	}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
@@ -357,7 +357,7 @@ public final class RegionalGeo {
         if (result.getType() == DENIED) {
             routeResult.setResponseCode(result.getHttpResponseCode());
         } else {
-            routeResult.setUrl(new URL(createRedirectURIString(httpRequest, deliveryService, cache, result)));
+            routeResult.addUrl(new URL(createRedirectURIString(httpRequest, deliveryService, cache, result)));
         }
     }
 


### PR DESCRIPTION
…st. (#3476)


## What does this PR (Pull Request) do?
Client Steering Delivery Services build up the list of target DS URLs in the RouteResult object. This commit modifies AnonymousBlocking and Regional Geo Blocking to call setUrl() instead of addUrl() on the RouteResult. The incorrect addUrl() call will clear out any pre-existing URLs from earlier target DSs.

- [X] This PR fixes #3476 

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Router

No docs required because this is a bugfix.


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
* Run Traffic Router Unit Tests - `mvn test`
* Configure a CLIENT_STEERING Delivery Service with RGB and/or Anonymous Blocking enabled. 
  * Make a curl request to the TR for that delivery service with the query parameter `trred=false`
  * Verify multiple locations are return in the JSON response

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [X] This PR includes tests OR I have explained why tests are unnecessary
- [X] This PR includes documentation OR I have explained why documentation is unnecessary
- [X] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
