### PR TITLE
Rewrite /cachegroups/{{id}}/parameters to Go

### DIFF
--- a/docs/source/api/cachegroups_id_parameters.rst
+++ b/docs/source/api/cachegroups_id_parameters.rst
@@ -33,7 +33,7 @@ Request Structure
 	+-------------+----------+---------------------------------------------------+
 	| Name        | Required | Description                                       |
 	+=============+==========+===================================================+
-	| parameterId | no       | Show only the :term:`Paramater` with the given ID |
+	| parameterId | no       | Show only the :term:`Parameter` with the given ID |
 	+-------------+----------+---------------------------------------------------+
 
 .. table:: Request Path Parameters

--- a/docs/source/api/cachegroups_id_parameters.rst
+++ b/docs/source/api/cachegroups_id_parameters.rst
@@ -28,6 +28,14 @@ Gets all the :term:`Parameters` associated with a :term:`Cache Group`
 
 Request Structure
 -----------------
+.. table:: Request Query Parameters
+
+	+-------------+----------+---------------------------------------------------+
+	| Name        | Required | Description                                       |
+	+=============+==========+===================================================+
+	| parameterId | no       | Show only the :term:`Paramater` with the given ID |
+	+-------------+----------+---------------------------------------------------+
+
 .. table:: Request Path Parameters
 
 	+-----------+----------------------------------------------------------+

