### PR TITLE
Removed restangular from CacheStatsService

### DIFF
--- a/traffic_portal/app/src/common/api/CacheStatsService.js
+++ b/traffic_portal/app/src/common/api/CacheStatsService.js
@@ -17,49 +17,49 @@
  * under the License.
  */
 
-var CacheStatsService = function($http, $q, httpService, ENV, messageModel) {
+var CacheStatsService = function($http, ENV, messageModel) {
 
 	this.getBandwidth = function(cdnName, start, end) {
-		var request = $q.defer();
+		const url = ENV.api['root'] + "cache_stats";
+		const params = {
+			cdnName: cdnName,
+			metricType: 'bandwidth',
+			startDate: start.seconds(0).format(),
+			endDate: end.seconds(0).format()
+		};
 
-		var url = ENV.api['root'] + "cache_stats",
-			params = { cdnName: cdnName, metricType: 'bandwidth', startDate: start.seconds(00).format(), endDate: end.seconds(00).format()};
-
-		$http.get(url, { params: params })
-			.then(
-				function(result) {
-					request.resolve(result.data.response);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-					request.reject();
-				}
-			);
-
-		return request.promise;
+		return $http.get(url, { params: params }).then(
+			function(result) {
+				return result.data.response;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
+			}
+		);
 	};
 
 	this.getConnections = function(cdnName, start, end) {
-		var request = $q.defer();
+		const url = ENV.api['root'] + "cache_stats";
+		const params = {
+			cdnName: cdnName,
+			metricType: 'connections',
+			startDate: start.seconds(0).format(),
+			endDate: end.seconds(0).format()
+		};
 
-		var url = ENV.api['root'] + "cache_stats",
-			params = { cdnName: cdnName, metricType: 'connections', startDate: start.seconds(00).format(), endDate: end.seconds(00).format()};
-
-		$http.get(url, { params: params })
-			.then(
-				function(result) {
-					request.resolve(result.data.response);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-					request.reject();
-				}
-			);
-
-		return request.promise;
+		return $http.get(url, { params: params }).then(
+			function(result) {
+				return result.data.response;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
+			}
+		);
 	};
 
 };
 
-CacheStatsService.$inject = ['$http', '$q', 'httpService', 'ENV', 'messageModel'];
+CacheStatsService.$inject = ['$http', 'ENV', 'messageModel'];
 module.exports = CacheStatsService;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "CacheStatsService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. ensure the bandwidth/connections chart on TP's dashboard works as expected.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 