### PR TITLE
Removed restangular from DeliveryServiceRegexService

### DIFF
--- a/traffic_portal/app/src/common/api/DeliveryServiceRegexService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRegexService.js
@@ -25,7 +25,7 @@ var DeliveryServiceRegexService = function($http, locationUtils, messageModel, E
 				return result.data.response;
 			},
 			function(err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -36,7 +36,7 @@ var DeliveryServiceRegexService = function($http, locationUtils, messageModel, E
 				return result.data.response[0];
 			},
 			function(err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -50,6 +50,7 @@ var DeliveryServiceRegexService = function($http, locationUtils, messageModel, E
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -62,6 +63,7 @@ var DeliveryServiceRegexService = function($http, locationUtils, messageModel, E
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -74,6 +76,7 @@ var DeliveryServiceRegexService = function($http, locationUtils, messageModel, E
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, true);
+				throw err;
 			}
 		);
 	};

--- a/traffic_portal/app/src/common/api/DeliveryServiceRegexService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRegexService.js
@@ -17,54 +17,68 @@
  * under the License.
  */
 
-var DeliveryServiceRegexService = function(Restangular, locationUtils, messageModel) {
+var DeliveryServiceRegexService = function($http, locationUtils, messageModel, ENV) {
 
 	this.getDeliveryServiceRegexes = function(dsId) {
-		return Restangular.one('deliveryservices', dsId).getList('regexes');
+		return $http.get(ENV.api['root'] + 'deliveryservices/' + dsId + '/regexes').then(
+			function(result) {
+				return result.data.response;
+			},
+			function(err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.getDeliveryServiceRegex = function(dsId, regexId) {
-		return Restangular.one('deliveryservices', dsId).one('regexes', regexId).get();
+		return $http.get(ENV.api['root'] + 'deliveryservices/' + dsId + '/regexes/' + regexId).then(
+			function(result) {
+				return result.data.response[0];
+			},
+			function(err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.createDeliveryServiceRegex = function(dsId, regex) {
-		return Restangular.one('deliveryservices', dsId).all('regexes').post(regex)
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Regex created' } ], true);
-					locationUtils.navigateToPath('/delivery-services/' + dsId + '/regexes');
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+		return $http.post(ENV.api['root'] + 'deliveryservices/' + dsId + '/regexes', regex).then(
+			function(result) {
+				messageModel.setMessages(result.data.alerts, true);
+				locationUtils.navigateToPath('/delivery-services/' + dsId + '/regexes');
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
-	this.updateDeliveryServiceRegex = function(regex) {
-		return regex.put()
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Regex updated' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+	this.updateDeliveryServiceRegex = function(dsId, regex) {
+		return $http.put(ENV.api['root'] + 'deliveryservices/' + dsId + '/regexes/' + regex.id, regex).then(
+			function(result) {
+				messageModel.setMessages([{level: 'success', text:'Regex updated'}], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 	this.deleteDeliveryServiceRegex = function(dsId, regexId) {
-		return Restangular.one('deliveryservices', dsId).one('regexes', regexId).remove()
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Regex deleted' } ], true);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, true);
-				}
-			);
+		return $http.delete(ENV.api['root'] + 'deliveryservices/' + dsId + '/regexes/' + regexId).then(
+			function(result) {
+				messageModel.setMessages(result.data.alerts, true);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, true);
+			}
+		);
 	};
 
 };
 
-DeliveryServiceRegexService.$inject = ['Restangular', 'locationUtils', 'messageModel'];
+DeliveryServiceRegexService.$inject = ['$http', 'locationUtils', 'messageModel', 'ENV'];
 module.exports = DeliveryServiceRegexService;

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceRegex/edit/FormEditDeliveryServiceRegexController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceRegex/edit/FormEditDeliveryServiceRegexController.js
@@ -37,7 +37,7 @@ var FormEditDeliveryServiceRegexController = function(deliveryService, regex, $s
 	};
 
 	$scope.save = function(dsId, regex) {
-		deliveryServiceRegexService.updateDeliveryServiceRegex(regex).
+		deliveryServiceRegexService.updateDeliveryServiceRegex(dsId, regex).
 			then(function() {
 				$scope.regexPattern = angular.copy(regex.pattern);
 				$anchorScroll(); // scrolls window to top


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "DeliveryServiceRegexService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 