### PR TITLE
Fixed cachegroup deliveryservice ISE

### DIFF
--- a/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
@@ -63,9 +63,12 @@ func DSPostHandler(w http.ResponseWriter, r *http.Request) {
 
 // postDSes returns the post response, any user error, any system error, and the HTTP status code to be returned in the event of an error.
 func postDSes(tx *sql.Tx, user *auth.CurrentUser, cgID int64, dsIDs []int64) (tc.CacheGroupPostDSResp, error, error, int) {
-	cdnName, err := getCachegroupCDN(tx, cgID)
-	if err != nil {
-		return tc.CacheGroupPostDSResp{}, nil, errors.New("getting cachegroup CDN: " + err.Error()), http.StatusInternalServerError
+	cdnName, usrErr, sysErr, errCode := getCachegroupCDN(tx, cgID)
+	if sysErr != nil {
+		sysErr = errors.New("getting cachegroup CDN: " + sysErr.Error())
+	}
+	if usrErr != nil || sysErr != nil {
+		return tc.CacheGroupPostDSResp{}, usrErr, sysErr, errCode
 	}
 
 	tenantIDs, err := getDSTenants(tx, dsIDs)
@@ -157,7 +160,7 @@ AND cdn.name <> $2::text
 	return nil
 }
 
-func getCachegroupCDN(tx *sql.Tx, cgID int64) (string, error) {
+func getCachegroupCDN(tx *sql.Tx, cgID int64) (string, error, error, int) {
 	q := `
 SELECT cdn.name
 FROM cdn
@@ -168,26 +171,26 @@ AND (type.name LIKE 'EDGE%' OR type.name LIKE 'ORG%')
 `
 	rows, err := tx.Query(q, cgID)
 	if err != nil {
-		return "", errors.New("selecting cachegroup CDNs: " + err.Error())
+		return "", nil, errors.New("selecting cachegroup CDNs: " + err.Error()), http.StatusInternalServerError
 	}
 	defer rows.Close()
 	cdn := ""
 	for rows.Next() {
 		serverCDN := ""
 		if err := rows.Scan(&serverCDN); err != nil {
-			return "", errors.New("scanning cachegroup CDN: " + err.Error())
+			return "", nil, errors.New("scanning cachegroup CDN: " + err.Error()), http.StatusInternalServerError
 		}
 		if cdn == "" {
 			cdn = serverCDN
 		}
 		if cdn != serverCDN {
-			return "", errors.New("cachegroup servers have different CDNs '" + cdn + "' and '" + serverCDN + "'")
+			return "", nil, errors.New("cachegroup servers have different CDNs '" + cdn + "' and '" + serverCDN + "'"), http.StatusInternalServerError
 		}
 	}
 	if cdn == "" {
-		return "", errors.New("no edge or origin servers found on cachegroup " + strconv.FormatInt(cgID, 10))
+		return "", errors.New("no edge or origin servers found on cachegroup " + strconv.FormatInt(cgID, 10)), nil, http.StatusBadRequest
 	}
-	return cdn, nil
+	return cdn, nil, nil, http.StatusOK
 }
 
 // updateParams updated the header rewrite, cacheurl, and regex remap params for the given edge caches, on the given delivery services. NOTE it does not update Mid params.


### PR DESCRIPTION

## What does this PR (Pull Request) do?

- [x] This PR fixes #2932

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Create a cachegroup with no severs.

Perform the following command:
`curl -XPOST --cookie $mc -Lvsk https://localhost:6443/api/1.4/cachegroups/473/deliveryservices -d @cachegroup_deliveryservice.json | jq .`

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
    - I don't think I could test anything useful.
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
    - No new significant updates.
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
    - No new significant updates.
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
