### PR TITLE
Removed restangular from StaticDnsEntryService

### DIFF
--- a/traffic_portal/app/src/common/api/StaticDnsEntryService.js
+++ b/traffic_portal/app/src/common/api/StaticDnsEntryService.js
@@ -17,69 +17,69 @@
  * under the License.
  */
 
-var StaticDnsEntryService = function($http, $q, Restangular, locationUtils, messageModel, ENV) {
+var StaticDnsEntryService = function($http, locationUtils, messageModel, ENV) {
 
 	this.getStaticDnsEntries = function(queryParams) {
-		return Restangular.all('staticdnsentries').getList(queryParams);
+        return $http.get(ENV.api['root'] + 'staticdnsentries', {params: queryParams}).then(
+            function (result) {
+                return result.data.response;
+            },
+            function (err) {
+                console.error(err);
+            }
+        )
 	};
 
 	this.getStaticDnsEntry = function(id) {
-        return Restangular.one('staticdnsentries?id=' + id).get();
+        return $http.get(ENV.api['root'] + 'staticdnsentries', {params: {id: id}}).then(
+            function (result) {
+                return result.data.response[0];
+            },
+            function (err) {
+                console.error(err);
+            }
+        )
     };
 
     this.createDeliveryServiceStaticDnsEntry = function(staticDnsEntry) {
-        var request = $q.defer();
-
-        $http.post(ENV.api['root'] + "staticdnsentries", staticDnsEntry)
-            .then(
-                function(response) {
-                    messageModel.setMessages(response.data.alerts, true);
-                    locationUtils.navigateToPath('/delivery-services/' + staticDnsEntry.deliveryServiceId + '/static-dns-entries');
-                    request.resolve(response);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false)
-                    request.reject(fault);
-                }
-            );
-
-        return request.promise;
+        return $http.post(ENV.api['root'] + "staticdnsentries", staticDnsEntry).then(
+            function(response) {
+                messageModel.setMessages(response.data.alerts, true);
+                locationUtils.navigateToPath('/delivery-services/' + staticDnsEntry.deliveryServiceId + '/static-dns-entries');
+                return response;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false)
+                throw err;
+            }
+        );
     };
 
     this.deleteDeliveryServiceStaticDnsEntry = function(id) {
-        var deferred = $q.defer();
-
-        $http.delete(ENV.api['root'] + "staticdnsentries?id=" + id)
-            .then(
-                function(response) {
-                    messageModel.setMessages(response.data.alerts, true);
-                    deferred.resolve(response);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                    deferred.reject(fault);
-                }
-            );
-        return deferred.promise;
+        return $http.delete(ENV.api['root'] + "staticdnsentries", {params: {id: id}}).then(
+            function(response) {
+                messageModel.setMessages(response.data.alerts, true);
+                return response;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+                throw err;
+            }
+        );
     };
 
     this.updateDeliveryServiceStaticDnsEntry = function(id, staticDnsEntry) {
-        var request = $q.defer();
-
-        $http.put(ENV.api['root'] + "staticdnsentries?id=" + id, staticDnsEntry)
-            .then(
-                function(response) {
-                    messageModel.setMessages(response.data.alerts, false);
-                    request.resolve();
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                    request.reject();
-                }
-            );
-        return request.promise;
+        return $http.put(ENV.api['root'] + "staticdnsentries", staticDnsEntry, {params: {id: id}}).then(
+            function(response) {
+                messageModel.setMessages(response.data.alerts, false);
+                return response;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 };
 
-StaticDnsEntryService.$inject = ['$http', '$q', 'Restangular', 'locationUtils', 'messageModel', 'ENV'];
+StaticDnsEntryService.$inject = ['$http', 'locationUtils', 'messageModel', 'ENV'];
 module.exports = StaticDnsEntryService;

--- a/traffic_portal/app/src/common/api/StaticDnsEntryService.js
+++ b/traffic_portal/app/src/common/api/StaticDnsEntryService.js
@@ -25,7 +25,7 @@ var StaticDnsEntryService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response;
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         )
 	};
@@ -36,7 +36,7 @@ var StaticDnsEntryService = function($http, locationUtils, messageModel, ENV) {
                 return result.data.response[0];
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         )
     };
@@ -76,6 +76,7 @@ var StaticDnsEntryService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "StaticDnsEntryService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 