### PR TITLE
fixes inaccurate change log message when queuing/dequeuing server upd…

### DIFF
--- a/traffic_ops/traffic_ops_golang/cdn/queue.go
+++ b/traffic_ops/traffic_ops_golang/cdn/queue.go
@@ -68,7 +68,7 @@ func Queue(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 		return
 	}
-	api.CreateChangeLogRawTx(api.ApiChange, "CDN: "+string(cdnName)+", ID: "+strconv.Itoa(inf.IntParams["id"])+", ACTION: Queue CDN updates", inf.User, inf.Tx.Tx)
+	api.CreateChangeLogRawTx(api.ApiChange, "CDN: "+string(cdnName)+", ID: "+strconv.Itoa(inf.IntParams["id"])+", ACTION: CDN server updates "+reqObj.Action+"d", inf.User, inf.Tx.Tx)
 	api.WriteResp(w, r, QueueResp{Action: reqObj.Action, CDNID: int64(inf.IntParams["id"])})
 }
 


### PR DESCRIPTION
…ates for a cdn

## What does this PR (Pull Request) do?
Regardless of whether you were queuing or dequeuing (clearing) server updates for a cdn, the change log message always said:

"...ACTION: Queue CDN updates"

when, in fact, the message should differ depending on the action, for example:

"ACTION: CDN server updates queued"
"ACTION: CDN server updates dequeued"

change logs messages are not documented so no doc changes
we don't test the format of change log messages for non-shared handlers
too small to justify a changelog.md entry

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Run the TO unit tests -

cd trafficcontrol/traffic_ops/traffic_ops_golang
go test $(go list ./...)

Run the API tests - https://github.com/apache/trafficcontrol/blob/master/traffic_ops/testing/api/README.md

Manually - Open TP and navigate to a cdn. 

queue updates for the cdn, check https://tp.domain.com/#!/change-logs
dequeue (clear) updates for the cdn, check https://tp.domain.com/#!/change-logs

## If this is a bug fix, what versions of Traffic Control are affected?

- master (241c537)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
