### PR TITLE
CiaB: Enabled remap_stats.so in ats

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
@@ -252,6 +252,12 @@
 			"value": ""
 		},
 		{
+			"configFile": "plugin.config",
+			"name": "remap_stats.so",
+			"secure": false,
+			"value": ""
+		},
+		{
 			"configFile": "astats.config",
 			"name": "allow_ip",
 			"secure": false,


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Enabled remap_stats.so in ats
Traffic stats can not collect some data without this plugin so we should enable it

## Which Traffic Control components are affected by this PR?

- CDN in a Box

## What is the best way to verify this PR?

1. Start CiaB
2. Send some requests to demo site, e.g.
```
curl -L http://video.demo1.mycdn.ciab.test
curl -L http://video.demo1.mycdn.ciab.test/tc_logo.svg
curl -L http://video.demo1.mycdn.ciab.test/1213 # used to generate 4xx status
```
3. Check status in influxdb. you can use the following instructions in influxdb container:
```
# connect influxdb
influx

# query data
use deliveryservice_stats
select * from status_4xx where value != 0  # you should find some records
select * from tps_2xx where value != 0  # you should find some records
```

4. You can also check charts on portal:
```
https://trafficportal.infra.ciab.test/#!/delivery-services/1/charts?type=HTTP
```

Since there is no any new feature so I didn't provide test

## If this is a bug fix, what versions of Traffic Ops are affected?

master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
