### PR TITLE
CIAB: Fix the environment variable and cron jobs

### DIFF
--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort.crontab
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-*/1 * * * * /usr/bin/traffic_ops_ort -k --dispersion 0 SYNCDS ALL $TO_URL $TO_USER:$TO_PASSWORD >> /var/log/ort.log 2>&1
+*/1 * * * * /usr/local/bin/traffic_ops_ort -k --dispersion 0 SYNCDS ALL $TO_URL $TO_USER:$TO_PASSWORD >> /var/log/ort.log 2>&1

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -49,7 +49,7 @@ insert-self-into-dns.sh
 source /to-access.sh
 
 # Write config files
-/config.sh
+. /config.sh
 
 while ! nc "$TO_PERL_FQDN" $TO_PERL_PORT </dev/null 2>/dev/null; do
         echo "waiting for $TO_PERL_FQDN:$TO_PERL_PORT" 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

1. Fix the environment variable in trafficops-go. SSL keys can not be set without X509-related environment variable.
2. Fix the traffic_ops_ort path from `/usr/bin/traffic_ops_ort` to `/usr/local/bin/traffic_ops_ort` because the python version is upgraded

No procedural change, so no tests or doc or CHANGELOG changes needed.

## Which Traffic Control components are affected by this PR?

- CDN in a Box

## What is the best way to verify this PR?

1. Start CIAB
2. The cached demo page can be retrieved.
3. Enter mid or edge container. There should not any error in `/var/log/ort.log`


## If this is a bug fix, what versions of Traffic Ops are affected?

- master
- 3.0.0
- Basically every active branch

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
