### PR TITLE
Fixed double-build of TR RPMs in CiaB makefile

### DIFF
--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -57,8 +57,6 @@ traffic_monitor/traffic_monitor.rpm: ../../dist/traffic_monitor-$(SPECIAL_SAUCE)
 	cp -f $? $@
 traffic_ops/traffic_ops.rpm: ../../dist/traffic_ops-$(SPECIAL_SAUCE)
 	cp -f $? $@
-mid/traffic_ops_ort.rpm edge/traffic_ops_ort.rpm: ../../dist/traffic_ops_ort-$(SPECIAL_SAUCE)
-	cp -f $? $@
 traffic_portal/traffic_portal.rpm: ../../dist/traffic_portal-$(SPECIAL_SAUCE)
 	cp -f $? $@
 traffic_router/traffic_router.rpm: ../../dist/traffic_router-$(SPECIAL_SAUCE)
@@ -75,13 +73,10 @@ traffic_stats/traffic_stats.rpm: ../../dist/traffic_stats-$(SPECIAL_SAUCE)
 ../../dist/traffic_ops-$(SPECIAL_SAUCE): $(TO_SOURCE)
 	sudo ../../pkg -v traffic_ops_build
 
-../../dist/traffic_ops_ort-$(SPECIAL_SAUCE): $(ORT_SOURCE)
-	sudo ../../pkg -v traffic_ops_build
-
 ../../dist/traffic_portal-$(SPECIAL_SAUCE): $(TP_SOURCE)
 	sudo ../../pkg -v traffic_portal_build
 
-../../dist/traffic_router-$(SPECIAL_SAUCE) ../../dist/tomcat-$(SPECIAL_SEASONING): $(TR_SOURCE)
+../../dist/traffic_rou%er-$(SPECIAL_SAUCE) ../../dist/tomca%-$(SPECIAL_SEASONING): $(TR_SOURCE)
 	sudo ../../pkg -v traffic_router_build
 
 ../../dist/traffic_stats-$(SPECIAL_SAUCE): $(TS_SOURCE)


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

When building packages for CDN-in-a-Box using `make` with multiple "jobs" (i.e. with `-j`), there is a race condition building the Traffic Router and Tomcat RPMs, since one build process creates both and they both depend on changes to the TR source. In cases where this manifested - which is often - the build will either fail or simply do double the work it needs to do when building those RPMs. This PR eliminates that by changing the rule to a pattern-based one, which `make` will now properly recognize as a single output (consisting of multiple files) of a single build process.


## Which Traffic Control components are affected by this PR?
- CDN in a Box

No docs because it's a bugfix

## What is the best way to verify this PR?
Build the RPMs for CDN-in-a-Box using `make` with the `-j` flag, observe that it consistently has no issue creating RPMs for both Tomcat and Traffic Router exactly once (note that in order to do that, the `build_default` Docker network must already exist - which is accomplished by just having built an RPM on the same machine before - as otherwise duplicate networks will be created).

No tests because this is just the build system for a toy environment.

## If this is a bug fix, what versions of Traffic Control are affected?
N/A - CDN-in-a-Box is not a supported component of Traffic Control, and no such support is purported to exist in any existing releases.

## The following criteria are ALL met by this PR
- [x] I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**