### PR TITLE
TP: uses tenantId query param to fetch the users for a tenant

### DIFF
--- a/docs/source/api/users.rst
+++ b/docs/source/api/users.rst
@@ -36,7 +36,9 @@ Request Structure
 	+===========+==========+==========================================================================================+
 	| id        | no       | Return only the user identified by this integral, unique identifier                      |
 	+-----------+----------+------------------------------------------------------------------------------------------+
-	| tenant    | no       | Return only users belonging to the :term:`Tenant` identified by this integral, unique    |
+	| tenant    | no       | Return only users belonging to the :term:`Tenant` identified by tenant name              |
+	+-----------+----------+------------------------------------------------------------------------------------------+
+	| tenantId  | no       | Return only users belonging to the :term:`Tenant` identified by this integral, unique    |
 	|           |          | identifier                                                                               |
 	+-----------+----------+------------------------------------------------------------------------------------------+
 	| username  | no       | Return only the user with this username                                                  |

--- a/traffic_portal/app/src/modules/private/tenants/users/index.js
+++ b/traffic_portal/app/src/modules/private/tenants/users/index.js
@@ -31,7 +31,7 @@ module.exports = angular.module('trafficPortal.private.tenants.users', [])
 								return tenantService.getTenant($stateParams.tenantId);
 							},
 							tenantUsers: function(tenant, userService) {
-								return userService.getUsers({ tenant: tenant.id });
+								return userService.getUsers({ tenantId: tenant.id });
 							}
 						}
 					}


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #3679 

https://tp.domain.net/#!/tenants/1/users makes a call to GET api/1.4/users?tenant=1 but the appropriate query param is `tenantId`. This PR uses the `tenantId` query param and fixes the bug.

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Portal

## What is the best way to verify this PR?
In TP:

1. navigate to a tenant that you know has users assigned to it: https://tp.domain.com/#!/tenants/1
2. click on 'view users'

you should see a list of users assigned to that tenant. (before the list was always empty because the wrong query param was being used)

There are no UI tests with this PR because there are no UI tests for users in general at the moment. This is an area already identified as a gap and will be addressed with a future PR.

## If this is a bug fix, what versions of Traffic Control are affected?

- master (593e15f)
- 3.0.2
- 2.2.2

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
