### PR TITLE
fixes var name $ds -> $remap

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2893,7 +2893,7 @@ sub build_remap_line {
 		}
 		else {
 			#If we are on ats 6 and later we want to use the cachekey plugin, otherwise we have to use cacheurl
-		    	$text .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server_obj ), $ds->{range_request_handling});
+			$text .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server_obj ), $remap->{range_request_handling});
 		}
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #3498 for an incorrect variable reference introduced in #3452 

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?

start cdn-in-a-box:
```
cd infrastructure/cdn-in-a-box
cp ../../dist/traffic_ops*x86.rpm ./traffic_ops/traffic_ops.rpm
docker-compose up --build -d
docker-compose logs -f trafficops-perl
```

Examine the output for this message: 
 ```[ERROR] Global symbol "$ds" requires explicit package name at /opt/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm line 2896.```

Simple var reference fix -- no docs, tests, changelog changes needed.

## If this is a bug fix, what versions of Traffic Ops are affected?
- master (21e50ee)

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
