### PR TITLE
CDN-in-a-Box now uses Snapshots instead of legacy CRConfig

### DIFF
--- a/infrastructure/cdn-in-a-box/README.md
+++ b/infrastructure/cdn-in-a-box/README.md
@@ -166,9 +166,9 @@ To expose the ports of each service on the host, add the `docker-compose.expose-
 
 If you scroll back through the output ( or use `docker-compose logs trafficops-perl | grep "User defined signal 2"` ) and see a line that says something like `/run.sh: line 79: 118 User defined signal 2 $TO_DIR/local/bin/hypnotoad script/cdn` then you've hit a mysterious known error. We don't know what this is or why it happens, but your best bet is to send up a quick prayer and restart the stack.
 
-### Traffic Monitor is stuck waiting for a valid CRConfig 
+### Traffic Monitor is stuck waiting for a valid Snapshot
 
-Often times you must snap the CDN in order for a valid CRConfig to be generated. This can be done by logging into the Traffic Portal and clicking the camera icon, then clicking the perform snapshot button.
+Often times you must take a CDN [Snapshot](https://traffic-control-cdn.readthedocs.io/en/latest/glossary.html#term-snapshot) in order for a valid Snapshot to be generated. This can be done through [Traffic Portal's "CDNs" view](https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_portal/usingtrafficportal.html#cdns), clicking on the "CDN-in-a-Box" CDN, then pressing the camera button, and finally the "Perform Snapshot" button.
 
 ### I'm seeing a failure to open a socket and/or set a socket option
 

--- a/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
@@ -104,7 +104,7 @@ export TO_PASSWORD=$TO_ADMIN_PASSWORD
 touch /opt/traffic_monitor/var/log/traffic_monitor.log
 
 # Do not start until there a valid Snapshot has been taken
-until [ $(to-get "/api/1.4/cdns/$CDN_NAME/snapshot" 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do
+until [ $(to-get "/api/1.4/cdns/$CDN_NAME/snapshot" 2>/dev/null | jq -c -e '.response.config|length') -gt 0 ] ; do
 	echo "Waiting on valid Snapshot...";
   	sleep 3;
 done

--- a/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
@@ -103,10 +103,10 @@ export TO_PASSWORD=$TO_ADMIN_PASSWORD
 
 touch /opt/traffic_monitor/var/log/traffic_monitor.log
 
-# Do not start until there is a valid CRConfig available
-until [ $(to-get "/CRConfig-Snapshots/$CDN_NAME/CRConfig.json" 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do
-	echo "Waiting on valid CRConfig..."; 
-  	sleep 3; 
+# Do not start until there a valid Snapshot has been taken
+until [ $(to-get "/api/1.4/cdns/$CDN_NAME/snapshot" 2>/dev/null | jq -c -e '.config|length') -gt 0 ] ; do
+	echo "Waiting on valid Snapshot...";
+  	sleep 3;
 done
 
 cd /opt/traffic_monitor


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Switches the Traffic Monitor init script from using a legacy, undocumented endpoint to a standard one, and updated documentation accordingly.

## Which Traffic Control components are affected by this PR?
- CDN in a Box
- Documentation

## What is the best way to verify this PR?
Build and run CDN-in-a-Box
CDN-in-a-Box has no tests.

## The following criteria are ALL met by this PR
- [x] I have explained why tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**