### PR TITLE
Removed restangular from CacheGroupService

### DIFF
--- a/traffic_portal/app/src/common/api/CacheGroupService.js
+++ b/traffic_portal/app/src/common/api/CacheGroupService.js
@@ -25,7 +25,7 @@ var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response;
             },
             function(err) {
-                console.error(err);
+                throw err;
             }
         );
     };
@@ -36,7 +36,6 @@ var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response[0];
             },
             function (err) {
-                console.error(err);
                 throw err;
             }
         );
@@ -51,6 +50,7 @@ var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -63,6 +63,7 @@ var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -75,6 +76,7 @@ var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -87,6 +89,7 @@ var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -99,6 +102,7 @@ var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -109,7 +113,6 @@ var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response;
             },
             function(err) {
-                console.error(err);
                 throw err;
             }
         );

--- a/traffic_portal/app/src/common/api/CacheGroupService.js
+++ b/traffic_portal/app/src/common/api/CacheGroupService.js
@@ -17,104 +17,105 @@
  * under the License.
  */
 
-var CacheGroupService = function($http, $q, Restangular, locationUtils, messageModel, ENV) {
+var CacheGroupService = function($http, locationUtils, messageModel, ENV) {
 
     this.getCacheGroups = function(queryParams) {
-        return Restangular.all('cachegroups').getList(queryParams);
+        return $http.get(ENV.api['root'] + 'cachegroups', {params: queryParams}).then(
+            function(result) {
+                return result.data.response;
+            },
+            function(err) {
+                console.error(err);
+            }
+        );
     };
 
     this.getCacheGroup = function(id) {
-        return Restangular.one("cachegroups", id).get();
+        return $http.get(ENV.api['root'] + 'cachegroups', {params: {'id': id}}).then(
+            function (result) {
+                return result.data.response[0];
+            },
+            function (err) {
+                console.error(err);
+                throw err;
+            }
+        );
     };
 
     this.createCacheGroup = function(cacheGroup) {
-        return Restangular.service('cachegroups').post(cacheGroup)
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'CacheGroup created' } ], true);
-                    locationUtils.navigateToPath('/cache-groups');
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
+        return $http.post(ENV.api['root'] + 'cachegroups', cacheGroup).then(
+            function (result) {
+                messageModel.setMessages(result.data.alerts, true);
+                locationUtils.navigateToPath('/cache-groups');
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.updateCacheGroup = function(cacheGroup) {
-        return cacheGroup.put()
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Cache group updated' } ], false);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
+        return $http.put(ENV.api['root'] + 'cachegroups/' + cacheGroup.id, cacheGroup).then(
+            function(result) {
+                messageModel.setMessages(result.data.alerts, false);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.deleteCacheGroup = function(id) {
-        var request = $q.defer();
-
-        $http.delete(ENV.api['root'] + "cachegroups/" + id)
-            .then(
-                function(result) {
-                    request.resolve(result.data);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                    request.reject(fault);
-                }
-            );
-
-        return request.promise;
+        return $http.delete(ENV.api['root'] + "cachegroups/" + id).then(
+            function(result) {
+                messageModel.setMessages(result.data.alerts, false);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.queueServerUpdates = function(cgId, cdnId) {
-        return Restangular.one("cachegroups", cgId).customPOST( { action: "queue", cdnId: cdnId }, "queue_update" )
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Queued cache group server updates' } ], false);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
+        return $http.post(ENV.api['root'] + 'cachegroups/' + cgId + '/queue_update', {action: "queue", cdnId: cdnId}).then(
+            function(result) {
+                messageModel.setMessages([{level: 'success', text: 'Queued Cache Group server updates'}], false);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.clearServerUpdates = function(cgId, cdnId) {
-        return Restangular.one("cachegroups", cgId).customPOST( { action: "dequeue", cdnId: cdnId}, "queue_update" )
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Cleared cache group server updates' } ], false);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
-    };
-
-    this.getParameterCacheGroups = function(paramId) {
-        // todo: this needs an api: /parameters/:id/cachegroups
-        return Restangular.one('parameters', paramId).getList('cachegroups');
+        return $http.post(ENV.api['root'] + 'cachegroups/' + cgId + '/queue_update', {action: "dequeue", cdnId: cdnId}).then(
+            function(result) {
+                messageModel.setMessages([{level: 'success', text: 'Cleared Cache Group server updates'}], false);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.getCacheGroupHealth = function() {
-        var deferred = $q.defer();
-
-        $http.get(ENV.api['root'] + "cdns/health")
-            .then(
-                function(result) {
-                    deferred.resolve(result.data.response);
-                },
-                function(fault) {
-                    deferred.reject(fault);
-                }
-            );
-
-        return deferred.promise;
+        return $http.get(ENV.api['root'] + "cdns/health").then(
+            function(result) {
+                return result.data.response;
+            },
+            function(err) {
+                console.error(err);
+                throw err;
+            }
+        );
     };
 
 };
 
-CacheGroupService.$inject = ['$http', '$q', 'Restangular', 'locationUtils', 'messageModel', 'ENV'];
+CacheGroupService.$inject = ['$http', 'locationUtils', 'messageModel', 'ENV'];
 module.exports = CacheGroupService;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "CacheGroupService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well, these include the following views:
- list all cache groups - tp.domain.com/#!/cache-groups
- create a cache group
- edit a cache group
- delete a cache group
- queue server updates on a cache group
- clear server updates on a cache group
- check cache groups health widget on dashboard page

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 