### PR TITLE
removed the 'Health Tab' parts of the TO UI documentation

### DIFF
--- a/docs/source/admin/traffic_ops/using.rst
+++ b/docs/source/admin/traffic_ops/using.rst
@@ -38,32 +38,6 @@ The Traffic Ops Menu
 
 The following tabs are available in the menu at the top of the Traffic Ops user interface.
 
-.. index::
-	Health Tab
-
-Health
-------
-Information on the health of the system. Hover over this tab to get to the following options:
-
-+---------------+------------------------------------------------------------------------------------------------------------------------------------+
-|     Option    |                                                            Description                                                             |
-+===============+====================================================================================================================================+
-| Table View    | A real time view into the main performance indicators of the CDNs managed by Traffic Control.                                      |
-|               | This view is sourced directly by the Traffic Monitor data and is updated every 10 seconds.                                         |
-|               | This is the default screen of Traffic Ops.                                                                                         |
-|               | See :ref:`health-table` for details.                                                                                               |
-+---------------+------------------------------------------------------------------------------------------------------------------------------------+
-| Graph View    | A real graphical time view into the main performance indicators of the CDNs managed by Traffic Control.                            |
-|               | This view is sourced by the Traffic Monitor data and is updated every 10 seconds.                                                  |
-|               | On loading, this screen will show a history of 24 hours of data from Traffic Stats                                                 |
-|               | See :ref:`health-graph` for details.                                                                                               |
-+---------------+------------------------------------------------------------------------------------------------------------------------------------+
-| Server Checks | A table showing the results of the periodic check extension scripts that are run. See :ref:`server-checks`                         |
-+---------------+------------------------------------------------------------------------------------------------------------------------------------+
-| Daily Summary | A graph displaying the daily peaks of bandwidth, overall bytes served per day, and overall bytes served since initial installation |
-|               | per CDN.                                                                                                                           |
-+---------------+------------------------------------------------------------------------------------------------------------------------------------+
-
 Servers
 -------
 The main Servers table. This is where you Create/Read/Update/Delete servers of all types.  Click the main tab to get to the main table, and hover over to get these sub options:
@@ -166,78 +140,6 @@ Help for Traffic Ops and Traffic Control. Hover over this tab to get the followi
 +---------------+---------------------------------------------------------------------+
 | Logout        | Logout from Traffic Ops                                             |
 +---------------+---------------------------------------------------------------------+
