### PR TITLE
Fix Monitor Thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Issue #3605: Fixed Traffic Monitor custom ports in health polling URL.
 - Issue 3587: Fixed Traffic Ops Golang reverse proxy and Riak logs to be consistent with the format of other error logs.
 - Database migrations have been collapsed. Rollbacks to migrations that previously existed are no longer possible.
+- Issue #3646: Fixed Traffic Monitor Thresholds.
 
 ## [3.0.0] - 2018-10-30
 ### Added

--- a/traffic_monitor/health/cache_test.go
+++ b/traffic_monitor/health/cache_test.go
@@ -1,0 +1,149 @@
+package health
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_monitor/cache"
+	"github.com/apache/trafficcontrol/traffic_monitor/peer"
+	"github.com/apache/trafficcontrol/traffic_monitor/threadsafe"
+	"github.com/apache/trafficcontrol/traffic_monitor/todata"
+)
+
+func TestCalcAvailabilityThresholds(t *testing.T) {
+	result := cache.Result{
+		ID:    "myCacheName",
+		Error: nil,
+		Astats: cache.Astats{
+			Ats: map[string]interface{}{},
+			System: cache.AstatsSystem{
+				InfName:           "bond0",
+				InfSpeed:          20000,
+				ProcNetDev:        "bond0: 1234567891011121 123456789101    0    5    0     0          0  9876543 12345678910111213 1234567891011    0 1234    0     0       0          0",
+				ProcLoadavg:       "5.43 4.32 3.21 3/1234 32109",
+				ConfigLoadRequest: 9,
+				LastReloadRequest: 1559237772,
+				ConfigReloads:     1,
+				LastReload:        1559237773,
+				AstatsLoad:        1559237774,
+				NotAvailable:      false,
+			},
+		},
+		Time:            time.Now(),
+		RequestTime:     time.Second,
+		Vitals:          cache.Vitals{},
+		PollID:          42,
+		PollFinished:    make(chan uint64, 1),
+		PrecomputedData: cache.PrecomputedData{},
+		Available:       true,
+	}
+	GetVitals(&result, nil, nil)
+
+	prevResult := cache.Result{
+		Time:   result.Time.Add(time.Second * -1),
+		Vitals: cache.Vitals{BytesOut: result.Vitals.BytesOut - 1250000000}, // 10 gigabits
+	}
+	GetVitals(&result, &prevResult, nil)
+
+	statResultHistory := (*threadsafe.ResultStatHistory)(nil)
+	mc := tc.TrafficMonitorConfigMap{
+		TrafficServer: map[string]tc.TrafficServer{
+			string(result.ID): {
+				ServerStatus: string(tc.CacheStatusReported),
+				Profile:      "myProfileName",
+			},
+		},
+		Profile: map[string]tc.TMProfile{},
+	}
+	mc.Profile[mc.TrafficServer[string(result.ID)].Profile] = tc.TMProfile{
+		Name: mc.TrafficServer[string(result.ID)].Profile,
+		Parameters: tc.TMParameters{
+			Thresholds: map[string]tc.HealthThreshold{
+				"availableBandwidthInKbps": tc.HealthThreshold{
+					Val:        15000000,
+					Comparator: ">",
+				},
+			},
+		},
+	}
+
+	toData := todata.TOData{
+		ServerTypes:            map[tc.CacheName]tc.CacheType{},
+		DeliveryServiceServers: map[tc.DeliveryServiceName][]tc.CacheName{},
+		ServerCachegroups:      map[tc.CacheName]tc.CacheGroupName{},
+	}
+	toData.ServerTypes[result.ID] = tc.CacheTypeEdge
+	toData.DeliveryServiceServers["myDS"] = []tc.CacheName{result.ID}
+	toData.ServerCachegroups[result.ID] = "myCG"
+
+	localCacheStatusThreadsafe := threadsafe.NewCacheAvailableStatus()
+	localStates := peer.NewCRStatesThreadsafe()
+	events := NewThreadsafeEvents(200)
+
+	// test that a normal stat poll over the kbps threshold marks down
+
+	pollerName := "stat"
+	results := []cache.Result{result}
+	CalcAvailability(results, pollerName, statResultHistory, mc, toData, localCacheStatusThreadsafe, localStates, events)
+
+	localCacheStatuses := localCacheStatusThreadsafe.Get()
+	if localCacheStatus, ok := localCacheStatuses[result.ID]; !ok {
+		t.Fatalf("expected: localCacheStatus[cacheName], actual: missing")
+	} else if localCacheStatus.Available {
+		t.Fatalf("localCacheStatus.Available over kbps threshold expected: false, actual: true")
+	} else if localCacheStatus.Status != string(tc.CacheStatusReported) {
+		t.Fatalf("localCacheStatus.Status expected %v actual %v", "todo", localCacheStatus.Status)
+	} else if localCacheStatus.UnavailableStat != "availableBandwidthInKbps" {
+		t.Fatalf("localCacheStatus.UnavailableStat expected %v actual %v", "availableBandwidthInKbps", localCacheStatus.UnavailableStat)
+	} else if localCacheStatus.Poller != pollerName {
+		t.Fatalf("localCacheStatus.Poller expected %v actual %v", pollerName, localCacheStatus.Poller)
+	} else if !strings.Contains(localCacheStatus.Why, "availableBandwidthInKbps too low") {
+		t.Fatalf("localCacheStatus.Why expected 'availableBandwidthInKbps too low' actual %v", localCacheStatus.Why)
+	}
+
+	// test that the health poll didn't override the stat poll threshold markdown and mark available
+	// https://github.com/apache/trafficcontrol/issues/3646
+
+	healthResult := result
+	healthResult.Astats.System.ProcNetDev = "bond0: 1234567891011121 123456789101    0    5    0     0          0  9876543 12345680160111212 1234567891011    0 1234    0     0       0          0" // 10Gb more than result
+	GetVitals(&healthResult, &result, nil)
+	healthPollerName := "health"
+	healthResults := []cache.Result{healthResult}
+	CalcAvailability(healthResults, healthPollerName, nil, mc, toData, localCacheStatusThreadsafe, localStates, events)
+
+	localCacheStatuses = localCacheStatusThreadsafe.Get()
+	if localCacheStatus, ok := localCacheStatuses[result.ID]; !ok {
+		t.Fatalf("expected: localCacheStatus[cacheName], actual: missing")
+	} else if localCacheStatus.Available {
+		t.Fatalf("localCacheStatus.Available over kbps threshold expected: false, actual: true")
+	} else if localCacheStatus.Status != string(tc.CacheStatusReported) {
+		t.Fatalf("localCacheStatus.Status expected %v actual %v", "tc.CacheStatusReported", localCacheStatus.Status)
+	} else if localCacheStatus.UnavailableStat != "availableBandwidthInKbps" {
+		t.Fatalf("localCacheStatus.UnavailableStat expected %v actual %v", "availableBandwidthInKbps", localCacheStatus.UnavailableStat)
+	} else if localCacheStatus.Poller != healthPollerName {
+		t.Fatalf("localCacheStatus.Poller expected %v actual %v", healthPollerName, localCacheStatus.Poller)
+	} else if !strings.Contains(localCacheStatus.Why, "availableBandwidthInKbps too low") {
+		t.Fatalf("localCacheStatus.Why expected 'availableBandwidthInKbps too low' actual %v", localCacheStatus.Why)
+	}
+}

