### PR TITLE
Removed restangular from DeliveryServiceUrlSigKeysService

### DIFF
--- a/traffic_portal/app/src/common/api/DeliveryServiceUrlSigKeysService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceUrlSigKeysService.js
@@ -17,55 +17,43 @@
  * under the License.
  */
 
-var DeliveryServiceUrlSigKeysService = function(locationUtils, messageModel, $http, $q, ENV) {
+var DeliveryServiceUrlSigKeysService = function(locationUtils, messageModel, $http, ENV) {
 
 	this.generateUrlSigKeys = function(dsXmlId) {
-		var request = $q.defer();
-		$http.post(ENV.api['root'] + 'deliveryservices/xmlId/' + dsXmlId + '/urlkeys/generate')
-		.then(
+		return $http.post(ENV.api['root'] + 'deliveryservices/xmlId/' + dsXmlId + '/urlkeys/generate').then(
 			function(result) {
 				messageModel.setMessages(result.data.alerts, false);
-				request.resolve();
+				return result;
 			},
 			function(fault) {
 				messageModel.setMessages(fault.data.alerts, false);
-				request.reject();
 			}
 		);
-		return request.promise;
 	};
 
 	this.copyUrlSigKeys = function(dsXmlId, copyFromXmlId) {
-		var request = $q.defer();
-		 $http.post(ENV.api['root'] + 'deliveryservices/xmlId/' + dsXmlId + '/urlkeys/copyFromXmlId/' + copyFromXmlId)
-		.then(
+		return $http.post(ENV.api['root'] + 'deliveryservices/xmlId/' + dsXmlId + '/urlkeys/copyFromXmlId/' + copyFromXmlId).then(
 			function(result) {
 				messageModel.setMessages(result.data.alerts, false);
-				request.resolve();
+				return result;
 			},
 			function(fault) {
 				messageModel.setMessages(fault.data.alerts, false);
-				request.reject();
 			}
 		);
-		return request.promise;
 	};
 
 	this.getDeliveryServiceUrlSigKeys = function(dsId) {
-		var request = $q.defer();
-        $http.get(ENV.api['root'] + "deliveryservices/" + dsId + "/urlkeys")
-        .then(
+        return $http.get(ENV.api['root'] + "deliveryservices/" + dsId + "/urlkeys").then(
             function(result) {
-                request.resolve(result.data.response);
+                return result.data.response;
             },
             function(fault) {
             	messageModel.setMessages(fault.data.alerts, false);
-                request.reject();
             }
         );
-        return request.promise;
 	};
 };
 
-DeliveryServiceUrlSigKeysService.$inject = ['locationUtils', 'messageModel', '$http', '$q', 'ENV'];
+DeliveryServiceUrlSigKeysService.$inject = ['locationUtils', 'messageModel', '$http', 'ENV'];
 module.exports = DeliveryServiceUrlSigKeysService;

--- a/traffic_portal/app/src/common/api/DeliveryServiceUrlSigKeysService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceUrlSigKeysService.js
@@ -25,8 +25,9 @@ var DeliveryServiceUrlSigKeysService = function(locationUtils, messageModel, $ht
 				messageModel.setMessages(result.data.alerts, false);
 				return result;
 			},
-			function(fault) {
-				messageModel.setMessages(fault.data.alerts, false);
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -37,8 +38,9 @@ var DeliveryServiceUrlSigKeysService = function(locationUtils, messageModel, $ht
 				messageModel.setMessages(result.data.alerts, false);
 				return result;
 			},
-			function(fault) {
-				messageModel.setMessages(fault.data.alerts, false);
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -48,8 +50,9 @@ var DeliveryServiceUrlSigKeysService = function(locationUtils, messageModel, $ht
             function(result) {
                 return result.data.response;
             },
-            function(fault) {
-            	messageModel.setMessages(fault.data.alerts, false);
+            function(err) {
+            	messageModel.setMessages(err.data.alerts, false);
+            	throw err;
             }
         );
 	};


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "DeliveryServiceUrlSigKeysService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 