### PR TITLE
Removed restangular from CoordinateService

### DIFF
--- a/traffic_portal/app/src/common/api/CoordinateService.js
+++ b/traffic_portal/app/src/common/api/CoordinateService.js
@@ -17,66 +17,60 @@
  * under the License.
  */
 
-var CoordinateService = function($http, $q, Restangular, locationUtils, messageModel, ENV) {
+var CoordinateService = function($http, locationUtils, messageModel, ENV) {
 
     this.getCoordinates = function(queryParams) {
-        return Restangular.all('coordinates').getList(queryParams);
+        return $http.get(ENV.api['root'] + 'coordinates', {params: queryParams}).then(
+            function(result) {
+                return result.data.response;
+            },
+            function (err) {
+                console.error(error);
+            }
+        );
     };
 
     this.createCoordinate = function(coordinate) {
-        var request = $q.defer();
-
-        $http.post(ENV.api['root'] + "coordinates", coordinate)
-            .then(
-                function(response) {
-                    messageModel.setMessages(response.data.alerts, true);
-                    locationUtils.navigateToPath('/coordinates');
-                    request.resolve(response);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false)
-                    request.reject(fault);
-                }
-            );
-
-        return request.promise;
+        return $http.post(ENV.api['root'] + "coordinates", coordinate).then(
+            function(response) {
+                messageModel.setMessages(response.data.alerts, true);
+                locationUtils.navigateToPath('/coordinates');
+                return response;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false)
+                throw err;
+            }
+        );
     };
 
     this.updateCoordinate = function(id, coordinate) {
-        var request = $q.defer();
-
-        $http.put(ENV.api['root'] + "coordinates?id=" + id, coordinate)
-            .then(
-                function(response) {
-                    messageModel.setMessages(response.data.alerts, false);
-                    request.resolve();
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                    request.reject();
-                }
-            );
-        return request.promise;
+        return $http.put(ENV.api['root'] + "coordinates", coordinate, {params: {id: id}}).then(
+            function(response) {
+                messageModel.setMessages(response.data.alerts, false);
+                return response;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+                throw err;
+            }
+        );
     };
 
     this.deleteCoordinate = function(id) {
-        var deferred = $q.defer();
-
-        $http.delete(ENV.api['root'] + "coordinates?id=" + id)
-            .then(
-                function(response) {
-                    messageModel.setMessages(response.data.alerts, true);
-                    deferred.resolve(response);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                    deferred.reject(fault);
-                }
-            );
-        return deferred.promise;
+        return $http.delete(ENV.api['root'] + "coordinates", {params: {id: id}}).then(
+            function(response) {
+                messageModel.setMessages(response.data.alerts, true);
+                return response;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+                throw err;
+            }
+        );
     };
 
 };
 
-CoordinateService.$inject = ['$http', '$q', 'Restangular', 'locationUtils', 'messageModel', 'ENV'];
+CoordinateService.$inject = ['$http', 'locationUtils', 'messageModel', 'ENV'];
 module.exports = CoordinateService;

--- a/traffic_portal/app/src/common/api/CoordinateService.js
+++ b/traffic_portal/app/src/common/api/CoordinateService.js
@@ -25,7 +25,7 @@ var CoordinateService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response;
             },
             function (err) {
-                console.error(error);
+                throw err;
             }
         );
     };


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "CoordinateService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 