### PR TITLE
Fix typo in GetProfileDS query used to generate cache.config

### DIFF
--- a/traffic_ops/traffic_ops_golang/ats/db.go
+++ b/traffic_ops/traffic_ops_golang/ats/db.go
@@ -108,7 +108,7 @@ WHERE
     SELECT DISTINCT deliveryservice
     FROM deliveryservice_server
     WHERE server IN (SELECT id FROM server WHERE profile = $1)
-  )p
+  )
 `
 	rows, err := tx.Query(qry, profileID)
 	if err != nil {


### PR DESCRIPTION
Fix typo from merge conflict

## What does this PR (Pull Request) do?
Fix typo from merge conflict

No documentation, no interface change.
Endpoint already has tests, they caught this.

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
- Traffic Ops
## What is the best way to verify this PR?

curl ats config endpoints.

## If this is a bug fix, what versions of Traffic Control are affected?
no versions


## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

