### PR TITLE
Fix ordering in overview docs section

### DIFF
--- a/docs/source/overview/index.rst
+++ b/docs/source/overview/index.rst
@@ -19,15 +19,14 @@ Traffic Control Overview
 Introduces the Traffic Control architecture, components, and their integration.
 
 .. toctree::
-	:maxdepth: 2
-	:glob:
+	:maxdepth: 3
 
 	introduction
-	delivery_services
-	profiles_and_parameters
 	traffic_ops
 	traffic_router
 	traffic_monitor
 	traffic_stats
 	traffic_portal
 	traffic_vault
+	delivery_services
+	profiles_and_parameters

--- a/docs/source/overview/index.rst
+++ b/docs/source/overview/index.rst
@@ -22,4 +22,12 @@ Introduces the Traffic Control architecture, components, and their integration.
 	:maxdepth: 2
 	:glob:
 
-	*
+	introduction
+	delivery_services
+	profiles_and_parameters
+	traffic_ops
+	traffic_router
+	traffic_monitor
+	traffic_stats
+	traffic_portal
+	traffic_vault


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fix ordering in overview docs section

Introduction was not first which makes it confusing to the end user as they come in 

- [x] This is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Documentation

## What is the best way to verify this PR?
Build docs locally and look at ordering of overview section

## If this is a bug fix, what versions of Traffic Control are affected?

## The following criteria are ALL met by this PR


- [x] This PR does not include tests
- [x] This PR includes documentation
- [x] This PR does not include an update to CHANGELOG.md as such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
