### PR TITLE
added ability to select TLS version in TR

### DIFF
--- a/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
+++ b/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 public class RouterNioEndpoint extends NioEndpoint {
 	private static final Logger LOGGER = Logger.getLogger(RouterNioEndpoint.class);
+	private String protocols;
 
 	// Grabs the aliases from our custom certificate registry, creates a sslHostConfig for them
 	// and adds the newly created config to the list of sslHostConfigs.  We also remove the default config
@@ -65,7 +66,7 @@ public class RouterNioEndpoint extends NioEndpoint {
 			cert.setCertificateKeyAlias(alias);
 			sslHostConfig.addCertificate(cert);
 			sslHostConfig.setCertificateKeyAlias(alias);
-			sslHostConfig.setProtocols("all");
+			sslHostConfig.setProtocols(protocols != null ? protocols : "all");
 			sslHostConfig.setConfigType(getSslConfigType());
 			sslHostConfig.setCertificateVerification("none");
 			LOGGER.info("sslHostConfig: "+sslHostConfig.getHostName() + " " + sslHostConfig.getTruststoreAlgorithm());
@@ -118,6 +119,14 @@ public class RouterNioEndpoint extends NioEndpoint {
 				SSL.getLastErrorNumber();
 			}
 		}
+	}
+
+	public String getProtocols() {
+		return protocols;
+	}
+
+	public void setProtocols(final String protocols) {
+		this.protocols = protocols;
 	}
 
 }


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #3764 

This PR allows the selection of TLS version in Traffic Router.  It allows the protocols field in the Connector setup to be read in and used instead of the default "all" value.  No tests or documentation have been updated as this is a minor bug fix and adds functionality back in that was previously supported


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

In server.xml, add a protocols field to the 443 Connectors like this:
protocols="TLS1.2"

In CDN in a Box docker, run and wait until TR has been successfully started.  Log into any of the containers (i used TO) and verify that only the specified version of TLS is available.  Here is how i did the verification, though there are other ways:
Download this zip locally: https://github.com/drwetter/testssl.sh/archive/3.0.zip
Copy it into the TO container: docker cp ~/Downloads/testssl.sh-3.0.zip cdn-in-a-box_trafficops_1:/testsshl.zip
Log into the TO container: docker exec -it cdn-in-a-box_trafficops_1 /bin/bash
Install unzip: yum install unzip
Unzip the file: unzip /testsshl.zip 
Run the script on the test delivery service: testssl.sh-3.0/testssl.sh -p https://video.demo1.mycdn.ciab.test
Verify the results look like this:
 Testing protocols via sockets except NPN+ALPN 

 SSLv2      not offered (OK)
 SSLv3      not offered (OK)
 TLS 1      not offered
 TLS 1.1    not offered
 TLS 1.2    offered (OK)
 TLS 1.3    not offered and downgraded to a weaker protocol
 NPN/SPDY   not offered
 ALPN/HTTP2 not offered


Run the script against the API endpoint: testssl.sh-3.0/testssl.sh -p https://trafficrouter.infra.ciab.test:3443/crs/stats

Verify that this endpoint still allows all TLS versions with an output like this:
 Testing protocols via sockets except NPN+ALPN 

 SSLv2      not offered (OK)
 SSLv3      not offered (OK)
 TLS 1      offered (deprecated)
 TLS 1.1    offered (deprecated)
 TLS 1.2    offered (OK)
 TLS 1.3    not offered and downgraded to a weaker protocol
 NPN/SPDY   not offered
 ALPN/HTTP2 not offered



## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
