### PR TITLE
fixed bug in CertificateRegistry

### DIFF
--- a/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
+++ b/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
@@ -27,6 +27,9 @@ import org.apache.tomcat.util.net.SSLHostConfigCertificate;
 import org.apache.tomcat.util.net.SocketEvent;
 import org.apache.tomcat.util.net.SocketProcessorBase;
 import org.apache.tomcat.util.net.SocketWrapperBase;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -53,10 +56,11 @@ public class RouterNioEndpoint extends NioEndpoint {
 		}
 	}
 
-	@SuppressWarnings({"PMD.NPathComplexity", "PMD.UseStringBufferForStringAppends"})
-	synchronized public void replaceSSLHosts(final Map<String, HandshakeData> sslHostsData) {
-		final Set<String> aliases = sslHostsData.keySet();
-		String lastHostName = "";
+    synchronized private List<String> replaceSSLHosts(final Map<String, HandshakeData> sslHostsData) {
+        final Set<String> aliases = sslHostsData.keySet();
+        boolean defaultHasBeenSet = (sslHostConfigs.get(getDefaultSSLHostConfigName()) != null);
+        String lastHostName = "";
+        final List<String> failedUpdates = new ArrayList<>();
 
 		for (final String alias : aliases) {
 			final SSLHostConfig sslHostConfig = new SSLHostConfig();
@@ -70,17 +74,56 @@ public class RouterNioEndpoint extends NioEndpoint {
 			sslHostConfig.setCertificateVerification("none");
 			LOGGER.info("sslHostConfig: "+sslHostConfig.getHostName() + " " + sslHostConfig.getTruststoreAlgorithm());
 
-			if (!sslHostConfig.getHostName().equals(lastHostName)){
-				addSslHostConfig(sslHostConfig, true);
-				lastHostName = sslHostConfig.getHostName();
-			}
+            if (!sslHostConfig.getHostName().equals(lastHostName)) {
+                try{
+                    addSslHostConfig(sslHostConfig, true);
+                }
+                catch (Exception fubar)
+                {
+                    LOGGER.error("In RouterNioEndpoint.replaceSSLHosts, sslHostConfig and certs did not get replaced " +
+                            "for host: "+sslHostConfig.getHostName()+", because of execption - "+fubar.toString());
+                    failedUpdates.add(alias);
+                }
+                lastHostName = sslHostConfig.getHostName();
+            }
 
-			if (CertificateRegistry.DEFAULT_SSL_KEY.equals(alias)){
+			if (CertificateRegistry.DEFAULT_SSL_KEY.equals(alias) && !failedUpdates.contains(alias)){
 				// One of the configs must be set as the default
 				setDefaultSSLHostConfigName(sslHostConfig.getHostName());
 			}
 		}
-	}
+        return failedUpdates;
+    }
+
+    synchronized public List<String> reloadSSLHosts(final Map<String, HandshakeData> cr) {
+        final List<String> failedUpdates = replaceSSLHosts(cr);
+        if (!failedUpdates.isEmpty()) {
+            failedUpdates.forEach(alias-> {
+                cr.remove(alias);
+            });
+        }
+
+        final List<String> failedContextUpdates = new ArrayList<>();
+        for (final String alias : cr.keySet()) {
+            try{
+                final HandshakeData data = cr.get(alias);
+                final SSLHostConfig sslHostConfig = sslHostConfigs.get(data.getHostname());
+                sslHostConfig.setConfigType(getSslConfigType());
+                createSSLContext(sslHostConfig);
+            }
+            catch (Exception rfubar) {
+                LOGGER.error("In RouterNioEndpoint could not create new SSLContext for cert " + alias +
+                        " because of exception: "+rfubar.toString());
+                failedContextUpdates.add(alias);
+            }
+        }
+
+        if (!failedContextUpdates.isEmpty()) {
+            failedUpdates.addAll(failedContextUpdates);
+        }
+
+        return failedUpdates;
+    }
 
 	@Override
 	protected SSLHostConfig getSSLHostConfig(final String sniHostName){

--- a/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
+++ b/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
@@ -58,7 +58,6 @@ public class RouterNioEndpoint extends NioEndpoint {
 
     synchronized private List<String> replaceSSLHosts(final Map<String, HandshakeData> sslHostsData) {
         final Set<String> aliases = sslHostsData.keySet();
-        boolean defaultHasBeenSet = (sslHostConfigs.get(getDefaultSSLHostConfigName()) != null);
         String lastHostName = "";
         final List<String> failedUpdates = new ArrayList<>();
 

--- a/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/secure/CertificateRegistry.java
+++ b/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/secure/CertificateRegistry.java
@@ -236,8 +236,15 @@ public class CertificateRegistry {
 		}
 		handshakeDataMap = master;
 
-		if (sslEndpoint != null) {
-			sslEndpoint.replaceSSLHosts(changes);
+		// This will update the SSLHostConfig objects stored in the server
+		// if any of those updates fail then we need to be sure to remove them
+		// from the previousData list so that we will try to update them again
+		// next time we import certificates
+		if (sslEndpoint != null && !changes.isEmpty()) {
+			final List<String> failedUpdates = sslEndpoint.reloadSSLHosts(changes);
+			failedUpdates.forEach(alias-> {
+				previousData.remove(alias);
+			});
 		}
 	}
 

--- a/traffic_router/connector/src/test/java/protocol/RouterSslImplementationTest.java
+++ b/traffic_router/connector/src/test/java/protocol/RouterSslImplementationTest.java
@@ -53,6 +53,11 @@ public class RouterSslImplementationTest {
 		assertThat(new RouterSslImplementation().getSSLUtil(sslHostConfigCertificate), instanceOf(SSLUtil.class));
 	}
 
+	@Test
+	public void itRegistersSSLHostConfigs() throws Exception {
+
+	}
+
 	@Before
 	public void before() {
 	}

--- a/traffic_router/connector/src/test/java/secure/CertificateRegistryTest.java
+++ b/traffic_router/connector/src/test/java/secure/CertificateRegistryTest.java
@@ -15,6 +15,7 @@
 
 package secure;
 
+import com.comcast.cdn.traffic_control.traffic_router.protocol.RouterNioEndpoint;
 import com.comcast.cdn.traffic_control.traffic_router.secure.CertificateDataConverter;
 import com.comcast.cdn.traffic_control.traffic_router.secure.CertificateRegistry;
 import com.comcast.cdn.traffic_control.traffic_router.secure.HandshakeData;
@@ -22,21 +23,24 @@ import com.comcast.cdn.traffic_control.traffic_router.shared.CertificateData;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyMap;
 
 public class CertificateRegistryTest {
 
 	private CertificateRegistry certificateRegistry = CertificateRegistry.getInstance();
-	private List<CertificateData> certificateDataList;
+	private List certificateDataList;
 	private CertificateDataConverter certificateDataConverter;
 	private CertificateData certificateData1;
 	private CertificateData certificateData2;
@@ -54,7 +58,7 @@ public class CertificateRegistryTest {
 		when(certificateData2.alias()).thenReturn("ds-2.some-cdn.example.com");
 		when(certificateData3.alias()).thenReturn("ds-3.some-cdn.example.com");
 
-		certificateDataList = Arrays.asList(certificateData1, certificateData2, certificateData3);
+		certificateDataList = new ArrayList(Arrays.asList(certificateData1, certificateData2, certificateData3));
 
 		handshakeData1 = mock(HandshakeData.class);
 		when(handshakeData1.getHostname()).thenReturn("*.ds-1.some-cdn.example.com");
@@ -89,5 +93,50 @@ public class CertificateRegistryTest {
 		assertThat(certificateRegistry.getAliases(),
 			containsInAnyOrder(CertificateRegistry.DEFAULT_SSL_KEY, "ds-1.some-cdn.example.com",
 					"ds-2.some-cdn.example.com", "ds-3.some-cdn.example.com"));
+	}
+
+	@Test
+	public void itRetrysCertificateDataOnEndpointFail() throws Exception {
+		HandshakeData handshakeData3mod = mock(HandshakeData.class);
+		when(handshakeData3mod.getHostname()).thenReturn("*.ds-3.some-cdn.example.com");
+		CertificateData certificateData3mod = mock(CertificateData.class);
+		when(certificateData3mod.alias()).thenReturn("ds-3.some-cdn.example.com");
+		when(certificateDataConverter.toHandshakeData(certificateData3mod)).thenReturn(handshakeData3mod);
+		certificateDataList.remove(certificateData3);
+		certificateDataList.add(certificateData3mod);
+		RouterNioEndpoint endpoint = mock(RouterNioEndpoint.class);
+		List<String> failist = new ArrayList<>();
+		failist.add("ds-3.some-cdn.example.com");
+		when(endpoint.reloadSSLHosts(anyMap())).thenReturn(failist);
+		certificateRegistry.setEndPoint(endpoint);
+		certificateRegistry.importCertificateDataList(certificateDataList);
+
+		assertThat(certificateRegistry.getHandshakeData("ds-1.some-cdn.example.com"), equalTo(handshakeData1));
+		assertThat(certificateRegistry.getHandshakeData("ds-2.some-cdn.example.com"), equalTo(handshakeData2));
+		assertThat(certificateRegistry.getHandshakeData("ds-3.some-cdn.example.com"), equalTo(handshakeData3mod));
+
+		verify(certificateDataConverter).toHandshakeData(certificateData1);
+		verify(certificateDataConverter).toHandshakeData(certificateData2);
+		verify(certificateDataConverter).toHandshakeData(certificateData3mod);
+		verify(endpoint).reloadSSLHosts(anyMap());
+
+		assertThat(certificateRegistry.getAliases(),
+			containsInAnyOrder("ds-1.some-cdn.example.com", "ds-2.some-cdn.example.com", "ds-3.some-cdn.example.com"));
+
+		// try again
+		// we should see that reloadSSLHosts gets called again even though none of the inputs have changed
+		when(endpoint.reloadSSLHosts(anyMap())).thenReturn(new ArrayList<>());
+		certificateRegistry.importCertificateDataList(certificateDataList);
+		assertThat(certificateRegistry.getHandshakeData("ds-1.some-cdn.example.com"), equalTo(handshakeData1));
+		assertThat(certificateRegistry.getHandshakeData("ds-2.some-cdn.example.com"), equalTo(handshakeData2));
+		assertThat(certificateRegistry.getHandshakeData("ds-3.some-cdn.example.com"), equalTo(handshakeData3mod));
+
+		verify(certificateDataConverter, times(2)).toHandshakeData(certificateData1);
+		verify(certificateDataConverter, times(2)).toHandshakeData(certificateData2);
+		verify(certificateDataConverter, times(2)).toHandshakeData(certificateData3mod);
+		verify(endpoint, times(2)).reloadSSLHosts(anyMap());
+
+		assertThat(certificateRegistry.getAliases(),
+			containsInAnyOrder("ds-1.some-cdn.example.com", "ds-2.some-cdn.example.com", "ds-3.some-cdn.example.com"));
 	}
 }

--- a/traffic_router/connector/src/test/java/secure/CertificateRegistryTest.java
+++ b/traffic_router/connector/src/test/java/secure/CertificateRegistryTest.java
@@ -121,7 +121,7 @@ public class CertificateRegistryTest {
 		verify(endpoint).reloadSSLHosts(anyMap());
 
 		assertThat(certificateRegistry.getAliases(),
-			containsInAnyOrder("ds-1.some-cdn.example.com", "ds-2.some-cdn.example.com", "ds-3.some-cdn.example.com"));
+			containsInAnyOrder(CertificateRegistry.DEFAULT_SSL_KEY, "ds-1.some-cdn.example.com", "ds-2.some-cdn.example.com", "ds-3.some-cdn.example.com"));
 
 		// try again
 		// we should see that reloadSSLHosts gets called again even though none of the inputs have changed
@@ -137,6 +137,6 @@ public class CertificateRegistryTest {
 		verify(endpoint, times(2)).reloadSSLHosts(anyMap());
 
 		assertThat(certificateRegistry.getAliases(),
-			containsInAnyOrder("ds-1.some-cdn.example.com", "ds-2.some-cdn.example.com", "ds-3.some-cdn.example.com"));
+			containsInAnyOrder(CertificateRegistry.DEFAULT_SSL_KEY, "ds-1.some-cdn.example.com", "ds-2.some-cdn.example.com", "ds-3.some-cdn.example.com"));
 	}
 }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/secure/CertificatesClient.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/secure/CertificatesClient.java
@@ -80,7 +80,7 @@ public class CertificatesClient {
 
 		try {
 			final ProtectedFetcher fetcher = new ProtectedFetcher(trafficOpsUtils.getAuthUrl(), trafficOpsUtils.getAuthJSON().toString(), 15000);
-			return fetcher.getIfModifiedSince(certificatesUrl, lastValidfetchTimestamp, stringBuilder);
+			return fetcher.getIfModifiedSince(certificatesUrl, 0L, stringBuilder);
 		} catch (Exception e) {
 			LOGGER.warn("Failed to fetch data for certificates from " + certificatesUrl + "(" + e.getClass().getSimpleName() + ") : " + e.getMessage(), e);
 		}
@@ -90,6 +90,7 @@ public class CertificatesClient {
 
 	public List<CertificateData> getCertificateData(final String jsonData) {
 		try {
+			LOGGER.debug("Certificates successfully updated @ "+lastValidfetchTimestamp);
 			return ((CertificatesResponse) new ObjectMapper().readValue(jsonData, new TypeReference<CertificatesResponse>() { })).getResponse();
 		} catch (Exception e) {
 			LOGGER.warn("Failed parsing json data: " + e.getMessage());


### PR DESCRIPTION
## What does this PR (Pull Request) do?
This PR adds exception handling and logging where the TR code interfaces with the tomcat-native library to create or modify the SSL Host data structures used by openssl. The exception handling prevents TR from saving host configurations when they do not get successfully written to the native structures in openssl. Therefore TR will continue to try and update them each time it polls for SSL cert changes. This PR also fixes a bug that may have been unregistering the native SSL host configurations with JMX causing them to become eligible for untimely garbage collection. 
This PR does not change any functionality of TR and does not affect the documentation. One unit test has been added to demonstrate that failed updates will cause TR to attempt the update again the next time it retrieves SSL certs from TO. 
- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- CDN in a Box
- Traffic Router

## What is the best way to verify this PR?
1. First start Traffic Router and wait for it to finish initializing.
2. Go into Traffic Portal and add a new certificate for an existing HTTPS delivery service. 
3. Wait for 5 minutes. There should be a log message in the TR logs indicating that new certificate has been loaded for the delivery service.
4. Use 'curl' to connect to the delivery service that has the updated certificate and then verify that the new certificate is being used by observing the 'curl' output. The expiration date in the curl output should match the expiration date set on the certificate. 
 
## If this is a bug fix, what versions of Traffic Control are affected?

- master (79897553d46a)
- 3.0.0
- 3.0.1 (RC1)

## The following criteria are ALL met by this PR
- [X] This PR includes tests OR I have explained why tests are unnecessary
- [X] This PR includes documentation OR I have explained why documentation is unnecessary
- [X] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
