### PR TITLE
Remove atstccfg unused code

### DIFF
--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -168,10 +168,6 @@ func GetServerConfigRemapDotConfigForEdge(
 	atsMajorVersion int,
 	header string,
 ) string {
-	for name, val := range serverPackageParamData {
-		serverPackageParamData[name] = strings.Replace(val, "__HOSTNAME__", server.HostName+"."+server.DomainName, -1)
-	}
-
 	textLines := []string{}
 
 	for _, ds := range dses {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes code, where remap.config was replacing `__HOSTNAME__` in server
parameters, but if you trace thru the code, the only usage
of that data is to check a 'dscp_remap' parameter. The hostname
replacement is totally unused, and at worst, deceptive.

- [x] This PR is not related to any other Issue

This is tech debt.
No documentation, no interface change.
No tests, impossible to test, as the code was unused.
No changelog, no interface change.

## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT

## What is the best way to verify this PR?

Follow the code in the file, and verify the variable is never used for any data that can be a hostname.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
