### PR TITLE
CDN-in-a-Box now caches Carton dependencies by default

### DIFF
--- a/infrastructure/cdn-in-a-box/docker-compose.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.yml
@@ -78,10 +78,10 @@ services:
   # in place until all API endpoints have been rewritten in Go
   trafficops-perl:
     build:
-      context: .
-      dockerfile: traffic_ops/Dockerfile
+      context: ../..
+      dockerfile: infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
       args:
-        TRAFFIC_OPS_RPM: traffic_ops/traffic_ops.rpm
+        TRAFFIC_OPS_RPM: infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
     depends_on:
       - db
       - enroller

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -23,6 +23,9 @@
 
 FROM centos:7
 
+EXPOSE 443
+ENV MOJO_MODE production
+
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 && \
     rpm --import https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG && \
@@ -31,63 +34,76 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum install -y \
         epel-release \
         pgdg-redhat-latest && \
-    yum -y clean all
-
-RUN yum install -y \
-        cpanminus \
+    yum install -y \
         bind-utils \
-        net-tools \
+        cpanminus \
+        expat-devel \
+        gcc-c++ \
         gettext \
+        git \
         golang \
+        iproute \
+        jq \
+        libcurl \
+        libcurl-devel \
+        libidn-devel \
+        libpcap-devel \
+        mkisofs \
+        net-tools \
         nmap-ncat \
         openssl \
+        openssl-devel \
         perl \
+        perl-core \
         perl-Crypt-ScryptKDF \
-        perl-Test-CPAN-Meta \
+        perl-DBD-Pg \
+        perl-DBI \
+        perl-DBIx-Connector \
+        perl-Digest-SHA1 \
+        perl-JSON \
         perl-JSON-PP \
-        git \
-        iproute \
-        jq && \
+        perl-libwww-perl \
+        perl-TermReadKey \
+        perl-Test-CPAN-Meta \
+        perl-WWW-Curl \
+        postgresql96 \
+        postgresql96-devel \
+        postgresql96-libs \
+        tar &&\
     yum -y clean all
-
-RUN yum install -y perl-DBIx-Connector
-
-# Override TRAFFIC_OPS_RPM arg to use a different one using --build-arg TRAFFIC_OPS_RPM=...  Can be local file or http://...
-ARG TRAFFIC_OPS_RPM=traffic_ops/traffic_ops.rpm
-ADD $TRAFFIC_OPS_RPM /
-RUN yum install -y \
-        /$(basename $TRAFFIC_OPS_RPM) \
-        rm /$(basename $TRAFFIC_OPS_RPM) && \
-    yum clean all
-
-# copy any dir structure in overrides to TO -- allows modification of the install and shortcut to get perl modules/goose installed
-WORKDIR /opt/traffic_ops/app
-COPY traffic_ops/overrides/ /opt/traffic_ops/.
-RUN cpanm -l ./local Carton
-
-# run carton whether or not local dir was installed
-RUN POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton && \
-     rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz
-
-RUN /opt/traffic_ops/install/bin/install_goose.sh
 
 ADD https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz /
 
-EXPOSE 443
 WORKDIR /opt/traffic_ops/app
-ENV MOJO_MODE production
+ADD traffic_ops/app/cpanfile .
+RUN cpanm -l ./local Carton && \
+    POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton  && \
+    rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz ./cpanfile
 
-ADD enroller/server_template.json \
-    traffic_ops/run.sh \
-    traffic_ops/config.sh \
-    traffic_ops/adduser.pl \
-    traffic_ops/to-access.sh \
-    traffic_ops/generate-certs.sh \
-    traffic_ops/trafficops-init.sh \
-    variables.env \
+# Override TRAFFIC_OPS_RPM arg to use a different one using --build-arg TRAFFIC_OPS_RPM=...  Can be local file or http://...
+ARG TRAFFIC_OPS_RPM=infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
+ADD $TRAFFIC_OPS_RPM /
+RUN yum install -y /$(basename $TRAFFIC_OPS_RPM) && \
+    rm /$(basename $TRAFFIC_OPS_RPM) && \
+    yum -y clean all
+
+# Run carton again, in case the cpanfile included in the RPM differs from the one used earlier in the
+# build (should never happen - Perl is supposed to be going away)
+RUN /opt/traffic_ops/install/bin/install_goose.sh && \
+    POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton && \
+    rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz
+
+ADD infrastructure/cdn-in-a-box/enroller/server_template.json \
+    infrastructure/cdn-in-a-box/traffic_ops/run.sh \
+    infrastructure/cdn-in-a-box/traffic_ops/config.sh \
+    infrastructure/cdn-in-a-box/traffic_ops/adduser.pl \
+    infrastructure/cdn-in-a-box/traffic_ops/to-access.sh \
+    infrastructure/cdn-in-a-box/traffic_ops/generate-certs.sh \
+    infrastructure/cdn-in-a-box/traffic_ops/trafficops-init.sh \
+    infrastructure/cdn-in-a-box/variables.env \
     /
 
