### PR TITLE
Fix TM nil panic in CRConfig validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Fix TO Servers validation to allow "" ipv6
 
-
 ### Fixed
-
+- Fixed a bug where TM crashes when PostgreSQL is unavailable
 
 ## [3.0.1] - 2019-04-09
 ### Added


### PR DESCRIPTION
(cherry picked from commit 4d86b1d10ecb32c5d52e1feddcb512d74aab208c)

This fixes a bug where TM crashes when PostgreSQL is unavailable
Updated Changelog

This was done on behalf of @smalenfant 

## What does this PR (Pull Request) do?

- This PR fixes a bug where TM crashes when PostgreSQL is unavailable

## Which Traffic Control components are affected by this PR?

- Traffic Monitor

## What is the best way to verify this PR?

Install and configure this version of TM, stop PostgreSQL and verify this version of TM didn't crash

## If this is a bug fix, what versions of Traffic Control are affected?

3.0

