### PR TITLE
3.1.x backport: to go fix server ipv6 validation allow empty str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Fix TO Servers validation to allow "" ipv6
 
 
 ### Fixed

--- a/lib/go-tc/tovalidate/rules.go
+++ b/lib/go-tc/tovalidate/rules.go
@@ -154,7 +154,7 @@ func IsValidIPv6CIDROrAddress(value interface{}) error {
 				}
 			}
 		}
-		return fmt.Errorf("unable to parse an IPv6 address or CIDR from: %s", v)
+		return fmt.Errorf("unable to parse an IPv6 address or CIDR from: %s", *v)
 	default:
 		return fmt.Errorf("IsValidIPv6CIDROrAddress validation failure: unknown type %T", value)
 	}

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -91,8 +91,14 @@ func (server *TOServer) GetType() string {
 	return "server"
 }
 
-func (server *TOServer) Validate() error {
+func (server *TOServer) Sanitize() {
+	if server.IP6Address != nil && *server.IP6Address == "" {
+		server.IP6Address = nil
+	}
+}
 
+func (server *TOServer) Validate() error {
+	server.Sanitize()
 	noSpaces := validation.NewStringRule(tovalidate.NoSpaces, "cannot contain spaces")
 
 	validateErrs := validation.Errors{


### PR DESCRIPTION
This PR backports #2845

Fix TO Servers validation to allow "" ipv6

(cherry picked from commit b4ab947)