### PR TITLE
Removed restangular from FormProfileController.js

### DIFF
--- a/traffic_portal/app/src/common/modules/form/profile/FormProfileController.js
+++ b/traffic_portal/app/src/common/modules/form/profile/FormProfileController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var FormProfileController = function(profile, Restangular, $scope, $location, $uibModal, fileUtils, formUtils, locationUtils, cdnService, profileService) {
+var FormProfileController = function(profile, $scope, $location, $uibModal, fileUtils, formUtils, locationUtils, cdnService, profileService) {
 
     var getCDNs = function() {
         cdnService.getCDNs(true)
@@ -108,5 +108,5 @@ var FormProfileController = function(profile, Restangular, $scope, $location, $u
 
 };
 
-FormProfileController.$inject = ['profile', 'Restangular', '$scope', '$location', '$uibModal', 'fileUtils', 'formUtils', 'locationUtils', 'cdnService', 'profileService'];
+FormProfileController.$inject = ['profile', '$scope', '$location', '$uibModal', 'fileUtils', 'formUtils', 'locationUtils', 'cdnService', 'profileService'];
 module.exports = FormProfileController;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "FormProfileController"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests 
2. use the profile form to create and/or edit a profile and ensure it works properly.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 