### PR TITLE
Improved TP UI tests performance and fixed up the README

### DIFF
--- a/traffic_portal/test/end_to_end/CDNs/cdns-spec.js
+++ b/traffic_portal/test/end_to_end/CDNs/cdns-spec.js
@@ -29,7 +29,8 @@ describe('Traffic Portal CDNs Test Suite', function() {
 
 	it('should go to the CDNs page', function() {
 		console.log("Go to the CDNs page");
-		browser.get(browser.baseUrl + "/#!/cdns");
+		browser.setLocation("cdns");
+		browser.getCurrentUrl().then(x => console.log(x));
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/cdns");
 	});
 

--- a/traffic_portal/test/end_to_end/DeliveryServiceRequests/delivery-service-requests-spec.js
+++ b/traffic_portal/test/end_to_end/DeliveryServiceRequests/delivery-service-requests-spec.js
@@ -36,7 +36,7 @@ describe('Traffic Portal Delivery Service Requests', function() {
 
 	it('should open ds services page and click button to create a new one', function() {
 		console.log('Opening delivery service requests page');
-		browser.get(browser.baseUrl + "/#!/delivery-services");
+		browser.setLocation("delivery-services");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services");
 	});
 

--- a/traffic_portal/test/end_to_end/DeliveryServices/delivery-services-spec.js
+++ b/traffic_portal/test/end_to_end/DeliveryServices/delivery-services-spec.js
@@ -34,7 +34,7 @@ describe('Traffic Portal Delivery Services Suite', function() {
 
 	it('should open ds page and click button to create a new one', function() {
 		console.log('Opening delivery services page');
-		browser.get(browser.baseUrl + "/#!/delivery-services");
+		browser.setLocation("delivery-services");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services");
 	});
 
@@ -70,7 +70,7 @@ describe('Traffic Portal Delivery Services Suite', function() {
 
 	it('should back out to ds page and verify new ds and update it', function() {
 		console.log('Backing out and verifying ' + mockVals.xmlId + ' exists');
-		browser.get(browser.baseUrl + "/#!/delivery-services");
+		browser.setLocation("delivery-services");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-services");
 	});
 

--- a/traffic_portal/test/end_to_end/README.md
+++ b/traffic_portal/test/end_to_end/README.md
@@ -1,39 +1,34 @@
 <!--
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements. See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership. The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied. See the License for the
+	specific language governing permissions and limitations
+	under the License.
 -->
 
-# UI Tests  (Using Protractor)
+# UI Tests
 
-- Install and run protractor
-  http://www.protractortest.org/#/tutorial
-    
-- Start up Selenium Server
-    webdriver-manager start
+The Traffic Portal UI tests use [Protractor](https://www.protractortest.org/#/tutorial), which thus must be installed prior to their execution. To run them, follow these steps:
 
-- Make sure Traffic Portal is running
+1. Start up Selenium Server - typically done with `webdriver-manager start`
+1. Make sure Traffic Portal is running (see [the official documentation](https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_portal/installation.html))
+1. Edit [conf.js](./conf.js) if necessary to match the environment (most notably ensure the port numbers match those in ([../conf/conf.js](../conf/conf.js) and that the login credentials are correct).
+1. Run the tests - typically done with `protractor conf.js`
 
-- Edit conf.js if necessary to match your environment.
-
-- Run your tests
-  protractor conf.js --params.adminUser 'user' --params.adminPassword 'password'
-
-- NOTE: Errors with webdriver
-  Most errors with webdriver can be remedied by running the following:
-  webdriver-manager clean
-  webdriver-manager update
-
+## Errors with webdriver
+Most errors with webdriver can be remedied by running:
+```shellsession
+$ webdriver-manager clean
+$ webdriver-manager update
+```

--- a/traffic_portal/test/end_to_end/Servers/servers-spec.js
+++ b/traffic_portal/test/end_to_end/Servers/servers-spec.js
@@ -37,7 +37,7 @@ describe('Traffic Portal Servers Test Suite', function() {
 
 	it('should go to the Servers page', function() {
 		console.log('Looading Configure/Servers');
-		browser.get(browser.baseUrl + "/#!/servers");
+		browser.setLocation("servers");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/servers");
 	});
 

--- a/traffic_portal/test/end_to_end/cacheGroups/cache-groups-spec.js
+++ b/traffic_portal/test/end_to_end/cacheGroups/cache-groups-spec.js
@@ -31,7 +31,7 @@ describe('Traffic Portal Cache Groups Test Suite', function() {
 
 	it('should go to the cache groups page', function() {
 		console.log("Go to the cache groups page");
-		browser.get(browser.baseUrl + "/#!/cache-groups");
+		browser.setLocation("cache-groups");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/cache-groups");
 	});
 

--- a/traffic_portal/test/end_to_end/divisions/divisions-spec.js
+++ b/traffic_portal/test/end_to_end/divisions/divisions-spec.js
@@ -29,7 +29,7 @@ describe('Traffic Portal Divisions Test Suite', function() {
 
 	it('should go to the divisions page', function() {
 		console.log("Go to the divisions page");
-		browser.get(browser.baseUrl + "/#!/divisions");
+		browser.setLocation("divisions");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/divisions");
 	});
 

--- a/traffic_portal/test/end_to_end/login/login-spec.js
+++ b/traffic_portal/test/end_to_end/login/login-spec.js
@@ -21,6 +21,7 @@ var cfunc = require('../common/commonFunctions.js');
 
 describe('Traffic Portal Login Test Suite', function() {
 	const commonFunctions = new cfunc();
+	// browser.get(browser.baseUrl);
 
 	beforeEach(function() {
 		browser.get(browser.baseUrl + '/#!/cdns');

--- a/traffic_portal/test/end_to_end/physLocations/phys-locations-spec.js
+++ b/traffic_portal/test/end_to_end/physLocations/phys-locations-spec.js
@@ -33,7 +33,7 @@ describe('Traffic Portal Phys Locations Test Suite', function() {
 
 	it('should go to the phys locations page', function() {
 		console.log("Go to the phys locations page");
-		browser.get(browser.baseUrl + "/#!/phys-locations");
+		browser.setLocation("phys-locations");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/phys-locations");
 	});
 

--- a/traffic_portal/test/end_to_end/profiles/profiles-spec.js
+++ b/traffic_portal/test/end_to_end/profiles/profiles-spec.js
@@ -29,7 +29,7 @@ describe('Traffic Portal Profiles Test Suite', function() {
 
 	it('should go to the profiles page', function() {
 		console.log("Go to the profiles page");
-		browser.get(browser.baseUrl + "/#!/profiles");
+		browser.setLocation("profiles");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/profiles");
 	});
 

--- a/traffic_portal/test/end_to_end/regions/regions-spec.js
+++ b/traffic_portal/test/end_to_end/regions/regions-spec.js
@@ -29,7 +29,7 @@ describe('Traffic Portal Regions Test Suite', function() {
 
 	it('should go to the regions page', function() {
 		console.log("Go to the regions page");
-		browser.get(browser.baseUrl + "/#!/regions");
+		browser.setLocation("regions");
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/regions");
 	});
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Previously, each view change was accompanied by issuing a fresh request to the running TP instance. This means that every time a view was loaded, both Angular and Protractor need to run through their
bootstrap and setup processes. This behavior has been replaced by the more proper navigation using AngularJS's router for 'in-page navigation'

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Portal

## What is the best way to verify this PR?
Run the TP UI tests. If you don't know how to do that, that's perfect, because I also changed the README that describes how to run them. So also make sure they aren't too vague for you to run the tests.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**