### PR TITLE
Make entire row clickable in TP assignment popups

### DIFF
--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParamsUnassignedController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParamsUnassignedController.js
@@ -44,6 +44,10 @@ var TableCacheGroupParamsUnassignedController = function(cg, parameters, $scope,
 		}
 	};
 
+	$scope.handleRowClick = function($index) {
+		$('#checkbox-' + $index).trigger('click');
+	};
+
 	$scope.submit = function() {
 		$uibModalInstance.close(selectedParams);
 	};

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParamsUnassignedController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParamsUnassignedController.js
@@ -36,7 +36,7 @@ var TableCacheGroupParamsUnassignedController = function(cg, parameters, $scope,
 	};
 
 	$scope.updateParams = function($event, paramId) {
-		var checkbox = $event.currentTarget.firstChild.firstChild; // finds the input element from the table row which was clicked
+		var checkbox = $event.currentTarget.firstElementChild.firstElementChild; // finds the input element from the table row which was clicked
 		if (!checkbox.checked) {
 			addParam(paramId);
 			checkbox.checked = true;

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParamsUnassignedController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParamsUnassignedController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var TableProfileParamsUnassignedController = function(cg, parameters, $scope, $uibModalInstance) {
+var TableCacheGroupParamsUnassignedController = function(cg, parameters, $scope, $uibModalInstance) {
 
 	var selectedParams = [];
 
@@ -36,11 +36,13 @@ var TableProfileParamsUnassignedController = function(cg, parameters, $scope, $u
 	};
 
 	$scope.updateParams = function($event, paramId) {
-		var checkbox = $event.target;
-		if (checkbox.checked) {
+		var checkbox = $event.currentTarget.firstChild.firstChild; // finds the input element from the table row which was clicked
+		if (!checkbox.checked) {
 			addParam(paramId);
+			checkbox.checked = true;
 		} else {
 			removeParam(paramId);
+			checkbox.checked = false;
 		}
 	};
 
@@ -65,5 +67,5 @@ var TableProfileParamsUnassignedController = function(cg, parameters, $scope, $u
 
 };
 
-TableProfileParamsUnassignedController.$inject = ['cg', 'parameters', '$scope', '$uibModalInstance'];
-module.exports = TableProfileParamsUnassignedController;
+TableCacheGroupParamsUnassignedController.$inject = ['cg', 'parameters', '$scope', '$uibModalInstance'];
+module.exports = TableCacheGroupParamsUnassignedController;

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParamsUnassignedController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/TableCacheGroupParamsUnassignedController.js
@@ -36,13 +36,11 @@ var TableCacheGroupParamsUnassignedController = function(cg, parameters, $scope,
 	};
 
 	$scope.updateParams = function($event, paramId) {
-		var checkbox = $event.currentTarget.firstElementChild.firstElementChild; // finds the input element from the table row which was clicked
-		if (!checkbox.checked) {
+		var checkbox = $event.target;
+		if (checkbox.checked) {
 			addParam(paramId);
-			checkbox.checked = true;
 		} else {
 			removeParam(paramId);
-			checkbox.checked = false;
 		}
 	};
 

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParamsUnassigned.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParamsUnassigned.tpl.html
@@ -34,8 +34,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="p in ::unassignedParams" ng-click="angular.element('#checkbox-' + $index).triggerHandler('click')">
-            <td><input id="checkbox-{{$index}}" ng-class="::{'active': p.selected}" type="checkbox" ng-click="updateParams($event, p.id); $event.stopPropagation()"></td>
+        <tr ng-repeat="p in ::unassignedParams" ng-class="::{'active': p.selected}" ng-click="handleRowClick($index)">
+            <td><input id="checkbox-{{$index}}" ng-model="p.selected" type="checkbox" ng-click="updateParams($event, p.id); $event.stopPropagation()"></td>
             <td data-search="^{{::p.name}}$">{{::p.name}}</td>
             <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
             <td data-search="^{{::p.value}}$">{{::p.value}}</td>

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParamsUnassigned.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParamsUnassigned.tpl.html
@@ -35,7 +35,7 @@ under the License.
         </thead>
         <tbody>
         <tr ng-repeat="p in ::unassignedParams" ng-click="angular.element('#checkbox-' + $index).triggerHandler('click')">
-            <td><input id="checkbox-{{$index}}" type="checkbox" ng-click="updateParams($event, p.id); $event.stopPropagation()"></td>
+            <td><input id="checkbox-{{$index}}" ng-class="::{'active': p.selected}" type="checkbox" ng-click="updateParams($event, p.id); $event.stopPropagation()"></td>
             <td data-search="^{{::p.name}}$">{{::p.name}}</td>
             <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
             <td data-search="^{{::p.value}}$">{{::p.value}}</td>

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParamsUnassigned.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParamsUnassigned.tpl.html
@@ -34,8 +34,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="p in ::unassignedParams">
-            <td><input type="checkbox" ng-click="updateParams($event, p.id)"></td>
+        <tr ng-repeat="p in ::unassignedParams" ng-click="updateParams($event, p.id)"">
+            <td><input type="checkbox" ng-click="$event.preventDefault()"></td>
             <td data-search="^{{::p.name}}$">{{::p.name}}</td>
             <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
             <td data-search="^{{::p.value}}$">{{::p.value}}</td>

--- a/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParamsUnassigned.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupParameters/table.cacheGroupParamsUnassigned.tpl.html
@@ -34,8 +34,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="p in ::unassignedParams" ng-click="updateParams($event, p.id)"">
-            <td><input type="checkbox" ng-click="$event.preventDefault()"></td>
+        <tr ng-repeat="p in ::unassignedParams" ng-click="angular.element('#checkbox-' + $index).triggerHandler('click')">
+            <td><input id="checkbox-{{$index}}" type="checkbox" ng-click="updateParams($event, p.id); $event.stopPropagation()"></td>
             <td data-search="^{{::p.name}}$">{{::p.name}}</td>
             <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
             <td data-search="^{{::p.value}}$">{{::p.value}}</td>

--- a/traffic_portal/app/src/common/modules/table/cdnFederationDeliveryServices/table.assignFederationDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdnFederationDeliveryServices/table.assignFederationDeliveryServices.tpl.html
@@ -34,8 +34,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{ds.id}}" class="ds-row" ng-repeat="ds in ::deliveryServices">
-            <td><input type="checkbox" ng-checked="ds.selected" ng-model="ds.selected" ng-change="onChange()"></td>
+        <tr id="{{ds.id}}" class="ds-row" ng-repeat="ds in ::deliveryServices" ng-click="ds.selected = !ds.selected; onChange()">
+            <td><input type="checkbox" ng-model="ds.selected"></td>
             <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
             <td data-search="^{{::ds.displayName}}$">{{::ds.displayName}}</td>
             <td data-search="^{{::ds.type}}$">{{::ds.type}}</td>

--- a/traffic_portal/app/src/common/modules/table/cdnFederationDeliveryServices/table.assignFederationDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdnFederationDeliveryServices/table.assignFederationDeliveryServices.tpl.html
@@ -34,7 +34,7 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{ds.id}}" class="ds-row" ng-repeat="ds in ::deliveryServices" ng-click="ds.selected = !ds.selected; onChange()">
+        <tr id="{{ds.id}}" class="ds-row" ng-class="::{'active': ds.selected}" ng-repeat="ds in ::deliveryServices" ng-click="ds.selected = !ds.selected; onChange()">
             <td><input type="checkbox" ng-model="ds.selected"></td>
             <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
             <td data-search="^{{::ds.displayName}}$">{{::ds.displayName}}</td>

--- a/traffic_portal/app/src/common/modules/table/cdnFederationUsers/table.assignFederationUsers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdnFederationUsers/table.assignFederationUsers.tpl.html
@@ -35,8 +35,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{u.id}}" class="user-row" ng-repeat="u in ::users">
-            <td><input type="checkbox" ng-checked="u.selected" ng-model="u.selected" ng-change="onChange()"></td>
+        <tr id="{{u.id}}" class="user-row" ng-repeat="u in ::users" ng-click="u.selected = !u.selected; onChange()">
+            <td><input type="checkbox" ng-model="u.selected"></td>
             <td data-search="^{{::u.fullName}}$">{{::u.fullName}}</td>
             <td data-search="^{{::u.username}}$">{{::u.username}}</td>
             <td data-search="^{{::u.email}}$">{{::u.email}}</td>

--- a/traffic_portal/app/src/common/modules/table/cdnFederationUsers/table.assignFederationUsers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdnFederationUsers/table.assignFederationUsers.tpl.html
@@ -35,7 +35,7 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{u.id}}" class="user-row" ng-repeat="u in ::users" ng-click="u.selected = !u.selected; onChange()">
+        <tr id="{{u.id}}" class="user-row" ng-class="::{'active': u.selected}" ng-repeat="u in ::users" ng-click="u.selected = !u.selected; onChange()">
             <td><input type="checkbox" ng-model="u.selected"></td>
             <td data-search="^{{::u.fullName}}$">{{::u.fullName}}</td>
             <td data-search="^{{::u.username}}$">{{::u.username}}</td>

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceServers/table.assignDSServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceServers/table.assignDSServers.tpl.html
@@ -34,7 +34,7 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::s.id}}" class="server-row" ng-repeat="s in ::servers" ng-click="s.selected = !s.selected; onChange()">
+        <tr id="{{::s.id}}" class="server-row" ng-class="::{'active': s.selected}" ng-repeat="s in ::servers" ng-click="s.selected = !s.selected; onChange()">
             <td><input type="checkbox" ng-model="s.selected"></td>
             <td data-search="^{{::s.hostName}}$">{{::s.hostName}}</td>
             <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceServers/table.assignDSServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceServers/table.assignDSServers.tpl.html