-
-
-.. index::
-	Edge Health
-	Health
-
-Health
-======
-
-.. _health-table:
-
-The Health Table
-----------------
-The Health table is the default landing screen for Traffic Ops, it displays the status of the EDGE caches in a table form directly from Traffic Monitor (bypassing Traffic Stats), sorted by Mbps Out. The columns in this table are:
-
-
-:Profile:          the Profile of this server or ALL, meaning this row shows data for multiple servers, and the row shows the sum of all values.
-:Edge Cache Group: the edge :term:`Cache Group` short name or ALL, meaning this row shows data for multiple servers, and the row shows the sum of all values.
-:Host Name:        the host name of the server or ALL, meaning this row shows data for multiple servers, and the row shows the sum of all values.
-:Healthy:          indicates if this cache is healthy according to the Health Protocol. A row with ALL in any of the columns will always show a |checkmark|, this column is valid only for individual EDGE caches.
-:Admin:            shows the administrative status of the server.
-:Connections:      the number of connections this cache (or group of caches) has open (``ats.proxy.process.http.current_client_connections`` from ATS).
-:Mbps Out:         the bandwidth being served out if this cache (or group of caches)
-
-Since the top line has ALL, ALL, ALL, it shows the total connections and bandwidth for all caches managed by this instance of Traffic Ops.
-
-.. _health-graph:
-
-Graph View
-----------
-The Graph View shows a live view of the last 24 hours of bits per seconds served and open connections at the edge in a graph. This data is sourced from Traffic Stats. If there are 2 CDNs configured, this view will show the statistis for both, and the graphs are stacked. On the left-hand side, the totals and immediate values as well as the percentage of total possible capacity are displayed. This view is update every 10 seconds.
-
-
-.. _server-checks:
-
-Server Checks
--------------
-The server checks page is intended to give an overview of the Servers managed by Traffic Control as well as their status. This data comes from `Traffic Ops extensions <traffic_ops_extensions.html>`_.
-
-+------+-----------------------------------------------------------------------+
-| Name |                 Description                                           |
-+======+=======================================================================+
-| ILO  | Ping the iLO interface for EDGE or MID servers                        |
-+------+-----------------------------------------------------------------------+
-| 10G  | Ping the IPv4 address of the EDGE or MID servers                      |
-+------+-----------------------------------------------------------------------+
-| 10G6 | Ping the IPv6 address of the EDGE or MID servers                      |
-+------+-----------------------------------------------------------------------+
-| MTU  | Ping the EDGE or MID using the configured MTU from Traffic Ops        |
-+------+-----------------------------------------------------------------------+
-| FQDN | DNS check that matches what the DNS servers responds with compared to |
-|      | what Traffic Ops has.                                                 |
-+------+-----------------------------------------------------------------------+
-| DSCP | Checks the DSCP value of packets from the edge server to the Traffic  |
-|      | Ops server.                                                           |
-+------+-----------------------------------------------------------------------+
-| RTR  | Content Router checks. Checks the health of the Content Routers.      |
-|      | Checks the health of the caches using the Content Routers.            |
-+------+-----------------------------------------------------------------------+
-| CHR  | Cache Hit Ratio in percent.                                           |
-+------+-----------------------------------------------------------------------+
-| CDU  | Total Cache Disk Usage in percent.                                    |
-+------+-----------------------------------------------------------------------+
-| ORT  | Operational Readiness Test. Uses the ORT script on the edge and mid   |
-|      | servers to determine if the configuration in Traffic Ops matches the  |
-|      | configuration on the edge or mid. The user that this script runs as   |
-|      | must have an ssh key on the edge servers.                             |
-+------+-----------------------------------------------------------------------+
-
-Daily Summary
--------------
-Displays daily max gbps and bytes served for all CDNs.  In order for the graphs to appear, the 'daily_bw_url' and 'daily_served_url' parameters need to be be created, assigned to the global profile, and have a value of a grafana graph.  For more information on configuring grafana, see the `Traffic Stats <../traffic_stats.html>`_  section.
 
 .. _server:
 

--- a/docs/source/admin/traffic_portal/usingtrafficportal.rst
+++ b/docs/source/admin/traffic_portal/usingtrafficportal.rst
@@ -38,33 +38,31 @@ Current Connections
 	The current number of connections to all of your CDNs.
 
 Healthy Caches
-	Displays the number of healthy caches across all CDNs. Click the link to view the healthy caches on the cache stats page.
+	Displays the number of healthy :term:`cache servers` across all CDNs. Click the link to view the healthy caches on the cache stats page.
 
 Unhealthy Caches
-	Displays the number of unhealthy caches across all CDNs. Click the link to view the unhealthy caches on the cache stats page.
+	Displays the number of unhealthy :term:`cache servers` across all CDNs. Click the link to view the unhealthy caches on the cache stats page.
 
 Online Caches
-	Displays the number of :term:`cache server` s with ONLINE status. Traffic Monitor will not monitor the state of ONLINE servers [1]_.
+	Displays the number of :term:`cache servers` with ONLINE :term:`Status`. Traffic Monitor will not monitor the state of ONLINE servers.
 
 Reported Caches
-	Displays the number of :term:`cache server` s with REPORTED status [1]_.
+	Displays the number of :term:`cache servers` with REPORTED :term:`Status`.
 
 Offline Caches
-	Displays the number of :term:`cache server` s with OFFLINE status [1]_.
+	Displays the number of :term:`cache servers` with OFFLINE :term:`Status`.
 
 Admin Down Caches
-	Displays the number of caches with ADMIN_DOWN status [1]_.
+	Displays the number of caches with ADMIN_DOWN :term:`Status`.
 
