### PR TITLE
3.1.x Backport: Restricted job creation to Portal and above (#3742)

### DIFF
--- a/docs/source/api/v11/user.rst
+++ b/docs/source/api/v11/user.rst
@@ -1,17 +1,17 @@
-.. 
-.. 
+..
+..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.
 .. You may obtain a copy of the License at
-.. 
+..
 ..     http://www.apache.org/licenses/LICENSE-2.0
-.. 
+..
 .. Unless required by applicable law or agreed to in writing, software
 .. distributed under the License is distributed on an "AS IS" BASIS,
 .. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
-.. 
+..
 
 .. _to-api-v11-users:
 
@@ -279,7 +279,7 @@ Users
     }
 
 |
-  
+
 **POST /api/1.1/user/current/update**
 
   Updates the date for the authenticated user.
@@ -466,7 +466,7 @@ Invalidating content on the CDN is sometimes necessary when the origin was mis-c
 
 Authentication Required: Yes
 
-Role(s) Required: Yes
+Role(s) Required: Portal
 
   **Request Properties**
 
@@ -528,7 +528,7 @@ Role(s) Required: Yes
     {
           "alerts":
                   [
-                      { 
+                      {
                             "level": "success",
                             "text": "Successfully created purge job for: ."
                       }
@@ -764,7 +764,7 @@ Role(s) Required: Yes
 
   **Response Example** ::
 
-    
+
 
     {
      "alerts": [
@@ -775,4 +775,4 @@ Role(s) Required: Yes
      ],
     }
 
-  
+

--- a/traffic_ops/app/lib/API/Job.pm
+++ b/traffic_ops/app/lib/API/Job.pm
@@ -154,6 +154,10 @@ sub get_current_user_jobs {
 sub create_current_user_job {
 	my $self = shift;
 
+	if (!&is_portal($self)) {
+		return $self->forbidden();
+	}
+
 	my $ds_id      = $self->req->json->{dsId};
 	my $regex      = $self->req->json->{regex};
 	my $ttl        = $self->req->json->{ttl};


### PR DESCRIPTION
This PR backports #3742:

* Restricted job creation to Portal and above

* Fixed double check for proper Role

* rolled back ineffectual change

* updated version at which endpoint permissions changed

(cherry picked from commit 2e6a679)