### PR TITLE
Rewrite /cachegroups/{id}/unassigned_parameters to golang

### DIFF
--- a/docs/source/api/cachegroups_id_parameters.rst
+++ b/docs/source/api/cachegroups_id_parameters.rst
@@ -30,11 +30,24 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+-------------+----------+---------------------------------------------------+
-	| Name        | Required | Description                                       |
-	+=============+==========+===================================================+
-	| parameterId | no       | Show only the :term:`Parameter` with the given ID |
-	+-------------+----------+---------------------------------------------------+
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| Name        | Required | Description                                                                                                   |
+	+=============+==========+===============================================================================================================+
+	| parameterId | no       | Show only the :term:`Parameter` with the given ID                                                             |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| orderby     | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` |
+	|             |          | array                                                                                                         |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| sortOrder   | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                      |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| limit       | no       | Choose the maximum number of results to return                                                                |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| offset      | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit          |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long   |
+	|             |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
+	|             |          | defined to make use of ``page``.                                                                              |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
 
 .. table:: Request Path Parameters
 

--- a/docs/source/api/cachegroups_id_unassigned_parameters.rst
+++ b/docs/source/api/cachegroups_id_unassigned_parameters.rst
@@ -29,6 +29,27 @@ Gets all the :term:`Parameters` *not* associated with a specific :term:`Cache Gr
 
 Request Structure
 -----------------
