### PR TITLE
Removed restangular from DeliveryServiceUriSigningKeysService

### DIFF
--- a/traffic_portal/app/src/common/api/DeliveryServiceUriSigningKeysService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceUriSigningKeysService.js
@@ -19,8 +19,8 @@
 
 var DeliveryServiceUriSigningKeysService = function($http, ENV) {
 
-	this.getKeys = function(id) {
-		return $http.get(ENV.api['root'] + 'deliveryservices/' + id + '/urisignkeys').then(
+	this.getKeys = function(xmlID) {
+		return $http.get(ENV.api['root'] + 'deliveryservices/' + xmlID + '/urisignkeys').then(
 			function(result) {
 				return result.data;
 			},
@@ -30,8 +30,8 @@ var DeliveryServiceUriSigningKeysService = function($http, ENV) {
 		);
 	};
 
-	this.setKeys = function(id, newKeys) {
-		return $http.post(ENV.api['root'] + 'deliveryservices/' + id + '/urisignkeys', newKeys).then(
+	this.setKeys = function(xmlID, newKeys) {
+		return $http.post(ENV.api['root'] + 'deliveryservices/' + xmlID + '/urisignkeys', newKeys).then(
 			function(result) {
 				return result.data;
 			},

--- a/traffic_portal/app/src/common/api/DeliveryServiceUriSigningKeysService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceUriSigningKeysService.js
@@ -25,7 +25,7 @@ var DeliveryServiceUriSigningKeysService = function($http, ENV) {
 				return result.data;
 			},
 			function(err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -36,7 +36,7 @@ var DeliveryServiceUriSigningKeysService = function($http, ENV) {
 				return result.data;
 			},
 			function(err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	}

--- a/traffic_portal/app/src/common/api/DeliveryServiceUriSigningKeysService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceUriSigningKeysService.js
@@ -17,17 +17,31 @@
  * under the License.
  */
 
-var DeliveryServiceUriSigningKeysService = function(Restangular) {
+var DeliveryServiceUriSigningKeysService = function($http, ENV) {
 
 	this.getKeys = function(id) {
-		return Restangular.one("deliveryservices", id).one("urisignkeys").get();
+		return $http.get(ENV.api['root'] + 'deliveryservices/' + id + '/urisignkeys').then(
+			function(result) {
+				return result.data;
+			},
+			function(err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.setKeys = function(id, newKeys) {
-		return Restangular.one("deliveryservices", id).post("urisignkeys", newKeys);
+		return $http.post(ENV.api['root'] + 'deliveryservices/' + id + '/urisignkeys', newKeys).then(
+			function(result) {
+				return result.data;
+			},
+			function(err) {
+				console.error(err);
+			}
+		);
 	}
 
 };
 
-DeliveryServiceUriSigningKeysService.$inject = ['Restangular'];
+DeliveryServiceUriSigningKeysService.$inject = ['$http', 'ENV'];
 module.exports = DeliveryServiceUriSigningKeysService;

--- a/traffic_portal/app/src/modules/private/deliveryServices/uriSigningKeys/DeliveryServiceUriSigningKeysController.js
+++ b/traffic_portal/app/src/modules/private/deliveryServices/uriSigningKeys/DeliveryServiceUriSigningKeysController.js
@@ -20,7 +20,7 @@
 var DeliveryServiceUriSigningKeysController = function($scope, $state, $uibModal, $log, deliveryService, keys, deliveryServiceUriSigningKeysService, messageModel, locationUtils) {
 	$scope.deliveryService = deliveryService;
 	$scope.keys = keys;
-	$scope.keysString = angular.toJson(keys.plain(), 4);
+	$scope.keysString = angular.toJson(keys, 4);
 	$scope.navigateToPath = locationUtils.navigateToPath;
 
 	$scope.saveKeys = function(newKeys) {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "DeliveryServiceUriSigningKeysService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 