### PR TITLE
Rewrote jobs endpoints to go

### DIFF
--- a/docs/source/api/jobs.rst
+++ b/docs/source/api/jobs.rst
@@ -21,78 +21,470 @@
 
 ``GET``
 =======
-Get all jobs (currently limited to invalidate content (PURGE) jobs) sorted by start time (descending).
+Retrieve content invalidation jobs.
 
 :Auth. Required: Yes
-:Roles Required: "operations" or "admin"
+:Roles Required: None\ [#tenancy]_
 :Response Type:  Array
-
-.. warning:: This endpoint will respect tenancy rules *if and only if*  the ``dsId`` query parameter is used.
 
 Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+--------+----------+----------------------------------------------------------------------------------------------------------------------+
-	|  Name  | Required | Description                                                                                                          |
-	+========+==========+======================================================================================================================+
-	|  dsId  | no       | Return only invalidation jobs pending on the :term:`Delivery Service` identified by this integral, unique identifier |
-	+--------+----------+----------------------------------------------------------------------------------------------------------------------+
-	| userId | no       | Return only invalidation jobs created by the user identified by this integral, unique identifier                     |
-	+--------+----------+----------------------------------------------------------------------------------------------------------------------+
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| Name            | Required | Description                                                                                                          |
+	+=================+==========+======================================================================================================================+
+	| assetUrl        | no       | Return only invalidation jobs that operate on URLs by matching this regular expression                               |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| createdBy       | no       | Return only invalidation jobs that were created by the user with this username                                       |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| deliveryService | no       | Return only invalidation jobs that operate on the :term:`Delivery Service` with this :ref:`ds-xmlid`                 |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| dsId            | no       | Return only invalidation jobs pending on the :term:`Delivery Service` identified by this integral, unique identifier |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| id              | no       | Return only the single invalidation job identified by this integral, unique identifer                                |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| keyword         | no       | Return only invalidation jobs that have this "keyword" - only "PURGE" should exist                                   |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| userId          | no       | Return only invalidation jobs created by the user identified by this integral, unique identifier                     |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 
-.. note:: If the ``dsId`` parameter is given, an error will be returned if the thereby identified :term:`Delivery Service` is not visible to the logged-in user's Tenant
 
 .. code-block:: http
 	:caption: Request Example
 
-	GET /api/1.4/jobs?dsId=1&userId=2 HTTP/1.1
+	GET /api/1.4/jobs?id=3&dsId=1&userId=2 HTTP/1.1
 	Host: trafficops.infra.ciab.test
-	User-Agent: curl/7.47.0
+	User-Agent: python-requests/2.20.1
+	Accept-Encoding: gzip, deflate
 	Accept: */*
+	Connection: keep-alive
 	Cookie: mojolicious=...
 
 Response Structure
 ------------------
 :assetUrl:        A regular expression - matching URLs will be operated upon according to ``keyword``
 :createdBy:       The username of the user who initiated the job
-:deliveryService: The 'xml_id' that uniquely identifies the :term:`Delivery Service` on which this job operates
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates
 :id:              An integral, unique identifier for this job
 :keyword:         A keyword that represents the operation being performed by the job:
 
 	PURGE
-		This job will prevent caching of URLs matching the ``assetURL`` until it is removed (or its Time to Live expires)
+		This job will prevent caching of URLs matching the ``assetUrl`` until it is removed (or its Time to Live expires)
 
 :parameters: A string containing key/value pairs representing parameters associated with the job - currently only uses Time to Live e.g. ``"TTL:48h"``
-:startTime:  The date and time at which the job began, in ISO format
+:startTime:  The date and time at which the job began, in a non-standard format
 
 .. code-block:: http
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
-	Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+	Content-Encoding: gzip
 	Content-Type: application/json
-	Date: Wed, 05 Dec 2018 15:44:07 GMT
-	Server: Mojolicious (Perl)
-	Set-Cookie: mojolicious=...; expires=Wed, 05 Dec 2018 19:44:07 GMT; path=/; HttpOnly
-	Vary: Accept-Encoding
-	Whole-Content-Sha512: PfKJyahkUTjK2iNAuY3NZiljuHHVNJyNkdKRdtzHZN9fg4+HidejGIC19tcyRCDATQyZQ49/BLEIJDAAaqTwzA==
-	Content-Length: 202
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: gH41oEi2zrd3y8yo+wfohn4/oHU098RpyPnqBzU7HlLUDkMOPKjAZnamcYqfdy7yDCFDUcgqkvbFAvnljxyb8w==
+	X-Server-Name: traffic_ops_golang/
+	Date: Tue, 18 Jun 2019 19:47:30 GMT
+	Content-Length: 186
 
-	{ "response": [
-		{
-			"parameters": "TTL:48h",
-			"keyword": "PURGE",
-			"assetUrl": "http://origin.infra.ciab.test/.*\\.jpg",
+	{ "response": [{
+		"assetUrl": "http://origin.infra.ciab.test/.*",
+		"createdBy": "admin",
+		"deliveryService": "demo1",
+		"id": 3,
+		"keyword": "PURGE",
+		"parameters": "TTL:2h",
+		"startTime": "2019-06-18 21:28:31+00"
+	}]}
+
+
+``POST``
+========
+.. versionadded:: 1.4
+
+Creates a new content invalidation job.
+
+.. caution:: Creating a content invalidation job immediately triggers a CDN-wide revalidation update. In the case that the global :term:`Parameter` ``use_reval_pending`` has a value of exactly ``"0"``, this will instead trigger a CDN-wide "Queue Updates". This means that content invalidation jobs become active **immediately** at their ``startTime`` - unlike most other configuration changes they do not wait for a :term:`Snapshot` or a "Queue Updates". Furthermore, if the global :term:`Parameter` ``use_reval_pending`` *is* ``"0"``, this will cause all pending configuration changes to propagate to all :term:`cache servers` in the CDN. Take care when using this endpoint.
+
+:Auth. Required: Yes
+:Roles Required: "operations" or "admin"\ [#tenancy]_
+:Response Type:  Object
+
+Request Structure
+-----------------
+:deliveryService: This should either be the integral, unique identifier of a :term:`Delivery Service`, or a string containing an :ref:`ds-xmlid`
+:startTime: This can be a string in the legacy ``YYYY-MM-DD HH:MM:SS`` format, or a string in :rfc:`3339` format, or a string representing a date in the same non-standard format as the ``last_updated`` fields common in other API responses, or finally it can be a number indicating the number of milliseconds since the Unix Epoch (January 1, 1970 UTC). This date must be in the future, but unlike :ref:`to-api-user-current-jobs` (or the PUT_ method of this endpoint), it is not required to be within two days from the time of creation.
+:regex: A regular expression that will be used to match the path part of URIs for content stored on :term:`cache servers` that service traffic for the :term:`Delivery Service` identified by ``deliveryService``.
+:ttl: Either the number of hours for which the content invalidation job should remain active, or a "duration" string, which is a sequence of numbers followed by units. The accepted units are:
+
+	- ``h`` gives a duration in hours
+	- ``m`` gives a duration in minutes
+	- ``s`` gives a duration in seconds
+	- ``ms`` gives a duration in milliseconds
+	- ``us`` (or ``µs``) gives a duration in microseconds
+	- ``ns`` gives a duration in nanoseconds
+
+	These durations can be combined e.g. ``2h45m`` specifies a TTL of two hours and forty-five minutes - however note that durations are always rounded up to the nearest hour so that e.g. ``121m`` becomes three hours. TTLs cannot ever be negative, obviously.
+
+.. code-block:: http
+	:caption: Request Example
+
+	POST /api/1.4/jobs HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: python-requests/2.20.1
+	Accept-Encoding: gzip, deflate
+	Accept: */*
+	Connection: keep-alive
+	Cookie: mojolicious=...
+	Content-Length: 80
+	Content-Type: application/json
+
+	{
+		"deliveryService": "demo1",
+		"startTime": 1560893311219,
+		"regex": "/.*",
+		"ttl": "121m"
+	}
+
+Response Structure
+------------------
+:assetUrl:        A regular expression - matching URLs will be operated upon according to ``keyword``
+:createdBy:       The username of the user who initiated the job
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates
+:id:              An integral, unique identifier for this job
+:keyword:         A keyword that represents the operation being performed by the job:
+
+	PURGE
+		This job will prevent caching of URLs matching the ``assetUrl`` until it is removed (or its Time to Live expires)
+
+:parameters: A string containing key/value pairs representing parameters associated with the job - currently only uses Time to Live e.g. ``"TTL:48h"``
+:startTime:  The date and time at which the job began, in a non-standard format
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 201 Created
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
+	Content-Type: application/json
+	Location: https://trafficops.infra.ciab.test/api/1.4/jobs?id=3
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: nB2xg2IqO56rLT8dI4+KZgxOsTe5ShctG1U8epRsY9NyyMIpx8TZYt5MrO2QikuYh+NnyoR6V0VICCnGCKZpKw==
+	X-Server-Name: traffic_ops_golang/
+	Date: Tue, 18 Jun 2019 19:37:06 GMT
+	Content-Length: 238
+
+	{
+		"alerts": [
+			{
+				"text": "Invalidation Job creation was successful",
+				"level": "success"
+			}
+		],
+		"response": {
+			"assetUrl": "http://origin.infra.ciab.test/.*",
 			"createdBy": "admin",
-			"startTime": "2018-12-05 15:43:42+00",
-			"id": 1,
-			"deliveryService": "demo1"
+			"deliveryService": "demo1",
+			"id": 3,
+			"keyword": "PURGE",
+			"parameters": "TTL:2h",
+			"startTime": "2019-06-18 21:28:31+00"
 		}
-	]}
+	}
 
