### PR TITLE
Cachegroup fallbacks deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed Traffic Ops Golang POST servers/id/deliveryservice continuing erroneously after a database error.
 - Fixed Traffic Ops Golang POST servers/id/deliveryservice double-logging errors.
 
+### Deprecated/Removed
+- The TO API `cachegroup_fallbacks` endpoint is now deprecated
+
 ## [3.0.0] - 2018-10-30
 ### Added
 - Removed MySQL-to-Postgres migration tools.  This tool is supported for 1.x to 2.x upgrades only and should not be used with 3.x.

--- a/docs/source/api/cachegroup_fallbacks.rst
+++ b/docs/source/api/cachegroup_fallbacks.rst
@@ -21,7 +21,7 @@
 
 .. deprecated:: ATCv4.0
 
-	The :ref:`to-api-cachegroups` endpoint now contains a list of "fallbacks" in the output, and supports it in input, and so this endpoint is redundant.
+	The :ref:`to-api-cachegroups` and :ref:`to-api-cachegroups-id` endpoints now contain a list of "fallbacks" in the output, and support it in input, and so this endpoint is redundant.
 
 ``GET``
 =======

--- a/docs/source/api/cachegroup_fallbacks.rst
+++ b/docs/source/api/cachegroup_fallbacks.rst
@@ -19,6 +19,10 @@
 ``cachegroup_fallbacks``
 ************************
 
+.. deprecated:: ATCv4.0
+
+	The :ref:`to-api-cachegroups` endpoint now contains a list of "fallbacks" in the output, and supports it in input, and so this endpoint is redundant.
+
 ``GET``
 =======
 Retrieve fallback-related configurations for a :term:`Cache Group`.

--- a/docs/source/api/cachegroups.rst
+++ b/docs/source/api/cachegroups.rst
@@ -21,7 +21,7 @@
 
 ``GET``
 =======
-Extract information about all :term:`Cache Groups`.
+Extract information about :term:`Cache Groups`.
 
 :Auth. Required: Yes
 :Roles Required: None
@@ -62,16 +62,22 @@ Request Structure
 
 Response Structure
 ------------------
-:fallbackToClosest:             If ``true``, Traffic Router will direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable.
+:fallbacks: An array of :term:`Cache Group` names that are registered as "fallbacks" for use when this :term:`Cache Group` is unavailable.\ [#fallbacks]_
+
+	.. versionadded:: ATCv4.0
+
+		This field was added to all versions of this endpoint with Apache Traffic Control version 4.0
+
+:fallbackToClosest:             If ``true``, Traffic Router will direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable.\ [#fallbacks]_
 :id:                            A numeric, unique identifier for the :term:`Cache Group`
 :lastUpdated:                   The time and date at which this entry was last updated in ISO format
 :latitude:                      Latitude for the :term:`Cache Group`
 :longitude:                     Longitude for the :term:`Cache Group`
 :name:                          The name of the :term:`Cache Group` entry
-:parentCachegroupId:            ID of this :term:`Cache Group`\ 's parent :term:`Cache Group` (if any)
-:parentCachegroupName:          Name of this :term:`Cache Group`\ 's parent :term:`Cache Group` (if any)
-:secondaryParentCachegroupId:   ID of this :term:`Cache Group`\ 's secondary parent :term:`Cache Group` (if any)
-:secondaryParentCachegroupName: Name of this :term:`Cache Group`\ 's secondary parent :term:`Cache Group` (if any)
+:parentCachegroupId:            ID of this :term:`Cache Group`'s parent :term:`Cache Group` (if any)
+:parentCachegroupName:          Name of this :term:`Cache Group`'s parent :term:`Cache Group` (if any)
+:secondaryParentCachegroupId:   ID of this :term:`Cache Group`'s secondary parent :term:`Cache Group` (if any)
+:secondaryParentCachegroupName: Name of this :term:`Cache Group`'s secondary parent :term:`Cache Group` (if any)
 :shortName:                     Abbreviation of the :term:`Cache Group` name
 :typeId:                        Unique identifier for the 'Type' of :term:`Cache Group` entry
 :typeName:                      The name of the type of :term:`Cache Group` entry
@@ -108,7 +114,8 @@ Response Structure
 			"localizationMethods": [],
 			"typeName": "EDGE_LOC",
 			"typeId": 23,
-			"lastUpdated": "2018-11-07 14:45:43+00"
+			"lastUpdated": "2018-11-07 14:45:43+00",
+			"fallbacks": []
 		}
 	]}
 
