### PR TITLE
Removed restangular from TypeService

### DIFF
--- a/traffic_portal/app/src/common/api/TypeService.js
+++ b/traffic_portal/app/src/common/api/TypeService.js
@@ -17,54 +17,68 @@
  * under the License.
  */
 
-var TypeService = function(Restangular, locationUtils, messageModel) {
+var TypeService = function($http, ENV, locationUtils, messageModel) {
 
     this.getTypes = function(queryParams) {
-        return Restangular.all('types').getList(queryParams);
+        return $http.get(ENV.api['root'] + 'types', {params: queryParams}).then(
+            function (result) {
+                return result.data.response;
+            },
+            function (err) {
+                console.error(err);
+            }
+        )
     };
 
     this.getType = function(id) {
-        return Restangular.one("types", id).get();
+        return $http.get(ENV.api['root'] + 'types', {params: {id: id}}).then(
+            function (result) {
+                return result.data.response[0];
+            },
+            function (err) {
+                console.error(err);
+            }
+        )
     };
 
     this.createType = function(type) {
-        return Restangular.service('types').post(type)
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Type created' } ], true);
-                    locationUtils.navigateToPath('/types');
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
+        return $http.post(ENV.api['root'] + 'types', type).then(
+            function(result) {
+                messageModel.setMessages([ { level: 'success', text: 'Type created' } ], true);
+                locationUtils.navigateToPath('/types');
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.updateType = function(type) {
-        return type.put()
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Type updated' } ], false);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
+        return $http.put(ENV.api['root'] + 'types/' + type.id, type).then(
+            function(result) {
+                messageModel.setMessages([ { level: 'success', text: 'Type updated' } ], false);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
         );
     };
 
     this.deleteType = function(id) {
-        return Restangular.one("types", id).remove()
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Type deleted' } ], true);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, true);
-                }
+        return $http.delete(ENV.api['root'] + "types/" + id).then(
+            function(result) {
+                messageModel.setMessages([ { level: 'success', text: 'Type deleted' } ], true);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, true);
+            }
         );
     };
 
 };
 
-TypeService.$inject = ['Restangular', 'locationUtils', 'messageModel'];
+TypeService.$inject = ['$http', 'ENV', 'locationUtils', 'messageModel'];
 module.exports = TypeService;

--- a/traffic_portal/app/src/common/api/TypeService.js
+++ b/traffic_portal/app/src/common/api/TypeService.js
@@ -25,7 +25,7 @@ var TypeService = function($http, ENV, locationUtils, messageModel) {
                 return result.data.response;
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         )
     };
@@ -36,7 +36,7 @@ var TypeService = function($http, ENV, locationUtils, messageModel) {
                 return result.data.response[0];
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         )
     };
@@ -50,6 +50,7 @@ var TypeService = function($http, ENV, locationUtils, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -62,6 +63,7 @@ var TypeService = function($http, ENV, locationUtils, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -74,6 +76,7 @@ var TypeService = function($http, ENV, locationUtils, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, true);
+                throw err;
             }
         );
     };


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "TypeService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 