### PR TITLE
Client steering forced diversity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Router: TR now generates a self-signed certificate at startup and uses it as the default TLS cert.
   The default certificate is used whenever a client attempts an SSL handshake for an SNI host which does not match
   any of the other certificates.
+- Client Steering Forced Diversity: force Traffic Router to return more unique edge caches in CLIENT_STEERING results instead of the default behavior which can sometimes return a result of multiple targets using the same edge cache. In the case of edge cache failures, this feature will give clients a chance to retry a different edge cache. This can be enabled with the new "client.steering.forced.diversity" Traffic Router profile parameter.
 - Traffic Ops Golang Endpoints
   - /api/1.4/deliveryservices `(GET,POST,PUT)`
   - /api/1.4/users `(GET,POST,PUT)`

--- a/docs/source/admin/traffic_ops/using.rst
+++ b/docs/source/admin/traffic_ops/using.rst
@@ -413,6 +413,8 @@ Traffic Router Profile
 +-----------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
 | deepcoveragezone.polling.url            | CRConfig.json          | The location (URL) to retrieve the deep coverage zone map file in JSON format from.                                                              |
 +-----------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
+| client.steering.forced.diversity        | CRConfig.json          | Enable the Client Steering Forced Diversity feature (value = "true") to diversify CLIENT_STEERING results by including more unique edge caches   |
++-----------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
 | tld.soa.expire                          | CRConfig.json          | The value for the expire field the Traffic Router DNS Server will respond with on Start of Authority (SOA) records.                              |
 +-----------------------------------------+------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
 | tld.soa.minimum                         | CRConfig.json          | The value for the minimum field the Traffic Router DNS Server will respond with on SOA records.                                                  |

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -547,14 +547,18 @@ public class TrafficRouter {
 		for (final SteeringResult steeringResult : steeringResults) {
 			final DeliveryService ds = steeringResult.getDeliveryService();
 
-			final List<Cache> caches = selectCaches(request, ds, track);
+			List<Cache> caches = selectCaches(request, ds, track);
 
 			// child Delivery Services can use their query parameters
 			final String pathToHash = steeringHash + ds.extractSignificantQueryParams(request);
 
 			if (caches != null && !caches.isEmpty()) {
-				if (isClientSteeringDiversityEnabled() && caches.size() > selectedCaches.size()) {
-					caches.removeAll(selectedCaches);
+				if (isClientSteeringDiversityEnabled()) {
+				    final List<Cache> tryCaches = new ArrayList<>(caches);
+				    tryCaches.removeAll(selectedCaches);
+				    if (!tryCaches.isEmpty()) {
+						caches = tryCaches;
+					}
 				}
 				final Cache cache = consistentHasher.selectHashable(caches, ds.getDispersion(), pathToHash);
 				steeringResult.setCache(cache);

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -566,6 +566,7 @@ public class TrafficRouter {
 					} else if (track.result == ResultType.DEEP_CZ) {
 						// deep caches have been selected already, try non-deep selection
 						tryCaches = selectCaches(request, ds, track, false);
+						track.setResult(ResultType.DEEP_CZ); // request should still be tracked as a DEEP_CZ hit
 						tryCaches.removeAll(selectedCaches);
 						if (!tryCaches.isEmpty()) {
 							caches = tryCaches;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -81,6 +81,7 @@ import com.comcast.cdn.traffic_control.traffic_router.core.loc.AnonymousIpDataba
 public class TrafficRouter {
 	public static final Logger LOGGER = Logger.getLogger(TrafficRouter.class);
 	public static final String XTC_STEERING_OPTION = "x-tc-steering-option";
+	public static final String CLIENT_STEERING_FORCED_DIVERSITY = "client.steering.forced.diversity";
 
 	private final CacheRegister cacheRegister;
 	private final ZoneManager zoneManager;
@@ -89,6 +90,7 @@ public class TrafficRouter {
 	private final AnonymousIpDatabaseService anonymousIpService;
 	private final FederationRegistry federationRegistry;
 	private final boolean consistentDNSRouting;
+	private final boolean clientSteeringForcedDiversityEnabled;
 
 	private final Random random = new Random(System.nanoTime());
 	private Set<String> requestHeaders = new HashSet<String>();
@@ -114,6 +116,7 @@ public class TrafficRouter {
 		this.anonymousIpService = anonymousIpService;
 		this.federationRegistry = federationRegistry;
 		this.consistentDNSRouting = JsonUtils.optBoolean(cr.getConfig(), "consistent.dns.routing");
+		this.clientSteeringForcedDiversityEnabled = JsonUtils.optBoolean(cr.getConfig(), CLIENT_STEERING_FORCED_DIVERSITY);
 		this.zoneManager = new ZoneManager(this, statTracker, trafficOpsUtils, trafficRouterManager);
 
 		if (cr.getConfig() != null) {
@@ -537,6 +540,8 @@ public class TrafficRouter {
 
 		final List<SteeringResult> resultsToRemove = new ArrayList<>();
 
+		final Set<Cache> selectedCaches = new HashSet<>();
+
 		// Pattern based consistent hashing - use consistentHashRegex from steering DS instead of targets
 		final String steeringHash = buildPatternBasedHashString(entryDeliveryService.getConsistentHashRegex(), request.getPath());
 		for (final SteeringResult steeringResult : steeringResults) {
@@ -548,8 +553,12 @@ public class TrafficRouter {
 			final String pathToHash = steeringHash + ds.extractSignificantQueryParams(request);
 
 			if (caches != null && !caches.isEmpty()) {
+				if (isClientSteeringForcedDiversityEnabled() && caches.size() > selectedCaches.size()) {
+					caches.removeAll(selectedCaches);
+				}
 				final Cache cache = consistentHasher.selectHashable(caches, ds.getDispersion(), pathToHash);
 				steeringResult.setCache(cache);
+				selectedCaches.add(cache);
 			} else {
 				resultsToRemove.add(steeringResult);
 			}
@@ -1224,6 +1233,10 @@ public class TrafficRouter {
 
 	public boolean isConsistentDNSRouting() {
 		return consistentDNSRouting;
+	}
+
+	public boolean isClientSteeringForcedDiversityEnabled() {
+		return clientSteeringForcedDiversityEnabled;
 	}
 
 	private List<Cache> enforceGeoRedirect(final Track track, final DeliveryService ds, final String clientIp, final Geolocation queriedClientLocation) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -81,7 +81,7 @@ import com.comcast.cdn.traffic_control.traffic_router.core.loc.AnonymousIpDataba
 public class TrafficRouter {
 	public static final Logger LOGGER = Logger.getLogger(TrafficRouter.class);
 	public static final String XTC_STEERING_OPTION = "x-tc-steering-option";
-	public static final String CLIENT_STEERING_FORCED_DIVERSITY = "client.steering.forced.diversity";
+	public static final String CLIENT_STEERING_DIVERSITY = "client.steering.forced.diversity";
 
 	private final CacheRegister cacheRegister;
 	private final ZoneManager zoneManager;
@@ -90,7 +90,7 @@ public class TrafficRouter {
 	private final AnonymousIpDatabaseService anonymousIpService;
 	private final FederationRegistry federationRegistry;
 	private final boolean consistentDNSRouting;
-	private final boolean clientSteeringForcedDiversityEnabled;
+	private final boolean clientSteeringDiversityEnabled;
 
 	private final Random random = new Random(System.nanoTime());
 	private Set<String> requestHeaders = new HashSet<String>();
@@ -116,7 +116,7 @@ public class TrafficRouter {
 		this.anonymousIpService = anonymousIpService;
 		this.federationRegistry = federationRegistry;
 		this.consistentDNSRouting = JsonUtils.optBoolean(cr.getConfig(), "consistent.dns.routing");
-		this.clientSteeringForcedDiversityEnabled = JsonUtils.optBoolean(cr.getConfig(), CLIENT_STEERING_FORCED_DIVERSITY);
+		this.clientSteeringDiversityEnabled = JsonUtils.optBoolean(cr.getConfig(), CLIENT_STEERING_DIVERSITY);
 		this.zoneManager = new ZoneManager(this, statTracker, trafficOpsUtils, trafficRouterManager);
 
 		if (cr.getConfig() != null) {
@@ -553,7 +553,7 @@ public class TrafficRouter {
 			final String pathToHash = steeringHash + ds.extractSignificantQueryParams(request);
 
 			if (caches != null && !caches.isEmpty()) {
-				if (isClientSteeringForcedDiversityEnabled() && caches.size() > selectedCaches.size()) {
+				if (isClientSteeringDiversityEnabled() && caches.size() > selectedCaches.size()) {
 					caches.removeAll(selectedCaches);
 				}
 				final Cache cache = consistentHasher.selectHashable(caches, ds.getDispersion(), pathToHash);
@@ -1235,8 +1235,8 @@ public class TrafficRouter {
 		return consistentDNSRouting;
 	}
 
-	public boolean isClientSteeringForcedDiversityEnabled() {
-		return clientSteeringForcedDiversityEnabled;
+	public boolean isClientSteeringDiversityEnabled() {
+		return clientSteeringDiversityEnabled;
 	}
 
 	private List<Cache> enforceGeoRedirect(final Track track, final DeliveryService ds, final String clientIp, final Geolocation queriedClientLocation) {

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouterTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouterTest.java
@@ -170,6 +170,7 @@ public class TrafficRouterTest {
         when(deliveryService.filterAvailableLocations(any(Collection.class))).thenCallRealMethod();
 
         when(trafficRouter.selectCaches(any(HTTPRequest.class), any(DeliveryService.class), any(Track.class))).thenCallRealMethod();
+        when(trafficRouter.selectCaches(any(HTTPRequest.class), any(DeliveryService.class), any(Track.class), anyBoolean())).thenCallRealMethod();
         when(trafficRouter.selectCachesByGeo(anyString(), any(DeliveryService.class), any(CacheLocation.class), any(Track.class))).thenCallRealMethod();
 
         Geolocation clientLocation = new Geolocation(40, -100);

--- a/traffic_router/core/src/test/resources/dczmap.json
+++ b/traffic_router/core/src/test/resources/dczmap.json
@@ -20,6 +20,18 @@
 				"host3",
 				"host4"
 			]
+		},
+		"csd-group": {
+			"network6": [
+				"fd12:3456::/64"
+			],
+			"network": [
+				"192.168.42.0/24"
+			],
+			"caches": [
+				"edge-cache-csd-1",
+				"edge-cache-csd-2"
+			]
 		}
 	}
 }

--- a/traffic_router/core/src/test/resources/internal/api/1.3/steering.json
+++ b/traffic_router/core/src/test/resources/internal/api/1.3/steering.json
@@ -45,6 +45,32 @@
       "clientSteering": true
     },
     {
+      "deliveryService": "client-steering-diversity-test",
+      "targets": [
+        {
+          "deliveryService": "csd-target-1",
+          "weight": "5000"
+        },
+        {
+          "deliveryService": "csd-target-2",
+          "weight": "5000"
+        },
+        {
+          "deliveryService": "csd-target-3",
+          "weight": "5000"
+        },
+        {
+          "deliveryService": "csd-target-4",
+          "weight": "5000"
+        },
+        {
+          "deliveryService": "csd-target-5",
+          "weight": "5000"
+        }
+      ],
+      "clientSteering": true
+    },
+    {
       "deliveryService": "client-steering-test-2",
       "targets": [
         {

--- a/traffic_router/core/src/test/resources/publish/CrConfig.json
+++ b/traffic_router/core/src/test/resources/publish/CrConfig.json
@@ -479,6 +479,69 @@
       "deliveryServices": {
         "http-and-https-test": [ "edge-cache-082.http-and-https-test.thecdn.example.com"]
       }
+    },
+    "edge-cache-csd-1": {
+      "type": "EDGE",
+      "profile": "EDGE_STATIC",
+      "status": "REPORTED",
+      "hashId": "edge-cache-csd-1@xmpp.cdn.example.com",
+      "fqdn": "edge-cache-csd-1.thecdn.example.com",
+      "port": "8090",
+      "ip": "12.34.8.201",
+      "ip6": "2001:dead:beef:8:C::81/64",
+      "cacheGroup": "cache-group-csd",
+      "locationId": "location-csd",
+      "hashCount": 1000,
+      "interfaceName": "bond0",
+      "deliveryServices": {
+        "csd-target-1": ["edge-cache-csd-1.csd-target-1.thecdn.example.com"],
+        "csd-target-2": ["edge-cache-csd-1.csd-target-2.thecdn.example.com"],
+        "csd-target-3": ["edge-cache-csd-1.csd-target-3.thecdn.example.com"],
+        "csd-target-4": ["edge-cache-csd-1.csd-target-4.thecdn.example.com"],
+        "csd-target-5": ["edge-cache-csd-1.csd-target-5.thecdn.example.com"]
+      }
+    },
+    "edge-cache-csd-2": {
+      "type": "EDGE",
+      "profile": "EDGE_STATIC",
+      "status": "REPORTED",
+      "hashId": "edge-cache-csd-2@xmpp.cdn.example.com",
+      "fqdn": "edge-cache-csd-2.thecdn.example.com",
+      "port": "8090",
+      "ip": "12.34.8.202",
+      "ip6": "2001:dead:beef:8:C::82/64",
+      "cacheGroup": "cache-group-csd",
+      "locationId": "location-csd",
+      "hashCount": 1000,
+      "interfaceName": "bond0",
+      "deliveryServices": {
+        "csd-target-1": ["edge-cache-csd-2.csd-target-1.thecdn.example.com"],
+        "csd-target-2": ["edge-cache-csd-2.csd-target-2.thecdn.example.com"],
+        "csd-target-3": ["edge-cache-csd-2.csd-target-3.thecdn.example.com"],
+        "csd-target-4": ["edge-cache-csd-2.csd-target-4.thecdn.example.com"],
+        "csd-target-5": ["edge-cache-csd-2.csd-target-5.thecdn.example.com"]
+      }
+    },
+    "edge-cache-csd-3": {
+      "type": "EDGE",
+      "profile": "EDGE_STATIC",
+      "status": "REPORTED",
+      "hashId": "edge-cache-csd-3@xmpp.cdn.example.com",
+      "fqdn": "edge-cache-csd-3.thecdn.example.com",
+      "port": "8090",
+      "ip": "12.34.8.203",
+      "ip6": "2001:dead:beef:8:C::83/64",
+      "cacheGroup": "cache-group-csd",
+      "locationId": "location-csd",
+      "hashCount": 1000,
+      "interfaceName": "bond0",
+      "deliveryServices": {
+        "csd-target-1": ["edge-cache-csd-3.csd-target-1.thecdn.example.com"],
+        "csd-target-2": ["edge-cache-csd-3.csd-target-2.thecdn.example.com"],
+        "csd-target-3": ["edge-cache-csd-3.csd-target-3.thecdn.example.com"],
+        "csd-target-4": ["edge-cache-csd-3.csd-target-4.thecdn.example.com"],
+        "csd-target-5": ["edge-cache-csd-3.csd-target-5.thecdn.example.com"]
+      }
     }
   },
   "contentRouters": {
@@ -665,6 +728,305 @@
       },
       "geolocationProvider": "maxmindGeolocationService",
       "staticDnsEntries": []
+    },
+    "client-steering-diversity-test": {
+      "sslEnabled": "false",
+      "protocol": {
+        "acceptHttp" : "true",
+        "acceptHttps" : "false",
+        "redirectToHttps" : "false"
+      },
+      "requestHeaders": ["X-MoneyTrace"],
+      "domains": ["client-steering-diversity-test.thecdn.example.com"],
+      "missLocation": {
+        "long": "-87.627778",
+        "lat": "41.881944"
+      },
+      "ttls": {
+        "AAAA": "3600",
+        "SOA": "7200",
+        "A": "3600",
+        "NS": "3600"
+      },
+      "ttl": "3600",
+      "ip6RoutingEnabled": "true",
+      "bypassDestination": {"HTTP": {
+        "port": "80",
+        "fqdn": "client-steering-diversity-test.overflowcdn.net"
+      }},
+      "dispersion": {
+        "limit": 1,
+        "shuffled": "true"
+      },
+      "coverageZoneOnly": "false",
+      "routingName": "cdn",
+      "regionalGeoBlocking": "false",
+      "matchsets": [{
+        "protocol": "HTTP",
+        "matchlist": [{
+          "regex": ".*\\.client-steering-diversity-test\\..*",
+          "match-type": "HOST"
+        }]
+      }],
+      "soa": {
+        "expire": "604800",
+        "minimum": "30",
+        "admin": "operations@thecdn.example.com",
+        "retry": "7200",
+        "refresh": "28800"
+      },
+      "geolocationProvider": "maxmindGeolocationService",
+      "staticDnsEntries": []
+    },
+    "csd-target-1": {
+      "sslEnabled": "false",
+      "protocol": {
+        "acceptHttp" : "true",
+        "acceptHttps" : "false",
+        "redirectToHttps" : "false"
+      },
+      "requestHeaders": [
+        "User-Agent",
+        "MyHeader",
+        "Date"
+      ],
+      "dispersion": {
+        "limit": 1,
+        "shuffled": "true"
+      },
+      "domains": ["csd-target-1.thecdn.example.com"],
+      "coverageZoneOnly": "false",
+      "routingName": "cdn",
+      "matchsets": [
+        {
+          "protocol": "HTTP",
+          "matchlist": [{
+            "regex": ".*\\.csd-target-1\\..*",
+            "match-type": "HOST"
+          }]
+        }
+      ],
+      "regionalGeoBlocking": "false",
+      "ttls": {
+        "AAAA": "3600",
+        "SOA": "7200",
+        "A": "3600",
+        "NS": "3600"
+      },
+      "missLocation": {
+        "long": "-87.627778",
+        "lat": "41.881944"
+      },
+      "soa": {
+        "expire": "604800",
+        "minimum": "3 0",
+        "admin": "operations@thecdn.example.com",
+        "retry": "7200",
+        "refresh": "28800"
+      },
+      "geolocationProvider": "maxmindGeolocationService",
+      "ttl": "3600",
+      "ip6RoutingEnabled": "false"
+    },
+    "csd-target-2": {
+      "sslEnabled": "false",
+      "protocol": {
+        "acceptHttp" : "true",
+        "acceptHttps" : "false",
+        "redirectToHttps" : "false"
+      },
+      "requestHeaders": [
+        "User-Agent",
+        "MyHeader",
+        "Date"
+      ],
+      "dispersion": {
+        "limit": 1,
+        "shuffled": "true"
+      },
+      "domains": ["csd-target-2.thecdn.example.com"],
+      "coverageZoneOnly": "false",
+      "routingName": "cdn",
+      "matchsets": [
+        {
+          "protocol": "HTTP",
+          "matchlist": [{
+            "regex": ".*\\.csd-target-2\\..*",
+            "match-type": "HOST"
+          }]
+        }
+      ],
+      "regionalGeoBlocking": "false",
+      "ttls": {
+        "AAAA": "3600",
+        "SOA": "7200",
+        "A": "3600",
+        "NS": "3600"
+      },
+      "missLocation": {
+        "long": "-87.627778",
+        "lat": "41.881944"
+      },
+      "soa": {
+        "expire": "604800",
+        "minimum": "3 0",
+        "admin": "operations@thecdn.example.com",
+        "retry": "7200",
+        "refresh": "28800"
+      },
+      "geolocationProvider": "maxmindGeolocationService",
+      "ttl": "3600",
+      "ip6RoutingEnabled": "false"
+    },
+    "csd-target-3": {
+      "sslEnabled": "false",
+      "protocol": {
+        "acceptHttp" : "true",
+        "acceptHttps" : "false",
+        "redirectToHttps" : "false"
+      },
+      "requestHeaders": [
+        "User-Agent",
+        "MyHeader",
+        "Date"
+      ],
+      "dispersion": {
+        "limit": 1,
+        "shuffled": "true"
+      },
+      "domains": ["csd-target-3.thecdn.example.com"],
+      "coverageZoneOnly": "false",
+      "routingName": "cdn",
+      "matchsets": [
+        {
+          "protocol": "HTTP",
+          "matchlist": [{
+            "regex": ".*\\.csd-target-3\\..*",
+            "match-type": "HOST"
+          }]
+        }
+      ],
+      "regionalGeoBlocking": "false",
+      "ttls": {
+        "AAAA": "3600",
+        "SOA": "7200",
+        "A": "3600",
+        "NS": "3600"
+      },
+      "missLocation": {
+        "long": "-87.627778",
+        "lat": "41.881944"
+      },
+      "soa": {
+        "expire": "604800",
+        "minimum": "3 0",
+        "admin": "operations@thecdn.example.com",
+        "retry": "7200",
+        "refresh": "28800"
+      },
+      "geolocationProvider": "maxmindGeolocationService",
+      "ttl": "3600",
+      "ip6RoutingEnabled": "false"
+    },
+    "csd-target-4": {
+      "sslEnabled": "false",
+      "protocol": {
+        "acceptHttp" : "true",
+        "acceptHttps" : "false",
+        "redirectToHttps" : "false"
+      },
+      "requestHeaders": [
+        "User-Agent",
+        "MyHeader",
+        "Date"
+      ],
+      "dispersion": {
+        "limit": 1,
+        "shuffled": "true"
+      },
+      "domains": ["csd-target-4.thecdn.example.com"],
+      "coverageZoneOnly": "false",
+      "routingName": "cdn",
+      "matchsets": [
+        {
+          "protocol": "HTTP",
+          "matchlist": [{
+            "regex": ".*\\.csd-target-4\\..*",
+            "match-type": "HOST"
+          }]
+        }
+      ],
+      "regionalGeoBlocking": "false",
+      "ttls": {
+        "AAAA": "3600",
+        "SOA": "7200",
+        "A": "3600",
+        "NS": "3600"
+      },
+      "missLocation": {
+        "long": "-87.627778",
+        "lat": "41.881944"
+      },
+      "soa": {
+        "expire": "604800",
+        "minimum": "3 0",
+        "admin": "operations@thecdn.example.com",
+        "retry": "7200",
+        "refresh": "28800"
+      },
+      "geolocationProvider": "maxmindGeolocationService",
+      "ttl": "3600",
+      "ip6RoutingEnabled": "false"
+    },
+    "csd-target-5": {
+      "sslEnabled": "false",
+      "protocol": {
+        "acceptHttp" : "true",
+        "acceptHttps" : "false",
+        "redirectToHttps" : "false"
+      },
+      "requestHeaders": [
+        "User-Agent",
+        "MyHeader",
+        "Date"
+      ],
+      "dispersion": {
+        "limit": 1,
+        "shuffled": "true"
+      },
+      "domains": ["csd-target-5.thecdn.example.com"],
+      "coverageZoneOnly": "false",
+      "routingName": "cdn",
+      "matchsets": [
+        {
+          "protocol": "HTTP",
+          "matchlist": [{
+            "regex": ".*\\.csd-target-5\\..*",
+            "match-type": "HOST"
+          }]
+        }
+      ],
+      "regionalGeoBlocking": "false",
+      "ttls": {
+        "AAAA": "3600",
+        "SOA": "7200",
+        "A": "3600",
+        "NS": "3600"
+      },
+      "missLocation": {
+        "long": "-87.627778",
+        "lat": "41.881944"
+      },
+      "soa": {
+        "expire": "604800",
+        "minimum": "3 0",
+        "admin": "operations@thecdn.example.com",
+        "retry": "7200",
+        "refresh": "28800"
+      },
+      "geolocationProvider": "maxmindGeolocationService",
+      "ttl": "3600",
+      "ip6RoutingEnabled": "false"
     },
     "client-steering-target-1": {
       "sslEnabled": "false",
@@ -1450,10 +1812,16 @@
       "localizationMethods": ["CZ", "DEEP_CZ", "GEO"],
       "longitude": -86.0,
       "latitude": 36.0
+    },
+    "location-csd": {
+      "localizationMethods": ["CZ", "DEEP_CZ", "GEO"],
+      "longitude": -87.0,
+      "latitude": 37.0
     }
   },
   "config": {
     "certificate.api.url": "http://${toHostname}/api/1.3/cdns/name/${cdnName}/sslkeys.json",
+    "client.steering.forced.diversity": "true",
     "federationmapping.polling.url": "http://${toHostname}/internal/api/1.3/federations.json",
     "federationmapping.polling.interval": "600000",
     "steeringmapping.polling.url": "http://${toHostname}/internal/api/1.3/steering.json",

--- a/traffic_router/core/src/test/resources/publish/CrConfig.json
+++ b/traffic_router/core/src/test/resources/publish/CrConfig.json
@@ -790,6 +790,7 @@
         "MyHeader",
         "Date"
       ],
+      "deepCachingType": "ALWAYS",
       "dispersion": {
         "limit": 1,
         "shuffled": "true"
@@ -840,6 +841,7 @@
         "MyHeader",
         "Date"
       ],
+      "deepCachingType": "ALWAYS",
       "dispersion": {
         "limit": 1,
         "shuffled": "true"
@@ -890,6 +892,7 @@
         "MyHeader",
         "Date"
       ],
+      "deepCachingType": "ALWAYS",
       "dispersion": {
         "limit": 1,
         "shuffled": "true"
@@ -1856,6 +1859,7 @@
       "refresh": "28800"
     },
     "coveragezone.polling.url": "http://localhost:8889/czf.json",
+    "deepcoveragezone.polling.url": "http://localhost:8889/dczmap.json",
     "api.auth.url": "http://${toHostname}/api/1.3/user/login",
     "certificates.polling.interval": "10000",
     "dnssec.enabled": "false"

--- a/traffic_router/core/src/test/resources/publish/CrStates
+++ b/traffic_router/core/src/test/resources/publish/CrStates
@@ -99,7 +99,10 @@
     "edge-cache-096": {"isAvailable": true},
     "edge-cache-097": {"isAvailable": true},
     "edge-cache-098": {"isAvailable": true},
-    "edge-cache-099": {"isAvailable": true}
+    "edge-cache-099": {"isAvailable": true},
+    "edge-cache-csd-1": {"isAvailable": true},
+    "edge-cache-csd-2": {"isAvailable": true},
+    "edge-cache-csd-3": {"isAvailable": true}
   },
   "deliveryServices": {
     "steering-test-1": {
@@ -143,6 +146,30 @@
       "isAvailable": true
     },
     "test-dns": {
+      "disabledLocations": [],
+      "isAvailable": true
+    },
+    "client-steering-diversity-test": {
+      "disabledLocations": [],
+      "isAvailable": true
+    },
+    "csd-target-1": {
+      "disabledLocations": [],
+      "isAvailable": true
+    },
+    "csd-target-2": {
+      "disabledLocations": [],
+      "isAvailable": true
+    },
+    "csd-target-3": {
+      "disabledLocations": [],
+      "isAvailable": true
+    },
+    "csd-target-4": {
+      "disabledLocations": [],
+      "isAvailable": true
+    },
+    "csd-target-5": {
       "disabledLocations": [],
       "isAvailable": true
     },


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
Add a Traffic Router profile parameter that enables the Client Steering Forced Diversity feature. With this feature enabled, Traffic Router will modify its default consistent-hashing behavior w.r.t. CLIENT_STEERING in order to force a more diverse result (one that includes more unique edge caches). This is beneficial for clients to have a better chance at recovery in case of edge cache failures, because they are more likely to retry a different edge cache. With the default behavior, a client can sometimes receive a result with the same edge multiple times, causing a client to potentially retry a failed node multiple times.

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Documentation
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Run the Traffic Router tests: ```mvn clean verify -Djava.library.path=/usr/local/opt/tomcat-native/lib # replace path with your system's path to tc-native```
2. Manually: create a parameter called `client.steering.forced.diversity` with file = CRConfig.json and value = "false", link it it your Traffic Router profile, and snapshot. Make requests to a CLIENT_STEERING delivery service and observe the default (non-diverse) responses. Now, set the value to "true", snapshot, and make the same requests. Observe that the responses contain a more diverse set of edges for all requests.

## If this is a bug fix, what versions of Traffic Ops are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
