### PR TITLE
Fix CIAB goose, login, and config gen issues

### DIFF
--- a/infrastructure/cdn-in-a-box/enroller/enroller.go
+++ b/infrastructure/cdn-in-a-box/enroller/enroller.go
@@ -832,6 +832,7 @@ func main() {
 	toSession, err := newSession(reqTimeout, toCreds.URL, toCreds.User, toCreds.Password)
 	if err != nil {
 		log.Errorln("error starting TrafficOps session: " + err.Error())
+		os.Exit(1)
 	}
 	log.Infoln("TrafficOps session established")
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -78,7 +78,8 @@ WORKDIR /opt/traffic_ops/app
 ADD traffic_ops/app/cpanfile traffic_ops/install/bin/install_goose.sh ./
 RUN cpanm -l ./local Carton && \
     POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton  && \
-    rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz ./cpanfile && ./install_goose.sh
+    rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz ./cpanfile
+RUN ./install_goose.sh
 
 # Override TRAFFIC_OPS_RPM arg to use a different one using --build-arg TRAFFIC_OPS_RPM=...  Can be local file or http://...
 ARG TRAFFIC_OPS_RPM=infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm

--- a/infrastructure/cdn-in-a-box/traffic_ops/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run.sh
@@ -108,11 +108,11 @@ export PATH=/usr/local/go/bin:/opt/traffic_ops/go/bin:$PATH
 export GOPATH=/opt/traffic_ops/go
 
 cd $TO_DIR && \
-	./db/admin.pl --env=production reset && \
-	./db/admin.pl --env=production upgrade || echo "db upgrade failed!"
+	./db/admin --env=production reset && \
+	./db/admin --env=production upgrade || { echo "db upgrade failed!"; exit 1; }
 
 # Add admin user -- all other users should be created using API
-/adduser.pl $TO_ADMIN_USER $TO_ADMIN_PASSWORD admin | psql -U$DB_USER -h$DB_SERVER $DB_NAME || echo "adding traffic_ops admin user failed!"
+/adduser.pl $TO_ADMIN_USER $TO_ADMIN_PASSWORD admin | psql -v ON_ERROR_STOP=1 -U$DB_USER -h$DB_SERVER $DB_NAME || { echo "adding traffic_ops admin user failed!"; exit 1; }
 
 cd $TO_DIR && $TO_DIR/local/bin/hypnotoad script/cdn
 

--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/config.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/config.sh
@@ -21,11 +21,17 @@
 # This script, which should be run when the container is run (it's the ENTRYPOINT), will configure the container.
 
 # Check that env vars are set
-envvars=( DB_SERVER DB_PORT DB_ROOT_PASS DB_USER DB_USER_PASS ADMIN_USER ADMIN_PASS DOMAIN TO_PERL_HOST TO_PERL_PORT TO_HOST TO_PORT TP_HOST)
-for v in $envvars
-do
-    if [[ -z $$v ]]; then echo "$v is unset"; exit 1; fi
+envvars=( DB_NAME DB_FQDN DB_USER DB_USER_PASS DB_PORT TO_HOST TO_PORT TO_ADMIN_PASSWORD )
+unset_vars=""
+for v in "${envvars[@]}"; do
+    if [[ -z "${!v}" ]]; then
+        unset_vars="$unset_vars $v"
+    fi
 done
+if [[ ! -z "$unset_vars" ]]; then
+    echo "required env vars are unset:$unset_vars"
+    exit 1
+fi
 
 cat <<-EOF >/opt/integration/app/traffic-ops-test.conf
 {
@@ -43,7 +49,7 @@ cat <<-EOF >/opt/integration/app/traffic-ops-test.conf
     },
     "trafficOps": {
         "URL": "https://$TO_HOST:$TO_PORT",
-        "password": "$ADMIN_PASS",
+        "password": "$TO_ADMIN_PASSWORD",
         "users": {
             "disallowed": "disallowed",
             "operations": "operations",


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

Fix the code that checks if required env vars are set and properly
return an error with all the unset vars. Fix it to use TO_ADMIN_PASSWORD
(from variables.env) instead of ADMIN_PASS which doesn't actually get
set anywhere.

The goose binary was not being installed properly, and the psql command
to add the TO admin user into the db was failing silently because of
this. Make sure the enroller gracefully exits if it's unable to login
properly.

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Build and run CIAB then run the CIAB TO API tests:
```
cd infrastructure/cdn-in-a-box
docker-compose -f docker-compose.yml --no-ansi up --build db trafficops trafficops-perl trafficportal trafficvault
docker-compose -f docker-compose.traffic-ops-test.yml -f docker-compose.yml --no-ansi  up --build integration
```

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] CIAB fix - no extra tests necessary
- [x] CIAB fix - no docs necessary
- [x] CIAB fix - no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