@@ -34,8 +34,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::s.id}}" class="server-row" ng-repeat="s in ::servers">
-            <td><input type="checkbox" ng-checked="s.selected" ng-model="s.selected" ng-change="onChange()"></td>
+        <tr id="{{::s.id}}" class="server-row" ng-repeat="s in ::servers" ng-click="s.selected = !s.selected; onChange()">
+            <td><input type="checkbox" ng-model="s.selected"></td>
             <td data-search="^{{::s.hostName}}$">{{::s.hostName}}</td>
             <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
             <td data-search="^{{::s.profile}}$">{{::s.profile}}</td>

--- a/traffic_portal/app/src/common/modules/table/federationResolvers/table.assignFedResolvers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/federationResolvers/table.assignFedResolvers.tpl.html
@@ -33,8 +33,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::r.id}}" class="resolver-row" ng-repeat="r in ::resolvers">
-            <td><input type="checkbox" ng-checked="r.selected" ng-model="r.selected" ng-change="onChange()"></td>
+        <tr id="{{::r.id}}" class="resolver-row" ng-repeat="r in ::resolvers" ng-click="r.selected = !r.selected; onChange()">
+            <td><input type="checkbox" ng-model="r.selected"></td>
             <td data-search="^{{::r.ipAddress}}$">{{::r.ipAddress}}</td>
             <td data-search="^{{::r.type}}$">{{::r.type}}</td>
         </tr>

