### PR TITLE
Default unavailable_server_retry_responses

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2526,7 +2526,7 @@ sub parent_dot_config { #fix qstring - should be ignore for quika
 			my $multi_site_origin                  = $ds->{multi_site_origin} || 0;
 			my $mso_algorithm                      = $ds->{'param'}->{'parent.config'}->{'mso.algorithm'} || 'consistent_hash';
 			my $parent_retry                       = $ds->{'param'}->{'parent.config'}->{'mso.parent_retry'} || 'both';
-			my $unavailable_server_retry_responses = $ds->{'param'}->{'parent.config'}->{'mso.unavailable_server_retry_responses'} || '';
+			my $unavailable_server_retry_responses = $ds->{'param'}->{'parent.config'}->{'mso.unavailable_server_retry_responses'} || '"503"';
 			my $max_simple_retries                 = $ds->{'param'}->{'parent.config'}->{'mso.max_simple_retries'} || 1;
 			my $max_unavailable_server_retries     = $ds->{'param'}->{'parent.config'}->{'mso.max_unavailable_server_retries'} || 1;
 
@@ -2617,13 +2617,8 @@ sub parent_dot_config { #fix qstring - should be ignore for quika
 				}
 				$text .= "$parents round_robin=$mso_algorithm qstring=$parent_qstring go_direct=false parent_is_proxy=false";
 
-				if ( $ats_major_version >= 6 && $parent_retry ne "" ) {
-					if ( $unavailable_server_retry_responses ne "" && $unavailable_server_retry_responses =~ /^"(?:\d{3},)+\d{3}"\s*$/) {
-						$text .= " parent_retry=$parent_retry unavailable_server_retry_responses=$unavailable_server_retry_responses";
-					} else {
-						$text .= " parent_retry=$parent_retry";
-					}
-					$text .= " max_simple_retries=$max_simple_retries max_unavailable_server_retries=$max_unavailable_server_retries";
+				if ( $ats_major_version >= 6 ) {
+					$text .= " parent_retry=$parent_retry unavailable_server_retry_responses=$unavailable_server_retry_responses max_simple_retries=$max_simple_retries max_unavailable_server_retries=$max_unavailable_server_retries";
 				}
 				$text .= "\n";
 				push @text_array, $text;
@@ -2663,7 +2658,7 @@ sub parent_dot_config { #fix qstring - should be ignore for quika
 			my %seen;
 			@secondary_parent_info = grep { !$seen{$_}++ } @secondary_parent_info;
 		}
-		#If the ats version supports it, put secondary parents into secondary parent group.
+		#If the ats version supports it, put secondary parents into secondary parent group
 		#This will ensure that secondary parents will be unused unless all hosts in the primary group are unavailable.
 		my $parents = '';
 		my $secparents = '';


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This avoid warnings in Traffic Server logs by setting the default value explicitly

```
[May  7 18:48:34.899] Server {0x2b8caf4ddd40} WARNING: [ParentSelection] initializing UnavailableServerResponseCodes on line 2 to 503 default.
[May  7 18:48:34.899] Server {0x2b8caf4ddd40} WARNING: UnavailableServerResponseCodes - unavailable_server_retry_responses is null loading default 503 code.
[May  7 18:48:34.901] Server {0x2b8caf4ddd40} WARNING: [ParentSelection] initializing UnavailableServerResponseCodes on line 4 to 503 default.
[May  7 18:48:34.901] Server {0x2b8caf4ddd40} WARNING: UnavailableServerResponseCodes - unavailable_server_retry_responses is null loading default 503 cod
```

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops
- Traffic Ops ORT
- Documentation: Not required, just avoid a warning.

## What is the best way to verify this PR?

Run ORT against Traffic Server and verify not warning or errors displayed in diags.log

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
