### PR TITLE
Add qstring to path in TO access logs and log actual protocol used

### DIFF
--- a/traffic_ops/traffic_ops_golang/routing/routing.go
+++ b/traffic_ops/traffic_ops_golang/routing/routing.go
@@ -193,10 +193,10 @@ func Handler(
 	reqID := getReqID()
 
 	reqIDStr := strconv.FormatUint(reqID, 10)
-	log.Infoln(r.Method + " " + r.URL.Path + " handling (reqid " + reqIDStr + ")")
+	log.Infoln(r.Method + " " + r.URL.Path + "?" + r.URL.RawQuery + " handling (reqid " + reqIDStr + ")")
 	start := time.Now()
 	defer func() {
-		log.Infoln(r.Method + " " + r.URL.Path + " handled (reqid " + reqIDStr + ") in " + time.Since(start).String())
+		log.Infoln(r.Method + " " + r.URL.Path + "?" + r.URL.RawQuery + " handled (reqid " + reqIDStr + ") in " + time.Since(start).String())
 	}()
 
 	ctx := r.Context()

--- a/traffic_ops/traffic_ops_golang/routing/wrappers.go
+++ b/traffic_ops/traffic_ops_golang/routing/wrappers.go
@@ -142,7 +142,7 @@ func wrapAccessLog(secret string, h http.Handler) http.HandlerFunc {
 		}
 		start := time.Now()
 		defer func() {
-			log.EventfRaw(`%s - %s [%s] "%v %v HTTP/1.1" %v %v %v "%v"`, r.RemoteAddr, user, time.Now().Format(AccessLogTimeFormat), r.Method, r.URL.Path, iw.code, iw.byteCount, int(time.Now().Sub(start)/time.Millisecond), r.UserAgent())
+			log.EventfRaw(`%s - %s [%s] "%v %v?%v %s" %v %v %v "%v"`, r.RemoteAddr, user, time.Now().Format(AccessLogTimeFormat), r.Method, r.URL.Path, r.URL.RawQuery, r.Proto, iw.code, iw.byteCount, int(time.Now().Sub(start)/time.Millisecond), r.UserAgent())
 		}()
 		h.ServeHTTP(iw, r)
 	}


### PR DESCRIPTION

<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
Capture the entire request qstring in the log which will include things like resource IDs that are important to log. Without this, those IDs would only be logged if they were path params not qstring params. Also, don't hardcode HTTP/1.1 as the protocol used when other HTTP versions can actually be used.

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue


## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Make some TO API requests with nonempty qstrings to TO while tailing the TO logs and verify that the qstrings are now showing up in the logs (e.g. `/api/1.4/ping?foo=bar`).

## The following criteria are ALL met by this PR

- [x] Enhances log output, no new tests necessary
- [x] Enhances log output, no docs necessary
- [x] Enhances log output, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