-.. TODO: figure out why POST at this endpoint is giving 'unauthenticated' instead of 'resource not found'
+
+``PUT``
+=======
+.. versionadded:: 1.4
+	This was added at the same time as `PATCH`_, so it's recommended in most cases to instead use that method.
+
+Replaces an existing content invalidation job with a new one provided in the request. This method of editing a content invalidation job is necessarily more verbose than a PATCH_, and it does not prevent the requesting user from changing fields that normally only have one value. Use with care.
+
+.. caution:: Modifying a content invalidation job immediately triggers a CDN-wide revalidation update. In the case that the global :term:`Parameter` ``use_reval_pending`` has a value of exactly ``"0"``, this will instead trigger a CDN-wide "Queue Updates". This means that content invalidation jobs become active **immediately** at their ``startTime`` - unlike most other configuration changes they do not wait for a :term:`Snapshot` or a "Queue Updates". Furthermore, if the global :term:`Parameter` ``use_reval_pending`` *is* ``"0"``, this will cause all pending configuration changes to propagate to all :term:`cache servers` in the CDN. Take care when using this endpoint.
+
+:Auth. Required: Yes
+:Roles Required: "operations" or "admin"\ [#tenancy]_
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Query Parameters
+
+	+------+----------+--------------------------------------------------------------------------------+
+	| Name | Required | Description                                                                    |
+	+======+==========+================================================================================+
+	| id   | yes      | The integral, unique identifier of the content invalidation job being modified |
+	+------+----------+--------------------------------------------------------------------------------+
+
+:assetUrl: A regular expression - matching URLs will be operated upon according to ``keyword``
+
+	.. note:: Unlike in the payloads of POST_ and PATCH_ requests to this endpoint, this must be a **full** URL regular expression, as it is **not** combined with the :ref:`ds-origin-url` of the :term:`Delivery Service` identified by ``deliveryService``.
+
+:createdBy:       The username of the user who initiated the job\ [#readonly]_
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates\ [#readonly]_ - unlike POST_ and PATCH_ request payloads, this cannot be an integral, unique identifier
+:id:              An integral, unique identifier for this job\ [#readonly]_
+:keyword:         A keyword that represents the operation being performed by the job. It can have any (string) value, but the only value with any meaning to Traffic Control is:
+
+	PURGE
+		This job will prevent caching of URLs matching the ``assetUrl`` until it is removed (or its Time to Live expires)
+
+:parameters: A string containing space-separated key/value pairs - delimited by colons (:kbd:`:`\ s) representing parameters associated with the job. In practice, any string can be passed as a job's ``parameters``, but the only value with meaning is a single key/value pair indicated a :abbr:`TTL (Time To Live)` in hours in the format :file:`TTL:{hours}h`, and any other type of value may cause components of Traffic Control to work improperly or not at all.
+:startTime:  This can be a string in the legacy ``YYYY-MM-DD HH:MM:SS`` format, or a string in :rfc:`3339` format, or a string representing a date in the same non-standard format as the ``last_updated`` fields common in other API responses, or finally it can be a number indicating the number of milliseconds since the Unix Epoch (January 1, 1970 UTC). This **must** be in the future, but only by no more than two days.
+
+.. code-block:: http
+	:caption: Request Example
+
+	PUT /api/1.4/jobs?id=3 HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: python-requests/2.20.1
+	Accept-Encoding: gzip, deflate
+	Accept: */*
+	Connection: keep-alive
+	Cookie: mojolicious=...
+	Content-Length: 188
+	Content-Type: application/json
+
+	{
+		"assetUrl": "http://origin.infra.ciab.test/.*",
+		"createdBy": "admin",
+		"deliveryService": "demo1",
+		"id": 3,
+		"keyword": "PURGE",
+		"parameters": "TTL:360h",
+		"startTime": "2019-06-20 18:33:40+00"
+	}
+
+Response Structure
+------------------
+:assetUrl:        A regular expression - matching URLs will be operated upon according to ``keyword``
+:createdBy:       The username of the user who initiated the job
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates
+:id:              An integral, unique identifier for this job
+:keyword:         A keyword that represents the operation being performed by the job:
+
+	PURGE
+		This job will prevent caching of URLs matching the ``assetUrl`` until it is removed (or its Time to Live expires)
+
+:parameters: A string containing key/value pairs representing parameters associated with the job - currently only uses Time to Live e.g. ``"TTL:48h"``
+:startTime:  The date and time at which the job began, in a non-standard format
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: +P1PTav4ZBoiQcCqQnUqf+J0dCfQgVj8mzzKtUCA69mWYulya9Bjf6BUd8Aro2apmpgPBkCEA5sITJV1tMYA0Q==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 19 Jun 2019 13:38:59 GMT
+	Content-Length: 234
+
+	{ "alerts": [{
+		"text": "Content invalidation job updated",
+		"level": "success"
+	}],
+	"response": {
+		"assetUrl": "http://origin.infra.ciab.test/.*",
+		"createdBy": "admin",
+		"deliveryService": "demo1",
+		"id": 3,
+		"keyword": "PURGE",
+		"parameters": "TTL:360h",
+		"startTime": "2019-06-20 18:33:40+00"
+	}}
+
+
+``PATCH``
+=========
+.. versionadded:: 1.4
+
+Edits parts of an existing content invalidation job.
+
+.. caution:: Modifying a content invalidation job immediately triggers a CDN-wide revalidation update. In the case that the global :term:`Parameter` ``use_reval_pending`` has a value of exactly ``"0"``, this will instead trigger a CDN-wide "Queue Updates". This means that content invalidation jobs become active **immediately** at their ``startTime`` - unlike most other configuration changes they do not wait for a :term:`Snapshot` or a "Queue Updates". Furthermore, if the global :term:`Parameter` ``use_reval_pending`` *is* ``"0"``, this will cause all pending configuration changes to propagate to all :term:`cache servers` in the CDN. Take care when using this endpoint.
+
+:Auth. Required: Yes
+:Roles Required: "operations" or "admin"\ [#tenancy]_
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Query Parameters
+
+	+------+----------+--------------------------------------------------------------------------------+
+	| Name | Required | Description                                                                    |
+	+======+==========+================================================================================+
+	| id   | yes      | The integral, unique identifier of the content invalidation job being modified |
+	+------+----------+--------------------------------------------------------------------------------+
+
+:startTime: This can be a string in the legacy ``YYYY-MM-DD HH:MM:SS`` format, or a string in :rfc:`3339` format, or a string representing a date in the same non-standard format as the ``last_updated`` fields common in other API responses, or finally it can be a number indicating the number of milliseconds since the Unix Epoch (January 1, 1970 UTC). This must be in the future, but unlike :ref:`to-api-user-current-jobs` (or the PUT_ method of this endpoint), it is not required to be within two days from the time of creation.
+:regex: A regular expression that will be used to match the path part of URIs for content stored on :term:`cache servers` that service traffic for the :term:`Delivery Service` identified by ``deliveryService``.
+:ttl: Either the number of hours for which the content invalidation job should remain active, or a "duration" string, which is a sequence of numbers followed by units. The accepted units are:
+
+	- ``h`` gives a duration in hours
+	- ``m`` gives a duration in minutes
+	- ``s`` gives a duration in seconds
+	- ``ms`` gives a duration in milliseconds
+	- ``us`` (or ``µs``) gives a duration in microseconds
+	- ``ns`` gives a duration in nanoseconds
+
+	These durations can be combined e.g. ``2h45m`` specifies a TTL of two hours and forty-five minutes - however note that durations are always rounded up to the nearest hour so that e.g. ``121m`` becomes three hours.
+
+.. note:: A content invalidation job cannot be assigned to a different Delivery Service than the one to which it was initially assigned, and neither can the 'createdBy' field seen in responses ever be changed.
+
+.. code-block:: http
+	:caption: Request Example
+
+	PATCH /api/1.4/jobs?id=3 HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: python-requests/2.20.1
+	Accept-Encoding: gzip, deflate
+	Accept: */*
+	Connection: keep-alive
+	Cookie: mojolicious=...
+	Content-Length: 12
+	Content-Type: application/json
+
+	{"ttl": 36.2}
+
+
+Response Structure
+------------------
+:assetUrl:        A regular expression - matching URLs will be operated upon according to ``keyword``
+:createdBy:       The username of the user who initiated the job
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates
+:id:              An integral, unique identifier for this job
+:keyword:         A keyword that represents the operation being performed by the job:
+
+	PURGE
+		This job will prevent caching of URLs matching the ``assetUrl`` until it is removed (or its Time to Live expires)
+
+:parameters: A string containing key/value pairs representing parameters associated with the job - currently only uses Time to Live e.g. ``"TTL:48h"``
+:startTime:  The date and time at which the job began, in a non-standard format
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: FnmTkJKGlETI6TzXER7dxQk4qEVgwPdBNInxH1Mlkqa66xsJagUoyeDEqrHlfD/EcuUmrUNZbIakEC8WnuSjOA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 19 Jun 2019 13:43:29 GMT
+	Content-Length: 234
+
+	{"alerts": [{
+		"text": "Content invalidation job updated",
+		"level": "success"
+	}],
+	"response": {
+		"assetUrl": "http://origin.infra.ciab.test/.*",
+		"createdBy": "admin",
+		"deliveryService": "demo1",
+		"id": 3,
+		"keyword": "PURGE",
+		"parameters": "TTL:36h",
+		"startTime": "2019-06-20 18:33:40+00"
+	}}
+
+``DELETE``
+==========
+.. versionadded:: 1.4
+
+Deletes a content invalidation job.
+
+.. tip:: Content invalidation jobs that have passed their :abbr:`TTL (Time To Live)` are not automatically deleted - for record-keeping purposes - so use this to clean up old jobs that are no longer useful.
+
+.. caution:: Deleting a content invalidation job immediately triggers a CDN-wide revalidation update. In the case that the global :term:`Parameter` ``use_reval_pending`` has a value of exactly ``"0"``, this will instead trigger a CDN-wide "Queue Updates". This means that content invalidation jobs become active **immediately** at their ``startTime`` - unlike most other configuration changes they do not wait for a :term:`Snapshot` or a "Queue Updates". Furthermore, if the global :term:`Parameter` ``use_reval_pending`` *is* ``"0"``, this will cause all pending configuration changes to propagate to all :term:`cache servers` in the CDN. Take care when using this endpoint.
+
+:Auth. Required: Yes
+:Roles Required: "operations" or "admin"\ [#tenancy]_
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Query Parameters
+
+	+------+----------+--------------------------------------------------------------------------------+
+	| Name | Required | Description                                                                    |
+	+======+==========+================================================================================+
+	| id   | yes      | The integral, unique identifier of the content invalidation job being modified |
+	+------+----------+--------------------------------------------------------------------------------+
+
+.. code-block:: http
+	:caption: Request Example
+
+	DELETE /api/1.4/jobs?id=3 HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: python-requests/2.20.1
+	Accept-Encoding: gzip, deflate
+	Accept: */*
+	Connection: keep-alive
+	Cookie: mojolicious=...
+	Content-Length: 0
+
+Response Structure
+------------------
+:assetUrl:        A regular expression - matching URLs will be operated upon according to ``keyword``
+:createdBy:       The username of the user who initiated the job
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates
+:id:              An integral, unique identifier for this job
+:keyword:         A keyword that represents the operation being performed by the job:
+
+	PURGE
+		This job will prevent caching of URLs matching the ``assetUrl`` until it is removed (or its Time to Live expires)
+
+:parameters: A string containing key/value pairs representing parameters associated with the job - currently only uses Time to Live e.g. ``"TTL:48h"``
+:startTime:  The date and time at which the job began, in a non-standard format
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: FqfziXJYYwHb84Fac9+p4NEY3EsklYxe94wg/VOmlXk4R6l4SaPSh015CChPt/yT72MsWSETnIuRD9KtoK4I+w==
+	X-Server-Name: traffic_ops_golang/
+	Date: Tue, 18 Jun 2019 22:55:15 GMT
+	Content-Length: 234
+
+	{ "alerts": [
+		{
+			"text": "Content invalidation job was deleted",
+			"level": "success"
+		}
+	],
+	"response": {
+		"assetUrl": "http://origin.infra.ciab.test/.*",
+		"createdBy": "admin",
+		"deliveryService": "demo1",
+		"id": 3,
+		"keyword": "PURGE",
+		"parameters": "TTL:36h",
+		"startTime": "2019-06-20 18:33:40+00"
+	}}
+
+
+.. [#tenancy] When viewing content invalidation jobs, only those jobs that operate on a :term:`Delivery Service` visible to the requesting user's :term:`Tenant` will be returned. Likewise, creating a new content invalidation job requires that the target :term:`Delivery Service` is modifiable by the requesting user's :term:`Tenant`. However, when modifying or deleting an existing content invalidation job, the operation can be completed if and only if the requesting user's :term:`Tenant` is the same as the job's :term:`Delivery Service`'s :term:`Tenant` or a descendant thereof, **and** if the requesting user's :term:`Tenant` is the same as the :term:`Tenant` of the *user who initially created the job* or a descendant thereof.
+.. [#readonly] This field must exist, but it must *not* be different than the same field of the existing job (i.e. as seen in a GET_ response)

--- a/docs/source/api/jobs.rst
+++ b/docs/source/api/jobs.rst
@@ -203,9 +203,8 @@ Response Structure
 ``PUT``
 =======
 .. versionadded:: 1.4
-	This was added at the same time as `PATCH`_, so it's recommended in most cases to instead use that method.
 
-Replaces an existing content invalidation job with a new one provided in the request. This method of editing a content invalidation job is necessarily more verbose than a PATCH_, and it does not prevent the requesting user from changing fields that normally only have one value. Use with care.
+Replaces an existing content invalidation job with a new one provided in the request. This method of editing a content invalidation job does not prevent the requesting user from changing fields that normally only have one value. Use with care.
 
 .. caution:: Modifying a content invalidation job immediately triggers a CDN-wide revalidation update. In the case that the global :term:`Parameter` ``use_reval_pending`` has a value of exactly ``"0"``, this will instead trigger a CDN-wide "Queue Updates". This means that content invalidation jobs become active **immediately** at their ``startTime`` - unlike most other configuration changes they do not wait for a :term:`Snapshot` or a "Queue Updates". Furthermore, if the global :term:`Parameter` ``use_reval_pending`` *is* ``"0"``, this will cause all pending configuration changes to propagate to all :term:`cache servers` in the CDN. Take care when using this endpoint.
 
@@ -225,10 +224,10 @@ Request Structure
 
 :assetUrl: A regular expression - matching URLs will be operated upon according to ``keyword``
 
-	.. note:: Unlike in the payloads of POST_ and PATCH_ requests to this endpoint, this must be a **full** URL regular expression, as it is **not** combined with the :ref:`ds-origin-url` of the :term:`Delivery Service` identified by ``deliveryService``.
+	.. note:: Unlike in the payloads of POST_ requests to this endpoint, this must be a **full** URL regular expression, as it is **not** combined with the :ref:`ds-origin-url` of the :term:`Delivery Service` identified by ``deliveryService``.
 
 :createdBy:       The username of the user who initiated the job\ [#readonly]_
-:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates\ [#readonly]_ - unlike POST_ and PATCH_ request payloads, this cannot be an integral, unique identifier
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates\ [#readonly]_ - unlike POST_ request payloads, this cannot be an integral, unique identifier
 :id:              An integral, unique identifier for this job\ [#readonly]_
 :keyword:         A keyword that represents the operation being performed by the job. It can have any (string) value, but the only value with any meaning to Traffic Control is:
 
@@ -305,103 +304,6 @@ Response Structure
 		"startTime": "2019-06-20 18:33:40+00"
 	}}
 
-
-``PATCH``
-=========
-.. versionadded:: 1.4
-
-Edits parts of an existing content invalidation job.
-
-.. caution:: Modifying a content invalidation job immediately triggers a CDN-wide revalidation update. In the case that the global :term:`Parameter` ``use_reval_pending`` has a value of exactly ``"0"``, this will instead trigger a CDN-wide "Queue Updates". This means that content invalidation jobs become active **immediately** at their ``startTime`` - unlike most other configuration changes they do not wait for a :term:`Snapshot` or a "Queue Updates". Furthermore, if the global :term:`Parameter` ``use_reval_pending`` *is* ``"0"``, this will cause all pending configuration changes to propagate to all :term:`cache servers` in the CDN. Take care when using this endpoint.
-
-:Auth. Required: Yes
-:Roles Required: "operations" or "admin"\ [#tenancy]_
-:Response Type:  Object
-
-Request Structure
------------------
-.. table:: Query Parameters
-
-	+------+----------+--------------------------------------------------------------------------------+
-	| Name | Required | Description                                                                    |
-	+======+==========+================================================================================+
-	| id   | yes      | The integral, unique identifier of the content invalidation job being modified |
-	+------+----------+--------------------------------------------------------------------------------+
-
-:startTime: This can be a string in the legacy ``YYYY-MM-DD HH:MM:SS`` format, or a string in :rfc:`3339` format, or a string representing a date in the same non-standard format as the ``last_updated`` fields common in other API responses, or finally it can be a number indicating the number of milliseconds since the Unix Epoch (January 1, 1970 UTC). This must be in the future, but unlike :ref:`to-api-user-current-jobs` (or the PUT_ method of this endpoint), it is not required to be within two days from the time of creation.
-:regex: A regular expression that will be used to match the path part of URIs for content stored on :term:`cache servers` that service traffic for the :term:`Delivery Service` identified by ``deliveryService``.
-:ttl: Either the number of hours for which the content invalidation job should remain active, or a "duration" string, which is a sequence of numbers followed by units. The accepted units are:
-
-	- ``h`` gives a duration in hours
-	- ``m`` gives a duration in minutes
-	- ``s`` gives a duration in seconds
-	- ``ms`` gives a duration in milliseconds
-	- ``us`` (or ``µs``) gives a duration in microseconds
-	- ``ns`` gives a duration in nanoseconds
-
-	These durations can be combined e.g. ``2h45m`` specifies a TTL of two hours and forty-five minutes - however note that durations are always rounded up to the nearest hour so that e.g. ``121m`` becomes three hours.
-
-.. note:: A content invalidation job cannot be assigned to a different Delivery Service than the one to which it was initially assigned, and neither can the 'createdBy' field seen in responses ever be changed.
-
-.. code-block:: http
-	:caption: Request Example
-
-	PATCH /api/1.4/jobs?id=3 HTTP/1.1
-	Host: trafficops.infra.ciab.test
-	User-Agent: python-requests/2.20.1
-	Accept-Encoding: gzip, deflate
-	Accept: */*
-	Connection: keep-alive
-	Cookie: mojolicious=...
-	Content-Length: 12
-	Content-Type: application/json
-
-	{"ttl": 36.2}
-
-
-Response Structure
-------------------
-:assetUrl:        A regular expression - matching URLs will be operated upon according to ``keyword``
-:createdBy:       The username of the user who initiated the job
-:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates
-:id:              An integral, unique identifier for this job
-:keyword:         A keyword that represents the operation being performed by the job:
-
-	PURGE
-		This job will prevent caching of URLs matching the ``assetUrl`` until it is removed (or its Time to Live expires)
-
-:parameters: A string containing key/value pairs representing parameters associated with the job - currently only uses Time to Live e.g. ``"TTL:48h"``
-:startTime:  The date and time at which the job began, in a non-standard format
-
-.. code-block:: http
-	:caption: Response Example
-
-	HTTP/1.1 200 OK
-	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-	Access-Control-Allow-Origin: *
-	Content-Encoding: gzip
-	Content-Type: application/json
-	Set-Cookie: mojolicious=...; Path=/; HttpOnly
-	Whole-Content-Sha512: FnmTkJKGlETI6TzXER7dxQk4qEVgwPdBNInxH1Mlkqa66xsJagUoyeDEqrHlfD/EcuUmrUNZbIakEC8WnuSjOA==
-	X-Server-Name: traffic_ops_golang/
-	Date: Wed, 19 Jun 2019 13:43:29 GMT
-	Content-Length: 234
-
-	{"alerts": [{
-		"text": "Content invalidation job updated",
-		"level": "success"
-	}],
-	"response": {
-		"assetUrl": "http://origin.infra.ciab.test/.*",
-		"createdBy": "admin",
-		"deliveryService": "demo1",
-		"id": 3,
-		"keyword": "PURGE",
-		"parameters": "TTL:36h",
-		"startTime": "2019-06-20 18:33:40+00"
-	}}
 
 ``DELETE``
 ==========

--- a/docs/source/api/jobs_id.rst
+++ b/docs/source/api/jobs_id.rst
@@ -18,13 +18,14 @@
 ***************
 ``jobs/{{ID}}``
 ***************
+.. caution:: In the vast majority of cases, it is preferred to use the ``id`` query parameter of the :ref:`to-api-jobs` endpoint instead.
 
 ``GET``
 =======
-Get details about a specific job.
+Get details about a specific content invalidation job.
 
 :Auth. Required: Yes
-:Roles Required: "operations" or "admin"
+:Roles Required: "operations" or "admin"\ [#tenancy]_
 :Response Type:  Array
 
 Request Structure
@@ -37,31 +38,53 @@ Request Structure
 	|  ID  | An integral, unique identifier for the job to be inspected |
 	+------+------------------------------------------------------------+
 
+.. code-block:: http
+	:caption: Request Example
+
+	GET /api/1.4/jobs/3 HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+
 Response Structure
 ------------------
 :assetUrl:        A regular expression - matching URLs will be operated upon according to ``keyword``
 :createdBy:       The username of the user who initiated the job
-:deliveryService: The 'xml_id' that uniquely identifies the :term:`Delivery Service` on which this job operates
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates
 :id:              An integral, unique identifier for this job
 :keyword:         A keyword that represents the operation being performed by the job:
 
 	PURGE
-		This job will prevent caching of URLs matching the ``assetURL`` until it is removed (or its Time to Live expires)
+		This job will prevent caching of URLs matching the ``assetUrl`` until it is removed (or its Time to Live expires)
 
 :parameters: A string containing key/value pairs representing parameters associated with the job - currently only uses Time to Live e.g. ``"TTL:48h"``
-:startTime:  The date and time at which the job began, in ISO format
+:startTime:  The date and time at which the job began, in a non-standard format
 
-.. code-block:: json
+.. code-block:: http
 	:caption: Response Example
 
-	{ "response": [
-		{
-			"id": 1
-			"assetUrl": "http:\/\/foo-bar.domain.net\/taco.html",
-			"deliveryService": "foo-bar",
-			"keyword": "PURGE",
-			"parameters": "TTL:48h",
-			"startTime": "2015-05-14 08:56:36-06",
-			"createdBy": "jdog24"
-		}
-	 ]}
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: l7qvgOShdIFukHyOhi8es2BG6zJZ6RXTT7OKABtI8b1y+cE4nxFq11T5OG5yXjKo69eTYOD7xUUdLqneT2E/VA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 19 Jun 2019 13:29:21 GMT
+	Content-Length: 192
+
+	{ "response": [{
+		"assetUrl": "http://origin.infra.ciab.test/.*",
+		"createdBy": "admin",
+		"deliveryService": "demo1",
+		"id": 3,
+		"keyword": "PURGE",
+		"parameters": "TTL:3h",
+		"startTime": "2019-06-21 00:00:00+00"
+	}]}
+
+
+.. [#tenancy] When viewing content invalidation jobs, only those jobs that operate on a :term:`Delivery Service` visible to the requesting user's :term:`Tenant` will be returned.

--- a/docs/source/api/user_current_jobs.rst
+++ b/docs/source/api/user_current_jobs.rst
@@ -18,10 +18,12 @@
 *********************
 ``user/current/jobs``
 *********************
+.. deprecated:: ATCv4
+
+	Both request methods supported by this endpoint are implemented (better) by :ref:`to-api-jobs`, and in the future that will be the only way to interact with jobs. Developers and administrators are encouraged to switch at their earliest convenience.
 
 ``GET``
 =======
-.. caution:: In the vast majority of cases, it is much better to use the `userId` query parameter of a ``GET`` request to :ref:`to-api-jobs` instead.
 
 Retrieves the user's list of running and pending content invalidation jobs.
 
@@ -110,7 +112,6 @@ Response Structure
 
 ``POST``
 ========
-.. caution:: In many cases, it is better to instead send a ``POST`` request to the :ref:`to-api-jobs` endpoint.
 
 Creates a new content revalidation job.
 

--- a/docs/source/api/user_current_jobs.rst
+++ b/docs/source/api/user_current_jobs.rst
@@ -98,8 +98,8 @@ Response Structure
 
 	{ "response": [{
 		"agent": 1,
-		"assetUrl": "file",
-		"assetType": "http://origin.infra.ciab.test/.*",
+		"assetType": "file",
+		"assetUrl": "http://origin.infra.ciab.test/.*",
 		"deliveryService": "demo1",
 		"enteredTime": "2019-06-19 13:19:51+00",
 		"id": 3,

--- a/docs/source/api/user_current_jobs.rst
+++ b/docs/source/api/user_current_jobs.rst
@@ -21,27 +21,18 @@
 
 ``GET``
 =======
-.. deprecated:: 1.1
-	Use the ``userId`` query parameter of a ``GET`` request to the :ref:`to-api-jobs` endpoint instead.
+.. caution:: In the vast majority of cases, it is much better to use the `userId` query parameter of a ``GET`` request to :ref:`to-api-jobs` instead.
 
 Retrieves the user's list of running and pending content invalidation jobs.
 
 :Auth. Required: Yes
-:Roles Required: None
+:Roles Required: None\ [#tenancy]_
 :Response Type:  Array
 
 Request Structure
 -----------------
-.. table:: Request Query Parameters
-
-	+---------+----------+-------------------------------------------------------------------------------------------------------------------------------------------+
-	|  Name   | Required | Description                                                                                                                               |
-	+=========+==========+===========================================================================================================================================+
-	| keyword | no       | Return only jobs that have this keyword - keyword corresponds to the operation or type of job (currently only "PURGE" is a valid keyword) |
-	+---------+----------+-------------------------------------------------------------------------------------------------------------------------------------------+
-
-.. deprecated:: 1.1
-	This query parameter has been deprecated because the only supported keyword is "PURGE". Jobs used to be much more versatile, but such versatility is no longer required of them. This still "works", but never has any effect on the output, except to make it an empty array if it is anything other than "PURGE".
+.. versionchanged:: ATCv4
+	Prior to version 4 of Traffic Control, the deprecated ``keyword`` query parameter was available to filter jobs in the response. As only one keyword is meaningful, this was never used and so has been removed.
 
 .. code-block:: http
 	:caption: Request Example
@@ -60,16 +51,19 @@ Response Structure
 		This field is no longer used, but does still exist for legacy compatibility reasons. It will always be ``"dummy"``.
 
 :assetUrl:  A regular expression - matching URLs will be operated upon according to ``keyword``
-:assetType: The type of asset being revalidated e.g. "file"
+:assetType: The type of asset being invalidated
 
 	.. deprecated:: 1.1
 		This field still exists, but has no purpose as all assets are now treated as remote files; i.e. it will always be ``"file"``.
 
-:createdBy:       The username of the user who initiated the job
-:deliveryService: The 'xml_id' that uniquely identifies the :term:`Delivery Service` on which this job operates
-:enteredTime:     The date and time at which the job was created, in ISO format
-:id:              An integral, unique identifier for this job
-:keyword:         A keyword that represents the operation being performed by the job:
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` on which this job operates
+:enteredTime:     The date and time at which the job was created, in the same format as the ``last_updated`` fields seen throughout other API responses
+
+	.. versionchanged:: ATCv4
+		This used to be in the legacy ``YYYY-MM-DD HH:MM:SS`` format, but as of Traffic Control version 4 they are standardized to match the format of other date strings in API responses
+
+:id:      An integral, unique identifier for this job
+:keyword: A keyword that represents the operation being performed by the job:
 
 	PURGE
 		This job will prevent caching of URLs matching the ``assetURL`` until it is removed (or its Time to Live expires)
@@ -77,52 +71,53 @@ Response Structure
 :objectName: A deprecated field of unknown use - it only still exists for legacy compatibility reasons, and will always be ``null``
 :objectType: A deprecated field of unknown use - it only still exists for legacy compatibility reasons, and will always be ``null``
 :parameters: A string containing key/value pairs representing parameters associated with the job - currently only uses Time to Live e.g. ``"TTL:48h"``
-:startTime:  The date and time at which the job began or will begin, in ISO format
-:status:     A deprecated field of unknown use - it only still exists for legacy compatibility reasons, and appears to always be ``"PENDING"``
-:username:   The username of the user who created this revalidation job
+:startTime:  The date and time at which the job began or will begin, in the same format as the ``last_updated`` fields seen throughout other API responses
+
+	.. versionchanged:: ATCv4
+		This used to be in the legacy ``YYYY-MM-DD HH:MM:SS`` format, but as of Traffic Control version 4 they are standardized to match the format of other date strings in API responses
+
+:status:   A deprecated field of unknown use - it only still exists for legacy compatibility reasons, and appears to always be ``"PENDING"``
+:username: The username of the user who created this revalidation job
 
 .. code-block:: http
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
-	Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 	Content-Type: application/json
-	Date: Thu, 13 Dec 2018 14:23:54 GMT
-	Server: Mojolicious (Perl)
-	Set-Cookie: mojolicious=...; expires=Thu, 13 Dec 2018 18:23:54 GMT; path=/; HttpOnly
-	Vary: Accept-Encoding
-	Whole-Content-Sha512: Ijr9pDZ4XwPIBX0Qnl+yihTYa8bK7TjJdrpDiV9VNg9k7OC9FSNQV4HSmX35KUAKMFpIHe/azutbvr0xZzQucg==
-	Content-Length: 301
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: RxFZN2+OvP3HEyp+KlCPDFT74PwPFNjxBjibGIMPhbRjVEb8PhdaF7Gq61wklNRfda4PgTP2tzOheiM0oUzUTQ==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 19 Jun 2019 13:23:18 GMT
+	Content-Length: 747
 
-	{ "response": [
-		{
-			"keyword": "PURGE",
-			"objectName": null,
-			"assetUrl": "http://origin.infra.ciab.test/.*\\.jpg",
-			"assetType": "file",
-			"status": "PENDING",
-			"username": "admin",
-			"parameters": "TTL:1h",
-			"enteredTime": "2018-12-13 13:56:35+00",
-			"objectType": null,
-			"agent": "dummy",
-			"id": 1,
-			"startTime": "2018-12-13 13:56:09+00"
-		}
-	]}
+	{ "response": [{
+		"agent": 1,
+		"assetUrl": "file",
+		"assetType": "http://origin.infra.ciab.test/.*",
+		"deliveryService": "demo1",
+		"enteredTime": "2019-06-19 13:19:51+00",
+		"id": 3,
+		"keyword": "PURGE",
+		"objectName": null,
+		"objectType": null,
+		"parameters": "TTL:3h",
+		"username": "admin"
+	}]}
 
 ``POST``
 ========
+.. caution:: In many cases, it is better to instead send a ``POST`` request to the :ref:`to-api-jobs` endpoint.
+
 Creates a new content revalidation job.
 
-.. Note:: This method forces a HTTP *revalidation* of the content, and not a new ``GET`` - the origin needs to support revalidation according to the HTTP/1.1 specification, and send a ``200 OK`` or ``304 Not Modified`` HTTP response as appropriate.
+.. caution:: Creating a content invalidation job immediately triggers a CDN-wide revalidation update. In the case that the global :term:`Parameter` ``use_reval_pending`` has a value of exactly ``"0"``, this will instead trigger a CDN-wide "Queue Updates". This means that content invalidation jobs become active **immediately** at their ``startTime`` - unlike most other configuration changes they do not wait for a :term:`Snapshot` or a "Queue Updates". Furthermore, if the global :term:`Parameter` ``use_reval_pending`` *is* ``"0"``, this will cause all pending configuration changes to propagate to all :term:`cache servers` in the CDN. Take care when using this endpoint.
 
 :Auth. Required: Yes
-:Roles Required: "portal"
+:Roles Required: "portal"\ [#tenancy]_
 
 	.. versionchanged:: ATCv3.1.0
 		For security reasons, the endpoint was reworked so that regardless of tenancy, the "portal" :term:`Role` or higher is required.
@@ -131,62 +126,76 @@ Creates a new content revalidation job.
 
 Request Structure
 -----------------
-:dsId: The integral, unique identifier of the :term:`Delivery Service` on which the revalidation job shall operate
-
+:dsId:  The integral, unique identifier of the :term:`Delivery Service` on which the revalidation job shall operate
 :regex: This should be a `PCRE <http://www.pcre.org/>`_-compatible regular expression for the path to match for forcing the revalidation
 
 	.. warning:: This is concatenated directly to the origin URL of the :term:`Delivery Service` identified by ``dsId`` to make the full regular expression. Thus it is not necessary to restate the URL but it should be noted that if the origin URL does not end with a backslash (``/``) then this should begin with an escaped backslash to ensure proper behavior (otherwise it will match against FQDNs, which leads to undefined behavior in Traffic Control).
 
 	.. note:: Be careful to only match on the content that must be removed - revalidation is an expensive operation for many origins, and a simple ``/.*`` can cause an overload in requests to the origin.
 
-:startTime: The time and date at which the revalidation rule will be made active, in ISO format
-:ttl:       Specifies the Time To Live (TTL) - in hours - for which the revalidation rule will remain active after ``startTime``
+:startTime: This can be a string in the legacy ``YYYY-MM-DD HH:MM:SS`` format, or a string in :rfc:`3339` format, or a string representing a date in the same non-standard format as the ``last_updated`` fields common in other API responses, or finally it can be a number indicating the number of milliseconds since the Unix Epoch (January 1, 1970 UTC). This date must be in the future, and unlike a ``PATCH`` or ``POST`` request to :ref:`to-api-jobs`, it must be *within two days from the time of creation*.
 
-	.. note:: It usually makes sense to make this the same as the ``Cache-Control`` header from the origin which sets the object time to live in cache (by ``max-age`` or ``Expires``). Entering a longer TTL here will make the caches do unnecessary work.
+	.. versionchanged:: ATCv4
+		Prior to Traffic Control version 4, this used to **only** accept the legacy ``YYYY-MM-DD HH:MM:SS`` date string format, but this constraint has been relaxed. Developers are encouraged to submit date/time strings in either :rfc:`3339` format or as a numerical Unix timestamp (in milliseconds).
 
-:urgent: An optional boolean which, if present and ``true``, marks the job as "urgent", which has no meaning to machines but is visible to humans for their consideration
+:ttl: Specifies the :abbr:`TTL (Time To Live)` - in hours - for which the revalidation rule will remain active after ``startTime``
+:urgent: An optional boolean which, if present and ``true``, marks the job as "urgent", which has no meaning whatsoever, and in fact is not even stored by Traffic Control. So don't use it.
 
 .. code-block:: http
 	:caption: Request Example
 
 	POST /api/1.4/user/current/jobs HTTP/1.1
 	Host: trafficops.infra.ciab.test
-	User-Agent: curl/7.47.0
+	User-Agent: python-requests/2.20.1
+	Accept-Encoding: gzip, deflate
 	Accept: */*
+	Connection: keep-alive
 	Cookie: mojolicious=...
-	Content-Length: 79
+	Content-Length: 67
 	Content-Type: application/json
 
 	{
 		"dsId": 1,
-		"regex": "\\/.*\\.jpg",
-		"startTime": "2018-12-13 13:55:09",
-		"ttl": 1
+		"startTime": "2019-06-21T00:00:00Z",
+		"regex": "/.*",
+		"ttl": 3
 	}
+
 
 Response Structure
 ------------------
+.. versionchanged:: ATCv4
+	This method of this endpoint used to only return a successful ``alert`` (presuming success), but in ATCv4 a representation of the newly-created content invalidation job was added to the response.
+
 .. code-block:: http
 	:caption: Response Example
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 201 Created
 	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
-	Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+	Content-Encoding: gzip
 	Content-Type: application/json
-	Date: Thu, 13 Dec 2018 13:56:35 GMT
-	Server: Mojolicious (Perl)
-	Set-Cookie: mojolicious=...; expires=Thu, 13 Dec 2018 17:56:35 GMT; path=/; HttpOnly
-	Vary: Accept-Encoding
-	Whole-Content-Sha512: Uyz2P6gkzsSu8xESEHSKQCG6+6Xw0o+wgjx30+UTBFNIZzFYlkjDK1wZdIUYUPdSbPcTRy5ZaxT1qFpl8+4aGQ==
-	Content-Length: 141
+	Location: https://trafficops.infra.ciab.test/api/1.4/jobs?id=3
+	Set-Cookie: mojolicious=...
+	Whole-Content-Sha512: zQrzB3SLXTbpxLaVWq4WHeONUfEirXDaLRlCi/4+fekgtbjnDgGnA+Sq6MGaxRyQ92/96IsYjAP3Re6ZoN7rzg==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 19 Jun 2019 13:19:51 GMT
+	Content-Length: 235
 
-	{ "alerts": [
-		{
-			"level": "success",
-			"text": "Invalidate content request submitted for demo1 [ http://origin.infra.ciab.test.*\\.jpg - TTL:1h ]"
-		}
-	]}
+	{ "alerts": [{
+		"text": "Invalidation Job creation was successful.",
+		"level": "success"
+	}],
+	"response": {
+		"assetUrl": "http://origin.infra.ciab.test/.*",
+		"createdBy": "admin",
+		"deliveryService": "demo1",
+		"id": 3,
+		"keyword": "PURGE",
+		"parameters": "TTL:3h",
+		"startTime": "2019-06-21 00:00:00+00"
+	}}
 
+.. [#tenancy] When viewing content invalidation jobs, only those jobs that operate on a :term:`Delivery Service` visible to the requesting user's :term:`Tenant` will be returned. Likewise, creating a new content invalidation job requires that the target :term:`Delivery Service` is modifiable by the requesting user's :term:`Tenant`.

--- a/lib/go-tc/invalidationjobs.go
+++ b/lib/go-tc/invalidationjobs.go
@@ -1,0 +1,361 @@
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "errors"
+import "fmt"
+import "regexp"
+import "database/sql"
+import "math"
+import "strconv"
+import "strings"
+import "time"
+
+import "github.com/apache/trafficcontrol/lib/go-log"
+
+// This is the maximum value of TTL representable as a time.Duration object, which is used
+// internally by InvalidationJobInput objects to store the TTL.
+const MaxTTL = math.MaxInt64 / 3600000000000
+
+// Represents a content invalidation job as returned by the API.
+type InvalidationJob struct {
+	AssetURL        *string `json:"assetUrl"`
+	CreatedBy       *string `json:"createdBy"`
+	DeliveryService *string `json:"deliveryService"`
+	ID              *uint64 `json:"id"`
+	Keyword         *string `json:"keyword"`
+	Parameters      *string `json:"parameters"`
+
+	// The time at which the job will come into effect. Must be in the future, but will fail to
+	// Validate if it is further in the future than two days.
+	StartTime *Time `json:"startTime"`
+}
+
+// Represents user input intending to create or modify a content invalidation job.
+type InvalidationJobInput struct {
+
+	// This needs to be an identifier for a Delivery Service. It can be either a string - in which
+	// case it is treated as an XML_ID - or a float64 (because that's the type used by encoding/json
+	// to represent all JSON numbers) - in which case it's treated as an integral, unique identifier
+	// (and any fractional part is discarded, i.e. 2.34 -> 2)
+	DeliveryService *interface{} `json:"deliveryService"`
+
+	// A regular expression which not only must be valid, but should also start with '/'
+	// (or escaped: '\/')
+	Regex *string `json:"regex"`
+
+	// The time at which the job will come into effect. Must be in the future.
+	StartTime *Time `json:"startTime"`
+
+	// Indicates the Time-to-Live of the job. This can be either a valid string for
+	// time.ParseDuration, or a float64 indicating the number of hours. Note that regardless of the
+	// actual value here, Traffic Ops will only consider it rounded down to the nearest natural
+	// number
+	TTL *interface{} `json:"ttl"`
+
+	dsid *uint          `json:"-"`
+	ttl  *time.Duration `json:"-"`
+}
+
+// Represents legacy-style user input to the /user/current/jobs API endpoint. This is much less
+// flexible than InvalidationJobInput, which should be used instead when possible.
+type UserInvalidationJobInput struct {
+	DSID  *uint   `json:"dsId"`
+	Regex *string `json:"regex"`
+
+	// The time at which the job will come into effect. Must be in the future, but will fail to
+	// Validate if it is further in the future than two days.
+	StartTime *Time   `json:"startTime"`
+	TTL       *uint64 `json:"ttl"`
+	Urgent    *bool   `json:"urgent"`
+}
+
+// This is a full representation of content invalidation jobs as stored in the database, including
+// several unused fields.
+type UserInvalidationJob struct {
+
+	// Unused
+	Agent    *uint   `json:"agent"`
+	AssetURL *string `json:"assetUrl"`
+
+	// Unused
+	AssetType       *string `json:"assetType"`
+	DeliveryService *string `json:"deliveryService"`
+	EnteredTime     *Time   `json:"enteredTime"`
+	ID              *uint   `json:"id"`
+	Keyword         *string `json:"keyword"`
+
+	// Unused
+	ObjectName *string `json:"objectName"`
+
+	// Unused
+	ObjectType *string `json:"objectType"`
+	Parameters *string `json:"parameters"`
+	Username   *string `json:"username"`
+}
+
+// Gets the number of hours of the job's TTL - rounded down to the nearest natural number, or an
+// error if it is an invalid value.
+func (j *InvalidationJobInput) TTLHours() (uint, error) {
+	if j.ttl != nil {
+		return uint((*j.ttl).Hours()), nil
+	}
+	if j.TTL == nil {
+		return 0, errors.New("Attempted to convert a nil TTL into hours")
+	}
+
+	var ret uint
+	switch t := (*j.TTL).(type) {
+	case float64:
+		v := (*j.TTL).(float64)
+		if v < 0 {
+			return 0, errors.New("TTL cannot be negative!")
+		}
+		if v >= MaxTTL {
+			return 0, fmt.Errorf("TTL cannot exceed %d hours!", MaxTTL)
+		}
+		ttl := time.Duration(int64(v * 3600000000000))
+		j.ttl = &ttl
+		ret = uint(ttl.Hours())
+
+	case string:
+		d, err := time.ParseDuration((*j.TTL).(string))
+		if err != nil || d.Hours() < 1 {
+			return 0, fmt.Errorf("Invalid duration entered for TTL! Must be at least one hour, but no more than %d hours!", MaxTTL)
+		}
+		j.ttl = &d
+		ret = uint(d.Hours())
+
+	default:
+		log.Errorf("unsupported TTL key type: %T\n", t)
+		return 0, errors.New("Unknown error occurred")
+	}
+
+	return ret, nil
+}
+
+// Gets the integral, unique identifier of the Delivery Service identified by
+// InvalidationJobInput.DeliveryService
+//
+// This requires a transaction connected to a Traffic Ops database, because if DeliveryService is
+// an xml_id, a database lookup will be necessary to get the unique, integral identifier. Thus,
+// this method also checks for the existence of the identified Delivery Service, and will return
+// an error if it does not exist.
+func (j *InvalidationJobInput) DSID(tx *sql.Tx) (uint, error) {
+	if j.dsid != nil {
+		return *j.dsid, nil
+	}
+
+	if j.DeliveryService == nil {
+		return 0, errors.New("Attempted to turn a nil DeliveryService into a DSID")
+	}
+	if tx == nil {
+		return 0, errors.New("Attempted to turn a DeliveryService into a DSID with no DB connection")
+	}
+
+	var ret uint
+	switch t := (*j.DeliveryService).(type) {
+	case float64:
+		v := (*j.DeliveryService).(float64)
+		if v < 0 {
+			return 0, errors.New("Delivery Service ID cannot be negative")
+		}
+
+		u := uint(v)
+		var exists bool
+		row := tx.QueryRow(`SELECT EXISTS(SELECT * FROM deliveryservice WHERE id=$1)`, u)
+		if err := row.Scan(&exists); err != nil {
+			log.Errorf("Error checking for deliveryservice existence in DSID: %v\n", err)
+			return 0, errors.New("Unknown error occurred")
+		} else if !exists {
+			return 0, fmt.Errorf("No Delivery Service exists matching identifier: %v", *j.DeliveryService)
+		}
+
+		j.dsid = &u
+		return u, nil
+
+	case string:
+		row := tx.QueryRow(`SELECT id FROM deliveryservice WHERE xml_id=$1`, *j.DeliveryService)
+		if err := row.Scan(&ret); err != nil {
+			if err == sql.ErrNoRows {
+				return 0, fmt.Errorf("No DeliveryService exists matching identifier: %v", *j.DeliveryService)
+			}
+			return 0, errors.New("Unknown error occurred")
+		}
+		j.dsid = &ret
+		return ret, nil
+
+	default:
+		log.Errorf("unsupported DS key type: %T\n", t)
+		return 0, errors.New("Unknown error occurred")
+
+	}
+}
+
+// Given a transaction connected to the Traffic Ops database, this validates that the user input
+// is correct. In particular, it enforces the constraints described on each field, as well as
+// ensuring they actually exist. This method calls InvalidationJobInput.DSID to validate the
+// DeliveryService field.
+//
+// Returns an array of strings that describe what, if any, problematic fields were encountered in
+// validation.
+func (job *InvalidationJobInput) Validate(tx *sql.Tx) []string {
+	errs := []string{}
+	if job.DeliveryService == nil {
+		errs = append(errs, "'deliveryService' is a required field!")
+	} else if _, err := job.DSID(tx); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if job.Regex == nil || *job.Regex == "" {
+		errs = append(errs, "'regex' is a required field - and cannot be empty!")
+	} else {
+		if !strings.HasPrefix(*job.Regex, "\\/") && !strings.HasPrefix(*job.Regex, "/") {
+			errs = append(errs, "'regex' must start with '/' (or an escaped '/')!")
+		}
+		if _, err := regexp.Compile(*job.Regex); err != nil {
+			errs = append(errs, "'regex' is not a valid Regular Expression: "+err.Error())
+		}
+	}
+
+	if job.StartTime == nil {
+		errs = append(errs, "'startTime' is a required field!")
+	} else if job.StartTime.Time.Before(time.Now()) {
+		errs = append(errs, "'startTime' must be in the future!")
+	}
+
+	if job.TTL == nil {
+		errs = append(errs, "'ttl' is a required field!")
+	} else if _, err := job.TTLHours(); err != nil {
+		errs = append(errs, "'ttl' must be a number of hours, or a duration string e.g. '48h'!")
+	}
+
+	return errs
+}
+
+// Checks that the InvalidationJob is valid, by ensuring all of its fields are well-defined.
+//
+// This returns an error describing any and all problematic fields encountered during validation.
+func (job *InvalidationJob) Validate() error {
+	errs := []string{}
+	if job.AssetURL == nil || *job.AssetURL == "" {
+		errs = append(errs, "'assetUrl' is a required field (and cannot be empty)")
+	}
+
+	if job.CreatedBy == nil || *job.CreatedBy == "" {
+		errs = append(errs, "'createdBy' is a required field (and cannot be empty)")
+	}
+
+	if job.DeliveryService == nil || *job.DeliveryService == "" {
+		errs = append(errs, "'deliveryService' is a required field (and cannot be empty)")
+	}
+
+	if job.ID == nil {
+		errs = append(errs, "'id' is a required field!")
+	}
+
+	if job.Keyword == nil || *job.Keyword == "" {
+		errs = append(errs, "'keyword' is a required field (and cannot be empty)")
+	}
+
+	if job.Parameters == nil || *job.Parameters == "" {
+		errs = append(errs, "'parameters' is a required field (and cannot be empty)")
+	}
+
+	if job.StartTime == nil {
+		errs = append(errs, "'startTime' is a required field!")
+	} else {
+		twoDaysFromNow, err := time.ParseDuration("48h")
+		if err != nil {
+			errs = append(errs, "Unknown internal error occurred")
+			log.Errorf("Couldn't construct 2-day duration: %v\n", err)
+		} else if job.StartTime.After(time.Now().Add(twoDaysFromNow)) {
+			errs = append(errs, "'startTime' must be within two days from now")
+		} else if job.StartTime.Before(time.Now()) {
+			errs = append(errs, "'startTime' cannot be in the past!")
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errors.New(strings.Join(errs, ", "))
+}
+
+// Given a transaction connected to the Traffic Ops database, this validates that the user input
+// is correct.
+//
+// This requires a database transaction to check that the DSID is a valid identifier for an existing
+// Delivery Service
+//
+// Returns an error describing any and all problematic fields encountered during validation.
+func (job *UserInvalidationJobInput) Validate(tx *sql.Tx) error {
+	errs := []string{}
+	if job.StartTime == nil {
+		errs = append(errs, "'startTime' is a required field!")
+	} else {
+		twoDaysFromNow, err := time.ParseDuration("48h")
+		if err != nil {
+			log.Errorf("Couldn't construct 2-day duration: %v\n", err)
+		} else if job.StartTime.After(time.Now().Add(twoDaysFromNow)) {
+			errs = append(errs, "'startTime' must be within two days!")
+		}
+	}
+
+	if job.Regex == nil || *(job.Regex) == "" {
+		errs = append(errs, "'regex' is a required field!")
+	} else {
+		if _, err := regexp.Compile(*(job.Regex)); err != nil {
+			errs = append(errs, "'regex' is not a valid regular expression: "+err.Error())
+		}
+		if !strings.HasPrefix(*(job.Regex), "/") {
+			errs = append(errs, "'regex' must start with '/'!")
+		}
+	}
+
+	if job.DSID == nil {
+		errs = append(errs, "'dsId' is a required field!")
+	} else {
+		row := tx.QueryRow(`SELECT id FROM deliveryservice WHERE id = $1::bigint`, job.DSID)
+		var id uint
+		if err := row.Scan(&id); err != nil {
+			log.Errorln(err.Error())
+			errs = append(errs, "No Delivery Service corresponding to 'dsId'!")
+		}
+	}
+
+	if job.TTL == nil {
+		errs = append(errs, "'ttl' is a required field!")
+	} else {
+		row := tx.QueryRow(`SELECT value FROM parameter WHERE name='maxRevalDurationDays' AND config_file='regex_revalidate.config'`)
+		var max uint64
+		if err := row.Scan(&max); err == nil && max < *(job.TTL) {
+			errs = append(errs, "'ttl' cannot exceed "+strconv.FormatUint(max, 10)+"!")
+		} else if *(job.TTL) < 1 {
+			errs = append(errs, "'ttl' must be at least 1!")
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ", "))
+	}
+	return nil
+}

--- a/lib/go-tc/invalidationjobs_test.go
+++ b/lib/go-tc/invalidationjobs_test.go
@@ -1,0 +1,42 @@
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "fmt"
+
+func ExampleInvalidationJobInput_TTLHours_duration() {
+	j := InvalidationJobInput{nil, nil, nil, "121m"}
+	ttl, e := j.TTLHours()
+	if e != nil {
+		fmt.Printf("Error: %v\n", e)
+	}
+	fmt.Println(ttl)
+	// Output: 2
+}
+
+func ExampleInvalidationJobInput_TTLHours_number() {
+	j := InvalidationJobInput{nil, nil, nil, 2.1}
+	ttl, e := j.TTLHours()
+	if e != nil {
+		fmt.Printf("Error: %v\n", e)
+	}
+	fmt.Println(ttl)
+	// Output: 2
+}

--- a/lib/go-tc/jobs.go
+++ b/lib/go-tc/jobs.go
@@ -25,6 +25,9 @@ import (
 	"time"
 )
 
+// Represents a content invalidation job as stored in the database
+//
+// Deprecated: Use InvalidationJob instead, as it's more flexible
 type Job struct {
 	Parameters      string `json:"parameters"`
 	Keyword         string `json:"keyword"`
@@ -37,6 +40,8 @@ type Job struct {
 
 // JobRequest contains the data to create a job.
 // Note this is a convenience struct for posting users; the actual JSON object is a JobRequestAPI
+//
+// Deprecated: Use InvalidationJobInput instead, as it's more flexible
 type JobRequest struct {
 	TTL               time.Duration
 	StartTime         time.Time
@@ -45,12 +50,19 @@ type JobRequest struct {
 	Urgent            bool
 }
 
-// JobRequestTimeFormat is a Go reference time format, for use with time.Format, of the format required for Traffic Ops POST /user/current/jobs.
+// JobRequestTimeFormat is a Go reference time format, for use with time.Format, of the format
+// used by the Perl version of the /jobs and /user/current/jobs endpoints.
+//
+// Deprecated: Since job inputs no longer strictly require this format, an RFC 3339 format or a
+// timestamp in milliseconds should be used instead
 const JobRequestTimeFormat = `2006-01-02 15:04:05`
 
-// JobTimeFormat is a Go reference time format, for use with time.Format, of the format sent by Traffic Ops GET /jobs
+// JobTimeFormat is a Go reference time format, for use with time.Format.
+//
+// Deprecated: this format is the same as TimeLayout - which should be used instead.
 const JobTimeFormat = `2006-01-02 15:04:05-07`
 
+// Implements the encoding/json.Marshaler interface.
 func (jr JobRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(JobRequestAPI{
 		TTLSeconds: int64(jr.TTL / time.Second),
@@ -61,6 +73,7 @@ func (jr JobRequest) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// Implements the encoding/json Unmarshaler interface.
 func (jr *JobRequest) UnmarshalJSON(b []byte) error {
 	jri := JobRequestAPI{}
 	if err := json.Unmarshal(b, &jri); err != nil {
@@ -80,6 +93,10 @@ func (jr *JobRequest) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// Represents the JSON input accepted by the API for creating new content invalidation jobs
+//
+// Deprecated: This structure is technically incorrect, and has been superseded by the
+// InvalidationJobInput structure.
 type JobRequestAPI struct {
 	TTLSeconds int64  `json:"ttl"`
 	StartTime  string `json:"startTime"`

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -574,6 +574,10 @@ insert into api_capability (http_method, route, capability) values ('GET', 'osve
 insert into api_capability (http_method, route, capability) values ('POST', 'isos', 'iso-generate') ON CONFLICT (http_method, route, capability) DO NOTHING;
 -- jobs
 insert into api_capability (http_method, route, capability) values ('GET', 'jobs', 'jobs-read') ON CONFLICT (http_method, route, capability) DO NOTHING;
+INSERT INTO api_capability (http_method, route, capability) VALUES ('POST', 'jobs', 'jobs-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
+INSERT INTO api_capability (http_method, route, capability) VALUES ('PUT', 'jobs', 'jobs-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
+INSERT INTO api_capability (http_method, route, capability) VALUES ('PATCH', 'jobs', 'jobs-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
+INSERT INTO api_capability (http_method, route, capability) VALUES ('DELETE', 'jobs', 'jobs-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
 insert into api_capability (http_method, route, capability) values ('GET', 'jobs/*', 'jobs-read') ON CONFLICT (http_method, route, capability) DO NOTHING;
 insert into api_capability (http_method, route, capability) values ('GET', 'user/current/jobs', 'jobs-read') ON CONFLICT (http_method, route, capability) DO NOTHING;
 insert into api_capability (http_method, route, capability) values ('POST', 'user/current/jobs', 'jobs-write') ON CONFLICT (http_method, route, capability) DO NOTHING;

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -654,8 +654,8 @@ sub api_routes {
 	$r->post("/api/$version/isos")->over( authenticated => 1, not_ldap => 1 )->to( 'Iso#generate', namespace => $namespace );
 
 	# -- JOBS (CURRENTLY LIMITED TO INVALIDATE CONTENT (PURGE) JOBS)
-	$r->get("/api/$version/jobs")->over( authenticated => 1, not_ldap => 1 )->to( 'Job#index', namespace => $namespace );
-	$r->get("/api/$version/jobs/:id" => [ id => qr/\d+/ ] )->over( authenticated => 1, not_ldap => 1 )->to( 'Job#show', namespace => $namespace );
+	# $r->get("/api/$version/jobs")->over( authenticated => 1, not_ldap => 1 )->to( 'Job#index', namespace => $namespace );
+	# $r->get("/api/$version/jobs/:id" => [ id => qr/\d+/ ] )->over( authenticated => 1, not_ldap => 1 )->to( 'Job#show', namespace => $namespace );
 
 	# -- JOBS: CURRENT USER (CURRENTLY LIMITED TO INVALIDATE CONTENT (PURGE) JOBS)
 	$r->get("/api/$version/user/current/jobs")->over( authenticated => 1, not_ldap => 1 )->to( 'Job#get_current_user_jobs', namespace => $namespace );

--- a/traffic_ops/client/job.go
+++ b/traffic_ops/client/job.go
@@ -17,6 +17,8 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -25,6 +27,8 @@ import (
 )
 
 // CreateJob creates a Job.
+//
+// Deprecated: Use CreateInvalidationJob instead
 func (to *Session) CreateJob(job tc.JobRequest) (tc.Alerts, ReqInf, error) {
 	remoteAddr := (net.Addr)(nil)
 	reqBody, err := json.Marshal(job)
@@ -42,8 +46,29 @@ func (to *Session) CreateJob(job tc.JobRequest) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, err
 }
 
+// Creates a new Content Invalidation Job
+func (to *Session) CreateInvalidationJob(job tc.InvalidationJobInput) (tc.Alerts, ReqInf, error) {
+	remoteAddr := (net.Addr)(nil)
+	reqBody, err := json.Marshal(job)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, apiBase+`/jobs`, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, err
+}
+
 // GetJobs returns a list of Jobs.
-// If deliveryServiceID or userID are not nil, only jobs for that delivery service or belonging to that user are returned. Both deliveryServiceID and userID may be nil.
+// If deliveryServiceID or userID are not nil, only jobs for that delivery service or belonging to
+// that user are returned. Both deliveryServiceID and userID may be nil.
+//
+// Deprecated, use GetInvalidationJobs instead
 func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, ReqInf, error) {
 	path := apiBase + "/jobs"
 	if deliveryServiceID != nil || userID != nil {
@@ -68,6 +93,103 @@ func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, ReqIn
 
 	data := struct {
 		Response []tc.Job `json:"response"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, err
+}
+
+// Returns a list of Content Invalidation Jobs visible to your Tenant, filtered according to
+// ds and user
+//
+// Either or both of ds and user may be nil, but when they are not they cause filtering of the
+// returned jobs by Delivery Service and Traffic Ops user, respectively.
+//
+// ds may be a uint, int, or float64 indicating the integral, unique identifier of the desired
+// Delivery Service (in the case of a float64 the fractional part is dropped, e.g. 3.45 -> 3), or
+// it may be a string, in which case it should be the xml_id of the desired Delivery Service, or it
+// may be an actual tc.DeliveryService or tc.DeliveryServiceNullable structure.
+//
+// Likewise, user may be a uint, int or float64 indicating the integral, unique identifier of the
+// desired user (in the case of a float64 the fractional part is dropped, e.g. 3.45 -> 3), or it may
+// be a string, in which case it should be the username of the desired user, or it may be an actual
+// tc.User or tc.UserCurrent structure.
+func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc.InvalidationJob, ReqInf, error) {
+	path := apiBase + "/jobs"
+	if ds != nil || user != nil {
+		path += "?"
+
+		if ds != nil {
+			d := *ds
+			switch t := d.(type) {
+			case uint:
+				path += "dsId=" + strconv.FormatUint(uint64(d.(uint)), 10)
+			case float64:
+				path += "dsId=" + strconv.FormatInt(int64(d.(float64)), 10)
+			case int:
+				path += "dsId=" + strconv.FormatInt(int64(d.(int)), 10)
+			case string:
+				path += "deliveryService=" + d.(string)
+			case tc.DeliveryService:
+				path += "deliveryService=" + d.(tc.DeliveryService).XMLID
+			case tc.DeliveryServiceNullable:
+				if d.(tc.DeliveryServiceNullable).XMLID != nil {
+					path += "deliveryService=" + *d.(tc.DeliveryServiceNullable).XMLID
+				} else if d.(tc.DeliveryServiceNullable).ID != nil {
+					path += "dsId=" + strconv.FormatInt(int64(*d.(tc.DeliveryServiceNullable).ID), 10)
+				} else {
+					return nil, ReqInf{}, errors.New("No non-nil identifier on passed Delivery Service!")
+				}
+			default:
+				return nil, ReqInf{}, fmt.Errorf("Invalid type for argument 'ds': %T*", t)
+			}
+
+			if user != nil {
+				path += "&"
+			}
+		}
+
+		if user != nil {
+			u := *user
+			switch t := u.(type) {
+			case uint:
+				path += "userId=" + strconv.FormatUint(uint64(u.(uint)), 10)
+			case float64:
+				path += "userId=" + strconv.FormatInt(int64(u.(float64)), 10)
+			case int:
+				path += "userId=" + strconv.FormatInt(int64(u.(int64)), 10)
+			case string:
+				path += "createdBy=" + u.(string)
+			case tc.User:
+				if u.(tc.User).Username != nil {
+					path += "createdBy=" + *u.(tc.User).Username
+				} else if u.(tc.User).ID != nil {
+					path += "userId=" + strconv.FormatInt(int64(*u.(tc.User).ID), 10)
+				} else {
+					return nil, ReqInf{}, errors.New("No non-nil identifier on passed User!")
+				}
+			case tc.UserCurrent:
+				if u.(tc.UserCurrent).UserName != nil {
+					path += "createdBy=" + *u.(tc.UserCurrent).UserName
+				} else if u.(tc.UserCurrent).ID != nil {
+					path += "userId=" + strconv.FormatInt(int64(*u.(tc.UserCurrent).ID), 10)
+				} else {
+					return nil, ReqInf{}, errors.New("No non-nil identifier on passed UserCurrent!")
+				}
+			default:
+				return nil, ReqInf{}, fmt.Errorf("Invalid type for argument 'user': %T*", t)
+			}
+		}
+	}
+
+	resp, remoteAddr, err := to.request(http.MethodGet, path, nil)
+	reqInf := ReqInf{CacheHitStatusMiss, remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	data := struct {
+		Response []tc.InvalidationJob `json:"response"`
 	}{}
 	err = json.NewDecoder(resp.Body).Decode(&data)
 	return data.Response, reqInf, err

--- a/traffic_ops/testing/api/v14/jobs_test.go
+++ b/traffic_ops/testing/api/v14/jobs_test.go
@@ -84,9 +84,9 @@ func GetTestJobs(t *testing.T) {
 			if !strings.HasSuffix(toJob.AssetURL, testJob.Request.Regex) {
 				continue
 			}
-			toJobTime, err := time.Parse(tc.JobTimeFormat, toJob.StartTime)
+			toJobTime, err := time.Parse(tc.TimeLayout, toJob.StartTime)
 			if err != nil {
-				t.Errorf("job ds %v regex %v start time expected format '%+v' actual '%+v' error '%+v'", testJob.Request.DeliveryServiceID, testJob.Request.Regex, tc.JobTimeFormat, toJob.StartTime, err)
+				t.Errorf("job ds %v regex %v start time expected format '%+v' actual '%+v' error '%+v'", testJob.Request.DeliveryServiceID, testJob.Request.Regex, tc.TimeLayout, toJob.StartTime, err)
 				continue
 			}
 			toJobTime = toJobTime.Round(time.Minute)

--- a/traffic_ops/testing/api/v14/jobs_test.go
+++ b/traffic_ops/testing/api/v14/jobs_test.go
@@ -72,9 +72,9 @@ func CreateTestInvalidationJobs(t *testing.T) {
 	}
 
 	for _, job := range testData.InvalidationJobs {
-		id, ok := dsNameIDs[job.DeliveryService.(string)]
+		_, ok := dsNameIDs[(*job.DeliveryService).(string)]
 		if !ok {
-			t.Fatalf("can't create test data job: delivery service '%v' not found in Traffic Ops", job.DSName)
+			t.Fatalf("can't create test data job: delivery service '%v' not found in Traffic Ops", job.DeliveryService)
 		}
 		if _, _, err := TOSession.CreateInvalidationJob(job); err != nil {
 			t.Errorf("could not CREATE job: %v\n", err)

--- a/traffic_ops/testing/api/v14/jobs_test.go
+++ b/traffic_ops/testing/api/v14/jobs_test.go
@@ -26,7 +26,9 @@ import (
 func TestJobs(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
 		CreateTestJobs(t)
+		CreateTestInvalidationJobs(t)
 		GetTestJobs(t)
+		GetTestInvalidationJobs(t)
 	})
 }
 
@@ -59,10 +61,31 @@ func CreateTestJobs(t *testing.T) {
 	}
 }
 
+func CreateTestInvalidationJobs(t *testing.T) {
+	toDSes, _, err := TOSession.GetDeliveryServices()
+	if err != nil {
+		t.Fatalf("cannot GET Delivery Services: %v - %v\n", err, toDSes)
+	}
+	dsNameIDs := map[string]int64{}
+	for _, ds := range toDSes {
+		dsNameIDs[ds.XMLID] = int64(ds.ID)
+	}
+
+	for _, job := range testData.InvalidationJobs {
+		id, ok := dsNameIDs[job.DeliveryService.(string)]
+		if !ok {
+			t.Fatalf("can't create test data job: delivery service '%v' not found in Traffic Ops", job.DSName)
+		}
+		if _, _, err := TOSession.CreateInvalidationJob(job); err != nil {
+			t.Errorf("could not CREATE job: %v\n", err)
+		}
+	}
+}
+
 func GetTestJobs(t *testing.T) {
 	toJobs, _, err := TOSession.GetJobs(nil, nil)
 	if err != nil {
-		t.Fatalf("error getting jobs: " + err.Error())
+		t.Fatalf("error getting jobs: %v", err)
 	}
 
 	toDSes, _, err := TOSession.GetDeliveryServices()
@@ -100,6 +123,47 @@ func GetTestJobs(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("test job ds %v regex %v expected: exists, actual: not found", testJob.Request.DeliveryServiceID, testJob.Request.Regex)
+		}
+	}
+}
+
+func GetTestInvalidationJobs(t *testing.T) {
+	jobs, _, err := TOSession.GetInvalidationJobs(nil, nil)
+	if err != nil {
+		t.Fatalf("error getting invalidation jobs: %v\n", err)
+	}
+
+	toDSes, _, err := TOSession.GetDeliveryServices()
+	if err != nil {
+		t.Fatalf("cannot GET DeliveryServices: %v - %v\n", err, toDSes)
+	}
+
+	dsIDNames := map[uint]string{}
+	for _, ds := range toDSes {
+		if ds.ID <= 0 {
+			t.Fatalf("Erroneous Delivery Service - has invalid ID: %+v\n", ds)
+		}
+		dsIDNames[uint(ds.ID)] = ds.XMLID
+	}
+
+	for _,testJob := range testData.InvalidationJobs {
+		found := false
+		for _,toJob := range jobs {
+			if *toJob.DeliveryService != (*testJob.DeliveryService).(string) {
+				continue
+			}
+			if !strings.HasSuffix(*toJob.AssetURL, *testJob.Regex) {
+				continue
+			}
+			if !toJob.StartTime.Round(time.Minute).Equal(testJob.StartTime.Round(time.Minute)) {
+				t.Errorf("test invalidation job start time expected '%+v' actual '%+v'\n", testJob.StartTime, toJob.StartTime)
+				continue
+			}
+			found = true
+			break
+		}
+		if !found {
+			t.Errorf("expected a test job %+v to exist, but it didn't\n", testJob)
 		}
 	}
 }

--- a/traffic_ops/testing/api/v14/jobs_test.go
+++ b/traffic_ops/testing/api/v14/jobs_test.go
@@ -138,12 +138,10 @@ func GetTestInvalidationJobs(t *testing.T) {
 		t.Fatalf("cannot GET DeliveryServices: %v - %v\n", err, toDSes)
 	}
 
-	dsIDNames := map[uint]string{}
 	for _, ds := range toDSes {
 		if ds.ID <= 0 {
 			t.Fatalf("Erroneous Delivery Service - has invalid ID: %+v\n", ds)
 		}
-		dsIDNames[uint(ds.ID)] = ds.XMLID
 	}
 
 	for _,testJob := range testData.InvalidationJobs {

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -2180,6 +2180,20 @@
             "servercheck_short_name": "ORT",
             "host_name": "atlanta-edge-01",
             "value": 13
+        },
+    ],
+    "invalidationJobs": [
+        {
+            "deliveryService": "ds1",
+            "regex": "/.*",
+            "startTime": 4117118271000,
+            "ttl": "121m"
+        },
+        {
+            "deliveryService":  "ds2",
+            "regex": "\\/some-path?.+\\.jpg",
+            "startTime": "2100-06-19T13:57:51-06:00",
+            "ttl": 2.1
         }
     ]
 }

--- a/traffic_ops/testing/api/v14/traffic_control.go
+++ b/traffic_ops/testing/api/v14/traffic_control.go
@@ -48,6 +48,7 @@ type TrafficControl struct {
 	Serverchecks                   []tc.ServercheckRequestNullable    `json:"serverchecks"`
 	Users                          []tc.User                          `json:"users"`
 	Jobs                           []JobRequest                       `json:"jobs"`
+	InvalidationJobs               []tc.InvalidationJobInput          `json:"invalidationJobs"`
 }
 
 type JobRequest struct {

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -292,6 +292,14 @@ type APIInfo struct {
 	Config    *config.Config
 }
 
+// Creates a deprecation warning for an endpoint, with a proposed alternative.
+func DeprecationWarning(alternative string) tc.Alert {
+	return tc.Alert{
+		Level: tc.WarnLevel.String(),
+		Text: fmt.Sprintf("This request method of this endpoint is deprecated. You are advised to switch to '%s' at your earliest convenience", alternative),
+	}
+}
+
 // NewInfo get and returns the context info needed by handlers. It also returns any user error, any system error, and the status code which should be returned to the client if an error occurred.
 //
 // It is encouraged to call APIInfo.Tx.Tx.Commit() manually when all queries are finished, to release database resources early, and also to return an error to the user if the commit failed.

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -621,10 +621,9 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err = setRevalFlags(dsid, inf.Tx.Tx); err != nil {
-		userErr = errors.New("Something wicked happened... Please queue server updates (or set reval_pending=true) manually to avoid problems!")
 		sysErr = fmt.Errorf("setting reval_pending after deleting job #%s: %v", inf.Params["id"], err)
 		errCode = http.StatusInternalServerError
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -1,0 +1,916 @@
+package invalidationjobs
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "database/sql"
+import "encoding/json"
+import "errors"
+import "fmt"
+import "net/http"
+import "regexp"
+import "strconv"
+import "strings"
+import "time"
+
+import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/lib/go-log"
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
+
+type InvalidationJob struct {
+	api.APIInfoImpl `json:"-"`
+	tc.InvalidationJob
+}
+
+const readQuery = `
+SELECT job.id,
+       keyword,
+       parameters,
+       asset_url,
+       start_time,
+       u.username AS createdBy,
+       ds.xml_id AS dsId
+FROM job
+JOIN tm_user u ON job.job_user = u.id
+JOIN deliveryservice ds  ON job.job_deliveryservice = ds.id
+`
+
+const insertQuery = `
+INSERT INTO job (
+	agent,
+	asset_type,
+	asset_url,
+	entered_time,
+	job_deliveryservice,
+	job_user,
+	keyword,
+	parameters,
+	start_time,
+	status)
+VALUES (
+	1::bigint,
+	'file',
+	(
+		SELECT o.protocol::text || '://' || o.fqdn || rtrim(concat(':', o.port::text), ':')
+		FROM origin o
+		WHERE o.deliveryservice = $1
+		AND o.is_primary
+	) || $2,
+	$3,
+	$4,
+	$5,
+	'PURGE',
+	$6,
+	$7,
+	1::bigint
+)
+RETURNING
+	asset_url,
+	(SELECT deliveryservice.xml_id
+	 FROM deliveryservice
+	 WHERE deliveryservice.id=job_deliveryservice) AS deliveryservice,
+	id,
+	(SELECT tm_user.username
+	 FROM tm_user
+	 WHERE tm_user.id=job_user) AS createdBy,
+	keyword,
+	parameters,
+	start_time
+`
+
+const revalQuery = `
+UPDATE server SET %s=TRUE
+WHERE server.status NOT IN (
+                             SELECT status.id
+                             FROM status
+                             WHERE name IN ('OFFLINE', 'PRE_PROD')
+                           )
+     AND server.profile IN (
+                             SELECT profile_parameter.profile
+                             FROM profile_parameter
+                             WHERE profile_parameter.parameter IN (
+                                                                    SELECT parameter.id
+                                                                    FROM parameter
+                                                                    WHERE parameter.name='location'
+                                                                     AND parameter.config_file='regex_revalidate.config'
+                                                                  )
+                           )
+     AND server.cdn_id  =  (
+                             SELECT deliveryservice.cdn_id
+                             FROM deliveryservice
+                             WHERE deliveryservice.%s=$1
+                           )
+`
+
+const updateQuery = `
+UPDATE job
+SET asset_url=$1,
+    keyword=$2,
+    parameters=$3,
+    start_time=$4
+WHERE job.id=$5
+RETURNING job.asset_url,
+          (
+           SELECT tm_user.username
+           FROM tm_user
+           WHERE tm_user.id=job.job_user
+          ) AS created_by,
+          (
+           SELECT deliveryservice.xml_id
+           FROM deliveryservice
+           WHERE deliveryservice.id=job.job_deliveryservice
+          ) AS delivery_service,
+          job.id,
+          job.keyword,
+          job.parameters,
+          job.start_time
+`
+
+const patchUpdateQuery = `
+UPDATE job
+SET asset_url=$1,
+    parameters=$2,
+    start_time=$3
+WHERE id=$4
+RETURNING job.asset_url,
+          (SELECT tm_user.username
+           FROM tm_user
+           WHERE tm_user.id=job.job_user) AS created_by,
+           (SELECT deliveryservice.xml_id
+            FROM deliveryservice
+            WHERE deliveryservice.id=job.job_deliveryservice) AS deliveryservice,
+           job.id,
+           job.keyword,
+           job.parameters,
+           job.start_time
+`
+
+const patchInfoQuery = `
+SELECT job.id AS id,
+       tm_user.username AS createdBy,
+       job.job_user AS createdByID,
+       job.job_deliveryservice AS dsid,
+       deliveryservice.xml_id AS dsxmlid,
+       job.asset_url AS assetURL,
+       ltrim(rtrim(job.parameters, 'h'), 'TTL:')::bigint AS ttl,
+       job.parameters,
+       job.start_time AS start_time,
+       origin.protocol || '://' || origin.fqdn || rtrim(concat(':', origin.port), ':') AS OFQDN
+FROM job
+INNER JOIN origin ON origin.deliveryservice=job.job_deliveryservice
+INNER JOIN tm_user ON tm_user.id=job.job_user
+INNER JOIN deliveryservice ON deliveryservice.id=job.job_deliveryservice
+WHERE job.id=$1
+`
+
+const putInfoQuery = `
+SELECT job.id AS id,
+       tm_user.username AS createdBy,
+       job.job_user AS createdByID,
+       job.job_deliveryservice AS dsid,
+       deliveryservice.xml_id AS dsxmlid,
+       job.asset_url AS assetURL,
+       job.parameters,
+       job.start_time AS start_time,
+       origin.protocol || '://' || origin.fqdn || rtrim(concat(':', origin.port), ':') AS OFQDN
+FROM job
+INNER JOIN origin ON origin.deliveryservice=job.job_deliveryservice
+INNER JOIN tm_user ON tm_user.id=job.job_user
+INNER JOIN deliveryservice ON deliveryservice.id=job.job_deliveryservice
+WHERE job.id=$1
+`
+
+const deleteQuery = `
+DELETE
+FROM job
+WHERE job.id=$1
+RETURNING job.asset_url,
+          (
+           SELECT tm_user.username
+           FROM tm_user
+           WHERE tm_user.id=job.job_user
+          ) AS created_by,
+          (
+           SELECT deliveryservice.xml_id
+           FROM deliveryservice
+           WHERE deliveryservice.id=job.job_deliveryservice
+          ) AS deliveryservice,
+          job.id,
+          job.keyword,
+          job.parameters,
+          job.start_time
+`
+
+type apiResponse struct {
+	Alerts   []tc.Alert         `json:"alerts,omitempty"`
+	Response tc.InvalidationJob `json:"response,omitempty"`
+}
+
+// Used by GET requests to `/jobs`, simply returns a filtered list of
+// content invalidation jobs according to the provided query parameters.
+func (job *InvalidationJob) Read() ([]interface{}, error, error, int) {
+	queryParamsToSQLCols := map[string]dbhelpers.WhereColumnInfo{
+		"id":              dbhelpers.WhereColumnInfo{"job.id", api.IsInt},
+		"keyword":         dbhelpers.WhereColumnInfo{"job.keyword", nil},
+		"assetUrl":        dbhelpers.WhereColumnInfo{"job.asset_url", nil},
+		"userId":          dbhelpers.WhereColumnInfo{"job.job_user", api.IsInt},
+		"createdBy":       dbhelpers.WhereColumnInfo{`(SELECT tm_user.username FROM tm_user WHERE tm_user.id=job.job_user)`, nil},
+		"deliveryService": dbhelpers.WhereColumnInfo{`(SELECT deliveryservice.xml_id FROM deliveryservice WHERE deliveryservice.id=job.job_deliveryservice)`, nil},
+		"dsId":            dbhelpers.WhereColumnInfo{"job.job_deliveryservice", api.IsInt},
+	}
+
+	where, orderBy, queryValues, errs := dbhelpers.BuildWhereAndOrderBy(job.APIInfo().Params, queryParamsToSQLCols)
+	if len(errs) > 0 {
+		var b strings.Builder
+		b.WriteString("Reading jobs:")
+		for _, err := range errs {
+			b.WriteString("\n\t")
+			b.WriteString(err.Error())
+		}
+
+		return nil, nil, errors.New(b.String()), http.StatusInternalServerError
+	}
+
+	// TODO: check tenancy here
+	query := readQuery + where + orderBy
+
+	log.Debugln("generated job query: " + query)
+	log.Debugf("executing with values: %++v\n", queryValues)
+
+	returnable := []tc.InvalidationJob{}
+	rows, err := job.APIInfo().Tx.NamedQuery(query, queryValues)
+	if err != nil {
+		return nil, nil, fmt.Errorf("querying: %v", err), http.StatusInternalServerError
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		j := tc.InvalidationJob{}
+		err := rows.Scan(&j.ID,
+			&j.Keyword,
+			&j.Parameters,
+			&j.AssetURL,
+			&j.StartTime,
+			&j.CreatedBy,
+			&j.DeliveryService)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing db response: %v", err), http.StatusInternalServerError
+		}
+
+		returnable = append(returnable, j)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("Parsing db responses: %v", err), http.StatusInternalServerError
+	}
+
+	// This cannot be done in the scanning loop, because pq will throw an error if you try to make
+	// another query before exhausting the rows returned by an earlier query
+	filtered := []interface{}{}
+	for _, r := range returnable {
+		userErr, sysErr, errCode := IsUserAuthorizedToModifyDSXMLID(job.APIInfo(), *r.DeliveryService)
+		if sysErr != nil {
+			return nil, userErr, sysErr, errCode
+		} else if userErr == nil {
+			filtered = append(filtered, r)
+		}
+	}
+
+	return filtered, nil, nil, http.StatusOK
+}
+
+// Used by POST requests to `/jobs`, creates a new content invalidation job
+// from the provided request body.
+func Create(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	job := tc.InvalidationJobInput{}
+	cType := r.Header.Get(http.CanonicalHeaderKey("content-type"))
+	if cType == tc.ApplicationJson || cType == "" {
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&job); err != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("Unable to parse Invalidation Job"), fmt.Errorf("parsing jobs/ POST: %v", err))
+			return
+		}
+	} else {
+		w.Header().Set(http.CanonicalHeaderKey("accept"), strings.Join([]string{tc.ApplicationJson, "application/x-www-form-urlencoded", "multipart/form-data"}, ";"))
+		err := fmt.Errorf("unsupported content-type: %s", cType)
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusUnsupportedMediaType, err, err)
+		return
+	}
+
+	w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+	if errs := job.Validate(inf.Tx.Tx); len(errs) > 0 {
+		response := []tc.Alert{}
+		for _, e := range errs {
+			response = append(response, tc.Alert{e, tc.ErrorLevel.String()})
+		}
+
+		resp, err := json.Marshal(struct {
+			Alerts []tc.Alert `json:"alerts"`
+		}{response})
+		if err != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Encoding bad request response: %v", err))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write(resp)
+			w.Write([]byte{'\n'})
+		}
+		return
+	}
+
+	// Validate() would have already checked for deliveryservice existence and
+	// parsed the ttl, so if either of these throws an error now, something
+	// weird has happened
+	dsid, err := job.DSID(nil)
+	if err != nil {
+		sysErr = fmt.Errorf("retrieving parsed DSID: %v", err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+		return
+	}
+	var ttl uint
+	if ttl, err = job.TTLHours(); err != nil {
+		sysErr = fmt.Errorf("retrieving parsed TTL: %v", err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+		return
+	}
+
+	if userErr, sysErr, errCode = IsUserAuthorizedToModifyDSID(inf, dsid); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	row := inf.Tx.Tx.QueryRow(insertQuery,
+		dsid,
+		*job.Regex,
+		time.Now(),
+		dsid,
+		inf.User.ID,
+		fmt.Sprintf("TTL:%dh", ttl),
+		(*job.StartTime).Time)
+
+	result := tc.InvalidationJob{}
+	err = row.Scan(&result.AssetURL,
+		&result.DeliveryService,
+		&result.ID,
+		&result.CreatedBy,
+		&result.Keyword,
+		&result.Parameters,
+		&result.StartTime)
+	if err != nil {
+		userErr, sysErr, errCode = api.ParseDBError(err)
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	if err := setRevalFlags(dsid, inf.Tx.Tx); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("setting reval flags: %v", err))
+	} else {
+		resp, err := json.Marshal(apiResponse{[]tc.Alert{{"Invalidation Job creation was successful", tc.SuccessLevel.String()}}, result})
+		if err != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Marshaling JSON: %v", err))
+		} else {
+			w.Header().Set(http.CanonicalHeaderKey("location"), inf.Config.URL.Scheme+"://"+r.Host+"/api/1.4/jobs?id="+strconv.FormatUint(uint64(*result.ID), 10))
+			w.WriteHeader(http.StatusCreated)
+			w.Write(resp)
+			w.Write([]byte{'\n'})
+		}
+	}
+
+	api.CreateChangeLogRawTx(api.ApiChange, api.Created+"content invalidation job: #"+strconv.FormatUint(*result.ID, 10), inf.User, inf.Tx.Tx)
+}
+
+// Used by PUT requests to `/jobs`, replaces an existing content invalidation job
+// with the provided request body.
+func Update(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	var oFQDN string
+	var dsid uint
+	var uid uint
+	job := tc.InvalidationJob{}
+	row := inf.Tx.Tx.QueryRow(putInfoQuery, inf.Params["id"])
+	err := row.Scan(&job.ID,
+		&job.CreatedBy,
+		&uid,
+		&dsid,
+		&job.DeliveryService,
+		&job.AssetURL,
+		&job.Parameters,
+		&job.StartTime,
+		&oFQDN)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			userErr = fmt.Errorf("No job found by id %s", inf.Params["id"])
+			errCode = http.StatusNotFound
+		} else {
+			sysErr = fmt.Errorf("fetching job update info: %v", err)
+			errCode = http.StatusInternalServerError
+		}
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	if userErr, sysErr, errCode = IsUserAuthorizedToModifyDSID(inf, dsid); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	if userErr, sysErr, errCode = IsUserAuthorizedToModifyJobsMadeByUsername(inf, *job.CreatedBy); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	input := tc.InvalidationJob{}
+	cType := r.Header.Get(http.CanonicalHeaderKey("content-type"))
+	if cType == tc.ApplicationJson || cType == "" {
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&input); err != nil {
+			userErr = fmt.Errorf("Unable to parse input: %v", err)
+			sysErr = fmt.Errorf("parsing input to PUT jobs?id=%s: %v", inf.Params["id"], err)
+			errCode = http.StatusBadRequest
+			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+			return
+		}
+	} else {
+		w.Header().Set(http.CanonicalHeaderKey("accept"), strings.Join([]string{tc.ApplicationJson, "application/x-www-form-urlencoded", "multipart/form-data"}, ";"))
+		err := fmt.Errorf("unsupported content-type: %s", cType)
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusUnsupportedMediaType, err, err)
+		return
+	}
+
+	if err := input.Validate(); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, err, nil)
+		return
+	}
+
+	if *job.DeliveryService != *input.DeliveryService {
+		userErr = errors.New("Cannot change 'deliveryService' of existing invalidation job!")
+		errCode = http.StatusConflict
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+		return
+	}
+
+	if *job.CreatedBy != *input.CreatedBy {
+		userErr = errors.New("Cannot change 'createdBy' of existing invalidation jobs!")
+		errCode = http.StatusConflict
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+		return
+	}
+
+	if *job.ID != *input.ID {
+		userErr = errors.New("Cannot change an invalidation job 'id'!")
+		errCode = http.StatusConflict
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+		return
+	}
+
+	row = inf.Tx.Tx.QueryRow(updateQuery,
+		input.AssetURL,
+		input.Keyword,
+		input.Parameters,
+		input.StartTime.Time,
+		*job.ID)
+	err = row.Scan(&job.AssetURL,
+		&job.CreatedBy,
+		&job.DeliveryService,
+		&job.ID,
+		&job.Keyword,
+		&job.Parameters,
+		&job.StartTime)
+	if err != nil {
+		sysErr = fmt.Errorf("Updating a job: %v", err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+		return
+	}
+
+	if err = setRevalFlags(*job.DeliveryService, inf.Tx.Tx); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Setting reval flags: %v", err))
+		return
+	}
+
+	response := apiResponse{
+		[]tc.Alert{
+			tc.Alert{
+				"Content invalidation job updated",
+				tc.SuccessLevel.String(),
+			},
+		},
+		job,
+	}
+
+	resp, err := json.Marshal(response)
+	if err != nil {
+		sysErr = fmt.Errorf("encoding response: %v", err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+	} else {
+		w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+		w.Write(resp)
+		w.Write([]byte{'\n'})
+	}
+
+	api.CreateChangeLogRawTx(api.ApiChange, api.Updated+"content invalidation job: #"+strconv.FormatUint(*job.ID, 10), inf.User, inf.Tx.Tx)
+}
+
+// Used by DELETE requests to `/jobs`, deletes an existing content invalidation job
+func Delete(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	var dsid uint
+	var createdBy uint
+	row := inf.Tx.Tx.QueryRow(`SELECT job_deliveryservice, job_user FROM job WHERE id=$1`, inf.Params["id"])
+	if err := row.Scan(&dsid, &createdBy); err != nil {
+		if err == sql.ErrNoRows {
+			userErr = fmt.Errorf("No job by id '%s'!", inf.Params["id"])
+			errCode = http.StatusNotFound
+		} else {
+			sysErr = fmt.Errorf("Getting info for job #%s: %v", inf.Params["id"], err)
+			errCode = http.StatusInternalServerError
+		}
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	if userErr, sysErr, errCode = IsUserAuthorizedToModifyDSID(inf, dsid); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	if userErr, sysErr, errCode = IsUserAuthorizedToModifyJobsMadeByUserID(inf, createdBy); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	result := tc.InvalidationJob{}
+	row = inf.Tx.Tx.QueryRow(deleteQuery, inf.Params["id"])
+	err := row.Scan(&result.AssetURL,
+		&result.CreatedBy,
+		&result.DeliveryService,
+		&result.ID,
+		&result.Keyword,
+		&result.Parameters,
+		&result.StartTime)
+	if err != nil {
+		sysErr = fmt.Errorf("deleting job #%s: %v", inf.Params["id"], err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+		return
+	}
+
+	if err = setRevalFlags(dsid, inf.Tx.Tx); err != nil {
+		userErr = errors.New("Something wicked happened... Please queue server updates (or set reval_pending=true) manually to avoid problems!")
+		sysErr = fmt.Errorf("setting reval_pending after deleting job #%s: %v", inf.Params["id"], err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	} else {
+		response := apiResponse{[]tc.Alert{tc.Alert{"Content invalidation job was deleted", tc.SuccessLevel.String()}}, result}
+		resp, err := json.Marshal(response)
+		if err != nil {
+			sysErr = fmt.Errorf("encoding response: %v", err)
+			errCode = http.StatusInternalServerError
+			api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+		} else {
+			w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+			w.Write(resp)
+			w.Write([]byte{'\n'})
+		}
+	}
+
+	api.CreateChangeLogRawTx(api.ApiChange, api.Deleted+"content invalidation job: #"+strconv.FormatUint(*result.ID, 10), inf.User, inf.Tx.Tx)
+}
+
+// Used by PATCH requests to `/jobs`, updates an existing content invalidation job
+// using new values for the fields found in the provided request body.
+func Patch(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	var oFQDN string
+	var dsid uint
+	var uid uint
+	var ttl uint
+	job := tc.InvalidationJob{}
+	patchInfo := inf.Tx.Tx.QueryRow(patchInfoQuery, inf.Params["id"])
+	err := patchInfo.Scan(&job.ID,
+		&job.CreatedBy,
+		&uid,
+		&dsid,
+		&job.DeliveryService,
+		&job.AssetURL,
+		&ttl,
+		&job.Parameters,
+		&job.StartTime,
+		&oFQDN)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			userErr = fmt.Errorf("No job found by id %s", inf.Params["id"])
+			errCode = http.StatusNotFound
+		} else {
+			sysErr = fmt.Errorf("fetching job patch info: %v", err)
+			errCode = http.StatusInternalServerError
+		}
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	if userErr, sysErr, errCode = IsUserAuthorizedToModifyDSID(inf, dsid); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	if userErr, sysErr, errCode = IsUserAuthorizedToModifyJobsMadeByUsername(inf, *job.CreatedBy); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	input := tc.InvalidationJobInput{}
+	cType := r.Header.Get(http.CanonicalHeaderKey("content-type"))
+	if cType == tc.ApplicationJson || cType == "" {
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&input); err != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, fmt.Errorf("Unable to parse input: %v", err), fmt.Errorf("parsing jobs/ PATCH: %v", err))
+			return
+		}
+	} else {
+		w.Header().Set(http.CanonicalHeaderKey("accept"), strings.Join([]string{tc.ApplicationJson, "application/x-www-form-urlencoded", "multipart/form-data"}, ";"))
+		err := fmt.Errorf("unsupported content-type: %s", cType)
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusUnsupportedMediaType, err, err)
+		return
+	}
+
+	if input.DeliveryService != nil {
+		userErr = errors.New("'deliveryService' cannot be modified on an existing job!")
+		errCode = http.StatusBadRequest
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+		return
+	}
+
+	if input.Regex != nil {
+		if !strings.HasPrefix(*input.Regex, "/") && !strings.HasPrefix(*input.Regex, "\\/") {
+			userErr = errors.New("'regex' must begin with '/'!")
+			errCode = http.StatusBadRequest
+			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+			return
+		}
+		if _, err := regexp.Compile(*input.Regex); err != nil {
+			userErr = fmt.Errorf("Invalid regular expression: %v", err)
+			errCode = http.StatusBadRequest
+			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+			return
+		}
+		*job.AssetURL = oFQDN + *input.Regex
+	}
+
+	if input.TTL != nil {
+		t, err := input.TTLHours()
+		if err != nil {
+			userErr = errors.New("Invalid TTL - should be number of hours or a duration e.g. '2h'")
+			sysErr = fmt.Errorf("Parsing duration: %v", err)
+			errCode = http.StatusBadRequest
+			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+			return
+		}
+		if t != ttl {
+			*job.Parameters = fmt.Sprintf("TTL:%dh", t)
+		}
+	}
+
+	if input.StartTime != nil {
+		if input.StartTime.Before(time.Now()) {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("'startTime' must be in the future!"), nil)
+			return
+		}
+		job.StartTime = input.StartTime
+	}
+
+	result := tc.InvalidationJob{}
+	row := inf.Tx.Tx.QueryRow(patchUpdateQuery, job.AssetURL, job.Parameters, job.StartTime.Time, job.ID)
+	err = row.Scan(&result.AssetURL,
+		&result.CreatedBy,
+		&result.DeliveryService,
+		&result.ID,
+		&result.Keyword,
+		&result.Parameters,
+		&result.StartTime)
+	if err != nil {
+		sysErr = fmt.Errorf("Patching a job: %v", err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+		return
+	}
+
+	if err = setRevalFlags(*result.DeliveryService, inf.Tx.Tx); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Setting reval flags: %v", err))
+		return
+	}
+
+	response := apiResponse{
+		[]tc.Alert{
+			tc.Alert{
+				"Content invalidation job updated",
+				tc.SuccessLevel.String(),
+			},
+		},
+		result,
+	}
+
+	resp, err := json.Marshal(response)
+	if err != nil {
+		sysErr = fmt.Errorf("encoding response: %v", err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+	} else {
+		w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+		w.Write(resp)
+		w.Write([]byte{'\n'})
+	}
+
+	api.CreateChangeLogRawTx(api.ApiChange, api.Updated+"content invalidation job: #"+strconv.FormatUint(*result.ID, 10), inf.User, inf.Tx.Tx)
+}
+
+func setRevalFlags(d interface{}, tx *sql.Tx) error {
+	var useReval string
+	row := tx.QueryRow(`SELECT value FROM parameter WHERE name='use_reval_pending' AND config_file='global'`)
+	if err := row.Scan(&useReval); err != nil {
+		if err != sql.ErrNoRows {
+			return err
+		}
+		useReval = "0"
+	}
+
+	col := "reval_pending"
+	if useReval == "0" {
+		col = "upd_pending"
+	}
+
+	var q string
+	switch t := d.(type) {
+	case uint:
+		q = fmt.Sprintf(revalQuery, col, "id")
+	case string:
+		q = fmt.Sprintf(revalQuery, col, "xml_id")
+	default:
+		return fmt.Errorf("Invalid type passed to 'setRevalFlags': %v", t)
+	}
+
+	row = tx.QueryRow(q, d)
+	if err := row.Scan(); err != nil && err != sql.ErrNoRows {
+		return err
+	}
+	return nil
+}
+
+// Checks if the current user's (identified in the APIInfo) tenant has permissions to
+// edit a Delivery Service. `ds` is expected to be the integral, unique identifer of the
+// Delivery Service in question.
+//
+// This returns, in order, an error suitable for the requesting user to see (if an
+// error occurred), an error for printing to the logs (if an error occurred) and an
+// HTTP response code. The returned code only has meaning if at least one of the
+// returned errors is not nil, otherwise its value is undefined.
+func IsUserAuthorizedToModifyDSID(inf *api.APIInfo, ds uint) (error, error, int) {
+	var t uint
+	row := inf.Tx.Tx.QueryRow(`SELECT tenant_id FROM deliveryservice where id=$1`, ds)
+	if err := row.Scan(&t); err != nil {
+		return nil, fmt.Errorf("checking user #%d's permissions for ds #%d: %v", inf.User.ID, ds, err), http.StatusInternalServerError
+	}
+
+	ok, err := tenant.IsResourceAuthorizedToUserTx(int(t), inf.User, inf.Tx.Tx)
+	if err != nil {
+		return nil, fmt.Errorf("checking user #%d's permissions for ds #%d: %v", inf.User.ID, ds, err), http.StatusInternalServerError
+	}
+
+	if !ok {
+		return errors.New("Your tenant does not have permissions to create, delete, or modify content invalidation jobs for this Delivery Service!"),
+			nil,
+			http.StatusForbidden
+	}
+	return nil, nil, 0
+}
+
+// Checks if the current user's (identified in the APIInfo) tenant has permissions to
+// edit a Delivery Service. `ds` is expected to be the "xml_id" of the
+// Delivery Service in question.
+//
+// This returns, in order, an error suitable for the requesting user to see (if an
+// error occurred), an error for printing to the logs (if an error occurred) and an
+// HTTP response code. The returned code only has meaning if at least one of the
+// returned errors is not nil, otherwise its value is undefined.
+func IsUserAuthorizedToModifyDSXMLID(inf *api.APIInfo, ds string) (error, error, int) {
+	var t uint
+	row := inf.Tx.Tx.QueryRow(`SELECT tenant_id FROM deliveryservice where xml_id=$1`, ds)
+	if err := row.Scan(&t); err != nil {
+		return nil, fmt.Errorf("checking user #%d's permissions for ds '%s': %v", inf.User.ID, ds, err), http.StatusInternalServerError
+	}
+
+	log.Debugln("passed initial SELECT")
+
+	ok, err := tenant.IsResourceAuthorizedToUserTx(int(t), inf.User, inf.Tx.Tx)
+	if err != nil {
+		return nil, fmt.Errorf("checking user #%d's permissions for ds '%s': %v", inf.User.ID, ds, err), http.StatusInternalServerError
+	}
+
+	if !ok {
+		return errors.New("Your tenant does not have permissions to create, delete, or modify content invalidation jobs for this Delivery Service!"),
+			nil,
+			http.StatusForbidden
+	}
+	return nil, nil, 0
+}
+
+// Checks if the current user's (identified in the APIInfo) tenant has permissions to
+// edit on par with the user identified by `u`. `u` is expected to be the integral,
+// unique identifer of the user in question (not the current, requesting user).
+//
+// This returns, in order, an error suitable for the requesting user to see (if an
+// error occurred), an error for printing to the logs (if an error occurred) and an
+// HTTP response code. The returned code only has meaning if at least one of the
+// returned errors is not nil, otherwise its value is undefined.
+func IsUserAuthorizedToModifyJobsMadeByUserID(inf *api.APIInfo, u uint) (error, error, int) {
+	var t uint
+	row := inf.Tx.Tx.QueryRow(`SELECT tenant_id FROM tm_user where id=$1`, u)
+	if err := row.Scan(&t); err != nil {
+		return nil, fmt.Errorf("checking user #%d's permissions for user #%d: %v", inf.User.ID, u, err), http.StatusInternalServerError
+	}
+
+	ok, err := tenant.IsResourceAuthorizedToUserTx(int(t), inf.User, inf.Tx.Tx)
+	if err != nil {
+		return nil, fmt.Errorf("checking user #%d's permissions for user #%d: %v", inf.User.ID, u, err), http.StatusInternalServerError
+	}
+
+	if !ok {
+		return errors.New("Your tenant does not have permissions to modify this content invalidation job!"),
+			nil,
+			http.StatusForbidden
+	}
+	return nil, nil, 0
+}
+
+// Checks if the current user's (identified in the APIInfo) tenant has permissions to
+// edit on par with the user identified by `u`. `u` is expected to be the username of
+// the user in question (not the current, requesting user).
+//
+// This returns, in order, an error suitable for the requesting user to see (if an
+// error occurred), an error for printing to the logs (if an error occurred) and an
+// HTTP response code. The returned code only has meaning if at least one of the
+// returned errors is not nil, otherwise its value is undefined.
+func IsUserAuthorizedToModifyJobsMadeByUsername(inf *api.APIInfo, u string) (error, error, int) {
+	var t uint
+	row := inf.Tx.Tx.QueryRow(`SELECT tenant_id FROM tm_user where username=$1`, u)
+	if err := row.Scan(&t); err != nil {
+		return nil, fmt.Errorf("checking user #%d's permissions for user '%s': %v", inf.User.ID, u, err), http.StatusInternalServerError
+	}
+
+	ok, err := tenant.IsResourceAuthorizedToUserTx(int(t), inf.User, inf.Tx.Tx)
+	if err != nil {
+		return nil, fmt.Errorf("checking user #%d's permissions for user '%s': %v", inf.User.ID, u, err), http.StatusInternalServerError
+	}
+
+	if !ok {
+		return errors.New("Your tenant does not have permissions to modify this content invalidation job!"),
+			nil,
+			http.StatusForbidden
+	}
+	return nil, nil, 0
+}

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -825,9 +825,9 @@ func IsUserAuthorizedToModifyDSID(inf *api.APIInfo, ds uint) (error, error, int)
 	}
 
 	if !ok {
-		return errors.New("Your tenant does not have permissions to create, delete, or modify content invalidation jobs for this Delivery Service!"),
-			nil,
-			http.StatusForbidden
+		return errors.New("No such Delivery Service!"),
+			fmt.Errorf("User %s attempted to modify DS %d, which is outside of its tenancy (have: %d, want: %d)", inf.User.UserName, ds, inf.User.TenantId, t),
+			http.StatusNotFound
 	}
 	return nil, nil, 0
 }
@@ -855,9 +855,9 @@ func IsUserAuthorizedToModifyDSXMLID(inf *api.APIInfo, ds string) (error, error,
 	}
 
 	if !ok {
-		return errors.New("Your tenant does not have permissions to create, delete, or modify content invalidation jobs for this Delivery Service!"),
-			nil,
-			http.StatusForbidden
+		return errors.New("No such Delivery Service!"),
+			fmt.Errorf("User %s attempted to modify DS %s, which is outside of its tenancy (have: %d, want: %d)", inf.User.UserName, ds, inf.User.TenantId, t),
+			http.StatusNotFound
 	}
 	return nil, nil, 0
 }

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -192,7 +192,7 @@ SELECT job.id AS id,
        job.start_time AS start_time,
        origin.protocol || '://' || origin.fqdn || rtrim(concat(':', origin.port), ':') AS OFQDN
 FROM job
-INNER JOIN origin ON origin.deliveryservice=job.job_deliveryservice
+INNER JOIN origin ON origin.deliveryservice=job.job_deliveryservice AND origin.is_primary
 INNER JOIN tm_user ON tm_user.id=job.job_user
 INNER JOIN deliveryservice ON deliveryservice.id=job.job_deliveryservice
 WHERE job.id=$1

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -237,7 +237,7 @@ func (job *InvalidationJob) Read() ([]interface{}, error, error, int) {
 		"dsId":            dbhelpers.WhereColumnInfo{"job.job_deliveryservice", api.IsInt},
 	}
 
-	where, orderBy, queryValues, errs := dbhelpers.BuildWhereAndOrderBy(job.APIInfo().Params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(job.APIInfo().Params, queryParamsToSQLCols)
 	if len(errs) > 0 {
 		var b strings.Builder
 		b.WriteString("Reading jobs:")
@@ -250,7 +250,7 @@ func (job *InvalidationJob) Read() ([]interface{}, error, error, int) {
 	}
 
 	// TODO: check tenancy here
-	query := readQuery + where + orderBy
+	query := readQuery + where + orderBy + pagination
 
 	log.Debugln("generated job query: " + query)
 	log.Debugf("executing with values: %++v\n", queryValues)

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -474,6 +474,14 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if job.StartTime.Before(time.Now()) {
+		userErr = errors.New("Cannot modify a job that has already started!")
+		errCode = http.StatusMethodNotAllowed
+		w.Header().Set(http.CanonicalHeaderKey("allow"), "GET,HEAD,DELETE")
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+		return
+	}
+
 	if *job.DeliveryService != *input.DeliveryService {
 		userErr = errors.New("Cannot change 'deliveryService' of existing invalidation job!")
 		errCode = http.StatusConflict
@@ -494,6 +502,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
 		return
 	}
+
 
 	row = inf.Tx.Tx.QueryRow(updateQuery,
 		input.AssetURL,
@@ -826,7 +835,7 @@ func IsUserAuthorizedToModifyDSID(inf *api.APIInfo, ds uint) (error, error, int)
 
 	if !ok {
 		return errors.New("No such Delivery Service!"),
-			fmt.Errorf("User %s attempted to modify DS %d, which is outside of its tenancy (have: %d, want: %d)", inf.User.UserName, ds, inf.User.TenantId, t),
+			fmt.Errorf("User %s attempted to modify DS %d, which is outside of its tenancy (have: %d, want: %d)", inf.User.UserName, ds, inf.User.TenantID, t),
 			http.StatusNotFound
 	}
 	return nil, nil, 0
@@ -856,7 +865,7 @@ func IsUserAuthorizedToModifyDSXMLID(inf *api.APIInfo, ds string) (error, error,
 
 	if !ok {
 		return errors.New("No such Delivery Service!"),
-			fmt.Errorf("User %s attempted to modify DS %s, which is outside of its tenancy (have: %d, want: %d)", inf.User.UserName, ds, inf.User.TenantId, t),
+			fmt.Errorf("User %s attempted to modify DS %s, which is outside of its tenancy (have: %d, want: %d)", inf.User.UserName, ds, inf.User.TenantID, t),
 			http.StatusNotFound
 	}
 	return nil, nil, 0

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -24,7 +24,6 @@ import "encoding/json"
 import "errors"
 import "fmt"
 import "net/http"
-import "regexp"
 import "strconv"
 import "strings"
 import "time"
@@ -163,23 +162,24 @@ RETURNING job.asset_url,
            job.start_time
 `
 
-const patchInfoQuery = `
-SELECT job.id AS id,
-       tm_user.username AS createdBy,
-       job.job_user AS createdByID,
-       job.job_deliveryservice AS dsid,
-       deliveryservice.xml_id AS dsxmlid,
-       job.asset_url AS assetURL,
-       ltrim(rtrim(job.parameters, 'h'), 'TTL:')::bigint AS ttl,
-       job.parameters,
-       job.start_time AS start_time,
-       origin.protocol || '://' || origin.fqdn || rtrim(concat(':', origin.port), ':') AS OFQDN
-FROM job
-INNER JOIN origin ON origin.deliveryservice=job.job_deliveryservice
-INNER JOIN tm_user ON tm_user.id=job.job_user
-INNER JOIN deliveryservice ON deliveryservice.id=job.job_deliveryservice
-WHERE job.id=$1
-`
+// See the commented-out 'Patch' function for why this is commented out
+// const patchInfoQuery = `
+// SELECT job.id AS id,
+//        tm_user.username AS createdBy,
+//        job.job_user AS createdByID,
+//        job.job_deliveryservice AS dsid,
+//        deliveryservice.xml_id AS dsxmlid,
+//        job.asset_url AS assetURL,
+//        ltrim(rtrim(job.parameters, 'h'), 'TTL:')::bigint AS ttl,
+//        job.parameters,
+//        job.start_time AS start_time,
+//        origin.protocol || '://' || origin.fqdn || rtrim(concat(':', origin.port), ':') AS OFQDN
+// FROM job
+// INNER JOIN origin ON origin.deliveryservice=job.job_deliveryservice
+// INNER JOIN tm_user ON tm_user.id=job.job_user
+// INNER JOIN deliveryservice ON deliveryservice.id=job.job_deliveryservice
+// WHERE job.id=$1
+// `
 
 const putInfoQuery = `
 SELECT job.id AS id,
@@ -618,156 +618,159 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 
 // Used by PATCH requests to `/jobs`, updates an existing content invalidation job
 // using new values for the fields found in the provided request body.
-func Patch(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
-		return
-	}
-	defer inf.Close()
+//
+// TO doesn't have the functionality yet to support this request method safely.
+//
+// func Patch(w http.ResponseWriter, r *http.Request) {
+// 	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+// 	if userErr != nil || sysErr != nil {
+// 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+// 		return
+// 	}
+// 	defer inf.Close()
 
-	var oFQDN string
-	var dsid uint
-	var uid uint
-	var ttl uint
-	job := tc.InvalidationJob{}
-	patchInfo := inf.Tx.Tx.QueryRow(patchInfoQuery, inf.Params["id"])
-	err := patchInfo.Scan(&job.ID,
-		&job.CreatedBy,
-		&uid,
-		&dsid,
-		&job.DeliveryService,
-		&job.AssetURL,
-		&ttl,
-		&job.Parameters,
-		&job.StartTime,
-		&oFQDN)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			userErr = fmt.Errorf("No job found by id %s", inf.Params["id"])
-			errCode = http.StatusNotFound
-		} else {
-			sysErr = fmt.Errorf("fetching job patch info: %v", err)
-			errCode = http.StatusInternalServerError
-		}
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
-		return
-	}
+// 	var oFQDN string
+// 	var dsid uint
+// 	var uid uint
+// 	var ttl uint
+// 	job := tc.InvalidationJob{}
+// 	patchInfo := inf.Tx.Tx.QueryRow(patchInfoQuery, inf.Params["id"])
+// 	err := patchInfo.Scan(&job.ID,
+// 		&job.CreatedBy,
+// 		&uid,
+// 		&dsid,
+// 		&job.DeliveryService,
+// 		&job.AssetURL,
+// 		&ttl,
+// 		&job.Parameters,
+// 		&job.StartTime,
+// 		&oFQDN)
+// 	if err != nil {
+// 		if err == sql.ErrNoRows {
+// 			userErr = fmt.Errorf("No job found by id %s", inf.Params["id"])
+// 			errCode = http.StatusNotFound
+// 		} else {
+// 			sysErr = fmt.Errorf("fetching job patch info: %v", err)
+// 			errCode = http.StatusInternalServerError
+// 		}
+// 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+// 		return
+// 	}
 
-	if userErr, sysErr, errCode = IsUserAuthorizedToModifyDSID(inf, dsid); userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
-		return
-	}
+// 	if userErr, sysErr, errCode = IsUserAuthorizedToModifyDSID(inf, dsid); userErr != nil || sysErr != nil {
+// 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+// 		return
+// 	}
 
-	if userErr, sysErr, errCode = IsUserAuthorizedToModifyJobsMadeByUsername(inf, *job.CreatedBy); userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
-		return
-	}
+// 	if userErr, sysErr, errCode = IsUserAuthorizedToModifyJobsMadeByUsername(inf, *job.CreatedBy); userErr != nil || sysErr != nil {
+// 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+// 		return
+// 	}
 
-	input := tc.InvalidationJobInput{}
-	cType := r.Header.Get(http.CanonicalHeaderKey("content-type"))
-	if cType == tc.ApplicationJson || cType == "" {
-		decoder := json.NewDecoder(r.Body)
-		if err := decoder.Decode(&input); err != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, fmt.Errorf("Unable to parse input: %v", err), fmt.Errorf("parsing jobs/ PATCH: %v", err))
-			return
-		}
-	} else {
-		w.Header().Set(http.CanonicalHeaderKey("accept"), strings.Join([]string{tc.ApplicationJson, "application/x-www-form-urlencoded", "multipart/form-data"}, ";"))
-		err := fmt.Errorf("unsupported content-type: %s", cType)
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusUnsupportedMediaType, err, err)
-		return
-	}
+// 	input := tc.InvalidationJobInput{}
+// 	cType := r.Header.Get(http.CanonicalHeaderKey("content-type"))
+// 	if cType == tc.ApplicationJson || cType == "" {
+// 		decoder := json.NewDecoder(r.Body)
+// 		if err := decoder.Decode(&input); err != nil {
+// 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, fmt.Errorf("Unable to parse input: %v", err), fmt.Errorf("parsing jobs/ PATCH: %v", err))
+// 			return
+// 		}
+// 	} else {
+// 		w.Header().Set(http.CanonicalHeaderKey("accept"), strings.Join([]string{tc.ApplicationJson, "application/x-www-form-urlencoded", "multipart/form-data"}, ";"))
+// 		err := fmt.Errorf("unsupported content-type: %s", cType)
+// 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusUnsupportedMediaType, err, err)
+// 		return
+// 	}
 
-	if input.DeliveryService != nil {
-		userErr = errors.New("'deliveryService' cannot be modified on an existing job!")
-		errCode = http.StatusBadRequest
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
-		return
-	}
+// 	if input.DeliveryService != nil {
+// 		userErr = errors.New("'deliveryService' cannot be modified on an existing job!")
+// 		errCode = http.StatusBadRequest
+// 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+// 		return
+// 	}
 
-	if input.Regex != nil {
-		if !strings.HasPrefix(*input.Regex, "/") && !strings.HasPrefix(*input.Regex, "\\/") {
-			userErr = errors.New("'regex' must begin with '/'!")
-			errCode = http.StatusBadRequest
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
-			return
-		}
-		if _, err := regexp.Compile(*input.Regex); err != nil {
-			userErr = fmt.Errorf("Invalid regular expression: %v", err)
-			errCode = http.StatusBadRequest
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
-			return
-		}
-		*job.AssetURL = oFQDN + *input.Regex
-	}
+// 	if input.Regex != nil {
+// 		if !strings.HasPrefix(*input.Regex, "/") && !strings.HasPrefix(*input.Regex, "\\/") {
+// 			userErr = errors.New("'regex' must begin with '/'!")
+// 			errCode = http.StatusBadRequest
+// 			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+// 			return
+// 		}
+// 		if _, err := regexp.Compile(*input.Regex); err != nil {
+// 			userErr = fmt.Errorf("Invalid regular expression: %v", err)
+// 			errCode = http.StatusBadRequest
+// 			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
+// 			return
+// 		}
+// 		*job.AssetURL = oFQDN + *input.Regex
+// 	}
 
-	if input.TTL != nil {
-		t, err := input.TTLHours()
-		if err != nil {
-			userErr = errors.New("Invalid TTL - should be number of hours or a duration e.g. '2h'")
-			sysErr = fmt.Errorf("Parsing duration: %v", err)
-			errCode = http.StatusBadRequest
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
-			return
-		}
-		if t != ttl {
-			*job.Parameters = fmt.Sprintf("TTL:%dh", t)
-		}
-	}
+// 	if input.TTL != nil {
+// 		t, err := input.TTLHours()
+// 		if err != nil {
+// 			userErr = errors.New("Invalid TTL - should be number of hours or a duration e.g. '2h'")
+// 			sysErr = fmt.Errorf("Parsing duration: %v", err)
+// 			errCode = http.StatusBadRequest
+// 			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+// 			return
+// 		}
+// 		if t != ttl {
+// 			*job.Parameters = fmt.Sprintf("TTL:%dh", t)
+// 		}
+// 	}
 
-	if input.StartTime != nil {
-		if input.StartTime.Before(time.Now()) {
-			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("'startTime' must be in the future!"), nil)
-			return
-		}
-		job.StartTime = input.StartTime
-	}
+// 	if input.StartTime != nil {
+// 		if input.StartTime.Before(time.Now()) {
+// 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("'startTime' must be in the future!"), nil)
+// 			return
+// 		}
+// 		job.StartTime = input.StartTime
+// 	}
 
-	result := tc.InvalidationJob{}
-	row := inf.Tx.Tx.QueryRow(patchUpdateQuery, job.AssetURL, job.Parameters, job.StartTime.Time, job.ID)
-	err = row.Scan(&result.AssetURL,
-		&result.CreatedBy,
-		&result.DeliveryService,
-		&result.ID,
-		&result.Keyword,
-		&result.Parameters,
-		&result.StartTime)
-	if err != nil {
-		sysErr = fmt.Errorf("Patching a job: %v", err)
-		errCode = http.StatusInternalServerError
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
-		return
-	}
+// 	result := tc.InvalidationJob{}
+// 	row := inf.Tx.Tx.QueryRow(patchUpdateQuery, job.AssetURL, job.Parameters, job.StartTime.Time, job.ID)
+// 	err = row.Scan(&result.AssetURL,
+// 		&result.CreatedBy,
+// 		&result.DeliveryService,
+// 		&result.ID,
+// 		&result.Keyword,
+// 		&result.Parameters,
+// 		&result.StartTime)
+// 	if err != nil {
+// 		sysErr = fmt.Errorf("Patching a job: %v", err)
+// 		errCode = http.StatusInternalServerError
+// 		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+// 		return
+// 	}
 
-	if err = setRevalFlags(*result.DeliveryService, inf.Tx.Tx); err != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Setting reval flags: %v", err))
-		return
-	}
+// 	if err = setRevalFlags(*result.DeliveryService, inf.Tx.Tx); err != nil {
+// 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Setting reval flags: %v", err))
+// 		return
+// 	}
 
-	response := apiResponse{
-		[]tc.Alert{
-			tc.Alert{
-				"Content invalidation job updated",
-				tc.SuccessLevel.String(),
-			},
-		},
-		result,
-	}
+// 	response := apiResponse{
+// 		[]tc.Alert{
+// 			tc.Alert{
+// 				"Content invalidation job updated",
+// 				tc.SuccessLevel.String(),
+// 			},
+// 		},
+// 		result,
+// 	}
 
-	resp, err := json.Marshal(response)
-	if err != nil {
-		sysErr = fmt.Errorf("encoding response: %v", err)
-		errCode = http.StatusInternalServerError
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
-	} else {
-		w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
-		w.Write(resp)
-		w.Write([]byte{'\n'})
-	}
+// 	resp, err := json.Marshal(response)
+// 	if err != nil {
+// 		sysErr = fmt.Errorf("encoding response: %v", err)
+// 		errCode = http.StatusInternalServerError
+// 		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
+// 	} else {
+// 		w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+// 		w.Write(resp)
+// 		w.Write([]byte{'\n'})
+// 	}
 
-	api.CreateChangeLogRawTx(api.ApiChange, api.Updated+"content invalidation job: #"+strconv.FormatUint(*result.ID, 10), inf.User, inf.Tx.Tx)
-}
+// 	api.CreateChangeLogRawTx(api.ApiChange, api.Updated+"content invalidation job: #"+strconv.FormatUint(*result.ID, 10), inf.User, inf.Tx.Tx)
+// }
 
 func setRevalFlags(d interface{}, tx *sql.Tx) error {
 	var useReval string

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -309,16 +309,9 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 	job := tc.InvalidationJobInput{}
 	cType := r.Header.Get(http.CanonicalHeaderKey("content-type"))
-	if cType == tc.ApplicationJson || cType == "" {
-		decoder := json.NewDecoder(r.Body)
-		if err := decoder.Decode(&job); err != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("Unable to parse Invalidation Job"), fmt.Errorf("parsing jobs/ POST: %v", err))
-			return
-		}
-	} else {
-		w.Header().Set(http.CanonicalHeaderKey("accept"), strings.Join([]string{tc.ApplicationJson, "application/x-www-form-urlencoded", "multipart/form-data"}, ";"))
-		err := fmt.Errorf("unsupported content-type: %s", cType)
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusUnsupportedMediaType, err, err)
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&job); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("Unable to parse Invalidation Job"), fmt.Errorf("parsing jobs/ POST: %v", err))
 		return
 	}
 
@@ -452,20 +445,11 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	input := tc.InvalidationJob{}
-	cType := r.Header.Get(http.CanonicalHeaderKey("content-type"))
-	if cType == tc.ApplicationJson || cType == "" {
-		decoder := json.NewDecoder(r.Body)
-		if err := decoder.Decode(&input); err != nil {
-			userErr = fmt.Errorf("Unable to parse input: %v", err)
-			sysErr = fmt.Errorf("parsing input to PUT jobs?id=%s: %v", inf.Params["id"], err)
-			errCode = http.StatusBadRequest
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
-			return
-		}
-	} else {
-		w.Header().Set(http.CanonicalHeaderKey("accept"), strings.Join([]string{tc.ApplicationJson, "application/x-www-form-urlencoded", "multipart/form-data"}, ";"))
-		err := fmt.Errorf("unsupported content-type: %s", cType)
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusUnsupportedMediaType, err, err)
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		userErr = fmt.Errorf("Unable to parse input: %v", err)
+		sysErr = fmt.Errorf("parsing input to PUT jobs?id=%s: %v", inf.Params["id"], err)
+		errCode = http.StatusBadRequest
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -143,24 +143,24 @@ RETURNING job.asset_url,
           job.start_time
 `
 
-const patchUpdateQuery = `
-UPDATE job
-SET asset_url=$1,
-    parameters=$2,
-    start_time=$3
-WHERE id=$4
-RETURNING job.asset_url,
-          (SELECT tm_user.username
-           FROM tm_user
-           WHERE tm_user.id=job.job_user) AS created_by,
-           (SELECT deliveryservice.xml_id
-            FROM deliveryservice
-            WHERE deliveryservice.id=job.job_deliveryservice) AS deliveryservice,
-           job.id,
-           job.keyword,
-           job.parameters,
-           job.start_time
-`
+// const patchUpdateQuery = `
+// UPDATE job
+// SET asset_url=$1,
+//     parameters=$2,
+//     start_time=$3
+// WHERE id=$4
+// RETURNING job.asset_url,
+//           (SELECT tm_user.username
+//            FROM tm_user
+//            WHERE tm_user.id=job.job_user) AS created_by,
+//            (SELECT deliveryservice.xml_id
+//             FROM deliveryservice
+//             WHERE deliveryservice.id=job.job_deliveryservice) AS deliveryservice,
+//            job.id,
+//            job.keyword,
+//            job.parameters,
+//            job.start_time
+// `
 
 // See the commented-out 'Patch' function for why this is commented out
 // const patchInfoQuery = `
@@ -477,6 +477,13 @@ func Update(w http.ResponseWriter, r *http.Request) {
 
 	if err := input.Validate(); err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, err, nil)
+		return
+	}
+
+	if !strings.HasPrefix(*input.AssetURL, oFQDN) {
+		userErr = fmt.Errorf("Cannot set asset URL that does not start with Delivery Service origin URL: %s", oFQDN)
+		errCode = http.StatusBadRequest
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/userinvalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/userinvalidationjobs.go
@@ -1,0 +1,184 @@
+package invalidationjobs
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "encoding/json"
+import "fmt"
+import "net/http"
+import "strconv"
+import "time"
+
+import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+
+const userReadQuery = `
+SELECT job.agent,
+       job.asset_url,
+       job.asset_type,
+       (
+       	SELECT tm_user.username
+       	FROM tm_user
+       	WHERE tm_user.id=$1
+       ) AS username,
+       (
+       	SELECT deliveryservice.xml_id
+       	FROM deliveryservice
+       	WHERE deliveryservice.id=job.job_deliveryservice
+       ) AS deliveryservice,
+       job.entered_time,
+       job.id,
+       job.keyword,
+       job.object_name,
+       job.object_type,
+       job.parameters
+FROM job
+WHERE job.job_user=$1
+`
+
+// Creates a new job for the current user (via POST request to `/user/current/jobs`)
+// this uses its own special format encoded in the tc.UserInvalidationJobInput structure
+func CreateUserJob(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	job := tc.UserInvalidationJobInput{}
+	if err := api.Parse(r.Body, inf.Tx.Tx, &job); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, err, fmt.Errorf("error parsing jobs POST body: %v", err))
+		return
+	}
+
+	if userErr, sysErr, errCode = IsUserAuthorizedToModifyDSID(inf, *job.DSID); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+
+	resultRow := inf.Tx.Tx.QueryRow(insertQuery,
+		job.DSID,
+		job.Regex,
+		time.Now(),
+		job.DSID,
+		inf.User.ID,
+		fmt.Sprintf("TTL:%dh", *job.TTL),
+		job.StartTime.Time)
+
+	result := tc.InvalidationJob{}
+	err := resultRow.Scan(&result.AssetURL,
+		&result.DeliveryService,
+		&result.ID,
+		&result.CreatedBy,
+		&result.Keyword,
+		&result.Parameters,
+		&result.StartTime)
+	if err != nil {
+		userErr, sysErr, code := api.ParseDBError(err)
+		api.HandleErr(w, r, inf.Tx.Tx, code, userErr, sysErr)
+		return
+	}
+
+	if err := setRevalFlags(*job.DSID, inf.Tx.Tx); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("setting reval flags: %v", err))
+	} else {
+		resp, err := json.Marshal(apiResponse{[]tc.Alert{{"Invalidation Job creation was successful.", tc.SuccessLevel.String()}}, result})
+		if err != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Marshaling JSON: %v", err))
+		} else {
+			w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+			w.Header().Set(http.CanonicalHeaderKey("location"), inf.Config.URL.Scheme+"://"+r.Host+"/api/1.4/jobs?id="+strconv.FormatUint(uint64(*result.ID), 10))
+			w.WriteHeader(http.StatusCreated)
+			w.Write(resp)
+			w.Write([]byte("\n"))
+		}
+	}
+	api.CreateChangeLogRawTx(api.ApiChange, api.Created+"content invalidation job: #"+strconv.FormatUint(*result.ID, 10), inf.User, inf.Tx.Tx)
+}
+
+// Gets all jobs that were created by the requesting user, and returns them in
+// in a special format encoded in the tc.UserInvalidationJob structure
+func GetUserJobs(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	rows, err := inf.Tx.Query(userReadQuery, inf.User.ID)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Fetching user jobs: %v", err))
+		return
+	}
+	defer rows.Close()
+
+	jobs := []tc.UserInvalidationJob{}
+	for rows.Next() {
+		var j tc.UserInvalidationJob
+		err := rows.Scan(&j.Agent,
+			&j.AssetType,
+			&j.AssetURL,
+			&j.Username,
+			&j.DeliveryService,
+			&j.EnteredTime,
+			&j.ID,
+			&j.Keyword,
+			&j.ObjectName,
+			&j.ObjectType,
+			&j.Parameters)
+
+		if err != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Parsing user job DB row: %v", err))
+			return
+		}
+
+		jobs = append(jobs, j)
+	}
+
+	if err := rows.Err(); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Parsing user job DB rows: %v", err))
+		return
+	}
+
+	// This cannot be done in the scanning loop, because pq will throw an error if you try to make
+	// another query before exhausting the rows returned by an earlier query
+	filtered := []tc.UserInvalidationJob{}
+	for _, j := range jobs {
+		userErr, sysErr, errCode := IsUserAuthorizedToModifyDSXMLID(inf, *j.DeliveryService)
+		if sysErr != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+			return
+		} else if userErr == nil {
+			filtered = append(filtered, j)
+		}
+	}
+
+	resp, err := json.Marshal(struct {
+		Response []tc.UserInvalidationJob `json:"response"`
+	}{filtered})
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("encoding user jobs response: %v", err))
+	} else {
+		w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+		w.Write(resp)
+		w.Write([]byte("\n"))
+	}
+}

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/userinvalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/userinvalidationjobs.go
@@ -159,8 +159,8 @@ func GetUserJobs(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		var j tc.UserInvalidationJob
 		err := rows.Scan(&j.Agent,
-			&j.AssetType,
 			&j.AssetURL,
+			&j.AssetType,
 			&j.Username,
 			&j.DeliveryService,
 			&j.EnteredTime,

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -182,7 +182,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `jobs(/|\.json/?)?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.4, http.MethodDelete, `jobs/?$`, invalidationjobs.Delete, auth.PrivLevelPortal, Authenticated, nil},
 		{1.4, http.MethodPut, `jobs/?$`, invalidationjobs.Update, auth.PrivLevelPortal, Authenticated, nil},
-		{1.4, http.MethodPatch, `jobs/?$`, invalidationjobs.Patch, auth.PrivLevelPortal, Authenticated, nil},
+		// {1.4, http.MethodPatch, `jobs/?$`, invalidationjobs.Patch, auth.PrivLevelPortal, Authenticated, nil}, See the commented-out 'invalidationjobs.Patch' function for why this is commented out
 		{1.4, http.MethodPost, `jobs/?`, invalidationjobs.Create, auth.PrivLevelPortal, Authenticated, nil},
 		{1.1, http.MethodGet, `jobs/{id}(/|\.json/?)?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodPost, `user/current/jobs(/|\.json/?)?$`, invalidationjobs.CreateUserJob, auth.PrivLevelPortal, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -180,12 +180,12 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		//Content invalidation jobs
 		{1.1, http.MethodGet, `jobs(/|\.json/?)?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.4, http.MethodDelete, `jobs/?$`, invalidationjobs.Delete, auth.PrivLevelOperations, Authenticated, nil},
-		{1.4, http.MethodPut, `jobs/?$`, invalidationjobs.Update, auth.PrivLevelOperations, Authenticated, nil},
-		{1.4, http.MethodPatch, `jobs/?$`, invalidationjobs.Patch, auth.PrivLevelOperations, Authenticated, nil},
-		{1.4, http.MethodPost, `jobs/?`, invalidationjobs.Create, auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodDelete, `jobs/?$`, invalidationjobs.Delete, auth.PrivLevelPortal, Authenticated, nil},
+		{1.4, http.MethodPut, `jobs/?$`, invalidationjobs.Update, auth.PrivLevelPortal, Authenticated, nil},
+		{1.4, http.MethodPatch, `jobs/?$`, invalidationjobs.Patch, auth.PrivLevelPortal, Authenticated, nil},
+		{1.4, http.MethodPost, `jobs/?`, invalidationjobs.Create, auth.PrivLevelPortal, Authenticated, nil},
 		{1.1, http.MethodGet, `jobs/{id}(/|\.json/?)?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, Authenticated, nil},
-		{1.1, http.MethodPost, `user/current/jobs(/|\.json/?)?$`, invalidationjobs.CreateUserJob, auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodPost, `user/current/jobs(/|\.json/?)?$`, invalidationjobs.CreateUserJob, auth.PrivLevelPortal, Authenticated, nil},
 		{1.1, http.MethodGet, `user/current/jobs(/|\.json/?)?$`, invalidationjobs.GetUserJobs, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Login

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -57,6 +57,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/division"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/federations"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/hwinfo"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/invalidationjobs"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/login"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/logs"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/origin"
@@ -176,6 +177,16 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		//HWInfo
 		{1.1, http.MethodGet, `hwinfo-wip/?(\.json)?$`, hwinfo.Get, auth.PrivLevelReadOnly, Authenticated, nil},
+
+		//Content invalidation jobs
+		{1.1, http.MethodGet, `jobs(/|\.json/?)?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.4, http.MethodDelete, `jobs/?$`, invalidationjobs.Delete, auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodPut, `jobs/?$`, invalidationjobs.Update, auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodPatch, `jobs/?$`, invalidationjobs.Patch, auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodPost, `jobs/?`, invalidationjobs.Create, auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `jobs/{id}(/|\.json/?)?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodPost, `user/current/jobs(/|\.json/?)?$`, invalidationjobs.CreateUserJob, auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `user/current/jobs(/|\.json/?)?$`, invalidationjobs.GetUserJobs, auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Login
 		{1.1, http.MethodGet, `users/{id}/deliveryservices/?(\.json)?$`, user.GetDSes, auth.PrivLevelReadOnly, Authenticated, nil},

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceJobs/table.deliveryServiceJobs.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceJobs/table.deliveryServiceJobs.tpl.html
@@ -37,7 +37,7 @@ under the License.
             <tr class="headings">
                 <th>Asset URL</th>
                 <th>Parameters</th>
-                <th>Start (UTC)</th>
+                <th>Start Time</th>
                 <th>Created By</th>
             </tr>
             </thead>

--- a/traffic_portal/app/src/modules/private/deliveryServices/jobs/new/index.js
+++ b/traffic_portal/app/src/modules/private/deliveryServices/jobs/new/index.js
@@ -31,7 +31,7 @@ module.exports = angular.module('trafficPortal.private.deliveryServices.jobs.new
 								return deliveryServiceService.getDeliveryService($stateParams.deliveryServiceId);
 							},
 							job: function($stateParams) {
-								return { dsId: $stateParams.deliveryServiceId, startTime: moment().utc().format('YYYY-MM-DD HH:mm:ss') };
+								return { dsId: parseInt($stateParams.deliveryServiceId, 10), startTime: moment().utc().format('YYYY-MM-DD HH:mm:ss') };
 							}
 						}
 					}


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR resolves #1867, fixes #3116, closes #3803, closes #3804 and closes #3802 

Rewrites the "Jobs" endpoints from Perl to Go. This includes

- /jobs
    - `DELETE` method - *NEW* deletes an existing Job. Queues reval_pending on all servers.
    - `GET` method
    - `PUT` method - *NEW* replaces an existing Job. Queues reval_pending on all servers.
    - `POST` method - *NEW* creates a new Job. Queues reval_pending on all servers.
- /user/current/jobs
    - `GET` method
    - `POST` method - now requires privilege Role >= Portal, regardless of tenancy. No longer checks DS-to-user assignments when considering permissions.

Input timestamps are now accepted in RFC3339 format (with or without nanosecond precision) as well as our proprietary format used for "Last Updated" fields.

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Ops
- Traffic Ops Client (Go)
- Traffic Portal

## What is the best way to verify this PR?
Creating, deleting, editing, replacing and viewing Jobs. Output and behavior should match the provided documentation. Client code has associated tests, which should pass when run.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)