### PR TITLE
Duplicate parameter names

### DIFF
--- a/traffic_portal/app/src/common/api/AuthService.js
+++ b/traffic_portal/app/src/common/api/AuthService.js
@@ -76,5 +76,5 @@ var AuthService = function($rootScope, $http, $state, $location, $q, httpService
 
 };
 
-AuthService.$inject = ['$rootScope', '$http', '$state', '$location', '$q', '$state', 'httpService', 'userModel', 'messageModel', 'ENV'];
+AuthService.$inject = ['$rootScope', '$http', '$state', '$location', '$q', 'httpService', 'userModel', 'messageModel', 'ENV'];
 module.exports = AuthService;

--- a/traffic_portal/app/src/common/api/AuthService.js
+++ b/traffic_portal/app/src/common/api/AuthService.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var AuthService = function($rootScope, $http, $state, $location, $q, $state, httpService, userModel, messageModel, ENV) {
+var AuthService = function($rootScope, $http, $state, $location, $q, httpService, userModel, messageModel, ENV) {
 
     this.login = function(username, password) {
         userModel.resetUser();


### PR DESCRIPTION
If a function has two parameters with the same name, the second parameter shadows the first one, which makes the code hard to understand and error-prone.