### PR TITLE
Added IDImpl struct

### DIFF
--- a/lib/go-tc/cdns.go
+++ b/lib/go-tc/cdns.go
@@ -1,5 +1,7 @@
 package tc
 
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api/impl"
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -83,7 +85,7 @@ type CDNNullable struct {
 	// ID of the CDN
 	//
 	// required: true
-	ID *int `json:"id" db:"id"`
+	impl.ID
 
 	// LastUpdated
 	//

--- a/traffic_ops/traffic_ops_golang/api/impl/impl.go
+++ b/traffic_ops/traffic_ops_golang/api/impl/impl.go
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// impl was made to prevent a circular import between the tc and api
+// packages. The TC structs are referenced by the api, so embedding
+// something like api.IDImpl in the TC struct won't work.
+//
+// The APIInfoImpl references api.APIInfo, so it isn't included in
+// this package.
+//
+// By making common implementations here we can define behavior by
+// embedding it.
+
+package impl
+
+// IDImpl implements GetKeys and SetKeys for the Identifier interface
+// They do not complete the interface. IDImpl makes the ID Nullable.
+// Although natural keys are prefereable, the current most common case
+// of the keys we use are for a single integer key.
+//
+type IDImpl struct {
+	ID *int `json:"id" db:"id"`
+}
+
+func (val IDImpl) GetKeys() (map[string]interface{}, bool) {
+	if val.ID == nil {
+		return map[string]interface{}{"id": 0}, false
+	}
+	return map[string]interface{}{"id": *val.ID}, true
+}
+
+func (val *IDImpl) SetKeys(keys map[string]interface{}) {
+	id, _ := keys["id"].(int)
+	val.ID = &id
+}

--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -58,14 +58,6 @@ func (cdn TOCDN) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}
 }
 
-//Implementation of the Identifier, Validator interface functions
-func (cdn TOCDN) GetKeys() (map[string]interface{}, bool) {
-	if cdn.ID == nil {
-		return map[string]interface{}{"id": 0}, false
-	}
-	return map[string]interface{}{"id": *cdn.ID}, true
-}
-
 func (cdn TOCDN) GetAuditName() string {
 	if cdn.Name != nil {
 		return *cdn.Name
@@ -78,11 +70,6 @@ func (cdn TOCDN) GetAuditName() string {
 
 func (cdn TOCDN) GetType() string {
 	return "cdn"
-}
-
-func (cdn *TOCDN) SetKeys(keys map[string]interface{}) {
-	i, _ := keys["id"].(int) //this utilizes the non panicking type assertion, if the thrown away ok variable is false i will be the zero of the type, 0 here.
-	cdn.ID = &i
 }
 
 func isValidCDNchar(r rune) bool {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

IDImpl is a struct that implements GetKeys and SetKeys for the common case where the only key is a single numerical ID. The idea is to make a single, common implementation that can be used across all endpoints that can use it. As a bonus these endpoints don't need to make a GetKeys or SetKeys function, nor do they have to provide the json and db tags and we know the behavior we want is implemented.

The downside is that current swagger comments may be broken (although we weren't exactly using it anyway).

This is mostly a test to get feedback. I've had an idea like this for awhile, but didn't implement it because I had doubts. I think it is relatively useful, although it is debatable whether or not this works well as a layer of abstraction since "every abstraction layer has a cost". I was considering other ways to do the same thing in a better way. Also, some might perfer to keep the tc structs 'clean'.

For now, I've only made the CDN struct use the IDImpl. IDImpl only works for Nullable structs (the structs that we define endpoints on).

## Which Traffic Control components are affected by this PR?

The main affected component is Traffic Ops, but since I've edited a TC struct, it could affect any component that uses the structs. go is smart enough so that `StructType.EmbeddedType.Field` can be called as `StructType.Field` as long as that field name doesn't exist higher up in the embedded struct hierarchy, so moving the field to an embedded type shouldn't affect much.

## What is the best way to verify this PR?

Tests already exist for CDNs and should pass.

## The following criteria are ALL met by this PR

- [x] Tests already exist for affected pieces of code
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
