### PR TITLE
Add Traffic Ops /deliveryservices, /servers If-Modified-Since support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added /#!/sso page to Traffic Portal to catch redirects back from OAuth provider and POST token into the API.
 - In Traffic Portal, server table columns can now be rearranged and their visibility toggled on/off as desired by the user. Hidden table columns are excluded from the table search. These settings are persisted in the browser.
 - Added pagination support to some Traffic Ops endpoints via three new query parameters, limit and offset/page
+- Traffic Ops /servers and /deliveryservices endpoints now support If-Modified-Since and If-None-Match requests.
 - Traffic Ops now supports a "sortOrder" query parameter on some endpoints to return API responses in descending order
 - Traffic Ops now uses a consistent format for audit logs across all Go endpoints
 - Added cache-side config generator, atstccfg, installed with ORT. Includes all configs.

--- a/grove/web/util.go
+++ b/grove/web/util.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 )
 
 type Hdr struct {
@@ -178,22 +179,7 @@ func GetHTTPDate(headers http.Header, key string) (time.Time, bool) {
 	if maybeDate == "" {
 		return time.Time{}, false
 	}
-	return ParseHTTPDate(maybeDate)
-}
-
-// ParseHTTPDate parses the given RFC7231§7.1.1 HTTP-date
-func ParseHTTPDate(d string) (time.Time, bool) {
-	if t, err := time.Parse(time.RFC1123, d); err == nil {
-		return t, true
-	}
-	if t, err := time.Parse(time.RFC850, d); err == nil {
-		return t, true
-	}
-	if t, err := time.Parse(time.ANSIC, d); err == nil {
-		return t, true
-	}
-	return time.Time{}, false
-
+	return rfc.ParseHTTPDate(maybeDate)
 }
 
 // RemapTextKey is the plugin shared data key inserted by grovetccfg for the Remap Line of the Delivery Service in Traffic Control, Traffic Ops.

--- a/lib/go-rfc/cachecontrol.go
+++ b/lib/go-rfc/cachecontrol.go
@@ -1,0 +1,110 @@
+package rfc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const HdrETag = "ETag"
+const HdrIfNoneMatch = "If-None-Match"
+const HdrIfModifiedSince = "If-Modified-Since"
+const HdrLastModified = "Last-Modified"
+const HdrCacheControl = "Cache-Control"
+
+const ETagVersion = 0
+
+// NotModified is a helper type for users of this library.
+// It allows users to return a NotModified instead of a bool, to make it obvious what the value is.
+type NotModified bool
+
+const IsModified = NotModified(false)
+const IsNotModified = NotModified(true)
+
+// AddModifiedHdrs adds the ETag and Last-Modified headers to the response of w.
+// This must be called before any body is written, of course, or the headers won't be.
+// The lastModified should be the last time this resource was modified.
+func AddModifiedHdrs(w http.ResponseWriter, lastModified time.Time) {
+	w.Header().Set(HdrCacheControl, `max-age=0, must-revalidate`)
+	w.Header().Set(HdrLastModified, FormatHTTPDate(lastModified))
+	w.Header().Set(HdrETag, ETag(lastModified))
+}
+
+// GetModifiedHdr gets the modified time from the ETag or Last-Modified.
+// Returns the modified time, and whether a time was found.
+func GetModifiedHdr(r *http.Request) (time.Time, bool) {
+	// Note we intentionally ignore errors. Logging client errs would be spammy and a potential attack vector, and we want to just return the real object to the client, not an error, if their headers were malformed.
+	if eTag := r.Header.Get(HdrIfNoneMatch); eTag != "" {
+		if t, err := ParseETag(eTag); err == nil {
+			return t, true
+		}
+	}
+	if lastModified := r.Header.Get(HdrIfModifiedSince); lastModified != "" {
+		if t, ok := ParseHTTPDate(lastModified); ok {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// FormatHTTPDate formats t as an RFC7231§7.1.1 HTTP-date.
+func FormatHTTPDate(t time.Time) string {
+	return t.Format(time.RFC1123)
+}
+
+// ETag takes the last time the object was modified, and returns an ETag string. Note the string is the complete header value, including quotes. ETags must be quoted strings.
+func ETag(t time.Time) string {
+	return `"v` + strconv.Itoa(ETagVersion) + `-` + strconv.FormatInt(t.UnixNano(), 36) + `"`
+}
+
+// ParseETag takes a complete ETag header string, including the quotes (if the client correctly set them), and returns the last modified time encoded in the ETag.
+func ParseETag(e string) (time.Time, error) {
+	if len(e) < 2 || e[0] != '"' || e[len(e)-1] != '"' {
+		return time.Time{}, errors.New("unquoted string, value must be quoted")
+	}
+	e = e[1 : len(e)-1] // strip quotes
+
+	prefix := `v` + strconv.Itoa(ETagVersion) + `-`
+	if len(e) < len(prefix) || !strings.HasPrefix(e, prefix) {
+		return time.Time{}, errors.New("malformed, no version prefix")
+	}
+
+	timeStr := e[len(prefix):]
+
+	i, err := strconv.ParseInt(timeStr, 36, 64)
+	if err != nil {
+		return time.Time{}, errors.New("malformed")
+	}
+
+	t := time.Unix(0, i)
+
+	const year = time.Hour * 24 * 365
+
+	// sanity check - if the time isn't +/- 20 years, error. This catches overflows and near-zero errors
+	if t.After(time.Now().Add(20*year)) || t.Before(time.Now().Add(-20*year)) {
+		return time.Time{}, errors.New("malformed, out of range")
+	}
+
+	return t, nil
+}

--- a/lib/go-rfc/rfc.go
+++ b/lib/go-rfc/rfc.go
@@ -1,0 +1,33 @@
+package rfc
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"time"
+)
+
+// ParseHTTPDate parses the given RFC7231§7.1.1 HTTP-date
+func ParseHTTPDate(d string) (time.Time, bool) {
+	if t, err := time.Parse(time.RFC1123, d); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC850, d); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.ANSIC, d); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}

--- a/traffic_ops/app/db/migrations/20190810000000_add-ds-update-last-modified-triggers.sql
+++ b/traffic_ops/app/db/migrations/20190810000000_add-ds-update-last-modified-triggers.sql
@@ -1,0 +1,70 @@
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	    http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE deliveryservice_consistent_hash_query_param ADD COLUMN IF NOT EXISTS last_updated timestamp with time zone NOT NULL DEFAULT NOW();
+
+CREATE OR REPLACE FUNCTION update_ds_last_updated_old_deliveryservice() RETURNS trigger AS $$
+BEGIN
+  UPDATE deliveryservice SET last_updated=NOW() WHERE id = OLD.deliveryservice;
+  RETURN old;
+END;
+$$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION update_ds_last_updated_new_deliveryservice() RETURNS trigger AS $$
+BEGIN
+  UPDATE deliveryservice SET last_updated=NOW() WHERE id = NEW.deliveryservice;
+  RETURN old;
+END;
+$$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION update_ds_last_updated_old_deliveryservice_id() RETURNS trigger AS $$
+BEGIN
+  UPDATE deliveryservice SET last_updated=NOW() WHERE id = OLD.deliveryservice_id;
+  RETURN old;
+END;
+$$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION update_ds_last_updated_new_deliveryservice_id() RETURNS trigger AS $$
+BEGIN
+  UPDATE deliveryservice SET last_updated=NOW() WHERE id = NEW.deliveryservice_id;
+  RETURN old;
+END;
+$$ language plpgsql;
+
+CREATE TRIGGER origin_delete_update_ds_modified AFTER DELETE ON origin FOR EACH ROW EXECUTE PROCEDURE update_ds_last_updated_old_deliveryservice();
+CREATE TRIGGER origin_update_update_ds_modified AFTER UPDATE ON origin FOR EACH ROW EXECUTE PROCEDURE update_ds_last_updated_new_deliveryservice();
+CREATE TRIGGER origin_insert_update_ds_modified AFTER INSERT ON origin FOR EACH ROW EXECUTE PROCEDURE update_ds_last_updated_new_deliveryservice();
+
+CREATE TRIGGER dsc_delete_update_ds_modified AFTER DELETE on deliveryservice_consistent_hash_query_param FOR EACH ROW EXECUTE PROCEDURE update_ds_last_updated_old_deliveryservice_id();
+CREATE TRIGGER dsc_update_update_ds_modified AFTER UPDATE on deliveryservice_consistent_hash_query_param FOR EACH ROW EXECUTE PROCEDURE update_ds_last_updated_new_deliveryservice_id();
+CREATE TRIGGER dsc_insert_update_ds_modified AFTER INSERT on deliveryservice_consistent_hash_query_param FOR EACH ROW EXECUTE PROCEDURE update_ds_last_updated_new_deliveryservice_id();
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP TRIGGER IF EXISTS origin_delete_update_ds_modified ON origin;
+DROP TRIGGER IF EXISTS origin_update_update_ds_modified ON origin;
+DROP TRIGGER IF EXISTS origin_insert_update_ds_modified ON origin;
+
+DROP TRIGGER IF EXISTS dsc_delete_update_ds_modified ON deliveryservice_consistent_hash_query_param;
+DROP TRIGGER IF EXISTS dsc_update_update_ds_modified ON deliveryservice_consistent_hash_query_param;
+DROP TRIGGER IF EXISTS dsc_insert_update_ds_modified ON deliveryservice_consistent_hash_query_param;
+
+DROP FUNCTION IF EXISTS update_ds_last_updated_old_deliveryservice();
+DROP FUNCTION IF EXISTS update_ds_last_updated_new_deliveryservice();
+DROP FUNCTION IF EXISTS update_ds_last_updated_old_deliveryservice_id();
+DROP FUNCTION IF EXISTS update_ds_last_updated_new_deliveryservice_id();
+
+ALTER TABLE deliveryservice_consistent_hash_query_param DROP COLUMN IF EXISTS last_updated;

--- a/traffic_ops/app/db/migrations/20190811000000_add-server-update-last-modified-triggers.sql
+++ b/traffic_ops/app/db/migrations/20190811000000_add-server-update-last-modified-triggers.sql
@@ -1,0 +1,42 @@
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	    http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+CREATE OR REPLACE FUNCTION update_cdn_last_updated_old_server() RETURNS trigger AS $$
+BEGIN
+  UPDATE cdn SET last_updated=NOW() WHERE id = (select cdn_id from server where id = OLD.server);
+  RETURN old;
+END;
+$$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION update_server_last_updated_new_server() RETURNS trigger AS $$
+BEGIN
+  UPDATE server SET last_updated=NOW() WHERE id = NEW.server;
+  RETURN old;
+END;
+$$ language plpgsql;
+
+CREATE TRIGGER dss_delete_update_server_modified AFTER DELETE ON deliveryservice_server FOR EACH ROW EXECUTE PROCEDURE update_cdn_last_updated_old_server();
+CREATE TRIGGER dss_update_update_server_modified AFTER UPDATE ON deliveryservice_server FOR EACH ROW EXECUTE PROCEDURE update_server_last_updated_new_server();
+CREATE TRIGGER dss_insert_update_server_modified AFTER INSERT ON deliveryservice_server FOR EACH ROW EXECUTE PROCEDURE update_server_last_updated_new_server();
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled oback
+
+DROP TRIGGER IF EXISTS dss_delete_update_server_modified ON deliveryservice_server;
+DROP TRIGGER IF EXISTS dss_update_update_server_modified ON deliveryservice_server;
+DROP TRIGGER IF EXISTS dss_insert_update_server_modified ON deliveryservice_server;
+
+DROP FUNCTION IF EXISTS update_cdn_last_updated_old_server();
+DROP FUNCTION IF EXISTS update_server_last_updated_new_server();

--- a/traffic_ops/testing/api/v14/deliveryservice_ims_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservice_ims_test.go
@@ -1,0 +1,277 @@
+package v14
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-rfc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestDeliveryServiceIMS(t *testing.T) {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		GetTestDeliveryServiceIMSAll(t)
+		GetTestDeliveryServiceIMSSingle(t)
+	})
+}
+
+func GetTestDeliveryServiceIMSAll(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+
+	resp, err := TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+	resp.Body.Close()
+
+	lastModified := resp.Header.Get(rfc.HdrLastModified)
+	if lastModified == "" {
+		t.Fatalf("deliveryservices request expected: " + rfc.HdrLastModified + " header, actual: missing")
+	}
+
+	etag := resp.Header.Get(rfc.HdrETag)
+	if etag == "" {
+		t.Fatalf("deliveryservices request expected: " + rfc.HdrETag + " header, actual: missing")
+	}
+
+	{
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+		req.Header.Add(rfc.HdrIfModifiedSince, lastModified)
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotModified {
+			t.Errorf("deliveryservices request with " + rfc.HdrIfModifiedSince + " expected: 304, actual: " + strconv.Itoa(resp.StatusCode))
+		}
+	}
+
+	{
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+		req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotModified {
+			t.Errorf("deliveryservices request with " + rfc.HdrIfNoneMatch + " expected: 304, actual: " + strconv.Itoa(resp.StatusCode))
+		}
+	}
+}
+
+func GetTestDeliveryServiceIMSSingle(t *testing.T) {
+	dses, _, err := TOSession.GetDeliveryServices()
+	if err != nil {
+		t.Errorf("cannot GET DeliveryServices: %v\n", err)
+	}
+	ds := tc.DeliveryService{}
+	for _, tods := range dses {
+		if !tods.Type.IsHTTP() && !tods.Type.IsDNS() {
+			continue
+		}
+		ds = tods
+		break
+	}
+	if ds.ID == 0 {
+		t.Fatalf("GET DeliveryServices returned no DNS or HTTP dses, must have at least 1 to test")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices?id="+strconv.Itoa(ds.ID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+
+	resp, err := TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+	resp.Body.Close()
+
+	lastModified := resp.Header.Get(rfc.HdrLastModified)
+	if lastModified == "" {
+		t.Fatalf("deliveryservices request expected: " + rfc.HdrLastModified + " header, actual: missing")
+	}
+
+	etag := resp.Header.Get(rfc.HdrETag)
+	if etag == "" {
+		t.Fatalf("deliveryservices request expected: " + rfc.HdrETag + " header, actual: missing")
+	}
+
+	{
+		// test a single DS with INM works
+
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices?id="+strconv.Itoa(ds.ID), nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+		req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotModified {
+			t.Errorf("deliveryservices request with " + rfc.HdrIfNoneMatch + " expected: 304, actual: " + strconv.Itoa(resp.StatusCode))
+		}
+	}
+
+	{
+		// test modifying the DS with a field on the same table, and verify an IMS/INM do NOT return a 304
+
+		ds.MaxOriginConnections += 50
+		time.Sleep(time.Second) // sleep for 1s, because IMS is 1-second resolution. Otherwise, it may not be modified.
+		if _, err := TOSession.UpdateDeliveryService(strconv.Itoa(ds.ID), &ds); err != nil {
+			t.Fatalf("cannot UPDATE DeliveryService by ID: %v\n", err)
+		}
+
+		{
+			req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices?id="+strconv.Itoa(ds.ID), nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err.Error())
+			}
+			req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+			resp, err := TOSession.Client.Do(req)
+			if err != nil {
+				t.Fatalf("running request: %s", err.Error())
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("deliveryservices request with " + rfc.HdrIfNoneMatch + " and modified DS expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+			}
+		}
+		{
+			req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices?id="+strconv.Itoa(ds.ID), nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err.Error())
+			}
+			req.Header.Add(rfc.HdrIfModifiedSince, lastModified)
+
+			resp, err := TOSession.Client.Do(req)
+			if err != nil {
+				t.Fatalf("running request: %s", err.Error())
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("deliveryservices request with " + rfc.HdrIfModifiedSince + " and modified DS expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+			}
+		}
+	}
+
+	{
+		// test modifying the DS with a field on a different table, and verify an IMS/INM do NOT return a 304
+
+		// Need to get a new LastModified and ETag, because of the above modification
+
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices?id="+strconv.Itoa(ds.ID), nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		lastModified := resp.Header.Get(rfc.HdrLastModified)
+		if lastModified == "" {
+			t.Fatalf("deliveryservices request expected: " + rfc.HdrLastModified + " header, actual: missing")
+		}
+
+		etag := resp.Header.Get(rfc.HdrETag)
+		if etag == "" {
+			t.Fatalf("deliveryservices request expected: " + rfc.HdrETag + " header, actual: missing")
+		}
+
+		types, _, err := TOSession.GetTypeByID(ds.TypeID)
+		if err != nil {
+			t.Fatalf("cannot get type by ID: %v\n", err)
+		}
+		if len(types) != 1 {
+			t.Fatalf("get types expected 1, actual %v\n", len(types))
+		}
+		typ := types[0]
+		typ.Description += " addsomething"
+
+		time.Sleep(time.Second) // sleep for 1s, because IMS is 1-second resolution. Otherwise, it may not be modified.
+		if _, _, err := TOSession.UpdateTypeByID(typ.ID, typ); err != nil {
+			t.Fatalf("cannot update type by ID: %v\n", err)
+		}
+
+		{
+			// test INM after update of single DS with non-ds table
+
+			req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices?id="+strconv.Itoa(ds.ID), nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err.Error())
+			}
+			req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+			resp, err := TOSession.Client.Do(req)
+			if err != nil {
+				t.Fatalf("running request: %s", err.Error())
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("deliveryservices request with " + rfc.HdrIfNoneMatch + " and modified DS expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+			}
+		}
+		{
+			// test IMS after update of single DS with non-ds table
+
+			req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/deliveryservices?id="+strconv.Itoa(ds.ID), nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err.Error())
+			}
+			req.Header.Add(rfc.HdrIfModifiedSince, lastModified)
+
+			resp, err := TOSession.Client.Do(req)
+			if err != nil {
+				t.Fatalf("running request: %s", err.Error())
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("deliveryservices request with " + rfc.HdrIfModifiedSince + " and modified DS expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+			}
+		}
+	}
+}

--- a/traffic_ops/testing/api/v14/server_ims_test.go
+++ b/traffic_ops/testing/api/v14/server_ims_test.go
@@ -1,0 +1,518 @@
+package v14
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-rfc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestServerIMS(t *testing.T) {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		defer DeleteTestDeliveryServiceServersCreated(t)
+		CreateTestDeliveryServiceServers(t)
+
+		GetTestServerIMSAllServers(t)
+		GetTestServerIMSSingleServer(t)
+		GetTestServerIMSDeliveryServiceServers(t)
+		GetTestServerIMSMids(t)
+	})
+}
+
+func GetTestServerIMSAllServers(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+
+	resp, err := TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+	resp.Body.Close()
+
+	lastModified := resp.Header.Get(rfc.HdrLastModified)
+	if lastModified == "" {
+		t.Fatalf("servers request expected: " + rfc.HdrLastModified + " header, actual: missing")
+	}
+
+	etag := resp.Header.Get(rfc.HdrETag)
+	if etag == "" {
+		t.Fatalf("servers request expected: " + rfc.HdrETag + " header, actual: missing")
+	}
+
+	{
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+		req.Header.Add(rfc.HdrIfModifiedSince, lastModified)
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotModified {
+			t.Errorf("servers request with " + rfc.HdrIfModifiedSince + " expected: 304, actual: " + strconv.Itoa(resp.StatusCode))
+		}
+	}
+
+	{
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+		req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotModified {
+			t.Errorf("servers request with " + rfc.HdrIfNoneMatch + " expected: 304, actual: " + strconv.Itoa(resp.StatusCode))
+		}
+	}
+}
+
+func GetTestServerIMSSingleServer(t *testing.T) {
+	servers, _, err := TOSession.GetServers()
+	if err != nil {
+		t.Errorf("cannot GET servers: %v\n", err)
+	}
+	server := tc.Server{}
+	for _, toserver := range servers {
+		if toserver.Type != string(tc.CacheTypeEdge) {
+			continue
+		}
+		server = toserver
+		break
+	}
+	if server.ID == 0 {
+		t.Fatalf("GET Servers returned no EDGE server, must have at least 1 to test")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?id="+strconv.Itoa(server.ID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+
+	resp, err := TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+	resp.Body.Close()
+
+	lastModified := resp.Header.Get(rfc.HdrLastModified)
+	if lastModified == "" {
+		t.Fatalf("server request expected: " + rfc.HdrLastModified + " header, actual: missing")
+	}
+
+	etag := resp.Header.Get(rfc.HdrETag)
+	if etag == "" {
+		t.Fatalf("server request expected: " + rfc.HdrETag + " header, actual: missing")
+	}
+
+	{
+		// test a single server with INM works
+
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?id="+strconv.Itoa(server.ID), nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+		req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotModified {
+			t.Errorf("servers request with " + rfc.HdrIfNoneMatch + " expected: 304, actual: " + strconv.Itoa(resp.StatusCode))
+		}
+	}
+
+	{
+		// test modifying the server with a field on the same table, and verify an IMS/INM do NOT return a 304
+
+		server.XMPPID += "-testchange"
+		time.Sleep(time.Second) // sleep for 1s, because IMS is 1-second resolution. Otherwise, it may not be modified.
+		if _, _, err := TOSession.UpdateServerByID(server.ID, server); err != nil {
+			t.Fatalf("cannot UPDATE server by ID: %v\n", err)
+		}
+
+		{
+			req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?id="+strconv.Itoa(server.ID), nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err.Error())
+			}
+			req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+			resp, err := TOSession.Client.Do(req)
+			if err != nil {
+				t.Fatalf("running request: %s", err.Error())
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("servers request with " + rfc.HdrIfNoneMatch + " and modified DS expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+			}
+		}
+		{
+			req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?id="+strconv.Itoa(server.ID), nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err.Error())
+			}
+			req.Header.Add(rfc.HdrIfModifiedSince, lastModified)
+
+			resp, err := TOSession.Client.Do(req)
+			if err != nil {
+				t.Fatalf("running request: %s", err.Error())
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("servers request with " + rfc.HdrIfModifiedSince + " and modified server expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+			}
+		}
+	}
+
+	{
+		// test modifying the server with a field on a different table, and verify an IMS/INM do NOT return a 304
+
+		// Need to get a new LastModified and ETag, because of the above modification
+
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?id="+strconv.Itoa(server.ID), nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		lastModified := resp.Header.Get(rfc.HdrLastModified)
+		if lastModified == "" {
+			t.Fatalf("servers request expected: " + rfc.HdrLastModified + " header, actual: missing")
+		}
+
+		etag := resp.Header.Get(rfc.HdrETag)
+		if etag == "" {
+			t.Fatalf("server request expected: " + rfc.HdrETag + " header, actual: missing")
+		}
+
+		types, _, err := TOSession.GetTypeByID(server.TypeID)
+		if err != nil {
+			t.Fatalf("cannot get type by ID: %v\n", err)
+		}
+		if len(types) != 1 {
+			t.Fatalf("get types expected 1, actual %v\n", len(types))
+		}
+		typ := types[0]
+		typ.Description += " addsomething"
+
+		time.Sleep(time.Second) // sleep for 1s, because IMS is 1-second resolution. Otherwise, it may not be modified.
+		if _, _, err := TOSession.UpdateTypeByID(typ.ID, typ); err != nil {
+			t.Fatalf("cannot update type by ID: %v\n", err)
+		}
+
+		{
+			// test INM after update of single server with non-server table
+
+			req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?id="+strconv.Itoa(server.ID), nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err.Error())
+			}
+			req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+			resp, err := TOSession.Client.Do(req)
+			if err != nil {
+				t.Fatalf("running request: %s", err.Error())
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("servers request with " + rfc.HdrIfNoneMatch + " and modified server expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+			}
+		}
+		{
+			// test IMS after update of single server with non-server table
+
+			req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?id="+strconv.Itoa(server.ID), nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err.Error())
+			}
+			req.Header.Add(rfc.HdrIfModifiedSince, lastModified)
+
+			resp, err := TOSession.Client.Do(req)
+			if err != nil {
+				t.Fatalf("running request: %s", err.Error())
+			}
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("servers request with " + rfc.HdrIfModifiedSince + " and modified server expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+			}
+		}
+	}
+}
+
+func GetTestServerIMSDeliveryServiceServers(t *testing.T) {
+	dsServers, _, err := TOSession.GetDeliveryServiceServers()
+	if err != nil {
+		t.Fatalf("GET delivery service servers: %v\n", err)
+	} else if len(dsServers.Response) == 0 {
+		t.Fatalf("GET delivery service servers: no servers found\n")
+	} else if dsServers.Response[0].Server == nil {
+		t.Fatalf("GET delivery service servers: returned nil server\n")
+	} else if dsServers.Response[0].DeliveryService == nil {
+		t.Fatalf("GET delivery service servers: returned nil ds\n")
+	}
+	serverID := *dsServers.Response[0].Server
+	dsID := *dsServers.Response[0].DeliveryService
+
+	dsServerIDs := map[int]struct{}{}
+	for _, dss := range dsServers.Response {
+		if dss.DeliveryService == nil || dss.Server == nil || *dss.DeliveryService != dsID {
+			continue
+		}
+		dsServerIDs[*dss.Server] = struct{}{}
+	}
+
+	// get a different serverID not already assigned to this dsID
+
+	servers, _, err := TOSession.GetServers()
+	if err != nil {
+		t.Errorf("cannot GET servers: %v\n", err)
+	}
+	otherServer := tc.Server{}
+	for _, toserver := range servers {
+		if toserver.Type != string(tc.CacheTypeEdge) || toserver.ID == serverID {
+			continue
+		}
+		if _, ok := dsServerIDs[toserver.ID]; ok {
+			continue
+		}
+		otherServer = toserver
+		break
+	}
+	if otherServer.ID == 0 {
+		t.Fatalf("GET Servers returned no EDGE server not assigned to dsID %v, must have at least 1 to test", dsID)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?dsId="+strconv.Itoa(dsID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+
+	resp, err := TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+	resp.Body.Close()
+
+	lastModified := resp.Header.Get(rfc.HdrLastModified)
+	if lastModified == "" {
+		t.Fatalf("server request expected: " + rfc.HdrLastModified + " header, actual: missing")
+	}
+
+	etag := resp.Header.Get(rfc.HdrETag)
+	if etag == "" {
+		t.Fatalf("server request expected: " + rfc.HdrETag + " header, actual: missing")
+	}
+
+	time.Sleep(time.Second) // sleep for 1s, because IMS is 1-second resolution. Otherwise, it may not be modified.
+	_, err = TOSession.CreateDeliveryServiceServers(dsID, []int{otherServer.ID}, false)
+	if err != nil {
+		t.Fatalf("create dss request err: " + err.Error())
+	}
+
+	// test IMS of ?dsId after creating a DSS
+
+	req, err = http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?dsId="+strconv.Itoa(dsID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+	req.Header.Add(rfc.HdrIfModifiedSince, lastModified)
+
+	resp, err = TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("servers request with " + rfc.HdrIfModifiedSince + " and added DSS expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+	}
+
+	// re-get lastModified+etag of servers?dsId after we created a DSS
+
+	req, err = http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?dsId="+strconv.Itoa(dsID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+
+	resp, err = TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+	resp.Body.Close()
+
+	lastModified = resp.Header.Get(rfc.HdrLastModified)
+	if lastModified == "" {
+		t.Fatalf("server request expected: "+rfc.HdrLastModified+" header, actual: missing (code %v) (hdrs %++v)\n", resp.StatusCode, resp.Header)
+	}
+
+	etag = resp.Header.Get(rfc.HdrETag)
+	if etag == "" {
+		t.Fatalf("server request expected: " + rfc.HdrETag + " header, actual: missing")
+	}
+
+	time.Sleep(time.Second) // sleep for 1s, because IMS is 1-second resolution. Otherwise, it may not be modified.
+	_, _, err = TOSession.DeleteDeliveryServiceServer(dsID, otherServer.ID)
+	if err != nil {
+		t.Fatalf("delete dss request err: " + err.Error())
+	}
+
+	// test IMS of ?dsId after deleting a DSS
+
+	req, err = http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?dsId="+strconv.Itoa(dsID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+	req.Header.Add(rfc.HdrIfModifiedSince, lastModified)
+
+	resp, err = TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("servers request with " + rfc.HdrIfModifiedSince + " and deleted DSS expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+	}
+}
+
+func GetTestServerIMSMids(t *testing.T) {
+	dses, _, err := TOSession.GetDeliveryServices()
+	if err != nil {
+		t.Errorf("cannot GET DeliveryServices: %v - %v\n", err, dses)
+	}
+	dsIDMap := map[int]tc.DeliveryService{}
+	for _, ds := range dses {
+		dsIDMap[ds.ID] = ds
+	}
+
+	dsServers, _, err := TOSession.GetDeliveryServiceServers()
+	if err != nil {
+		t.Fatalf("GET delivery service servers: %v\n", err)
+	} else if len(dsServers.Response) == 0 {
+		t.Fatalf("GET delivery service servers: no servers found\n")
+	} else if dsServers.Response[0].Server == nil {
+		t.Fatalf("GET delivery service servers: returned nil server\n")
+	} else if dsServers.Response[0].DeliveryService == nil {
+		t.Fatalf("GET delivery service servers: returned nil ds\n")
+	}
+
+	ds := tc.DeliveryService{}
+	for _, dss := range dsServers.Response {
+		if dss.Server == nil || dss.DeliveryService == nil {
+			continue
+		}
+		dssDS := dsIDMap[*dss.DeliveryService]
+		if dssDS.Type.UsesMidCache() {
+			ds = dssDS
+			break
+		}
+	}
+	if ds.ID == 0 {
+		t.Fatalf("DSS returned no UsesMidCache type DS %v, must have at least 1 to test", ds.ID)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?dsId="+strconv.Itoa(ds.ID), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %s", err.Error())
+	}
+
+	resp, err := TOSession.Client.Do(req)
+	if err != nil {
+		t.Fatalf("running request: %s", err.Error())
+	}
+
+	lastModified := resp.Header.Get(rfc.HdrLastModified)
+	if lastModified == "" {
+		t.Fatalf("server request expected: " + rfc.HdrLastModified + " header, actual: missing")
+	}
+
+	etag := resp.Header.Get(rfc.HdrETag)
+	if etag == "" {
+		t.Fatalf("server request expected: " + rfc.HdrETag + " header, actual: missing")
+	}
+
+	serversResp := tc.ServersResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&serversResp)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("/servers?dsId failed to decode body: " + err.Error())
+	}
+
+	midServer := tc.Server{}
+	for _, sv := range serversResp.Response {
+		if sv.Type == string(tc.CacheTypeMid) {
+			midServer = sv
+			break
+		}
+	}
+	if midServer.ID == 0 {
+		t.Fatalf("/servers?dsId=%v returned no mids, must have at least 1 to test", ds.ID)
+	}
+
+	midServer.XMPPID += "-testchange"
+	time.Sleep(time.Second) // sleep for 1s, because IMS is 1-second resolution. Otherwise, it may not be modified.
+	if _, _, err := TOSession.UpdateServerByID(midServer.ID, midServer); err != nil {
+		t.Fatalf("cannot UPDATE mid server by ID: %v\n", err)
+	}
+
+	{
+		req, err := http.NewRequest(http.MethodGet, TOSession.URL+"/api/1.4/servers?dsId="+strconv.Itoa(ds.ID), nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %s", err.Error())
+		}
+		req.Header.Add(rfc.HdrIfNoneMatch, etag)
+
+		resp, err := TOSession.Client.Do(req)
+		if err != nil {
+			t.Fatalf("running request: %s", err.Error())
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("servers request with " + rfc.HdrIfNoneMatch + " and modified parent mid expected: 200, actual: " + strconv.Itoa(resp.StatusCode))
+		}
+	}
+}

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -298,7 +298,7 @@
             "sslKeyVersion": 2,
             "tenant": "tenant1",
             "tenantName": "tenant1",
-            "type": "HTTP_LIVE",
+            "type": "HTTP",
             "xmlId": "ds1",
             "anonymousBlockingEnabled": true
         },

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -297,13 +297,14 @@ func Parse(r io.Reader, tx *sql.Tx, v ParseValidator) error {
 }
 
 type APIInfo struct {
-	Params    map[string]string
-	IntParams map[string]int
-	User      *auth.CurrentUser
-	ReqID     uint64
-	Version   *Version
-	Tx        *sqlx.Tx
-	Config    *config.Config
+	Params       map[string]string
+	IntParams    map[string]int
+	User         *auth.CurrentUser
+	ReqID        uint64
+	Version      *Version
+	Tx           *sqlx.Tx
+	Config       *config.Config
+	LastModified *time.Time
 }
 
 // Creates a deprecation warning for an endpoint, with a proposed alternative.
@@ -371,14 +372,21 @@ func NewInfo(r *http.Request, requiredParams []string, intParamNames []string) (
 	if err != nil {
 		return &APIInfo{Tx: &sqlx.Tx{}}, userErr, errors.New("could not begin transaction: " + err.Error()), http.StatusInternalServerError
 	}
+
+	lastModified := (*time.Time)(nil)
+	if lastModifiedHdr, ok := rfc.GetModifiedHdr(r); ok {
+		lastModified = &lastModifiedHdr
+	}
+
 	return &APIInfo{
-		Config:    cfg,
-		ReqID:     reqID,
-		Version:   version,
-		Params:    params,
-		IntParams: intParams,
-		User:      user,
-		Tx:        tx,
+		Config:       cfg,
+		ReqID:        reqID,
+		Version:      version,
+		Params:       params,
+		IntParams:    intParams,
+		User:         user,
+		Tx:           tx,
+		LastModified: lastModified,
 	}, nil, nil, http.StatusOK
 }
 

--- a/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
@@ -20,6 +20,8 @@ package api
  */
 
 import (
+	"time"
+
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 )
 
@@ -62,6 +64,7 @@ type Reader interface {
 	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Read() ([]interface{}, error, error, int)
 	APIInfoer
+	Identifier
 }
 
 type Updater interface {
@@ -92,4 +95,10 @@ type Tenantable interface {
 type APIInfoer interface {
 	SetInfo(*APIInfo)
 	APIInfo() *APIInfo
+}
+
+// Modifieder allows Readers to set a LastModified time, to be returned to clients.
+// If a Reader implements Modifieder, the "CRUDer" ReadHandler will use it to set an ETag and Last-Modified header.
+type Modifieder interface {
+	LastModified() time.Time
 }

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -54,6 +54,32 @@ func (cgparam *TOCacheGroupParameter) GetType() string {
 	return "cachegroup_params"
 }
 
+func (cgparam TOCacheGroupParameter) GetAuditName() string {
+	if cgparam.Name != nil {
+		return *cgparam.Name
+	}
+	if cgparam.ID != nil {
+		return strconv.Itoa(*cgparam.ID)
+	}
+	return "unknown"
+}
+
+func (cgparam TOCacheGroupParameter) GetKeyFieldsInfo() []api.KeyFieldInfo {
+	return []api.KeyFieldInfo{{"id", api.GetIntKey}}
+}
+
+func (cgparam TOCacheGroupParameter) GetKeys() (map[string]interface{}, bool) {
+	if cgparam.ID == nil {
+		return map[string]interface{}{"id": 0}, false
+	}
+	return map[string]interface{}{"id": *cgparam.ID}, true
+}
+
+func (cgparam *TOCacheGroupParameter) SetKeys(keys map[string]interface{}) {
+	i, _ := keys["id"].(int) //this utilizes the non panicking type assertion, if the thrown away ok variable is false i will be the zero of the type, 0 here.
+	cgparam.ID = &i
+}
+
 func (cgparam *TOCacheGroupParameter) Read() ([]interface{}, error, error, int) {
 	queryParamsToQueryCols := cgparam.ParamColumns()
 	parameters := cgparam.APIInfo().Params

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/unassigned_parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/unassigned_parameters.go
@@ -51,6 +51,32 @@ func (cgunparam *TOCacheGroupUnassignedParameter) GetType() string {
 	return "cachegroup_unassigned_params"
 }
 
+func (cgunparam TOCacheGroupUnassignedParameter) GetAuditName() string {
+	if cgunparam.Name != nil {
+		return *cgunparam.Name
+	}
+	if cgunparam.ID != nil {
+		return strconv.Itoa(*cgunparam.ID)
+	}
+	return "unknown"
+}
+
+func (cgunparam TOCacheGroupUnassignedParameter) GetKeyFieldsInfo() []api.KeyFieldInfo {
+	return []api.KeyFieldInfo{{"id", api.GetIntKey}}
+}
+
+func (cgunparam TOCacheGroupUnassignedParameter) GetKeys() (map[string]interface{}, bool) {
+	if cgunparam.ID == nil {
+		return map[string]interface{}{"id": 0}, false
+	}
+	return map[string]interface{}{"id": *cgunparam.ID}, true
+}
+
+func (cgunparam *TOCacheGroupUnassignedParameter) SetKeys(keys map[string]interface{}) {
+	i, _ := keys["id"].(int) //this utilizes the non panicking type assertion, if the thrown away ok variable is false i will be the zero of the type, 0 here.
+	cgunparam.ID = &i
+}
+
 func (cgunparam *TOCacheGroupUnassignedParameter) Read() ([]interface{}, error, error, int) {
 	queryParamsToQueryCols := cgunparam.ParamColumns()
 	parameters := cgunparam.APIInfo().Params

--- a/traffic_ops/traffic_ops_golang/deliveryservice/cachecontrol.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/cachecontrol.go
@@ -1,0 +1,53 @@
+package deliveryservice
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"time"
+
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func dsModified(tx *sqlx.Tx, lastModified time.Time, where string, whereParams map[string]interface{}) bool {
+	return dbhelpers.ResourceModified(tx, lastModified, makeDSModifiedQry(where), whereParams)
+}
+
+func makeDSModifiedQry(where string) string {
+	return `
+SELECT
+  MAX(GREATEST(
+    ds.last_updated,
+    type.last_updated,
+    cdn.last_updated,
+    profile.last_updated,
+    tenant.last_updated,
+    o.last_updated
+  )) as last_updated
+FROM
+  deliveryservice AS ds
+  JOIN type ON ds.type = type.id
+  JOIN cdn ON ds.cdn_id = cdn.id
+  LEFT JOIN profile ON ds.profile = profile.id
+  LEFT JOIN tenant ON ds.tenant_id = tenant.id
+  LEFT JOIN origin o ON (o.deliveryservice = ds.id AND o.is_primary)
+` + where
+}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -615,6 +615,33 @@ type TODSSDeliveryService struct {
 	tc.DeliveryServiceNullable
 }
 
+func (ds *TODSSDeliveryService) GetAuditName() string {
+	if ds.XMLID != nil {
+		return *ds.XMLID
+	}
+	return ""
+}
+
+func (ds TODSSDeliveryService) GetKeyFieldsInfo() []api.KeyFieldInfo {
+	return []api.KeyFieldInfo{{"id", api.GetIntKey}}
+}
+
+func (ds TODSSDeliveryService) GetKeys() (map[string]interface{}, bool) {
+	if ds.ID == nil {
+		return map[string]interface{}{"id": 0}, false
+	}
+	return map[string]interface{}{"id": *ds.ID}, true
+}
+
+func (ds *TODSSDeliveryService) SetKeys(keys map[string]interface{}) {
+	i, _ := keys["id"].(int) //this utilizes the non panicking type assertion, if the thrown away ok variable is false i will be the zero of the type, 0 here.
+	ds.ID = &i
+}
+
+func (ds *TODSSDeliveryService) GetType() string {
+	return "ds"
+}
+
 // Read shows all of the delivery services associated with the specified server.
 func (dss *TODSSDeliveryService) Read() ([]interface{}, error, error, int) {
 	returnable := []interface{}{}
@@ -660,9 +687,9 @@ func (dss *TODSSDeliveryService) Read() ([]interface{}, error, error, int) {
 	log.Debugln("generated deliveryServices query: " + query)
 	log.Debugf("executing with values: %++v\n", queryValues)
 
-	dses, userErr, sysErr, _ := deliveryservice.GetDeliveryServices(query, queryValues, dss.APIInfo().Tx)
+	dses, _, userErr, sysErr, _ := deliveryservice.GetDeliveryServices(query, queryValues, dss.APIInfo().Tx)
 	if sysErr != nil {
-		sysErr = fmt.Errorf("reading server dses: %v ", sysErr)
+		sysErr = errors.New("reading server dses: " + sysErr.Error())
 	}
 	if userErr != nil || sysErr != nil {
 		return nil, userErr, sysErr, http.StatusInternalServerError

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -181,6 +181,34 @@ RETURNING job.asset_url,
           job.start_time
 `
 
+func (job InvalidationJob) GetType() string {
+	return "invalidation_job"
+}
+
+func (job InvalidationJob) GetAuditName() string {
+	if job.ID != nil {
+		return strconv.Itoa(int(*job.ID))
+	}
+	return "unknown"
+}
+
+func (job InvalidationJob) GetKeyFieldsInfo() []api.KeyFieldInfo {
+	return []api.KeyFieldInfo{{"id", api.GetIntKey}}
+}
+
+func (job InvalidationJob) GetKeys() (map[string]interface{}, bool) {
+	if job.ID == nil {
+		return map[string]interface{}{"id": 0}, false
+	}
+	return map[string]interface{}{"id": *job.ID}, true
+}
+
+func (job *InvalidationJob) SetKeys(keys map[string]interface{}) {
+	i, _ := keys["id"].(int) //this utilizes the non panicking type assertion, if the thrown away ok variable is false i will be the zero of the type, 0 here.
+	ii := uint64(i)
+	job.ID = &ii
+}
+
 type apiResponse struct {
 	Alerts   []tc.Alert         `json:"alerts,omitempty"`
 	Response tc.InvalidationJob `json:"response,omitempty"`

--- a/traffic_ops/traffic_ops_golang/server/cachecontrol.go
+++ b/traffic_ops/traffic_ops_golang/server/cachecontrol.go
@@ -1,0 +1,61 @@
+package server
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+	"time"
+
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func serverModified(tx *sqlx.Tx, lastModified time.Time, where string, whereParams map[string]interface{}) bool {
+	return dbhelpers.ResourceModified(tx, lastModified, makeServerModifiedQry(where), whereParams)
+}
+
+func makeServerModifiedQry(where string) string {
+	maybeDSSLastUpdated := ``
+	if strings.Contains(where, "deliveryservice_server") {
+		maybeDSSLastUpdated += `dss.last_updated,`
+	}
+	return `
+SELECT
+  MAX(GREATEST(
+    s.last_updated,
+    cg.last_updated,
+    cdn.last_updated,
+    pl.last_updated,
+    pr.last_updated,
+    st.last_updated,
+    ` + maybeDSSLastUpdated + `
+    tp.last_updated
+  )) AS last_updated_any
+FROM
+  server s
+  JOIN cachegroup cg on cg.id = s.cachegroup
+  JOIN cdn cdn on cdn.id = s.cdn_id
+  JOIN phys_location pl on pl.id = s.phys_location
+  JOIN profile pr on pr.id = s.profile
+  JOIN status st on st.id = s.status
+  JOIN type tp on tp.id = s.type
+` + where
+}

--- a/traffic_ops/traffic_ops_golang/test/helpers.go
+++ b/traffic_ops/traffic_ops_golang/test/helpers.go
@@ -30,8 +30,15 @@ import (
 func ColsFromStructByTag(tagName string, thing interface{}) []string {
 	cols := []string{}
 	t := reflect.TypeOf(thing)
+	v := reflect.ValueOf(thing)
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
+		vField := v.Field(i)
+		if vField.Kind() == reflect.Struct && field.Anonymous {
+			structCols := ColsFromStructByTag(tagName, vField.Interface())
+			cols = append(cols, structCols...)
+			continue
+		}
 		if (strings.Compare(tagName, "db") == 0) && (tagName != "") {
 			// Get the field tag value
 			tag := field.Tag.Get(tagName)


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Adds Traffic Ops /deliveryservices, /servers If-Modified-Since support.

Also adds ETags and If-None-Match support.

Includes API tests.
Includes Changelog.
No documentation; it does technically change the interface, but we don't document headers in the API.

Some notes:
- this is extremely valuable for ORT and cache-side-configs, which will now be able to avoid unnecessary large requests.
- I noticed this doesn't actually work in the Portal. It works in a browser for actual TO, but TP doesn't. It looks like either Node isn't making the request correctly, or Express is stripping the headers somewhere, probably the latter.
- This also fixes some other issues, like the DS query doing a heinously expensive `FULL OUTER JOIN` when it only needs to `LEFT JOIN` (unless I'm mistaken?)
- Also changes the Fixtures to include a DS which uses the mids. Until now, all "fixtures" were DS types that bypassed the mids. This is a critical part of TC that we need more tests for.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Run API tests.

Make a request to a /deliveryservices or /servers endpoint, get the ETag or Last-Modified header, make another request with a If-Modified-Since or If-None-Match header, verify a 304. Make a change to a server or deliveryservice in the request, make a request with a IMS or INM header and verify it does NOT 304 but responds with a 200 and the full object.

## If this is a bug fix, what versions of Traffic Control are affected?

Not a bug fix.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
