### PR TITLE
Fix Traffic Ops servers/deliveryservices missing error check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added fields to traffic_portal_properties.json to configure SSO through OAuth.
 - Added field to cdn.conf to configure whitelisted URLs for Json Key Set URL returned from OAuth provider.
 - Improved [profile comparison view in Traffic Portal](https://github.com/apache/trafficcontrol/blob/master/blueprints/profile-param-compare-manage.md).
+- Fixed Traffic Ops Golang POST servers/id/deliveryservice continuing erroneously after a database error.
+- Fixed Traffic Ops Golang POST servers/id/deliveryservice double-logging errors.
 
 ## [3.0.0] - 2018-10-30
 ### Added

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -68,6 +68,7 @@ func AssignDeliveryServicesToServerHandler(w http.ResponseWriter, r *http.Reques
 		return
 	} else if !ok {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("no server with that ID found"), nil)
+		return
 	}
 
 	assignedDSes, err := assignDeliveryServicesToServer(server, dsList, replace, inf.Tx.Tx)
@@ -108,14 +109,14 @@ INSERT INTO deliveryservice_server (deliveryservice, server)
 	SELECT * FROM q1,q2 ON CONFLICT DO NOTHING
 `
 	if _, err := tx.Exec(q, dsPqArray, server); err != nil {
-		log.Errorf("could not execute deliveryservice_server bulk insert: %s\n", err)
-		return nil, tc.DBError
+		return nil, errors.New("inserting deliveryservice_server: " + err.Error())
 	}
 
 	//need remap config location
-	row := tx.QueryRow("SELECT value FROM parameter WHERE name = 'location' AND config_file = '" + ats.RemapFile + "'")
 	var atsConfigLocation string
-	row.Scan(&atsConfigLocation)
+	if err := tx.QueryRow("SELECT value FROM parameter WHERE name = 'location' AND config_file = '" + ats.RemapFile + "'").Scan(&atsConfigLocation); err != nil {
+		return nil, errors.New("scanning location parameter: " + err.Error())
+	}
 	if strings.HasSuffix(atsConfigLocation, "/") {
 		atsConfigLocation = atsConfigLocation[:len(atsConfigLocation)-1]
 	}
@@ -123,8 +124,7 @@ INSERT INTO deliveryservice_server (deliveryservice, server)
 	//we need dses: xmlids and edge_header_rewrite, regex_remap, and cache_url
 	rows, err := tx.Query(`SELECT xml_id, edge_header_rewrite, regex_remap, cacheurl FROM deliveryservice WHERE id = ANY($1::bigint[])`, dsPqArray)
 	if err != nil {
-		log.Error.Printf("could not execute ds fields select query: %s\n", err)
-		return nil, tc.DBError
+		return nil, errors.New("querying deliveryservice: " + err.Error())
 	}
 	defer rows.Close()
 
@@ -141,10 +141,8 @@ INSERT INTO deliveryservice_server (deliveryservice, server)
 		var edgeHeaderRewrite sql.NullString
 		var regexRemap sql.NullString
 		var cacheURL sql.NullString
-
 		if err := rows.Scan(&xmlID, &edgeHeaderRewrite, &regexRemap, &cacheURL); err != nil {
-			log.Error.Printf("could not scan ds fields row: %s\n", err)
-			return nil, tc.DBError
+			return nil, errors.New("scanning deliveryservice: " + err.Error())
 		}
 		if xmlID.Valid && len(xmlID.String) > 0 {
 			//param := "hdr_rw_" + xmlID.String + ".config"
@@ -181,15 +179,13 @@ INSERT INTO parameter (config_file, name, value)
 `
 	fileNamePqArray := pq.Array(insert)
 	if _, err = tx.Exec(q, fileNamePqArray, "location", atsConfigLocation); err != nil {
-		log.Error.Printf("could not execute parameter bulk insert: %s\n", err)
-		return nil, tc.DBError
+		return nil, errors.New("inserting parameters: " + err.Error())
 	}
 
 	//select the ids associated with the parameters we created above (may be able to get them from insert above to optimize)
 	rows, err = tx.Query(`SELECT id FROM parameter WHERE name = 'location' AND config_file IN ($1)`, fileNamePqArray)
 	if err != nil {
-		log.Error.Printf("could not execute parameter id select query: %s\n", err)
-		return nil, tc.DBError
+		return nil, errors.New("selecting location parameter after insert: " + err.Error())
 	}
 	defer rows.Close()
 
@@ -213,14 +209,12 @@ INSERT INTO profile_parameter (profile, parameter)
 	ON CONFLICT DO NOTHING
 `
 	if _, err = tx.Exec(q, dsPqArray, pq.Array(parameterIds)); err != nil {
-		log.Error.Printf("could not execute profile_parameter bulk insert: %s\n", err)
-		return nil, tc.DBError
+		return nil, errors.New("inserting profile_parameter: " + err.Error())
 	}
 
 	//process delete list
 	if _, err = tx.Exec(`DELETE FROM parameter WHERE name = 'location' AND config_file = ANY($1)`, pq.Array(delete)); err != nil {
-		log.Error.Printf("could not execute parameter delete query: %s\n", err)
-		return nil, tc.DBError
+		return nil, errors.New("deleting parameters: " + err.Error())
 	}
 
 	return dses, nil


### PR DESCRIPTION
# What does this PR (Pull Request) do?

Fixes Traffic Ops missing an error check in the servers assignment endpoint.

Fixes a missing `return` after a HandleErr, which will result in a double HTTP write to the client (or would, except the api helper has a safety to catch that; but it's still a bug).

Also fixes double-logging errors.

Tests for DSS endpoints already exist. This only happens on database error, it's not possible to simulate this particular error.

No documentation, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?

Run TO API Tests. Verify `servers/{id}/deliveryservices` endpoint works as expected.

## If this is a bug fix, what versions of Traffic Control are affected?
- 2.2.0
- 3.0.0

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
