### PR TITLE
Removed restangular from DeliveryServiceStatsService

### DIFF
--- a/traffic_portal/app/src/common/api/DeliveryServiceStatsService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceStatsService.js
@@ -17,69 +17,75 @@
  * under the License.
  */
 
-var DeliveryServiceStatsService = function($http, $q, ENV, messageModel) {
+var DeliveryServiceStatsService = function($http, ENV, messageModel) {
 
 	this.getBPS = function(xmlId, start, end) {
-		var request = $q.defer();
+		const url = ENV.api['root'] + "deliveryservice_stats";
+		const params = {
+			deliveryServiceName: xmlId,
+			metricType: 'kbps',
+			serverType: 'edge',
+			startDate: start.seconds(0).format(),
+			endDate: end.seconds(0).format(),
+			interval: '60s'
+		};
 
-		var url = ENV.api['root'] + "deliveryservice_stats",
-			params = { deliveryServiceName: xmlId, metricType: 'kbps', serverType: 'edge', startDate: start.seconds(00).format(), endDate: end.seconds(00).format(), interval: '1m' };
-
-		$http.get(url, { params: params })
-			.then(
+		return $http.get(url, { params: params }).then(
 				function(result) {
-					request.resolve(result.data.response);
+					return result.data.response;
 				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-					request.reject();
+				function(err) {
+					messageModel.setMessages(err.data.alerts, false);
+					throw err;
 				}
 			);
-
-		return request.promise;
 	};
 
 	this.getTPS = function(xmlId, start, end) {
-		var request = $q.defer();
+		const url = ENV.api['root'] + "deliveryservice_stats";
+		const params = {
+			deliveryServiceName: xmlId,
+			metricType: 'tps_total',
+			serverType: 'edge',
+			startDate: start.seconds(0).format(),
+			endDate: end.seconds(0).format(),
+			interval: '60s'
+		};
 
-		var url = ENV.api['root'] + "deliveryservice_stats",
-			params = { deliveryServiceName: xmlId, metricType: 'tps_total', serverType: 'edge', startDate: start.seconds(00).format(), endDate: end.seconds(00).format(), interval: '1m' };
-
-		$http.get(url, { params: params })
-			.then(
-				function(result) {
-					request.resolve(result.data.response);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-					request.reject();
-				}
-			);
-
-		return request.promise;
+		return $http.get(url, { params: params }).then(
+			function(result) {
+				return result.data.response;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
+			}
+		);
 	};
 
 	this.getHttpStatusByGroup = function(xmlId, httpStatus, start, end) {
-		var request = $q.defer();
+		const url = ENV.api['root'] + "deliveryservice_stats";
+		const params = {
+			deliveryServiceName: xmlId,
+			metricType: 'tps_' + httpStatus,
+			serverType: 'edge',
+			startDate: start.seconds(0).format(),
+			endDate: end.seconds(0).format(),
+			interval: '60s'
+		};
 
-		var url = ENV.api['root'] + "deliveryservice_stats",
-			params = { deliveryServiceName: xmlId, metricType: 'tps_' + httpStatus, serverType: 'edge', startDate: start.seconds(00).format(), endDate: end.seconds(00).format(), interval: '1m' };
-
-		$http.get(url, { params: params })
-			.then(
-				function(result) {
-					request.resolve(result.data.response);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-					request.reject();
-				}
-			);
-
-		return request.promise;
+		return $http.get(url, { params: params }).then(
+			function(result) {
+				return result.data.response;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
+			}
+		);
 	};
 
 };
 
-DeliveryServiceStatsService.$inject = ['$http', '$q', 'ENV', 'messageModel'];
+DeliveryServiceStatsService.$inject = ['$http', 'ENV', 'messageModel'];
 module.exports = DeliveryServiceStatsService;

--- a/traffic_portal/app/src/common/api/DeliveryServiceStatsService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceStatsService.js
@@ -27,7 +27,7 @@ var DeliveryServiceStatsService = function($http, ENV, messageModel) {
 			serverType: 'edge',
 			startDate: start.seconds(0).format(),
 			endDate: end.seconds(0).format(),
-			interval: '60s'
+			interval: '1m'
 		};
 
 		return $http.get(url, { params: params }).then(
@@ -49,7 +49,7 @@ var DeliveryServiceStatsService = function($http, ENV, messageModel) {
 			serverType: 'edge',
 			startDate: start.seconds(0).format(),
 			endDate: end.seconds(0).format(),
-			interval: '60s'
+			interval: '1m'
 		};
 
 		return $http.get(url, { params: params }).then(
@@ -71,7 +71,7 @@ var DeliveryServiceStatsService = function($http, ENV, messageModel) {
 			serverType: 'edge',
 			startDate: start.seconds(0).format(),
 			endDate: end.seconds(0).format(),
-			interval: '60s'
+			interval: '1m'
 		};
 
 		return $http.get(url, { params: params }).then(


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "DeliveryServiceStatsService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 