### PR TITLE
CIAB: add sanity checks around x509 file existence

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops/generate-certs.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/generate-certs.sh
@@ -404,7 +404,6 @@ x509v3_create_cert()
   echo "X509_${env_name}_CERT_FILE=\"$cert_file\"" >> "$X509_CA_ENV_FILE"
   echo "X509_${env_name}_KEY_FILE=\"$key_file\"" >> "$X509_CA_ENV_FILE"
   echo "X509_${env_name}_REQUEST_FILE=\"$request_file\"" >> "$X509_CA_ENV_FILE"
-  echo "X509_GENERATION_COMPLETE=\"YES\"" >> "$X509_CA_ENV_FILE"
 }
 
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -87,6 +87,12 @@ while true; do
 done
 
 ### Add SSL keys for demo1 delivery service
+until [[ -s "$X509_DEMO1_CERT_FILE" && -s "$X509_DEMO1_REQUEST_FILE" && -s "$X509_DEMO1_KEY_FILE" ]]
+do
+  echo "Waiting on X509_DEMO1 files to exist"
+  sleep 3
+  source "$X509_CA_ENV_FILE"
+done
 to-add-sslkeys $CDN_NAME $ds_name "*.demo1.mycdn.ciab.test" $X509_DEMO1_CERT_FILE $X509_DEMO1_REQUEST_FILE $X509_DEMO1_KEY_FILE
 
 ### Automatic Queue/Snapshot ###

--- a/infrastructure/cdn-in-a-box/traffic_ops/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run.sh
@@ -70,6 +70,7 @@ elif x509v3_init; then
 		do
 			x509v3_create_cert "$ds" "$ds.$CDN_FQDN"
 		done
+		echo "X509_GENERATION_COMPLETE=\"YES\"" >> "$X509_CA_ENV_FILE"
 		x509v3_dump_env
     # Save newly generated certs for future restarts.
     rsync -av "$X509_CA_DIR/" "$X509_CA_PERSIST_DIR/"


### PR DESCRIPTION


<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

There is a race condition around the readability/existence of generated
certs and attempting to add them into TO. This adds some sanity checks
aorund the existence of delivery service x509 env vars and file
existence and sets the X509_GENERATION_COMPLETE env var only after all
the delivery service sslkeys have been genereated.

- [x] This PR fixes #3769 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Build and start CIAB, stop it, delete the `traffic_ops/ca` dir and `docker-compose down -v`, and start it again. Verify that it starts up properly.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This is CIAB, no tests necessary
- [x] Minor bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
