### PR TITLE
Removed restangular from CompareController

### DIFF
--- a/traffic_portal/app/src/common/modules/compare/CompareController.js
+++ b/traffic_portal/app/src/common/modules/compare/CompareController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var CompareController = function(Restangular, item1Name, item2Name, item1, item2, $scope, $window) {
+var CompareController = function(item1Name, item2Name, item1, item2, $scope, $window) {
 
 	$scope.item1Name = item1Name;
 	$scope.item2Name = item2Name;
@@ -59,8 +59,7 @@ var CompareController = function(Restangular, item1Name, item2Name, item1, item2
 
 	var compare = function() {
 		$('#diff').html('<i class="fa fa-refresh fa-spin fa-1x fa-fw"></i> Comparing...');
-		// if the response has been decorated with Restangular methods / properties, remove them...they will pollute the diff
-		performDiff(Restangular.stripRestangular(item1), Restangular.stripRestangular(item2), 'diff');
+		performDiff(item1, item2, 'diff');
 	};
 
 	$scope.back = function() {
@@ -73,5 +72,5 @@ var CompareController = function(Restangular, item1Name, item2Name, item1, item2
 
 };
 
-CompareController.$inject = ['Restangular', 'item1Name', 'item2Name', 'item1', 'item2', '$scope', '$window'];
+CompareController.$inject = ['item1Name', 'item2Name', 'item1', 'item2', '$scope', '$window'];
 module.exports = CompareController;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes a dependency on Restangular from the "CompareController"
- [x] This PR partially addresses #3571 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

Traffic Portal dependencies are not individually documented, and so no documentation changes are necessary.

## What is the best way to verify this PR?

No functionality should have changed (except that errors will now be logged instead of ignored in many cases), so the existing tests should all pass.

Jeremy: actually, the only way to truly verify that the functionality did not change is to:

1. run the UI tests (which is a very small subset of all TP functionality)
2. manually verify the functionality associated with ALL the services functions that changed just to be sure all is well.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 