### PR TITLE
Removed restangular from JobService

### DIFF
--- a/traffic_portal/app/src/common/api/JobService.js
+++ b/traffic_portal/app/src/common/api/JobService.js
@@ -17,17 +17,32 @@
  * under the License.
  */
 
-var JobService = function(Restangular) {
+var JobService = function($http, ENV) {
 
 	this.getJobs = function(queryParams) {
-		return Restangular.all('jobs').getList(queryParams);
+		return $http.get(ENV.api['root'] + 'jobs', {params: queryParams}).then(
+			function(result) {
+				return result.data.response;
+			},
+			function (err) {
+				console.error(err);
+			}
+		);
 	};
 
 	this.createJob = function(job) {
-		return Restangular.service('user/current/jobs').post(job);
+		return $http.post(ENV.api['root'] + 'user/current/jobs', job).then(
+			function (result) {
+				console.info('new job created: ', result);
+				return result;
+			},
+			function (err) {
+				console.error(err);
+			}
+		);
 	};
 
 };
 
-JobService.$inject = ['Restangular'];
+JobService.$inject = ['$http', 'ENV'];
 module.exports = JobService;

--- a/traffic_portal/app/src/common/api/JobService.js
+++ b/traffic_portal/app/src/common/api/JobService.js
@@ -25,7 +25,7 @@ var JobService = function($http, ENV) {
 				return result.data.response;
 			},
 			function (err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};
@@ -37,7 +37,7 @@ var JobService = function($http, ENV) {
 				return result;
 			},
 			function (err) {
-				console.error(err);
+				throw err;
 			}
 		);
 	};


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "JobService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.
- create a job
- view all jobs


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 