-Each component of this view is updated on the intervals defined in the :file:`traffic_portal_properties.json` configuration file.
-
-.. [1] For more information, see :ref:`health-proto`.
+Each component of this view is updated on the intervals defined in the :atc-file:`traffic_portal/app/src/traffic_portal_properties.json` configuration file.
 
 CDNs
 ====
 A table of CDNs with the following columns:
 
 :Name:           The name of the CDN
-:Domain:         The CDN's Top-Level Domain (TLD)
+:Domain:         The CDN's :abbr:`TLD (Top-Level Domain)`
 :DNSSEC Enabled: 'true' if :ref:`tr-dnssec` is enabled on this CDN, 'false' otherwise.
 
 CDN management includes the ability to (where applicable):
@@ -73,17 +71,16 @@ CDN management includes the ability to (where applicable):
 - update an existing CDN
 - delete an existing CDN
 - queue/clear updates on all servers in a CDN
-- diff CDN snapshots
-- create a CDN snapshot
+- compare and take CDN :term:`Snapshots`
 - manage a CDN's DNSSEC keys
-- manage a CDN's federations
-- view :term:`Delivery Service`\ s of a CDN
-- view CDN profiles
+- manage a CDN's :term:`Federations`
+- view :term:`Delivery Services` of a CDN
+- view CDN :term:`Profiles`
 - view servers within a CDN
 
 Monitor
 =======
-The :guilabel:`Monitor` section of Traffic Portal is used to display statistics regarding the various :term:`cache server` s within all CDNs visible to the user. It retrieves this information through the Traffic Ops API from Traffic Monitor instances.
+The :guilabel:`Monitor` section of Traffic Portal is used to display statistics regarding the various :term:`cache servers` within all CDNs visible to the user. It retrieves this information through the :ref:`to-api` from Traffic Monitor instances.
 
 .. figure:: ./images/tp_menu_monitor.png
 	:align: center
@@ -94,41 +91,43 @@ The :guilabel:`Monitor` section of Traffic Portal is used to display statistics 
 
 Cache Checks
 ------------
-A real-time view into the status of each cache. The :menuselection:`Monitor --> Cache Checks` page is intended to give an overview of the caches managed by Traffic Control as well as their status.
+A real-time view into the status of each :term:`cache server`. The :menuselection:`Monitor --> Cache Checks` page is intended to give an overview of the caches managed by Traffic Control as well as their status.
 
-:Hostname: Cache host name
-:Profile:  The name of the profile applied to the cache
-:Status:   The status of the cache (one of: ONLINE, REPORTED, ADMIN_DOWN, OFFLINE)
+.. warning:: Several of these columns may be empty by default - particularly in the :ref:`ciab` environment - and require :ref:`Traffic Ops Extensions <admin-to-ext-script>` to be installed/enabled/configured in order to work.
+
+:Hostname: The (short) hostname of the :term:`cache server`
+:Profile:  The name of the :term:`Profile` used by the :term:`cache server`
+:Status:   The :term:`Status` of the :term:`cache server`
 
 	.. seealso:: :ref:`health-proto`
 