@@ -123,17 +130,23 @@ Creates a :term:`Cache Group`
 
 Request Structure
 -----------------
-:fallbackToClosest: If ``true``, the Traffic Router will fall back on the 'closest' :term:`Cache Group` to this one, when this one fails
+:fallbacks: An optional field which, when present, should contain an array of names of other :term:`Cache Groups` on which the Traffic Router will fall back in the event that this :term:`Cache Group` fails/becomes unavailable\ [#fallbacks]_
+
+	.. versionadded:: ATCv4.0
+
+		Support for this field was added to all versions of this endpoint with Apache Traffic Control version 4.0
+
+:fallbackToClosest: If ``true``, the Traffic Router will fall back on the 'closest' :term:`Cache Group` to this one, when this one fails\ [#fallbacks]_
 
 	.. note:: The default value of ``fallbackToClosest`` is 'true', and if it is 'null' Traffic Control components will still interpret it as 'true'.
 
-:latitude:                    An optional field which, if present, will define the latitude for the :term:`Cache Group` to ISO-standard double specification\ [1]_
-:longitude:                   An optional field which, if present, will define the longitude for the :term:`Cache Group` to ISO-standard double specification\ [1]_
+:latitude:                    An optional field which, if present, will define the latitude for the :term:`Cache Group` to ISO-standard double specification\ [#optional]_
+:longitude:                   An optional field which, if present, will define the longitude for the :term:`Cache Group` to ISO-standard double specification\ [#optional]_
 :localizationMethods:         Array of enabled localization methods (as strings)
 :fallbacks:                   Array of fallback server hostnames.
 :name:                        The name of the :term:`Cache Group`
-:parentCachegroupId:          An optional field which, if present, should be an integral, unique identifier for this :term:`Cache Group`\ 's primary parent
-:secondaryParentCachegroupId: An optional field which, if present, should be an integral, unique identifier for this :term:`Cache Group`\ 's secondary parent
+:parentCachegroupId:          An optional field which, if present, should be an integral, unique identifier for this :term:`Cache Group`'s primary parent
+:secondaryParentCachegroupId: An optional field which, if present, should be an integral, unique identifier for this :term:`Cache Group`'s secondary parent
 :shortName:                   An abbreviation of the ``name``
 :typeId:                      An integral, unique identifier for the type of :term:`Cache Group`; one of:
 
@@ -171,7 +184,13 @@ Request Structure
 
 Response Structure
 ------------------
-:fallbackToClosest:             If ``true``, Traffic Router will direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable.
+:fallbacks: An array of :term:`Cache Group` names that are registered as "fallbacks" for use when this :term:`Cache Group` is unavailable\ [#fallbacks]_
+
+	.. versionadded:: ATCv4.0
+
+		This field was added to all versions of this endpoint with Apache Traffic Control version 4.0
+
+:fallbackToClosest:             If ``true``, Traffic Router will direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable\ [#fallbacks]_
 :id:                            A numeric, unique identifier for the :term:`Cache Group`
 :lastUpdated:                   The time and date at which this entry was last updated in ISO format
 :latitude:                      Latitude for the :term:`Cache Group`
@@ -227,7 +246,8 @@ Response Structure
 		"lastUpdated": "2018-11-07 22:11:50+00"
 	}}
 
-.. [1] While these fields are technically optional, note that if they are not specified many things may break. For this reason, Traffic Portal requires them when creating or editing :term:`Cache Group`\ s.
+.. [#fallbacks] A ``fallbackToClosest`` setting of ``true`` is mutually exclusive with a non-empty ``fallbacks`` array.
+.. [#optional] While these fields are technically optional, note that if they are not specified many things may break. For this reason, Traffic Portal requires them when creating or editing :term:`Cache Groups`.
 
 .. This doesn't appear to exist anymore - can't reproduce in CIAB nor production
 .. ``/api/1.1/cachegroups/:parameter_id/parameter/available``

--- a/docs/source/api/cachegroups.rst
+++ b/docs/source/api/cachegroups.rst
@@ -79,8 +79,8 @@ Response Structure
 :secondaryParentCachegroupId:   ID of this :term:`Cache Group`'s secondary parent :term:`Cache Group` (if any)
 :secondaryParentCachegroupName: Name of this :term:`Cache Group`'s secondary parent :term:`Cache Group` (if any)
 :shortName:                     Abbreviation of the :term:`Cache Group` name
-:typeId:                        Unique identifier for the 'Type' of :term:`Cache Group` entry
-:typeName:                      The name of the type of :term:`Cache Group` entry
+:typeId:                        Unique identifier for the ':term:`Type`' of :term:`Cache Group` entry
+:typeName:                      The name of the :term:`type` of :term:`Cache Group` entry
 
 .. note:: The default value of ``fallbackToClosest`` is 'true', and if it is 'null' Traffic Control components will still interpret it as 'true'.
 
@@ -148,7 +148,7 @@ Request Structure
 :parentCachegroupId:          An optional field which, if present, should be an integral, unique identifier for this :term:`Cache Group`'s primary parent
 :secondaryParentCachegroupId: An optional field which, if present, should be an integral, unique identifier for this :term:`Cache Group`'s secondary parent
 :shortName:                   An abbreviation of the ``name``
-:typeId:                      An integral, unique identifier for the type of :term:`Cache Group`; one of:
+:typeId:                      An integral, unique identifier for the :term:`type` of :term:`Cache Group`; one of:
 
 	EDGE_LOC
 		Indicates a group of Edge-tier caches
@@ -198,13 +198,13 @@ Response Structure
 :localizationMethods:           Array of enabled localization methods (as strings)
 :fallbacks:                     Array of fallback server hostnames
 :name:                          The name of the :term:`Cache Group` entry
-:parentCachegroupId:            ID of this :term:`Cache Group`\ 's parent :term:`Cache Group` (if any)
-:parentCachegroupName:          Name of this :term:`Cache Group`\ 's parent :term:`Cache Group` (if any)
-:secondaryParentCachegroupId:   ID of this :term:`Cache Group`\ 's secondary parent :term:`Cache Group` (if any)
-:secondaryParentCachegroupName: Name of this :term:`Cache Group`\ 's secondary parent :term:`Cache Group` (if any)
+:parentCachegroupId:            ID of this :term:`Cache Group`'s parent :term:`Cache Group` (if any)
+:parentCachegroupName:          Name of this :term:`Cache Group`'s parent :term:`Cache Group` (if any)
+:secondaryParentCachegroupId:   ID of this :term:`Cache Group`'s secondary parent :term:`Cache Group` (if any)
+:secondaryParentCachegroupName: Name of this :term:`Cache Group`'s secondary parent :term:`Cache Group` (if any)
 :shortName:                     Abbreviation of the :term:`Cache Group` name
-:typeId:                        Unique identifier for the 'Type' of :term:`Cache Group` entry
-:typeName:                      The name of the type of :term:`Cache Group` entry
+:typeId:                        Unique identifier for the ':term:`Type`' of :term:`Cache Group` entry
+:typeName:                      The name of the :term:`type` of :term:`Cache Group` entry
 
 
 .. code-block:: http
@@ -246,7 +246,7 @@ Response Structure
 		"lastUpdated": "2018-11-07 22:11:50+00"
 	}}
 
-.. [#fallbacks] A ``fallbackToClosest`` setting of ``true`` is mutually exclusive with a non-empty ``fallbacks`` array.
+.. [#fallbacks] Traffic Router will first check for a ``fallbacks`` array and, when that is empty/unset/all the :term:`Cache Groups` in it are also unavailable, will subsequently check for ``fallbackToClosest``. If that is ``true``, then it falls back to the geographically closest :term:`Cache Group` capable of serving the same content or, when it is ``false``/no such :term:`Cache Group` exists/said :term:`Cache Group` is also unavailable, will respond to clients with a failure response indicating the problem.
 .. [#optional] While these fields are technically optional, note that if they are not specified many things may break. For this reason, Traffic Portal requires them when creating or editing :term:`Cache Groups`.
 
 .. This doesn't appear to exist anymore - can't reproduce in CIAB nor production

--- a/docs/source/api/cachegroups_id.rst
+++ b/docs/source/api/cachegroups_id.rst
@@ -57,7 +57,13 @@ Request Structure
 
 Response Structure
 ------------------
-:fallbackToClosest:   If ``true``, Traffic Router will direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable
+:fallbacks: An array of :term:`Cache Group` names that are registered as "fallbacks" for use when this :term:`Cache Group` is unavailable\ [#fallbacks]_
+
+	.. versionadded:: ATCv4.0
+
+		This field was added to all versions of this endpoint with Apache Traffic Control version 4.0
+
+:fallbackToClosest:   If ``true``, Traffic Router will direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable\ [#fallbacks]_
 :id:                  Integral, unique identifier for the :term:`Cache Group`
 :lastUpdated:         The date and time at which this :term:`Cache Group` was last updated, in an ISO-like format
 :latitude:            Latitude of the :term:`Cache Group`
@@ -72,13 +78,13 @@ Response Structure
 
 :longitude:                     Longitude of the :term:`Cache Group`
 :name:                          The name of the :term:`Cache Group`
-:parentCachegroupId:            Integral, unique identifier of the :term:`Cache Group` that is this :term:`Cache Group`\ 's parent
-:parentCachegroupName:          The name of the :term:`Cache Group` that is this :term:`Cache Group`\ 's parent
-:secondaryParentCachegroupId:   Integral, unique identifier of the :term:`Cache Group` that is this :term:`Cache Group`\ 's secondary parent
-:secondaryParentCachegroupName: The name of the :term:`Cache Group` that is this :term:`Cache Group`\ 's secondary parent
+:parentCachegroupId:            Integral, unique identifier of the :term:`Cache Group` that is this :term:`Cache Group`'s parent
+:parentCachegroupName:          The name of the :term:`Cache Group` that is this :term:`Cache Group`'s parent
+:secondaryParentCachegroupId:   Integral, unique identifier of the :term:`Cache Group` that is this :term:`Cache Group`'s secondary parent
+:secondaryParentCachegroupName: The name of the :term:`Cache Group` that is this :term:`Cache Group`'s secondary parent
 :shortName:                     Abbreviation of the :term:`Cache Group` Name
-:typeId:                        The integral, unique identifier for the 'Type' of :term:`Cache Group`
-:typeName:                      The name of the type of this :term:`Cache Group`
+:typeId:                        The integral, unique identifier for the :term:`Type` of :term:`Cache Group`
+:typeName:                      The name of the :term:`type` of this :term:`Cache Group`
 
 .. note:: The default value of ``fallbackToClosest`` is 'true', and if it is 'null' Traffic Control components will still interpret it as 'true'.
 
@@ -108,14 +114,15 @@ Response Structure
 			"parentCachegroupId": 6,
 			"secondaryParentCachegroupName": null,
 			"secondaryParentCachegroupId": null,
-			"fallbackToClosest": [],
+			"fallbackToClosest": true,
 			"localizationMethods": [
 				"DEEP_CZ",
 				"CZ"
 			],
 			"typeName": "EDGE_LOC",
 			"typeId": 23,
-			"lastUpdated": "2018-11-14 18:23:33+00"
+			"lastUpdated": "2018-11-14 18:23:33+00",
+			"fallbacks": []
 		}
 	]}
 
@@ -138,11 +145,17 @@ Request Structure
 	| ID           | The integral, unique identifier of a :term:`Cache Group`      |
 	+--------------+---------------------------------------------------------------+
 
-:fallbackToClosest: An optional field which, if present and ``true``, will cause Traffic Router to direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable
+:fallbacks: An optional field which, when present, should contain an array of names of other :term:`Cache Groups` on which the Traffic Router will fall back in the event that this :term:`Cache Group` fails/becomes unavailable\ [#fallbacks]_
+
+	.. versionadded:: ATCv4.0
+
+		Support for this field was added to all versions of this endpoint with Apache Traffic Control version 4.0
+
+:fallbackToClosest: An optional field which, if present and ``true``, will cause Traffic Router to direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable\ [#fallbacks]_
 
 	.. note:: The default value of ``fallbackToClosest`` is ``true``, and if it is ``null`` or ``undefined`` Traffic Control components will still interpret it as ``true``.
 
-:latitude:            An optional field which, if specified, will set the latitude of the new :term:`Cache Group`\ [1]_
+:latitude:            An optional field which, if specified, will set the latitude of the new :term:`Cache Group`\ [#optional]_
 :localizationMethods: An optional array of strings that name the localization methods enabled for this :term:`Cache Group`. Each of the three available localization methods may be present, with the following meanings:
 
 	CZ
@@ -152,14 +165,14 @@ Request Structure
 	GEO
 		Use of a geographical location-to-IP mapping database will be enabled
 
-:longitude:                 An optional field which, if specified, will set the longitude of the new :term:`Cache Group`\ [1]_
+:longitude:                 An optional field which, if specified, will set the longitude of the new :term:`Cache Group`\ [#optional]_
 :name:                      The desired name of the :term:`Cache Group` entry
-:parentCachegroup:          An optional field which, if specified, should be the integral, unique identifier of :term:`Cache Group` to use as the new :term:`Cache Group`\ 's parent
-:secondaryParentCachegroup: An optional field which, if specified, should be the integral, unique identifier of :term:`Cache Group` to use as the new :term:`Cache Group`\ 's parent
-:shortName:                 A more human-friendly abbreviation of the :term:`Cache Group`\ 's name
-:typeId:                    The integral, unique identifier of the desired type of the new :term:`Cache Group` - by default the valid options are: "EDGE_LOC", "MID_LOC" or "ORG_LOC"
+:parentCachegroup:          An optional field which, if specified, should be the integral, unique identifier of :term:`Cache Group` to use as the new :term:`Cache Group`'s parent
+:secondaryParentCachegroup: An optional field which, if specified, should be the integral, unique identifier of :term:`Cache Group` to use as the new :term:`Cache Group`'s parent
+:shortName:                 A more human-friendly abbreviation of the :term:`Cache Group`'s name
+:typeId:                    The integral, unique identifier of the desired :term:`type` of the new :term:`Cache Group` - by default the valid options are: "EDGE_LOC", "MID_LOC" or "ORG_LOC"
 
-	.. note:: Rather than the actual name of the type, be sure to use the "database ID" of the desired type. Typically this will require looking up the types via the API first, as the IDs of even these default types is not deterministic.
+	.. note:: Rather than the actual name of the :term:`type`, be sure to use the "database ID" of the desired :term:`type`. Typically this will require looking up the types via the API first, as the IDs of even these default types is not deterministic.
 
 .. code-block:: http
 	:caption: Request Example
@@ -172,11 +185,26 @@ Request Structure
 	Content-Length: 118
 	Content-Type: application/json
 
-	{"latitude": 0.0, "longitude": 0.0, "name": "test", "shortName": "test", "typeId": 23, "localizationMethods": ["GEO"]}
+	{
+		"latitude": 0.0,
+		"longitude": 0.0,
+		"name": "test",
+		"fallbacks": [],
+		"fallbackToClosest": true,
+		"shortName": "test",
+		"typeId": 23,
+		"localizationMethods": ["GEO"]
+	}
 
 Response Structure
 ------------------
-:fallbackToClosest:   If ``true``, Traffic Router will direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable
+:fallbacks: An array of :term:`Cache Group` names that are registered as "fallbacks" for use when this :term:`Cache Group` is unavailable\ [#fallbacks]_
+
+	.. versionadded:: ATCv4.0
+
+		This field was added to all versions of this endpoint with Apache Traffic Control version 4.0
+
+:fallbackToClosest:   If ``true``, Traffic Router will direct clients to peers of this :term:`Cache Group` in the event that it becomes unavailable\ [#fallbacks]_
 :id:                  Integral, unique identifier for the :term:`Cache Group`
 :lastUpdated:         The date and time at which this :term:`Cache Group` was last updated, in an ISO-like format
 :latitude:            Latitude of the :term:`Cache Group`
@@ -191,13 +219,13 @@ Response Structure
 
 :longitude:                     Longitude of the :term:`Cache Group`
 :name:                          The name of the :term:`Cache Group`
-:parentCachegroupId:            Integral, unique identifier of the :term:`Cache Group` that is this :term:`Cache Group`\ 's parent
-:parentCachegroupName:          The name of the :term:`Cache Group` that is this :term:`Cache Group`\ 's parent
-:secondaryParentCachegroupId:   Integral, unique identifier of the :term:`Cache Group` that is this :term:`Cache Group`\ 's secondary parent
-:secondaryParentCachegroupName: The name of the :term:`Cache Group` that is this :term:`Cache Group`\ 's secondary parent
+:parentCachegroupId:            Integral, unique identifier of the :term:`Cache Group` that is this :term:`Cache Group`'s parent
+:parentCachegroupName:          The name of the :term:`Cache Group` that is this :term:`Cache Group`'s parent
+:secondaryParentCachegroupId:   Integral, unique identifier of the :term:`Cache Group` that is this :term:`Cache Group`'s secondary parent
+:secondaryParentCachegroupName: The name of the :term:`Cache Group` that is this :term:`Cache Group`'s secondary parent
 :shortName:                     Abbreviation of the :term:`Cache Group` Name
-:typeId:                        The integral, unique identifier for the 'Type' of :term:`Cache Group`
-:typeName:                      The name of the type of this :term:`Cache Group`
+:typeId:                        The integral, unique identifier for the :term:`Type` of :term:`Cache Group`
+:typeName:                      The name of the :term:`Type` of this :term:`Cache Group`
 
 .. code-block:: http
 	:caption: Response Example
@@ -230,7 +258,8 @@ Response Structure
 		"parentCachegroupId": null,
 		"secondaryParentCachegroupName": null,
 		"secondaryParentCachegroupId": null,
-		"fallbackToClosest": [],
+		"fallbacks": [],
+		"fallbackToClosest": true,
 		"localizationMethods": [
 			"GEO"
 		],
@@ -239,11 +268,10 @@ Response Structure
 		"lastUpdated": "2018-11-14 19:14:28+00"
 	}}
 
-.. [1] While these fields are technically optional, note that if they are not specified many things may break. For this reason, Traffic Portal requires them when creating or editing :term:`Cache Group`\ s.
 
 ``DELETE``
 ==========
-Delete :term:`Cache Group`. :term:`Cache Group`\ s which have assigned servers or child :term:`Cache Group`\ s cannot be deleted.
+Delete :term:`Cache Group`. :term:`Cache Groups` which have assigned servers or child :term:`Cache Groups` cannot be deleted.
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"
@@ -292,3 +320,5 @@ Response Structure
 		}
 	]}
 
+.. [#fallbacks] Traffic Router will first check for a ``fallbacks`` array and, when that is empty/unset/all the :term:`Cache Groups` in it are also unavailable, will subsequently check for ``fallbackToClosest``. If that is ``true``, then it falls back to the geographically closest :term:`Cache Group` capable of serving the same content or, when it is ``false``/no such :term:`Cache Group` exists/said :term:`Cache Group` is also unavailable, will respond to clients with a failure response indicating the problem.
+.. [#optional] While these fields are technically optional, note that if they are not specified many things may break. For this reason, Traffic Portal requires them when creating or editing :term:`Cache Group`\ s.

--- a/traffic_ops/app/lib/MojoPlugins/Response.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Response.pm
@@ -119,6 +119,44 @@ sub register {
 		}
 	);
 
+	$app->renderer->add_helper(
+		deprecation => sub {
+			my $self = shift || confess("Call on an instance of MojoPlugins::Response");
+			my $code = shift || confess("Please supply a response code e.g. 400");
+			my $alternative = shift || confess("Please supply an alternative handler, like 'PUT /api/1.4/user/current'");
+			my $response_object = shift;
+
+			my $builder ||= MojoPlugins::Response::Builder->new($self, @_);
+			my @alerts_response = ({$LEVEL_KEY => $WARNING_LEVEL, $TEXT_KEY => "This endpoint is deprecated, please use '" . $alternative . "' instead"});
+
+			if (defined($response_object)) {
+				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response, $RESPONSE_KEY => $response_object } );
+			} else {
+				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response } );
+			}
+		}
+	);
+
+	$app->renderer->add_helper(
+		with_deprecation => sub {
+			my $self = shift || confess("Call on an instance of MojoPlugins::Response");
+			my $alert = shift || confess("Please supply an alert string");
+			my $level = shift || confess("Please supply an alert level such as 'error' or 'warning'");
+			my $code = shift || confess("Please supply a response code e.g. 400");
+			my $alternative = shift || confess("Please supply an alternative handler, like 'PUT /api/1.4/user/current'");
+			my $response_object = shift;
+
+			my $builder ||= MojoPlugins::Response::Builder->new($self, @_);
+			my @alerts_response = ({$LEVEL_KEY => $level, $TEXT_KEY => $alert}, {$LEVEL_KEY => $WARNING_LEVEL, $TEXT_KEY => "This endpoint is deprecated, please use '" . $alternative . "' instead"});
+
+			if (defined($response_object)) {
+				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response, $RESPONSE_KEY => $response_object } );
+			} else {
+				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response } );
+			}
+		}
+	);
+
 	# Alerts (500)
 	$app->renderer->add_helper(
 		internal_server_error => sub {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

Adds a deprecation notice to the `cachegroup_fallbacks` TO API endpoint documentation, as discussed in the dev mailing list. Also added missing documentation for the `fallbacks` property of API request/response payloads to/from the `cachegroups` and `cachegroups/{{ID}}` endpoints. Plus I did a little cleaning up of unnamed footnotes and unnecessary escape sequences.

## Which Traffic Control components are affected by this PR?

- Documentation

## What is the best way to verify this PR?
Build and read the documentation.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**