### PR TITLE
Fix Origins TO API tests

### DIFF
--- a/traffic_ops/testing/api/v14/origins_test.go
+++ b/traffic_ops/testing/api/v14/origins_test.go
@@ -154,34 +154,43 @@ func OriginTenancyTest(t *testing.T) {
 }
 
 func VerifyPaginationSupport(t *testing.T) {
-	origins, _, err := TOSession.GetOrigins()
+	origins, _, err := TOSession.GetOriginsByQueryParams("?orderby=id")
 	if err != nil {
 		t.Fatalf("cannot GET origins: %v\n", err)
 	}
 
-	originsWithLimit, _, err := TOSession.GetOriginsByQueryParams("?limit=1")
+	originsWithLimit, _, err := TOSession.GetOriginsByQueryParams("?orderby=id&limit=1")
 	if !reflect.DeepEqual(origins[:1], originsWithLimit) {
 		t.Errorf("expected GET origins with limit = 1 to return first result")
 	}
 
-	originsWithOffset, _, err := TOSession.GetOriginsByQueryParams("?limit=1&offset=1")
+	originsWithOffset, _, err := TOSession.GetOriginsByQueryParams("?orderby=id&limit=1&offset=1")
 	if !reflect.DeepEqual(origins[1:2], originsWithOffset) {
 		t.Errorf("expected GET origins with limit = 1, offset = 1 to return second result")
 	}
 
-	originsWithPage, _, err := TOSession.GetOriginsByQueryParams("?limit=1&page=2")
+	originsWithPage, _, err := TOSession.GetOriginsByQueryParams("?orderby=id&limit=1&page=2")
 	if !reflect.DeepEqual(origins[1:2], originsWithPage) {
 		t.Errorf("expected GET origins with limit = 1, page = 2 to return second result")
 	}
 
-	if _, _, err := TOSession.GetOriginsByQueryParams("?limit=0"); !strings.Contains(err.Error(), "must be a positive integer") {
-		t.Errorf("expected GET origins to return an error when limit is not a positive integer: " + err.Error())
+	_, _, err = TOSession.GetOriginsByQueryParams("?limit=0")
+	if err == nil {
+		t.Errorf("expected GET origins to return an error when limit is not a positive integer")
+	} else if !strings.Contains(err.Error(), "must be a positive integer") {
+		t.Errorf("expected GET origins to return an error for limit is not a positive integer, actual error: " + err.Error())
 	}
-	if _, _, err := TOSession.GetOriginsByQueryParams("?limit=1&offset=0"); !strings.Contains(err.Error(), "must be a positive integer") {
-		t.Errorf("expected GET origins to return an error when offset is not a positive integer: " + err.Error())
+	_, _, err = TOSession.GetOriginsByQueryParams("?limit=1&offset=0")
+	if err == nil {
+		t.Errorf("expected GET origins to return an error when offset is not a positive integer")
+	} else if !strings.Contains(err.Error(), "must be a positive integer") {
+		t.Errorf("expected GET origins to return an error for offset is not a positive integer, actual error: " + err.Error())
 	}
-	if _, _, err := TOSession.GetOriginsByQueryParams("?limit=1&page=0"); !strings.Contains(err.Error(), "must be a positive integer") {
-		t.Errorf("expected GET origins to return an error when page is not a positive integer: " + err.Error())
+	_, _, err = TOSession.GetOriginsByQueryParams("?limit=1&page=0")
+	if err == nil {
+		t.Errorf("expected GET origins to return an error when page is not a positive integer")
+	} else if !strings.Contains(err.Error(), "must be a positive integer") {
+		t.Errorf("expected GET origins to return an error for page is not a positive integer, actual error: " + err.Error())
 	}
 }
 


### PR DESCRIPTION
The offset/limit/page query parameters should be paired with orderby for
determinate results.

<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- tests, no doc changes required


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Run the TO API tests.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
