### PR TITLE
Removed restangular from DivisionService

### DIFF
--- a/traffic_portal/app/src/common/api/DivisionService.js
+++ b/traffic_portal/app/src/common/api/DivisionService.js
@@ -17,54 +17,67 @@
  * under the License.
  */
 
-var DivisionService = function(Restangular, locationUtils, messageModel) {
+var DivisionService = function($http, ENV, locationUtils, messageModel) {
 
     this.getDivisions = function(queryParams) {
-        return Restangular.all('divisions').getList(queryParams);
+        return $http.get(ENV.api['root'] + 'divisions', {params: queryParams}).then(
+            function(result) {
+                return result.data.response;
+            },
+            function(err) {
+                console.error(err);
+            }
+        );
     };
 
     this.getDivision = function(id) {
-        return Restangular.one("divisions", id).get();
+        return $http.get(ENV.api['root'] + 'divisions', {params: {id: id}}).then(
+            function(result) {
+                return result.data.response[0];
+            },
+            function(err) {
+                console.error(err);
+            }
+        );
     };
 
     this.createDivision = function(division) {
-        return Restangular.service('divisions').post(division)
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Division created' } ], true);
-                    locationUtils.navigateToPath('/divisions');
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
+        return $http.post(ENV.api['root'] + 'divisions', division).then(
+            function(result) {
+                messageModel.setMessages(result.data.alerts, true);
+                locationUtils.navigateToPath('/divisions');
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.updateDivision = function(division) {
-        return division.put()
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Division updated' } ], false);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
+        return $http.put(ENV.api['root'] + 'divisions/' + division.id).then(
+            function(result) {
+                messageModel.setMessages(result.data.alerts, false);
+                return result;            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.deleteDivision = function(id) {
-        return Restangular.one("divisions", id).remove()
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Division deleted' } ], true);
+        return $http.delete(ENV.api['root'] + 'divisions/' + id).then(
+                function(result) {
+                    messageModel.setMessages(result.data.alerts, true);
+                    return result;
                 },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, true);
+                function(err) {
+                    messageModel.setMessages(err.data.alerts, true);
                 }
             );
     };
 
 };
 
-DivisionService.$inject = ['Restangular', 'locationUtils', 'messageModel'];
+DivisionService.$inject = ['$http', 'ENV', 'locationUtils', 'messageModel'];
 module.exports = DivisionService;

--- a/traffic_portal/app/src/common/api/DivisionService.js
+++ b/traffic_portal/app/src/common/api/DivisionService.js
@@ -56,7 +56,7 @@ var DivisionService = function($http, ENV, locationUtils, messageModel) {
     };
 
     this.updateDivision = function(division) {
-        return $http.put(ENV.api['root'] + 'divisions/' + division.id).then(
+        return $http.put(ENV.api['root'] + 'divisions/' + division.id, division).then(
             function(result) {
                 messageModel.setMessages(result.data.alerts, false);
                 return result;            },

--- a/traffic_portal/app/src/common/api/DivisionService.js
+++ b/traffic_portal/app/src/common/api/DivisionService.js
@@ -25,7 +25,7 @@ var DivisionService = function($http, ENV, locationUtils, messageModel) {
                 return result.data.response;
             },
             function(err) {
-                console.error(err);
+                throw err;
             }
         );
     };
@@ -36,7 +36,7 @@ var DivisionService = function($http, ENV, locationUtils, messageModel) {
                 return result.data.response[0];
             },
             function(err) {
-                console.error(err);
+                throw err;
             }
         );
     };
@@ -50,6 +50,7 @@ var DivisionService = function($http, ENV, locationUtils, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -61,6 +62,7 @@ var DivisionService = function($http, ENV, locationUtils, messageModel) {
                 return result;            },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -73,6 +75,7 @@ var DivisionService = function($http, ENV, locationUtils, messageModel) {
                 },
                 function(err) {
                     messageModel.setMessages(err.data.alerts, true);
+                    throw err;
                 }
             );
     };

--- a/traffic_portal/app/src/common/modules/table/divisions/table.divisions.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/divisions/table.divisions.tpl.html
@@ -38,7 +38,7 @@ under the License.
             </thead>
             <tbody>
             <tr ng-click="editDivision(d.id)" ng-repeat="d in ::divisions">
-                <td data-search="^{{::d.name}}$">{{::d.name}}</td>
+                <td name="name" data-search="^{{::d.name}}$">{{::d.name}}</td>
             </tr>
             </tbody>
         </table>

--- a/traffic_portal/test/end_to_end/divisions/divisions-spec.js
+++ b/traffic_portal/test/end_to_end/divisions/divisions-spec.js
@@ -39,13 +39,34 @@ describe('Traffic Portal Divisions Test Suite', function() {
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/divisions/new");
 	});
 
-	it('should fill out form, create button is enabled and submit', function () {
-		console.log("Filling out form, check create button is enabled and submit");
+	it('should create a new division', function () {
+		console.log("Creating a new division");
 		expect(pageData.createButton.isEnabled()).toBe(false);
 		pageData.name.sendKeys(myNewDiv.name);
 		expect(pageData.createButton.isEnabled()).toBe(true);
 		pageData.createButton.click();
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/divisions");
+	});
+
+	it('should update a division', function() {
+		console.log('Updating the new division: ' + myNewDiv.name);
+		pageData.searchFilter.sendKeys(myNewDiv.name);
+		element.all(by.repeater('d in ::divisions')).filter(function(row){
+			return row.element(by.name('name')).getText().then(function(val){
+				return val === myNewDiv.name;
+			});
+		}).get(0).click();
+		pageData.name.clear();
+		pageData.name.sendKeys(myNewDiv.name + ' updated');
+		pageData.updateButton.click();
+		expect(pageData.name.getText() === myNewDiv.name + ' updated');
+	});
+
+	it('should delete the new division', function() {
+		console.log('Deleting the new division: ' + myNewDiv.name + ' updated');
+		pageData.deleteButton.click();
+		pageData.confirmWithNameInput.sendKeys(myNewDiv.name + ' updated');
+		pageData.deletePermanentlyButton.click();
 	});
 
 });


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "DivisionService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 