### PR TITLE
Fix bug that causes DS requests to fulfill immediately while other requests are still open

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -59,8 +59,8 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, type, 
 				deliveryService: deliveryService
 			};
 
-			// if the user chooses to complete/fulfill the delete request immediately, the ds will be deleted and behind the
-			// scenes a delivery service request will be created and marked as complete
+			// if the user chooses to complete/fulfill the delete request immediately, a delivery service request will be made and marked as complete, 
+			// then if that is successful, the DS will be deleted
 			if (options.status.id === $scope.COMPLETE) {
 				// first create the ds request
 				deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest)
@@ -194,8 +194,8 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, type, 
 					status: status,
 					deliveryService: deliveryService
 				};
-				// if the user chooses to complete/fulfill the update request immediately, the ds will be updated and behind the
-				// scenes a delivery service request will be created and marked as complete
+				// if the user chooses to complete/fulfill the update request immediately, a delivery service request will be made and marked as complete, 
+				// then if that is successful, the DS will be updated
 				if (options.status.id == $scope.COMPLETE) {
 					createDeliveryServiceUpdateRequest(dsRequest, options.comment, true).then(
 						function() {

--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -22,6 +22,21 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, type, 
 	// extends the FormDeliveryServiceController to inherit common methods
 	angular.extend(this, $controller('FormDeliveryServiceController', { deliveryService: deliveryService, dsCurrent: deliveryService, origin: origin, type: type, types: types, $scope: $scope }));
 
+	var confirmNoOutstandingRequests = function(deliveryService) {
+		deliveryServiceRequestService.getDeliveryServiceRequests()
+		.then(
+			function(dsRequests) {
+				// search all requests for those that are not completed and share the same deliveryservice id
+				angular.forEach(dsRequests, function(value) {
+					if (value.status != 'complete' && value.deliveryService.id == deliveryService.id) {
+						return false;
+					}
+				});
+				return true;
+			}
+		);
+	};
+
 	var createDeliveryServiceDeleteRequest = function(deliveryService) {
 		var params = {
 			title: "Delivery Service Delete Request",
@@ -61,7 +76,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, type, 
 
 			// if the user chooses to complete/fulfill the delete request immediately, the ds will be deleted and behind the
 			// scenes a delivery service request will be created and marked as complete
-			if (options.status.id == $scope.COMPLETE) {
+			if (options.status.id == $scope.COMPLETE && confirmNoOutstandingRequests(deliveryService)) {
 				// first delete the ds
 				deliveryServiceService.deleteDeliveryService(deliveryService)
 					.then(
@@ -200,7 +215,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, type, 
 				};
 				// if the user chooses to complete/fulfill the update request immediately, the ds will be updated and behind the
 				// scenes a delivery service request will be created and marked as complete
-				if (options.status.id == $scope.COMPLETE) {
+				if (options.status.id == $scope.COMPLETE && confirmNoOutstandingRequests(deliveryService)) {
 					deliveryServiceService.updateDeliveryService(deliveryService).
 						then(
 							function() {

--- a/traffic_portal/test/end_to_end/DeliveryServiceRequests/delivery-service-requests-spec.js
+++ b/traffic_portal/test/end_to_end/DeliveryServiceRequests/delivery-service-requests-spec.js
@@ -144,6 +144,7 @@ describe('Traffic Portal Delivery Service Requests', function() {
 		pageData.deleteButton.click();
 		pageData.confirmWithNameInput.sendKeys(mockVals.xmlId + ' request');
 		pageData.deletePermanentlyButton.click();
+		browser.sleep(250);
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/delivery-service-requests");
 	});
 });


### PR DESCRIPTION
I also made a small tweak to the DS requests TP test as it seemed to be failing locally for me because it wasn't waiting long enough for TP to change its URL

<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #2595

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Portal

This is a small bug that should not require documentation or a changelog entry

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Enable DS requests in TP and run the DS requests TP test, then manually verify that updating or deleting a DS while at least one DS request for that same DS is open fails

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