-ADD traffic_ops_data /traffic_ops_data
+ADD infrastructure/cdn-in-a-box/traffic_ops_data /traffic_ops_data
 
 RUN chown -R trafops:trafops /opt/traffic_ops
 CMD /run.sh

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -75,10 +75,10 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 ADD https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz /
 
 WORKDIR /opt/traffic_ops/app
-ADD traffic_ops/app/cpanfile .
+ADD traffic_ops/app/cpanfile traffic_ops/install/bin/install_goose.sh ./
 RUN cpanm -l ./local Carton && \
     POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton  && \
-    rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz ./cpanfile
+    rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz ./cpanfile && ./install_goose.sh
 
 # Override TRAFFIC_OPS_RPM arg to use a different one using --build-arg TRAFFIC_OPS_RPM=...  Can be local file or http://...
 ARG TRAFFIC_OPS_RPM=infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
@@ -89,8 +89,7 @@ RUN yum install -y /$(basename $TRAFFIC_OPS_RPM) && \
 
 # Run carton again, in case the cpanfile included in the RPM differs from the one used earlier in the
 # build (should never happen - Perl is supposed to be going away)
-RUN /opt/traffic_ops/install/bin/install_goose.sh && \
-    POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton && \
+RUN POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton && \
     rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz
 
 ADD infrastructure/cdn-in-a-box/enroller/server_template.json \

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
@@ -22,16 +22,15 @@
 
 
 FROM centos:7
-RUN yum -y install nmap-ncat openssl epel-release
-RUN yum -y install jq && yum clean all
-
-RUN mkdir -p /opt/traffic_ops/app/bin /opt/traffic_ops/app/conf/production /opt/traffic_ops/app/db
-COPY --from=trafficops-perl /opt/traffic_ops/app/bin/traffic_ops_golang /opt/traffic_ops/app/bin/traffic_ops_golang
-COPY --from=trafficops-perl /opt/traffic_ops/app/conf/ /opt/traffic_ops/app/conf
+RUN yum -y install epel-release && \
+	yum -y install jq bind-utils net-tools gettext perl-JSON-PP nmap-ncat openssl && \
+	yum clean all
 
 EXPOSE 443
 WORKDIR /opt/traffic_ops/app
-RUN yum install -y bind-utils net-tools gettext perl-JSON-PP
+
+COPY --from=trafficops-perl /opt/traffic_ops/app/bin/traffic_ops_golang /opt/traffic_ops/app/bin/traffic_ops_golang
+COPY --from=trafficops-perl /opt/traffic_ops/app/conf/ /opt/traffic_ops/app/conf/
 
 
 ADD enroller/server_template.json \


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This moves some stuff around in the CDN-in-a-Box Traffic Ops (Perl) Dockerfile. It copies the source `traffic_ops/app/cpanfile` file into the container before importing the RPM, and will download Traffic Ops's Carton dependencies before installing it. This means that changes to the Traffic Ops RPM won't trigger downloading Carton dependencies, thus significantly reducing the time it takes to rebuild the image after making changes. It also pre-installs the dependencies currently listed in the Traffic Ops spec file to make that installation a little faster.

This _does_ make the cached layers of the build bigger, but the resulting image should not actually be any larger. Hopefully, for frequent re-builders, the cache space can be easily reclaimed with `docker prune` or similar.

Previously, something similar could be accomplished by keeping a local copy of the dependencies tarballed and gzipped in a special place (`infrastructure/cdn-in-a-box/traffic_ops/local/tmp.tgz`, I think?) and the build process would load that data if it exists. However, in order to make use of that feature, the user must first have knowledge of the install process of Traffic Ops, as well as requiring them to have both a Perl interpreter and Carton and their associated dependencies. This runs counter to the philosophy of self-containment that Docker promotes, and could be difficult for, say, Windows users who want to run CDN-in-a-Box. It also runs somewhat counter to the philosophy of CDN-in-a-Box, in my opinion, in that a user should be able to just "press a button" and have a Traffic Control ecosystem spring to life. So I do believe that changing the system in this way is a worthwhile improvement.

## Which Traffic Control components are affected by this PR?

- CDN in a Box

Feature change is an implementation detail - shouldn't be documented. I looked for documentation on the "old" way of using locally-cached dependencies, but I couldn't find anything.

## What is the best way to verify this PR?
Build and run CDN-in-a-Box to verify that Traffic Ops is properly built/installed and operates as normal. No tests because it only affects CDN-in-a-Box, which has no testing.

Here's what I would do (and did) to test this:

```bash
sudo docker-compose down -v --remove-orphans
sudo docker system prune -af
make
sudo docker-compose build
sudo docker-compose up

# At this point you wanna stop and verify that CiaB is working,
# do a curl of the demo1 DS, look at TP to see if anything stands out, etc.

# Now change some file in `traffic_ops/`; add a newline to a
# Perl script or something. Just to change the RPM hash.

sudo docker-compose down -v --remove-orphans
rm traffic_ops/*.rpm
rm ../../dist/*traffic_ops*.rpm
make traffic_ops/traffic_ops.rpm
sudo docker-compose build trafficops && trafficops-perl # this step should be waaayyy faster than before
sudo docker-compose up

# And again verify that everything works as expected in the resulting environment.
```

## The following criteria are ALL met by this PR
- [x] I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**