### PR TITLE
Fix Traffic Ops error log format for Riak, ReverseProxy errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Upgraded Traffic Portal to AngularJS 1.7.8
 - Issue 3275: Improved the snapshot diff performance and experience.
 - Issue #3605: Fixed Traffic Monitor custom ports in health polling URL.
+- Issue 3587: Fixed Traffic Ops Golang reverse proxy and Riak logs to be consistent with the format of other error logs.
 
 ## [3.0.0] - 2018-10-30
 ### Added

--- a/lib/go-log/log.go
+++ b/lib/go-log/log.go
@@ -72,56 +72,36 @@ func Init(eventW, errW, warnW, infoW, debugW io.WriteCloser) {
 	initLogger(&Event, &eventCloser, eventW, "", 0)
 }
 
+func logf(logger *log.Logger, format string, v ...interface{}) {
+	if logger == nil {
+		return
+	}
+	logger.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
+}
+
+func logln(logger *log.Logger, v ...interface{}) {
+	if logger == nil {
+		return
+	}
+	logger.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
+}
+
 const timeFormat = time.RFC3339Nano
 const stackFrame = 3
 
-func Errorf(format string, v ...interface{}) {
-	if Error == nil {
-		return
-	}
-	Error.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
-}
-func Errorln(v ...interface{}) {
-	if Error == nil {
-		return
-	}
-	Error.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
-}
-func Warnf(format string, v ...interface{}) {
-	if Warning == nil {
-		return
-	}
-	Warning.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
-}
-func Warnln(v ...interface{}) {
-	if Warning == nil {
-		return
-	}
-	Warning.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
-}
-func Infof(format string, v ...interface{}) {
-	if Info == nil {
-		return
-	}
-	Info.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
-}
-func Infoln(v ...interface{}) {
-	if Info == nil {
-		return
-	}
-	Info.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
-}
-func Debugf(format string, v ...interface{}) {
-	if Debug == nil {
-		return
-	}
-	Debug.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
-}
-func Debugln(v ...interface{}) {
-	if Debug == nil {
-		return
-	}
-	Debug.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
+func Errorf(format string, v ...interface{}) { logf(Error, format, v...) }
+func Errorln(v ...interface{})               { logln(Error, v...) }
+func Warnf(format string, v ...interface{})  { logf(Warning, format, v...) }
+func Warnln(v ...interface{})                { logln(Warning, v...) }
+func Infof(format string, v ...interface{})  { logf(Info, format, v...) }
+func Infoln(v ...interface{})                { logln(Info, v...) }
+func Debugf(format string, v ...interface{}) { logf(Debug, format, v...) }
+func Debugln(v ...interface{})               { logln(Debug, v...) }
+
+const eventFormat = "%.3f %s"
+
+func eventTime(t time.Time) float64 {
+	return float64(t.Unix()) + (float64(t.Nanosecond()) / 1e9)
 }
 
 // event log entries (TM event.log, TR access.log, etc)
@@ -130,7 +110,7 @@ func Eventf(t time.Time, format string, v ...interface{}) {
 		return
 	}
 	// 1484001185.287 ...
-	Event.Printf("%.3f %s", float64(t.Unix())+(float64(t.Nanosecond())/1e9), fmt.Sprintf(format, v...))
+	Event.Printf(eventFormat, eventTime(t), fmt.Sprintf(format, v...))
 }
 
 // EventfRaw writes to the event log with no prefix.

