### PR TITLE
Backbport 3326 logging yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [3.1.0] - 2019-08-16
 ### Added
+- Added logging.yaml support
 
 ### Changed
 - Fix TO Servers validation to allow "" ipv6

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1106,6 +1106,7 @@ sub process_config_files {
 				|| $file =~ m/\.key$/
 				|| $file eq "logs_xml.config"
 				|| $file eq "logging.config"
+				|| $file eq "logging.yaml"
 				|| $file eq "ssl_multicert.config" )
 			)
 		{


### PR DESCRIPTION
This PR backports #3326 :

    Added logging.yaml support (#3326)
    
    Added logging.yaml support to generate a yaml file if the logging.yaml file is specified as output. Tested with CIAB and it appears to work
    
    (cherry picked from commit 8fcde36019e37965ad5d1dd137032f26e3e4113d)