### PR TITLE
Removed restangular from RegionService

### DIFF
--- a/traffic_portal/app/src/common/api/RegionService.js
+++ b/traffic_portal/app/src/common/api/RegionService.js
@@ -17,53 +17,67 @@
  * under the License.
  */
 
-var RegionService = function(Restangular, messageModel) {
+var RegionService = function($http, ENV, messageModel) {
 
     this.getRegions = function(queryParams) {
-        return Restangular.all('regions').getList(queryParams);
+        return $http.get(ENV.api['root'] + 'regions', {params: queryParams}).then(
+            function (result) {
+                return result.data.response;
+            },
+            function (err) {
+                console.error(err);
+            }
+        );
     };
 
     this.getRegion = function(id) {
-        return Restangular.one("regions", id).get();
+        return $http.get(ENV.api['root'] + 'regions', {params: {id: id}}).then(
+            function (result) {
+                return result.data.response[0];
+            },
+            function (err) {
+                console.error(err);
+            }
+        )
     };
 
     this.createRegion = function(region) {
-        return Restangular.service('regions').post(region)
-            .then(
-            function() {
+        return $http.post(ENV.api['root'] + 'regions', region).then(
+            function(result) {
                 messageModel.setMessages([ { level: 'success', text: 'Region created' } ], true);
+                return result;
             },
-            function(fault) {
-                messageModel.setMessages(fault.data.alerts, false);
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
             }
         );
     };
 
     this.updateRegion = function(region) {
-        return region.put()
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Region updated' } ], false);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
+        return $http.put(ENV.api['root'] + 'regions/' + region.id, region).then(
+            function(result) {
+                messageModel.setMessages([ { level: 'success', text: 'Region updated' } ], false);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.deleteRegion = function(id) {
-        return Restangular.one("regions", id).remove()
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Region deleted' } ], true);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, true);
-                }
-            );
+        return $http.delete(ENV.api['root'] + "regions/" + id).then(
+            function(result) {
+                messageModel.setMessages([ { level: 'success', text: 'Region deleted' } ], true);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, true);
+            }
+        );
     };
 
 };
 
-RegionService.$inject = ['Restangular', 'messageModel'];
+RegionService.$inject = ['$http', 'ENV', 'messageModel'];
 module.exports = RegionService;

--- a/traffic_portal/app/src/common/api/RegionService.js
+++ b/traffic_portal/app/src/common/api/RegionService.js
@@ -25,7 +25,7 @@ var RegionService = function($http, ENV, messageModel) {
                 return result.data.response;
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         );
     };
@@ -36,7 +36,7 @@ var RegionService = function($http, ENV, messageModel) {
                 return result.data.response[0];
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         )
     };
@@ -49,6 +49,7 @@ var RegionService = function($http, ENV, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -61,6 +62,7 @@ var RegionService = function($http, ENV, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -73,6 +75,7 @@ var RegionService = function($http, ENV, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, true);
+                throw err;
             }
         );
     };


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "RegionService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 