### PR TITLE
Removed restangular from FederationResolverService

### DIFF
--- a/traffic_portal/app/src/common/api/FederationResolverService.js
+++ b/traffic_portal/app/src/common/api/FederationResolverService.js
@@ -25,7 +25,7 @@ var FederationResolverService = function($http, ENV, locationUtils, messageModel
 				return result.data.response;
 			},
 			function (err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -36,7 +36,6 @@ var FederationResolverService = function($http, ENV, locationUtils, messageModel
 				return result;
 			},
 			function(err) {
-				console.error(err);
 				throw err;
 			}
 		);
@@ -50,6 +49,7 @@ var FederationResolverService = function($http, ENV, locationUtils, messageModel
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};

--- a/traffic_portal/app/src/common/api/FederationResolverService.js
+++ b/traffic_portal/app/src/common/api/FederationResolverService.js
@@ -17,42 +17,45 @@
  * under the License.
  */
 
-var FederationResolverService = function(Restangular, $http, $q, ENV, locationUtils, messageModel) {
+var FederationResolverService = function($http, ENV, locationUtils, messageModel) {
 
 	this.getFederationResolvers = function(queryParams) {
-		return Restangular.all('federation_resolvers').getList(queryParams);
+		return $http.get(ENV.api['root'] + 'federation_resolvers', {params: queryParams}).then(
+			function (result) {
+				return result.data.response;
+			},
+			function (err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.createFederationResolver = function(fedResolver) {
-		var deferred = $q.defer();
-
-		$http.post(ENV.api['root'] + 'federation_resolvers', fedResolver)
-			.then(
-				function(result) {
-					deferred.resolve(result);
-				},
-				function(fault) {
-					deferred.reject(fault);
-				}
-			);
-
-		return deferred.promise;
+		return $http.post(ENV.api['root'] + 'federation_resolvers', fedResolver).then(
+			function(result) {
+				return result;
+			},
+			function(err) {
+				console.error(err);
+				throw err;
+			}
+		);
 	};
 
 	this.assignFederationResolvers = function(fedId, fedResIds, replace) {
-		return $http.post(ENV.api['root'] + 'federations/' + fedId + '/federation_resolvers', { fedResolverIds: fedResIds, replace: replace })
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: fedResIds.length + ' resolver(s) assigned to federation' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+		return $http.post(ENV.api['root'] + 'federations/' + fedId + '/federation_resolvers', { fedResolverIds: fedResIds, replace: replace }).then(
+			function(result) {
+				messageModel.setMessages([ { level: 'success', text: fedResIds.length + ' resolver(s) assigned to federation' } ], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 
 };
 
-FederationResolverService.$inject = ['Restangular', '$http', '$q', 'ENV', 'locationUtils', 'messageModel'];
+FederationResolverService.$inject = ['$http', 'ENV', 'locationUtils', 'messageModel'];
 module.exports = FederationResolverService;

--- a/traffic_portal/app/src/common/modules/form/federation/edit/FormEditFederationController.js
+++ b/traffic_portal/app/src/common/modules/form/federation/edit/FormEditFederationController.js
@@ -156,7 +156,6 @@ var FormEditFederationController = function(cdn, federation, resolvers, delivery
 			}
 		});
 		modalInstance.result.then(function(selectedResolverIds) {
-			debugger;
 			assignFederationResolvers($scope.federation.id, selectedResolverIds);
 		}, function () {
 			// do nothing


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "FederationResolverService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 