### PR TITLE
Add support for Cache Assignment Groups to DB and TO API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.4/cdns/dnsseckeys/refresh `GET`
   - /api/1.1/cdns/name/:name/dnsseckeys `GET`
   - /api/1.4/cdns/name/:name/dnsseckeys `GET`
+  - /api/1.4/cacheassignmentgroups `(GET, POST, PUT, DELETE)`
 - To support reusing a single riak cluster connection, an optional parameter is added to riak.conf: "HealthCheckInterval". This options takes a 'Duration' value (ie: 10s, 5m) which affects how often the riak cluster is health checked.  Default is currently set to: "HealthCheckInterval": "5s".
 - Added a new Go db/admin binary to replace the Perl db/admin.pl script which is now deprecated and will be removed in a future release. The new db/admin binary is essentially a drop-in replacement for db/admin.pl since it supports all of the same commands and options; therefore, it should be used in place of db/admin.pl for all the same tasks.
 - Added an API 1.4 endpoint, /api/1.4/cdns/dnsseckeys/refresh, to perform necessary behavior previously served outside the API under `/internal`.
@@ -29,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Portal standalone Dockerfile
 - In Traffic Portal, removes the need to specify line breaks using `__RETURN__` in delivery service edge/mid header rewrite rules, regex remap expressions, raw remap text and traffic router additional request/response headers.
 - In Traffic Portal, provides the ability to clone delivery service assignments from one cache to another cache of the same type. Issue #2963.
+- Added support for Cache Assignment Groups. Cache Assignment Groups simplify assigning overlapping subsets of caches to Delivery Services. Cache Assignment Groups also provide a way to override which mid caches are used on a per-delivery service basis.
 
 ### Changed
 - Traffic Router, added TLS certificate validation on certificates imported from Traffic Ops

--- a/docs/source/api/cacheassignmentgroup.rst
+++ b/docs/source/api/cacheassignmentgroup.rst
@@ -1,0 +1,239 @@
+..
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _to-api-cacheassignmentgroups:
+
+***************
+``cacheassignmentgroups``
+***************
+.. versionadded:: 1.4
+
+``GET``
+=======
+Gets a list of all cache assignment groups in the Traffic Ops database
+
+:Auth. Required: Yes
+:Roles Required: None
+:Response Type:  Array
+
+Request Structure
+-----------------
+.. table:: Request Query Parameters
+
+	+---------+----------+--------------------------------------------------------------------------------+
+	| Name    | Required | Description                                                                    |
+	+=========+==========+================================================================================+
+	| id      | no       | Return only cache assignment groups that have this integral, unique identifier |
+	+---------+----------+--------------------------------------------------------------------------------+
+	| name    | no       | Return only cache assignment groups with this name                             |
+	+---------+----------+--------------------------------------------------------------------------------+
+	| server  | no       | Return only cache assignment groups with this server assigned                  |
+	+---------+----------+--------------------------------------------------------------------------------+
+	| cdnId   | no       | Return only cache assignment groups with this CDN ID                           |
+	+---------+----------+--------------------------------------------------------------------------------+
+	| orderby | no       | Order results by this field, may be one of: id, name, cdnId                    |
+	+---------+----------+--------------------------------------------------------------------------------+
+
+
+Response Structure
+------------------
+:id:          Integral, unique, identifier for this cache assignment group
+:name:        The name of the cache assignment group
+:description: Description of the cache assignment group
+:cdnId:       ID of the CDN to which this cache assignment group belongs
+:servers:     List of server IDs assigned to this cache assignment group
+:lastUpdated: The time and date at which this entry was last updated, in a ``ctime``-like format
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+
+	{ "response": [
+		{
+            "id": 5,		
+            "name": "Live Caches",            
+            "description": "All Live Caches",
+	        "cdnId": 1,
+            "servers": [1, 2, 3],
+  			"lastUpdated": "2018-10-24 16:07:05+00"
+		}
+	]}
+
+``POST``
+========
+Creates a new cache assignment group pair
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Response Type:  Object
+
+Request Structure
+-----------------
+:name:        The name of the cache assignment group
+:description: Description of the cache assignment group
+:cdnId:       ID of the CDN to which this cache assignment group belongs
+:servers:     List of server IDs assigned to this cache assignment group
+
+
+.. code-block:: http
+	:caption: Request Example
+
+	POST /api/1.4/cacheassignmentgroups/ HTTP/1.1
+	Cookie: mojolicious=...
+	Content-Type: application/json
+
+    {
+       "name": "East Coast Edge Caches",
+       "description": "All Edge Caches on East Coast of US",
+       "cdnId": 1,
+       "servers": [10, 12, 14]
+    }
+
+Response Structure
+------------------
+:id:          Integral, unique, identifier for this cache assignment group
+:name:        The name of the cache assignment group
+:description: Description of the cache assignment group
+:cdnId:       ID of the CDN to which this cache assignment group belongs
+:servers:     List of server IDs assigned to this cache assignment group
+:lastUpdated: The time and date at which this entry was last updated, in a ``ctime``-like format
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+
+	{ "response": [
+		{
+            "id": 5,		
+            "name": "Live Caches",            
+            "description": "All Live Caches",
+	        "cdnId": 1,
+            "servers": [1, 2, 3],
+  			"lastUpdated": "2018-10-24 16:07:05+00"
+		}
+	  ], 
+	 "alerts": [
+		{
+			"text": "cacheassignmentgroup was created.",
+			"level": "success"
+		}
+	 ]
+	}
+
+
+``PUT``
+=======
+Updates a cache assignment group
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Request Query Parameters
+
+	+------+----------+-----------------------------------------------------------------------+
+	| Name | Required | Description                                                           |
+	+======+==========+=======================================================================+
+	| id   | yes      | The integral, unique identifier of the cache assignment group to edit |
+	+------+----------+-----------------------------------------------------------------------+
+
+:name:        The name of the cache assignment group
+:description: Description of the cache assignment group
+:cdnId:       ID of the CDN to which this cache assignment group belongs
+:servers:     List of server IDs assigned to this cache assignment group
+
+
+.. code-block:: http
+	:caption: Request Example
+
+	POST /api/1.4/cacheassignmentgroups/?id=4 HTTP/1.1
+	Cookie: mojolicious=...
+	Content-Type: application/json
+
+    {
+       "name": "East Coast Edge Caches",
+       "description": "All Edge Caches on East Coast of US",
+       "cdnId": 1,
+       "servers": [10, 12, 14]
+    }
+
+Response Structure
+------------------
+:id:          Integral, unique, identifier for this cache assignment group
+:name:        The name of the cache assignment group
+:description: Description of the cache assignment group
+:cdnId:       ID of the CDN to which this cache assignment group belongs
+:servers:     List of server IDs assigned to this cache assignment group
+:lastUpdated: The time and date at which this entry was last updated, in a ``ctime``-like format
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+
+	{ "response": [
+		{
+            "id": 5,		
+            "name": "Live Caches",            
+            "description": "All Live Caches",
+	        "cdnId": 1,
+            "servers": [1, 2, 3],
+  			"lastUpdated": "2018-10-24 16:07:05+00"
+		}
+	  ], 
+	 "alerts": [
+		{
+			"text": "cacheassignmentgroup was created.",
+			"level": "success"
+		}
+	 ]
+	}
+
+``DELETE``
+==========
+Deletes a cache assignment group
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Response Type:  ``undefined``
+
+Request Structure
+-----------------
+.. table:: Request Query Parameters
+
+	+------+----------+-------------------------------------------------------------------------+
+	| Name | Required | Description                                                             |
+	+======+==========+=========================================================================+
+	| id   | yes      | The integral, unique identifier of the cache assignment group to delete |
+	+------+----------+-------------------------------------------------------------------------+
+
+Response Structure
+------------------
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	
+
+	{ "alerts": [
+		{
+			"text": "cacheassignmentgroup was deleted.",
+			"level": "success"
+		}
+	]}

