### PR TITLE
Gives admins the ability to mark delivery service requests as complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added fields to traffic_portal_properties.json to configure SSO through OAuth.
 - Added field to cdn.conf to configure whitelisted URLs for Json Key Set URL returned from OAuth provider.
 - Improved [profile comparison view in Traffic Portal](https://github.com/apache/trafficcontrol/blob/master/blueprints/profile-param-compare-manage.md).
+- Issue #3871 - provides users with a specified role the ability to mark any delivery service request as complete.
 - Fixed Traffic Ops Golang POST servers/id/deliveryservice continuing erroneously after a database error.
 - Fixed Traffic Ops Golang POST servers/id/deliveryservice double-logging errors.
 

--- a/docs/source/admin/quick_howto/ds_requests.rst
+++ b/docs/source/admin/quick_howto/ds_requests.rst
@@ -58,5 +58,7 @@ Fulfill the Delivery Service Request
 Complete the Delivery Service Request
 	Only after the Delivery Service Request has been fulfilled and the changes have been applied can a Delivery Service Request be marked as 'complete'. Marking a Delivery Service Request as 'complete' is currently a manual step because some changes require :term:`cache server` configuration updates (i.e. :term:`Queue Updates`) and/or a CDN :term:`Snapshot`. Once that is done and the changes have been deployed, the request status should be changed from 'pending' to 'complete'.
 
+	..  Note:: Only the user that fulfilled the delivery service request can mark a delivery service as 'complete'. This prevents other users from interfering in the process and marking delivery services as 'complete' when further action is required for the changes to truly be deployed. However, in traffic_portal_properties.json, users with the 'overrideRole' are given the ability to mark any delivery service requests as 'complete'.
+
 Delete the Delivery Service request
 	Delivery Service Requests with a status of 'draft' or 'submitted' can always be deleted entirely if appropriate.

--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -40,7 +40,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, type, 
 						{ id: $scope.DRAFT, name: 'Save Request as Draft' },
 						{ id: $scope.SUBMITTED, name: 'Submit Request for Review and Deployment' }
 					];
-					if (userModel.user.roleName == propertiesModel.properties.dsRequests.roleNeededToSkip) {
+					if (userModel.user.roleName == propertiesModel.properties.dsRequests.overrideRole) {
 						statuses.push({ id: $scope.COMPLETE, name: 'Fulfill Request Immediately' });
 					}
 					return statuses;
@@ -177,7 +177,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, type, 
 							{ id: $scope.DRAFT, name: 'Save Request as Draft' },
 							{ id: $scope.SUBMITTED, name: 'Submit Request for Review and Deployment' }
 						];
