### PR TITLE
3.1.x backport: Fix DELETE deliveryservice_server permissions (#3773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fix port handling for traffic ops port checks on ports other than 80.
 - Return a json response with a 200 for a successful snapshot PUT.
 - Correct FQDN case mismatch when generating DNSSEC.
+- Fixed permissions on DELETE /api/$version/deliveryservice_server/{dsid}/{serverid} endpoint
 - Issue 3223 - cannot add steering targets to steering delivery service.
 - Issue 3466 - docs fail to build in python 3.6.
 - Issue #3605: Fixed Traffic Monitor custom ports in health polling URL.

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -193,7 +193,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `regions/?$`, api.CreateHandler(region.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodDelete, `regions/{id}$`, api.DeleteHandler(region.GetTypeSingleton()), auth.PrivLevelOperations, Authenticated, nil},
 
-		{1.1, http.MethodDelete, `deliveryservice_server/{dsid}/{serverid}`, dsserver.Delete, auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodDelete, `deliveryservice_server/{dsid}/{serverid}`, dsserver.Delete, auth.PrivLevelOperations, Authenticated, nil},
 
 		// get all edge servers associated with a delivery service (from deliveryservice_server table)
 


### PR DESCRIPTION
This PR backports #3773:

The permissions are supposed to be Operations and above (not read-only).

(cherry picked from commit 206ccb6d125fcecfd546b69b08b91214ecf4601f)