-:UPD:      Configuration updates pending for an Edge-tier or Mid-tier :term:`cache server`
-:RVL:      Content invalidation requests are pending for this server and/or its parent(s)
-:ILO:      Ping the iLO interface for Edge-tier or Mid-tier :term:`cache server` s
-:10G:      Ping the IPv4 address of the Edge-tier or Mid-tier :term:`cache server` s
-:FQDN:     DNS check that matches what the DNS servers responds with compared to what Traffic Ops has
-:DSCP:     Checks the :abbr:`DSCP (Differentiated Services Code Point)` value of packets from the Edge-tier :term:`cache server` to the Traffic Ops server
-:10G6:     Ping the IPv6 address of the Edge-tier or Mid-tier :term:`cache server` s
-:MTU:      Ping the Edge-tier or Mid-tier using the configured :abbr:`MTU (Maximum Transmission Unit)` from Traffic Ops
-:RTR:      Content Router checks. Checks the health of the Traffic Router servers. Also checks the health of the :term:`cache server` s using the Traffic Routers
-:CHR:      Cache Hit Ratio percent
-:CDU:      Total Cache Disk Usage percent
-:ORT:      Operational Readiness Test - uses the :term:`ORT` script on the Edge-tier and Mid-tier :term:`cache server` s to determine if the configuration in Traffic Ops matches the configuration on the Edge-tier or Mid-tier. The user as whom this script runs must have an SSH key on the Edge-tier servers.
+:UPD:  Displays whether or not this :term:`cache server` has configuration updates pending
+:RVL:  Displays whether or not this :term:`cache server` (or one or more of its :term:`parents`) has content invalidation requests pending
+:ILO:  Indicates the status of an :abbr:`iLO (Integrated Lights-Out)` interface for this :term:`cache server`
+:10G:  Indicates whether or not the IPv4 address of this :term:`cache server` is reachable via ICMP "pings"
+:FQDN: DNS check that matches what the DNS servers respond with compared to what Traffic Ops has configured
+:DSCP: Checks the :abbr:`DSCP (Differentiated Services Code Point)` value of packets received from this :term:`cache server`
+:10G6: Indicates whether or not the IPv6 address of this :term:`cache server` is reachable via ICMP "pings"
+:MTU:  Checks the :abbr:`MTU (Maximum Transmission Unit)` by sending ICMP "pings" from the Traffic Ops server
+:RTR:  Checks the reachability of the :term:`cache server` from the CDN's configured Traffic Routers
+:CHR:  Cache-Hit Ratio (percent)
+:CDU:  Total Cache-Disk Usage (percent)
+:ORT:  Uses the :term:`ORT` script on the :term:`cache server` to determine if the configuration in Traffic Ops matches the configuration on :term:`cache server` itself. The user as whom this script runs must have an SSH key on each server.
 
 
 Cache Stats
 -----------
 A table showing the results of the periodic :ref:`to-check-ext` that are run. These can be grouped by :term:`Cache Group` and/or :term:`Profile`.
 
-:Profile:     Name of the :term:`Profile` applied to the Edge-tier or Mid-tier :term:`cache server`
+:Profile:     Name of the :term:`Profile` applied to the Edge-tier or Mid-tier :term:`cache server`, or the special name "ALL" indicating that this row is a group of all :term:`cache servers` within a single :term:`Cache Group`
 :Host:        'ALL' for entries grouped by :term:`Cache Group`, or the hostname of a particular :term:`cache server`
-:Cache Group: Name of the :term:`Cache Group` to which this server belongs, or the name of the :term:`Cache Group` that is grouped for entries grouped by :term:`Cache Group`
+:Cache Group: Name of the :term:`Cache Group` to which this server belongs, or the name of the :term:`Cache Group` that is grouped for entries grouped by :term:`Cache Group`, or the special name "ALL" indicating that this row is an aggregate across all :term:`Cache Groups`
 :Healthy:     True/False as determined by Traffic Monitor
 
 	.. seealso:: :ref:`health-proto`
 
 :Status:      Status of the :term:`cache server` or :term:`Cache Group`
-:Connections: Number of connections to this :term:`cache server` or :term:`Cache Group`
+:Connections: Number of currently open connections to this :term:`cache server` or :term:`Cache Group`
 :MbpsOut:     Data flow rate outward from the CDN (toward client) in Megabits per second
 
 .. _tp-services:

--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -60,7 +60,7 @@ influxPassword
 pollingInterval
 	The interval at which Traffic Monitor is polled and stats are stored in InfluxDB
 statusToMon
-	The status of Traffic Monitor to poll (poll ONLINE or OFFLINE traffic monitors)
+	The status of Traffic Monitor to poll (poll ONLINE or OFFLINE Traffic Monitors)
 seelogConfig
 	The absolute path of the seelog configuration file
 dailySummaryPollingInterval
@@ -68,9 +68,9 @@ dailySummaryPollingInterval
 cacheRetentionPolicy
 	The default retention policy for cache stats
 dsRetentionPolicy
-	The default retention policy for :term:`Delivery Service`\ stats
+	The default retention policy for :term:`Delivery Service` statistics
 dailySummaryRetentionPolicy
