### PR TITLE
Remove unused function in Traffic Portal

### DIFF
--- a/traffic_portal/app/src/common/api/ProfileService.js
+++ b/traffic_portal/app/src/common/api/ProfileService.js
@@ -91,17 +91,6 @@ var ProfileService = function($http, locationUtils, messageModel, ENV) {
         );
     };
 
-    this.getParamUnassignedProfiles = function(paramId) {
-        return $http.get(ENV.api['root'] + 'parameters/' + paramId + '/unassigned_profiles').then(
-            function (result) {
-                return result.data.response;
-            },
-            function (err) {
-                throw err;
-            }
-        );
-    };
-
     this.cloneProfile = function(sourceName, cloneName) {
         return $http.post(ENV.api['root'] + "profiles/name/" + cloneName + "/copy/" + sourceName).then(
             function(result) {


### PR DESCRIPTION

## What does this PR (Pull Request) do?
Remove an unused Traffic Portal function.
- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
1. Double-check the TP codebase for any actual usage of `getParamUnassignedProfiles`
2. Maybe overkill, but you could run the end_to_end TP tests to verify (I did this via CIAB and everything passed)

## The following criteria are ALL met by this PR

- [x] Removes unused code, no new tests necessary
- [x] Removes unused code, no docs necessary
- [x] Removes unused code, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
