### PR TITLE
[Issue-3915] Use LTS version of ubuntu image for dns container

### DIFF
--- a/infrastructure/cdn-in-a-box/dns/Dockerfile
+++ b/infrastructure/cdn-in-a-box/dns/Dockerfile
@@ -14,10 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FROM ubuntu:trusty-20170817
+FROM ubuntu:18.04
 
 ENV BIND_USER=bind \
-    BIND_VERSION=1:9.9.5 \
+    BIND_VERSION=1:9.11.3 \
     DATA_DIR=/data
 
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
Sets version used in dns Dockerfile to LTS version.

- [x] This PR fixes #3915 

## Which Traffic Control components are affected by this PR?
- CDN in a Box

## What is the best way to verify this PR?

```
cd infrastructure/cdn-in-a-box
docker-compose build dns   # just to test that it builds
docker-compose up --build  # to test that the whole thing comes up
```

## If this is a bug fix, what versions of Traffic Control are affected?
- master (c99b0fb3bff309f61166b335309917413cf46e5e)

Only fixes downloaded version.  Test is build and run cdn-in-a-box.  No doc changes or CHANGELOG needed.  No new files, so no license headers.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
