### PR TITLE
TM: Report time for full body download for _astats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Issue 2821: Fixed "Traffic Router may choose wrong certificate when SNI names overlap"
 - traffic_ops/app/bin/checks/ToDnssecRefresh.pl now requires "user" and "pass" parameters of an operations-level user! Update your scripts accordingly! This was necessary to move to an API endpoint with proper authentication, which may be safely exposed.
 - Traffic Monitor UI updated to support HTTP or HTTPS traffic.
+- Traffic Monitor health/stat time now includes full body download (like prior TM <=2.1 version)
 - Modified Traffic Router logging format to include an additional field for DNS log entries, namely `rhi`. This defaults to '-' and is only used when EDNS0 client subnet extensions are enabled and a client subnet is present in the request. When enabled and a subnet is present, the subnet appears in the `chi` field and the resolver address is in the `rhi` field.
 - Changed traffic_ops_ort.pl so that hdr_rw-<ds>.config files are compared with strict ordering and line duplication when detecting configuration changes.
 - Traffic Ops (golang), Traffic Monitor, Traffic Stats are now compiled using Go version 1.11. Grove was already being compiled with this version which improves performance for TLS when RSA certificates are used.

--- a/traffic_monitor/poller/poller_type_http.go
+++ b/traffic_monitor/poller/poller_type_http.go
@@ -107,21 +107,26 @@ func httpPoll(ctxI interface{}, url string, host string, pollID uint64) ([]byte,
 	req.Host = host
 	startReq := time.Now()
 	resp, err := ctx.Client.Do(req)
-	reqEnd := time.Now()
-	reqTime := reqEnd.Sub(startReq) // note this is essentially the roundtrip, not the body transfer time.
 	if err != nil {
+		reqEnd := time.Now()
+		reqTime := reqEnd.Sub(startReq) // note this is the time to transfer the entire body, not just the roundtrip
 		return nil, reqEnd, reqTime, fmt.Errorf("id %v url %v fetch error: %v", ctx.PollerID, url, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, reqEnd, reqTime, fmt.Errorf("id %v url %v fetch error: bad HTTP status: %v", ctx.PollerID, url, resp.StatusCode)
+		reqEnd := time.Now()
+		reqTime := reqEnd.Sub(startReq) // note this is the time to transfer the entire body, not just the roundtrip
+    return nil, reqEnd, reqTime, fmt.Errorf("id %v url %v fetch error: bad HTTP status: %v", ctx.PollerID, url, resp.StatusCode)
 	}
 
 	bts, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+		reqEnd := time.Now()
+		reqTime := reqEnd.Sub(startReq) // note this is the time to transfer the entire body, not just the roundtrip
 		return nil, reqEnd, reqTime, fmt.Errorf("id %v url %v fetch error: reading body: %v", ctx.PollerID, url, err)
 	}
-
+	reqEnd := time.Now()
+	reqTime := reqEnd.Sub(startReq) // note this is the time to transfer the entire body, not just the roundtrip
 	return bts, reqEnd, reqTime, nil
 }

--- a/traffic_monitor/poller/poller_type_http.go
+++ b/traffic_monitor/poller/poller_type_http.go
@@ -117,7 +117,7 @@ func httpPoll(ctxI interface{}, url string, host string, pollID uint64) ([]byte,
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		reqEnd := time.Now()
 		reqTime := reqEnd.Sub(startReq) // note this is the time to transfer the entire body, not just the roundtrip
-    return nil, reqEnd, reqTime, fmt.Errorf("id %v url %v fetch error: bad HTTP status: %v", ctx.PollerID, url, resp.StatusCode)
+		return nil, reqEnd, reqTime, fmt.Errorf("id %v url %v fetch error: bad HTTP status: %v", ctx.PollerID, url, resp.StatusCode)
 	}
 
 	bts, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Reverting back to Traffic Monitor <= 2.1 behavior regarding health/stats query reported time (full body download) 

- [x] This PR fixes #1923 

## Which Traffic Control components are affected by this PR?

- Traffic Monitor

## What is the best way to verify this PR?

You should see increased latency for both Health and Stats query time. Mostly on the stats side.

## If this is a bug fix, what versions of Traffic Control are affected?
This is a small regression from Traffic Monitor 2.2 and up.

- master
- 3.x

## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [ ] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
