### PR TITLE
fix seeds.sql

### DIFF
--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -57,9 +57,9 @@ $do$;
 
 -- parameters
 ---------------------------------
-INSERT INTO parameter (name, config_file, value) VALUES ('mso.parent_retry', 'parent.config', 'simple_retry');
-INSERT INTO parameter (name, config_file, value) VALUES ('mso.parent_retry', 'parent.config', 'unavailable_server_retry');
-INSERT INTO parameter (name, config_file, value) VALUES ('mso.parent_retry', 'parent.config', 'both');
+INSERT INTO parameter (name, config_file, value) VALUES ('mso.parent_retry', 'parent.config', 'simple_retry') ON CONFLICT DO NOTHING;
+INSERT INTO parameter (name, config_file, value) VALUES ('mso.parent_retry', 'parent.config', 'unavailable_server_retry') ON CONFLICT DO NOTHING;
+INSERT INTO parameter (name, config_file, value) VALUES ('mso.parent_retry', 'parent.config', 'both') ON CONFLICT DO NOTHING;
 
 -- profiles
 ---------------------------------


### PR DESCRIPTION

## What does this PR (Pull Request) do?
- [x] This PR fixes a bug introduced in  PR #3524.

It fixes one issue introduced when the `go` migration was removed.   Several `insert` sql commands did not protect against the same row already existing in the db.  This fixes that issue.

No tests or documentation or CHANGELOG changes needed.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
`db/admin -env <test> seed` where `<test>` is the name of an environment with a previously populated database.   No error should be produced.

## If this is a bug fix, what versions of Traffic Ops are affected?
master (41cc65a8621094fd7403574e0dd6f9c36b49ea87)

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