-	The retention policy to be used for the daily stats
+	The retention policy to be used for the daily statistics
 influxUrls
 	An array of InfluxDB hosts for Traffic Stats to write stats to.
 
@@ -86,7 +86,7 @@ To easily create databases, retention policies, and continuous queries, run :pro
 
 Configuring Grafana
 -------------------
-In Traffic Portal the :menuselection:`Other --> Grafana` menu item can be configured to display Grafana graphs using InfluxDB data. In order for this to work correctly, you will need two things:
+In Traffic Portal the :menuselection:`Other --> Grafana` menu item can be configured to display Grafana graphs using InfluxDB data (when not configured, this menu item will not appear). In order for this to work correctly, you will need two things:
 
 #. A :term:`Parameter` with the graph URL (more information below)
 #. The graphs created in Grafana. See below for how to create some simple graphs in Grafana. These instructions assume that InfluxDB has been configured and that data has been written to it. If this is not true, you will not see any graphs.
@@ -112,41 +112,52 @@ To create a graph in Grafana, you can follow these basic steps:
 
 In order for Traffic Portal users to see Grafana graphs, Grafana will need to allow anonymous access. Information on how to configure anonymous access can be found on the configuration page of the `Grafana Website  <http://docs.grafana.org/installation/configuration/#authanonymous>`_.
 
-Traffic Portal uses custom dashboards to display information about individual :term:`Delivery Service`\ s or :term:`Cache Group`\ s. In order for the custom graphs to display correctly, the `traffic_ops_*.js <https://github.com/apache/trafficcontrol/blob/master/traffic_stats/grafana/>`_ files need to be in the ``/usr/share/grafana/public/dashboards/`` directory on the Grafana server. If your Grafana server is the same as your Traffic Stats server the RPM install process will take care of putting the files in place. If your Grafana server is different from your Traffic Stats server, you will need to manually copy the files to the correct directory.
+Traffic Portal uses custom dashboards to display information about individual :term:`Delivery Services` or :term:`Cache Groups`. In order for the custom graphs to display correctly, the Javascript files in :atc-file:`traffic_stats/grafana/`  need to be in the :file:`/usr/share/grafana/public/dashboards/` directory on the Grafana server. If your Grafana server is the same as your Traffic Stats server the RPM install process will take care of putting the files in place. If your Grafana server is different from your Traffic Stats server, you will need to manually copy the files to the correct directory.
 
-More information on custom scripted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
+.. seealso:: More information on custom scripted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
 
 Configuring Traffic Portal for Traffic Stats
 --------------------------------------------
 - The InfluxDB servers need to be added to Traffic Portal with profile = InfluxDB. Make sure to use port 8086 in the configuration.
 - The traffic stats server should be added to Traffic Ops with profile = Traffic Stats.
-- :term:`Parameter`\ s for which stats will be collected are added with the release, but any changes can be made via parameters that are assigned to the Traffic Stats profile.
+- :term:`Parameters` for which stats will be collected are added with the release, but any changes can be made via parameters that are assigned to the Traffic Stats profile.
 
 Configuring Traffic Portal to use Grafana Dashboards
 ----------------------------------------------------
-To configure Traffic Portal to use Grafana Dashboards, you need to enter the following :term:`Parameter`\ s and assign them to the GLOBAL profile. This assumes you followed the above instructions to install and configure InfluxDB and Grafana. You will need to place 'cdn-stats','deliveryservice-stats', and 'daily-summary' with the name of your dashboards.
+To configure Traffic Portal to use Grafana Dashboards, you need to enter the following :term:`Parameters` and assign them to the special GLOBAL :term:`Profile`. This assumes you followed instructions in the Installation_, `Configuring Traffic Stats`_, `Configuring InfluxDB`_, and `Configuring Grafana`_ sections.
 
 .. table:: Traffic Stats Parameters
 