--- a/docs/source/api/cacheassignmentgroup.rst
+++ b/docs/source/api/cacheassignmentgroup.rst
@@ -15,14 +15,14 @@
 
 .. _to-api-cacheassignmentgroups:
 
-***************
+*************************
 ``cacheassignmentgroups``
-***************
+*************************
 .. versionadded:: 1.4
 
 ``GET``
 =======
-Gets a list of all cache assignment groups in the Traffic Ops database
+Gets a list of all :term:`Cache Assignment Groups` in the Traffic Ops database
 
 :Auth. Required: Yes
 :Roles Required: None
@@ -60,15 +60,16 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Content-Type: application/json
 
 	{ "response": [
 		{
-            "id": 5,		
-            "name": "Live Caches",            
-            "description": "All Live Caches",
-	        "cdnId": 1,
-            "servers": [1, 2, 3],
-  			"lastUpdated": "2018-10-24 16:07:05+00"
+			"id": 5,		
+			"name": "Live Caches",            
+			"description": "All Live Caches",
+			"cdnId": 1,
+			"servers": [1, 2, 3],
+			"lastUpdated": "2018-10-24 16:07:05+00"
 		}
 	]}
 
@@ -95,12 +96,12 @@ Request Structure
 	Cookie: mojolicious=...
 	Content-Type: application/json
 
-    {
-       "name": "East Coast Edge Caches",
-       "description": "All Edge Caches on East Coast of US",
-       "cdnId": 1,
-       "servers": [10, 12, 14]
-    }
+	{
+	   "name": "East Coast Edge Caches",
+	   "description": "All Edge Caches on East Coast of US",
+	   "cdnId": 1,
+	   "servers": [10, 12, 14]
+	}
 
 Response Structure
 ------------------
