### PR TITLE
Removed restangular from ParameterService

### DIFF
--- a/traffic_portal/app/src/common/api/ParameterService.js
+++ b/traffic_portal/app/src/common/api/ParameterService.js
@@ -25,7 +25,7 @@ var ParameterService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         );
     };
@@ -36,7 +36,7 @@ var ParameterService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response[0];
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         );
     };
@@ -50,6 +50,7 @@ var ParameterService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -62,6 +63,7 @@ var ParameterService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -85,7 +87,7 @@ var ParameterService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response;
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         );
     };
@@ -96,7 +98,7 @@ var ParameterService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response;
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         );
     };
@@ -107,7 +109,7 @@ var ParameterService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response;
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         );
     };

--- a/traffic_portal/app/src/common/api/ParameterService.js
+++ b/traffic_portal/app/src/common/api/ParameterService.js
@@ -17,72 +17,102 @@
  * under the License.
  */
 
-var ParameterService = function(Restangular, $http, $q, locationUtils, messageModel, ENV) {
+var ParameterService = function($http, locationUtils, messageModel, ENV) {
 
     this.getParameters = function(queryParams) {
-        return Restangular.all('parameters').getList(queryParams);
+        return $http.get(ENV.api['root'] + 'parameters', {params: queryParams}).then(
+            function (result) {
+                return result.data.response
+            },
+            function (err) {
+                console.error(err);
+            }
+        );
     };
 
     this.getParameter = function(id) {
-        return Restangular.one("parameters", id).get();
+        return $http.get(ENV.api['root'] + 'parameters', {params: {id: id}}).then(
+            function (result) {
+                return result.data.response[0];
+            },
+            function (err) {
+                console.error(err);
+            }
+        );
     };
 
     this.createParameter = function(parameter) {
-        return Restangular.service('parameters').post(parameter)
-            .then(
-            function() {
+        return $http.post(ENV.api['root'] + 'parameters', parameter).then(
+            function(result) {
                 messageModel.setMessages([ { level: 'success', text: 'Parameter created' } ], true);
                 locationUtils.navigateToPath('/parameters');
+                return result;
             },
-            function(fault) {
-                messageModel.setMessages(fault.data.alerts, false);
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
             }
         );
     };
 
     this.updateParameter = function(parameter) {
-        return parameter.put()
-            .then(
-            function() {
+        return $http.put(ENV.api['root'] + 'parameters/' + parameter.id, parameter).then(
+            function(result) {
                 messageModel.setMessages([ { level: 'success', text: 'Parameter updated' } ], false);
+                return result;
             },
-            function(fault) {
-                messageModel.setMessages(fault.data.alerts, false);
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
             }
         );
     };
 
     this.deleteParameter = function(id) {
-        var request = $q.defer();
-
-        $http.delete(ENV.api['root'] + "parameters/" + id)
-            .then(
-                function(result) {
-                    request.resolve(result.data);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                    request.reject(fault);
-                }
-            );
-
-        return request.promise;
+        return $http.delete(ENV.api['root'] + "parameters/" + id).then(
+            function(result) {
+                return result.data;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+                throw err;
+            }
+        );
     };
 
 
     this.getProfileParameters = function(profileId) {
-        return Restangular.one('profiles', profileId).getList('parameters');
+        return $http.get(ENV.api['root'] + 'profiles/' + profileId + '/parameters').then(
+            function (result) {
+                return result.data.response;
+            },
+            function (err) {
+                console.error(err);
+            }
+        );
     };
 
     this.getProfileUnassignedParams = function(profileId) {
-        return Restangular.one('profiles', profileId).getList('unassigned_parameters');
+        return $http.get(ENV.api['root'] + 'profiles/' + profileId + 'unassigned_parameters').then(
+            function (result) {
+                return result.data.response;
+            },
+            function (err) {
+                console.error(err);
+            }
+        );
     };
 
     this.getCacheGroupUnassignedParams = function(cgId) {
-        return Restangular.one('cachegroups', cgId).getList('unassigned_parameters');
+        return $http.get(ENV.api['root'] + 'cachegroups/' + cgId + '/unassigned_parameters').then(
+            function (result) {
+                return result.data.response;
+            },
+            function (err) {
+                console.error(err);
+            }
+        );
     };
 
 };
 
-ParameterService.$inject = ['Restangular', '$http', '$q', 'locationUtils', 'messageModel', 'ENV'];
+ParameterService.$inject = ['$http', 'locationUtils', 'messageModel', 'ENV'];
 module.exports = ParameterService;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "ParameterService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 