### PR TITLE
TP: removes hard coding of 'Edge' from clone ds functionality because TO …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a context menu in place of the "Actions" column from the following tables in Traffic Portal: cache group tables, CDN tables, delivery service tables, parameter tables, profile tables, server tables.
 - Traffic Portal standalone Dockerfile
 - In Traffic Portal, removes the need to specify line breaks using `__RETURN__` in delivery service edge/mid header rewrite rules, regex remap expressions, raw remap text and traffic router additional request/response headers.
+- In Traffic Portal, provides the ability to clone delivery service assignments from one cache to another cache of the same type. Issue #2963.
 
 ### Changed
 - Traffic Router, added TLS certificate validation on certificates imported from Traffic Ops

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -67,6 +67,12 @@ func AssignDeliveryServicesToServerHandler(w http.ResponseWriter, r *http.Reques
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
+
+	if err := api.CreateChangeLogRawErr(api.ApiChange, "Assigned "+strconv.Itoa(len(assignedDSes))+" delivery services to server id: "+strconv.Itoa(server) , inf.User, inf.Tx.Tx); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("error writing to change log: " + err.Error()))
+		return
+	}
+
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "successfully assigned dses to server", tc.AssignedDsResponse{server, assignedDSes, replace})
 }
 

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/TableServerDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/TableServerDeliveryServicesController.js
@@ -48,10 +48,10 @@ var TableServerDeliveryServicesController = function(server, deliveryServices, $
 
 	$scope.isEdge = serverUtils.isEdge;
 
-	$scope.cloneDsAssignments = function() {
+	$scope.cloneDsAssignments = function(server) {
 		var params = {
 			title: 'Clone Delivery Service Assignments',
-			message: "Please select an edge cache to assign these " + deliveryServices.length + " delivery services to.<br><br>Warning - Any delivery services currently assigned to the selected edge cache will be lost and replaced with these delivery service assignments...",
+			message: "Please select an " + server.type + " cache to assign these " + deliveryServices.length + " delivery services to.<br><br>Warning - Any delivery services currently assigned to the target cache will be lost and replaced with these delivery service assignments...",
 			labelFunction: function(item) { return item['hostName'] + '.' + item['domainName'] }
 		};
 		var modalInstance = $uibModal.open({
@@ -63,7 +63,7 @@ var TableServerDeliveryServicesController = function(server, deliveryServices, $
 					return params;
 				},
 				collection: function(serverService) {
-					return serverService.getServers({ type: 'EDGE', orderby: 'hostName' });
+					return serverService.getServers({ type: server.type, orderby: 'hostName' });
 				}
 			}
 		});

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.serverDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.serverDeliveryServices.tpl.html
@@ -33,7 +33,7 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li><a ng-click="cloneDsAssignments()">Clone Delivery Service Assignments</a></li>
+                    <li><a ng-click="cloneDsAssignments(server)">Clone Delivery Service Assignments</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
…allows you to create servers of type EDGE_* for example and those types were excluded from the clone ds assignment feature in TP. So after this change you can clone ds assignments from an EDGE_FOO server to another EDGE_FOO server instead of the target servers only being of type=EDGE

![image](https://user-images.githubusercontent.com/251272/56752868-89df5f80-6746-11e9-8506-0be8ebfd300e.png)

note: this only allows you to clone ds assignments from a source and target server where the type is the same. EDGE-->EDGE, EDGE_FOO --> EDGE_FOO, etc.

also, added a change log entry (not to be confused with CHANGELOG.md) when a bulk assignment of ds's to a server occurs.

- [x] This PR fixes #2963 

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
Navigate to a server's delivery services - i.e. https://localhost:8442/#!/servers/2591/delivery-services

under "More" you'll see:

![image](https://user-images.githubusercontent.com/251272/56756948-35d97880-6750-11e9-8713-24fd6a35ae53.png)

in the list of target servers, you'll see those of the same type as the source server. clone and ensure, the ds's are assigned to the target server and check the change log as well: https://localhost:8442/#!/change-logs

Mostly UI code, no UI tests were added for this. No documentation changes required as this functionality was never documented in the first place.

## If this is a bug fix, what versions of Traffic Ops are affected?

- master (488039c)
- 3.0.1

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
