### PR TITLE
Add TO Go server cache configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.4/cdns/name/:name/dnsseckeys `GET`
   - /api/1.4/user/login/oauth `POST`
   - /api/1.1/profiles/:name/configfiles/ats/* `GET`
+  - /api/1.1/servers/:name/configfiles/ats/* `GET`
   - /api/1.1/dbdump `GET`
   - /api/1.1/servers/:name/configfiles/ats/parent.config
   - /api/1.1/servers/:name/configfiles/ats/remap.config

--- a/lib/go-atscfg/chkconfig.go
+++ b/lib/go-atscfg/chkconfig.go
@@ -1,0 +1,56 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+)
+
+const ChkconfigFileName = `chkconfig`
+
+const ChkconfigParamConfigFile = `chkconfig`
+
+type ChkConfigEntry struct {
+	Name string `json:"name"`
+	Val  string `json:"value"`
+}
+
+// MakeChkconfig returns the 'chkconfig' ATS config file endpoint.
+// This is a JSON object, and should be served with an 'application/json' Content-Type.
+func MakeChkconfig(
+	params map[string][]string, // map[name]value - config file should always be 'chkconfig'
+) string {
+
+	chkconfig := []ChkConfigEntry{}
+	for name, vals := range params {
+		for _, val := range vals {
+			chkconfig = append(chkconfig, ChkConfigEntry{Name: name, Val: val})
+		}
+	}
+	bts, err := json.Marshal(&chkconfig)
+	if err != nil {
+		// should never happen
+		log.Errorln("marshalling chkconfig NameVals: " + err.Error())
+		bts = []byte("error encoding params to json, see Traffic Ops log for details")
+	}
+	return string(bts)
+}

--- a/lib/go-atscfg/chkconfig_test.go
+++ b/lib/go-atscfg/chkconfig_test.go
@@ -1,0 +1,52 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMakeChkconfig(t *testing.T) {
+	params := map[string][]string{
+		"p0": []string{"p0v0", "p0v1"},
+		"1":  []string{"p1v0"},
+	}
+
+	txt := MakeChkconfig(params)
+
+	chkconfig := []ChkConfigEntry{}
+	if err := json.Unmarshal([]byte(txt), &chkconfig); err != nil {
+		t.Fatalf("MakePackages expected a JSON array of objects, actual: " + err.Error())
+	}
+
+	for _, chkConfigEntry := range chkconfig {
+		vals, ok := params[chkConfigEntry.Name]
+		if !ok {
+			t.Errorf("expected %+v actual %v\n", params, chkConfigEntry.Name)
+		}
+
+		if !strArrContains(vals, chkConfigEntry.Val) {
+			t.Errorf("expected %+v actual %v\n", vals, chkConfigEntry.Val)
+		}
+
+		params[chkConfigEntry.Name] = strArrRemove(vals, chkConfigEntry.Val)
+	}
+}

--- a/lib/go-atscfg/hostingdotconfig.go
+++ b/lib/go-atscfg/hostingdotconfig.go
@@ -1,0 +1,69 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const HostingConfigFileName = `hosting.config`
+
+const HostingConfigParamConfigFile = `storage.config`
+
+const ParamDrivePrefix = "Drive_Prefix"
+const ParamRAMDrivePrefix = "RAM_Drive_Prefix"
+
+func MakeHostingDotConfig(
+	serverName tc.CacheName,
+	toToolName string, // tm.toolname global parameter (TODO: cache itself?)
+	toURL string, // tm.url global parameter (TODO: cache itself?)
+	params map[string]string, // map[name]value - config file should always be storage.config
+	origins []string, // origins of delivery services assigned to this server. Should only include LIVE and LIVE_NATNL for Edges, and only LIVE_NATNL for Mids.
+) string {
+	text := GenericHeaderComment(string(serverName), toToolName, toURL)
+
+	if _, ok := params[ParamRAMDrivePrefix]; ok {
+		nextVolume := 1
+		if _, ok := params[ParamDrivePrefix]; ok {
+			diskVolume := nextVolume
+			text += `# TRAFFIC OPS NOTE: volume ` + strconv.Itoa(diskVolume) + ` is the Disk volume` + "\n"
+			nextVolume++
+		}
+		ramVolume := nextVolume
+		text += `# TRAFFIC OPS NOTE: volume ` + strconv.Itoa(ramVolume) + ` is the RAM volume` + "\n"
+
+		seenOrigins := map[string]struct{}{}
+		for _, origin := range origins {
+			if _, ok := seenOrigins[origin]; ok {
+				continue
+			}
+			seenOrigins[origin] = struct{}{}
+			origin = strings.TrimPrefix(origin, `http://`)
+			origin = strings.TrimPrefix(origin, `https://`)
+			text += `hostname=` + origin + ` volume=` + strconv.Itoa(ramVolume) + "\n"
+		}
+	}
+	diskVolume := 1 // note this will actually be the RAM (RAM_Drive_Prefix) volume if there is no Drive_Prefix parameter.
+	text += `hostname=*   volume=` + strconv.Itoa(diskVolume) + "\n"
+	return text
+}

--- a/lib/go-atscfg/hostingdotconfig_test.go
+++ b/lib/go-atscfg/hostingdotconfig_test.go
@@ -1,0 +1,116 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestMakeHostingDotConfig(t *testing.T) {
+	serverName := tc.CacheName("server0")
+	toToolName := "to0"
+	toURL := "trafficops.example.net"
+	params := map[string]string{
+		ParamRAMDrivePrefix: "ParamRAMDrivePrefix-shouldnotappearinconfig",
+		ParamDrivePrefix:    "ParamDrivePrefix-shouldnotappearinconfig",
+		"somethingelse":     "somethingelse-shouldnotappearinconfig",
+	}
+	origins := []string{
+		"https://origin0.example.net",
+		"http://origin1.example.net",
+		"http://origin2.example.net/path0",
+		"origin3.example.net/",
+		"https://origin4.example.net/",
+		"http://origin5.example.net/",
+	}
+
+	txt := MakeHostingDotConfig(serverName, toToolName, toURL, params, origins)
+
+	lines := strings.Split(txt, "\n")
+
+	if len(lines) == 0 {
+		t.Fatalf("expected: lines actual: no lines\n")
+	}
+
+	commentLine := lines[0]
+	commentLine = strings.TrimSpace(commentLine)
+	if !strings.HasPrefix(commentLine, "#") {
+		t.Errorf("expected: comment line starting with '#', actual: '%v'\n", commentLine)
+	}
+	if !strings.Contains(commentLine, toToolName) {
+		t.Errorf("expected: comment line containing toolName '%v', actual: '%v'\n", toToolName, commentLine)
+	}
+	if !strings.Contains(commentLine, toURL) {
+		t.Errorf("expected: comment line containing toURL '%v', actual: '%v'\n", toURL, commentLine)
+	}
+
+	lines = lines[1:] // remove comment line
+
+	originFQDNs := getFQDNs(origins)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strArrContainsSubstr(originFQDNs, line) {
+			t.Errorf("expected %+v actual '%v'\n", originFQDNs, line)
+		}
+		originFQDNs = strArrRemoveSubstr(originFQDNs, line)
+	}
+
+	if len(originFQDNs) > 0 {
+		t.Errorf("expected %+v actual %v\n", originFQDNs, "missing")
+	}
+}
+
+func strArrContainsSubstr(arr []string, substr string) bool {
+	for _, as := range arr {
+		if strings.Contains(as, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func strArrRemoveSubstr(arr []string, substr string) []string {
+	// this is terribly inefficient, but it's just for testing, so it doesn't matter
+	newArr := []string{}
+	for _, as := range arr {
+		if strings.Contains(as, substr) {
+			continue
+		}
+		newArr = append(newArr, as)
+	}
+	return newArr
+}
+
+func getFQDNs(origins []string) []string {
+	newOrigins := []string{}
+	for _, origin := range origins {
+		origin = strings.TrimLeft(origin, "http://")
+		origin = strings.TrimLeft(origin, "https://")
+		origin = strings.TrimRight(origin, "/")
+	}
+	return newOrigins
+}

--- a/lib/go-atscfg/ipallowdotconfig.go
+++ b/lib/go-atscfg/ipallowdotconfig.go
@@ -1,0 +1,253 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+const IPAllowConfigFileName = `ip_allow.config`
+
+type IPAllowData struct {
+	Src    string
+	Action string
+	Method string
+}
+
+const ParamPurgeAllowIP = "purge_allow_ip"
+const ParamCoalesceMaskLenV4 = "coalesce_masklen_v4"
+const ParamCoalesceNumberV4 = "coalesce_number_v4"
+const ParamCoalesceMaskLenV6 = "coalesce_masklen_v6"
+const ParamCoalesceNumberV6 = "coalesce_number_v6"
+
+type IPAllowServer struct {
+	IPAddress  string
+	IP6Address string
+}
+
+const DefaultCoalesceMaskLenV4 = 24
+const DefaultCoalesceNumberV4 = 5
+const DefaultCoalesceMaskLenV6 = 48
+const DefaultCoalesceNumberV6 = 5
+
+// MakeIPAllowDotConfig creates the ip_allow.config ATS config file.
+// The childServers is a list of servers which are children for this Mid-tier server. This should be empty for Edge servers.
+// More specifically, it should be the list of edges whose cachegroup's parent_cachegroup or secondary_parent_cachegroup is the cachegroup of this Mid server.
+func MakeIPAllowDotConfig(
+	serverName tc.CacheName,
+	serverType tc.CacheType,
+	toToolName string, // tm.toolname global parameter (TODO: cache itself?)
+	toURL string, // tm.url global parameter (TODO: cache itself?)
+	params map[string][]string, // map[name]value - config file should always be ip_allow.config
+	childServers map[tc.CacheName]IPAllowServer,
+) string {
+	ipAllowData := []IPAllowData{}
+	const ActionAllow = "ip_allow"
+	const ActionDeny = "ip_deny"
+	const MethodAll = "ALL"
+
+	// localhost is trusted.
+	ipAllowData = append(ipAllowData, IPAllowData{
+		Src:    `127.0.0.1`,
+		Action: ActionAllow,
+		Method: MethodAll,
+	})
+	ipAllowData = append(ipAllowData, IPAllowData{
+		Src:    `::1`,
+		Action: ActionAllow,
+		Method: MethodAll,
+	})
+
+	// default for coalesce_ipv4 = 24, 5 and for ipv6 48, 5; override with the parameters in the server profile.
+	coalesceMaskLenV4 := DefaultCoalesceMaskLenV4
+	coalesceNumberV4 := DefaultCoalesceNumberV4
+	coalesceMaskLenV6 := DefaultCoalesceMaskLenV6
+	coalesceNumberV6 := DefaultCoalesceNumberV6
+
+	for name, vals := range params {
+		for _, val := range vals {
+			switch name {
+			case "purge_allow_ip":
+				ipAllowData = append(ipAllowData, IPAllowData{
+					Src:    val,
+					Action: ActionAllow,
+					Method: MethodAll,
+				})
+			case ParamCoalesceMaskLenV4:
+				if vi, err := strconv.Atoi(val); err != nil {
+					log.Warnln("MakeIPAllowDotConfig got param '" + name + "' val '" + val + "' not a number, ignoring!")
+				} else if coalesceMaskLenV4 != DefaultCoalesceMaskLenV4 {
+					log.Warnln("MakeIPAllowDotConfig got multiple param '" + name + "' - ignoring  val '" + val + "'!")
+				} else {
+					coalesceMaskLenV4 = vi
+				}
+			case ParamCoalesceNumberV4:
+				if vi, err := strconv.Atoi(val); err != nil {
+					log.Warnln("MakeIPAllowDotConfig got param '" + name + "' val '" + val + "' not a number, ignoring!")
+				} else if coalesceNumberV4 != DefaultCoalesceNumberV4 {
+					log.Warnln("MakeIPAllowDotConfig got multiple param '" + name + "' - ignoring  val '" + val + "'!")
+				} else {
+					coalesceNumberV4 = vi
+				}
+			case ParamCoalesceMaskLenV6:
+				if vi, err := strconv.Atoi(val); err != nil {
+					log.Warnln("MakeIPAllowDotConfig got param '" + name + "' val '" + val + "' not a number, ignoring!")
+				} else if coalesceMaskLenV6 != DefaultCoalesceMaskLenV6 {
+					log.Warnln("MakeIPAllowDotConfig got multiple param '" + name + "' - ignoring  val '" + val + "'!")
+				} else {
+					coalesceMaskLenV6 = vi
+				}
+			case ParamCoalesceNumberV6:
+				if vi, err := strconv.Atoi(val); err != nil {
+					log.Warnln("MakeIPAllowDotConfig got param '" + name + "' val '" + val + "' not a number, ignoring!")
+				} else if coalesceNumberV6 != DefaultCoalesceMaskLenV6 {
+					log.Warnln("MakeIPAllowDotConfig got multiple param '" + name + "' - ignoring  val '" + val + "'!")
+				} else {
+					coalesceNumberV6 = vi
+				}
+			}
+		}
+	}
+
+	// for edges deny "PUSH|PURGE|DELETE", allow everything else to everyone.
+	isMid := strings.HasPrefix(string(serverType), tc.MidTypePrefix)
+	if !isMid {
+		ipAllowData = append(ipAllowData, IPAllowData{
+			Src:    `0.0.0.0-255.255.255.255`,
+			Action: ActionDeny,
+			Method: `PUSH|PURGE|DELETE`,
+		})
+		ipAllowData = append(ipAllowData, IPAllowData{
+			Src:    `::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff`,
+			Action: ActionDeny,
+			Method: `PUSH|PURGE|DELETE`,
+		})
+	} else {
+
+		ips := []*net.IPNet{}
+		ip6s := []*net.IPNet{}
+		for serverName, server := range childServers {
+
+			if ip := net.ParseIP(server.IPAddress).To4(); ip != nil {
+				// got an IP - convert it to a CIDR and add it to the list
+				ips = append(ips, util.IPToCIDR(ip))
+			} else {
+				// not an IP, try a CIDR
+				if ip, cidr, err := net.ParseCIDR(server.IPAddress); err != nil {
+					// not a CIDR or IP - error out
+					log.Errorln("MakeIPAllowDotConfig server '" + string(serverName) + "' IP '" + server.IPAddress + " is not an IPv4 address or CIDR - skipping!")
+				} else {
+					// got a valid CIDR - now make sure it's v4
+					ip = ip.To4()
+					if ip == nil {
+						// valid CIDR, but not v4
+						log.Errorln("MakeIPAllowDotConfig server '" + string(serverName) + "' IP '" + server.IPAddress + " is a CIDR, but not v4 - skipping!")
+					} else {
+						// got a valid IPv4 CIDR - add it to the list
+						ips = append(ips, cidr)
+					}
+				}
+			}
+
+			if server.IP6Address != "" {
+				ip6 := net.ParseIP(server.IP6Address)
+				if ip6 != nil && ip6.To4() == nil {
+					// got a valid IPv6 - add it to the list
+					ip6s = append(ip6s, util.IPToCIDR(ip6))
+				} else {
+					// not a v6 IP, try a CIDR
+					if ip, cidr, err := net.ParseCIDR(server.IP6Address); err != nil {
+						// not a CIDR or IP - error out
+						log.Errorln("MakeIPAllowDotConfig server '" + string(serverName) + "' IP6 '" + server.IP6Address + " is not an IPv6 address or CIDR - skipping!")
+					} else {
+						// got a valid CIDR - now make sure it's v6
+						ip = ip.To4()
+						if ip != nil {
+							// valid CIDR, but not v6
+							log.Errorln("MakeIPAllowDotConfig server '" + string(serverName) + "' IP6 '" + server.IPAddress + " is a CIDR, but not v6 - skipping!")
+						} else {
+							// got a valid IPv6 CIDR - add it to the list
+							ip6s = append(ip6s, cidr)
+						}
+					}
+				}
+			}
+		}
+
+		cidrs := util.CoalesceCIDRs(ips, coalesceNumberV4, coalesceMaskLenV4)
+		cidr6s := util.CoalesceCIDRs(ip6s, coalesceNumberV6, coalesceMaskLenV6)
+
+		for _, cidr := range cidrs {
+			ipAllowData = append(ipAllowData, IPAllowData{
+				Src:    util.RangeStr(cidr),
+				Action: ActionAllow,
+				Method: MethodAll,
+			})
+		}
+		for _, cidr := range cidr6s {
+			ipAllowData = append(ipAllowData, IPAllowData{
+				Src:    util.RangeStr(cidr),
+				Action: ActionAllow,
+				Method: MethodAll,
+			})
+		}
+
+		// allow RFC 1918 server space - TODO JvD: parameterize
+		ipAllowData = append(ipAllowData, IPAllowData{
+			Src:    `10.0.0.0-10.255.255.255`,
+			Action: ActionAllow,
+			Method: MethodAll,
+		})
+		ipAllowData = append(ipAllowData, IPAllowData{
+			Src:    `172.16.0.0-172.31.255.255`,
+			Action: ActionAllow,
+			Method: MethodAll,
+		})
+		ipAllowData = append(ipAllowData, IPAllowData{
+			Src:    `192.168.0.0-192.168.255.255`,
+			Action: ActionAllow,
+			Method: MethodAll,
+		})
+
+		// end with a deny
+		ipAllowData = append(ipAllowData, IPAllowData{
+			Src:    `0.0.0.0-255.255.255.255`,
+			Action: ActionDeny,
+			Method: MethodAll,
+		})
+		ipAllowData = append(ipAllowData, IPAllowData{
+			Src:    `::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff`,
+			Action: ActionDeny,
+			Method: MethodAll,
+		})
+	}
+
+	text := GenericHeaderComment(string(serverName), toToolName, toURL)
+	for _, al := range ipAllowData {
+		text += `src_ip=` + al.Src + ` action=` + al.Action + ` method=` + al.Method + "\n"
+	}
+	return text
+}

--- a/lib/go-atscfg/ipallowdotconfig_test.go
+++ b/lib/go-atscfg/ipallowdotconfig_test.go
@@ -1,0 +1,204 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestMakeIPAllowDotConfig(t *testing.T) {
+	serverName := tc.CacheName("server0")
+	serverType := tc.CacheTypeMid
+	toToolName := "to0"
+	toURL := "trafficops.example.net"
+	params := map[string][]string{
+		"purge_allow_ip":       []string{"192.168.2.99"},
+		ParamCoalesceMaskLenV4: []string{"24"},
+		ParamCoalesceNumberV4:  []string{"3"},
+		ParamCoalesceMaskLenV6: []string{"48"},
+		ParamCoalesceNumberV6:  []string{"4"},
+	}
+	childServers := map[tc.CacheName]IPAllowServer{
+		"child0": IPAllowServer{
+			IPAddress:  "192.168.2.1",
+			IP6Address: "2001:DB8:1::1/64",
+		},
+		"child1": IPAllowServer{
+			IPAddress:  "192.168.2.100/30",
+			IP6Address: "2001:DB8:2::1/64",
+		},
+		"child2": IPAllowServer{
+			IPAddress: "192.168.2.150",
+		},
+		"child3": IPAllowServer{
+			IP6Address: "2001:DB8:2::2/64",
+		},
+		"child4": IPAllowServer{
+			IPAddress: "192.168.2.155/32",
+		},
+		"child5": IPAllowServer{
+			IP6Address: "2001:DB8:3::1",
+		},
+		"child6": IPAllowServer{
+			IP6Address: "2001:DB8:2::3/64",
+		},
+		"child7": IPAllowServer{
+			IP6Address: "2001:DB8:2::4/64",
+		},
+		"child8": IPAllowServer{
+			IP6Address: "2001:DB8:2::5/64",
+		},
+	}
+
+	expecteds := []string{
+		"127.0.0.1",
+		"::1",
+		"0.0.0.0-255.255.255.255",
+		"::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+		"172.16.0.0-172.31.255.255",
+		"10.0.0.0-10.255.255.255",
+		"2001:db8:3::1",
+		"192.168.2.0-192.168.2.255",
+		"192.168.2.99",
+		"2001:db8:1::-2001:db8:1:0:ffff:ffff:ffff:ffff",
+		"2001:db8:2::-2001:db8:2:ffff:ffff:ffff:ffff:ffff",
+	}
+
+	txt := MakeIPAllowDotConfig(serverName, serverType, toToolName, toURL, params, childServers)
+
+	lines := strings.Split(txt, "\n")
+
+	if len(lines) == 0 {
+		t.Fatalf("expected: lines actual: no lines\n")
+	}
+
+	commentLine := lines[0]
+	commentLine = strings.TrimSpace(commentLine)
+	if !strings.HasPrefix(commentLine, "#") {
+		t.Errorf("expected: comment line starting with '#', actual: '%v'\n", commentLine)
+	}
+	if !strings.Contains(commentLine, toToolName) {
+		t.Errorf("expected: comment line containing toolName '%v', actual: '%v'\n", toToolName, commentLine)
+	}
+	if !strings.Contains(commentLine, toURL) {
+		t.Errorf("expected: comment line containing toURL '%v', actual: '%v'\n", toURL, commentLine)
+	}
+
+	lines = lines[1:] // remove comment line
+
+	for _, expected := range expecteds {
+		if !strings.Contains(txt, expected) {
+			t.Errorf("expected %+v actual '%v'\n", expected, txt)
+		}
+	}
+}
+
+func TestMakeIPAllowDotConfigEdge(t *testing.T) {
+	serverName := tc.CacheName("server0")
+	serverType := tc.CacheTypeEdge
+	toToolName := "to0"
+	toURL := "trafficops.example.net"
+	params := map[string][]string{
+		ParamCoalesceMaskLenV4: []string{"24"},
+		ParamCoalesceNumberV4:  []string{"3"},
+		ParamCoalesceMaskLenV6: []string{"48"},
+		ParamCoalesceNumberV6:  []string{"4"},
+	}
+	childServers := map[tc.CacheName]IPAllowServer{
+		"child0": IPAllowServer{
+			IPAddress:  "192.168.2.1",
+			IP6Address: "2001:DB8:1::1/64",
+		},
+		"child1": IPAllowServer{
+			IPAddress:  "192.168.2.100/30",
+			IP6Address: "2001:DB8:2::1/64",
+		},
+		"child2": IPAllowServer{
+			IPAddress: "192.168.2.150",
+		},
+		"child3": IPAllowServer{
+			IP6Address: "2001:DB8:2::2/64",
+		},
+		"child4": IPAllowServer{
+			IPAddress: "192.168.2.155/32",
+		},
+		"child5": IPAllowServer{
+			IP6Address: "2001:DB8:3::1",
+		},
+		"child6": IPAllowServer{
+			IP6Address: "2001:DB8:2::3/64",
+		},
+		"child7": IPAllowServer{
+			IP6Address: "2001:DB8:2::4/64",
+		},
+		"child8": IPAllowServer{
+			IP6Address: "2001:DB8:2::5/64",
+		},
+	}
+
+	expecteds := []string{
+		"127.0.0.1",
+		"::1",
+		"0.0.0.0-255.255.255.255",
+		"::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+	}
+
+	notExpecteds := []string{
+		"2001:db8",
+		"192.168.2",
+	}
+
+	txt := MakeIPAllowDotConfig(serverName, serverType, toToolName, toURL, params, childServers)
+
+	lines := strings.Split(txt, "\n")
+
+	if len(lines) == 0 {
+		t.Fatalf("expected: lines actual: no lines\n")
+	}
+
+	commentLine := lines[0]
+	commentLine = strings.TrimSpace(commentLine)
+	if !strings.HasPrefix(commentLine, "#") {
+		t.Errorf("expected: comment line starting with '#', actual: '%v'\n", commentLine)
+	}
+	if !strings.Contains(commentLine, toToolName) {
+		t.Errorf("expected: comment line containing toolName '%v', actual: '%v'\n", toToolName, commentLine)
+	}
+	if !strings.Contains(commentLine, toURL) {
+		t.Errorf("expected: comment line containing toURL '%v', actual: '%v'\n", toURL, commentLine)
+	}
+
+	lines = lines[1:] // remove comment line
+
+	for _, expected := range expecteds {
+		if !strings.Contains(txt, expected) {
+			t.Errorf("expected %+v actual '%v'\n", expected, txt)
+		}
+	}
+
+	for _, notExpected := range notExpecteds {
+		if strings.Contains(txt, notExpected) {
+			t.Errorf("expected NOT %+v actual '%v'\n", notExpected, txt)
+		}
+	}
+}

--- a/lib/go-atscfg/packages.go
+++ b/lib/go-atscfg/packages.go
@@ -1,0 +1,54 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+)
+
+const PackagesFileName = `packages`
+const PackagesParamConfigFile = `package`
+
+type Package struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// MakePackages returns the 'packages' ATS config file endpoint.
+// This is a JSON object, and should be served with an 'application/json' Content-Type.
+func MakePackages(
+	params map[string][]string, // map[name]value - config file should always be 'package'
+) string {
+	packages := []Package{}
+	for name, versions := range params {
+		for _, version := range versions {
+			packages = append(packages, Package{Name: name, Version: version})
+		}
+	}
+	bts, err := json.Marshal(&packages)
+	if err != nil {
+		// should never happen
+		log.Errorln("marshalling chkconfig NameVersions: " + err.Error())
+		bts = []byte("error encoding params to json, see Traffic Ops log for details")
+	}
+	return string(bts)
+}

--- a/lib/go-atscfg/packages_test.go
+++ b/lib/go-atscfg/packages_test.go
@@ -1,0 +1,73 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMakePackages(t *testing.T) {
+	params := map[string][]string{
+		"p0": []string{"p0v0", "p0v1"},
+		"1":  []string{"p1v0"},
+	}
+
+	txt := MakePackages(params)
+
+	packages := []Package{}
+	if err := json.Unmarshal([]byte(txt), &packages); err != nil {
+		t.Fatalf("MakePackages expected a JSON array of objects, actual: " + err.Error())
+	}
+
+	for _, pkg := range packages {
+		vals, ok := params[pkg.Name]
+		if !ok {
+			t.Errorf("MakePackages expected %+v actual %v\n", params, pkg.Name)
+		}
+
+		if !strArrContains(vals, pkg.Version) {
+			t.Errorf("MakePackages expected %+v actual %v\n", vals, pkg.Version)
+		}
+
+		params[pkg.Name] = strArrRemove(vals, pkg.Version)
+	}
+}
+
+func strArrContains(arr []string, str string) bool {
+	for _, as := range arr {
+		if as == str {
+			return true
+		}
+	}
+	return false
+}
+
+func strArrRemove(arr []string, str string) []string {
+	// this is terribly inefficient, but it's just for testing, so it doesn't matter
+	newArr := []string{}
+	for _, as := range arr {
+		if as == str {
+			continue
+		}
+		newArr = append(newArr, as)
+	}
+	return newArr
+}

--- a/lib/go-atscfg/servercachedotconfig.go
+++ b/lib/go-atscfg/servercachedotconfig.go
@@ -1,0 +1,91 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+type ServerCacheConfigDS struct {
+	OrgServerFQDN string
+	Type          tc.DSType
+}
+
+func MakeServerCacheDotConfig(
+	serverName tc.CacheName,
+	toToolName string, // tm.toolname global parameter (TODO: cache itself?)
+	toURL string, // tm.url global parameter (TODO: cache itself?)
+	dses map[tc.DeliveryServiceName]ServerCacheConfigDS,
+) string {
+	text := GenericHeaderComment(string(serverName), toToolName, toURL)
+
+	seenOrigins := map[string]struct{}{}
+	for _, ds := range dses {
+		if ds.Type != tc.DSTypeHTTPNoCache {
+			continue
+		}
+		if _, ok := seenOrigins[ds.OrgServerFQDN]; ok {
+			continue
+		}
+		seenOrigins[ds.OrgServerFQDN] = struct{}{}
+
+		originFQDN, originPort := GetOriginFQDNAndPort(ds.OrgServerFQDN)
+		if originPort != nil {
+			text += `dest_domain=` + originFQDN + ` port=` + strconv.Itoa(*originPort) + ` scheme=http action=never-cache` + "\n"
+		} else {
+			text += `dest_domain=` + originFQDN + ` scheme=http action=never-cache` + "\n"
+		}
+	}
+	return text
+}
+
+// TODO unit test
+func GetOriginFQDNAndPort(origin string) (string, *int) {
+	origin = strings.TrimSpace(origin)
+	origin = strings.Replace(origin, `https://`, ``, -1)
+	origin = strings.Replace(origin, `http://`, ``, -1)
+
+	// if the origin includes a path, strip it
+
+	slashI := strings.Index(origin, `/`)
+	if slashI != -1 {
+		origin = origin[:slashI]
+	}
+
+	hostName := origin
+
+	colonI := strings.Index(origin, ":")
+	if colonI == -1 {
+		return hostName, nil // no :, the origin must not include a port
+	}
+	portStr := origin[colonI+1:]
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		// either the port isn't an integer, or the : we found was something else.
+		// Return the origin, as if it didn't contain a port.
+		return hostName, nil
+	}
+
+	hostName = origin[:colonI]
+	return hostName, &port
+}

--- a/lib/go-atscfg/servercachedotconfig_test.go
+++ b/lib/go-atscfg/servercachedotconfig_test.go
@@ -1,0 +1,114 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestMakeServerCacheDotConfig(t *testing.T) {
+	serverName := tc.CacheName("server0")
+	toToolName := "to0"
+	toURL := "trafficops.example.net"
+
+	dses := map[tc.DeliveryServiceName]ServerCacheConfigDS{
+		"ds0": ServerCacheConfigDS{
+			OrgServerFQDN: "https://ds0.example.test/path",
+			Type:          tc.DSTypeHTTP,
+		},
+		"ds1": ServerCacheConfigDS{
+			OrgServerFQDN: "https://ds1.example.test:42/path",
+			Type:          tc.DSTypeDNS,
+		},
+		"ds2": ServerCacheConfigDS{
+			OrgServerFQDN: "https://ds2.example.test:42",
+			Type:          tc.DSTypeHTTP,
+		},
+		"ds3": ServerCacheConfigDS{
+			OrgServerFQDN: "https://ds3.example.test",
+			Type:          tc.DSTypeHTTP,
+		},
+		"ds4": ServerCacheConfigDS{
+			OrgServerFQDN: "https://ds4.example.test/",
+			Type:          tc.DSTypeHTTP,
+		},
+		"ds5": ServerCacheConfigDS{
+			OrgServerFQDN: "http://ds5.example.test:1234/",
+			Type:          tc.DSTypeHTTP,
+		},
+		"ds6": ServerCacheConfigDS{
+			OrgServerFQDN: "ds6.example.test",
+			Type:          tc.DSTypeHTTP,
+		},
+		"ds7": ServerCacheConfigDS{
+			OrgServerFQDN: "ds7.example.test:80",
+			Type:          tc.DSTypeHTTP,
+		},
+		"ds8": ServerCacheConfigDS{
+			OrgServerFQDN: "ds8.example.test:8080/path",
+			Type:          tc.DSTypeHTTP,
+		},
+		"ds-nocache": ServerCacheConfigDS{
+			OrgServerFQDN: "http://ds-nocache.example.test",
+			Type:          tc.DSTypeHTTPNoCache,
+		},
+	}
+
+	txt := MakeServerCacheDotConfig(serverName, toToolName, toURL, dses)
+
+	lines := strings.Split(txt, "\n")
+
+	unexpecteds := map[string]struct{}{
+		"http://":  {},
+		"https://": {},
+		"path":     {},
+		"/":        {},
+		"ds0":      {},
+		"ds1":      {},
+		"ds2":      {},
+		"ds3":      {},
+		"ds4":      {},
+		"ds5":      {},
+		"ds6":      {},
+		"ds7":      {},
+		"ds8":      {},
+		"42":       {},
+		"1234":     {},
+	}
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		for unexpected, _ := range unexpecteds {
+			if strings.Contains(line, unexpected) {
+				t.Errorf("expected NOT '%v' actual '%v'\n", unexpected, line)
+			}
+		}
+
+		if !strings.Contains(line, "never-cache") && !strings.HasPrefix(line, "#") {
+			t.Errorf("expected '%v' actual '%v'\n", "only nocache DSes", line)
+		}
+	}
+}

--- a/lib/go-atscfg/serverunknown.go
+++ b/lib/go-atscfg/serverunknown.go
@@ -1,0 +1,83 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func MakeServerUnknown(
+	serverName tc.CacheName,
+	serverDomain string,
+	toToolName string, // tm.toolname global parameter (TODO: cache itself?)
+	toURL string, // tm.url global parameter (TODO: cache itself?)
+	params map[string][]string, // map[name]value - for the requested unknown 'take-and-bake' config_file
+) string {
+
+	hdr := GenericHeaderComment(string(serverName), toToolName, toURL)
+
+	txt := ""
+
+	sortedParams := SortParams(params)
+	for _, pa := range sortedParams {
+		if pa.Name == "location" {
+			continue
+		}
+		if pa.Name == "header" {
+			if pa.Val == "none" {
+				hdr = ""
+			} else {
+				hdr = pa.Val + "\n"
+			}
+			continue
+		}
+		txt += pa.Val + "\n"
+	}
+
+	txt = strings.Replace(txt, `__HOSTNAME__`, string(serverName)+`.`+serverDomain, -1)
+	txt = strings.Replace(txt, `__RETURN__`, "\n", -1)
+
+	return hdr + txt
+}
+
+type Param struct {
+	Name string
+	Val  string
+}
+
+type Params []Param
+
+func (a Params) Len() int           { return len(a) }
+func (a Params) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a Params) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
+func SortParams(params map[string][]string) []Param {
+	sortedParams := []Param{}
+	for name, vals := range params {
+		for _, val := range vals {
+			sortedParams = append(sortedParams, Param{Name: name, Val: val})
+		}
+	}
+	sort.Sort(Params(sortedParams))
+	return sortedParams
+}

--- a/lib/go-atscfg/serverunknown_test.go
+++ b/lib/go-atscfg/serverunknown_test.go
@@ -1,0 +1,81 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestMakeServerUnknown(t *testing.T) {
+	serverName := tc.CacheName("server0")
+	serverDomain := "example.test"
+	toToolName := "toName"
+	toURL := "to.url.example.test"
+
+	params := map[string][]string{
+		"location":   []string{"locationshouldnotexist"},
+		"param0name": []string{"param0val0", "param0val1"},
+		"param1name": []string{"param1val0"},
+		"header":     []string{"//hdr"},
+	}
+
+	txt := MakeServerUnknown(serverName, serverDomain, toToolName, toURL, params)
+
+	if strings.Contains(txt, "#") {
+		t.Errorf("expected: '%v' actual: '%v'", "no default header comment", txt)
+	}
+
+	if strings.Contains(txt, "param0name") {
+		t.Errorf("expected: '%v' actual: '%v'", "no param name", txt)
+	}
+
+	if strings.Contains(txt, "param1name") {
+		t.Errorf("expected: '%v' actual: '%v'", "no param name", txt)
+	}
+
+	if strings.Contains(txt, "location") {
+		t.Errorf("expected: '%v' actual: '%v'", "no location param name or value", txt)
+	}
+
+	if strings.Contains(txt, "header") {
+		t.Errorf("expected: '%v' actual: '%v'", "no header param name", txt)
+	}
+
+	if !strings.Contains(txt, "param0val0") {
+		t.Errorf("expected: '%v' actual: '%v'", "param0val0", txt)
+	}
+
+	if !strings.Contains(txt, "param0val1") {
+		t.Errorf("expected: '%v' actual: '%v'", "param0val1", txt)
+	}
+
+	if !strings.Contains(txt, "param1val0") {
+		t.Errorf("expected: '%v' actual: '%v'", "param1val0", txt)
+	}
+
+	txt = strings.TrimSpace(txt)
+	if !strings.HasPrefix(txt, "//hdr") {
+		t.Errorf("expected: '%v' actual: '%v'", "header param prefix", txt)
+	}
+
+}

--- a/lib/go-tc/enum.go
+++ b/lib/go-tc/enum.go
@@ -584,6 +584,9 @@ func (t DSType) UsesMidCache() bool {
 	return true
 }
 
+const DSTypeLiveNationalSuffix = "_LIVE_NATNL"
+const DSTypeLiveSuffix = "_LIVE"
+
 // QStringIgnore is an entry in the delivery_service table qstring_ignore column, and represents how to treat the URL query string for requests to that delivery service.
 // This enum's String function returns the numeric representation, because it is a legacy database value, and the number should be kept for both database and API JSON uses. For the same reason, this enum has no FromString function.
 type QStringIgnore int

--- a/lib/go-util/net.go
+++ b/lib/go-util/net.go
@@ -1,0 +1,202 @@
+package util
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"net"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+)
+
+const BitsPerByte = 8
+
+// CoalesceIPs combines ips into CIDRs, by combining overlapping networks into networks of size coalesceMaskLen, if there are at least coalesceNumber IPs in the larger mask.
+func CoalesceIPs(ips []net.IP, coalesceNumber int, coalesceMaskLen int) []*net.IPNet {
+	if len(ips) == 0 {
+		return nil
+	}
+
+	maskIP := ips[0].To4()
+	isV4 := maskIP != nil
+	if maskIP == nil {
+		maskIP = ips[0]
+	}
+
+	mask := net.CIDRMask(coalesceMaskLen, len(maskIP)*BitsPerByte)
+
+	type IPNetSources struct {
+		Net     *net.IPNet
+		Sources []net.IP
+	}
+
+	nets := []IPNetSources{}
+
+iploop:
+	for _, ip := range ips {
+		ipIsV4 := ip.To4() != nil
+		if isV4 != ipIsV4 {
+			log.Errorln("CoalesceIPs got both V4 and V6 IPs, ignoring IP '" + ip.String() + "'")
+			continue
+		}
+		for i, net := range nets {
+			if net.Net.Contains(ip) {
+				nets[i].Sources = append(nets[i].Sources, ip)
+				continue iploop
+			}
+		}
+
+		ipnet := &net.IPNet{IP: ip.Mask(mask), Mask: mask}
+		nets = append(nets, IPNetSources{ipnet, []net.IP{ip}})
+	}
+
+	finalNets := []*net.IPNet{}
+	for _, ipnet := range nets {
+		if len(ipnet.Sources) >= coalesceNumber {
+			finalNets = append(finalNets, ipnet.Net)
+			continue
+		}
+
+		for _, ip := range ipnet.Sources {
+			finalNets = append(finalNets, IPToCIDR(ip))
+		}
+	}
+
+	return finalNets
+}
+
+// CoalesceCIDRs coalesces cidrs into a smaller set of CIDRs, by combining overlapping networks into networks of size coalesceMaskLen, if there are at least coalesceNumber cidrs in the larger mask.
+func CoalesceCIDRs(cidrs []*net.IPNet, coalesceNumber int, coalesceMaskLen int) []*net.IPNet {
+	if len(cidrs) == 0 {
+		return nil
+	}
+
+	maskIP := cidrs[0].IP.To4()
+	isV4 := maskIP != nil
+	if maskIP == nil {
+		maskIP = cidrs[0].IP
+	}
+
+	mask := net.CIDRMask(coalesceMaskLen, len(maskIP)*BitsPerByte)
+
+	type IPNetSources struct {
+		Net     *net.IPNet
+		Sources []*net.IPNet
+	}
+
+	nets := []IPNetSources{}
+
+iploop:
+	for _, cidr := range cidrs {
+		ipIsV4 := cidr.IP.To4() != nil
+		if isV4 != ipIsV4 {
+			log.Errorln("CoalesceIPs got both V4 and V6 IPs, ignoring CIDR '" + cidr.String() + "'")
+			continue
+		}
+
+		for i, net := range nets {
+			if CIDRIsSubset(cidr, net.Net) {
+				nets[i].Sources = append(nets[i].Sources, cidr)
+				continue iploop
+			}
+			if CIDRIsSubset(net.Net, cidr) {
+				// if the existing net is a subset of the new cidr, replace the existing net with our larger cidr
+				nets[i].Net = cidr
+				nets[i].Sources = append(nets[i].Sources, cidr)
+				continue iploop
+			}
+		}
+
+		// use the larger of the coalesceMaskLen and this cidr's mask
+		largerMask := mask
+		if bytes.Compare(cidr.Mask, mask) < 1 {
+
+			// Note this means cidr.Mask is numerically smaller, but that actually means it's masking more things.
+			// Note bytes.Compare is defined to be lexographical, and we need a bit-wise comparison, but that's actually the same.
+			largerMask = cidr.Mask
+		}
+
+		ipnet := &net.IPNet{IP: cidr.IP.Mask(largerMask), Mask: largerMask}
+		nets = append(nets, IPNetSources{ipnet, []*net.IPNet{cidr}})
+	}
+
+	finalNets := []*net.IPNet{}
+	for _, ipnet := range nets {
+		if len(ipnet.Sources) >= coalesceNumber {
+			finalNets = append(finalNets, ipnet.Net)
+			continue
+		}
+
+		for _, cidr := range ipnet.Sources {
+			finalNets = append(finalNets, cidr)
+		}
+	}
+
+	return finalNets
+}
+
+// CIDRIsSubset returns whether na is a subset (possibly improper) of nb.
+func CIDRIsSubset(na *net.IPNet, nb *net.IPNet) bool {
+	return nb.Contains(FirstIP(na)) && nb.Contains(LastIP(na))
+}
+
+// FirstIP returns the first IP in the CIDR.
+// For example, The CIDR 192.0.2.0/24 returns 192.0.2.0.
+func FirstIP(ipn *net.IPNet) net.IP {
+	return ipn.IP.Mask(ipn.Mask)
+}
+
+// LastIP returns the last IP in the CIDR.
+// For example, The CIDR 192.0.2.0/24 returns 192.0.2.255.
+func LastIP(ipn *net.IPNet) net.IP {
+	inverseMask := make([]byte, len(ipn.Mask), len(ipn.Mask))
+	for i, b := range ipn.Mask {
+		inverseMask[i] = b ^ 0xFF
+	}
+
+	maxIPBts := make([]byte, len(ipn.IP), len(ipn.IP))
+
+	for i, b := range ipn.IP {
+		maxIPBts[i] = b | inverseMask[i]
+	}
+
+	maxIP := net.IP(maxIPBts)
+	return maxIP
+}
+
+// RangeStr returns the hyphenated range of IPs.
+// For example, The CIDR 192.0.2.0/24 returns "192.0.2.0-192.0.2.255".
+func RangeStr(ipn *net.IPNet) string {
+	firstIP := FirstIP(ipn)
+	lastIP := LastIP(ipn)
+	if firstIP.Equal(lastIP) {
+		return firstIP.String()
+	}
+	return firstIP.String() + "-" + lastIP.String()
+}
+
+// IPToCIDR returns the CIDR containing just the given IP. For IPv6, this means /128, for IPv4, /32.
+func IPToCIDR(ip net.IP) *net.IPNet {
+	fullMask := net.IPMask([]byte{255, 255, 255, 255})
+	if isV4 := ip.To4() != nil; !isV4 {
+		fullMask = net.IPMask([]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255})
+	}
+	return &net.IPNet{IP: ip, Mask: fullMask}
+}

--- a/lib/go-util/net_test.go
+++ b/lib/go-util/net_test.go
@@ -1,0 +1,192 @@
+package util
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package rfc contains functions implementing RFC 7234, 2616, and other RFCs.
+// When changing functions, be sure they still conform to the corresponding RFC.
+// When adding symbols, document the RFC and section they correspond to.
+
+import (
+	"net"
+	"testing"
+)
+
+func TestCoalesceIPs(t *testing.T) {
+	ips := []net.IP{
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		net.ParseIP("192.168.1.3"),
+		net.ParseIP("192.168.2.1"),
+		net.ParseIP("192.168.2.2"),
+		net.ParseIP("192.168.2.3"),
+		net.ParseIP("192.168.2.4"),
+	}
+
+	nets := CoalesceIPs(ips, 2, 24)
+
+	for _, ipnet := range nets {
+		if ipnet.String() != "192.168.1.0/24" && ipnet.String() != "192.168.2.0/24" {
+			t.Errorf("expected '192.168.1.0/24' and '192.168.2.0/24', actual: %+v\n", ipnet)
+		}
+	}
+}
+
+func TestCoalesceIPsSmallerThanNum(t *testing.T) {
+	ips := []net.IP{
+		net.ParseIP("192.168.1.1"),
+		net.ParseIP("192.168.1.2"),
+		net.ParseIP("192.168.1.3"),
+		net.ParseIP("192.168.2.1"),
+		net.ParseIP("192.168.2.2"),
+		net.ParseIP("192.168.2.3"),
+		net.ParseIP("192.168.2.4"),
+	}
+
+	nets := CoalesceIPs(ips, 4, 24)
+
+	expecteds := map[string]struct{}{
+		"192.168.1.1/32": {},
+		"192.168.1.2/32": {},
+		"192.168.1.3/32": {},
+		"192.168.2.0/24": {},
+	}
+
+	for _, ipnet := range nets {
+		if _, ok := expecteds[ipnet.String()]; !ok {
+			t.Errorf("expected: %+v actual: %+v\n", expecteds, ipnet)
+		}
+		delete(expecteds, ipnet.String())
+	}
+}
+
+func TestCoalesceIPsV6(t *testing.T) {
+	ips := []net.IP{
+		net.ParseIP("2001:db8::1"),
+		net.ParseIP("2001:db8::2"),
+		net.ParseIP("2001:db8::3"),
+		net.ParseIP("2001:db8::4:1"),
+		net.ParseIP("2001:db8::4:2"),
+		net.ParseIP("2001:db8::4:3"),
+	}
+
+	nets := CoalesceIPs(ips, 3, 112)
+
+	expecteds := map[string]struct{}{
+		"2001:db8::/112":    {},
+		"2001:db8::4:0/112": {},
+	}
+
+	for _, ipnet := range nets {
+		if _, ok := expecteds[ipnet.String()]; !ok {
+			t.Errorf("expected: %+v actual: %+v\n", expecteds, ipnet)
+		}
+		delete(expecteds, ipnet.String())
+	}
+}
+
+func TestCoalesceIPsV6SmallerThanNum(t *testing.T) {
+	ips := []net.IP{
+		net.ParseIP("2001:db8::1"),
+		net.ParseIP("2001:db8::2"),
+		net.ParseIP("2001:db8::3"),
+		net.ParseIP("2001:db8::4:1"),
+		net.ParseIP("2001:db8::4:2"),
+		net.ParseIP("2001:db8::4:3"),
+		net.ParseIP("2001:db8::4:4"),
+	}
+
+	nets := CoalesceIPs(ips, 4, 112)
+
+	expecteds := map[string]struct{}{
+		"2001:db8::1/128":   {},
+		"2001:db8::2/128":   {},
+		"2001:db8::3/128":   {},
+		"2001:db8::4:0/112": {},
+	}
+
+	for _, ipnet := range nets {
+		if _, ok := expecteds[ipnet.String()]; !ok {
+			t.Errorf("expected: %+v actual: %+v\n", expecteds, ipnet)
+		}
+		delete(expecteds, ipnet.String())
+	}
+}
+
+func TestRangeStr(t *testing.T) {
+	inputExpecteds := map[string]string{
+		"192.168.1.0/24":     "192.168.1.0-192.168.1.255",
+		"192.168.1.0/16":     "192.168.0.0-192.168.255.255",
+		"192.168.1.42/32":    "192.168.1.42",
+		"2001:db8::4:42/128": "2001:db8::4:42",
+		"2001:db8::4:0/112":  "2001:db8::4:0-2001:db8::4:ffff",
+	}
+	for input, expected := range inputExpecteds {
+		_, ipn, err := net.ParseCIDR(input)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		//	t.Errorf("ipn: " + ipn.String())
+
+		actual := RangeStr(ipn)
+		if expected != actual {
+			t.Errorf("expected: '" + expected + "' actual '" + actual + "'")
+		}
+	}
+}
+
+func TestFirstIP(t *testing.T) {
+	inputExpecteds := map[string]string{
+		"192.168.1.0/24":     "192.168.1.0",
+		"192.168.1.0/16":     "192.168.0.0",
+		"192.168.1.42/32":    "192.168.1.42",
+		"2001:db8::4:42/128": "2001:db8::4:42",
+		"2001:db8::4:0/112":  "2001:db8::4:0",
+	}
+	for input, expected := range inputExpecteds {
+		_, ipn, err := net.ParseCIDR(input)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		//	t.Errorf("ipn: " + ipn.String())
+
+		actual := FirstIP(ipn).String()
+		if expected != actual {
+			t.Errorf("expected: '" + expected + "' actual '" + actual + "'")
+		}
+	}
+}
+
+func TestLastIP(t *testing.T) {
+	inputExpecteds := map[string]string{
+		"192.168.1.0/24":     "192.168.1.255",
+		"192.168.1.0/16":     "192.168.255.255",
+		"192.168.1.42/32":    "192.168.1.42",
+		"2001:db8::4:42/128": "2001:db8::4:42",
+		"2001:db8::4:0/112":  "2001:db8::4:ffff",
+	}
+	for input, expected := range inputExpecteds {
+		_, ipn, err := net.ParseCIDR(input)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		//	t.Errorf("ipn: " + ipn.String())
+
+		actual := LastIP(ipn).String()
+		if expected != actual {
+			t.Errorf("expected: '" + expected + "' actual '" + actual + "'")
+		}
+	}
+}

--- a/traffic_ops/ort/atstccfg/chkconfig.go
+++ b/traffic_ops/ort/atstccfg/chkconfig.go
@@ -1,0 +1,78 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func GetConfigFileServerChkconfig(cfg TCCfg, serverNameOrID string) (string, error) {
+	// TODO TOAPI add /servers?cdn=1 query param
+	servers, err := GetServers(cfg)
+	if err != nil {
+		return "", errors.New("getting servers: " + err.Error())
+	}
+
+	server := tc.Server{ID: atscfg.InvalidID}
+	if serverID, err := strconv.Atoi(serverNameOrID); err == nil {
+		for _, toServer := range servers {
+			if toServer.ID == serverID {
+				server = toServer
+				break
+			}
+		}
+	} else {
+		serverName := serverNameOrID
+		for _, toServer := range servers {
+			if toServer.HostName == serverName {
+				server = toServer
+				break
+			}
+		}
+	}
+	if server.ID == atscfg.InvalidID {
+		return "", errors.New("server '" + serverNameOrID + " not found in servers")
+	}
+
+	profileParams, err := GetProfileParameters(cfg, server.Profile)
+	if err != nil {
+		return "", errors.New("getting profile '" + server.Profile + "' parameters: " + err.Error())
+	}
+	if len(profileParams) == 0 {
+		// The TO endpoint behind toclient.GetParametersByProfileName returns an empty object with a 200, if the Profile doesn't exist.
+		// So we act as though we got a 404 if there are no params, to make ORT behave correctly.
+		return "", ErrNotFound
+	}
+
+	fileParams := map[string][]string{}
+	for _, param := range profileParams {
+		if param.ConfigFile != atscfg.ChkconfigParamConfigFile {
+			continue
+		}
+		fileParams[param.Name] = append(fileParams[param.Name], param.Value)
+	}
+
+	txt := atscfg.MakeChkconfig(fileParams)
+	return txt, nil
+}

--- a/traffic_ops/ort/atstccfg/hostingdotconfig.go
+++ b/traffic_ops/ort/atstccfg/hostingdotconfig.go
@@ -1,0 +1,185 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const ServerHostingDotConfigMidIncludeInactive = false
+const ServerHostingDotConfigEdgeIncludeInactive = true
+
+func GetConfigFileServerHostingDotConfig(cfg TCCfg, serverNameOrID string) (string, error) {
+	// TODO TOAPI add /servers?cdn=1 query param
+	servers, err := GetServers(cfg)
+	if err != nil {
+		return "", errors.New("getting servers: " + err.Error())
+	}
+
+	server := tc.Server{ID: atscfg.InvalidID}
+	if serverID, err := strconv.Atoi(serverNameOrID); err == nil {
+		for _, toServer := range servers {
+			if toServer.ID == serverID {
+				server = toServer
+				break
+			}
+		}
+	} else {
+		serverName := serverNameOrID
+		for _, toServer := range servers {
+			if toServer.HostName == serverName {
+				server = toServer
+				break
+			}
+		}
+	}
+	if server.ID == atscfg.InvalidID {
+		return "", errors.New("server '" + serverNameOrID + " not found in servers")
+	}
+
+	serverName := tc.CacheName(server.HostName)
+
+	toToolName, toURL, err := GetTOToolNameAndURLFromTO(cfg)
+	if err != nil {
+		return "", errors.New("getting global parameters: " + err.Error())
+	}
+
+	profileParams, err := GetProfileParameters(cfg, server.Profile)
+	if err != nil {
+		return "", errors.New("getting profile '" + server.Profile + "' parameters: " + err.Error())
+	}
+	if len(profileParams) == 0 {
+		// The TO endpoint behind toclient.GetParametersByProfileName returns an empty object with a 200, if the Profile doesn't exist.
+		// So we act as though we got a 404 if there are no params, to make ORT behave correctly.
+		return "", ErrNotFound
+	}
+
+	fileParams := map[string]string{}
+	for _, param := range profileParams {
+		if param.ConfigFile != atscfg.HostingConfigParamConfigFile {
+			continue
+		}
+		if val, ok := fileParams[param.Name]; ok {
+			log.Errorln("hosting config parameter name '" + param.Name + "' got multiple values - using '" + val + "'")
+			continue
+		}
+		fileParams[param.Name] = param.Value
+	}
+
+	dses, err := GetCDNDeliveryServices(cfg, server.CDNID)
+	if err != nil {
+		return "", errors.New("getting delivery services: " + err.Error())
+	}
+
+	cdnServers := map[tc.CacheName]tc.Server{}
+	for _, sv := range servers {
+		if sv.CDNID != server.CDNID {
+			continue
+		}
+		cdnServers[tc.CacheName(sv.HostName)] = sv
+	}
+
+	serverIDs := []int{}
+	for _, sv := range cdnServers {
+		serverIDs = append(serverIDs, sv.ID)
+	}
+
+	dsIDs := []int{}
+	for _, ds := range dses {
+		if ds.ID != nil {
+			dsIDs = append(dsIDs, *ds.ID)
+		}
+	}
+
+	dsServers, err := GetDeliveryServiceServers(cfg, dsIDs, serverIDs)
+	if err != nil {
+		return "", errors.New("getting delivery service servers: " + err.Error())
+	}
+
+	dsServerMap := map[int]map[int]struct{}{} // set[dsID][serverID]
+	for _, dss := range dsServers {
+		if dss.Server == nil || dss.DeliveryService == nil {
+			return "", errors.New("deliveryserviceservers returned dss with nil values")
+		}
+		if _, ok := dsServerMap[*dss.DeliveryService]; !ok {
+			dsServerMap[*dss.DeliveryService] = map[int]struct{}{}
+		}
+		dsServerMap[*dss.DeliveryService][*dss.Server] = struct{}{}
+	}
+
+	hostingDSes := map[tc.DeliveryServiceName]tc.DeliveryServiceNullable{}
+	for _, ds := range dses {
+		if ds.Active == nil || ds.Type == nil || ds.XMLID == nil || ds.CDNID == nil || ds.ID == nil || ds.OrgServerFQDN == nil {
+			// some DSes have nil origins. I think MSO? TODO: verify
+			continue
+		}
+
+		if !ServerHostingDotConfigMidIncludeInactive && !*ds.Active {
+			continue
+		}
+		if *ds.CDNID != server.CDNID {
+			continue
+		}
+
+		if strings.HasPrefix(server.Type, tc.MidTypePrefix) {
+			if !strings.HasSuffix(string(*ds.Type), tc.DSTypeLiveNationalSuffix) {
+				continue
+			}
+
+			// mids: include all DSes with at least one server assigned
+			if len(dsServerMap[*ds.ID]) == 0 {
+				continue
+			}
+		} else {
+			if !strings.HasSuffix(string(*ds.Type), tc.DSTypeLiveNationalSuffix) && !strings.HasSuffix(string(*ds.Type), tc.DSTypeLiveSuffix) {
+				continue
+			}
+
+			// edges: only include DSes assigned to this edge
+			if dsServerMap[*ds.ID] == nil {
+				continue
+			}
+
+			if _, ok := dsServerMap[*ds.ID][server.ID]; !ok {
+				continue
+			}
+		}
+
+		hostingDSes[tc.DeliveryServiceName(*ds.XMLID)] = ds
+	}
+
+	originSet := map[string]struct{}{}
+	for _, ds := range hostingDSes {
+		originSet[*ds.OrgServerFQDN] = struct{}{}
+	}
+	origins := []string{}
+	for origin, _ := range originSet {
+		origins = append(origins, origin)
+	}
+
+	txt := atscfg.MakeHostingDotConfig(serverName, toToolName, toURL, fileParams, origins)
+	return txt, nil
+}

--- a/traffic_ops/ort/atstccfg/ipallowdotconfig.go
+++ b/traffic_ops/ort/atstccfg/ipallowdotconfig.go
@@ -1,0 +1,119 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func GetConfigFileServerIPAllowDotConfig(cfg TCCfg, serverNameOrID string) (string, error) {
+	// TODO TOAPI add /servers?cdn=1 query param
+	servers, err := GetServers(cfg)
+	if err != nil {
+		return "", errors.New("getting servers: " + err.Error())
+	}
+
+	server := tc.Server{ID: atscfg.InvalidID}
+	if serverID, err := strconv.Atoi(serverNameOrID); err == nil {
+		for _, toServer := range servers {
+			if toServer.ID == serverID {
+				server = toServer
+				break
+			}
+		}
+	} else {
+		serverName := serverNameOrID
+		for _, toServer := range servers {
+			if toServer.HostName == serverName {
+				server = toServer
+				break
+			}
+		}
+	}
+	if server.ID == atscfg.InvalidID {
+		return "", errors.New("server '" + serverNameOrID + " not found in servers")
+	}
+
+	serverName := tc.CacheName(server.HostName)
+	serverType := tc.CacheType(server.Type)
+
+	toToolName, toURL, err := GetTOToolNameAndURLFromTO(cfg)
+	if err != nil {
+		return "", errors.New("getting global parameters: " + err.Error())
+	}
+
+	profileParams, err := GetProfileParameters(cfg, server.Profile)
+	if err != nil {
+		return "", errors.New("getting profile '" + server.Profile + "' parameters: " + err.Error())
+	}
+	if len(profileParams) == 0 {
+		// The TO endpoint behind toclient.GetParametersByProfileName returns an empty object with a 200, if the Profile doesn't exist.
+		// So we act as though we got a 404 if there are no params, to make ORT behave correctly.
+		return "", ErrNotFound
+	}
+
+	fileParams := map[string][]string{}
+	for _, param := range profileParams {
+		if param.ConfigFile != atscfg.IPAllowConfigFileName {
+			continue
+		}
+		fileParams[param.Name] = append(fileParams[param.Name], param.Value)
+	}
+
+	cacheGroups, err := GetCacheGroups(cfg)
+	if err != nil {
+		return "", errors.New("getting cachegroups: " + err.Error())
+	}
+
+	cgMap := map[string]tc.CacheGroupNullable{}
+	for _, cg := range cacheGroups {
+		if cg.Name == nil {
+			return "", errors.New("got cachegroup with nil name!'")
+		}
+		cgMap[*cg.Name] = cg
+	}
+
+	serverCG, ok := cgMap[server.Cachegroup]
+	if !ok {
+		return "", errors.New("server cachegroup not in cachegroups!")
+	}
+
+	childCGs := map[string]tc.CacheGroupNullable{}
+	for cgName, cg := range cgMap {
+		if (cg.ParentName != nil && *cg.ParentName == *serverCG.Name) || (cg.SecondaryParentName != nil && *cg.SecondaryParentName == *serverCG.Name) {
+			childCGs[cgName] = cg
+		}
+	}
+
+	childServers := map[tc.CacheName]atscfg.IPAllowServer{}
+	for _, sv := range servers {
+		if _, ok := childCGs[sv.Cachegroup]; !ok {
+			continue
+		}
+		childServers[tc.CacheName(sv.HostName)] = atscfg.IPAllowServer{IPAddress: sv.IPAddress, IP6Address: sv.IP6Address}
+	}
+
+	txt := atscfg.MakeIPAllowDotConfig(serverName, serverType, toToolName, toURL, fileParams, childServers)
+	return txt, nil
+}

--- a/traffic_ops/ort/atstccfg/packages.go
+++ b/traffic_ops/ort/atstccfg/packages.go
@@ -1,0 +1,78 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func GetConfigFileServerPackages(cfg TCCfg, serverNameOrID string) (string, error) {
+	// TODO TOAPI add /servers?cdn=1 query param
+	servers, err := GetServers(cfg)
+	if err != nil {
+		return "", errors.New("getting servers: " + err.Error())
+	}
+
+	server := tc.Server{ID: atscfg.InvalidID}
+	if serverID, err := strconv.Atoi(serverNameOrID); err == nil {
+		for _, toServer := range servers {
+			if toServer.ID == serverID {
+				server = toServer
+				break
+			}
+		}
+	} else {
+		serverName := serverNameOrID
+		for _, toServer := range servers {
+			if toServer.HostName == serverName {
+				server = toServer
+				break
+			}
+		}
+	}
+	if server.ID == atscfg.InvalidID {
+		return "", errors.New("server '" + serverNameOrID + " not found in servers")
+	}
+
+	profileParams, err := GetProfileParameters(cfg, server.Profile)
+	if err != nil {
+		return "", errors.New("getting profile '" + server.Profile + "' parameters: " + err.Error())
+	}
+	if len(profileParams) == 0 {
+		// The TO endpoint behind toclient.GetParametersByProfileName returns an empty object with a 200, if the Profile doesn't exist.
+		// So we act as though we got a 404 if there are no params, to make ORT behave correctly.
+		return "", ErrNotFound
+	}
+
+	fileParams := map[string][]string{}
+	for _, param := range profileParams {
+		if param.ConfigFile != atscfg.PackagesParamConfigFile {
+			continue
+		}
+		fileParams[param.Name] = append(fileParams[param.Name], param.Value)
+	}
+
+	txt := atscfg.MakePackages(fileParams)
+	return txt, nil
+}

--- a/traffic_ops/ort/atstccfg/routing.go
+++ b/traffic_ops/ort/atstccfg/routing.go
@@ -124,21 +124,29 @@ func ProfileConfigFileFuncs() map[string]func(cfg TCCfg, serverNameOrID string) 
 
 func ServerConfigFileFuncs() map[string]func(cfg TCCfg, serverNameOrID string) (string, error) {
 	return map[string]func(cfg TCCfg, serverNameOrID string) (string, error){
-		"parent.config": GetConfigFileServerParentDotConfig,
-		"remap.config":  GetConfigFileServerRemapDotConfig,
+		"parent.config":   GetConfigFileServerParentDotConfig,
+		"remap.config":    GetConfigFileServerRemapDotConfig,
+		"cache.config":    GetConfigFileServerCacheDotConfig,
+		"ip_allow.config": GetConfigFileServerIPAllowDotConfig,
+		"hosting.config":  GetConfigFileServerHostingDotConfig,
+		"packages":        GetConfigFileServerPackages,
+		"chkconfig":       GetConfigFileServerChkconfig,
 	}
 }
 
 func GetConfigFileServer(cfg TCCfg, serverNameOrID string, fileName string) (string, int, error) {
 	log.Infoln("GetConfigFileServer server '" + serverNameOrID + "' fileName '" + fileName + "'")
+	txt := ""
+	err := error(nil)
 	if getCfgFunc, ok := ServerConfigFileFuncs()[fileName]; ok {
-		txt, err := getCfgFunc(cfg, serverNameOrID)
-		if err != nil {
-			return "", ExitCodeErrGeneric, err
-		}
-		return txt, ExitCodeSuccess, nil
+		txt, err = getCfgFunc(cfg, serverNameOrID)
+	} else {
+		txt, err = GetConfigFileServerUnknownConfig(cfg, serverNameOrID, fileName)
 	}
-	return GetConfigFileFromTrafficOps(cfg)
+	if err != nil {
+		return "", ExitCodeErrGeneric, err
+	}
+	return txt, ExitCodeSuccess, nil
 }
 
 func GetConfigFileFromTrafficOps(cfg TCCfg) (string, int, error) {

--- a/traffic_ops/ort/atstccfg/servercachedotconfig.go
+++ b/traffic_ops/ort/atstccfg/servercachedotconfig.go
@@ -1,0 +1,93 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const ServerCacheDotConfigIncludeInactiveDSes = false // TODO move to lib/go-atscfg
+
+func GetConfigFileServerCacheDotConfig(cfg TCCfg, serverNameOrID string) (string, error) {
+	// TODO TOAPI add /servers?cdn=1 query param
+	servers, err := GetServers(cfg)
+	if err != nil {
+		return "", errors.New("getting servers: " + err.Error())
+	}
+
+	server := tc.Server{ID: atscfg.InvalidID}
+	if serverID, err := strconv.Atoi(serverNameOrID); err == nil {
+		for _, toServer := range servers {
+			if toServer.ID == serverID {
+				server = toServer
+				break
+			}
+		}
+	} else {
+		serverName := serverNameOrID
+		for _, toServer := range servers {
+			if toServer.HostName == serverName {
+				server = toServer
+				break
+			}
+		}
+	}
+	if server.ID == atscfg.InvalidID {
+		return "", errors.New("server '" + serverNameOrID + " not found in servers")
+	}
+
+	if !strings.HasPrefix(string(server.Type), tc.MidTypePrefix) {
+		// emulates Perl
+		return "", errors.New("Error - incorrect file scope for route used.  Please use the profiles route.")
+	}
+
+	dses, err := GetCDNDeliveryServices(cfg, server.CDNID)
+	if err != nil {
+		return "", errors.New("getting delivery services: " + err.Error())
+	}
+
+	dsData := map[tc.DeliveryServiceName]atscfg.ServerCacheConfigDS{}
+	for _, ds := range dses {
+		if ds.XMLID == nil || ds.Active == nil || ds.OrgServerFQDN == nil || ds.Type == nil {
+			// TODO orgserverfqdn is nil for some DSes - MSO? Verify.
+			continue
+			//			return "", fmt.Errorf("getting delivery services: got DS with nil values! '%v' %v %+v\n", *ds.XMLID, *ds.ID, ds)
+		}
+		if !ServerCacheDotConfigIncludeInactiveDSes && !*ds.Active {
+			continue
+		}
+		dsData[tc.DeliveryServiceName(*ds.XMLID)] = atscfg.ServerCacheConfigDS{OrgServerFQDN: *ds.OrgServerFQDN, Type: *ds.Type}
+	}
+
+	serverName := tc.CacheName(server.HostName)
+
+	toToolName, toURL, err := GetTOToolNameAndURLFromTO(cfg)
+	if err != nil {
+		return "", errors.New("getting global parameters: " + err.Error())
+	}
+
+	txt := atscfg.MakeServerCacheDotConfig(serverName, toToolName, toURL, dsData)
+	return txt, nil
+}

--- a/traffic_ops/ort/atstccfg/serverunknownconfig.go
+++ b/traffic_ops/ort/atstccfg/serverunknownconfig.go
@@ -1,0 +1,85 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func GetConfigFileServerUnknownConfig(cfg TCCfg, serverNameOrID string, fileName string) (string, error) {
+	servers, err := GetServers(cfg)
+	if err != nil {
+		return "", errors.New("getting servers: " + err.Error())
+	}
+
+	server := tc.Server{ID: atscfg.InvalidID}
+	if serverID, err := strconv.Atoi(serverNameOrID); err == nil {
+		for _, toServer := range servers {
+			if toServer.ID == serverID {
+				server = toServer
+				break
+			}
+		}
+	} else {
+		serverName := serverNameOrID
+		for _, toServer := range servers {
+			if toServer.HostName == serverName {
+				server = toServer
+				break
+			}
+		}
+	}
+	if server.ID == atscfg.InvalidID {
+		return "", errors.New("server '" + serverNameOrID + " not found in servers")
+	}
+
+	serverName := tc.CacheName(server.HostName)
+	serverDomain := server.DomainName
+
+	toToolName, toURL, err := GetTOToolNameAndURLFromTO(cfg)
+	if err != nil {
+		return "", errors.New("getting global parameters: " + err.Error())
+	}
+
+	profileParams, err := GetProfileParameters(cfg, server.Profile)
+	if err != nil {
+		return "", errors.New("getting profile '" + server.Profile + "' parameters: " + err.Error())
+	}
+	if len(profileParams) == 0 {
+		// The TO endpoint behind toclient.GetParametersByProfileName returns an empty object with a 200, if the Profile doesn't exist.
+		// So we act as though we got a 404 if there are no params, to make ORT behave correctly.
+		return "", ErrNotFound
+	}
+
+	fileParams := map[string][]string{}
+
+	for _, param := range profileParams {
+		if param.ConfigFile != fileName {
+			continue
+		}
+		fileParams[param.Name] = append(fileParams[param.Name], param.Value)
+	}
+
+	return atscfg.MakeServerUnknown(serverName, serverDomain, toToolName, toURL, fileParams), nil
+}

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/cachedotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/cachedotconfig.go
@@ -1,0 +1,70 @@
+package atsserver
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
+)
+
+func GetCacheDotConfig(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-host"}, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	serverName, serverType, ok, err := GetServerNameAndTypeFromNameOrID(inf.Tx.Tx, inf.Params["id-or-host"])
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server name from ID: "+err.Error()))
+		return
+	} else if !ok {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("not found"), nil)
+		return
+	}
+
+	if !strings.HasPrefix(string(serverType), tc.MidTypePrefix) {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("Error - incorrect file scope for route used.  Please use the profiles route."), nil)
+		return
+	}
+
+	toToolName, toURL, err := ats.GetToolNameAndURL(inf.Tx.Tx)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting tool name and url: "+err.Error()))
+		return
+	}
+
+	dses, err := GetServerCacheConfigData(inf.Tx.Tx, serverName, serverType)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server delivery service cache config data: "+err.Error()))
+		return
+	}
+
+	txt := atscfg.MakeServerCacheDotConfig(serverName, toToolName, toURL, dses)
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte(txt))
+}

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/chkconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/chkconfig.go
@@ -1,0 +1,58 @@
+package atsserver
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+)
+
+func GetChkconfig(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-host"}, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	serverName, _, ok, err := GetServerNameAndTypeFromNameOrID(inf.Tx.Tx, inf.Params["id-or-host"])
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server name from ID: "+err.Error()))
+		return
+	} else if !ok {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("not found"), nil)
+		return
+	}
+
+	params, err := GetServerParams(inf.Tx.Tx, serverName, atscfg.ChkconfigParamConfigFile)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server '"+string(serverName)+"' + chkconfig parameters: "+err.Error()))
+		return
+	}
+
+	txt := atscfg.MakeChkconfig(params)
+
+	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Write([]byte(txt))
+}

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/hostingdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/hostingdotconfig.go
@@ -1,0 +1,139 @@
+package atsserver
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
+)
+
+func GetHostingDotConfig(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-host"}, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	serverName, serverType, ok, err := GetServerNameAndTypeFromNameOrID(inf.Tx.Tx, inf.Params["id-or-host"])
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server name from ID: "+err.Error()))
+		return
+	} else if !ok {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("not found"), nil)
+		return
+	}
+
+	toToolName, toURL, err := ats.GetToolNameAndURL(inf.Tx.Tx)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting tool name and url: "+err.Error()))
+		return
+	}
+
+	multiParams, err := GetServerParams(inf.Tx.Tx, serverName, atscfg.HostingConfigParamConfigFile)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server '"+string(serverName)+"' + hosting parameters: "+err.Error()))
+		return
+	}
+
+	params := map[string]string{}
+	for name, vals := range multiParams {
+		if len(vals) == 0 {
+			log.Warnln("hosting config got multiple parameters for ")
+			continue
+		}
+		if len(vals) > 1 {
+			log.Errorln("hosting config parameter name '"+name+"' got multiple values: %+v - using first!", name, vals)
+		}
+		params[name] = vals[0]
+	}
+
+	origins, err := GetServerHostingOrigins(inf.Tx.Tx, serverName, serverType)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server '"+string(serverName)+"' hosting origins: "+err.Error()))
+		return
+	}
+
+	log.Errorf("hosting config DEBUG params %+v\n", params)
+	log.Errorf("hosting config DEBUG multiParams %+v\n", multiParams)
+
+	txt := atscfg.MakeHostingDotConfig(serverName, toToolName, toURL, params, origins)
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte(txt))
+}
+
+// GetServerHostingOrigins returns the list of origins on delivery services assigned to the given server, to be used in the ATS config file.
+// It returns only LIVE_NATNL delivery services, for mids; and only LIVE and LIVE_NATNL services for edges.
+func GetServerHostingOrigins(tx *sql.Tx, serverName tc.CacheName, serverType tc.CacheType) ([]string, error) {
+	qry := `
+SELECT
+  DISTINCT(SELECT o.protocol::text || '://' || o.fqdn || rtrim(concat(':', o.port::text), ':')) as org_server_fqdn
+FROM
+  deliveryservice ds
+  JOIN deliveryservice_server dss on dss.deliveryservice = ds.id
+  JOIN server s on s.id = dss.server
+  LEFT JOIN origin o on (o.deliveryservice = ds.id AND o.is_primary)
+`
+	if strings.HasPrefix(string(serverType), tc.MidTypePrefix) {
+		// Note mids only include active DSes, but edges include inactive DSes as well.
+		qry += `
+WHERE
+  s.cdn_id = (select cdn_id from server where host_name = $1)
+  AND ds.type IN (SELECT id FROM type WHERE name like '%` + tc.DSTypeLiveNationalSuffix + `')
+  AND ds.active = true
+  AND ds.cdn_id = s.cdn_id
+`
+	} else {
+		qry += `
+WHERE
+  s.host_name = $1
+  AND ds.cdn_id = s.cdn_id
+  AND ds.type IN (SELECT id FROM type WHERE (name LIKE '%` + tc.DSTypeLiveSuffix + `' OR name LIKE '%` + tc.DSTypeLiveNationalSuffix + `'))
+`
+	}
+	// Note the 'ds.cdn_id = s.cdn_id' in the query shouldn't be necessary, but it is, because there's no DB constraint.
+
+	log.Errorln("hosting config DEBUG qry QQ" + qry + "QQ")
+
+	rows, err := tx.Query(qry, serverName)
+	if err != nil {
+		return nil, errors.New("querying: " + err.Error())
+	}
+	defer rows.Close()
+
+	origins := []string{}
+	for rows.Next() {
+		origin := ""
+		if err := rows.Scan(&origin); err != nil {
+			return nil, errors.New("scanning: " + err.Error())
+		}
+		origins = append(origins, origin)
+	}
+	return origins, nil
+}

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/hostingdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/hostingdotconfig.go
@@ -64,7 +64,7 @@ func GetHostingDotConfig(w http.ResponseWriter, r *http.Request) {
 	params := map[string]string{}
 	for name, vals := range multiParams {
 		if len(vals) == 0 {
-			log.Warnln("hosting config got multiple parameters for ")
+			log.Warnln("hosting config got no parameters for '" + name + "'")
 			continue
 		}
 		if len(vals) > 1 {

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/ipallowdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/ipallowdotconfig.go
@@ -1,0 +1,148 @@
+package atsserver
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
+)
+
+func GetIPAllowDotConfig(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-host"}, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	serverName, serverType, ok, err := GetServerNameAndTypeFromNameOrID(inf.Tx.Tx, inf.Params["id-or-host"])
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server name from ID: "+err.Error()))
+		return
+	} else if !ok {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("not found"), nil)
+		return
+	}
+
+	toToolName, toURL, err := ats.GetToolNameAndURL(inf.Tx.Tx)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting tool name and url: "+err.Error()))
+		return
+	}
+
+	params, err := GetServerParams(inf.Tx.Tx, serverName, atscfg.IPAllowConfigFileName)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server '"+string(serverName)+"' + ip_allow parameters: "+err.Error()))
+		return
+	}
+
+	childServers := map[tc.CacheName]atscfg.IPAllowServer{}
+	if strings.HasPrefix(string(serverType), tc.MidTypePrefix) {
+		if childServers, err = GetChildServers(inf.Tx.Tx, serverName); err != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting child servers from mid '"+string(serverName)+"': "+err.Error()))
+			return
+		}
+	}
+
+	txt := atscfg.MakeIPAllowDotConfig(serverName, serverType, toToolName, toURL, params, childServers)
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte(txt))
+}
+
+// GetChildServers returns the child servers of the given Mid serverName. This should not be called with an Edge server.
+func GetChildServers(tx *sql.Tx, serverName tc.CacheName) (map[tc.CacheName]atscfg.IPAllowServer, error) {
+	qry := `
+SELECT
+  s.host_name,
+  s.ip_address,
+  COALESCE(s.ip6_address, '')
+FROM
+  server s
+  JOIN type tp on tp.id = s.type
+  JOIN cachegroup cg on cg.id = s.cachegroup
+WHERE
+  (tp.name = '` + tc.MonitorTypeName + `' OR tp.name LIKE '` + tc.EdgeTypePrefix + `%')
+  AND cg.id IN (
+    SELECT
+      cg2.id
+    FROM
+     server s2
+     JOIN cachegroup cg2 ON (cg2.parent_cachegroup_id = s2.cachegroup OR cg2.secondary_parent_cachegroup_id = s2.cachegroup)
+    WHERE
+      s2.host_name = $1
+  )
+`
+	rows, err := tx.Query(qry, serverName)
+	if err != nil {
+		return nil, errors.New("querying: " + err.Error())
+	}
+	defer rows.Close()
+
+	servers := map[tc.CacheName]atscfg.IPAllowServer{}
+	for rows.Next() {
+		svName := tc.CacheName("")
+		sv := atscfg.IPAllowServer{}
+		if err := rows.Scan(&svName, &sv.IPAddress, &sv.IP6Address); err != nil {
+			return nil, errors.New("scanning: " + err.Error())
+		}
+		servers[svName] = sv
+	}
+	return servers, nil
+}
+
+func GetServerParams(tx *sql.Tx, serverName tc.CacheName, configFile string) (map[string][]string, error) {
+	qry := `
+SELECT
+  pa.name,
+  pa.value
+FROM
+  parameter pa
+  JOIN profile_parameter pp ON pp.parameter = pa.id
+  JOIN profile pr ON pr.id = pp.profile
+  JOIN server s ON s.profile = pr.id
+WHERE
+  s.host_name = $1
+  AND pa.config_file = $2
+`
+	rows, err := tx.Query(qry, serverName, configFile)
+	if err != nil {
+		return nil, errors.New("querying: " + err.Error())
+	}
+	defer rows.Close()
+
+	params := map[string][]string{}
+	for rows.Next() {
+		name := ""
+		val := ""
+		if err := rows.Scan(&name, &val); err != nil {
+			return nil, errors.New("scanning: " + err.Error())
+		}
+		params[name] = append(params[name], val)
+	}
+	return params, nil
+}

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/packages.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/packages.go
@@ -1,0 +1,58 @@
+package atsserver
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+)
+
+func GetPackages(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-host"}, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	serverName, _, ok, err := GetServerNameAndTypeFromNameOrID(inf.Tx.Tx, inf.Params["id-or-host"])
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server name from ID: "+err.Error()))
+		return
+	} else if !ok {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("not found"), nil)
+		return
+	}
+
+	params, err := GetServerParams(inf.Tx.Tx, serverName, atscfg.PackagesParamConfigFile)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server '"+string(serverName)+"' + package parameters: "+err.Error()))
+		return
+	}
+
+	txt := atscfg.MakePackages(params)
+
+	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Write([]byte(txt))
+}

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/server.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/server.go
@@ -1,0 +1,100 @@
+package atsserver
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"database/sql"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
+)
+
+func GetServerNameAndTypeFromNameOrID(tx *sql.Tx, nameOrID string) (tc.CacheName, tc.CacheType, bool, error) {
+	if id, err := strconv.Atoi(nameOrID); err == nil {
+		return ats.GetServerNameAndTypeFromID(tx, id)
+	}
+	name := tc.CacheName(nameOrID)
+	typ, ok, err := ats.GetServerTypeFromName(tx, name)
+	return name, typ, ok, err
+}
+
+func GetServerNameAndDomainFromNameOrID(tx *sql.Tx, nameOrID string) (tc.CacheName, string, bool, error) {
+	if id, err := strconv.Atoi(nameOrID); err == nil {
+		return ats.GetServerNameAndDomainFromID(tx, id)
+	}
+	name := tc.CacheName(nameOrID)
+	typ, ok, err := ats.GetServerDomainFromName(tx, name)
+	return name, typ, ok, err
+}
+
+func GetServerCacheConfigData(tx *sql.Tx, serverName tc.CacheName, serverType tc.CacheType) (map[tc.DeliveryServiceName]atscfg.ServerCacheConfigDS, error) {
+	qry := `
+SELECT
+  ds.xml_id,
+  (o.protocol::text || '://' || o.fqdn || rtrim(concat(':', o.port::text), ':')) as org_server_fqdn,
+  dt.name AS ds_type
+FROM
+  deliveryservice ds
+  JOIN type dt ON ds.type = dt.id
+  JOIN cdn ON cdn.id = ds.cdn_id
+  JOIN deliveryservice_server dss on dss.deliveryservice = ds.id
+  LEFT JOIN origin o on (o.deliveryservice = ds.id AND o.is_primary)
+`
+	if strings.HasPrefix(string(serverType), tc.MidTypePrefix) {
+		// Note inactive DSes are omitted from Mids, but not Edges
+		// See https://github.com/apache/trafficcontrol/issues/3746
+		qry += `
+WHERE
+  cdn.id = (select cdn_id from server where host_name = $1)
+  AND ds.active = true
+`
+	} else {
+		qry += `
+WHERE
+  dss.server = (select id from server where host_name = $1)
+`
+	}
+
+	qry += `
+  AND dt.name = '` + string(tc.DSTypeHTTPNoCache) + `'
+`
+
+	rows, err := tx.Query(qry, serverName)
+	if err != nil {
+		return nil, errors.New("querying: " + err.Error())
+	}
+	defer rows.Close()
+
+	dses := map[tc.DeliveryServiceName]atscfg.ServerCacheConfigDS{}
+	for rows.Next() {
+		dsName := tc.DeliveryServiceName("")
+		ds := atscfg.ServerCacheConfigDS{}
+		if err := rows.Scan(&dsName, &ds.OrgServerFQDN, &ds.Type); err != nil {
+			return nil, errors.New("scanning: " + err.Error())
+		}
+		ds.Type = tc.DSTypeFromString(string(ds.Type))
+		dses[dsName] = ds
+	}
+	return dses, nil
+}

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/unknown.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/unknown.go
@@ -1,0 +1,70 @@
+package atsserver
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
+)
+
+func GetUnknown(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-host"}, nil)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	serverName, serverDomain, ok, err := GetServerNameAndDomainFromNameOrID(inf.Tx.Tx, inf.Params["id-or-host"])
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server name from ID: "+err.Error()))
+		return
+	} else if !ok {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("not found"), nil)
+		return
+	}
+
+	toToolName, toURL, err := ats.GetToolNameAndURL(inf.Tx.Tx)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting tool name and url: "+err.Error()))
+		return
+	}
+
+	params, err := GetServerParams(inf.Tx.Tx, serverName, inf.Params["file"])
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting server '"+string(serverName)+"' + package parameters: "+err.Error()))
+		return
+	}
+
+	if len(params) == 0 {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("not found"), nil)
+		return
+	}
+
+	txt := atscfg.MakeServerUnknown(serverName, serverDomain, toToolName, toURL, params)
+
+	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Write([]byte(txt))
+}

--- a/traffic_ops/traffic_ops_golang/ats/db.go
+++ b/traffic_ops/traffic_ops_golang/ats/db.go
@@ -772,3 +772,89 @@ func GetFirstScopeParameter(tx *sql.Tx, cfgFile string) (string, bool, error) {
 	}
 	return v, true, nil
 }
+
+// GetServerNameAndTypeFromID returns the server's name, type, whether it exists, and any error.
+func GetServerNameAndTypeFromID(tx *sql.Tx, id int) (tc.CacheName, tc.CacheType, bool, error) {
+	qry := `
+SELECT
+  s.host_name,
+  tp.name
+FROM
+  server s
+  JOIN type tp on s.type = tp.id
+WHERE
+  s.id = $1
+`
+	name := tc.CacheName("")
+	typ := tc.CacheType("")
+	if err := tx.QueryRow(qry, id).Scan(&name, &typ); err != nil {
+		if err == sql.ErrNoRows {
+			return "", tc.CacheType(""), false, nil
+		}
+		return "", tc.CacheType(""), false, errors.New("querying: " + err.Error())
+	}
+	return name, typ, true, nil
+}
+
+// GetServerNameAndTypeFromID returns the server's name, type, whether it exists, and any error.
+func GetServerTypeFromName(tx *sql.Tx, name tc.CacheName) (tc.CacheType, bool, error) {
+	qry := `
+SELECT
+  tp.name
+FROM
+  server s
+  JOIN type tp on s.type = tp.id
+WHERE
+  s.host_name = $1
+`
+	typ := tc.CacheType("")
+	if err := tx.QueryRow(qry, name).Scan(&typ); err != nil {
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, errors.New("querying: " + err.Error())
+	}
+	return typ, true, nil
+}
+
+// GetServerNameAndDomainFromID returns the server's name, domain, whether it exists, and any error.
+func GetServerNameAndDomainFromID(tx *sql.Tx, id int) (tc.CacheName, string, bool, error) {
+	qry := `
+SELECT
+  s.host_name,
+  s.domain_name
+FROM
+  server s
+WHERE
+  s.id = $1
+`
+	name := tc.CacheName("")
+	domain := ""
+	if err := tx.QueryRow(qry, id).Scan(&name, &domain); err != nil {
+		if err == sql.ErrNoRows {
+			return "", "", false, nil
+		}
+		return "", "", false, errors.New("querying: " + err.Error())
+	}
+	return name, domain, true, nil
+}
+
+// GetServerNameAndDomainFromID returns the server's name, domain, whether it exists, and any error.
+func GetServerDomainFromName(tx *sql.Tx, name tc.CacheName) (string, bool, error) {
+	qry := `
+SELECT
+  s.domain_name
+FROM
+  server s
+WHERE
+  s.host_name = $1
+`
+	domain := ""
+	if err := tx.QueryRow(qry, name).Scan(&domain); err != nil {
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, errors.New("querying: " + err.Error())
+	}
+	return domain, true, nil
+}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -422,6 +422,13 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `servers/{server-name-or-id}/configfiles/ats/parent.config/?(\.json)?$`, atsserver.GetParentDotConfig, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodGet, `servers/{server-name-or-id}/configfiles/ats/remap.config/?(\.json)?$`, atsserver.GetServerConfigRemap, auth.PrivLevelOperations, Authenticated, nil},
 
+		{1.1, http.MethodGet, `servers/{id-or-host}/configfiles/ats/cache.config/?(\.json)?$`, atsserver.GetCacheDotConfig, auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `servers/{id-or-host}/configfiles/ats/ip_allow.config/?(\.json)?$`, atsserver.GetIPAllowDotConfig, auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `servers/{id-or-host}/configfiles/ats/hosting.config/?(\.json)?$`, atsserver.GetHostingDotConfig, auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `servers/{id-or-host}/configfiles/ats/packages/?(\.json)?$`, atsserver.GetPackages, auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `servers/{id-or-host}/configfiles/ats/chkconfig/?(\.json)?$`, atsserver.GetChkconfig, auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `servers/{id-or-host}/configfiles/ats/{file}/?(\.json)?$`, atsserver.GetUnknown, auth.PrivLevelOperations, Authenticated, nil},
+
 		// Federations
 		{1.4, http.MethodGet, `federations/all/?(\.json)?$`, federations.GetAll, auth.PrivLevelAdmin, Authenticated, nil},
 		{1.1, http.MethodGet, `federations/?(\.json)?$`, federations.Get, auth.PrivLevelFederation, Authenticated, nil},


### PR DESCRIPTION
Adds Traffic Ops Golang /servers ATS config routes.

I've parity tested against all our production servers, they all diff identical, except irrelevant ordering, and in some cases the ip_allow coalescing. 

As far as I can tell, the IP allow coalescing in Go is behaving like it should, but Perl sometimes doesn't seem to coalesce and combine like the parameters suggest. Specifically, sometimes Perl seems to combine fewer IPs than the combine parameter passed. Whoever reviews this can verify if they think it's correct.

Includes unit tests, includes changelog update. No documentation, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Generate configs, compare with Perl. This can be done with either an older TO, or personally, I change routes.go to serve Go at 1.4, causing /api/1.1 to return Perl for comparing.

## If this is a bug fix, what versions of Traffic Control are affected?

Not a bug fix.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