@@ -115,15 +116,16 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Content-Type: application/json
 
 	{ "response": [
 		{
-            "id": 5,		
-            "name": "Live Caches",            
-            "description": "All Live Caches",
-	        "cdnId": 1,
-            "servers": [1, 2, 3],
-  			"lastUpdated": "2018-10-24 16:07:05+00"
+			"id": 5,		
+			"name": "Live Caches",            
+			"description": "All Live Caches",
+			"cdnId": 1,
+			"servers": [1, 2, 3],
+			"lastUpdated": "2018-10-24 16:07:05+00"
 		}
 	  ], 
 	 "alerts": [
@@ -166,12 +168,12 @@ Request Structure
 	Cookie: mojolicious=...
 	Content-Type: application/json
 
-    {
-       "name": "East Coast Edge Caches",
-       "description": "All Edge Caches on East Coast of US",
-       "cdnId": 1,
-       "servers": [10, 12, 14]
-    }
+	{
+	   "name": "East Coast Edge Caches",
+	   "description": "All Edge Caches on East Coast of US",
+	   "cdnId": 1,
+	   "servers": [10, 12, 14]
+	}
 
 Response Structure
 ------------------
@@ -186,15 +188,16 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Content-Type: application/json
 
 	{ "response": [
 		{
-            "id": 5,		
-            "name": "Live Caches",            
-            "description": "All Live Caches",
-	        "cdnId": 1,
-            "servers": [1, 2, 3],
-  			"lastUpdated": "2018-10-24 16:07:05+00"
+			"id": 5,		
+			"name": "Live Caches",            
+			"description": "All Live Caches",
+			"cdnId": 1,
+			"servers": [1, 2, 3],
+			"lastUpdated": "2018-10-24 16:07:05+00"
 		}
 	  ], 
 	 "alerts": [
@@ -229,6 +232,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Content-Type: application/json
 	
 
 	{ "alerts": [

--- a/docs/source/api/deliveryservices.rst
+++ b/docs/source/api/deliveryservices.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :active:                   ``true`` if the :term:`Delivery Service` is active, ``false`` otherwise
 :anonymousBlockingEnabled: ``true`` if :ref:`Anonymous Blocking <anonymous_blocking-qht>` has been configured for the :term:`Delivery Service`, ``false`` otherwise
-:cacheAssignmentGroups:    Array of cache assignment group IDs that are assigned to this delivery service
+:cacheAssignmentGroups:    Array of :term:`Cache Assignment Group` IDs that are assigned to this delivery service
 
 	.. versionadded:: 1.4
 

--- a/docs/source/api/deliveryservices.rst
+++ b/docs/source/api/deliveryservices.rst
@@ -51,6 +51,10 @@ Response Structure
 ------------------
 :active:                   ``true`` if the :term:`Delivery Service` is active, ``false`` otherwise
 :anonymousBlockingEnabled: ``true`` if :ref:`Anonymous Blocking <anonymous_blocking-qht>` has been configured for the :term:`Delivery Service`, ``false`` otherwise
+:cacheAssignmentGroups:    Array of cache assignment group IDs that are assigned to this delivery service
+
+	.. versionadded:: 1.4
+
 :cacheurl:                 A setting for a deprecated feature of now-unsupported Trafficserver versions
 
 	.. deprecated:: ATCv3.0
@@ -61,6 +65,9 @@ Response Structure
 :cdnName:                  Name of the CDN to which the :term:`Delivery Service` belongs
 :checkPath:                The path portion of the URL to check connections to this :term:`Delivery Service`'s origin server
 :consistentHashRegex:      If defined, this is a regex used for the Pattern-Based Consistent Hashing feature. It is only applicable for HTTP and Steering Delivery Services
+
+	.. versionadded:: 1.4
+
 :displayName:              The display name of the :term:`Delivery Service`
 :dnsBypassCname:           Domain name to overflow requests for HTTP :term:`Delivery Service`\ s - bypass starts when the traffic on this :term:`Delivery Service` exceeds ``globalMaxMbps``, or when more than ``globalMaxTps`` is being exceeded within the :term:`Delivery Service`\ [4]_
 :dnsBypassIp:              The IPv4 IP to use for bypass on a DNS :term:`Delivery Service` - bypass starts when the traffic on this :term:`Delivery Service` exceeds ``globalMaxMbps``, or when more than ``globalMaxTps`` is being exceeded within the :term:`Delivery Service`\ [4]_
@@ -211,6 +218,7 @@ Response Structure
 	{
 		"active": true,
 		"anonymousBlockingEnabled": false,
+		"cacheAssignmentGroups": [5],
 		"cacheurl": null,
 		"ccrDnsTtl": null,
 		"cdnId": 2,
@@ -295,6 +303,10 @@ Request Structure
 -----------------
 :active:                   If ``true``, the :term:`Delivery Service` will immediately become active and serves traffic
 :anonymousBlockingEnabled: An optional field which, if defined and ``true`` will cause :ref:`Anonymous Blocking <anonymous_blocking-qht>` to be used with the new :term:`Delivery Service`
+:cacheAssignmentGroups:    Array of cache assignment group IDs that are assigned to this delivery service
+
+	.. versionadded:: 1.4
+
 :cacheurl:                 An optional setting for a deprecated feature of now-unsupported Trafficserver versions (read: "Don't use this")
 
 	.. deprecated:: ATCv3.0
@@ -441,6 +453,7 @@ Request Structure
 		"active": false,
 		"anonymousBlockingEnabled": false,
 		"cdnId": 2,
+		"cacheAssignmentGroups": [6],
 		"cdnName": "CDN-in-a-Box",
 		"deepCachingType": "NEVER",
 		"displayName": "test",
@@ -480,6 +493,10 @@ Response Structure
 ------------------
 :active:                   ``true`` if the :term:`Delivery Service` is active, ``false`` otherwise
 :anonymousBlockingEnabled: ``true`` if :ref:`Anonymous Blocking <anonymous_blocking-qht>` has been configured for the :term:`Delivery Service`, ``false`` otherwise
+:cacheAssignmentGroups:    Array of cache assignment group IDs to assign to this delivery service
+
+	.. versionadded:: 1.4
+
 :cacheurl:                 A setting for a deprecated feature of now-unsupported Trafficserver versions
 
 	.. deprecated:: ATCv3.0
@@ -646,6 +663,7 @@ Response Structure
 		{
 			"active": false,
 			"anonymousBlockingEnabled": false,
+			"cacheAssignmentGroups": [1, 2, 3],
 			"cacheurl": null,
 			"ccrDnsTtl": null,
 			"cdnId": 2,

--- a/docs/source/api/deliveryservices_id.rst
+++ b/docs/source/api/deliveryservices_id.rst
@@ -58,11 +58,18 @@ Request Structure
 
 Response Structure
 ------------------
+.. versionchanged:: 1.4
+	Added ``cacheassignmentgroups``, ``consistentHashRegex`` and ``maxOriginConnection`` fields
+
 .. versionchanged:: 1.3
-	Removed ``fqPacingRate`` field, added fields: ``deepCachingType``, ``signingAlgorithm``, and ``tenant``.
+	Added fields: ``deepCachingType``, ``signingAlgorithm``, ``tenant``, ``fqPacingRate``, ``trResponseHeaders`` and ``trRequestHeaders``.
 
 :active:                   ``true`` if the :term:`Delivery Service` is active, ``false`` otherwise
 :anonymousBlockingEnabled: ``true`` if :ref:`Anonymous Blocking <anonymous_blocking-qht>` has been configured for the :term:`Delivery Service`, ``false`` otherwise
+:cacheAssignmentGroups:    Array of cache assignment group IDs that are assigned to this delivery service
+
+	.. versionadded:: 1.4
+
 :cacheurl:                 A setting for a deprecated feature of now-unsupported Trafficserver versions
 
 	.. deprecated:: ATCv3.0
@@ -74,7 +81,7 @@ Response Structure
 :checkPath:                The path portion of the URL to check connections to this :term:`Delivery Service`'s origin server
 :consistentHashRegex:      If defined, this is a regex used for the Pattern-Based Consistent Hashing feature. It is only applicable for HTTP and Steering Delivery Services
 
-	.. versionadded:: 1.5
+	.. versionadded:: 1.4
 
 :deepCachingType:          A string that describes when "Deep Caching" will be used by this :term:`Delivery Service` - one of:
 
@@ -94,8 +101,7 @@ Response Structure
 :edgeHeaderRewrite:        Rewrite operations to be performed on TCP headers at the Edge-tier cache level - used by the Header Rewrite :abbr:`ATS (Apache Traffic Server)` plugin
 :fqPacingRate:             The Fair-Queuing Pacing Rate in Bytes per second set on the all TCP connection sockets in the :term:`Delivery Service` (see ``man tc-fc_codel`` for more information) - Linux only
 
-	.. deprecated:: 1.3
-		This field is only present/available in API versions 1.2 and lower - it has been removed in API version 1.3
+	.. versionadded:: 1.3
 
 :geoLimit:                 The setting that determines how content is geographically limited - this is an integer on the interval [0-2] where the values have these meanings:
 :geoLimitCountries:        A string containing a comma-separated list of country codes (e.g. "US,AU") which are allowed to request content through this :term:`Delivery Service`
@@ -208,7 +214,13 @@ Response Structure
 
 :tenantId:            The integral, unique identifier of the tenant who owns this :term:`Delivery Service`
 :trRequestHeaders:    If defined, this takes the form of a string of HTTP headers to be included in Traffic Router access logs for requests - it's a template where ``__RETURN__`` translates to a carriage return and line feed (``\r\n``)\ [2]_
+
+	.. versionadded:: 1.3
+
 :trResponseHeaders:   If defined, this takes the form of a string of HTTP headers to be included in Traffic Router responses - it's a template where ``__RETURN__`` translates to a carriage return and line feed (``\r\n``)\ [2]_
+
+	.. versionadded:: 1.3
+
 :type:                The name of the routing type of this :term:`Delivery Service` e.g. "HTTP"
 :typeId:              The integral, unique identifier of the routing type of this :term:`Delivery Service`
 :xmlId:               A unique string that describes this :term:`Delivery Service` - exists for legacy reasons
@@ -232,6 +244,7 @@ Response Structure
 		{
 			"active": true,
 			"anonymousBlockingEnabled": false,
+			"cacheAssignmentGroups": [1, 2, 3],
 			"cacheurl": null,
 			"ccrDnsTtl": null,
 			"cdnId": 2,
@@ -317,6 +330,9 @@ Request Structure
 -----------------
 :active:                   If ``true``, the :term:`Delivery Service` will immediately become active and serves traffic
 :anonymousBlockingEnabled: An optional field which, if defined and ``true`` will cause :ref:`Anonymous Blocking <anonymous_blocking-qht>` to be used with the new :term:`Delivery Service`
+:cacheAssignmentGroups:    Array of cache assignment group IDs to be assigned to this delivery service
+	.. versionadded:: 1.4
+
 :cacheurl:                 An optional setting for a deprecated feature of now-unsupported Trafficserver versions (read: "Don't use this")
 
 	.. deprecated:: ATCv3.0
@@ -327,7 +343,7 @@ Request Structure
 :checkPath:                The path portion of the URL which will be used to check connections to this :term:`Delivery Service`'s origin server
 :consistentHashRegex:      If defined, this is a regex used for the Pattern-Based Consistent Hashing feature. It is only applicable for HTTP and Steering Delivery Services
 
-	.. versionadded:: 1.5
+	.. versionadded:: 1.4
 
 :deepCachingType:          A string describing when to do Deep Caching for this :term:`Delivery Service`:
 
@@ -461,6 +477,7 @@ Request Structure
 	{
 		"active": true,
 		"anonymousBlockingEnabled": false,
+		"cacheAssignmentGroups": [],
 		"cdnId": 2,
 		"cdnName": "CDN-in-a-Box",
 		"deepCachingType": "NEVER",

--- a/docs/source/api/deliveryservices_id.rst
+++ b/docs/source/api/deliveryservices_id.rst
@@ -66,7 +66,7 @@ Response Structure
 
 :active:                   ``true`` if the :term:`Delivery Service` is active, ``false`` otherwise
 :anonymousBlockingEnabled: ``true`` if :ref:`Anonymous Blocking <anonymous_blocking-qht>` has been configured for the :term:`Delivery Service`, ``false`` otherwise
-:cacheAssignmentGroups:    Array of cache assignment group IDs that are assigned to this delivery service
+:cacheAssignmentGroups:    Array of :term:`Cache Assignment Group` IDs that are assigned to this delivery service
 
 	.. versionadded:: 1.4
 

--- a/docs/source/api/deliveryservices_id_servers.rst
+++ b/docs/source/api/deliveryservices_id_servers.rst
@@ -23,7 +23,7 @@
 
 ``GET``
 =======
-Retrieves properties of Edge-Tier servers assigned to a :term:`Delivery Service`.
+Retrieves properties of Edge-Tier servers assigned to a :term:`Delivery Service`. This includes servers explicitly assigned to a Delivery Service and servers assigned via a :term:`Cache Assignment Group`.
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"\ [1]_

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -35,6 +35,10 @@ Glossary
 		- :term:`Reverse Proxy`: Used by Traffic Control for Edge-tier :dfn:`cache servers`.
 		- :term:`Forward Proxy`: Used by Traffic Control for Mid-tier :dfn:`cache servers`.
 		- Transparent Proxy: These are not used by Traffic Control. If you are interested you can learn more about transparent proxies on `wikipedia <http://en.wikipedia.org/wiki/Proxy_server#Transparent_proxy>`_.
+		  
+	Cache Assignment Group
+	Cache Assignment Groups
+		Cache Assignment Groups are a logical grouping of servers outside the traditional Edge Cache Group/Mid Cache Group hierarchy. CAGS simplify assigning overlapping subsets of caches to Delivery Services. Cache Assignment Groups also provide a way to override which mid caches are used on a per-delivery service basis.
 
 	Cache Group
 	Cache Groups

--- a/lib/go-tc/cacheassignmentgroups.go
+++ b/lib/go-tc/cacheassignmentgroups.go
@@ -1,0 +1,44 @@
+package tc
+
+import "github.com/lib/pq"
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+type CacheAssignmentGroupResponse struct {
+	Response []CacheAssignmentGroup      `json:"response"`
+	Alerts
+	Size     int                         `json:"size"`
+	Limit    int                         `json:"limit"`
+}
+
+type CacheAssignmentGroup struct {
+	CDNID       int         `json:"cdnId" db:"cdn_id"`
+	Description string   	`json:"description" db:"description"`
+	ID          int         `json:"id" db:"id"`
+	LastUpdated TimeNoMod	`json:"lastUpdated" db:"last_updated"`
+	Name        string      `json:"name" db:"name"`
+	Servers	    []int       `json:"servers"`
+}
+
+type CacheAssignmentGroupNullable struct {
+	CDNID       *int        `json:"cdnId" db:"cdn_id"`
+	Description *string 	`json:"description" db:"description"`
+	ID          *int    	`json:"id" db:"id"`
+	LastUpdated *TimeNoMod	`json:"lastUpdated" db:"last_updated"`
+	Name        *string 	`json:"name" db:"name"`
+	Servers	    pq.Int64Array      `json:"servers" db:"servers"`
+}
+

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -74,6 +74,7 @@ type DeleteDeliveryServiceResponse struct {
 
 type DeliveryService struct {
 	DeliveryServiceV13
+	CacheAssignmentGroups []int `json:"cacheAssignmentGroups"`
 	MaxOriginConnections int `json:"maxOriginConnections" db:"max_origin_connections"`
 }
 
@@ -148,6 +149,7 @@ type DeliveryServiceV11 struct {
 
 type DeliveryServiceNullable struct {
 	DeliveryServiceNullableV13
+	CacheAssignmentGroups []int 	`json:"cacheAssignmentGroups"`
 	ConsistentHashRegex  *string `json:"consistentHashRegex"`
 	MaxOriginConnections *int    `json:"maxOriginConnections" db:"max_origin_connections"`
 }
@@ -229,7 +231,9 @@ type DeliveryServiceNullableV11 struct {
 	ExampleURLs              []string                `json:"exampleURLs"`
 }
 
-// NewDeliveryServiceNullableFromV12 creates a new V13 DS from a V12 DS, filling new fields with appropriate defaults.
+
+
+// NewDeliveryServiceNullableFromV12 creates a new V15 DS from a V12 DS, filling new fields with appropriate defaults.
 func NewDeliveryServiceNullableFromV12(ds DeliveryServiceNullableV12) DeliveryServiceNullable {
 	newDSv13 := DeliveryServiceNullableV13{DeliveryServiceNullableV12: ds}
 	newDS := DeliveryServiceNullable{DeliveryServiceNullableV13: newDSv13}
@@ -433,6 +437,7 @@ func (ds *DeliveryServiceNullable) Validate(tx *sql.Tx) error {
 	if v12Err := ds.DeliveryServiceNullableV12.Validate(tx); v12Err != nil {
 		errs = append(errs, v12Err)
 	}
+
 	if len(errs) == 0 {
 		return nil
 	}

--- a/lib/go-tc/nullable_test.go
+++ b/lib/go-tc/nullable_test.go
@@ -33,6 +33,7 @@ import (
 
 func TestNullStructs(t *testing.T) {
 	compareWithNullable(t, ASN{}, ASNNullable{})
+	compareWithNullable(t, CacheAssignmentGroup{}, CacheAssignmentGroupNullable{})
 	compareWithNullable(t, CacheGroupFallback{}, CacheGroupFallbackNullable{})
 	compareWithNullable(t, CacheGroup{}, CacheGroupNullable{})
 	compareWithNullable(t, CDN{}, CDNNullable{})

--- a/traffic_ops/app/db/migrations/20190513000000_cache-assignment-groups.sql
+++ b/traffic_ops/app/db/migrations/20190513000000_cache-assignment-groups.sql
@@ -1,0 +1,76 @@
+/*
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+-- cacheassignmentgroup
+CREATE TABLE cacheassignmentgroup (
+    id bigserial primary key NOT NULL,
+    name text UNIQUE NOT NULL,
+    description text NOT NULL,
+    cdn_id bigint NOT NULL,
+    last_updated timestamp WITH time zone NOT NULL DEFAULT now()
+);
+
+ALTER TABLE cacheassignmentgroup
+    ADD CONSTRAINT fk_cdnid FOREIGN KEY (cdn_id) REFERENCES cdn(id) ON DELETE CASCADE;
+
+CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON cacheassignmentgroup FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
+
+-- cacheassignmentgroup_server
+CREATE TABLE cacheassignmentgroup_server (
+    cacheassignmentgroup bigint NOT NULL,
+    server bigint NOT NULL,
+    last_updated timestamp WITH time zone NOT NULL DEFAULT now()    
+);
+
+ALTER TABLE cacheassignmentgroup_server
+    ADD CONSTRAINT idx_cag_srv_primary PRIMARY KEY (cacheassignmentgroup, server),
+    ADD CONSTRAINT fk_cacheassignmentgroupid FOREIGN KEY (cacheassignmentgroup) REFERENCES cacheassignmentgroup(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    ADD CONSTRAINT fk_serverid FOREIGN KEY (server) REFERENCES server(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+-- deliveryservice_cacheassignmentgroup
+CREATE TABLE deliveryservice_cacheassignmentgroup (
+    deliveryservice bigint NOT NULL,
+    cacheassignmentgroup bigint NOT NULL, 
+    last_updated timestamp WITH time zone NOT NULL DEFAULT now()   
+);
+
+ALTER TABLE deliveryservice_cacheassignmentgroup
+    ADD CONSTRAINT idx_ds_cag_primary PRIMARY KEY (deliveryservice, cacheassignmentgroup),
+    ADD CONSTRAINT fk_deliveryserviceid FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    ADD CONSTRAINT fk_cacheassignmentgroupid FOREIGN KEY (cacheassignmentgroup) REFERENCES cacheassignmentgroup(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+CREATE VIEW deliveryservice_assignedservers AS
+  SELECT
+    server.id AS server,
+    ds_cag.deliveryservice AS deliveryservice,
+    GREATEST(cags.last_updated, ds_cag.last_updated) AS last_updated
+  FROM server
+  INNER JOIN cacheassignmentgroup_server AS cags
+    ON server.id=cags.server
+  INNER JOIN deliveryservice_cacheassignmentgroup AS ds_cag
+    ON ds_cag.cacheassignmentgroup = cags.cacheassignmentgroup
+  UNION
+    SELECT server, deliveryservice, last_updated  FROM deliveryservice_server;
+    
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+DROP TABLE cacheassignmentgroup_server;
+DROP TABLE deliveryservice_cacheassignmentgroup;
+DROP TRIGGER IF EXISTS on_update_current_timestamp ON cacheassignmentgroup;
+DROP TABLE cacheassignmentgroup;
+

--- a/traffic_ops/client/cacheassignmentgroup.go
+++ b/traffic_ops/client/cacheassignmentgroup.go
@@ -1,0 +1,128 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"net"
+	"net/http"
+)
+
+const (
+	API_V14_CacheAssignmentGroups = "/api/1.4/cacheassignmentgroups/"
+)
+
+func (to *Session) CreateCacheAssignmentGroup(cag tc.CacheAssignmentGroup) (tc.Alerts, ReqInf, error) {
+	var remoteAddr net.Addr
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+
+	reqBody, err := json.Marshal(cag)
+
+	resp, remoteAddr, err := to.request(http.MethodPost, API_V14_CacheAssignmentGroups, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+func (to *Session) UpdateCacheAssignmentGroupByID(id int, cag tc.CacheAssignmentGroup) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cag)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s?id=%d", API_V14_CacheAssignmentGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+
+func (to *Session) GetCacheAssignmentGroups() ([]tc.CacheAssignmentGroup, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_V14_CacheAssignmentGroups, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheAssignmentGroupResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+
+func (to *Session) GetCacheAssignmentGroupByID(id int) ([]tc.CacheAssignmentGroup, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_V14_CacheAssignmentGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheAssignmentGroupResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+
+func (to *Session) GetCacheAssignmentGroupByName(name string) ([]tc.CacheAssignmentGroup, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_V14_CacheAssignmentGroups, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheAssignmentGroupResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+
+func (to *Session) DeleteCacheAssignmentGroupByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_V14_CacheAssignmentGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/testing/api/v14/cacheassignmentgroups_test.go
+++ b/traffic_ops/testing/api/v14/cacheassignmentgroups_test.go
@@ -1,0 +1,137 @@
+package v14
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCacheAssignmentGroups(t *testing.T) {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, CacheAssignmentGroups}, func() {
+		GetTestCacheAssignmentGroups(t)
+		CheckCacheAssignmentGroupsAuthentication(t)
+		UpdateTestCacheAssignmentGroups(t)
+	})
+}
+func GetTestCacheAssignmentGroups(t *testing.T) {
+	for _, cag := range testData.CacheAssignmentGroups {
+		resp, _, err := TOSession.GetCacheAssignmentGroupByName(cag.Name)
+		if err != nil {
+			t.Errorf("cannot GET CacheAssignmentGroup by name: %v - %v\n", err, resp)
+		}
+	}
+}
+
+func CheckCacheAssignmentGroupsAuthentication(t *testing.T) {
+	errFormat := "expected error from %s when unauthenticated"
+
+	cag := testData.CacheAssignmentGroups[0]
+
+	resp, _, err := TOSession.GetCacheAssignmentGroupByName(cag.Name)
+	if err != nil || len(resp) == 0 {
+		t.Errorf("cannot GET CacheAssignmentGroup by name: %v - %v\n", cag.Name, err)
+	}
+	cag = resp[0]
+
+	if _, _, err = NoAuthTOSession.CreateCacheAssignmentGroup(cag); err == nil {
+		t.Error(fmt.Errorf(errFormat, "CreateCacheAssignmentGroup"))
+	}
+	if _, _, err = NoAuthTOSession.GetCacheAssignmentGroups(); err == nil {
+		t.Error(fmt.Errorf(errFormat, "GetCacheAssignmentGroups"))
+	}
+	if _, _, err = NoAuthTOSession.GetCacheAssignmentGroupByName(cag.Name); err == nil {
+		t.Error(fmt.Errorf(errFormat, "GetCacheAssignmentGroupByName"))
+	}
+	if _, _, err = NoAuthTOSession.GetCacheAssignmentGroupByID(cag.ID); err == nil {
+		t.Error(fmt.Errorf(errFormat, "GetCacheAssignmentGroupByID"))
+	}
+	if _, _, err = NoAuthTOSession.UpdateCacheAssignmentGroupByID(cag.ID, cag); err == nil {
+		t.Error(fmt.Errorf(errFormat, "UpdateCacheAssignmentGroupByID"))
+	}
+	if _, _, err = NoAuthTOSession.DeleteCacheAssignmentGroupByID(cag.ID); err == nil {
+		t.Error(fmt.Errorf(errFormat, "DeleteCacheAssignmentGroupByID"))
+	}
+}
+
+func UpdateTestCacheAssignmentGroups(t *testing.T) {
+	firstCAG := testData.CacheAssignmentGroups[0]
+	resp, _, err := TOSession.GetCacheAssignmentGroupByName(firstCAG.Name)
+	if err != nil {
+		t.Errorf("cannot GET CacheAssignmentGroup by name: %v - %v\n", firstCAG.Name, err)
+	}
+	cag := resp[0]
+	expectedServers := []int{5}
+	expectedName := "blah"
+	cag.Name = expectedName
+	cag.Servers = expectedServers
+
+	updResp, _, err := TOSession.UpdateCacheAssignmentGroupByID(cag.ID, cag)
+	if err != nil {
+		t.Errorf("cannot UPDATE CacheAssignmentGroup by id: %v - %v\n", err, updResp)
+	}
+
+	// Retrieve the CacheAssignmentGroup to check name got updated
+	resp, _, err = TOSession.GetCacheAssignmentGroupByID(cag.ID)
+	if err != nil {
+		t.Errorf("cannot GET CacheAssignmentGroup by name: '%s', %v\n", firstCAG.Name, err)
+	}
+	cag = resp[0]
+	if cag.Name != expectedName {
+		t.Errorf("results do not match actual: %s, expected: %s\n", cag.Name, expectedName)
+	}
+
+	for idx, val := range expectedServers {
+		if cag.Servers[idx] != val {
+			t.Errorf("results do not match actual: idx: %d %d, expected: %d\n", idx, cag.Servers[idx], expectedServers)
+		}
+	}
+}
+
+func CreateTestCacheAssignmentGroups(t *testing.T) {
+	for _, cag := range testData.CacheAssignmentGroups {
+		_, _, err := TOSession.CreateCacheAssignmentGroup(cag)
+		if err != nil {
+			t.Errorf("could not CREATE cache assignment groups: %v, request: %v\n", err, cag)
+		}
+	}
+}
+
+func DeleteTestCacheAssignmentGroups(t *testing.T) {
+	for _, cag := range testData.CacheAssignmentGroups {
+		resp, _, err := TOSession.GetCacheAssignmentGroupByName(cag.Name)
+		if err != nil {
+			t.Errorf("cannot GET CacheAssignmentGroup by name: %v - %v\n", cag.Name, err)
+		}
+
+		if len(resp) > 0 {
+			respCAG := resp[0]
+			_, _, err := TOSession.DeleteCacheAssignmentGroupByID(respCAG.ID)
+			if err != nil {
+				t.Errorf("cannot DELETE CacheAssignmentGroup by name: '%s' %v\n", respCAG.Name, err)
+			}
+
+			// Retrieve the CacheAssignmentGroup to see if it got deleted
+			cgs, _, err := TOSession.GetCacheAssignmentGroupByName(cag.Name)
+			if err != nil {
+				t.Errorf("error deleting CacheAssignmentGroup by name: %s\n", err.Error())
+			}
+			if len(cgs) > 0 {
+				t.Errorf("expected CacheAssignmentGroup name: %s to be deleted\n", cag.Name)
+			}
+		}
+	}
+}

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -102,6 +102,18 @@
             ]
         }
     ],
+    "cacheAssignmentGroups": [
+        { "name": "cacheassignmentgroup1",
+           "description": "cag1_description",
+           "cdnId": 1,
+           "servers": [1, 4, 5]
+        },
+        { "name": "cacheassignmentgroup2",
+          "description": "cag2_description",
+          "cdnId": 1,
+          "servers": [5]
+        }
+    ],
     "cdns": [
         {
             "dnssecEnabled": false,
@@ -233,7 +245,6 @@
             "cdnName": "cdn1",
             "cacheurl": "cacheUrl1",
             "ccrDnsTtl": 3600,
-            "cdnName": "cdn1",
             "checkPath": "",
             "deepCachingType": "NEVER",
             "displayName": "ds1DisplayName",
@@ -300,7 +311,6 @@
             "cdnName": "cdn1",
             "cacheurl": "cacheUrl2",
             "ccrDnsTtl": 3600,
-            "cdnName": "cdn1",
             "checkPath": "",
             "deepCachingType": "NEVER",
             "displayName": "d s 1",
@@ -368,7 +378,6 @@
             "cdnName": "cdn1",
             "cacheurl": "cacheUrl3",
             "ccrDnsTtl": 3600,
-            "cdnName": "cdn1",
             "checkPath": "",
             "deepCachingType": "NEVER",
             "displayName": "d s 1",

--- a/traffic_ops/testing/api/v14/todb.go
+++ b/traffic_ops/testing/api/v14/todb.go
@@ -268,6 +268,8 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM cdn;
 	DELETE FROM tenant;
 	ALTER SEQUENCE tenant_id_seq RESTART WITH 1;
+	ALTER SEQUENCE cdn_id_seq RESTART WITH 1;
+	ALTER SEQUENCE server_id_seq RESTART WITH 1;
 `
 	err := execSQL(db, sqlStmt, "Tearing down")
 	if err != nil {

--- a/traffic_ops/testing/api/v14/traffic_control.go
+++ b/traffic_ops/testing/api/v14/traffic_control.go
@@ -23,6 +23,7 @@ import (
 type TrafficControl struct {
 	ASNs                           []tc.ASN                           `json:"asns"`
 	CDNs                           []tc.CDN                           `json:"cdns"`
+	CacheAssignmentGroups          []tc.CacheAssignmentGroup          `json:"cacheAssignmentGroups"`
 	CacheGroups                    []tc.CacheGroupNullable            `json:"cachegroups"`
 	Coordinates                    []tc.Coordinate                    `json:"coordinates"`
 	DeliveryServiceRequests        []tc.DeliveryServiceRequest        `json:"deliveryServiceRequests"`

--- a/traffic_ops/testing/api/v14/traffic_ops_test.go
+++ b/traffic_ops/testing/api/v14/traffic_ops_test.go
@@ -85,7 +85,7 @@ func TestMain(m *testing.M) {
 	toReqTimeout := time.Second * time.Duration(Config.Default.Session.TimeoutInSecs)
 	err = SetupSession(toReqTimeout, Config.TrafficOps.URL, Config.TrafficOps.Users.Admin, Config.TrafficOps.UserPassword)
 	if err != nil {
-		fmt.Printf("\nError creating session to %s - %s, %v\n", Config.TrafficOps.URL, Config.TrafficOpsDB.User, err)
+		fmt.Printf("\nError creating session to %s - %s:%s, %v\n", Config.TrafficOps.URL, Config.TrafficOps.Users.Admin, Config.TrafficOps.UserPassword, err)
 		os.Exit(1)
 	}
 

--- a/traffic_ops/testing/api/v14/withobjs.go
+++ b/traffic_ops/testing/api/v14/withobjs.go
@@ -37,6 +37,7 @@ type TCObj int
 
 const (
 	CacheGroups TCObj = iota
+	CacheAssignmentGroups
 	CDNs
 	CDNFederations
 	Coordinates
@@ -68,6 +69,7 @@ type TCObjFuncs struct {
 
 var withFuncs = map[TCObj]TCObjFuncs{
 	CacheGroups:                    {CreateTestCacheGroups, DeleteTestCacheGroups},
+	CacheAssignmentGroups:          {CreateTestCacheAssignmentGroups, DeleteTestCacheAssignmentGroups},
 	CDNs:                           {CreateTestCDNs, DeleteTestCDNs},
 	CDNFederations:                 {CreateTestCDNFederations, DeleteTestCDNFederations},
 	Coordinates:                    {CreateTestCoordinates, DeleteTestCoordinates},

--- a/traffic_ops/traffic_ops_golang/cacheassignmentgroup/cacheassignmentgroups.go
+++ b/traffic_ops/traffic_ops_golang/cacheassignmentgroup/cacheassignmentgroups.go
@@ -1,0 +1,280 @@
+package cacheassignmentgroup
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+type TOCacheAssignmentGroup struct {
+	api.APIInfoImpl `json:"-"`
+	tc.CacheAssignmentGroupNullable
+}
+
+func (cag *TOCacheAssignmentGroup) SetLastUpdated(t tc.TimeNoMod) { cag.LastUpdated = &t }
+
+func (cag *TOCacheAssignmentGroup) Validate() error {
+	errs := validation.Errors{
+		"name":   		validation.Validate(cag.Name, validation.Required),
+		"description":	validation.Validate(cag.Description, validation.Required),
+		"cdnId": 	    validation.Validate(cag.CDNID, validation.Required, validation.Min(0)),
+		"servers":      validation.Validate(cag.Servers, validation.Required),
+	}
+	if errs != nil {
+		return util.JoinErrs(tovalidate.ToErrors(errs))
+	}
+	return nil
+}
+
+func (cag *TOCacheAssignmentGroup) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
+	return map[string]dbhelpers.WhereColumnInfo{
+		"id":     dbhelpers.WhereColumnInfo{"cag.id", api.IsInt},
+		"name":   dbhelpers.WhereColumnInfo{"cag.name", nil},
+		"cdnId":  dbhelpers.WhereColumnInfo{"cag.cdn_id", api.IsInt},
+		// filtering by server is handled below, this also means we cannot orderby server
+	}
+}
+
+// Lots of copy and paste here from generic_crud.GenericRead(). Would like to refactor to use GenericRead() but there
+//  doesn't seem to be a good way to add custom WHERE and GROUP BY clauses without affecting all other GenericReaders
+func (cag *TOCacheAssignmentGroup) Read() ([]interface{}, error, error, int) {
+	where, orderBy, queryValues, errs := dbhelpers.BuildWhereAndOrderBy(cag.APIInfo().Params, cag.ParamColumns())
+	if len(errs) > 0 {
+		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest
+	}
+
+	if serverId, ok := cag.APIInfo().Params["server"]; ok {
+		if err := api.IsInt(serverId); err != nil {
+			return nil, errors.New("server "+err.Error()), nil, http.StatusBadRequest
+		}
+		queryValues["server"] = serverId
+
+		serverFilter := dbhelpers.BaseWhere
+		if len(where) > 0 {
+			serverFilter = " AND"
+		}
+
+		serverFilter += " cag.id in (SELECT cacheassignmentgroup FROM cacheassignmentgroup_server WHERE server = :server) "
+		where += serverFilter
+		log.Debugln("Updated Where clause")
+		log.Debugln(where)
+	}
+
+	selectQuery, groupBy := cag.SelectQuery()
+
+	query :=  selectQuery + where + groupBy + orderBy
+	log.Debugln(query)
+	rows, err := cag.APIInfo().Tx.NamedQuery(query, queryValues)
+	if err != nil {
+		return nil, nil, errors.New("querying " + cag.GetType() + ": " + err.Error()), http.StatusInternalServerError
+	}
+	defer rows.Close()
+
+	vals := []interface{}{}
+	for rows.Next() {
+		v := &tc.CacheAssignmentGroupNullable{}
+		if err = rows.StructScan(v); err != nil {
+			return nil, nil, errors.New("scanning " + cag.GetType() + ": " + err.Error()), http.StatusInternalServerError
+		}
+		vals = append(vals, v)
+	}
+	return vals, nil, nil, http.StatusOK
+}
+
+func (cag *TOCacheAssignmentGroup) SelectQuery() (string, string) {
+	selectQuery := `SELECT 
+       cag.id AS id,
+       name,
+       description,
+       cag.cdn_id AS cdn_id,
+       cag.last_updated AS last_updated,
+       ARRAY_REMOVE(ARRAY_AGG(server.id), NULL) AS servers
+FROM   cacheassignmentgroup cag
+       LEFT JOIN cacheassignmentgroup_server AS cag_s
+               ON cag_s.cacheassignmentgroup = cag.id
+       LEFT OUTER JOIN server
+               ON cag_s.server = server.id
+`
+
+	groupBy := " GROUP BY cag.id"
+	return selectQuery, groupBy
+ }
+
+
+func (cag *TOCacheAssignmentGroup) Update() (error, error, int) {
+	usrErr, sysErr, errCode := api.GenericUpdate(cag)
+	if usrErr != nil || sysErr != nil {
+		return usrErr, sysErr, errCode
+	}
+
+	err := cag.DeleteServerAssignments()
+	if err != nil {
+		return nil, err, http.StatusInternalServerError
+	}
+
+	if len(cag.Servers) > 0 {
+		usrErr, sysErr, errCode = cag.UpdateServerAssignments()
+		if usrErr != nil || sysErr != nil {
+			return usrErr, sysErr, errCode
+		}
+	}
+
+	return nil, nil, http.StatusOK
+}
+
+func (cag *TOCacheAssignmentGroup) UpdateQuery() string {
+	return `UPDATE
+cacheassignmentgroup SET
+name=:name,
+description=:description,
+cdn_id=:cdn_id
+WHERE id=:id RETURNING last_updated`
+}
+
+func (cag *TOCacheAssignmentGroup) DeleteServerAssignments() error {
+	deleteQuery := "DELETE FROM cacheassignmentgroup_server where cacheassignmentgroup = $1"
+	_, err := cag.APIInfo().Tx.Exec(deleteQuery, *cag.ID)
+	if (err != nil) {
+		return err
+	}
+
+	return nil
+}
+
+func (cag *TOCacheAssignmentGroup) UpdateServerAssignments() (error, error, int) {
+	serverInsertQuery, params := cag.BuildServerInsertQuery()
+	log.Debugln(serverInsertQuery)
+	log.Debugln(params)
+
+	// Because Go typing is draconian...
+	paramInterface := make([]interface{}, len(params))
+	for i, v := range params {
+		paramInterface[i] = v
+	}
+
+	result, err := cag.APIInfo().Tx.Exec(serverInsertQuery, paramInterface...)
+	if err != nil {
+		return api.ParseDBError(err)
+	}
+
+	rowsAffected, err := result.RowsAffected();
+	if err != nil {
+		return nil, err, http.StatusInternalServerError
+	}
+
+	if rowsAffected != int64(len(cag.Servers)) {
+		return nil, errors.New("wrong number of cag_server rows updated in " + cag.GetType()), http.StatusInternalServerError
+	}
+
+	return nil, nil, http.StatusOK
+}
+
+func (cag *TOCacheAssignmentGroup) BuildServerInsertQuery() (string, []int) {
+	insertQuery := "INSERT INTO cacheassignmentgroup_server (cacheassignmentgroup, server) VALUES "
+	var params []int
+
+	paramIdx := 1
+	for idx, server := range cag.Servers {
+		if idx > 0 	{
+			insertQuery += ", \n"
+		}
+
+		insertQuery +=  "($"+ strconv.Itoa(paramIdx) +", $"+ strconv.Itoa(paramIdx+1) +")"
+		paramIdx +=2
+
+		params = append(params, *cag.ID)
+		params = append(params, int(server))
+	}
+
+	return insertQuery, params
+}
+
+
+func (cag *TOCacheAssignmentGroup) Create() (error, error, int) {
+	usrErr, sysErr, errCode := api.GenericCreate(cag)
+	if usrErr != nil || sysErr != nil {
+		return usrErr, sysErr, errCode
+	}
+
+	if len(cag.Servers) > 0 {
+		usrErr, sysErr, errCode = cag.UpdateServerAssignments()
+		if usrErr != nil || sysErr != nil {
+			return usrErr, sysErr, errCode
+		}
+	}
+
+	return nil, nil, http.StatusOK
+}
+
+func (cag *TOCacheAssignmentGroup) InsertQuery() string {
+	return `INSERT INTO cacheassignmentgroup (
+name,
+description,
+cdn_id) VALUES (
+:name,
+:description,
+:cdn_id) RETURNING id,last_updated`
+}
+
+
+func (cag *TOCacheAssignmentGroup) Delete() (error, error, int)              { return api.GenericDelete(cag) }
+
+func (cag *TOCacheAssignmentGroup)  DeleteQuery() string {
+	return `DELETE FROM cacheassignmentgroup
+WHERE id=:id`
+}
+
+
+// Boilerplate for Identifier interface
+func (cag TOCacheAssignmentGroup) GetKeys() (map[string]interface{}, bool) {
+	if cag.ID == nil {
+		return map[string]interface{}{"id": 0}, false
+	}
+	return map[string]interface{}{"id": *cag.ID}, true
+}
+
+func (cag *TOCacheAssignmentGroup)  SetKeys(keys map[string]interface{}) {
+	i, _ := keys["id"].(int) //this utilizes the non panicking type assertion, if the thrown away ok variable is false i will be the zero of the type, 0 here.
+	cag.ID = &i
+}
+func (cag *TOCacheAssignmentGroup) GetType() string { return "cacheassignmentgroup" }
+func (cag *TOCacheAssignmentGroup) GetAuditName() string {
+	if cag.Name != nil {
+		return *cag.Name
+	}
+	if cag.ID != nil {
+		return strconv.Itoa(*cag.ID)
+	}
+	return "unknown"
+}
+
+func (cag TOCacheAssignmentGroup) GetKeyFieldsInfo() []api.KeyFieldInfo {
+	return []api.KeyFieldInfo{{"id", api.GetIntKey}}
+}

--- a/traffic_ops/traffic_ops_golang/cacheassignmentgroup/cacheassignmentgroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cacheassignmentgroup/cacheassignmentgroups_test.go
@@ -1,0 +1,132 @@
+package cacheassignmentgroup
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+
+func getTestCacheAssignmentGroups() []tc.CacheAssignmentGroup {
+	cag := []tc.CacheAssignmentGroup{}
+	testCase := tc.CacheAssignmentGroup{
+		Name:        "CacheAssignmentGroup1",
+		Description: "Description1",
+		CDNID:       1,
+	}
+	cag = append(cag, testCase)
+
+	testCase2 := tc.CacheAssignmentGroup{
+		Name:        "CacheAssignmentGroup2",
+		Description: "Description2",
+		CDNID:        2,
+	}
+	cag = append(cag, testCase2)
+
+	return cag
+}
+
+func TestGetCacheAssignmentGroup(t *testing.T) {
+
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
+
+	testCase := getTestCacheAssignmentGroups()
+	cols := test.ColsFromStructByTag("db", tc.CacheAssignmentGroup{})
+	rows := sqlmock.NewRows(cols)
+
+	for _, ts := range testCase {
+		rows = rows.AddRow(
+			ts.ID,
+			ts.Name,
+			ts.CDNID,
+			ts.LastUpdated,
+			ts.Description)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
+
+	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	obj := TOCacheAssignmentGroup{
+		api.APIInfoImpl{&reqInfo},
+		tc.CacheAssignmentGroupNullable{},
+	}
+	cags, userErr, sysErr, _ := obj.Read()
+	if userErr != nil || sysErr != nil {
+		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	}
+
+	if len(cags) != 2 {
+		t.Errorf("cacheassignmentgroup.Read expected: len(cacheassignmentgroup) == 2, actual: %v", len(cags))
+	}
+
+}
+
+func TestInterfaces(t *testing.T) {
+	var i interface{}
+	i = &TOCacheAssignmentGroup{}
+
+	if _, ok := i.(api.Creator); !ok {
+		t.Errorf("CacheAssignmentGroup must be Creator")
+	}
+	if _, ok := i.(api.Reader); !ok {
+		t.Errorf("CacheAssignmentGroup must be Reader")
+	}
+	if _, ok := i.(api.Updater); !ok {
+		t.Errorf("CacheAssignmentGroup must be Updater")
+	}
+	if _, ok := i.(api.Deleter); !ok {
+		t.Errorf("CacheAssignmentGroup must be Deleter")
+	}
+	if _, ok := i.(api.Identifier); !ok {
+		t.Errorf("CacheAssignmentGroup must be Identifier")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	p := TOCacheAssignmentGroup{}
+	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(p.Validate())))
+	expected := util.JoinErrsStr(test.SortErrors([]error{
+		errors.New("'name' cannot be blank"),
+		errors.New("'description' cannot be blank"),
+		errors.New("'cdnId' cannot be blank"),
+		errors.New("'servers' cannot be blank"),
+	}))
+
+	if !reflect.DeepEqual(expected, errs) {
+		t.Errorf("expected %++v,  got %++v", expected, errs)
+	}
+}

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -38,6 +39,8 @@ type WhereColumnInfo struct {
 
 const BaseWhere = "\nWHERE"
 const BaseOrderBy = "\nORDER BY"
+const BaseLimit = "\nLIMIT"
+const BaseOffset = "\nOFFSET"
 
 func BuildWhereAndOrderBy(parameters map[string]string, queryParamsToSQLCols map[string]WhereColumnInfo) (string, string, map[string]interface{}, []error) {
 	whereClause := BaseWhere
@@ -71,6 +74,28 @@ func BuildWhereAndOrderBy(parameters map[string]string, queryParamsToSQLCols map
 	}
 	log.Debugf("\n--\n Where: %s \n Order By: %s", whereClause, orderBy)
 	return whereClause, orderBy, queryValues, errs
+}
+
+func BuildLimitAndOffset(defaultLimit int, intParams map[string]int) (string, string) {
+	limit := defaultLimit
+	if plimit, ok := intParams["limit"]; ok {
+		limit = plimit
+
+	}
+	limitClause := BaseLimit + " " + strconv.Itoa(limit)
+
+	offsetClause := ""
+	if ppage, ok := intParams["page"]; ok {
+		page := ppage
+		offset := page
+		if offset > 0 {
+			offset -= 1
+		}
+		offset *= limit
+		offsetClause += BaseOffset + " " + strconv.Itoa(offset) + " ROWS "
+	} 
+
+	return limitClause, offsetClause
 }
 
 func parseCriteriaAndQueryValues(queryParamsToSQLCols map[string]WhereColumnInfo, parameters map[string]string) (string, map[string]interface{}, []error) {

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -40,6 +40,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cachegroup"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cachesstats"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cacheassignmentgroup"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cdn"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cdnfederation"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/coordinate"
@@ -423,6 +424,13 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `steering/{deliveryservice}/targets/?(\.json)?$`, api.CreateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, Authenticated, nil},
 		{1.1, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?(\.json)?$`, api.UpdateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, Authenticated, nil},
 		{1.1, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?(\.json)?$`, api.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, Authenticated, nil},
+
+		// Cache Assignment Groups
+		{1.4, http.MethodGet, `cacheassignmentgroups/?(\.json)?$`, api.ReadHandler(&cacheassignmentgroup.TOCacheAssignmentGroup{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.4, http.MethodGet, `cacheassignmentgroups/?$`, api.ReadHandler(&cacheassignmentgroup.TOCacheAssignmentGroup{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.4, http.MethodPut, `cacheassignmentgroups/?$`, api.UpdateHandler(&cacheassignmentgroup.TOCacheAssignmentGroup{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodPost, `cacheassignmentgroups/?$`, api.CreateHandler(&cacheassignmentgroup.TOCacheAssignmentGroup{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodDelete, `cacheassignmentgroups/$`, api.DeleteHandler(&cacheassignmentgroup.TOCacheAssignmentGroup{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Pattern based consistent hashing endpoint
 		{1.4, http.MethodPost, `consistenthash/?$`, consistenthash.Post, auth.PrivLevelReadOnly, Authenticated, nil},


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Cache Assignment Groups simplify assigning overlapping subsets of caches to Delivery Services. Cache Assignment Groups also provide a way to override which mid caches are used on a per-delivery service basis.

This commit does not yet include changes to CRConfig or remap.config generation. Those changes will follow in a future commit.

The DB schema is changed to:
  - Add cacheassignmentgroups, deliveryservice_cacheassignmentgroup, and cacheassignmentgroup_server tables
  - Add deliveryservice_assignedservers view

This change affects the following endpoints:
 - Add /api/1.4/cacheassignmentgroupsserver API endpoint (and added docs)
 - Add Cache Assignment Group support to /api/1.4/deliveryservice_server and /api/1.4/deliveryservice/servers and /unassigned_servers
 - Added cacheAssignmentGroup to /api/1.4/deliveryservices endpoint 

Also includes additional TO API tests for cache assignment groups

- [x] Relates to #3557 

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Go Client <!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Ops

## What is the best way to verify this PR?
Pull in the PR branch, migrate DB schema on `to_test` and run the API test on `TestCacheAssignmentGroups`

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
