### PR TITLE
Removed restangular from CapabilityService

### DIFF
--- a/traffic_portal/app/src/common/api/CapabilityService.js
+++ b/traffic_portal/app/src/common/api/CapabilityService.js
@@ -25,7 +25,6 @@ var CapabilityService = function($http, messageModel, ENV) {
 				return result.data.response;
 			},
 			function(err) {
-				console.error(err);
 				throw err;
 			}
 		);
@@ -37,7 +36,6 @@ var CapabilityService = function($http, messageModel, ENV) {
 				return result.data.response[0];
 			},
 			function(err) {
-				console.error(err);
 				throw err;
 			}
 		);

--- a/traffic_portal/app/src/common/api/CapabilityService.js
+++ b/traffic_portal/app/src/common/api/CapabilityService.js
@@ -17,68 +17,69 @@
  * under the License.
  */
 
-var CapabilityService = function(Restangular, $q, $http, messageModel, ENV) {
+var CapabilityService = function($http, messageModel, ENV) {
 
 	this.getCapabilities = function(queryParams) {
-		return Restangular.all('capabilities').getList(queryParams);
+		return $http.get(ENV.api['root'] + 'capabilities', {params: queryParams}).then(
+			function(result) {
+				return result.data.response;
+			},
+			function(err) {
+				console.error(err);
+				throw err;
+			}
+		);
 	};
 
 	this.getCapability = function(name) {
-		return Restangular.one("capabilities", name).get();
+		return $http.get(ENV.api['root'] + 'capabilities/' + name).then(
+			function(result) {
+				return result.data.response[0];
+			},
+			function(err) {
+				console.error(err);
+				throw err;
+			}
+		);
 	};
 
 	this.createCapability = function(cap) {
-		var request = $q.defer();
-
-		$http.post(ENV.api['root'] + "capabilities", cap)
-			.then(
-				function(result) {
-					request.resolve(result.data);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-					request.reject(fault);
-				}
-			);
-
-		return request.promise;
+		return $http.post(ENV.api['root'] + "capabilities", cap).then(
+			function(result) {
+				return result.data;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
+			}
+		);
 	};
 
 	this.updateCapability = function(cap) {
-		var request = $q.defer();
-
-		$http.put(ENV.api['root'] + "capabilities/" + cap.name, cap)
-			.then(
-				function(result) {
-					request.resolve(result.data);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-					request.reject();
-				}
-			);
-
-		return request.promise;
+		return $http.put(ENV.api['root'] + "capabilities/" + cap.name, cap).then(
+			function(result) {
+				return result.data;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
+			}
+		);
 	};
 
 	this.deleteCapability = function(cap) {
-		var request = $q.defer();
-
-		$http.delete(ENV.api['root'] + "capabilities/" + cap.name)
-			.then(
-				function(result) {
-					request.resolve(result.data);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-					request.reject(fault);
-				}
-			);
-
-		return request.promise;
+		return $http.delete(ENV.api['root'] + "capabilities/" + cap.name).then(
+			function(result) {
+				return result.data;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
+			}
+		);
 	};
 
 };
 
-CapabilityService.$inject = ['Restangular', '$q', '$http', 'messageModel', 'ENV'];
+CapabilityService.$inject = ['$http', 'messageModel', 'ENV'];
 module.exports = CapabilityService;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "CapabilityService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 