### PR TITLE
Removed restangular from CacheGroupParameterService

### DIFF
--- a/traffic_portal/app/src/common/api/CacheGroupParameterService.js
+++ b/traffic_portal/app/src/common/api/CacheGroupParameterService.js
@@ -25,7 +25,7 @@ var CacheGroupParameterService = function($http, messageModel, ENV) {
 				return result.data.response;
 			},
 			function(err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -38,6 +38,7 @@ var CacheGroupParameterService = function($http, messageModel, ENV) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, true);
+				throw err;
 			}
 		);
 	};
@@ -50,6 +51,7 @@ var CacheGroupParameterService = function($http, messageModel, ENV) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};

--- a/traffic_portal/app/src/common/api/CacheGroupParameterService.js
+++ b/traffic_portal/app/src/common/api/CacheGroupParameterService.js
@@ -17,37 +17,44 @@
  * under the License.
  */
 
-var CacheGroupParameterService = function(Restangular, messageModel, httpService, ENV) {
+var CacheGroupParameterService = function($http, messageModel, ENV) {
 
 	this.getCacheGroupParameters = function(cachegroupId) {
-		return Restangular.one('cachegroups', cachegroupId).getList('parameters')
+		return $http.get(ENV.api['root'] + 'cachegroups/' + cachegroupId + '/parameters').then(
+			function(result) {
+				return result.data.response;
+			},
+			function(err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.unlinkCacheGroupParameter = function(cgId, paramId) {
-		return httpService.delete(ENV.api['root'] + 'cachegroupparameters/' + cgId + '/' + paramId)
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Cachegroup and parameter were unlinked.' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, true);
-				}
-			);
+		return $http.delete(ENV.api['root'] + 'cachegroupparameters/' + cgId + '/' + paramId).then(
+			function(result) {
+				messageModel.setMessages([ { level: 'success', text: 'Cachegroup and parameter were unlinked.' } ], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, true);
+			}
+		);
 	};
 
 	this.linkCacheGroupParameters = function(cgParamMappings) {
-		return Restangular.service('cachegroupparameters').post(cgParamMappings)
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Parameters linked to cache group' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+		return $http.post(ENV.api['root'] + 'cachegroupparameters', cgParamMappings).then(
+			function(result) {
+				messageModel.setMessages([{level: 'success', text: 'Parameters linked to cache group'}], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 };
 
-CacheGroupParameterService.$inject = ['Restangular', 'messageModel', 'httpService', 'ENV'];
+CacheGroupParameterService.$inject = ['$http', 'messageModel', 'ENV'];
 module.exports = CacheGroupParameterService;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "CacheGroupParameterService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 