### PR TITLE
Removed restangular from StatusService

### DIFF
--- a/traffic_portal/app/src/common/api/StatusService.js
+++ b/traffic_portal/app/src/common/api/StatusService.js
@@ -25,7 +25,7 @@ var StatusService = function($http, ENV, locationUtils, messageModel) {
                 return result.data.response;
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         )
     };
@@ -36,7 +36,7 @@ var StatusService = function($http, ENV, locationUtils, messageModel) {
                 return result.data.response[0];
             },
             function (err) {
-                console.error(err);
+                throw err;
             }
         )
     };
@@ -50,6 +50,7 @@ var StatusService = function($http, ENV, locationUtils, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
@@ -62,18 +63,20 @@ var StatusService = function($http, ENV, locationUtils, messageModel) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, false);
+                throw err;
             }
         );
     };
 
     this.deleteStatus = function(id) {
-        return $http.get(ENZ.api['root'] + "statuses/" + id).then(
+        return $http.delete(ENV.api['root'] + "statuses/" + id).then(
             function(result) {
                 messageModel.setMessages([ { level: 'success', text: 'Status deleted' } ], true);
                 return result;
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, true);
+                throw err;
             }
         );
     };

--- a/traffic_portal/app/src/common/api/StatusService.js
+++ b/traffic_portal/app/src/common/api/StatusService.js
@@ -17,54 +17,68 @@
  * under the License.
  */
 
-var StatusService = function(Restangular, locationUtils, messageModel) {
+var StatusService = function($http, ENV, locationUtils, messageModel) {
 
     this.getStatuses = function(queryParams) {
-        return Restangular.all('statuses').getList(queryParams);
+        return $http.get(ENV.api['root'] + 'statuses', {params: queryParams}).then(
+            function (result) {
+                return result.data.response;
+            },
+            function (err) {
+                console.error(err);
+            }
+        )
     };
 
     this.getStatus = function(id) {
-        return Restangular.one("statuses", id).get();
+        return $http.get(ENV.api['root'] + 'statuses', {params: {id: id}}).then(
+            function (result) {
+                return result.data.response[0];
+            },
+            function (err) {
+                console.error(err);
+            }
+        )
     };
 
     this.createStatus = function(status) {
-        return Restangular.service('statuses').post(status)
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Status created' } ], true);
-                    locationUtils.navigateToPath('/statuses');
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
+        return $http.post(ENV.api['root'] + 'statuses', status).then(
+            function(result) {
+                messageModel.setMessages([ { level: 'success', text: 'Status created' } ], true);
+                locationUtils.navigateToPath('/statuses');
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
+            }
+        );
     };
 
     this.updateStatus = function(status) {
-        return status.put()
-            .then(
-            function() {
+        return $http.put(ENV.api['root'] + 'statuses/' + status.id, status).then(
+            function(result) {
                 messageModel.setMessages([ { level: 'success', text: 'Status updated' } ], false);
+                return result;
             },
-            function(fault) {
-                messageModel.setMessages(fault.data.alerts, false);
+            function(err) {
+                messageModel.setMessages(err.data.alerts, false);
             }
         );
     };
 
     this.deleteStatus = function(id) {
-        return Restangular.one("statuses", id).remove()
-            .then(
-                function() {
-                    messageModel.setMessages([ { level: 'success', text: 'Status deleted' } ], true);
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, true);
-                }
+        return $http.get(ENZ.api['root'] + "statuses/" + id).then(
+            function(result) {
+                messageModel.setMessages([ { level: 'success', text: 'Status deleted' } ], true);
+                return result;
+            },
+            function(err) {
+                messageModel.setMessages(err.data.alerts, true);
+            }
         );
     };
 
 };
 
-StatusService.$inject = ['Restangular', 'locationUtils', 'messageModel'];
+StatusService.$inject = ['$http', 'ENV', 'locationUtils', 'messageModel'];
 module.exports = StatusService;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "StatusService"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 