### PR TITLE
Added deprecation notices for /user/current/update

### DIFF
--- a/docs/source/api/user_current_update.rst
+++ b/docs/source/api/user_current_update.rst
@@ -107,5 +107,9 @@ Response Structure
 		{
 			"level": "success",
 			"text": "User profile was successfully updated"
+		},
+		{
+			"level": "warning",
+			"text": "This endpoint is deprecated, please use 'PUT /api/1.4/user/current' instead"
 		}
 	]}

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -105,5 +105,4 @@ ADD infrastructure/cdn-in-a-box/enroller/server_template.json \
 
 ADD infrastructure/cdn-in-a-box/traffic_ops_data /traffic_ops_data
 
-# RUN chown -R trafops:trafops /opt/traffic_ops
 CMD /run.sh

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -105,5 +105,5 @@ ADD infrastructure/cdn-in-a-box/enroller/server_template.json \
 
 ADD infrastructure/cdn-in-a-box/traffic_ops_data /traffic_ops_data
 
-RUN chown -R trafops:trafops /opt/traffic_ops
+# RUN chown -R trafops:trafops /opt/traffic_ops
 CMD /run.sh

--- a/traffic_ops/app/lib/MojoPlugins/Response.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Response.pm
@@ -119,6 +119,27 @@ sub register {
 		}
 	);
 
+	$app->renderer->add_helper(
+		with_deprecation => sub {
+			my $self = shift || confess("Call on an instance of MojoPlugins::Response");
+			my $alert = shift || confess("Please supply an alert string");
+			my $level = shift || confess("Please supply an alert level such as 'error' or 'warning'");
+			my $code = shift || confess("Please supply a response code e.g. 400");
+			my $alternative = shift || confess("Please supply an alternative handler, like 'PUT /api/1.4/user/current'");
+			my $response_object = shift;
+
+			my $builder ||= MojoPlugins::Response::Builder->new($self, @_);
+			my @alerts_response = [{$LEVEL_KEY => $level, $TEXT_KEY => $alert}];
+			push(@alerts_response, {$LEVEL_KEY => $WARNING_LEVEL, $TEXT_KEY => "This endpoint is deprecated, please use '" . $alternative . "' instead"});
+
+			if (defined($response_object)) {
+				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response, $RESPONSE_KEY => $response_object } );
+			} else {
+				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response } );
+			}
+		}
+	);
+
 	# Alerts (500)
 	$app->renderer->add_helper(
 		internal_server_error => sub {

--- a/traffic_ops/app/lib/MojoPlugins/Response.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Response.pm
@@ -129,8 +129,7 @@ sub register {
 			my $response_object = shift;
 
 			my $builder ||= MojoPlugins::Response::Builder->new($self, @_);
-			my @alerts_response = [{$LEVEL_KEY => $level, $TEXT_KEY => $alert}];
-			push(@alerts_response, {$LEVEL_KEY => $WARNING_LEVEL, $TEXT_KEY => "This endpoint is deprecated, please use '" . $alternative . "' instead"});
+			my @alerts_response = ({$LEVEL_KEY => $level, $TEXT_KEY => $alert}, {$LEVEL_KEY => $WARNING_LEVEL, $TEXT_KEY => "This endpoint is deprecated, please use '" . $alternative . "' instead"});
 
 			if (defined($response_object)) {
 				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response, $RESPONSE_KEY => $response_object } );

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -851,7 +851,7 @@ sub api_routes {
 	$r->put("/api/$version/user/current")->over( authenticated => 1, not_ldap => 1 )->to( 'User#update_current', namespace => $namespace );
 
 	# alternate current user routes
-	$r->post("/api/$version/user/current/update")->over( authenticated => 1, not_ldap => 1 )->to( 'User#update_current', namespace => $namespace );
+	$r->post("/api/$version/user/current/update")->over( authenticated => 1, not_ldap => 1 )->to( 'User#user_current_update', namespace => $namespace );
 
 	# -- USERS: LOGIN
 	# login w/ username and password


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

Adds deprecation notices for the `/user/current/update` to all responses from that endpoint as well as to the documentation.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Make requests to the `/user/current/update` endpoint and notice the new warning-level alert indicating its deprecation.
Also, build and read the documentation.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