--- a/lib/go-tc/cachegroup_parameters.go
+++ b/lib/go-tc/cachegroup_parameters.go
@@ -1,5 +1,3 @@
-package tc
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,6 +16,8 @@ package tc
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package tc
 
 // CacheGroupParameter Cache Group Parameter association
 type CacheGroupParameter struct {

--- a/lib/go-tc/cachegroup_parameters.go
+++ b/lib/go-tc/cachegroup_parameters.go
@@ -19,14 +19,40 @@
 
 package tc
 
-// CacheGroupParameter Cache Group Parameter association
-type CacheGroupParameter struct {
+// CacheGroupParameterRequest Cache Group Parameter request body
+type CacheGroupParameterRequest struct {
 	CacheGroupID int `json:"cacheGroupId"`
 	ParameterID  int `json:"parameterId"`
 }
 
-// CacheGroupParameterResponse Response body for associating parameters with cache groups
-type CacheGroupParameterResponse struct {
+// CacheGroupParameterPostResponse Response body when Posting to associate a Parameter with a Cache Group
+type CacheGroupParametersPostResponse struct {
+	Response []CacheGroupParameterRequest `json:"response"`
+	Alerts
+}
+
+// CacheGroupParameterResponse Cache Group Parameter response body
+type CacheGroupParametersResponse struct {
 	Response []CacheGroupParameter `json:"response"`
 	Alerts
+}
+
+// CacheGroupParameter ...
+type CacheGroupParameter struct {
+	ConfigFile  string    `json:"configFile"`
+	ID          int       `json:"id"`
+	LastUpdated TimeNoMod `json:"lastUpdated"`
+	Name        string    `json:"name"`
+	Secure      bool      `json:"secure"`
+	Value       string    `json:"value"`
+}
+
+// CacheGroupParameterNullable ...
+type CacheGroupParameterNullable struct {
+	ConfigFile  *string    `json:"configFile" db:"config_file"`
+	ID          *int       `json:"id" db:"id"`
+	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
+	Name        *string    `json:"name" db:"name"`
+	Secure      *bool      `json:"secure" db:"secure"`
+	Value       *string    `json:"value" db:"value"`
 }

--- a/lib/go-tc/cachegroup_parameters.go
+++ b/lib/go-tc/cachegroup_parameters.go
@@ -21,8 +21,8 @@ package tc
 
 // CacheGroupParameter Cache Group Parameter association
 type CacheGroupParameter struct {
-	ID          int `json:"cachegroupId"`
-	ParameterID int `json:"parameterId"`
+	CacheGroupID int `json:"cachegroupId"`
+	ParameterID  int `json:"parameterId"`
 }
 
 // CacheGroupParameterResponse Response body for associating parameters with cache groups

--- a/lib/go-tc/cachegroup_parameters.go
+++ b/lib/go-tc/cachegroup_parameters.go
@@ -1,0 +1,32 @@
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// CacheGroupParameter Cache Group Parameter association
+type CacheGroupParameter struct {
+	ID          int `json:"cachegroupId"`
+	ParameterID int `json:"parameterId"`
+}
+
+// CacheGroupParameterResponse Response body for associating parameters with cache groups
+type CacheGroupParameterResponse struct {
+	Response []CacheGroupParameter `json:"response"`
+	Alerts
+}

--- a/lib/go-tc/cachegroup_parameters.go
+++ b/lib/go-tc/cachegroup_parameters.go
@@ -21,7 +21,7 @@ package tc
 
 // CacheGroupParameter Cache Group Parameter association
 type CacheGroupParameter struct {
-	CacheGroupID int `json:"cachegroupId"`
+	CacheGroupID int `json:"cacheGroupId"`
 	ParameterID  int `json:"parameterId"`
 }
 

--- a/traffic_ops/client/cachegroup_parameters.go
+++ b/traffic_ops/client/cachegroup_parameters.go
@@ -28,8 +28,8 @@ const (
 )
 
 // GetCacheGroupParameters Gets a Cache Group's Parameters
-func (to *Session) GetCacheGroupParameters(id int) ([]tc.Parameter, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d/parameters", API_v13_CacheGroups, id)
+func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.Parameter, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/parameters", API_v13_CacheGroups, cacheGroupID)
 	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
@@ -38,13 +38,15 @@ func (to *Session) GetCacheGroupParameters(id int) ([]tc.Parameter, ReqInf, erro
 	defer resp.Body.Close()
 
 	var data tc.ParametersResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
 	return data.Response, reqInf, nil
 }
 
 // GetCacheGroupParametersByQueryParams Gets a Cache Group's Parameters with query parameters
-func (to *Session) GetCacheGroupParametersByQueryParams(id int, queryParams string) ([]tc.Parameter, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d/parameters%s", API_v13_CacheGroups, id, queryParams)
+func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.Parameter, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/parameters%s", API_v13_CacheGroups, cacheGroupID, queryParams)
 	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
@@ -53,13 +55,15 @@ func (to *Session) GetCacheGroupParametersByQueryParams(id int, queryParams stri
 	defer resp.Body.Close()
 
 	var data tc.ParametersResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
 	return data.Response, reqInf, nil
 }
 
 // DeleteCacheGroupParameter Deassociates a Parameter with a Cache Group
-func (to *Session) DeleteCacheGroupParameter(id, parameterID int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d/%d", API_v14_CacheGroupParameters, id, parameterID)
+func (to *Session) DeleteCacheGroupParameter(cacheGroupID, parameterID int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/%d", API_v14_CacheGroupParameters, cacheGroupID, parameterID)
 	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
@@ -68,15 +72,17 @@ func (to *Session) DeleteCacheGroupParameter(id, parameterID int) (tc.Alerts, Re
 	defer resp.Body.Close()
 
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
 	return alerts, reqInf, nil
 }
 
 // CreateCacheGroupParameter Associates a Parameter with a Cache Group
-func (to *Session) CreateCacheGroupParameter(id, parameterID int) (*tc.CacheGroupParameterResponse, ReqInf, error) {
+func (to *Session) CreateCacheGroupParameter(cacheGroupID, parameterID int) (*tc.CacheGroupParameterResponse, ReqInf, error) {
 	cacheGroupParameterReq := tc.CacheGroupParameter{
-		ID:          id,
-		ParameterID: parameterID,
+		CacheGroupID: cacheGroupID,
+		ParameterID:  parameterID,
 	}
 	reqBody, err := json.Marshal(cacheGroupParameterReq)
 	if err != nil {
@@ -90,6 +96,8 @@ func (to *Session) CreateCacheGroupParameter(id, parameterID int) (*tc.CacheGrou
 	defer resp.Body.Close()
 
 	var data tc.CacheGroupParameterResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
 	return &data, reqInf, nil
 }

--- a/traffic_ops/client/cachegroup_parameters.go
+++ b/traffic_ops/client/cachegroup_parameters.go
@@ -1,0 +1,95 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v14_CacheGroupParameters = "/api/1.4/cachegroupparameters"
+)
+
+// GetCacheGroupParameters Gets a Cache Group's Parameters
+func (to *Session) GetCacheGroupParameters(id int) ([]tc.Parameter, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/parameters", API_v13_CacheGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ParametersResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GetCacheGroupParametersByQueryParams Gets a Cache Group's Parameters with query parameters
+func (to *Session) GetCacheGroupParametersByQueryParams(id int, queryParams string) ([]tc.Parameter, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/parameters%s", API_v13_CacheGroups, id, queryParams)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ParametersResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// DeleteCacheGroupParameter Deassociates a Parameter with a Cache Group
+func (to *Session) DeleteCacheGroupParameter(id, parameterID int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/%d", API_v14_CacheGroupParameters, id, parameterID)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// CreateCacheGroupParameter Associates a Parameter with a Cache Group
+func (to *Session) CreateCacheGroupParameter(id, parameterID int) (*tc.CacheGroupParameterResponse, ReqInf, error) {
+	cacheGroupParameterReq := tc.CacheGroupParameter{
+		ID:          id,
+		ParameterID: parameterID,
+	}
+	reqBody, err := json.Marshal(cacheGroupParameterReq)
+	if err != nil {
+		return nil, ReqInf{}, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v14_CacheGroupParameters, reqBody)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheGroupParameterResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return &data, reqInf, nil
+}

--- a/traffic_ops/client/cachegroup_parameters.go
+++ b/traffic_ops/client/cachegroup_parameters.go
@@ -28,7 +28,7 @@ const (
 )
 
 // GetCacheGroupParameters Gets a Cache Group's Parameters
-func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.CacheGroupParameter, ReqInf, error) {
 	route := fmt.Sprintf("%s/%d/parameters", API_v13_CacheGroups, cacheGroupID)
 	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
@@ -37,7 +37,7 @@ func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.Parameter, Re
 	}
 	defer resp.Body.Close()
 
-	var data tc.ParametersResponse
+	var data tc.CacheGroupParametersResponse
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return nil, reqInf, err
 	}
@@ -45,7 +45,7 @@ func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.Parameter, Re
 }
 
 // GetCacheGroupParametersByQueryParams Gets a Cache Group's Parameters with query parameters
-func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.CacheGroupParameter, ReqInf, error) {
 	route := fmt.Sprintf("%s/%d/parameters%s", API_v13_CacheGroups, cacheGroupID, queryParams)
 	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
@@ -54,7 +54,7 @@ func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryP
 	}
 	defer resp.Body.Close()
 
-	var data tc.ParametersResponse
+	var data tc.CacheGroupParametersResponse
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return nil, reqInf, err
 	}
@@ -79,8 +79,8 @@ func (to *Session) DeleteCacheGroupParameter(cacheGroupID, parameterID int) (tc.
 }
 
 // CreateCacheGroupParameter Associates a Parameter with a Cache Group
-func (to *Session) CreateCacheGroupParameter(cacheGroupID, parameterID int) (*tc.CacheGroupParameterResponse, ReqInf, error) {
-	cacheGroupParameterReq := tc.CacheGroupParameter{
+func (to *Session) CreateCacheGroupParameter(cacheGroupID, parameterID int) (*tc.CacheGroupParametersPostResponse, ReqInf, error) {
+	cacheGroupParameterReq := tc.CacheGroupParameterRequest{
 		CacheGroupID: cacheGroupID,
 		ParameterID:  parameterID,
 	}
@@ -95,7 +95,7 @@ func (to *Session) CreateCacheGroupParameter(cacheGroupID, parameterID int) (*tc
 	}
 	defer resp.Body.Close()
 
-	var data tc.CacheGroupParameterResponse
+	var data tc.CacheGroupParametersPostResponse
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return nil, reqInf, err
 	}

--- a/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
@@ -1,0 +1,91 @@
+// /*
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// */
+
+package v14
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+)
+
+func TestCacheGroupParameters(t *testing.T) {
+	WithObjs(t, []TCObj{Types, Parameters, CacheGroups}, func() {
+		GetTestCacheGroupParameters(t)
+	})
+}
+
+func CreateTestCacheGroupParameters(t *testing.T) {
+
+	firstCacheGroup := testData.CacheGroups[0]
+	cacheGroupResp, _, err := TOSession.GetCacheGroupByName(*firstCacheGroup.Name)
+	if err != nil {
+		t.Errorf("cannot GET Cache Group by name: %v - %v\n", firstCacheGroup.Name, err)
+	}
+
+	firstParameter := testData.Parameters[0]
+	paramResp, _, err := TOSession.GetParameterByName(firstParameter.Name)
+	if err != nil {
+		t.Errorf("cannot GET Parameter by name: %v - %v\n", firstParameter.Name, err)
+	}
+
+	cacheGroupID := cacheGroupResp[0].ID
+	parameterID := paramResp[0].ID
+
+	resp, _, err := TOSession.CreateCacheGroupParameter(cacheGroupID, parameterID)
+	log.Debugln("Response: ", resp)
+	if err != nil {
+		t.Errorf("could not CREATE cache group parameter: %v\n", err)
+	}
+	testData.CacheGroupParameters = append(testData.CacheGroupParameters, resp.Response...)
+}
+
+func GetTestCacheGroupParameters(t *testing.T) {
+	for _, cgp := range testData.CacheGroupParameters {
+		resp, _, err := TOSession.GetCacheGroupParameters(cgp.ID)
+		if err != nil {
+			t.Errorf("cannot GET Parameter by cache group: %v - %v\n", err, resp)
+		}
+	}
+}
+
+func DeleteTestCacheGroupParameters(t *testing.T) {
+	for _, cgp := range testData.CacheGroupParameters {
+		DeleteTestCacheGroupParameter(t, cgp)
+	}
+}
+
+func DeleteTestCacheGroupParameter(t *testing.T, cgp tc.CacheGroupParameter) {
+
+	delResp, _, err := TOSession.DeleteCacheGroupParameter(cgp.ID, cgp.ParameterID)
+	if err != nil {
+		t.Errorf("cannot DELETE Parameter by cache group: %v - %v\n", err, delResp)
+	}
+
+	// Retrieve the Cache Group Parameter to see if it got deleted
+	queryParams := fmt.Sprintf("parameterId=%d", cgp.ParameterID)
+
+	parameters, _, err := TOSession.GetCacheGroupParametersByQueryParams(cgp.ID, queryParams)
+	if err != nil {
+		t.Errorf("error deleting Parameter name: %s\n", err.Error())
+	}
+	if len(parameters) > 0 {
+		t.Errorf("expected Parameter: %d to be to be disassociated from Cache Group: %d\n", cgp.ParameterID, cgp.ID)
+	}
+
+}

--- a/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
@@ -1,17 +1,17 @@
-// /*
+/*
 
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-//  http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-// */
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 
 package v14
 

--- a/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
@@ -57,11 +57,11 @@ func CreateTestCacheGroupParameters(t *testing.T) {
 	if resp == nil {
 		t.Fatalf("Cache Group Parameter response should not be nil")
 	}
-	testData.CacheGroupParameters = append(testData.CacheGroupParameters, resp.Response...)
+	testData.CacheGroupParameterRequests = append(testData.CacheGroupParameterRequests, resp.Response...)
 }
 
 func GetTestCacheGroupParameters(t *testing.T) {
-	for _, cgp := range testData.CacheGroupParameters {
+	for _, cgp := range testData.CacheGroupParameterRequests {
 		resp, _, err := TOSession.GetCacheGroupParameters(cgp.CacheGroupID)
 		if err != nil {
 			t.Errorf("cannot GET Parameter by cache group: %v - %v\n", err, resp)
@@ -70,12 +70,12 @@ func GetTestCacheGroupParameters(t *testing.T) {
 }
 
 func DeleteTestCacheGroupParameters(t *testing.T) {
-	for _, cgp := range testData.CacheGroupParameters {
+	for _, cgp := range testData.CacheGroupParameterRequests {
 		DeleteTestCacheGroupParameter(t, cgp)
 	}
 }
 
-func DeleteTestCacheGroupParameter(t *testing.T, cgp tc.CacheGroupParameter) {
+func DeleteTestCacheGroupParameter(t *testing.T, cgp tc.CacheGroupParameterRequest) {
 
 	delResp, _, err := TOSession.DeleteCacheGroupParameter(cgp.CacheGroupID, cgp.ParameterID)
 	if err != nil {

--- a/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
@@ -50,7 +50,6 @@ func CreateTestCacheGroupParameters(t *testing.T) {
 
 	cacheGroupID := cacheGroupResp[0].ID
 	parameterID := paramResp[0].ID
-
 	resp, _, err := TOSession.CreateCacheGroupParameter(*cacheGroupID, parameterID)
 	if err != nil {
 		t.Errorf("could not CREATE cache group parameter: %v\n", err)
@@ -84,7 +83,7 @@ func DeleteTestCacheGroupParameter(t *testing.T, cgp tc.CacheGroupParameter) {
 	}
 
 	// Retrieve the Cache Group Parameter to see if it got deleted
-	queryParams := fmt.Sprintf("parameterId=%d", cgp.ParameterID)
+	queryParams := fmt.Sprintf("?parameterId=%d", cgp.ParameterID)
 
 	parameters, _, err := TOSession.GetCacheGroupParametersByQueryParams(cgp.CacheGroupID, queryParams)
 	if err != nil {

--- a/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
+++ b/traffic_ops/testing/api/v14/cachegroups_parameters_test.go
@@ -20,22 +20,23 @@ import (
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func TestCacheGroupParameters(t *testing.T) {
-	WithObjs(t, []TCObj{Types, Parameters, CacheGroups}, func() {
+	WithObjs(t, []TCObj{Types, Parameters, CacheGroups, CacheGroupParameters}, func() {
 		GetTestCacheGroupParameters(t)
 	})
 }
 
 func CreateTestCacheGroupParameters(t *testing.T) {
-
 	firstCacheGroup := testData.CacheGroups[0]
-	cacheGroupResp, _, err := TOSession.GetCacheGroupByName(*firstCacheGroup.Name)
+	cacheGroupResp, _, err := TOSession.GetCacheGroupNullableByName(*firstCacheGroup.Name)
 	if err != nil {
 		t.Errorf("cannot GET Cache Group by name: %v - %v\n", firstCacheGroup.Name, err)
+	}
+
+	if cacheGroupResp == nil {
+		t.Fatalf("Cache Groups response should not be nil")
 	}
 
 	firstParameter := testData.Parameters[0]
@@ -43,21 +44,26 @@ func CreateTestCacheGroupParameters(t *testing.T) {
 	if err != nil {
 		t.Errorf("cannot GET Parameter by name: %v - %v\n", firstParameter.Name, err)
 	}
+	if paramResp == nil {
+		t.Fatalf("Parameter response should not be nil")
+	}
 
 	cacheGroupID := cacheGroupResp[0].ID
 	parameterID := paramResp[0].ID
 
-	resp, _, err := TOSession.CreateCacheGroupParameter(cacheGroupID, parameterID)
-	log.Debugln("Response: ", resp)
+	resp, _, err := TOSession.CreateCacheGroupParameter(*cacheGroupID, parameterID)
 	if err != nil {
 		t.Errorf("could not CREATE cache group parameter: %v\n", err)
+	}
+	if resp == nil {
+		t.Fatalf("Cache Group Parameter response should not be nil")
 	}
 	testData.CacheGroupParameters = append(testData.CacheGroupParameters, resp.Response...)
 }
 
 func GetTestCacheGroupParameters(t *testing.T) {
 	for _, cgp := range testData.CacheGroupParameters {
-		resp, _, err := TOSession.GetCacheGroupParameters(cgp.ID)
+		resp, _, err := TOSession.GetCacheGroupParameters(cgp.CacheGroupID)
 		if err != nil {
 			t.Errorf("cannot GET Parameter by cache group: %v - %v\n", err, resp)
 		}
@@ -72,7 +78,7 @@ func DeleteTestCacheGroupParameters(t *testing.T) {
 
 func DeleteTestCacheGroupParameter(t *testing.T, cgp tc.CacheGroupParameter) {
 
-	delResp, _, err := TOSession.DeleteCacheGroupParameter(cgp.ID, cgp.ParameterID)
+	delResp, _, err := TOSession.DeleteCacheGroupParameter(cgp.CacheGroupID, cgp.ParameterID)
 	if err != nil {
 		t.Errorf("cannot DELETE Parameter by cache group: %v - %v\n", err, delResp)
 	}
@@ -80,12 +86,15 @@ func DeleteTestCacheGroupParameter(t *testing.T, cgp tc.CacheGroupParameter) {
 	// Retrieve the Cache Group Parameter to see if it got deleted
 	queryParams := fmt.Sprintf("parameterId=%d", cgp.ParameterID)
 
-	parameters, _, err := TOSession.GetCacheGroupParametersByQueryParams(cgp.ID, queryParams)
+	parameters, _, err := TOSession.GetCacheGroupParametersByQueryParams(cgp.CacheGroupID, queryParams)
 	if err != nil {
 		t.Errorf("error deleting Parameter name: %s\n", err.Error())
 	}
+	if parameters == nil {
+		t.Fatalf("Cache Group Parameters response should not be nil")
+	}
 	if len(parameters) > 0 {
-		t.Errorf("expected Parameter: %d to be to be disassociated from Cache Group: %d\n", cgp.ParameterID, cgp.ID)
+		t.Errorf("expected Parameter: %d to be to be disassociated from Cache Group: %d\n", cgp.ParameterID, cgp.CacheGroupID)
 	}
 
 }

--- a/traffic_ops/testing/api/v14/traffic_control.go
+++ b/traffic_ops/testing/api/v14/traffic_control.go
@@ -24,6 +24,7 @@ type TrafficControl struct {
 	ASNs                           []tc.ASN                           `json:"asns"`
 	CDNs                           []tc.CDN                           `json:"cdns"`
 	CacheGroups                    []tc.CacheGroupNullable            `json:"cachegroups"`
+	CacheGroupParameters           []tc.CacheGroupParameter           `json:"cachegroupParameters"`
 	Coordinates                    []tc.Coordinate                    `json:"coordinates"`
 	DeliveryServiceRequests        []tc.DeliveryServiceRequest        `json:"deliveryServiceRequests"`
 	DeliveryServiceRequestComments []tc.DeliveryServiceRequestComment `json:"deliveryServiceRequestComments"`

--- a/traffic_ops/testing/api/v14/traffic_control.go
+++ b/traffic_ops/testing/api/v14/traffic_control.go
@@ -24,7 +24,7 @@ type TrafficControl struct {
 	ASNs                           []tc.ASN                           `json:"asns"`
 	CDNs                           []tc.CDN                           `json:"cdns"`
 	CacheGroups                    []tc.CacheGroupNullable            `json:"cachegroups"`
-	CacheGroupParameters           []tc.CacheGroupParameter           `json:"cachegroupParameters"`
+	CacheGroupParameterRequests    []tc.CacheGroupParameterRequest    `json:"cachegroupParameters"`
 	Coordinates                    []tc.Coordinate                    `json:"coordinates"`
 	DeliveryServiceRequests        []tc.DeliveryServiceRequest        `json:"deliveryServiceRequests"`
 	DeliveryServiceRequestComments []tc.DeliveryServiceRequestComment `json:"deliveryServiceRequestComments"`

--- a/traffic_ops/testing/api/v14/withobjs.go
+++ b/traffic_ops/testing/api/v14/withobjs.go
@@ -37,6 +37,7 @@ type TCObj int
 
 const (
 	CacheGroups TCObj = iota
+	CacheGroupParameters
 	CDNs
 	CDNFederations
 	Coordinates
@@ -46,7 +47,6 @@ const (
 	Divisions
 	Origins
 	Parameters
-	CacheGroupParameters
 	PhysLocations
 	Profiles
 	ProfileParameters
@@ -69,6 +69,7 @@ type TCObjFuncs struct {
 
 var withFuncs = map[TCObj]TCObjFuncs{
 	CacheGroups:                    {CreateTestCacheGroups, DeleteTestCacheGroups},
+	CacheGroupParameters:           {CreateTestCacheGroupParameters, DeleteTestCacheGroupParameters},
 	CDNs:                           {CreateTestCDNs, DeleteTestCDNs},
 	CDNFederations:                 {CreateTestCDNFederations, DeleteTestCDNFederations},
 	Coordinates:                    {CreateTestCoordinates, DeleteTestCoordinates},
@@ -81,7 +82,6 @@ var withFuncs = map[TCObj]TCObjFuncs{
 	PhysLocations:                  {CreateTestPhysLocations, DeleteTestPhysLocations},
 	Profiles:                       {CreateTestProfiles, DeleteTestProfiles},
 	ProfileParameters:              {CreateTestProfileParameters, DeleteTestProfileParameters},
-	CacheGroupParameters:           {CreateTestCacheGroupParameters, DeleteTestCacheGroupParameters},
 	Regions:                        {CreateTestRegions, DeleteTestRegions},
 	Roles:                          {CreateTestRoles, DeleteTestRoles},
 	Servers:                        {CreateTestServers, DeleteTestServers},

--- a/traffic_ops/testing/api/v14/withobjs.go
+++ b/traffic_ops/testing/api/v14/withobjs.go
@@ -46,6 +46,7 @@ const (
 	Divisions
 	Origins
 	Parameters
+	CacheGroupParameters
 	PhysLocations
 	Profiles
 	ProfileParameters
@@ -80,6 +81,7 @@ var withFuncs = map[TCObj]TCObjFuncs{
 	PhysLocations:                  {CreateTestPhysLocations, DeleteTestPhysLocations},
 	Profiles:                       {CreateTestProfiles, DeleteTestProfiles},
 	ProfileParameters:              {CreateTestProfileParameters, DeleteTestProfileParameters},
+	CacheGroupParameters:           {CreateTestCacheGroupParameters, DeleteTestCacheGroupParameters},
 	Regions:                        {CreateTestRegions, DeleteTestRegions},
 	Roles:                          {CreateTestRoles, DeleteTestRoles},
 	Servers:                        {CreateTestServers, DeleteTestServers},
@@ -89,5 +91,5 @@ var withFuncs = map[TCObj]TCObjFuncs{
 	Tenants:                        {CreateTestTenants, DeleteTestTenants},
 	Types:                          {CreateTestTypes, DeleteTestTypes},
 	Users:                          {CreateTestUsers, ForceDeleteTestUsers},
-	UsersDeliveryServices: {CreateTestUsersDeliveryServices, DeleteTestUsersDeliveryServices},
+	UsersDeliveryServices:          {CreateTestUsersDeliveryServices, DeleteTestUsersDeliveryServices},
 }

--- a/traffic_ops/traffic_ops_golang/cachegroup/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/parameters.go
@@ -1,0 +1,97 @@
+package cachegroup
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/parameter"
+)
+
+const (
+	CacheGroupIDQueryParam = "id"
+	ParameterIDQueryParam  = "parameterId"
+)
+
+//we need a type alias to define functions on
+type TOCacheGroupParameter struct {
+	api.APIInfoImpl `json:"-"`
+	tc.ParameterNullable
+}
+
+func (cgparam *TOCacheGroupParameter) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
+	return map[string]dbhelpers.WhereColumnInfo{
+		CacheGroupIDQueryParam: dbhelpers.WhereColumnInfo{"cgp.cachegroup", api.IsInt},
+		ParameterIDQueryParam:  dbhelpers.WhereColumnInfo{"p.id", api.IsInt},
+	}
+}
+
+func (cgparam *TOCacheGroupParameter) GetType() string {
+	return "cachegroup_params"
+}
+
+func (cgparam *TOCacheGroupParameter) Read() ([]interface{}, error, error, int) {
+	queryParamsToQueryCols := cgparam.ParamColumns()
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(cgparam.APIInfo().Params, queryParamsToQueryCols)
+	if len(errs) > 0 {
+		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest
+	}
+
+	query := selectQuery() + where + orderBy + pagination
+	rows, err := cgparam.ReqInfo.Tx.NamedQuery(query, queryValues)
+	if err != nil {
+		return nil, nil, errors.New("querying " + cgparam.GetType() + ": " + err.Error()), http.StatusInternalServerError
+	}
+	defer rows.Close()
+
+	params := []interface{}{}
+	for rows.Next() {
+		var p tc.ParameterNullable
+		if err = rows.StructScan(&p); err != nil {
+			return nil, nil, errors.New("scanning " + cgparam.GetType() + ": " + err.Error()), http.StatusInternalServerError
+		}
+		if p.Secure != nil && *p.Secure && cgparam.ReqInfo.User.PrivLevel < auth.PrivLevelAdmin {
+			p.Value = &parameter.HiddenField
+		}
+		params = append(params, p)
+	}
+
+	return params, nil, nil, http.StatusOK
+}
+
+func selectQuery() string {
+
+	query := `SELECT
+p.config_file,
+p.id,
+p.last_updated,
+p.name,
+p.value,
+p.secure
+FROM parameter p
+LEFT JOIN cachegroup_parameter cgp ON cgp.parameter = p.id`
+	return query
+}

--- a/traffic_ops/traffic_ops_golang/cachegroup/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/parameters.go
@@ -69,7 +69,7 @@ func (cgparam *TOCacheGroupParameter) Read() ([]interface{}, error, error, int) 
 
 	_, ok, err := getCGNameFromID(cgparam.ReqInfo.Tx.Tx, int64(cgID))
 	if err != nil {
-		return nil, nil, errors.New("getting cachegroup from id"), http.StatusInternalServerError
+		return nil, nil, err, http.StatusInternalServerError
 	} else if !ok {
 		return nil, errors.New("cachegroup does not exist"), nil, http.StatusNotFound
 	}

--- a/traffic_ops/traffic_ops_golang/cachegroup/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/parameters_test.go
@@ -1,0 +1,179 @@
+package cachegroup
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+var (
+	cgpRows = []string{
+		"config_file",
+		"id",
+		"last_updated",
+		"name",
+		"value",
+		"secure",
+	}
+)
+
+func TestReadCacheGroupParameters(t *testing.T) {
+
+	var testCases = []struct {
+		description       string
+		storageError      error
+		expectedUserError bool
+		params            map[string]string
+		cgParams          []tc.ParameterNullable
+	}{
+		{
+			description:       "Success: Read Cache Group Parameters",
+			storageError:      nil,
+			expectedUserError: false,
+			params: map[string]string{
+				"id": "1",
+			},
+			cgParams: []tc.ParameterNullable{
+				generateParameter("global", "param1", "val1", false, 1),
+				generateParameter("global", "param2", "val2", false, 2),
+			},
+		},
+		{
+			description:       "Success: Read Cache Group Parameters with parameter id",
+			storageError:      nil,
+			expectedUserError: false,
+			params: map[string]string{
+				"id":          "1",
+				"parameterId": "1",
+			},
+			cgParams: []tc.ParameterNullable{
+				generateParameter("global", "param1", "val1", false, 1),
+			},
+		},
+		{
+			description:       "Success: Read Cache Group Parameters no data",
+			storageError:      nil,
+			expectedUserError: false,
+			params: map[string]string{
+				"id": "1",
+			},
+			cgParams: []tc.ParameterNullable{},
+		},
+		{
+			description:       "Failure: Storage Error reading Cache Group Parameters",
+			storageError:      errors.New("failure getting cache group parameters"),
+			expectedUserError: false,
+			params: map[string]string{
+				"id": "1",
+			},
+			cgParams: []tc.ParameterNullable{
+				generateParameter("global", "param1", "val1", false, 1),
+				generateParameter("global", "param2", "val2", false, 2),
+			},
+		},
+		{
+			description:       "Failure: User Error invalid params",
+			storageError:      nil,
+			expectedUserError: true,
+			params: map[string]string{
+				"id": "not_an_id",
+			},
+			cgParams: []tc.ParameterNullable{
+				generateParameter("global", "param1", "val1", false, 1),
+				generateParameter("global", "param2", "val2", false, 2),
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			t.Log("Starting test scenario: ", testCase.description)
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer mockDB.Close()
+			db := sqlx.NewDb(mockDB, "sqlmock")
+			defer db.Close()
+			rows := sqlmock.NewRows(cgpRows)
+			for _, cgParam := range testCase.cgParams {
+				rows = rows.AddRow(
+					cgParam.ConfigFile,
+					cgParam.ID,
+					cgParam.LastUpdated,
+					cgParam.Name,
+					cgParam.Value,
+					cgParam.Secure,
+				)
+			}
+			mock.ExpectBegin()
+			if testCase.storageError != nil {
+				mock.ExpectQuery("SELECT").WillReturnError(testCase.storageError)
+			} else {
+				mock.ExpectQuery("SELECT").WillReturnRows(rows)
+			}
+			mock.ExpectCommit()
+
+			reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: testCase.params}
+			obj := TOCacheGroupParameter{
+				api.APIInfoImpl{&reqInfo},
+				tc.ParameterNullable{},
+			}
+			parameters, userErr, sysErr, _ := obj.Read()
+
+			if testCase.storageError != nil {
+				if sysErr == nil {
+					t.Errorf("Read error expected: received no sysErr")
+				}
+			} else if testCase.expectedUserError {
+				if userErr == nil {
+					t.Errorf("User error expected: received no userErr")
+				}
+			} else {
+				if userErr != nil || sysErr != nil {
+					t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+				}
+				if len(parameters) != len(testCase.cgParams) {
+					t.Errorf("cdn.Read expected: len(parameters) == %v, actual: %v", len(testCase.cgParams), len(parameters))
+				}
+			}
+		})
+	}
+}
+
+func generateParameter(configFile, param, val string, secureFlag bool, id int) tc.ParameterNullable {
+	lastUpdated := tc.TimeNoMod{}
+	lastUpdated.Scan(time.Now())
+	testParameter := tc.ParameterNullable{
+		ConfigFile:  &configFile,
+		ID:          &id,
+		LastUpdated: &lastUpdated,
+		Name:        &param,
+		Secure:      &secureFlag,
+		Value:       &val,
+	}
+	return testParameter
+}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -119,6 +119,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `cachegroups/{id}/queue_update$`, cachegroup.QueueUpdates, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `cachegroups/{id}/deliveryservices/?$`, cachegroup.DSPostHandler, auth.PrivLevelOperations, Authenticated, nil},
 
+		{1.1, http.MethodGet, `cachegroups/{id}/parameters/?$`, api.ReadHandler(&cachegroup.TOCacheGroupParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
+
 		//CDN
 		{1.1, http.MethodGet, `cdns/name/{name}/sslkeys/?(\.json)?$`, cdn.GetSSLKeys, auth.PrivLevelAdmin, Authenticated, nil},
 		{1.1, http.MethodGet, `cdns/metric_types`, notImplementedHandler, 0, NoAuth, nil}, // MUST NOT end in $, because the 1.x route is longer

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -119,7 +119,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `cachegroups/{id}/queue_update$`, cachegroup.QueueUpdates, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `cachegroups/{id}/deliveryservices/?$`, cachegroup.DSPostHandler, auth.PrivLevelOperations, Authenticated, nil},
 
-		{1.1, http.MethodGet, `cachegroups/{id}/parameters/?$`, api.ReadHandler(&cachegroup.TOCacheGroupParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `cachegroups/{id}/parameters/?(\.json)?$`, api.ReadHandler(&cachegroup.TOCacheGroupParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//CDN
 		{1.1, http.MethodGet, `cdns/name/{name}/sslkeys/?(\.json)?$`, cdn.GetSSLKeys, auth.PrivLevelAdmin, Authenticated, nil},


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This PR rewrites the  /cachegroups/{{id}}/parameters endpoint to Go

- [x] This PR fixes #3806 

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Ops

## What is the best way to verify this PR?

Bring up TO locally and hit the endpoint to ensure parity between perl implementation and newly written Golang implementation 

The API tests and/or unit tests for TO can be run to verify the PR.

## If this is a bug fix, what versions of Traffic Control are affected?

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md 
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