--- a/traffic_portal/app/src/common/modules/table/federationResolvers/table.assignFedResolvers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/federationResolvers/table.assignFedResolvers.tpl.html
@@ -33,7 +33,7 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::r.id}}" class="resolver-row" ng-repeat="r in ::resolvers" ng-click="r.selected = !r.selected; onChange()">
+        <tr id="{{::r.id}}" class="resolver-row" ng-class="::{'active': r.selected}" ng-repeat="r in ::resolvers" ng-click="r.selected = !r.selected; onChange()">
             <td><input type="checkbox" ng-model="r.selected"></td>
             <td data-search="^{{::r.ipAddress}}$">{{::r.ipAddress}}</td>
             <td data-search="^{{::r.type}}$">{{::r.type}}</td>

--- a/traffic_portal/app/src/common/modules/table/parameterProfiles/table.paramProfilesUnassigned.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/parameterProfiles/table.paramProfilesUnassigned.tpl.html
@@ -35,7 +35,7 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::p.id}}" class="profile-row" ng-repeat="p in ::selectedProfiles" ng-click="p.selected = !p.selected; onChange()">
+        <tr id="{{::p.id}}" class="profile-row" ng-class="::{'active': p.selected}" ng-repeat="p in ::selectedProfiles" ng-click="p.selected = !p.selected; onChange()">
             <td><input type="checkbox" ng-model="p.selected"></td>
             <td data-search="^{{::p.name}}$">{{::p.name}}</td>
             <td data-search="^{{::p.description}}$">{{::p.description}}</td>

--- a/traffic_portal/app/src/common/modules/table/parameterProfiles/table.paramProfilesUnassigned.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/parameterProfiles/table.paramProfilesUnassigned.tpl.html
@@ -35,8 +35,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::p.id}}" class="profile-row" ng-repeat="p in ::selectedProfiles">
-            <td><input type="checkbox" ng-checked="p.selected" ng-model="p.selected" ng-change="onChange()"></td>
+        <tr id="{{::p.id}}" class="profile-row" ng-repeat="p in ::selectedProfiles" ng-click="p.selected = !p.selected; onChange()">
+            <td><input type="checkbox" ng-model="p.selected"></td>
             <td data-search="^{{::p.name}}$">{{::p.name}}</td>
             <td data-search="^{{::p.description}}$">{{::p.description}}</td>
             <td data-search="^{{::p.type}}$">{{::p.type}}</td>

--- a/traffic_portal/app/src/common/modules/table/profileParameters/table.profileParamsUnassigned.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/profileParameters/table.profileParamsUnassigned.tpl.html
@@ -34,7 +34,7 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::p.id}}" class="param-row" ng-repeat="p in ::selectedParams" ng-click="p.selected = !p.selected; onChange()">
+        <tr id="{{::p.id}}" class="param-row" ng-class="::{'active': p.selected}" ng-repeat="p in ::selectedParams" ng-click="p.selected = !p.selected; onChange()">
             <td><input type="checkbox" ng-model="p.selected"></td>
             <td data-search="^{{::p.name}}$">{{::p.name}}</td>
             <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>