--- a/lib/go-log/standardlogger.go
+++ b/lib/go-log/standardlogger.go
@@ -1,0 +1,48 @@
+package log
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"log"
+	"strings"
+)
+
+// StandardLogger returns a new Logger which will write the appropriate prefix for standard log Printf calls.
+// This allows the given logger to prefix correctly when passed to third-party or standard library functions which only know about the standard Logger interface.
+// It does this by wrapping logger's error print as a writer, and sets that as the new Logger's io.Writer.
+//
+// prefix is a prefix to add, which will be added immediately before messages, but after any existing prefix on logger and the timestamp.
+//
+func StandardLogger(logger *log.Logger, prefix string) *log.Logger {
+	return log.New(&standardLoggerWriter{realLogger: logger, prefix: prefix}, "", 0)
+}
+
+type standardLoggerWriter struct {
+	realLogger *log.Logger
+	prefix     string
+}
+
+// Write writes to writer's underlying log, in the standard log format (note this is not the Event log format).
+// The writer.realLogger may be nil, in which case this does nothing.
+// This always returns len(p) and nil, claiming it successfully wrote even if it didn't.
+func (writer *standardLoggerWriter) Write(p []byte) (n int, err error) {
+	logln(writer.realLogger, writer.prefix+strings.TrimSpace(string(p)))
+	return len(p), nil
+}

--- a/lib/go-log/standardlogger_test.go
+++ b/lib/go-log/standardlogger_test.go
@@ -1,0 +1,69 @@
+package log
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStandardLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	realLogPrefix := "a-real-log-prefix: "
+	logger := log.New(buf, realLogPrefix, log.Lshortfile)
+
+	sPrefix := "a-standard-logger-prefix: "
+	sLogger := StandardLogger(logger, sPrefix)
+
+	msg := "a-message"
+	sLogger.Printf(msg + "\n") // newline, to verify a double-newline isn't printed.
+
+	actual := buf.String()
+
+	if !strings.HasPrefix(actual, realLogPrefix) {
+		t.Errorf("expected prefix '%v' actual '%v'\n", realLogPrefix, actual)
+	}
+
+	actualFields := strings.Fields(actual)
+	if len(actualFields) < 4 {
+		t.Fatalf("expected fields >4 (prefix, line, time, msg} actual %v '''%v'''\n", len(actualFields), actual)
+	}
+
+	timeField := actualFields[2]
+	if len(timeField) > 0 {
+		timeField = timeField[:len(timeField)-1] // timestamp ends with :, strip it for parsing
+	}
+
+	actualTime, err := time.Parse(time.RFC3339Nano, timeField)
+	if err != nil {
+		t.Fatalf("expected 3rd field is RFC3339 nano format, actual '%v'\n", timeField)
+	}
+	if actualTime.After(time.Now().Add(time.Minute)) || actualTime.Before(time.Now().Add(time.Minute*-1)) {
+		t.Errorf("expected 3rd field is RFC3339 nano format around now '%v', actual '%v'\n", time.Now(), actualTime)
+	}
+}
+
+func TestStandardLoggerNil(t *testing.T) {
+	// test that a nil logger doesn't panic
+	StandardLogger(nil, "").Println("foo")
+}


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fixes TO Go logging of Riak and ReverseProxy, which weren't properly
adding the prefix and date format of lib/go-log.

Fixes it by adding a func to create a new wrapper Logger, which
writes to the given logger with the standard log.Printf funcs,
properly setting the time and prefix.

Fixes #3587 

- [x] This PR fixes #3587 OR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Force an error with the proxy, by starting `traffic_ops_golang` with no Perl Traffic Ops running, and request a Perl endpoint, such as `/api/1.2/servers/your-server-name/configfiles/ats/remap.config`. Then check the error log, verify the proxy error was prefixed with `ERROR: ` and the RFC3339 timestamp.

Do the same for a Riak endpoint, by running TO with no Riak servers available and requesting a Riak endpoint, such as `/api/1.2/deliveryservices/xmlId/your-ds-name/sslkeys`.

No documentation necessary, we don't document the exact format of logs.

Includes unit tests verifying real logger prefix and RFC3339 time are applied, and that nil loggers don't panic.

## If this is a bug fix, what versions of Traffic Ops are affected?

All versions with traffic_ops_golang, so 2.2.x and newer.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
