### PR TITLE
Fix TO client merge error, duplicate func

### DIFF
--- a/traffic_ops/client/atsconfig.go
+++ b/traffic_ops/client/atsconfig.go
@@ -86,18 +86,3 @@ func (to *Session) getConfigFile(uri string) (string, ReqInf, error) {
 	bts, err := ioutil.ReadAll(resp.Body)
 	return string(bts), reqInf, err
 }
-
-func (to *Session) GetATSServerConfigList(serverID int) (tc.ATSConfigMetaData, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, apiBase+"/servers/"+strconv.Itoa(serverID)+"/configfiles/ats", nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.ATSConfigMetaData{}, reqInf, err
-	}
-	defer resp.Body.Close()
-
-	data := tc.ATSConfigMetaData{}
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return tc.ATSConfigMetaData{}, reqInf, err
-	}
-	return data, reqInf, nil
-}


### PR DESCRIPTION
Fix merge compile error.

No tests, nothing to test, compile error.
No docs, no interface change.
No changelog, only in master.

- [x] This PR fixes #3671

## Which Traffic Control components are affected by this PR?

- Traffic Control Client Go

## What is the best way to verify this PR?

`go build`

## If this is a bug fix, what versions of Traffic Ops are affected?

- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
