### PR TITLE
Issue 3910 - Fixes issue where targets with RGB enabled cannot be steered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Ops now uses a consistent format for audit logs across all Go endpoints
 
 ### Changed
+- Traffic Router:  TR will now allow *STEERING target DSs to have RGB enabled. (fixes #3910)
 - Traffic Router, added TLS certificate validation on certificates imported from Traffic Ops
   - validates modulus of private and public keys
   - validates current timestamp falls within the certificate date bracket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Ops now uses a consistent format for audit logs across all Go endpoints
 
 ### Changed
-- Traffic Router:  TR will now allow *STEERING target DSs to have RGB enabled. (fixes #3910)
+- Traffic Router:  TR will now allow steering DSs and steering target DSs to have RGB enabled. (fixes #3910)
+- Traffic Portal:  Traffic Portal now allows Regional Geo Blocking to be enabled for a Steering Delivery Service.
 - Traffic Router, added TLS certificate validation on certificates imported from Traffic Ops
   - validates modulus of private and public keys
   - validates current timestamp falls within the certificate date bracket

--- a/docs/source/admin/quick_howto/regionalgeo.rst
+++ b/docs/source/admin/quick_howto/regionalgeo.rst
@@ -58,9 +58,9 @@ Configure Regional Geo-blocking (RGB)
 
 #. Add :abbr:`RGB (Regional Geographic-based Blocking)` :term:`Parameters` in Traffic Portal to the :term:`Delivery Service`'s Traffic Router(s)'s :term:`Profile`\ (s). The :ref:`parameter-config-file` value should be set to ``CRConfig.json``, and the following two :term:`Parameter` :ref:`parameter-name`/:ref:`parameter-value` pairs need to be specified:
 
-	``regional_geoblocking.polling.url``
+	``regional_geoblock.polling.url``
 		The URL of the RGB configuration file. Traffic Router will fetch the file from this URL using an HTTP ``GET`` request.
-	``regional_geoblocking.polling.interval``
+	``regional_geoblock.polling.interval``
 		The interval on which Traffic Router polls the :abbr:`RGB (Regional Geographic-based Blocking)` configuration file.
 
 	.. figure:: regionalgeo/01.png

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -442,6 +442,25 @@ under the License.
                             </aside>
                         </div>
                     </div>
+                     <div class="form-group" ng-class="{'has-error': hasError(routingConfig.regionalGeoBlocking), 'has-feedback': hasError(routingConfig.regionalGeoBlocking)}">
+                        <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="regionalGeoBlocking">Regional Geoblocking *<div class="helptooltip">
+                            <div class="helptext">
+                                Define regional geo-blocking rules for Delivery Services in a JSON format and set this to 'Enabled' to use "Regional Geoblocking". <a href="https://traffic-control-cdn.readthedocs.io/en/latest/admin/quick_howto/regionalgeo.html" target="_blank">See Regional Geo-blocking</a>
+                            </div>
+                        </div>
+                        </label>
+                        <div class="col-md-10 col-sm-10 col-xs-12">
+                            <select id="regionalGeoBlocking" name="regionalGeoBlocking" class="form-control" ng-model="deliveryService.regionalGeoBlocking" required>
+                                <option ng-value="true">Enabled</option>
+                                <option ng-value="false" selected>Disabled</option>
+                            </select>
+                            <small class="input-error" ng-show="hasPropertyError(routingConfig.regionalGeoBlocking, 'required')">Required</small>
+                            <aside class="current-value" ng-if="settings.isRequest" ng-show="open() && deliveryService.regionalGeoBlocking != dsCurrent.regionalGeoBlocking">
+                                <h3>Current Value</h3>
+                                <pre>{{::dsCurrent.regionalGeoBlocking ? 'Enabled' : 'Disabled'}}</pre>
+                            </aside>
+                        </div>
+                    </div>
                 </ng-form>
             </fieldset>
             <div class="modal-footer">

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
@@ -51,6 +51,7 @@ import static com.comcast.cdn.traffic_control.traffic_router.core.loc.RegionalGe
 public final class RegionalGeo {
     private static final Logger LOGGER = Logger.getLogger(RegionalGeo.class);
     public static final String HTTP_SCHEME = "http://";
+    public static final String HTTPS_SCHEME = "https://";
     private boolean fallback = false;
     private final Map<String, RegionalGeoDsvc> regionalGeoDsvcs = new HashMap<String, RegionalGeoDsvc>();
 
@@ -101,7 +102,7 @@ public final class RegionalGeo {
             return false;
         }
 
-        if (alternateUrl.toLowerCase().startsWith(HTTP_SCHEME)
+        if ((alternateUrl.toLowerCase().startsWith(HTTP_SCHEME) || alternateUrl.toLowerCase().startsWith(HTTPS_SCHEME))
             && urlRegexPattern.matcher(alternateUrl).matches()) {
             LOGGER.error("RegionalGeo ERR: possible LOOP detected, alternate fqdn url " + alternateUrl
                          + " matches regex " + urlRegex + " in dsvc " +  dsvcId);
@@ -298,12 +299,12 @@ public final class RegionalGeo {
             result.setUrl(url);
             result.setType(ALLOWED);
         } else {
-            // For a disallowed client, if alternateUrl starts with "http://"
+            // For a disallowed client, if alternateUrl starts with "http://" or "https://"
             // just redirect the client to this url without any cache selection;
             // if alternateUrl only has path and file name like "/path/abc.html",
             // then cache selection process will be needed, and hostname will be
             // added to make it like "http://cache01.example.com/path/abc.html" later.
-            if (alternateUrl.toLowerCase().startsWith(HTTP_SCHEME)) {
+            if (alternateUrl.toLowerCase().startsWith(HTTP_SCHEME) || alternateUrl.toLowerCase().startsWith(HTTPS_SCHEME)) {
                 result.setUrl(alternateUrl);
                 result.setType(ALTERNATE_WITHOUT_CACHE);
             } else {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
@@ -355,12 +355,12 @@ public final class RegionalGeo {
         if (result.getType() == DENIED) {
             routeResult.setResponseCode(result.getHttpResponseCode());
         } else {
-                final String redirectURIString = createRedirectURIString(httpRequest, deliveryService, cache, result);
-                if(!"Denied".equals(redirectURIString)){
-                    routeResult.addUrl(new URL(redirectURIString));
-                }else{
-                    LOGGER.warn("RegionalGeo: this needs a better error message, createRedirectURIString returned denied");
-                }
+            final String redirectURIString = createRedirectURIString(httpRequest, deliveryService, cache, result);
+            if(!"Denied".equals(redirectURIString)){
+                routeResult.addUrl(new URL(redirectURIString));
+            }else{
+                LOGGER.warn("RegionalGeo: this needs a better error message, createRedirectURIString returned denied");
+            }
         }
     }
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -750,10 +750,7 @@ public class TrafficRouter {
 				track.setResultDetails(ResultDetails.DS_TLS_MISMATCH);
 				return null;
 			}
-			if (ds.isRegionalGeoEnabled()) {
-				LOGGER.error("Regional Geo Blocking is not supported with multi-route delivery services.. skipping " + entryDeliveryService.getId() + "/" + ds.getId());
-				toBeRemoved.add(steeringResult);
-			} else if (!ds.isAvailable()) {
+			if (!ds.isAvailable()) {
 				toBeRemoved.add(steeringResult);
 			}
 

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeoTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeoTest.java
@@ -178,6 +178,20 @@ public class RegionalGeoTest {
     }
 
     @Test
+    public void testEnforceAllowedHttpsRedirect() {
+        final String dsvcId = "ds-geoblock-redirect-https";
+        final String url = "http://ds1.example.com/httpsredirect";
+        final String postal = null;
+        final String ip = "129.100.254.2";
+
+        RegionalGeoResult result = RegionalGeo.enforce(dsvcId, url, ip, postal);
+
+        assertThat(result.getType(), equalTo(RegionalGeoResultType.ALTERNATE_WITHOUT_CACHE));
+        assertThat(result.getUrl(), equalTo("http://example.com/redirect_https"));
+    }
+
+
+    @Test
     public void testEnforceNotInWhiteListAlternate() {
         final String dsvcId = "ds-geoblock-include";
         final String url = "http://ds1.example.com/live4";

--- a/traffic_router/core/src/test/resources/regional_geoblock.json
+++ b/traffic_router/core/src/test/resources/regional_geoblock.json
@@ -49,6 +49,17 @@
                 "184.66.16.1/22"
             ],
             "urlRegex": ".*live4"
+        },
+        {
+            "redirectUrl": "http://example.com/redirect_https",
+            "deliveryServiceId": "ds-geoblock-redirect-https",
+            "geoLocation": {
+                "excludePostalCode": [
+                    "V5G",
+                    "M7A"
+                ]
+            },
+            "urlRegex": ".*httpsredirect"
         }
     ],
     "customer": "CU",


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [X] This PR fixes #3910 
This PR allows steering targets with Regional Geo Blocking (RGB) enabled to be returned in the steering list.  This also fixes some small documentation issues and fixes an issue where RGB did not allow https re-direct URLs

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Router


## What is the best way to verify this PR?
I added a unit test to test the https redirect functionality.
Testing the RGB routing functionality is much more involved to test and I did not see the unit or integration test foundations here to add to.  This can be tested by configuring a CLIENT_STEERING DS with at least one target that has RGB enabled and then send a request to the steering DS.

## If this is a bug fix, what versions of Traffic Control are affected?
master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