-	+---------------------------+----------------------------------------------------------------------------------------------------+
-	|       parameter name      |                                        parameter value                                             |
-	+===========================+====================================================================================================+
-	| all_graph_url             | ``https://<grafanaHost>/dashboard/db/deliveryservice-stats``                                       |
-	+---------------------------+----------------------------------------------------------------------------------------------------+
-	| cachegroup_graph_url      | ``https://<grafanaHost>/dashboard/script/traffic_ops_cachegroup.js?which=``                        |
-	+---------------------------+----------------------------------------------------------------------------------------------------+
-	| deliveryservice_graph_url | ``https://<grafanaHost>/dashboard/script/traffic_ops_deliveryservice.js?which=``                   |
-	+---------------------------+----------------------------------------------------------------------------------------------------+
-	| server_graph_url          | ``https://<grafanaHost>/dashboard/script/traffic_ops_server.js?which=``                            |
-	+---------------------------+----------------------------------------------------------------------------------------------------+
-	| visual_status_panel_1     | ``https://<grafanaHost>/dashboard-solo/db/cdn-stats?panelId=2&fullscreen&from=now-24h&to=now-60s`` |
-	+---------------------------+----------------------------------------------------------------------------------------------------+
-	| visual_status_panel_2     | ``https://<grafanaHost>/dashboard-solo/db/cdn-stats?panelId=1&fullscreen&from=now-24h&to=now-60s`` |
-	+---------------------------+----------------------------------------------------------------------------------------------------+
-	| daily_bw_url              | ``https://<grafanaHost>/dashboard-solo/db/daily-summary?panelId=1&fullscreen&from=now-3y&to=now``  |
-	+---------------------------+----------------------------------------------------------------------------------------------------+
-	| daily_served_url          | ``https://<grafanaHost>/dashboard-solo/db/daily-summary?panelId=2&fullscreen&from=now-3y&to=now``  |
-	+---------------------------+----------------------------------------------------------------------------------------------------+
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+	|       parameter name      |                                        parameter value                                                             |
+	+===========================+====================================================================================================================+
+	| all_graph_url             | :file:`https://{grafanaHost}/dashboard/db/{deliveryservice-stats-dashboard}`                                       |
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+	| cachegroup_graph_url      | :file:`https://{grafanaHost}/dashboard/script/traffic_ops_cachegroup.js?which=`                                    |
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+	| deliveryservice_graph_url | :file:`https://{grafanaHost}/dashboard/script/traffic_ops_deliveryservice.js?which=`                               |
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+	| server_graph_url          | :file:`https://{grafanaHost}/dashboard/script/traffic_ops_server.js?which=`                                        |
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+	| visual_status_panel_1     | :file:`https://{grafanaHost}/dashboard-solo/db/{cdn-stats-dashboard}?panelId=2&fullscreen&from=now-24h&to=now-60s` |
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+	| visual_status_panel_2     | :file:`https://{grafanaHost}/dashboard-solo/db/{cdn-stats-dashboard}?panelId=1&fullscreen&from=now-24h&to=now-60s` |
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+	| daily_bw_url              | :file:`https://{grafanaHost}/dashboard-solo/db/{daily-summary-dashboard}?panelId=1&fullscreen&from=now-3y&to=now`  |
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+	| daily_served_url          | :file:`https://{grafanaHost}/dashboard-solo/db/{daily-summary-dashboard}?panelId=2&fullscreen&from=now-3y&to=now`  |
+	+---------------------------+--------------------------------------------------------------------------------------------------------------------+
+
+where
+
+grafanaHost
+	is the :abbr:`FQDN (Fully Qualified Domain Name)` of the Grafana server (again, usually the same as the Traffic Stats server),
+cdn-stats-dashboard
+	is the name of the Dashboard providing CDN-level statistics,
+deliveryservice-stats-dashboard
+	is the name of the Dashboard providing :term:`Delivery Service`-level statistics, and
+daily-summary-dashboard
+	is the name of the Dashboard providing a daily summary of general statistics that would be of interest to administrators using Traffic Portal
 
 InfluxDB Tools
 ==============


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR partially addresses #3670

Removes the "Health Tab" parts of the now-removed UI's documentation. I also gave the related parts of the TP/TS docs a once-over to ensure they were properly formatted etc. as well as actually covered all of the information being deleted from the TO section.

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Build and read the documentation to ensure that it's complete, sensible, and covers all of the removed documentation's content.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary because this is only documentation changes
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**