### PR TITLE
Fix TO renamed route parameter

### DIFF
--- a/traffic_ops/traffic_ops_golang/ats/atsserver/parentdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/parentdotconfig.go
@@ -36,14 +36,14 @@ import (
 )
 
 func GetParentDotConfig(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-host"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"server-name-or-id"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
 	}
 	defer inf.Close()
 
-	idOrHost := strings.TrimSuffix(inf.Params["id-or-host"], ".json")
+	idOrHost := strings.TrimSuffix(inf.Params["server-name-or-id"], ".json")
 	hostName := ""
 	isHost := false
 	id, err := strconv.Atoi(idOrHost)


### PR DESCRIPTION
Fixes TO renamed route parameter. Route parameter was renamed, but not changed in the handler (actually, pretty sure I changed it, I think it was a bad merge, or merge non-conflict).

- [x] This PR is not related to any other issue

Tests already exist, this fixes them.
No documentation, no interface change.
No changelog, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?

Run API tests. Request parent.config endpoint.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
