### PR TITLE
astats plugin memory leak fix for intercept handler continuation mutex.

### DIFF
--- a/traffic_server/plugins/astats_over_http/astats_over_http.c
+++ b/traffic_server/plugins/astats_over_http/astats_over_http.c
@@ -436,7 +436,7 @@ static int astats_origin(TSCont cont, TSEvent event, void *edata) {
 	/* This is us -- register our intercept */
 	TSDebug(PLUGIN_TAG, "Intercepting request");
 
-	icontp = TSContCreate(stats_dostuff, TSMutexCreate());
+	icontp = TSContCreate(stats_dostuff, TSContMutexGet((TSCont)txnp));
 	my_state = (stats_state *) TSmalloc(sizeof(*my_state));
 	memset(my_state, 0, sizeof(*my_state));
 


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?

This PR fixes a memory leak in the astats plugin where a new mutex created by a continuation
that is passed to TSHttpTxnIntercept is never cleaned up.  Solution is to pass a handle to the
source transaction's mutex.  Patch is ported from ATS stats_over_http, inspired by the tls_bridge plugin which uses this technique (and was written by AMC).

## Which Traffic Control components are affected by this PR?

- Traffic Stats

## What is the best way to verify this PR?
Build this astats_over_http.so plugin, deploy to ATS.  Run ATS as normal.  Making a request against the _astats endpoint exercises the fix.  I used valgrind against ATS to verify that a leak existed before and that the leak no longer persists afterwards.

## If this is a bug fix, what versions of Traffic Ops are affected?

Currently all current astat plugin versions of Traffic Ops contains this bug.  The bug exists in other plugins in ATS 7, 8 and master.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