--- a/traffic_monitor/manager/health.go
+++ b/traffic_monitor/manager/health.go
@@ -184,7 +184,9 @@ func processHealthResult(
 		healthHistoryCopy[healthResult.ID] = pruneHistory(append([]cache.Result{healthResult}, healthHistoryCopy[healthResult.ID]...), maxHistory)
 	}
 
-	health.CalcAvailability(results, "health", monitorConfigCopy, toDataCopy, localCacheStatusThreadsafe, localStates, events)
+	pollerName := "health"
+	statResultHistoryNil := (*threadsafe.ResultStatHistory)(nil) // health poller doesn't have stats
+	health.CalcAvailability(results, pollerName, statResultHistoryNil, monitorConfigCopy, toDataCopy, localCacheStatusThreadsafe, localStates, events)
 
 	healthHistory.Set(healthHistoryCopy)
 	// TODO determine if we should combineCrStates() here

--- a/traffic_monitor/manager/stat.go
+++ b/traffic_monitor/manager/stat.go
@@ -318,7 +318,8 @@ func processStatResults(
 		lastStats.Set(*lastStatsCopy)
 	}
 
-	health.CalcAvailabilityWithStats(results, "stat", statResultHistoryThreadsafe, mc, toData, localCacheStatusThreadsafe, localStates, events)
+	pollerName := "stat"
+	health.CalcAvailability(results, pollerName, &statResultHistoryThreadsafe, mc, toData, localCacheStatusThreadsafe, localStates, events)
 	combineState()
 
 	endTime := time.Now()


### PR DESCRIPTION
This fixes the Monitor racing and the health poll marking Available
caches which were marked Unavailable by the Stat poll.

There was already logic to prevent that, but it wasn't accounting
for the Calculated stats, so the Health poll didn't check Calculated
stats for thresholds, but it does "have" those stats, so it thought
it could mark them available again.

This fixes the Health poll to also check thresholds for Calculated
stats, which not only fixes the race, but makes thresholds be
marked up and down faster with the quicker Health poll.

Includes unit tests.
Bug fix, no interface change, so no documentation change.
Includes changelog.

- [x] This PR is not related to any other Issue 

## Which Traffic Control components are affected by this PR?

- Traffic Monitor

## What is the best way to verify this PR?

Set low availableKbps thresholds, run the monitor, verify in the Event Log and Cache States that caches are marked unavailable from kbps threshold, verify health poll does not mark caches that remain above the threshold as available, and that caches remain Unavailable (unless they drop below the threshold).

## If this is a bug fix, what versions of Traffic Ops are affected?

- 2.2
- 3.0.0
- 3.0.1

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
