### PR TITLE
Restricted job creation to Portal and above

### DIFF
--- a/docs/source/api/user_current_jobs.rst
+++ b/docs/source/api/user_current_jobs.rst
@@ -122,7 +122,11 @@ Creates a new content revalidation job.
 .. Note:: This method forces a HTTP *revalidation* of the content, and not a new ``GET`` - the origin needs to support revalidation according to the HTTP/1.1 specification, and send a ``200 OK`` or ``304 Not Modified`` HTTP response as appropriate.
 
 :Auth. Required: Yes
-:Roles Required: "admin" or "operations"\ [1]_
+:Roles Required: "portal"
+
+	.. versionchanged:: ATCv3.0.2
+		For security reasons, the endpoint was reworked so that regardless of tenancy, the "portal" :term:`Role` or higher is required.
+
 :Response Type:  ``undefined``
 
 Request Structure
@@ -186,4 +190,3 @@ Response Structure
 		}
 	]}
 
-.. [1] A role is only required if tenancy is not used; if tenancy is used by Traffic Control, then the user will be able to create the content revalidation job on :term:`Delivery Service`\ s scoped to his or her tenancy regardless of role. This means that **even read-only users can create content invalidation jobs for :term:`Delivery Service`\ s scoped to their tenancy**. This behavior is considered a bug, and it is tracked by `GitHub Issue #3116 <https://github.com/apache/trafficcontrol/issues/3116>`_.

--- a/docs/source/api/user_current_jobs.rst
+++ b/docs/source/api/user_current_jobs.rst
@@ -124,7 +124,7 @@ Creates a new content revalidation job.
 :Auth. Required: Yes
 :Roles Required: "portal"
 
-	.. versionchanged:: ATCv3.0.2
+	.. versionchanged:: ATCv3.1.0
 		For security reasons, the endpoint was reworked so that regardless of tenancy, the "portal" :term:`Role` or higher is required.
 
 :Response Type:  ``undefined``

--- a/traffic_ops/app/lib/API/Job.pm
+++ b/traffic_ops/app/lib/API/Job.pm
@@ -154,6 +154,10 @@ sub get_current_user_jobs {
 sub create_current_user_job {
 	my $self = shift;
 
+	if (!&is_portal($self)) {
+		return $self->forbidden();
+	}
+
 	my $ds_id      = $self->req->json->{dsId};
 	my $regex      = $self->req->json->{regex};
 	my $ttl        = $self->req->json->{ttl};
@@ -181,7 +185,7 @@ sub create_current_user_job {
 			return $self->forbidden("Forbidden. Delivery-service tenant is not available to the user.");
 		}
 	} else {
-		if ( !&is_oper($self) && !$self->is_delivery_service_assigned($ds_id) ) {
+		if ( !&is_portal($self) && !$self->is_delivery_service_assigned($ds_id) ) {
 			return $self->forbidden();
 		}
 	}

--- a/traffic_ops/app/lib/API/Job.pm
+++ b/traffic_ops/app/lib/API/Job.pm
@@ -185,7 +185,7 @@ sub create_current_user_job {
 			return $self->forbidden("Forbidden. Delivery-service tenant is not available to the user.");
 		}
 	} else {
-		if ( !&is_portal($self) && !$self->is_delivery_service_assigned($ds_id) ) {
+		if ( !$self->is_delivery_service_assigned($ds_id) ) {
 			return $self->forbidden();
 		}
 	}

--- a/traffic_ops/app/lib/API/Job.pm
+++ b/traffic_ops/app/lib/API/Job.pm
@@ -185,7 +185,7 @@ sub create_current_user_job {
 			return $self->forbidden("Forbidden. Delivery-service tenant is not available to the user.");
 		}
 	} else {
-		if ( !$self->is_delivery_service_assigned($ds_id) ) {
+		if ( !&is_oper($self) && !$self->is_delivery_service_assigned($ds_id) ) {
 			return $self->forbidden();
 		}
 	}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3116 

Raises the required permissions level to submit new jobs to "Portal", regardless of tenancy and/or DS-to-user assignment(s).

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Build TO, try to create a job as a user with "read-only" Role, both with and without DS assigned to you, both with and without the proper tenant, and verify that the operation is forbidden. Then repeat with Portal Role and verify that under the right conditions, the operation is allowed.

## If this is a bug fix, what versions of Traffic Ops are affected?
- master (@ 95366ccaf333332990f1b4fe9d10ffd6f603d4ed)
- 3.0.1

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)