### PR TITLE
Adds the configuration parameter 'wrap_counters' to the  astats_over_http plugin.

### DIFF
--- a/traffic_server/plugins/astats_over_http/astats.config.example
+++ b/traffic_server/plugins/astats_over_http/astats.config.example
@@ -10,3 +10,10 @@ allow_ip6=::1/64
 # hexidecimal int (without 0x), each bit (1 through 7) representing a record type to return.  0x100 is for the built in system stats.  
 # This can be overriden from the url, e.g.: http://localhost/_astats?record.types=100
 record_types=144
+
+# wrap_counters
+# wrap_counters when set to true, will keep the signed int64_t values within the range of INT64_MAX so that they remain positive
+# and do not wrap to become negative in value.  Instead when they exceed INT64_MAX, they will start at 0 and begin counting
+# from there.  This affects the TS_RECORDDATATYPE_COUNTER and TS_RECORDDATATYPE_COUNTER
+# By default, wrap_counters is 'false'
+wrap_counters = true


### PR DESCRIPTION


## What does this PR (Pull Request) do?
This PR adds a configuration parameter to the traffic server astats_over_http plugin.  The parameter 'wrap_counters' may be set to 'true' in the astats.config to insure that int64 type counters and signed integers do not present negative values once they increment beyond the INT64_MAX range.  The impetus for this this is to help in addressing the remap stats bug in traffic server.

When traffic server core dumps, the remap stats indexes used to lookup particular counters in trafficserver become associated with the wrong stats due to a race condition that is triggered when traffic server is slammed with requests after it is restarted following a crash.  To mitigate this problem so that it does not happen, the remap stats plugin can be configured to create persistent statistics.  When this is done, all remap stats are loaded and created from persistent store in a controlled manner which avoids the race.  remap stats may be configured to create persistent stats using it's -p option in the plugin.config file.  When using this option, remap statistics will eventually wrap and show negative values once the INT64_MAX value is surpassed.  To prevent these negative values, the 'wrap_counters=true' parameter will cause the counters values to begin again at 0 and resume counting from there keeping the values positive in the INT64_MAX range.


## Which Traffic Control components are affected by this PR?
traffic_server astats_over_http plugin

The astats.config.example file has been updated as part of this PR to document the purpose and provides a 'wrap_counters' example.

- CDN in a Box
- Documentation
- Grove
- Traffic Control Client 
- Traffic Monitor
- Traffic Ops
- Traffic Ops ORT
- Traffic Portal
- Traffic Router
X Traffic Stats
- Traffic Vault

## What is the best way to verify this PR?
Add the 'wrap_counters=2' parameter in the astats.config file.  When a counter increments beyond INT64_MAX (9223372036854775807), the counter will wrap and start a 0 again rather than becoming negative.

## If this is a bug fix, what versions of Traffic Ops are affected?



## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [X] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [ ] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
