### PR TITLE
Rewrite profiles/{id}/export to golang

### DIFF
--- a/docs/source/api/profiles_id_export.rst
+++ b/docs/source/api/profiles_id_export.rst
@@ -1,0 +1,94 @@
+..
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _to-api-profiles-id-export:
+
+*******************
+``profiles/{{ID}}/export``
+*******************
+
+``GET``
+=======
+
+:Auth. Required: Yes
+:Roles Required: None
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Request Path Parameters
+
+	+-----------+--------------------------------------------------------------+
+	| Parameter | Description                                                  |
+	+===========+==============================================================+
+	|    id     | The :ref:`profile-id` of the :term:`Profile` to be exported  |
+	+-----------+--------------------------------------------------------------+
+
+.. code-block:: http
+	:caption: Request Example
+
+	GET /api/1.1/profiles/3/export HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.62.0
+	Accept: */*
+	Cookie: mojolicious=...
+
+Response Structure
+------------------
+:profile:     The exported :term:`Profile`
+	:cdnName:     The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
+	:description: The :term:`Profile`'s :ref:`profile-description`
+	:name:        The :term:`Profile`'s :ref:`profile-name`
+	:type:        The :term:`Profile`'s :ref:`profile-type`
+:parameters:  An array of :term:`Parameters` in use by this :term:`Profile`
+	:configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
+	:name:        :ref:`parameter-name` of the :term:`Parameter`
+	:value:       The :term:`Parameter`'s :ref:`parameter-value`
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: mzP7DVxFAGhICxqagwDyBDRea7oBZPMAx7NCDeOBVCRqlcCFFe7XL3JP58b80aaVOW/2ZGfg/jpYF70cdDfzQA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Fri, 13 Sep 2019 20:14:42 GMT
+	Transfer-Encoding: gzip
+
+
+	{ "profile": {
+        "name": "GLOBAL",
+        "description": "Global Traffic Ops profile, DO NOT DELETE",
+        "cdn": "ALL",
+        "type": "UNK_PROFILE"
+      },
+	  "parameters": [
+        {
+            "config_file": "global",
+            "name": "tm.instance_name",
+            "value": "Traffic Ops CDN"
+        },
+        {
+            "config_file": "global",
+            "name": "tm.toolname",
+            "value": "Traffic Ops"
+        }
+	  ]
+	}

--- a/docs/source/api/profiles_id_export.rst
+++ b/docs/source/api/profiles_id_export.rst
@@ -68,6 +68,7 @@ Response Structure
 	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
+	Content-Disposition: attachment; filename="GLOBAL.json"
 	Content-Type: application/json
 	Set-Cookie: mojolicious=...; Path=/; HttpOnly
 	Whole-Content-Sha512: mzP7DVxFAGhICxqagwDyBDRea7oBZPMAx7NCDeOBVCRqlcCFFe7XL3JP58b80aaVOW/2ZGfg/jpYF70cdDfzQA==

--- a/docs/source/api/profiles_id_export.rst
+++ b/docs/source/api/profiles_id_export.rst
@@ -15,9 +15,9 @@
 
 .. _to-api-profiles-id-export:
 
-*******************
+**************************
 ``profiles/{{ID}}/export``
-*******************
+**************************
 
 ``GET``
 =======
@@ -48,11 +48,14 @@ Request Structure
 Response Structure
 ------------------
 :profile:     The exported :term:`Profile`
+
 	:cdnName:     The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 	:description: The :term:`Profile`'s :ref:`profile-description`
 	:name:        The :term:`Profile`'s :ref:`profile-name`
 	:type:        The :term:`Profile`'s :ref:`profile-type`
+
 :parameters:  An array of :term:`Parameters` in use by this :term:`Profile`
+
 	:configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 	:name:        :ref:`parameter-name` of the :term:`Parameter`
 	:value:       The :term:`Parameter`'s :ref:`parameter-value`
@@ -73,9 +76,10 @@ Response Structure
 	Transfer-Encoding: gzip
 
 
-	{ "profile": {
+	{
+	  "profile": {
         "name": "GLOBAL",
-        "description": "Global Traffic Ops profile, DO NOT DELETE",
+        "description": "Global Traffic Ops profile",
         "cdn": "ALL",
         "type": "UNK_PROFILE"
       },

--- a/lib/go-tc/parameters.go
+++ b/lib/go-tc/parameters.go
@@ -265,3 +265,10 @@ type ProfileParametersNullable struct {
 	Profile     *string    `json:"profile" db:"profile"`
 	Parameter   *int       `json:"parameter" db:"parameter_id"`
 }
+
+// ProfileExportedParameterNullable is an object of the form returned by the Traffic Ops /profile/{id}/export endpoint.
+type ProfileExportedParameterNullable struct {
+	ConfigFile *string `json:"config_file"`
+	Name       *string `json:"name"`
+	Value      *string `json:"value"`
+}

--- a/lib/go-tc/profiles.go
+++ b/lib/go-tc/profiles.go
@@ -84,6 +84,35 @@ type ProfileNullable struct {
 	//
 	Parameters []ParameterNullable `json:"params,omitempty"`
 }
+
 type ProfileTrimmed struct {
 	Name string `json:"name"`
+}
+
+type ProfileExportedNullable struct {
+	// The Profile name
+	//
+	Name *string `json:"name"`
+
+	// The Profile Description
+	//
+	Description *string `json:"description"`
+
+	// The CDN name associated with the Profile
+	//
+	CDNName *string `json:"cdn"`
+
+	// The Type name associated with the Profile
+	//
+	Type *string `json:"type"`
+}
+
+type ProfileExportedResponse struct {
+	// Parameters associated to the profile
+	//
+	Profile ProfileExportedNullable `json:"profile"`
+
+	// Parameters associated to the profile
+	//
+	Parameters []ProfileExportedParameterNullable `json:"parameters"`
 }

--- a/traffic_ops/client/profile.go
+++ b/traffic_ops/client/profile.go
@@ -185,3 +185,21 @@ func (to *Session) DeleteProfileByID(id int) (tc.Alerts, ReqInf, error) {
 	err = json.NewDecoder(resp.Body).Decode(&alerts)
 	return alerts, reqInf, nil
 }
+
+// ExportProfile Returns an exported Profile
+func (to *Session) ExportProfile(id int) (*tc.ProfileExportedResponse, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/export", API_v13_Profiles, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ProfileExportedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data, reqInf, nil
+}

--- a/traffic_ops/testing/api/v14/profiles_test.go
+++ b/traffic_ops/testing/api/v14/profiles_test.go
@@ -136,6 +136,7 @@ func GetTestProfiles(t *testing.T) {
 		if err != nil {
 			t.Errorf("cannot GET Profile by name: %v - %v\n", err, resp)
 		}
+		profileID := resp[0].ID
 
 		resp, _, err = TOSession.GetProfileByParameter(pr.Parameter)
 		if err != nil {
@@ -145,6 +146,15 @@ func GetTestProfiles(t *testing.T) {
 		resp, _, err = TOSession.GetProfileByCDNID(pr.CDNID)
 		if err != nil {
 			t.Errorf("cannot GET Profile by cdn: %v - %v\n", err, resp)
+		}
+
+		// Export Profile
+		exportResp, _, err := TOSession.ExportProfile(profileID)
+		if err != nil {
+			t.Errorf("error exporting Profile: %v - %v\n", profileID, err)
+		}
+		if exportResp == nil {
+			t.Errorf("error exporting Profile: response nil\n")
 		}
 	}
 }
@@ -216,6 +226,12 @@ func DeleteTestProfiles(t *testing.T) {
 		}
 		if len(prs) > 0 {
 			t.Errorf("expected Profile Name: %s to be deleted\n", pr.Name)
+		}
+
+		// Attempt to export Profile
+		profile, _, err := TOSession.ExportProfile(profileID)
+		if profile != nil {
+			t.Errorf("expected Profile: %s to be nil on export\n", pr.Name)
 		}
 	}
 }

--- a/traffic_ops/traffic_ops_golang/profile/profile_export.go
+++ b/traffic_ops/traffic_ops_golang/profile/profile_export.go
@@ -1,0 +1,144 @@
+package profile
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+)
+
+// ExportProfileHandler exports a profile per ID
+func ExportProfileHandler(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{IDQueryParam}, []string{IDQueryParam})
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	profileID := inf.IntParams[IDQueryParam]
+
+	// Check that the profile attempting to be exported exists
+	_, exists, err := dbhelpers.GetProfileNameFromID(profileID, inf.Tx.Tx)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
+		return
+	}
+	if !exists {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("profile does not exist"), nil)
+		return
+	}
+
+	// Get Profile Response
+	exportedProfileResp, err := getExportProfileResponse(profileID, inf.Tx)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
+		return
+	}
+
+	api.WriteRespRaw(w, r, exportedProfileResp)
+}
+
+func getExportProfileResponse(profileID int, tx *sqlx.Tx) (*tc.ProfileExportedResponse, error) {
+	queryValues := map[string]interface{}{
+		IDQueryParam: profileID,
+	}
+	query := selectExportProfileQuery()
+	log.Debugln("Query is ", query)
+
+	rows, err := tx.NamedQuery(query, queryValues)
+	if err != nil {
+		return nil, errors.New("querying profile: " + err.Error())
+	}
+	defer rows.Close()
+
+	type epR struct {
+		ProfileDescription  *string `db:"profile_description"`
+		ProfileName         *string `db:"profile_name"`
+		ProfileType         *string `db:"profile_type"`
+		CDN                 *string `db:"cdn"`
+		ParameterName       *string `db:"parm_name"`
+		ParameterConfigFile *string `db:"parm_config_file"`
+		ParameterValue      *string `db:"parm_value"`
+	}
+
+	exportedProfileResp := &tc.ProfileExportedResponse{}
+
+	hasNext := rows.Next()
+	if !hasNext {
+		return exportedProfileResp, nil
+	}
+	var r epR
+	if err = rows.StructScan(&r); err != nil {
+		return nil, errors.New("profile read scanning: " + err.Error())
+	}
+
+	for hasNext { // Set Profile
+		exportedProfileResp.Profile = tc.ProfileExportedNullable{
+			Name:        r.ProfileName,
+			Description: r.ProfileDescription,
+			Type:        r.ProfileType,
+			CDNName:     r.CDN,
+		}
+		exportedProfileResp.Parameters = []tc.ProfileExportedParameterNullable{}
+		for hasNext { // Loop through parameters
+			if r.ParameterName != nil {
+				exportedProfileResp.Parameters = append(exportedProfileResp.Parameters,
+					tc.ProfileExportedParameterNullable{
+						ConfigFile: r.ParameterConfigFile,
+						Name:       r.ParameterName,
+						Value:      r.ParameterValue,
+					})
+			}
+			hasNext = rows.Next()
+			if hasNext {
+				if err = rows.StructScan(&r); err != nil {
+					return nil, errors.New("profile read scanning: " + err.Error())
+				}
+			}
+		}
+	}
+
+	return exportedProfileResp, nil
+}
+
+func selectExportProfileQuery() string {
+	query := `SELECT
+prof.description as profile_description,
+prof.name as profile_name,
+prof.type as profile_type,
+c.name as cdn,
+parm.name as parm_name,
+parm.config_file as parm_config_file,
+parm.value as parm_value
+FROM profile prof
+JOIN cdn c ON prof.cdn = c.id
+LEFT JOIN profile_parameter as pp ON pp.profile = prof.id
+LEFT JOIN parameter as parm ON parm.id = pp.parameter
+WHERE prof.id=:id`
+	return query
+}

--- a/traffic_ops/traffic_ops_golang/profile/profile_export.go
+++ b/traffic_ops/traffic_ops_golang/profile/profile_export.go
@@ -21,6 +21,7 @@ package profile
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -59,7 +60,7 @@ func ExportProfileHandler(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
-
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%v.json\"", *exportedProfileResp.Profile.Name))
 	api.WriteRespRaw(w, r, exportedProfileResp)
 }
 

--- a/traffic_ops/traffic_ops_golang/profile/profile_export_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profile_export_test.go
@@ -1,0 +1,157 @@
+package profile
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+var (
+	exProRows = []string{
+		"profile_description",
+		"profile_name",
+		"profile_type",
+		"cdn",
+		"parm_name",
+		"parm_config_file",
+		"parm_value",
+	}
+)
+
+func TestGetExportProfileResponse(t *testing.T) {
+	var testCases = []struct {
+		description  string
+		storageError error
+		profile      tc.ProfileExportedNullable
+		parameters   []tc.ProfileExportedParameterNullable
+	}{
+		{
+			description:  "Success: Read export profile successful",
+			storageError: nil,
+			profile:      generateExportProfile("profile", "test profile", "cdn", "type"),
+			parameters: []tc.ProfileExportedParameterNullable{
+				generateExportParameter("config", "param1", "val1"),
+				generateExportParameter("config", "param2", "val2"),
+			},
+		},
+		{
+			description:  "Success: Read export profile with no parameters successful",
+			storageError: nil,
+			profile:      generateExportProfile("profile", "test profile", "cdn", "type"),
+			parameters:   []tc.ProfileExportedParameterNullable{},
+		},
+		{
+			description:  "Failure: Storage error reading profile",
+			storageError: errors.New("Storage error"),
+			profile:      tc.ProfileExportedNullable{},
+			parameters:   []tc.ProfileExportedParameterNullable{},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			t.Log("Starting test scenario: ", testCase.description)
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer mockDB.Close()
+			db := sqlx.NewDb(mockDB, "sqlmock")
+			defer db.Close()
+			mock.ExpectBegin()
+			if testCase.storageError != nil {
+				mock.ExpectQuery("profile").WillReturnError(testCase.storageError)
+			} else {
+				rows := sqlmock.NewRows(exProRows)
+				if len(testCase.parameters) == 0 {
+					rows = rows.AddRow(
+						testCase.profile.Description,
+						testCase.profile.Name,
+						testCase.profile.Type,
+						testCase.profile.CDNName,
+						nil,
+						nil,
+						nil,
+					)
+				} else {
+					for _, param := range testCase.parameters {
+						rows = rows.AddRow(
+							testCase.profile.Description,
+							testCase.profile.Name,
+							testCase.profile.Type,
+							testCase.profile.CDNName,
+							param.Name,
+							param.ConfigFile,
+							param.Value,
+						)
+					}
+				}
+				mock.ExpectQuery("profile").WillReturnRows(rows)
+			}
+			mock.ExpectCommit()
+			exportProfileResponse, err := getExportProfileResponse(1, db.MustBegin())
+			if testCase.storageError != nil {
+				if err == nil {
+					t.Errorf("Read error expected: received no error")
+				}
+				if exportProfileResponse != nil {
+					t.Errorf("Export Profile response expected to be nil: received non nil")
+				}
+			} else {
+				if exportProfileResponse.Profile != testCase.profile {
+					t.Errorf("Returned profile does not match expected")
+				}
+				for _, param := range testCase.parameters {
+					found := false
+					for _, rParam := range exportProfileResponse.Parameters {
+						if rParam == param {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("Expected to find parameter %v in return but did not", param.Name)
+					}
+				}
+			}
+		})
+	}
+}
+
+func generateExportParameter(configFile, param, val string) tc.ProfileExportedParameterNullable {
+	return tc.ProfileExportedParameterNullable{
+		ConfigFile: &configFile,
+		Name:       &param,
+		Value:      &val,
+	}
+}
+
+func generateExportProfile(name, description, cdnName, profileType string) tc.ProfileExportedNullable {
+	return tc.ProfileExportedNullable{
+		Name:        &name,
+		CDNName:     &cdnName,
+		Description: &description,
+		Type:        &profileType,
+	}
+}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -214,6 +214,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `profiles/?$`, api.CreateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodDelete, `profiles/{id}$`, api.DeleteHandler(&profile.TOProfile{}), auth.PrivLevelOperations, Authenticated, nil},
 
+		{1.1, http.MethodGet, `profiles/{id}/export/?(\.json)?$`, profile.ExportProfileHandler, auth.PrivLevelReadOnly, Authenticated, nil},
+
 		//Region: CRUDs
 		{1.1, http.MethodGet, `regions/?(\.json)?$`, api.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodGet, `regions/{id}$`, api.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, Authenticated, nil},


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This PR rewrites the /cachegroups/{id}/unassigned_parameters endpoint to Go

- [x] This PR fixes #3814 

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Ops

## What is the best way to verify this PR?

Bring up TO locally and hit the endpoint to ensure parity between perl implementation and newly written Golang implementation 

The API tests and/or unit tests for TO can be run to verify the PR.

## If this is a bug fix, what versions of Traffic Control are affected?

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR does not include an update to CHANGELOG.md 
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
