### PR TITLE
Refactoring and Cleanup in parent.config

### DIFF
--- a/lib/go-tc/enum.go
+++ b/lib/go-tc/enum.go
@@ -564,6 +564,18 @@ func (t DSType) UsesMidCache() bool {
 	return true
 }
 
+func (t DSType) IsGoDirect() bool {
+	switch t {
+	case DSTypeHTTPNoCache:
+		fallthrough
+	case DSTypeDNSLive:
+		fallthrough
+	case DSTypeHTTPLive:
+		return true
+	}
+	return false
+}
+
 // QStringIgnore is an entry in the delivery_service table qstring_ignore column, and represents how to treat the URL query string for requests to that delivery service.
 // This enum's String function returns the numeric representation, because it is a legacy database value, and the number should be kept for both database and API JSON uses. For the same reason, this enum has no FromString function.
 type QStringIgnore int

--- a/traffic_ops/traffic_ops_golang/ats/parentdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/parentdotconfig.go
@@ -73,15 +73,15 @@ func GetParentDotConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hdr, err := headerComment(inf.Tx.Tx, serverInfo.HostName)
-	if err != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("Getting header comment: "+err.Error()))
-		return
-	}
-
 	atsMajorVer, err := GetATSMajorVersion(inf.Tx.Tx, serverInfo.ProfileID)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("Getting ATS major version: "+err.Error()))
+		return
+	}
+
+	hdr, err := headerComment(inf.Tx.Tx, serverInfo.HostName)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("Getting header comment: "+err.Error()))
 		return
 	}
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Refactors some duplicate functionality in parent.config and breaks up a few large functions
- [X] This PR is not related to any Issue 

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
`go test`, `curl api/1.1/servers/{id-or-host}/configfiles/ats/parent.config/`
Diff against existing parent.configs

## The following criteria are ALL met by this PR
- [X] This PR includes tests OR I have explained why tests are unnecessary
- [X] This PR includes documentation OR I have explained why documentation is unnecessary
- [X] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
