### PR TITLE
TO: upgrade todb test to go 1.11

### DIFF
--- a/traffic_ops_db/test/docker/Dockerfile-db-admin
+++ b/traffic_ops_db/test/docker/Dockerfile-db-admin
@@ -27,8 +27,7 @@ RUN yum install -y \
     epel-release \
     https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm \
     git && \
-    yum-config-manager --add-repo 'https://vault.centos.org/7.5.1804/os/x86_64/' && \
-    yum -y install --enablerepo=vault* golang-1.9.4
+    yum -y install golang
 
 # Override TRAFFIC_OPS_RPM arg to use a different one using --build-arg TRAFFIC_OPS_RPM=...  Can be local file or http://...
 ARG TRAFFIC_OPS_RPM=traffic_ops.rpm
@@ -46,6 +45,6 @@ ADD run-db-test.sh \
     goose-config.sh \
     /
 
-COPY initdb.d/*dump /db_dumps/
+COPY initdb.d/ /db_dumps/
 
 CMD /run-db-test.sh

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -63,7 +63,11 @@ get_current_db_version() {
     echo "$version"
 }
 
-for d in /db_dumps/*; do
+get_db_dumps() {
+    ls /db_dumps | grep '\.dump'
+}
+
+for d in $(get_db_dumps); do
     echo "checking integrity of DB dump: $d"
     pg_restore -l "$d" > /dev/null || { echo "invalid DB dump: $d. Unable to list contents"; exit 1; }
 done
@@ -106,7 +110,7 @@ if [[ "$run_db_downgrades" = true ]]; then
 fi
 
 # test full restoration of the initial DB dump
-for d in /db_dumps/*; do
+for d in $(get_db_dumps); do
     echo "testing restoration of DB dump: $d"
     pg_restore --verbose --clean --if-exists --create -h $DB_SERVER -p $DB_PORT -U postgres < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
 done


### PR DESCRIPTION

## What does this PR (Pull Request) do?
- [x] This PR fixes #3644 

## Which Traffic Control components are affected by this PR?
No components affected: only fixes building of docker image for traffic ops database testing.  No additional tests or documentation required.

## What is the best way to verify this PR?
Run the traffic ops db tests in docker:
```
cd traffic_ops_db/test/docker
docker-compose up --build --exit-code-from trafficops-db-admin
```

without this change, the trafficops-db-admin image would fail to build.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
