### PR TITLE
TO: "info" struct tag example for better generic endpoint handling

### DIFF
--- a/lib/go-tc/asns.go
+++ b/lib/go-tc/asns.go
@@ -71,7 +71,7 @@ type ASNNullable struct {
 
 	// Related cachegroup name
 	//
-	Cachegroup *string `json:"cachegroup" db:"cachegroup" info:"joinz"`
+	Cachegroup *string `json:"cachegroup" db:"cachegroup" info:"join"`
 
 	// Related cachegroup id
 	//

--- a/lib/go-tc/asns.go
+++ b/lib/go-tc/asns.go
@@ -71,7 +71,7 @@ type ASNNullable struct {
 
 	// Related cachegroup name
 	//
-	Cachegroup *string `json:"cachegroup" db:"cachegroup"`
+	Cachegroup *string `json:"cachegroup" db:"cachegroup" info:"joinz"`
 
 	// Related cachegroup id
 	//
@@ -80,11 +80,11 @@ type ASNNullable struct {
 	// ID of the ASN
 	//
 	// required: true
-	ID *int `json:"id" db:"id"`
+	ID *int `json:"id" db:"id" info:"key"`
 
 	// LastUpdated
 	//
-	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
+	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated" info:"lastUpdated"`
 }
 
 type ASNsV11 struct {

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -284,6 +284,7 @@ func Parse(r io.Reader, tx *sql.Tx, v ParseValidator) error {
 type APIInfo struct {
 	Params    map[string]string
 	IntParams map[string]int
+	Fields    StructFields
 	User      *auth.CurrentUser
 	ReqID     uint64
 	Tx        *sqlx.Tx

--- a/traffic_ops/traffic_ops_golang/api/struct_reflect.go
+++ b/traffic_ops/traffic_ops_golang/api/struct_reflect.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"bufio"
+	"errors"
+	"reflect"
+)
+
+// allExportedFields returns true if ALL fields are exported.
+// The input is expected to be a struct pointer.
+func allFieldsExported(obj interface{}) bool {
+	for i := 0; i < reflect.ValueOf(obj).Elem().NumField(); i++ {
+		if !reflect.ValueOf(obj).Elem().Field(i).CanInterface() {
+			return false
+		}
+	}
+	return true
+}
+
+// AllFields is a key value for the `StructFields` map returned.
+const AllFields = ""
+
+// StructFields is a map from an "info" struct tag to a list of pointers.
+// It can be obtained by using the `GetFieldInfo` function.
+type StructFields map[string][]interface{}
+
+// GetFieldInfo returns a list of pointers to fields in the struct.
+//
+// An error is returned for structs that have non-exported fields or if
+// a non-pointer is passed. It is not an error to pass a pointer to a
+// non-struct, but the pointer value will just be returned back wrapped
+// in the StructFields type, which isn't useful. EDIT: I think the last
+// sentence is no longer correct. TODO: This comment should be updated
+// after I verify the behavior while testing.
+//
+// Example:
+//
+//	type Example struct {
+//		ID int `info:"key"`
+//		F1 int
+//		F2 int
+//	}
+//
+//	obj := Example{}
+//	fields := GetFieldInfo(&obj)
+//	*fields["key"][0] = 42
+//
+//	// Note: The original object is changed
+//	fmt.Printf("The key is %d\n", obj.ID)
+//
+// Within the GetFieldInfo, there are no extra semantics for certain label
+// values. This means that any "info" struct tag can be specified multiple
+// times.
+//
+// The map also contains an entry `AllFields` to get a list of all the
+// struct field pointers in order of appearance. This may be useful for
+// database functions such as QueryRow:
+//
+//	QueryRow(GetQuery(), fields[AllFields]...)
+//
+func GetFieldInfo(obj interface{}) (StructFields, error) {
+
+	if reflect.ValueOf(obj).Kind() != reflect.Ptr {
+		return nil, errors.New("unpacking struct: expected pointer to struct")
+	}
+
+	val := reflect.ValueOf(obj).Elem()
+	if val.Kind() != reflect.Struct {
+		return nil, errors.New("unpacking struct: expected pointer to struct")
+	}
+
+	fields := StructFields{}
+
+	// infoTag is captured by the append function, and
+	// can be updated in the main loop.
+	var infoTag string = ""
+
+	// AppendToResult appends the passed argument (presumably a pointer)
+	// to the list of fields. Any info tag will create a new key, value
+	// pair in the map if it doesn't exist already.
+	AppendToResult := func(ptr ...interface{}) StructFields {
+		if infoTag != "" {
+			fields[infoTag] = append(fields[infoTag], ptr...)
+		}
+		fields[AllFields] = append(fields[AllFields], ptr...)
+		return fields
+	}
+
+	// if obj implements scanner, read obj as atomic value
+	if _, ok := obj.(bufio.Scanner); ok {
+		return AppendToResult(obj), nil
+	}
+
+	// Can't reflect on private data
+	// Beyond this point, CanAddr can be used on all fields
+	if !allFieldsExported(obj) {
+		return nil, errors.New("unpacking struct: can't iterate over non-exported fields")
+	}
+
+	type Helper func(f reflect.Value) error
+	var TraverseStruct Helper
+	var HandlePointer Helper
+	var GetAddressOfField Helper
+
+	TraverseStruct = func(ptr reflect.Value) error {
+
+		fieldMap, err := GetFieldInfo(ptr.Interface())
+		if err != nil {
+			return err
+		}
+
+		for infoTag, ptrs := range fieldMap {
+			fields[infoTag] = append(fields[infoTag], ptrs...)
+		}
+
+		return nil
+	}
+
+	GetAddressOfField = func(field reflect.Value) error {
+		AppendToResult(field.Addr().Interface())
+		return nil
+	}
+
+	HandlePointer = func(ptr reflect.Value) error {
+		switch ptr.Elem().Kind() {
+		case reflect.Struct:
+			return TraverseStruct(ptr)
+		case reflect.Ptr:
+			return errors.New("unpacking struct: double pointer not supported")
+		default:
+			return GetAddressOfField(ptr)
+		}
+	}
+
+	Struct := reflect.TypeOf(obj).Elem()
+
+	// Traversing Struct Fields
+	for i := 0; i < val.NumField(); i++ {
+
+		var err error
+		field := val.Field(i)
+
+		infoTag = Struct.Field(i).Tag.Get("info")
+
+		switch field.Kind() {
+		case reflect.Struct:
+			err = TraverseStruct(field.Addr())
+		case reflect.Ptr:
+			err = HandlePointer(field)
+		default:
+			err = GetAddressOfField(field)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return fields, nil
+}
+
+// MustGetFieldInfo is the version of GetFieldInfo that will
+// panic if an error occurs.
+func MustGetFieldInfo(obj interface{}) StructFields {
+	ptrs, err := GetFieldInfo(obj)
+	if err != nil {
+		panic(err)
+	}
+	return ptrs
+}

--- a/traffic_ops/traffic_ops_golang/api/struct_reflect.go
+++ b/traffic_ops/traffic_ops_golang/api/struct_reflect.go
@@ -1,5 +1,24 @@
 package api
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import (
 	"database/sql"
 	"errors"

--- a/traffic_ops/traffic_ops_golang/api/struct_reflect_test.go
+++ b/traffic_ops/traffic_ops_golang/api/struct_reflect_test.go
@@ -1,5 +1,24 @@
 package api
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import (
 	"fmt"
 	"testing"

--- a/traffic_ops/traffic_ops_golang/api/struct_reflect_test.go
+++ b/traffic_ops/traffic_ops_golang/api/struct_reflect_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+)
+
+type Dog struct {
+	Name string
+}
+
+func (d Dog) String() string {
+	return "bark!"
+}
+
+type IdentifierImpl struct {
+	ID int `info:"key"`
+}
+
+type Person struct {
+	Age  int
+	Name *string `info:"test"`
+
+	IdentifierImpl
+	Pet *Dog
+}
+
+type PrivatePerson struct {
+	name string
+	age  int
+}
+
+// good for debugging
+func printArgs(dest ...interface{}) error {
+	for _, elem := range dest {
+
+		switch v := elem.(type) {
+		case *int:
+			fmt.Printf("%v -> %v\n", v, *v)
+		case *string:
+			fmt.Printf("%v -> %v\n", v, *v)
+		case **int:
+			fmt.Printf("%v -> -> %v\n", v, **v)
+		case **string:
+			fmt.Printf("%v -> -> %v\n", v, **v)
+		default:
+			return fmt.Errorf("unknown type")
+		}
+	}
+	return nil
+}
+
+// TODO:
+//	Test Scanner
+//	Test Double Pointer
+//	Test Non-pointer
+//	Test Pointer to item
+//	Test Not All Fields exported
+//	Test MustGetFieldInfo? no..
+// Current coverage: 78.2% (this file)
+
+// Test cases:
+// case 0:	S   (EmbeddedStruct)
+// case 1:
+//		a)	*S  (EmbeddedStructPtr)
+//		b)	**T (UnsupportedField)
+//		c)	*T  (NullableStructField)
+// case 2:	T   (NonNullableStructField)
+//
+func TestGetFieldInfo(t *testing.T) {
+
+	name := "Matthew"
+	newName := "Matt"
+
+	key := IdentifierImpl{
+		ID: 118908,
+	}
+
+	p := &Person{
+		Age:            20,
+		Name:           &name,
+		IdentifierImpl: key,
+		Pet:            &Dog{Name: "Daisy"},
+	}
+
+	fields, err := GetFieldInfo(p)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	ptrs := fields[AllFields]
+
+	// Changing the struct will update `ptrs`
+	p.Age = 21
+	p.Name = &newName
+
+	// Increment all ints by 1 (via ptrs)
+	for _, elem := range ptrs {
+		if intPtr, ok := elem.(*int); ok {
+			*intPtr = *intPtr + 1
+			continue
+		}
+		if intPtr, ok := elem.(**int); ok {
+			**intPtr = **intPtr + 1
+		}
+	}
+
+	if p.Age != 22 {
+		t.Errorf("Person does not have expected age!")
+	}
+
+	// TODO: Change this..?
+	if **fields["test"][0].(**string) != newName {
+		t.Errorf("Person does not have expected name!")
+	}
+
+}


### PR DESCRIPTION
## What does this PR do?

This PR is related to the joined-fields issue: #2494

The issue of joined-fields was also briefly mentioned in #3107, where it is said that "ideally this would be fixable in the framework rather than requiring changes on a per-handler basis".

This PR implements joined fields for ASNs in a generic fashion. The reason I have only implemented the ASN handler is because replacing the current generic implementation with the one I did requires a change in struct tags for every endpoint it affects. I don't mind doing this, but I want to more or less present what I have now for potential feedback.

**How would the struct tags change?**

```
type ASNNullable struct {
	ASN          *int       `json:"asn"          db:"asn"`
	Cachegroup   *string    `json:"cachegroup"   db:"cachegroup"`
	CachegroupID *int       `json:"cachegroupId" db:"cachegroup_id"`
	ID           *int       `json:"id"           db:"id"`
	LastUpdated  *TimeNoMod `json:"lastUpdated"  db:"last_updated"`
}
```
```
type ASNNullable struct {
	ASN          *int       `json:"asn"`
	Cachegroup   *string    `json:"cachegroup"   info:"join"`
	CachegroupID *int       `json:"cachegroupId"`
	ID           *int       `json:"id"           info:"key"`
	LastUpdated  *TimeNoMod `json:"lastUpdated"  info:"lastUpdated"`
}
```

**What does the info tag do?**

It allows us to say `fields["join"]` and get all fields in the struct that have the info struct tag of "join".
Any value may be used, and for now I just specify "join", "key", and "lastUpdated".

**What advantage do we have with info tags over db tags?**

db struct tags are used with `NamedQuery`, `NamedExec`, and `StructScan`. In sql queries we may use syntax of the form `:field` to reference a field with `db:"field"`. The db tags use reflection to find the fields.

For a single endpoint implementation there is no need to use a named query. I believe _some_ endpoints have db tags because of copy-pasta, then used the `StructScan` for convenience. However, the main user of the named exec are the generic methods that greatly benefit from the reflection because the cruder only gets to work with interfaces.

The info tag gives us more control over the result of the reflection. Instead of just using the result to replace a name for a value in query, we can also use it to scan items into, since the sql database functions use interfaces (holding pointers of any type).

It is relevant to note that the named functions we are currently using is from `sqlx`. If we no longer use these functions anymore there is potential to remove a dependency that we don't need.

**What endpoints could this affect**

1) All endpoints in `asns`, `deliveryservices`, `regions`, `phys_locations`, `servers`, `tenants` from #2494  
2) Endpoints that did not use the generic methods in order to include join fields properly (I'm not sure specifically what endpoints). That being said, where tenancy is needed there is still no generic method created yet (methods exist, but the `GenericCreate`, `GenericUpdate`, etc. does not know how to check tenancy).

**Additional benefits beyond just replacing the db tag**

In our code we have methods like `SetLastUpdated`, `GetKeyFieldInfo`, etc. `SetLastUpdated` is no longer needed because with the info tag, we have recieved the pointer and scan into it. Some instances of `SetKeys` will also be removed for the same reason. I think in the future it would be beneficial to consider the complete removal of a struct's implementation for how it handles keys since this can simplify the logic and reduce boilerplate.

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## If this is a bug fix, what versions of Traffic Ops are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
This bug has been persistent since the affected endpoints were rewritten in go.

## The following criteria are ALL met by this PR

Although there are some tests, I haven't tested odd cases yet.
The documentation I've included is GoDoc

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
  - I'm not _fully_ sure when a changelog is necessary.
  - These changes are mostly internal, but also affect the visibility of certain joined fields.
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
