### PR TITLE
Fix TM polling urls with ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Issue 3476: Traffic Router returns partial result for CLIENT_STEERING Delivery Services when Regional Geoblocking or Anonymous Blocking is enabled.
 - Upgraded Traffic Portal to AngularJS 1.7.8
 - Issue 3275: Improved the snapshot diff performance and experience.
-- Issue 3605: Fixed Traffic Monitor custom ports in health polling URL.
+- Issue #3605: Fixed Traffic Monitor custom ports in health polling URL.
 
 ## [3.0.0] - 2018-10-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Issue 3476: Traffic Router returns partial result for CLIENT_STEERING Delivery Services when Regional Geoblocking or Anonymous Blocking is enabled.
 - Upgraded Traffic Portal to AngularJS 1.7.8
 - Issue 3275: Improved the snapshot diff performance and experience.
-
+- Issue 3605: Fixed Traffic Monitor custom ports in health polling URL.
 
 ## [3.0.0] - 2018-10-30
 ### Added

--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -56,15 +56,15 @@ Traffic Monitor is configured via two JSON configuration files, :file:`traffic_o
 Cache Polling URL
 -----------------------------------
 
-Caches are polled at the URL specified in the ``health.polling.url`` Parameter, on the cache's Server Profile.
+The :term:`cache servers` are polled at the URL specified in the ``health.polling.url`` :term:`parameter`, on the :term:`cache server`'s :term:`profile`.
 
-This Parameter must have the config file ``rascal.properties``.
+This :term:`parameter` must have the config file ``rascal.properties``.
 
-The value is a template with the text ``${hostname}`` being replaced with the cache server's Network IP (IPv4), and ``${interface_name}`` being replaced with the server's network Interface Name. For example, ``http://${hostname}/_astats?application=&inf.name=${interface_name}``.
+The value is a template with the text ``${hostname}`` being replaced with the :term:`cache server`'s Network IP (IPv4), and ``${interface_name}`` being replaced with the :term:`cache server`'s network Interface Name. For example, ``http://${hostname}/_astats?application=&inf.name=${interface_name}``.
 
-If the template contains a port, that port will be used, and the cache server's HTTPS and TCP Ports will not be added.
+If the template contains a port, that port will be used, and the :term:`cache server`'s HTTPS and TCP Ports will not be added.
 
-If the template does not contain a port, then if the template starts with ``https`` the cache server's HTTPS Port will be added, and if the template doesn't start with ``https`` the cache server's TCP Port will be added.
+If the template does not contain a port, then if the template starts with ``https`` the :term:`cache server`'s HTTPS Port will be added, and if the template doesn't start with ``https`` the :term:`cache server`'s TCP Port will be added.
 
 Examples:
 

--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -52,6 +52,27 @@ Configuration Overview
 ----------------------
 Traffic Monitor is configured via two JSON configuration files, :file:`traffic_ops.cfg` and :file:`traffic_monitor.cfg`, by default located in the ``conf`` directory in the install location. :file:`traffic_ops.cfg` contains Traffic Ops connection information. Specify the URL, username, and password for the instance of Traffic Ops of which this Traffic Monitor is a member. :file:`traffic_monitor.cfg` contains log file locations, as well as detailed application configuration variables such as processing flush times and initial poll intervals. Once started with the correct configuration, Traffic Monitor downloads its configuration from Traffic Ops and begins polling :term:`cache server` s. Once every :term:`cache server` has been polled, :ref:`health-proto` state is available via RESTful JSON endpoints and a web browser UI.
 
+
+Cache Polling URL
+-----------------------------------
+
+Caches are polled at the URL specified in the ``health.polling.url`` Parameter, on the cache's Server Profile.
+
+This Parameter must have the config file ``rascal.properties``.
+
+The value is a template with the text ``${hostname}`` being replaced with the cache server's Network IP (IPv4), and ``${interface_name}`` being replaced with the server's network Interface Name. For example, ``http://${hostname}/_astats?application=&inf.name=${interface_name}``.
+
+If the template contains a port, that port will be used, and the cache server's HTTPS and TCP Ports will not be added.
+
+If the template does not contain a port, then if the template starts with ``https`` the cache server's HTTPS Port will be added, and if the template doesn't start with ``https`` the cache server's TCP Port will be added.
+
+Examples:
+
+Template ``http://${hostname}/_astats?application=&inf.name=${interface_name}`` Server IP ``192.0.2.42`` Server TCP Port ``8080`` HTTPS Port ``8443`` becomes ``http://192.0.2.42:8080/_astats?application=&inf.name=${interface_name}``.
+Template ``https://${hostname}/_astats?application=&inf.name=${interface_name}`` Server IP ``192.0.2.42`` Server TCP Port ``8080`` HTTPS Port ``8443`` becomes ``https://192.0.2.42:8443/_astats?application=&inf.name=${interface_name}``.
+Template ``http://${hostname}:1234/_astats?application=&inf.name=${interface_name}`` Server IP ``192.0.2.42`` Server TCP Port ``8080`` HTTPS Port ``8443`` becomes ``http://192.0.2.42:1234/_astats?application=&inf.name=${interface_name}``.
+Template ``https://${hostname}:1234/_astats?application=&inf.name=${interface_name}`` Server IP ``192.0.2.42`` Server TCP Port ``8080`` HTTPS Port ``8443`` becomes ``https://192.0.2.42:1234/_astats?application=&inf.name=${interface_name}``.
+
 Stat and Health Flush Configuration
 -----------------------------------
 The Monitor has a health flush interval, a stat flush interval, and a stat buffer interval. Recall that the monitor polls both stats and health. The health poll is so small and fast, a buffer is largely unnecessary. However, in a large CDN, the stat poll may involve thousands of :term:`cache server` s with thousands of stats each, or more, and CPU may be a bottleneck.

--- a/lib/go-tc/traffic_router.go
+++ b/lib/go-tc/traffic_router.go
@@ -136,6 +136,7 @@ type TrafficServer struct {
 	CacheGroup       string              `json:"cacheGroup"`
 	IP6              string              `json:"ip6"`
 	Port             int                 `json:"port"`
+	HTTPSPort        int                 `json:"httpsPort,omitempty"`
 	HostName         string              `json:"hostName"`
 	FQDN             string              `json:"fqdn"`
 	InterfaceName    string              `json:"interfaceName"`

--- a/traffic_monitor/manager/monitorconfig_test.go
+++ b/traffic_monitor/manager/monitorconfig_test.go
@@ -1,0 +1,102 @@
+package manager
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestCreateServerHealthPollURL(t *testing.T) {
+	tmpl := `http://${hostname}/_astats?application=&inf.name=${interface_name}`
+	srv := tc.TrafficServer{IP: "192.0.2.42", InterfaceName: "george"}
+
+	expected := `http://` + srv.IP + `/_astats?application=system&inf.name=` + srv.InterfaceName
+	actual := createServerHealthPollURL(tmpl, srv)
+
+	if expected != actual {
+		t.Errorf("expected createServerHealthPollURL '" + expected + "' actual: '" + actual + "'")
+	}
+}
+
+func TestCreateServerHealthPollURLTemplatePort(t *testing.T) {
+	tmpl := `http://${hostname}:1234/_astats?application=&inf.name=${interface_name}`
+	srv := tc.TrafficServer{IP: "192.0.2.42", InterfaceName: "george"}
+
+	expected := `http://` + srv.IP + `:1234/_astats?application=system&inf.name=` + srv.InterfaceName
+	actual := createServerHealthPollURL(tmpl, srv)
+
+	if expected != actual {
+		t.Errorf("expected createServerHealthPollURL '" + expected + "' actual: '" + actual + "'")
+	}
+}
+
+func TestCreateServerHealthPollURLServerPort(t *testing.T) {
+	tmpl := `http://${hostname}/_astats?application=&inf.name=${interface_name}`
+	srv := tc.TrafficServer{IP: "192.0.2.42", Port: 5678, HTTPSPort: 910, InterfaceName: "george"}
+
+	expected := `http://` + srv.IP + ":" + strconv.Itoa(srv.Port) + `/_astats?application=system&inf.name=` + srv.InterfaceName
+	actual := createServerHealthPollURL(tmpl, srv)
+
+	if expected != actual {
+		t.Errorf("expected createServerHealthPollURL '" + expected + "' actual: '" + actual + "'")
+	}
+}
+
+func TestCreateServerHealthPollURLServerPortHTTPS(t *testing.T) {
+	tmpl := `hTTps://${hostname}/_astats?application=&inf.name=${interface_name}`
+	srv := tc.TrafficServer{IP: "192.0.2.42", Port: 5678, HTTPSPort: 910, InterfaceName: "george"}
+
+	expected := `https://` + srv.IP + ":" + strconv.Itoa(srv.HTTPSPort) + `/_astats?application=system&inf.name=` + srv.InterfaceName
+	actual := createServerHealthPollURL(tmpl, srv)
+
+	if expected != actual {
+		t.Errorf("expected createServerHealthPollURL '" + expected + "' actual: '" + actual + "'")
+	}
+}
+
+func TestCreateServerHealthPollURLTemplateAndServerPort(t *testing.T) {
+
+	// if both template and server ports exist, template takes precedence
+
+	tmpl := `http://${hostname}:1234/_astats?application=&inf.name=${interface_name}`
+	srv := tc.TrafficServer{IP: "192.0.2.42", Port: 5678, HTTPSPort: 910, InterfaceName: "george"}
+
+	expected := `http://` + srv.IP + `:1234/_astats?application=system&inf.name=` + srv.InterfaceName
+	actual := createServerHealthPollURL(tmpl, srv)
+
+	if expected != actual {
+		t.Errorf("expected createServerHealthPollURL '" + expected + "' actual: '" + actual + "'")
+	}
+}
+
+func TestCreateServerStatPollURL(t *testing.T) {
+	tmpl := `http://${hostname}/_astats?application=&inf.name=${interface_name}`
+	srv := tc.TrafficServer{IP: "192.0.2.42", InterfaceName: "george"}
+
+	expected := `http://` + srv.IP + `/_astats?application=&inf.name=` + srv.InterfaceName
+	actual := createServerStatPollURL(createServerHealthPollURL(tmpl, srv))
+
+	if expected != actual {
+		t.Errorf("expected createServerStatPollURL '" + expected + "' actual: '" + actual + "'")
+	}
+}

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -470,6 +470,11 @@ func CreateMonitorConfig(crConfig tc.CRConfig, mc *tc.TrafficMonitorConfigMap) (
 		} else {
 			log.Warnf("Creating monitor config: CRConfig server %s missing HashId field\n", name)
 		}
+		if srv.HttpsPort != nil {
+			s.HTTPSPort = *srv.HttpsPort
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing HttpsPort field\n", name)
+		}
 		mc.TrafficServer[name] = s
 	}
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fix TM polling urls with ports. Currently, setting a port in `health.polling.url` is broken, because it also appends the TO TCP Port, resulting in e.g. `http://${hostname}:80:8080/_astats?application=&inf.name=${interface_name}`

This fixes it to not add the TCP Port, if a port already exists in the polling URL.

- [x] This PR is not related to any Issue

Bug fix, does not affect documentation.
Includes unit tests.
Includes changelog.

## Which Traffic Control components are affected by this PR?

- Traffic Monitor

## What is the best way to verify this PR?

Verify the monitor can poll a cache whose Profile `health.polling.url` Parameter includes a port.

## If this is a bug fix, what versions of Traffic Ops are affected?

- 3.0.0
- 3.0.1

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
