### PR TITLE
Improvements to Server-to-Delivery Service assignments

### DIFF
--- a/traffic_ops/testing/api/v14/servers_to_deliveryservice_assignment_test.go
+++ b/traffic_ops/testing/api/v14/servers_to_deliveryservice_assignment_test.go
@@ -1,0 +1,133 @@
+package v14
+
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+
+import (
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestAssignments(t *testing.T) {
+	WithObjs(t, []TCObj{CDNs, Types, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, Tenants, DeliveryServices}, func() {
+		AssignTestDeliveryService(t)
+		AssignIncorrectTestDeliveryService(t)
+	})
+}
+
+func AssignTestDeliveryService(t *testing.T) {
+	rs, _, err := TOSession.GetServerByHostName(testData.Servers[0].HostName)
+	if err != nil {
+		t.Fatalf("Failed to fetch server information: %v", err)
+	} else if rs == nil || len(rs) == 0 {
+		t.Fatalf("Failed to fetch server information: No results returned!")
+	}
+	firstServer := rs[0]
+
+	rd, _, err := TOSession.GetDeliveryServiceByXMLID(testData.DeliveryServices[0].XMLID)
+	if err != nil {
+		t.Fatalf("Failed to fetch DS information: %v", err)
+	} else if rd == nil || len(rd) == 0 {
+		t.Fatalf("Failed to fetch DS information: No results returned!")
+	}
+	firstDS := rd[0]
+
+
+	alerts, _, err := TOSession.AssignDeliveryServiceIDsToServerID(firstServer.ID, []int{firstDS.ID}, true)
+	if err != nil {
+		t.Errorf("Couldn't assign DS '%+v' to server '%+v': %v (alerts: %v)", firstDS, firstServer, err, alerts)
+	}
+	log.Debugf("alerts: %+v", alerts)
+
+	response, _, err := TOSession.GetServerIDDeliveryServices(firstServer.ID)
+	log.Debugf("response: %+v", response)
+	if err != nil {
+		t.Fatalf("Couldn't get Delivery Services assigned to Server '%+v': %v", firstServer, err)
+	}
+
+	var found bool
+	for _,ds := range response {
+		if ds.ID == nil {
+			continue
+		}
+
+		if *ds.ID == firstDS.ID {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf(`Server/DS assignment not found after "successful" assignment!`)
+	}
+}
+
+func AssignIncorrectTestDeliveryService(t *testing.T) {
+	var server *tc.Server
+	for _, s := range testData.Servers {
+		if s.CDNName == "cdn2" {
+			server = &s
+			break
+		}
+	}
+	if server == nil {
+		t.Fatalf("Couldn't find a server in CDN 'cdn2'!")
+	}
+
+	rs, _, err := TOSession.GetServerByHostName(server.HostName)
+	if err != nil {
+		t.Fatalf("Failed to fetch server information: %v", err)
+	} else if rs == nil || len(rs) == 0 {
+		t.Fatalf("Failed to fetch server information: No results returned!")
+	}
+	server = &rs[0]
+
+	rd, _, err := TOSession.GetDeliveryServiceByXMLID(testData.DeliveryServices[0].XMLID)
+	if err != nil {
+		t.Fatalf("Failed to fetch DS information: %v", err)
+	} else if rd == nil || len(rd) == 0 {
+		t.Fatalf("Failed to fetch DS information: No results returned!")
+	}
+	firstDS := rd[0]
+
+	alerts, _, err := TOSession.AssignDeliveryServiceIDsToServerID(server.ID, []int{firstDS.ID}, false)
+	if err == nil {
+		t.Errorf("Expected bad assignment to fail, but it didn't! (alerts: %v)", alerts)
+	}
+
+	response, _, err := TOSession.GetServerIDDeliveryServices(server.ID)
+	log.Debugf("response: %+v", response)
+	if err != nil {
+		t.Fatalf("Couldn't get Delivery Services assigned to Server '%+v': %v", *server, err)
+	}
+
+	var found bool
+	for _,ds := range response {
+		if ds.ID == nil {
+			continue
+		}
+
+		if *ds.ID == firstDS.ID {
+			found = true
+			break
+		}
+	}
+
+	if found {
+		t.Errorf(`Invalid Server/DS assignment was created!`)
+	}
+}

--- a/traffic_ops/testing/api/v14/servers_to_deliveryservice_assignment_test.go
+++ b/traffic_ops/testing/api/v14/servers_to_deliveryservice_assignment_test.go
@@ -33,7 +33,7 @@ func AssignTestDeliveryService(t *testing.T) {
 	rs, _, err := TOSession.GetServerByHostName(testData.Servers[0].HostName)
 	if err != nil {
 		t.Fatalf("Failed to fetch server information: %v", err)
-	} else if rs == nil || len(rs) == 0 {
+	} else if len(rs) == 0 {
 		t.Fatalf("Failed to fetch server information: No results returned!")
 	}
 	firstServer := rs[0]
@@ -41,7 +41,7 @@ func AssignTestDeliveryService(t *testing.T) {
 	rd, _, err := TOSession.GetDeliveryServiceByXMLID(testData.DeliveryServices[0].XMLID)
 	if err != nil {
 		t.Fatalf("Failed to fetch DS information: %v", err)
-	} else if rd == nil || len(rd) == 0 {
+	} else if len(rd) == 0 {
 		t.Fatalf("Failed to fetch DS information: No results returned!")
 	}
 	firstDS := rd[0]
@@ -61,11 +61,7 @@ func AssignTestDeliveryService(t *testing.T) {
 
 	var found bool
 	for _,ds := range response {
-		if ds.ID == nil {
-			continue
-		}
-
-		if *ds.ID == firstDS.ID {
+		if ds.ID != nil && *ds.ID == firstDS.ID {
 			found = true
 			break
 		}
@@ -91,7 +87,7 @@ func AssignIncorrectTestDeliveryService(t *testing.T) {
 	rs, _, err := TOSession.GetServerByHostName(server.HostName)
 	if err != nil {
 		t.Fatalf("Failed to fetch server information: %v", err)
-	} else if rs == nil || len(rs) == 0 {
+	} else if len(rs) == 0 {
 		t.Fatalf("Failed to fetch server information: No results returned!")
 	}
 	server = &rs[0]
@@ -99,7 +95,7 @@ func AssignIncorrectTestDeliveryService(t *testing.T) {
 	rd, _, err := TOSession.GetDeliveryServiceByXMLID(testData.DeliveryServices[0].XMLID)
 	if err != nil {
 		t.Fatalf("Failed to fetch DS information: %v", err)
-	} else if rd == nil || len(rd) == 0 {
+	} else if len(rd) == 0 {
 		t.Fatalf("Failed to fetch DS information: No results returned!")
 	}
 	firstDS := rd[0]
@@ -117,11 +113,8 @@ func AssignIncorrectTestDeliveryService(t *testing.T) {
 
 	var found bool
 	for _,ds := range response {
-		if ds.ID == nil {
-			continue
-		}
 
-		if *ds.ID == firstDS.ID {
+		if ds.ID != nil && *ds.ID == firstDS.ID {
 			found = true
 			break
 		}

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -1279,7 +1279,7 @@
             "cdnName": "cdn2",
             "description": "edge2 description",
             "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
-            "name": "EDGE2",
+            "name": "EDGEInCDN2",
             "routing_disabled": false,
             "type": "ATS_PROFILE"
         },
@@ -1442,7 +1442,7 @@
             "mgmtIpNetmask": "",
             "offlineReason": null,
             "physLocation": "Denver",
-            "profile": "EDGE2",
+            "profile": "EDGEInCDN2",
             "rack": "",
             "revalPending": false,
             "routerHostName": "",

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -621,7 +621,7 @@
             "type": "HTTP_LIVE",
             "xmlId": "msods1",
             "anonymousBlockingEnabled": true
-        }    
+        }
     ],
     "deliveryservicesRequiredCapabilities": [
         {
@@ -902,7 +902,7 @@
             "routingDisabled": false,
             "type": "ATS_PROFILE",
             "params": [
-                 {
+                {
                     "configFile": "records.config",
                     "name": "CONFIG proxy.config.proxy_name",
                     "secure": false,
@@ -1276,6 +1276,14 @@
             "type": "ATS_PROFILE"
         },
         {
+            "cdnName": "cdn2",
+            "description": "edge2 description",
+            "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
+            "name": "EDGE2",
+            "routing_disabled": false,
+            "type": "ATS_PROFILE"
+        },
+        {
             "cdnName": "cdn4",
             "description": "edge2 description",
             "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
@@ -1408,6 +1416,43 @@
             "updPending": false,
             "xmppId": "atlanta-edge-01\\\\@ocdn.kabletown.net",
             "xmppPasswd": "X"
+        },
+        {
+            "cachegroup": "cachegroup1",
+            "cdnName": "cdn2",
+            "domainName": "ga.atlanta.kabletown.net",
+            "guid": null,
+            "hostName": "cdn2-test-edge",
+            "httpsPort": 443,
+            "iloIpAddress": "",
+            "iloIpGateway": "",
+            "iloIpNetmask": "",
+            "iloPassword": "",
+            "iloUsername": "",
+            "interfaceMtu": 1500,
+            "interfaceName": "eth0",
+            "ip6Address": "",
+            "ip6Gateway": "",
+            "ipAddress": "0.0.0.0",
+            "ipGateway": "0.0.0.0",
+            "ipNetmask": "0.0.0.0",
+            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+            "mgmtIpAddress": "",
+            "mgmtIpGateway": "",
+            "mgmtIpNetmask": "",
+            "offlineReason": null,
+            "physLocation": "Denver",
+            "profile": "EDGE2",
+            "rack": "",
+            "revalPending": false,
+            "routerHostName": "",
+            "routerPortName": "",
+            "status": "REPORTED",
+            "tcpPort": 80,
+            "type": "EDGE",
+            "updPending": false,
+            "xmppId": "",
+            "xmppPasswd": ""
         },
         {
             "cachegroup": "cachegroup1",

--- a/traffic_ops/testing/api/v14/user_test.go
+++ b/traffic_ops/testing/api/v14/user_test.go
@@ -81,7 +81,7 @@ func RolenameCapitalizationTest(t *testing.T) {
 		"localPasswd": "better_twelve",
 		"confirmLocalPasswd": "better_twelve",
 		"role": %d,
-		"tenantId": %d 
+		"tenantId": %d
 	}`, *roles[0].ID, tenants[0].ID)
 
 	reader := strings.NewReader(blob)

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -89,12 +89,13 @@ func AssignDeliveryServicesToServerHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	var serverCDN uint
-	row := inf.Tx.Tx.QueryRow(`SELECT cdn_id FROM server WHERE id=$1`)
+	row := inf.Tx.Tx.QueryRow(`SELECT cdn_id FROM server WHERE id=$1`, inf.IntParams["id"])
 	if err := row.Scan(&serverCDN); err != nil {
 		if err == sql.ErrNoRows {
 			userErr = errors.New("No such server!")
 			errCode = http.StatusNotFound
 		} else {
+			errCode = http.StatusInternalServerError
 			sysErr = fmt.Errorf("Getting CDN ID for server (%d): %v", server, err)
 		}
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -159,7 +159,7 @@ func checkTenancyAndCDN(tx *sql.Tx, serverCDN string, server int, serverInfo tc.
 		}
 
 		if int(t.CDN) != serverInfo.CDNID {
-			return http.StatusConflict, fmt.Errorf("Delivery Service %s (#%d) is not in the same CDN as server %s (#%d) (server is in %s (#%d), DS is in %s (#%d))!", t.DSXMLID, t.DSID, serverInfo.HostName, server, serverCDN, serverInfo.CDNID, t.CDN, t.CDNName), nil
+			return http.StatusConflict, fmt.Errorf("Delivery Service %s (#%d) is not in the same CDN as server %s (#%d) (server is in %s (#%d), DS is in %s (#%d))!", t.DSXMLID, t.DSID, serverInfo.HostName, server, serverCDN, serverInfo.CDNID, t.CDNName, t.CDN), nil
 		}
 	}
 

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -40,11 +40,11 @@ import (
 )
 
 type needsCheck struct {
-	CDN uint
+	CDN     uint
 	CDNName string
-	DSID uint
+	DSID    uint
 	DSXMLID string
-	Tenant int
+	Tenant  int
 }
 
 const needsCheckInfoQuery = `
@@ -149,7 +149,7 @@ func checkTenancyAndCDN(tx *sql.Tx, serverCDN string, server int, serverInfo tc.
 		return http.StatusNotFound, errors.New("Either no Delivery Service ids given, or at least one id doesn't exist!"), nil
 	}
 
-	for _,t := range tenantsToCheck {
+	for _, t := range tenantsToCheck {
 		if ok, err := tenant.IsResourceAuthorizedToUserTx(t.Tenant, user, tx); err != nil {
 			return http.StatusInternalServerError, nil, fmt.Errorf("Checking availability of ds %d (tenant_id: %d) to tenant_id %d: %v", t.DSID, t.Tenant, err, user.TenantID, err)
 		} else if !ok {

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/TableServerDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/TableServerDeliveryServicesController.js
@@ -94,7 +94,7 @@ var TableServerDeliveryServicesController = function(server, deliveryServices, $
 					return params;
 				},
 				collection: function(serverService) {
-					return serverService.getServers({ type: server.type, orderby: 'hostName' });
+					return serverService.getServers({ type: server.type, orderby: 'hostName', cdn: server.cdnId }).then(function(xs){return xs.filter(function(x){return x.id!=server.id})}, function(err){throw err});
 				}
 			}
 		});


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #3756 

Reworked the POST method handler of the `/servers/{{ID}}/deliveryservices` endpoint to both

a) respect CDN limitations in assignments
b) respect tenancy permissions

Also updated Traffic Portal so that servers which are unavailable for DS assignment cloning do not appear in the selection menu.


Draft status pending testing.

## Which Traffic Control components are affected by this PR?
- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
Build and run Traffic Ops and Traffic Portal, attempt to assign a server to one or more Delivery Services in a different CDN, and/or to one or more Delivery Services to which access by your tenant is forbidden. Traffic Portal should not present you with the ability to do so, and Traffic Ops should reject your attempt should you bypass the UI.

## If this is a bug fix, what versions of Traffic Control are affected?
- 3.0.1
- master (@ 5da4a5b43605d499c474a38dfdc33d20a88a3913)

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**