### PR TITLE
Removed restangular from ProfileParameterService

### DIFF
--- a/traffic_portal/app/src/common/api/ProfileParameterService.js
+++ b/traffic_portal/app/src/common/api/ProfileParameterService.js
@@ -17,45 +17,45 @@
  * under the License.
  */
 
-var ProfileParameterService = function(Restangular, httpService, messageModel, ENV) {
+var ProfileParameterService = function($http, messageModel, ENV) {
 
 	this.unlinkProfileParameter = function(profileId, paramId) {
-		return httpService.delete(ENV.api['root'] + 'profileparameters/' + profileId + '/' + paramId)
-			.then(
-				function() {
+		return $http.delete(ENV.api['root'] + 'profileparameters/' + profileId + '/' + paramId).then(
+				function(result) {
 					messageModel.setMessages([ { level: 'success', text: 'Profile and parameter were unlinked.' } ], false);
+					return result;
 				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, true);
+				function(err) {
+					messageModel.setMessages(err.data.alerts, true);
 				}
 			);
 	};
 
 	this.linkProfileParameters = function(profileId, params) {
-		return Restangular.service('profileparameter').post({ profileId: profileId, paramIds: params, replace: true })
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Parameters linked to profile' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+		return $http.post(ENV.api['root'] + 'profileparameter', { profileId: profileId, paramIds: params, replace: true }).then(
+			function(result) {
+				messageModel.setMessages([ { level: 'success', text: 'Parameters linked to profile' } ], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 	this.linkParamProfiles = function(paramId, profiles) {
-		return Restangular.service('parameterprofile').post({ paramId: paramId, profileIds: profiles, replace: true })
-			.then(
-				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Profiles linked to parameter' } ], false);
-				},
-				function(fault) {
-					messageModel.setMessages(fault.data.alerts, false);
-				}
-			);
+		return $http.post(ENV.api['root'] + 'parameterprofile', { paramId: paramId, profileIds: profiles, replace: true }).then(
+			function(result) {
+				messageModel.setMessages([ { level: 'success', text: 'Profiles linked to parameter' } ], false);
+				return result;
+			},
+			function(err) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+		);
 	};
 
 };
 
-ProfileParameterService.$inject = ['Restangular', 'httpService', 'messageModel', 'ENV'];
+ProfileParameterService.$inject = ['messageModel', 'ENV'];
 module.exports = ProfileParameterService;

--- a/traffic_portal/app/src/common/api/ProfileParameterService.js
+++ b/traffic_portal/app/src/common/api/ProfileParameterService.js
@@ -27,6 +27,7 @@ var ProfileParameterService = function($http, messageModel, ENV) {
 				},
 				function(err) {
 					messageModel.setMessages(err.data.alerts, true);
+					throw err;
 				}
 			);
 	};
@@ -39,6 +40,7 @@ var ProfileParameterService = function($http, messageModel, ENV) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
@@ -51,11 +53,12 @@ var ProfileParameterService = function($http, messageModel, ENV) {
 			},
 			function(err) {
 				messageModel.setMessages(err.data.alerts, false);
+				throw err;
 			}
 		);
 	};
 
 };
 
-ProfileParameterService.$inject = ['messageModel', 'ENV'];
+ProfileParameterService.$inject = ['$http', 'messageModel', 'ENV'];
 module.exports = ProfileParameterService;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "ProfileParameterService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 