### PR TITLE
TO: Fix 404 errors

### DIFF
--- a/traffic_ops/testing/api/v14/origins_test.go
+++ b/traffic_ops/testing/api/v14/origins_test.go
@@ -16,6 +16,7 @@ package v14
 */
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ func TestOrigins(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, Users, DeliveryServices, Coordinates, Origins}, func() {
 		UpdateTestOrigins(t)
 		GetTestOrigins(t)
+		NotFoundDeleteTest(t)
 		OriginTenancyTest(t)
 	})
 }
@@ -39,6 +41,13 @@ func CreateTestOrigins(t *testing.T) {
 		if err != nil {
 			t.Errorf("could not CREATE origins: %v\n", err)
 		}
+	}
+}
+
+func NotFoundDeleteTest(t *testing.T) {
+	_, _, err := TOSession.DeleteOriginByID(2020)
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("deleted origin with what should be a non-existent id\n")
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
@@ -234,7 +234,7 @@ func (st *TOSteeringTargetV11) Update() (error, error, int) {
 	st.LastUpdated = &lastUpdated
 	if rowsAffected != 1 {
 		if rowsAffected < 1 {
-			return nil, nil, http.StatusNotFound
+			return errors.New("steering target not found"), nil, http.StatusNotFound
 		}
 		return nil, errors.New("too many ids returned from steering target update"), http.StatusInternalServerError
 	}
@@ -256,7 +256,7 @@ func (st *TOSteeringTargetV11) Delete() (error, error, int) {
 	}
 
 	if rowsAffected < 1 {
-		return nil, nil, http.StatusNotFound
+		return errors.New("steering target not found"), nil, http.StatusNotFound
 	} else if rowsAffected != 1 {
 		return nil, fmt.Errorf("this create affected too many rows: %d", rowsAffected), http.StatusInternalServerError
 	}


### PR DESCRIPTION

## What does this PR (Pull Request) do?

This PR fixes #3448

The origins and steering targets did not return 404 errors for updating or deleting.

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Try to update an origin or steering target that doesn't exist.

## If this is a bug fix, what versions of Traffic Ops are affected?

As far as I know, this has been an issue since each endpoint got rewritten.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
    - No new features or significant changes
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
    - No new features or significant changes
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
