### PR TITLE
Removed now-unnecessary build step from TO in CiaB

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -71,12 +71,6 @@ RUN POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/car
 
 RUN /opt/traffic_ops/install/bin/install_goose.sh
 
-RUN export PERL5LIB=/opt/traffic_ops/app/local/lib/perl5/:/opt/traffic_ops/install/lib/ \
-	&& export TERM=xterm \
-	&& export USER=root \
-	&& /opt/traffic_ops/install/bin/download_web_deps -i || \
-	true # keep a failure here from failing all..
-
 ADD https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz /
 
 EXPOSE 443


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Since Traffic Ops Perl's web dependencies were removed, the step to download them is now unnecessary. This PR removes that step from the CDN-in-a-Box Dockerfile for the trafficops-perl service.
- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- CDN in a Box

This extremely minute change is pursuant to another - which ought to contain any and all needed documentation changes itself.
## What is the best way to verify this PR?
Build and run CDN-in-a-Box

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 