### PR TITLE
Removed restangular from FederationService

### DIFF
--- a/traffic_portal/app/src/common/api/FederationService.js
+++ b/traffic_portal/app/src/common/api/FederationService.js
@@ -146,7 +146,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 				return result.data.response;
 			},
 			function (err) {
-				return throw err;
+				throw err;
 			}
 		);
 	};

--- a/traffic_portal/app/src/common/api/FederationService.js
+++ b/traffic_portal/app/src/common/api/FederationService.js
@@ -17,136 +17,168 @@
  * under the License.
  */
 
-var FederationService = function(Restangular, $http, $q, ENV, locationUtils, messageModel, httpService) {
+var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 
-	var service = this;
+	const service = this;
 
 	this.getCDNFederations = function(cdnName) {
-		return Restangular.one('cdns', cdnName).getList('federations');
+		return $http.get(ENV.api['root'] + 'cdns/' + cdnName + '/federations').then(
+			function (result) {
+				return result.data.response;
+			},
+			function (err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.getCDNFederation = function(cdnName, fedId) {
-		return Restangular.one('cdns', cdnName).one('federations', fedId).get();
+		return $http.get(ENV.api['root'] + 'cdns/' + cdnName + '/federations', {params: {id: fedId}}).then(
+			function (result) {
+				return result.data.response[0];
+			},
+			function (err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.createFederation = function(cdn, fed) {
-		return $http.post(ENV.api['root'] + 'cdns/' + cdn.name + '/federations', fed)
-			.then(
-				function(result) {
-					var newFedId = result.data.response.id,
-						alerts = result.data.alerts,
-						promises = [];
-					// after creating the federation, assign the selected user and ds to the federation
-					promises.push(service.assignFederationUsers(newFedId, [ fed.userId ], false));
-					promises.push(service.assignFederationDeliveryServices(newFedId, [ fed.dsId ], false));
+		return $http.post(ENV.api['root'] + 'cdns/' + cdn.name + '/federations', fed).then(
+			function(result) {
+				const newFedId = result.data.response.id;
+				const alerts = result.data.alerts;
+				const promises = [];
 
-					$q.all(promises)
-						.then(
-							function() {
-								messageModel.setMessages(alerts, true);
-								locationUtils.navigateToPath('/cdns/' + cdn.id + '/federations/' + newFedId);
-							},
-							function(fault) {
-								// do nothing
-							});
+				// after creating the federation, assign the selected user and ds to the federation
+				promises.push(service.assignFederationUsers(newFedId, [ fed.userId ], false));
+				promises.push(service.assignFederationDeliveryServices(newFedId, [ fed.dsId ], false));
 
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+				$q.all(promises).then(
+					function() {
+						messageModel.setMessages(alerts, true);
+						locationUtils.navigateToPath('/cdns/' + cdn.id + '/federations/' + newFedId);
+					},
+					function(err) {
+						console.error(err);
+					}
+				);
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
-	this.updateFederation = function(fed) {
-		return fed.put()
-			.then(
-				function() {
-					service.assignFederationDeliveryServices(fed.id, [ fed.dsId ], true)
-						.then(
-								function() {
-									messageModel.setMessages([ { level: 'success', text: 'Federation updated' } ], false);
-								}
-							);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+	this.updateFederation = function(cdnName, fed) {
+		return $http.put(ENV.api['root'] + 'cdns/' + cdnName + '/federations/' + fed.id, fed).then(
+			function() {
+				service.assignFederationDeliveryServices(fed.id, [ fed.dsId ], true).then(
+					function() {
+						messageModel.setMessages([{level: 'success', text: 'Federation updated'}], false);
+					}
+				);
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 	this.deleteFederation = function(cdnId, fedId) {
-		return Restangular.one('cdns', cdnId).one('federations', fedId).remove()
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Federation deleted' } ], true);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, true);
-				}
-			);
+		return $http.delete(ENV.api['root'] + 'cdns/' + cdnId + '/federations/' + fedId).then(
+			function(result) {
+				messageModel.setMessages([{level: 'success', text: 'Federation deleted'}], true);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, true);
+			}
+		);
 	};
 
 	this.getFederationUsers = function(fedId) {
-		return Restangular.one('federations', fedId).getList('users');
+		return $http.get(ENV.api['root'] + 'federations/' + fedId + '/users').then(
+			function (result) {
+				return result.data.response;
+			},
+			function (err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.assignFederationUsers = function(fedId, userIds, replace) {
-		return $http.post(ENV.api['root'] + 'federations/' + fedId + '/users', { userIds: userIds, replace: replace })
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Users linked to federation' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+		return $http.post(ENV.api['root'] + 'federations/' + fedId + '/users', { userIds: userIds, replace: replace }).then(
+			function(result) {
+				messageModel.setMessages([{level: 'success', text: 'Users linked to federation'}], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 	this.deleteFederationUser = function(fedId, userId) {
-		return httpService.delete(ENV.api['root'] + 'federations/' + fedId + '/users/' + userId)
-			.then(
-				function() {
+		return $http.delete(ENV.api['root'] + 'federations/' + fedId + '/users/' + userId).then(
+				function(result) {
 					messageModel.setMessages([ { level: 'success', text: 'Federation and user were unlinked.' } ], false);
+					return result;
 				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, true);
+				function(err) {
+					messageModel.setMessages(err.data.alerts, true);
 				}
 			);
 	};
 
 	this.getFederationDeliveryServices = function(fedId) {
-		return Restangular.one('federations', fedId).getList('deliveryservices');
+		return $http.get(ENV.api['root'] + 'federations/' + fedId + '/deliveryservices').then(
+			function (result) {
+				return result.data.response;
+			},
+			function (err) {
+				return console.error(err);
+			}
+		);
 	};
 
 	this.assignFederationDeliveryServices = function(fedId, dsIds, replace) {
-		return $http.post(ENV.api['root'] + 'federations/' + fedId + '/deliveryservices', { dsIds: dsIds, replace: replace })
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Delivery services linked to federation' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+		return $http.post(ENV.api['root'] + 'federations/' + fedId + '/deliveryservices', { dsIds: dsIds, replace: replace }).then(
+			function(result) {
+				messageModel.setMessages([{level: 'success', text: 'Delivery services linked to federation'}], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 	this.deleteFederationDeliveryService = function(fedId, dsId) {
-		return httpService.delete(ENV.api['root'] + 'federations/' + fedId + '/deliveryservices/' + dsId)
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Federation and delivery service were unlinked.' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+		return $http.delete(ENV.api['root'] + 'federations/' + fedId + '/deliveryservices/' + dsId).then(
+			function(result) {
+				messageModel.setMessages([{level: 'success', text: 'Federation and delivery service were unlinked.'}], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 	this.getFederationFederationResolvers = function(fedId) {
-		return Restangular.one('federations', fedId).getList('federation_resolvers');
+		return $http.get(ENV.api['root'] + 'federations/' + fedId + '/federation_resolvers').then(
+			function (result) {
+				return result.data.response;
+			},
+			function (err) {
+				console.error(err);
+			}
+		);
 	};
 
 };
 
-FederationService.$inject = ['Restangular', '$http', '$q', 'ENV', 'locationUtils', 'messageModel', 'httpService'];
+FederationService.$inject = ['$http', '$q', 'ENV', 'locationUtils', 'messageModel'];
 module.exports = FederationService;

--- a/traffic_portal/app/src/common/api/FederationService.js
+++ b/traffic_portal/app/src/common/api/FederationService.js
@@ -27,7 +27,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 				return result.data.response;
 			},
 			function (err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -38,7 +38,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 				return result.data.response[0];
 			},
 			function (err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -66,6 +66,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -76,11 +77,15 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 				service.assignFederationDeliveryServices(fed.id, [ fed.dsId ], true).then(
 					function() {
 						messageModel.setMessages([{level: 'success', text: 'Federation updated'}], false);
+					},
+					function(err) {
+						console.error(err);
 					}
 				);
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -93,6 +98,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, true);
+				throw err;
 			}
 		);
 	};
@@ -103,7 +109,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 				return result.data.response;
 			},
 			function (err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -116,6 +122,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -128,6 +135,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 				},
 				function(err) {
 					messageModel.setMessages(err.data.alerts, true);
+					throw err;
 				}
 			);
 	};
@@ -138,7 +146,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 				return result.data.response;
 			},
 			function (err) {
-				return console.error(err);
+				return throw err;
 			}
 		);
 	};
@@ -151,6 +159,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -163,6 +172,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -173,7 +183,7 @@ var FederationService = function($http, $q, ENV, locationUtils, messageModel) {
 				return result.data.response;
 			},
 			function (err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};

--- a/traffic_portal/app/src/common/modules/form/federation/edit/FormEditFederationController.js
+++ b/traffic_portal/app/src/common/modules/form/federation/edit/FormEditFederationController.js
@@ -61,7 +61,7 @@ var FormEditFederationController = function(cdn, federation, resolvers, delivery
 	};
 
 	$scope.save = function(fed) {
-		federationService.updateFederation(fed).
+		federationService.updateFederation(cdn.name, fed).
 			then(function() {
 				$scope.cname = angular.copy(fed.cname);
 				$anchorScroll(); // scrolls window to top


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "FederationService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 