--- a/traffic_portal/app/src/common/modules/table/profileParameters/table.profileParamsUnassigned.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/profileParameters/table.profileParamsUnassigned.tpl.html
@@ -34,8 +34,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::p.id}}" class="param-row" ng-repeat="p in ::selectedParams">
-            <td><input type="checkbox" ng-checked="p.selected" ng-model="p.selected" ng-change="onChange()"></td>
+        <tr id="{{::p.id}}" class="param-row" ng-repeat="p in ::selectedParams" ng-click="p.selected = !p.selected; onChange()">
+            <td><input type="checkbox" ng-model="p.selected"></td>
             <td data-search="^{{::p.name}}$">{{::p.name}}</td>
             <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
             <td data-search="^{{::p.value}}$">{{::p.value}}</td>

--- a/traffic_portal/app/src/common/modules/table/roleCapabilities/table.assignCapabilities.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/roleCapabilities/table.assignCapabilities.tpl.html
@@ -30,7 +30,7 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::c.name}}" class="cap-row" ng-repeat="c in ::selectedCapabilities" ng-click="c.selected = !c.selected; onChange()">
+        <tr id="{{::c.name}}" class="cap-row" ng-class="::{'active': c.selected}" ng-repeat="c in ::selectedCapabilities" ng-click="c.selected = !c.selected; onChange()">
             <td><input type="checkbox" ng-model="c.selected"></td>
             <td data-search="^{{::c.name}}$">{{::c.name}}</td>
         </tr>

--- a/traffic_portal/app/src/common/modules/table/roleCapabilities/table.assignCapabilities.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/roleCapabilities/table.assignCapabilities.tpl.html
@@ -30,8 +30,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::c.name}}" class="cap-row" ng-repeat="c in ::selectedCapabilities">
-            <td><input type="checkbox" ng-checked="c.selected" ng-model="c.selected" ng-change="onChange()"></td>
+        <tr id="{{::c.name}}" class="cap-row" ng-repeat="c in ::selectedCapabilities" ng-click="c.selected = !c.selected; onChange()">
+            <td><input type="checkbox" ng-model="c.selected"></td>
             <td data-search="^{{::c.name}}$">{{::c.name}}</td>
         </tr>
         </tbody>

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.assignDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.assignDeliveryServices.tpl.html
@@ -32,8 +32,8 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::ds.id}}" class="ds-row" ng-repeat="ds in ::selectedDeliveryServices">
-            <td><input type="checkbox" ng-checked="ds.selected" ng-model="ds.selected" ng-change="onChange()"></td>
+        <tr id="{{::ds.id}}" class="ds-row" ng-repeat="ds in ::selectedDeliveryServices" ng-click="ds.selected = !ds.selected; onChange()">
+            <td><input type="checkbox" ng-model="ds.selected"></td>
             <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
             <td data-search="^{{::ds.displayName}}$">{{::ds.displayName}}</td>
             <td data-search="^{{::ds.type}}$">{{::ds.type}}</td>

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.assignDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.assignDeliveryServices.tpl.html
@@ -32,7 +32,7 @@ under the License.
         </tr>
         </thead>
         <tbody>
-        <tr id="{{::ds.id}}" class="ds-row" ng-repeat="ds in ::selectedDeliveryServices" ng-click="ds.selected = !ds.selected; onChange()">
+        <tr id="{{::ds.id}}" class="ds-row" ng-class="::{'active': ds.selected}" ng-repeat="ds in ::selectedDeliveryServices" ng-click="ds.selected = !ds.selected; onChange()">
             <td><input type="checkbox" ng-model="ds.selected"></td>
             <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
             <td data-search="^{{::ds.displayName}}$">{{::ds.displayName}}</td>


### PR DESCRIPTION
- [x] This PR fixes #3454 


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Portal

This is a very intuitive UI change, so I don't think it needs documentation or a changelog update, but I'm happy to add either if I'm wrong.

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Perform the following tasks in TP and ensure you can click both the checkbox and rest of the row:
- link a parameter to a cache group
- assign DSes, users, and resolvers to a federation
- assign DSes to servers (and vice versa)
- assign profiles to parameter (and vice versa)
- assign capabilities to a role

Since there aren't existing tests of these dialogs I could add to, I opted not to create new UI tests for this as that doesn't really seem like it's in the scope of what this PR is trying to do.

## If this is a bug fix, what versions of Traffic Ops are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