-						if (userModel.user.roleName == propertiesModel.properties.dsRequests.roleNeededToSkip) {
+						if (userModel.user.roleName == propertiesModel.properties.dsRequests.overrideRole) {
 							statuses.push({ id: $scope.COMPLETE, name: 'Fulfill Request Immediately' });
 						}
 						return statuses;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/new/FormNewDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/new/FormNewDeliveryServiceController.js
@@ -81,7 +81,7 @@ var FormNewDeliveryServiceController = function(deliveryService, origin, type, t
 							{ id: $scope.DRAFT, name: 'Save Request as Draft' },
 							{ id: $scope.SUBMITTED, name: 'Submit Request for Review and Deployment' }
 						];
-						if (userModel.user.roleName == propertiesModel.properties.dsRequests.roleNeededToSkip) {
+						if (userModel.user.roleName == propertiesModel.properties.dsRequests.overrideRole) {
 							statuses.push({ id: $scope.COMPLETE, name: 'Fulfill Request Immediately' });
 						}
 						return statuses;

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceRequests/TableDeliveryServiceRequestsController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceRequests/TableDeliveryServiceRequestsController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var TableDeliveryServicesRequestsController = function (dsRequests, $scope, $state, $uibModal, $anchorScroll, $q, $location, dateUtils, locationUtils, typeService, deliveryServiceService, deliveryServiceRequestService, messageModel, userModel) {
+var TableDeliveryServicesRequestsController = function (dsRequests, $scope, $state, $uibModal, $anchorScroll, $q, $location, dateUtils, locationUtils, typeService, deliveryServiceService, deliveryServiceRequestService, messageModel, propertiesModel, userModel) {
 
 	var createComment = function (request, placeholder) {
 		var params = {
@@ -141,7 +141,8 @@ var TableDeliveryServicesRequestsController = function (dsRequests, $scope, $sta
 	$scope.rejectRequest = function (request, $event) {
 		$event.stopPropagation(); // this kills the click event so it doesn't trigger anything else
 
-		if (request.assigneeId != userModel.user.id) {
+		// only the user assigned to the request can mark it as rejected (unless the user has override capabilities)
+		if ((request.assigneeId != userModel.user.id) && (userModel.user.roleName != propertiesModel.properties.dsRequests.overrideRole)) {
 			messageModel.setMessages([{
 				level: 'error',
 				text: 'Only the assignee can mark a delivery service request as rejected'
@@ -178,7 +179,8 @@ var TableDeliveryServicesRequestsController = function (dsRequests, $scope, $sta
 	$scope.completeRequest = function (request, $event) {
 		$event.stopPropagation(); // this kills the click event so it doesn't trigger anything else
 
-		if (request.assigneeId != userModel.user.id) {
+		// only the user assigned to the request can mark it as complete (unless the user has override capabilities)
+		if ((request.assigneeId != userModel.user.id) && (userModel.user.roleName != propertiesModel.properties.dsRequests.overrideRole)) {
 			messageModel.setMessages([{
 				level: 'error',
 				text: 'Only the assignee can mark a delivery service request as complete'
@@ -283,5 +285,5 @@ var TableDeliveryServicesRequestsController = function (dsRequests, $scope, $sta
 
 };
 
-TableDeliveryServicesRequestsController.$inject = ['dsRequests', '$scope', '$state', '$uibModal', '$anchorScroll', '$q', '$location', 'dateUtils', 'locationUtils', 'typeService', 'deliveryServiceService', 'deliveryServiceRequestService', 'messageModel', 'userModel'];
+TableDeliveryServicesRequestsController.$inject = ['dsRequests', '$scope', '$state', '$uibModal', '$anchorScroll', '$q', '$location', 'dateUtils', 'locationUtils', 'typeService', 'deliveryServiceService', 'deliveryServiceRequestService', 'messageModel', 'propertiesModel', 'userModel'];
 module.exports = TableDeliveryServicesRequestsController;

--- a/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
@@ -123,7 +123,7 @@ var TableDeliveryServicesController = function(deliveryServices, $anchorScroll, 
                         { id: $scope.DRAFT, name: 'Save Request as Draft' },
                         { id: $scope.SUBMITTED, name: 'Submit Request for Review and Deployment' }
                     ];
-                    if (userModel.user.roleName == propertiesModel.properties.dsRequests.roleNeededToSkip) {
+                    if (userModel.user.roleName == propertiesModel.properties.dsRequests.overrideRole) {
                         statuses.push({ id: $scope.COMPLETE, name: 'Fulfill Request Immediately' });
                     }
                     return statuses;

--- a/traffic_portal/app/src/traffic_portal_properties.json
+++ b/traffic_portal/app/src/traffic_portal_properties.json
@@ -179,9 +179,9 @@
       }
     },
     "dsRequests": {
-      "_comments": "Should all delivery service changes go through the delivery service review process? You can also provide a role that will skip the process.",
+      "_comments": "Should all delivery service changes go through the delivery service review process? You can also provide a role that will override the process.",
       "enabled": false,
-      "roleNeededToSkip": "admin"
+      "overrideRole": "admin"
     },
     "servers": {
       "_comment": "Server settings",

--- a/traffic_portal/app/src/traffic_portal_properties.json
+++ b/traffic_portal/app/src/traffic_portal_properties.json
@@ -179,9 +179,9 @@
       }
     },
     "dsRequests": {
-      "_comments": "Should all delivery service changes go through the delivery service review process? You can also provide a role that will override the process.",
+      "_comments": "Should all delivery service changes go through the delivery service request/review process? You can also provide a override role name (i.e. admin) that will allow users with the given role to circumvent the delivery service request process.",
       "enabled": false,
-      "overrideRole": "admin"
+      "overrideRole": ""
     },
     "servers": {
       "_comment": "Server settings",


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Allows users with the admin role to mark fulfilled delivery services requests as "complete".  Before this change, only the user that fulfilled the delivery service request could mark it as "complete". This can cause problems if the fulfilling user is not available to mark it as complete thus leaving the delivery service request in an "open" state. Because a delivery service can only have one open ds request at a time, this would block any further changes to a delivery service. Now anyone with the admin role can "complete" ds requests and unblock the delivery service from future updates.

- [x] This PR fixes #3871 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
- enable ds requests in traffic_portal_properties.json
- launch TP
- login as user 1 (with portal role or higher) and update a delivery service which will create a delivery service request and set the request status to 'submit request for review and deployment'
- login as user 2 (with operations role or higher) and fulfill the delivery service request
- login as user 3 (with admin role) and mark the delivery service request as "complete"

(before this change, only user 2 (the fulfiller of the ds request) could mark the ds request as complete)

There are no UI tests to cover ds requests currently as ds requests are disabled by default and no mechanism to turn them on for testing.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
