### PR TITLE
fixes trafficserver status check

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -504,7 +504,7 @@ sub start_service {
 	}
 	my $running_string = "";
 	if ( $pkg_name eq "trafficserver" ) {
-		$running_string = "traffic_manager";
+		$running_string = "traffic_manager|traffic_cop";
 	}
 	else {
 		$running_string = $pkg_name;
@@ -599,7 +599,7 @@ sub restart_service {
 	}
 	my $running_string = "";
 	if ( $pkg_name eq "trafficserver" ) {
-		$running_string = "traffic_manager";
+		$running_string = "traffic_manager|traffic_cop";
 	}
 	if ( $running_string ne "" ) {
 		if ( $pkg_running =~ m/$running_string \(pid  (\d+)\) is running.../ ) {


### PR DESCRIPTION

- [x] This PR fixes #3729

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT
Documentation not required - fixes a bug only.

## What is the best way to verify this PR?
Run traffic_ops_ort, if the output says that trafficserver is running, then the issue is fixed.

## If this is a bug fix, what versions of Traffic Ops are affected?

- master (2697ebac)

## The following criteria are ALL met by this PR

- [X] This PR includes tests OR I have explained why tests are unnecessary
- [X] This PR includes documentation OR I have explained why documentation is unnecessary
- [X] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