+.. table:: Request Query Parameters
+
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| Name        | Required | Description                                                                                                   |
+	+=============+==========+===============================================================================================================+
+	| parameterId | no       | Show only the :term:`Parameter` with the given ID                                                             |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| orderby     | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` |
+	|             |          | array                                                                                                         |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| sortOrder   | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                      |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| limit       | no       | Choose the maximum number of results to return                                                                |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| offset      | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit          |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long   |
+	|             |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
+	|             |          | defined to make use of ``page``.                                                                              |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+
 .. table:: Request Path Parameters
 
 	+------------------+----------+---------------------------------------------------------+

--- a/traffic_ops/client/cachegroup_parameters.go
+++ b/traffic_ops/client/cachegroup_parameters.go
@@ -30,24 +30,30 @@ const (
 // GetCacheGroupParameters Gets a Cache Group's Parameters
 func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.CacheGroupParameter, ReqInf, error) {
 	route := fmt.Sprintf("%s/%d/parameters", API_v13_CacheGroups, cacheGroupID)
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
-	var data tc.CacheGroupParametersResponse
-	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-	return data.Response, reqInf, nil
+	return to.getCacheGroupParameters(route, "")
 }
 
 // GetCacheGroupParametersByQueryParams Gets a Cache Group's Parameters with query parameters
 func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.CacheGroupParameter, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d/parameters%s", API_v13_CacheGroups, cacheGroupID, queryParams)
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	route := fmt.Sprintf("%s/%d/parameters", API_v13_CacheGroups, cacheGroupID)
+	return to.getCacheGroupParameters(route, queryParams)
+}
+
+// GetCacheGroupUnassignedParameters Gets a Cache Group's Unassigned Parameters
+func (to *Session) GetCacheGroupUnassignedParameters(cacheGroupID int) ([]tc.CacheGroupParameter, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/unassigned_parameters", API_v13_CacheGroups, cacheGroupID)
+	return to.getCacheGroupParameters(route, "")
+}
+
+// GetCacheGroupParametersByQueryParams Gets a Cache Group's Unassigned Parameters with query parameters
+func (to *Session) GetCacheGroupUnassignedParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.CacheGroupParameter, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/unassigned_parameters", API_v13_CacheGroups, cacheGroupID)
+	return to.getCacheGroupParameters(route, queryParams)
+}
+
+func (to *Session) getCacheGroupParameters(route, queryParams string) ([]tc.CacheGroupParameter, ReqInf, error) {
+	r := fmt.Sprintf("%s%s", route, queryParams)
+	resp, remoteAddr, err := to.request(http.MethodGet, r, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
 		return nil, reqInf, err

--- a/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
 
 	"github.com/lib/pq"
@@ -84,7 +85,7 @@ func postDSes(tx *sql.Tx, user *auth.CurrentUser, cgID int64, dsIDs []int64) (tc
 		}
 	}
 
-	cgName, ok, err := getCGNameFromID(tx, cgID)
+	cgName, ok, err := dbhelpers.GetCacheGroupNameFromID(tx, cgID)
 	if err != nil {
 		return tc.CacheGroupPostDSResp{}, nil, errors.New("getting cachegroup name from ID '" + string(cgID) + "': " + err.Error()), http.StatusInternalServerError
 	} else if !ok {

--- a/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
@@ -66,7 +66,7 @@ func QueueUpdates(w http.ResponseWriter, r *http.Request) {
 		reqObj.CDN = &cdn
 	}
 	cgID := int64(inf.IntParams["id"])
-	cgName, ok, err := getCGNameFromID(inf.Tx.Tx, cgID)
+	cgName, ok, err := dbhelpers.GetCacheGroupNameFromID(inf.Tx.Tx, cgID)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting cachegroup name from ID '"+inf.Params["id"]+"': "+err.Error()))
 		return
@@ -97,17 +97,6 @@ type QueueUpdatesResp struct {
 	ServerNames    []tc.CacheName    `json:"serverNames"`
 	CDN            tc.CDNName        `json:"cdn"`
 	CacheGroupID   int64             `json:"cachegroupID"`
-}
-
-func getCGNameFromID(tx *sql.Tx, id int64) (tc.CacheGroupName, bool, error) {
-	name := ""
-	if err := tx.QueryRow(`SELECT name FROM cachegroup WHERE id = $1`, id).Scan(&name); err != nil {
-		if err == sql.ErrNoRows {
-			return "", false, nil
-		}
-		return "", false, errors.New("querying cachegroup ID: " + err.Error())
-	}
-	return tc.CacheGroupName(name), true, nil
 }
 
 func queueUpdates(tx *sql.Tx, cgID int64, cdn tc.CDNName, queue bool) ([]tc.CacheName, error) {

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -1,0 +1,111 @@
+package cachegroupparameter
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/parameter"
+)
+
+const (
+	CacheGroupIDQueryParam = "id"
+	ParameterIDQueryParam  = "parameterId"
+)
+
+//we need a type alias to define functions on
+type TOCacheGroupParameter struct {
+	api.APIInfoImpl `json:"-"`
+	tc.CacheGroupParameterNullable
+}
+
+func (cgparam *TOCacheGroupParameter) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
+	return map[string]dbhelpers.WhereColumnInfo{
+		CacheGroupIDQueryParam: dbhelpers.WhereColumnInfo{"cgp.cachegroup", api.IsInt},
+		ParameterIDQueryParam:  dbhelpers.WhereColumnInfo{"p.id", api.IsInt},
+	}
+}
+
+func (cgparam *TOCacheGroupParameter) GetType() string {
+	return "cachegroup_params"
+}
+
+func (cgparam *TOCacheGroupParameter) Read() ([]interface{}, error, error, int) {
+	queryParamsToQueryCols := cgparam.ParamColumns()
+	parameters := cgparam.APIInfo().Params
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols)
+	if len(errs) > 0 {
+		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest
+	}
+
+	cgID, err := strconv.Atoi(parameters[CacheGroupIDQueryParam])
+	if err != nil {
+		return nil, errors.New("cache group id must be an integer"), nil, http.StatusBadRequest
+	}
+
+	_, ok, err := dbhelpers.GetCacheGroupNameFromID(cgparam.ReqInfo.Tx.Tx, int64(cgID))
+	if err != nil {
+		return nil, nil, err, http.StatusInternalServerError
+	} else if !ok {
+		return nil, errors.New("cachegroup does not exist"), nil, http.StatusNotFound
+	}
+
+	query := selectQuery() + where + orderBy + pagination
+	rows, err := cgparam.ReqInfo.Tx.NamedQuery(query, queryValues)
+	if err != nil {
+		return nil, nil, errors.New("querying " + cgparam.GetType() + ": " + err.Error()), http.StatusInternalServerError
+	}
+	defer rows.Close()
+
+	params := []interface{}{}
+	for rows.Next() {
+		var p tc.CacheGroupParameterNullable
+		if err = rows.StructScan(&p); err != nil {
+			return nil, nil, errors.New("scanning " + cgparam.GetType() + ": " + err.Error()), http.StatusInternalServerError
+		}
+		if p.Secure != nil && *p.Secure && cgparam.ReqInfo.User.PrivLevel < auth.PrivLevelAdmin {
+			p.Value = &parameter.HiddenField
+		}
+		params = append(params, p)
+	}
+
+	return params, nil, nil, http.StatusOK
+}
+
+func selectQuery() string {
+
+	query := `SELECT
+p.config_file,
+p.id,
+p.last_updated,
+p.name,
+p.value,
+p.secure
+FROM parameter p
+LEFT JOIN cachegroup_parameter cgp ON cgp.parameter = p.id`
+	return query
+}

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -120,7 +120,6 @@ func BuildWhereAndOrderByAndPagination(parameters map[string]string, queryParams
 }
 
 func parseCriteriaAndQueryValues(queryParamsToSQLCols map[string]WhereColumnInfo, parameters map[string]string) (string, map[string]interface{}, []error) {
-	m := make(map[string]interface{})
 	var criteria string
 
 	var criteriaArgs []string
@@ -135,7 +134,6 @@ func parseCriteriaAndQueryValues(queryParamsToSQLCols map[string]WhereColumnInfo
 			if err != nil {
 				errs = append(errs, errors.New(key+" "+err.Error()))
 			} else {
-				m[key] = urlValue
 				criteria = colInfo.Column + "=:" + key
 				criteriaArgs = append(criteriaArgs, criteria)
 				queryValues[key] = urlValue
@@ -335,4 +333,16 @@ func GetCDNs(tx *sql.Tx) (map[tc.CDNName]struct{}, error) {
 		cdns[cdn] = struct{}{}
 	}
 	return cdns, nil
+}
+
+// GetCacheGroupNameFromID Get Cache Group name from a given ID
+func GetCacheGroupNameFromID(tx *sql.Tx, id int64) (tc.CacheGroupName, bool, error) {
+	name := ""
+	if err := tx.QueryRow(`SELECT name FROM cachegroup WHERE id = $1`, id).Scan(&name); err != nil {
+		if err == sql.ErrNoRows {
+			return "", false, nil
+		}
+		return "", false, errors.New("querying cachegroup ID: " + err.Error())
+	}
+	return tc.CacheGroupName(name), true, nil
 }

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
@@ -20,9 +20,13 @@ package dbhelpers
  */
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"unicode"
+
+	"github.com/jmoiron/sqlx"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func stripAllWhitespace(s string) string {
@@ -73,6 +77,66 @@ FROM table t
 	expectedV2 := v["param2"]
 	if strings.Contains(actualQuery, expectedV2) {
 		t.Errorf("expected: %v error, actual: %v", actualQuery, expectedV2)
+	}
+
+}
+
+func TestGetCacheGroupByName(t *testing.T) {
+	var testCases = []struct {
+		description  string
+		storageError error
+		cgExists     bool
+	}{
+		{
+			description:  "Success: Cache Group exists",
+			storageError: nil,
+			cgExists:     true,
+		},
+		{
+			description:  "Failure: Cache Group does not exist",
+			storageError: nil,
+			cgExists:     false,
+		},
+		{
+			description:  "Failure: Storage error getting Cache Group",
+			storageError: errors.New("error getting the group name"),
+			cgExists:     false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			t.Log("Starting test scenario: ", testCase.description)
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer mockDB.Close()
+			db := sqlx.NewDb(mockDB, "sqlmock")
+			defer db.Close()
+			rows := sqlmock.NewRows([]string{
+				"name",
+			})
+			mock.ExpectBegin()
+			if testCase.storageError != nil {
+				mock.ExpectQuery("cachegroup").WillReturnError(testCase.storageError)
+			} else {
+				if testCase.cgExists {
+					rows = rows.AddRow("cachegroup_name")
+				}
+				mock.ExpectQuery("cachegroup").WillReturnRows(rows)
+			}
+			mock.ExpectCommit()
+			_, exists, err := GetCacheGroupNameFromID(db.MustBegin().Tx, int64(1))
+			if testCase.storageError != nil && err == nil {
+				t.Errorf("Storage error expected: received no storage error")
+			}
+			if testCase.storageError == nil && err != nil {
+				t.Errorf("Storage error not expected: received storage error")
+			}
+			if testCase.cgExists != exists {
+				t.Errorf("Expected return exists: %t, actual %t", testCase.cgExists, exists)
+			}
+		})
 	}
 
 }

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -40,6 +40,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats/atsprofile"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cachegroup"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cachegroupparameter"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cachesstats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cdn"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/cdnfederation"
@@ -119,7 +120,9 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `cachegroups/{id}/queue_update$`, cachegroup.QueueUpdates, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `cachegroups/{id}/deliveryservices/?$`, cachegroup.DSPostHandler, auth.PrivLevelOperations, Authenticated, nil},
 
-		{1.1, http.MethodGet, `cachegroups/{id}/parameters/?(\.json)?$`, api.ReadHandler(&cachegroup.TOCacheGroupParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		//CacheGroup Parameters: CRUD
+		{1.1, http.MethodGet, `cachegroups/{id}/parameters/?(\.json)?$`, api.ReadHandler(&cachegroupparameter.TOCacheGroupParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `cachegroups/{id}/unassigned_parameters/?(\.json)?$`, api.ReadHandler(&cachegroupparameter.TOCacheGroupUnassignedParameter{}), auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//CDN
 		{1.1, http.MethodGet, `cdns/name/{name}/sslkeys/?(\.json)?$`, cdn.GetSSLKeys, auth.PrivLevelAdmin, Authenticated, nil},


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This PR rewrites the /cachegroups/{id}/unassigned_parameters endpoint to Go

- [x] This PR fixes #3807 

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Ops

## What is the best way to verify this PR?

Bring up TO locally and hit the endpoint to ensure parity between perl implementation and newly written Golang implementation 

The API tests and/or unit tests for TO can be run to verify the PR.

## If this is a bug fix, what versions of Traffic Control are affected?

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md 
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
