### PR TITLE
Fix grove log fractional seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Issue #3605: Fixed Traffic Monitor custom ports in health polling URL.
 - Issue 3587: Fixed Traffic Ops Golang reverse proxy and Riak logs to be consistent with the format of other error logs.
 - Database migrations have been collapsed. Rollbacks to migrations that previously existed are no longer possible.
+- Issue #3750: Fixed Grove access log fractional seconds.
 - Issue #3646: Fixed Traffic Monitor Thresholds.
 
 ## [3.0.0] - 2018-10-30

--- a/grove/plugin/ats_log.go
+++ b/grove/plugin/ats_log.go
@@ -117,10 +117,10 @@ func atsEventLogStr(
 ) string {
 	unixNano := timestamp.UnixNano()
 	unixSec := unixNano / NSPerSec
-	unixFrac := 1 / (unixNano % NSPerSec)
+	unixFrac := (unixNano / (NSPerSec / 1000)) - (unixSec * 1000) // gives fractional seconds to three decimal points, like the ATS logs.
 	unixFracStr := strconv.FormatInt(unixFrac, 10)
-	if len(unixFracStr) > 3 {
-		unixFracStr = unixFracStr[:3]
+	for len(unixFracStr) < 3 {
+		unixFracStr = "0" + unixFracStr // leading zeros, so e.g. a fraction of '42' becomes '1234.042' not '1234.42'
 	}
 	cfsc := "FIN"
 	if !clientRespSuccess {

--- a/grove/plugin/ats_log_test.go
+++ b/grove/plugin/ats_log_test.go
@@ -1,0 +1,57 @@
+package plugin
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestATSLogTimeFractionalSeconds(t *testing.T) {
+	testTimes := []int64{
+		1563936732547355432,
+		1563937732000355432,
+		1563936732000000000,
+		1463136732999000000,
+		1563916732009000000,
+		1503936232090000000,
+		1563936732099000000,
+		1563936722900000000,
+		1563236282909000000,
+	}
+	for _, testTime := range testTimes {
+		timestamp := time.Unix(0, testTime)
+
+		logStr := atsEventLogStr(timestamp, "", "", "", "", "", "", "", "", "", 0, 0, 0, 0, 0, false, false, "", "", "", "", "", 0)
+
+		logFields := strings.Fields(logStr)
+		if len(logFields) < 1 {
+			t.Fatalf("atsEventLogStr expected >1 fields, actual %v", len(logFields))
+		}
+
+		timeField := logFields[0]
+
+		// the time field should be the Unix timestamp in seconds, as a float with 3 decimal places.
+		unixNano := timestamp.UnixNano()
+		unixSec := float64(unixNano) / float64(NSPerSec)
+		unixSecThreeDecimalPts := fmt.Sprintf("%.3f", unixSec)
+
+		if timeField != unixSecThreeDecimalPts {
+			t.Errorf("atsEventLogStr time expected '%v' actual '%v'", unixSecThreeDecimalPts, timeField)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fix grove log fractional seconds.

They were being dropped and logging `.0`, this fixes it to match ATS identically, logging the fractional second with trailing zeros to 3 decimal places.

Includes unit tests.
No documentation, no interface change.
Includes Changelog.

- [x] This PR is not related to any other Issue 

## Which Traffic Control components are affected by this PR?

- Grove

## What is the best way to verify this PR?

`go test`

Start grove, make a request, check the access log, verify fractional seconds are present in the timestamp (the first field).

## If this is a bug fix, what versions of Traffic Ops are affected?

- 3.0.0
- 3.0.1

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
