### PR TITLE
Add server capabilities API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Portal standalone Dockerfile
 - In Traffic Portal, removes the need to specify line breaks using `__RETURN__` in delivery service edge/mid header rewrite rules, regex remap expressions, raw remap text and traffic router additional request/response headers.
 - In Traffic Portal, provides the ability to clone delivery service assignments from one cache to another cache of the same type. Issue #2963.
+- Added an API 1.4 endpoint, /api/1.4/server_capabilities, to create, read, and delete server capabilities.
 - Traffic Ops now allows each delivery service to have a set of query parameter keys to be retained for consistent hash generation by Traffic Router.
 - In Traffic Portal, delivery service table columns can now be rearranged and their visibility toggled on/off as desired by the user. Hidden table columns are excluded from the table search. These settings are persisted in the browser.
 - Added an API 1.4 endpoint, /api/1.4/user/login/oauth to handle SSO login using OAuth.

--- a/lib/go-tc/server_capabilities.go
+++ b/lib/go-tc/server_capabilities.go
@@ -1,0 +1,31 @@
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ServerCapabilitiesResponse ...
+type ServerCapabilitiesResponse struct {
+	Response []ServerCapability `json:"response"`
+}
+
+// ServerCapability contains information about a given ServerCapability in Traffic Ops.
+type ServerCapability struct {
+	Name        string     `json:"name" db:"name"`
+	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
+}

--- a/lib/go-tc/server_capabilities.go
+++ b/lib/go-tc/server_capabilities.go
@@ -19,7 +19,7 @@ package tc
  * under the License.
  */
 
-// ServerCapabilitiesResponse ...
+// ServerCapabilitiesResponse contains the result data from a GET /server_capabilities request
 type ServerCapabilitiesResponse struct {
 	Response []ServerCapability `json:"response"`
 }
@@ -30,6 +30,7 @@ type ServerCapability struct {
 	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }
 
+// ServerCapabilityDetailResponse contains the result data from a POST /server_capabilities request
 type ServerCapabilityDetailResponse struct {
 	Response ServerCapability `json:"response"`
 	Alerts

--- a/lib/go-tc/server_capabilities.go
+++ b/lib/go-tc/server_capabilities.go
@@ -29,3 +29,8 @@ type ServerCapability struct {
 	Name        string     `json:"name" db:"name"`
 	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }
+
+type ServerCapabilityDetailResponse struct {
+	Response ServerCapability `json:"response"`
+	Alerts
+}

--- a/lib/go-tc/server_capabilities.go
+++ b/lib/go-tc/server_capabilities.go
@@ -19,7 +19,7 @@ package tc
  * under the License.
  */
 
-// ServerCapabilitiesResponse contains the result data from a GET /server_capabilities request
+// ServerCapabilitiesResponse contains the result data from a GET /server_capabilities request.
 type ServerCapabilitiesResponse struct {
 	Response []ServerCapability `json:"response"`
 }
@@ -30,7 +30,7 @@ type ServerCapability struct {
 	LastUpdated *TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }
 
-// ServerCapabilityDetailResponse contains the result data from a POST /server_capabilities request
+// ServerCapabilityDetailResponse contains the result data from a POST /server_capabilities request.
 type ServerCapabilityDetailResponse struct {
 	Response ServerCapability `json:"response"`
 	Alerts

--- a/lib/go-tc/tovalidate/rules.go
+++ b/lib/go-tc/tovalidate/rules.go
@@ -28,7 +28,7 @@ func NoSpaces(str string) bool {
 	return !strings.ContainsAny(str, " ")
 }
 
-// AlphanumericUnderscoreDash
+// IsAlphanumericUnderscoreDash returns true if the string consists of only alphanumeric, underscore, or dash characters.
 func IsAlphanumericUnderscoreDash(str string) bool {
 	return rxAlphanumericUnderscoreDash.MatchString(str)
 }

--- a/lib/go-tc/tovalidate/rules.go
+++ b/lib/go-tc/tovalidate/rules.go
@@ -17,12 +17,20 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"regexp"
 	"strings"
 )
+
+var rxAlphanumericUnderscoreDash = regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
 
 // NoSpaces returns true if the string has no spaces
 func NoSpaces(str string) bool {
 	return !strings.ContainsAny(str, " ")
+}
+
+// AlphanumericUnderscoreDash
+func IsAlphanumericUnderscoreDash(str string) bool {
+	return rxAlphanumericUnderscoreDash.MatchString(str)
 }
 
 // NoPeriods returns true if the string has no periods

--- a/traffic_ops/app/db/migrations/20191004000000_add_server_capabilities.sql
+++ b/traffic_ops/app/db/migrations/20191004000000_add_server_capabilities.sql
@@ -1,0 +1,27 @@
+/*
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+CREATE TABLE IF NOT EXISTS server_capability (
+    name TEXT PRIMARY KEY,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT name_empty CHECK (length(name) > 0)
+);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+DROP TABLE IF EXISTS server_capability;

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -169,6 +169,9 @@ insert into capability (name, description) values ('riak', 'Riak') ON CONFLICT (
 -- roles
 insert into capability (name, description) values ('roles-read', 'Ability to view roles') ON CONFLICT (name) DO NOTHING;
 insert into capability (name, description) values ('roles-write', 'ABILITY TO EDIT ROLES.') ON CONFLICT (name) DO NOTHING;
+-- server capabilities
+insert into capability (name, description) values ('server-capabilities-read', 'Ability to view server capabilities') ON CONFLICT (name) DO NOTHING;
+insert into capability (name, description) values ('server-capabilities-write', 'Ability to edit server capabilities') ON CONFLICT (name) DO NOTHING;
 -- servers
 insert into capability (name, description) values ('servers-read', 'Ability to view servers') ON CONFLICT (name) DO NOTHING;
 insert into capability (name, description) values ('servers-write', 'Ability to edit servers') ON CONFLICT (name) DO NOTHING;
@@ -253,6 +256,8 @@ insert into role_capability (role_id, cap_name) values ((select id from role whe
 insert into role_capability (role_id, cap_name) values ((select id from role where name='admin'), 'riak') ON CONFLICT (role_id, cap_name) DO NOTHING;
 insert into role_capability (role_id, cap_name) values ((select id from role where name='admin'), 'roles-read') ON CONFLICT (role_id, cap_name) DO NOTHING;
 insert into role_capability (role_id, cap_name) values ((select id from role where name='admin'), 'roles-write') ON CONFLICT (role_id, cap_name) DO NOTHING;
+insert into role_capability (role_id, cap_name) values ((select id from role where name='admin'), 'server-capabilities-read') ON CONFLICT (role_id, cap_name) DO NOTHING;
+insert into role_capability (role_id, cap_name) values ((select id from role where name='admin'), 'server-capabilities-write') ON CONFLICT (role_id, cap_name) DO NOTHING;
 insert into role_capability (role_id, cap_name) values ((select id from role where name='admin'), 'servers-read') ON CONFLICT (role_id, cap_name) DO NOTHING;
 insert into role_capability (role_id, cap_name) values ((select id from role where name='admin'), 'servers-write') ON CONFLICT (role_id, cap_name) DO NOTHING;
 insert into role_capability (role_id, cap_name) values ((select id from role where name='admin'), 'stats-read') ON CONFLICT (role_id, cap_name) DO NOTHING;
@@ -303,6 +308,7 @@ INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHER
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'read-only'), 'profiles-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'read-only') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'read-only'), 'regions-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'read-only') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'read-only'), 'roles-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'read-only') ON CONFLICT DO NOTHING;
+INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'read-only'), 'server-capabilities-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'read-only') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'read-only'), 'servers-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'read-only') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'read-only'), 'stats-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'read-only') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'read-only'), 'statuses-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'read-only') ON CONFLICT DO NOTHING;
@@ -344,6 +350,7 @@ INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHER
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'operations'), 'profiles-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'operations') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'operations'), 'regions-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'operations') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'operations'), 'roles-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'operations') ON CONFLICT DO NOTHING;
+INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'operations'), 'server-capabilities-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'operations') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'operations'), 'servers-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'operations') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'operations'), 'stats-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'operations') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) SELECT (SELECT id FROM role WHERE name = 'operations'), 'statuses-read' WHERE EXISTS (SELECT id FROM role WHERE name = 'operations') ON CONFLICT DO NOTHING;
@@ -641,6 +648,10 @@ insert into api_capability (http_method, route, capability) values ('GET', 'role
 insert into api_capability (http_method, route, capability) values ('POST', 'roles', 'roles-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
 insert into api_capability (http_method, route, capability) values ('PUT', 'roles', 'roles-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
 insert into api_capability (http_method, route, capability) values ('DELETE', 'roles', 'roles-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
+-- server capabilities
+insert into api_capability (http_method, route, capability) values ('GET', 'server_capabilities', 'server-capabilities-read') ON CONFLICT (http_method, route, capability) DO NOTHING;
+insert into api_capability (http_method, route, capability) values ('POST', 'server_capabilities', 'server-capabilities-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
+insert into api_capability (http_method, route, capability) values ('DELETE', 'server_capabilities', 'server-capabilities-write') ON CONFLICT (http_method, route, capability) DO NOTHING;
 -- servers
 insert into api_capability (http_method, route, capability) values ('GET', 'servers', 'servers-read') ON CONFLICT (http_method, route, capability) DO NOTHING;
 insert into api_capability (http_method, route, capability) values ('GET', 'servers/*', 'servers-read') ON CONFLICT (http_method, route, capability) DO NOTHING;

--- a/traffic_ops/client/servercapability.go
+++ b/traffic_ops/client/servercapability.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -67,8 +68,8 @@ func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, ReqInf, error
 
 // GetServerCapability returns the given server capability by name.
 func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, ReqInf, error) {
-	url := fmt.Sprintf("%s?name=%s", APIServerCapabilities, name)
-	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqUrl := fmt.Sprintf("%s?name=%s", APIServerCapabilities, url.QueryEscape(name))
+	resp, remoteAddr, err := to.request(http.MethodGet, reqUrl, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
 		return nil, reqInf, err
@@ -88,8 +89,8 @@ func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, ReqIn
 
 // DeleteServerCapability deletes the given server capability by name.
 func (to *Session) DeleteServerCapability(name string) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", APIServerCapabilities, name)
-	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqUrl := fmt.Sprintf("%s?name=%s", APIServerCapabilities, url.QueryEscape(name))
+	resp, remoteAddr, err := to.request(http.MethodDelete, reqUrl, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
 		return tc.Alerts{}, reqInf, err

--- a/traffic_ops/client/servercapability.go
+++ b/traffic_ops/client/servercapability.go
@@ -66,7 +66,7 @@ func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, ReqInf, error
 }
 
 // GetServerCapability returns the given server capability by name
-func (to *Session) GetServerCapability(name string) ([]tc.ServerCapability, ReqInf, error) {
+func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, ReqInf, error) {
 	url := fmt.Sprintf("%s?name=%s", APIServerCapabilities, name)
 	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
@@ -80,7 +80,10 @@ func (to *Session) GetServerCapability(name string) ([]tc.ServerCapability, ReqI
 		return nil, reqInf, err
 	}
 
-	return data.Response, reqInf, nil
+	if len(data.Response) == 1 {
+		return &data.Response[0], reqInf, nil
+	}
+	return nil, reqInf, fmt.Errorf("expected one server capability in response, instead got: %+v", data.Response)
 }
 
 // DeleteServerCapability deletes the given server capability by name

--- a/traffic_ops/client/servercapability.go
+++ b/traffic_ops/client/servercapability.go
@@ -28,7 +28,7 @@ const (
 	APIServerCapabilities = apiBase + "/server_capabilities"
 )
 
-// CreateServerCapability creates a server capability and returns the response
+// CreateServerCapability creates a server capability and returns the response.
 func (to *Session) CreateServerCapability(sc tc.ServerCapability) (*tc.ServerCapabilityDetailResponse, ReqInf, error) {
 	var remoteAddr net.Addr
 	reqBody, err := json.Marshal(sc)
@@ -48,7 +48,7 @@ func (to *Session) CreateServerCapability(sc tc.ServerCapability) (*tc.ServerCap
 	return &scResp, reqInf, nil
 }
 
-// GetServerCapabilities returns all the server capabilities
+// GetServerCapabilities returns all the server capabilities.
 func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, ReqInf, error) {
 	resp, remoteAddr, err := to.request(http.MethodGet, APIServerCapabilities, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
@@ -65,7 +65,7 @@ func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, ReqInf, error
 	return data.Response, reqInf, nil
 }
 
-// GetServerCapability returns the given server capability by name
+// GetServerCapability returns the given server capability by name.
 func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, ReqInf, error) {
 	url := fmt.Sprintf("%s?name=%s", APIServerCapabilities, name)
 	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
@@ -86,7 +86,7 @@ func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, ReqIn
 	return nil, reqInf, fmt.Errorf("expected one server capability in response, instead got: %+v", data.Response)
 }
 
-// DeleteServerCapability deletes the given server capability by name
+// DeleteServerCapability deletes the given server capability by name.
 func (to *Session) DeleteServerCapability(name string) (tc.Alerts, ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APIServerCapabilities, name)
 	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)

--- a/traffic_ops/client/servercapability.go
+++ b/traffic_ops/client/servercapability.go
@@ -1,0 +1,100 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	APIServerCapabilities = apiBase + "/server_capabilities"
+)
+
+// CreateServerCapability creates a server capability and returns the response
+func (to *Session) CreateServerCapability(sc tc.ServerCapability) (*tc.ServerCapabilityDetailResponse, ReqInf, error) {
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(sc)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, APIServerCapabilities, reqBody)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+	var scResp tc.ServerCapabilityDetailResponse
+	if err = json.NewDecoder(resp.Body).Decode(&scResp); err != nil {
+		return nil, reqInf, err
+	}
+	return &scResp, reqInf, nil
+}
+
+// GetServerCapabilities returns all the server capabilities
+func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, APIServerCapabilities, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ServerCapabilitiesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GetServerCapability returns the given server capability by name
+func (to *Session) GetServerCapability(name string) ([]tc.ServerCapability, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", APIServerCapabilities, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ServerCapabilitiesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DeleteServerCapability deletes the given server capability by name
+func (to *Session) DeleteServerCapability(name string) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APIServerCapabilities, name)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/testing/api/v14/servercapabilities_test.go
+++ b/traffic_ops/testing/api/v14/servercapabilities_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 func TestServerCapabilities(t *testing.T) {
 	WithObjs(t, []TCObj{ServerCapabilities}, func() {
 		GetTestServerCapabilities(t)
+		ValidationTestServerCapabilities(t)
 	})
 }
 
@@ -56,6 +58,13 @@ func GetTestServerCapabilities(t *testing.T) {
 	}
 	if len(resp) != len(testData.ServerCapabilities) {
 		t.Errorf("expected to GET %d server capabilities, actual: %d", len(testData.ServerCapabilities), len(resp))
+	}
+}
+
+func ValidationTestServerCapabilities(t *testing.T) {
+	_, _, err := TOSession.CreateServerCapability(tc.ServerCapability{Name: "b@dname"})
+	if err == nil {
+		t.Errorf("expected POST with invalid name to return an error, actual: nil")
 	}
 }
 

--- a/traffic_ops/testing/api/v14/servercapabilities_test.go
+++ b/traffic_ops/testing/api/v14/servercapabilities_test.go
@@ -1,0 +1,82 @@
+package v14
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+)
+
+func TestServerCapabilities(t *testing.T) {
+	WithObjs(t, []TCObj{ServerCapabilities}, func() {
+		GetTestServerCapabilities(t)
+	})
+}
+
+func CreateTestServerCapabilities(t *testing.T) {
+	log.Debugln("---- CreateTestServerCapabilities ----")
+
+	for _, sc := range testData.ServerCapabilities {
+		resp, _, err := TOSession.CreateServerCapability(sc)
+		if err != nil {
+			t.Errorf("could not CREATE server capability: %v\n", err)
+		}
+		log.Debugln("Response: ", resp)
+	}
+
+}
+
+func GetTestServerCapabilities(t *testing.T) {
+	log.Debugln("---- GetTestServerCapabilities ----")
+
+	for _, sc := range testData.ServerCapabilities {
+		resp, _, err := TOSession.GetServerCapability(sc.Name)
+		if err != nil {
+			t.Errorf("cannot GET server capability: %v - %v\n", err, resp)
+
+		}
+
+		log.Debugln("Response: ", resp)
+	}
+
+	resp, _, err := TOSession.GetServerCapabilities()
+	if err != nil {
+		t.Errorf("cannot GET server capabilities: %v\n", err)
+	}
+	if len(resp) != len(testData.ServerCapabilities) {
+		t.Errorf("expected to GET %d server capabilities, actual: %d", len(testData.ServerCapabilities), len(resp))
+	}
+}
+
+func DeleteTestServerCapabilities(t *testing.T) {
+	log.Debugln("---- DeleteTestServerCapabilities ----")
+
+	for _, sc := range testData.ServerCapabilities {
+		delResp, _, err := TOSession.DeleteServerCapability(sc.Name)
+		if err != nil {
+			t.Errorf("cannot DELETE server capability: %v - %v\n", err, delResp)
+		}
+
+		serverCapability, _, err := TOSession.GetServerCapability(sc.Name)
+		if err != nil {
+			t.Errorf("error deleting server capability: %s\n", err.Error())
+		}
+		if len(serverCapability) > 0 {
+			t.Errorf("expected server capability: %s to be deleted\n", sc.Name)
+		}
+	}
+}

--- a/traffic_ops/testing/api/v14/servercapabilities_test.go
+++ b/traffic_ops/testing/api/v14/servercapabilities_test.go
@@ -47,10 +47,9 @@ func GetTestServerCapabilities(t *testing.T) {
 		resp, _, err := TOSession.GetServerCapability(sc.Name)
 		if err != nil {
 			t.Errorf("cannot GET server capability: %v - %v\n", err, resp)
-
+		} else if resp == nil {
+			t.Errorf("GET server capability expected non-nil response")
 		}
-
-		log.Debugln("Response: ", resp)
 	}
 
 	resp, _, err := TOSession.GetServerCapabilities()
@@ -72,11 +71,11 @@ func DeleteTestServerCapabilities(t *testing.T) {
 		}
 
 		serverCapability, _, err := TOSession.GetServerCapability(sc.Name)
-		if err != nil {
-			t.Errorf("error deleting server capability: %s\n", err.Error())
+		if err == nil {
+			t.Errorf("expected error trying to GET deleted server capability: %s, actual: nil\n", sc.Name)
 		}
-		if len(serverCapability) > 0 {
-			t.Errorf("expected server capability: %s to be deleted\n", sc.Name)
+		if serverCapability != nil {
+			t.Errorf("expected nil trying to GET deleted server capability: %s, actual: non-nil\n", sc.Name)
 		}
 	}
 }

--- a/traffic_ops/testing/api/v14/servercapabilities_test.go
+++ b/traffic_ops/testing/api/v14/servercapabilities_test.go
@@ -28,7 +28,6 @@ func TestServerCapabilities(t *testing.T) {
 }
 
 func CreateTestServerCapabilities(t *testing.T) {
-	log.Debugln("---- CreateTestServerCapabilities ----")
 
 	for _, sc := range testData.ServerCapabilities {
 		resp, _, err := TOSession.CreateServerCapability(sc)
@@ -41,7 +40,6 @@ func CreateTestServerCapabilities(t *testing.T) {
 }
 
 func GetTestServerCapabilities(t *testing.T) {
-	log.Debugln("---- GetTestServerCapabilities ----")
 
 	for _, sc := range testData.ServerCapabilities {
 		resp, _, err := TOSession.GetServerCapability(sc.Name)
@@ -62,7 +60,6 @@ func GetTestServerCapabilities(t *testing.T) {
 }
 
 func DeleteTestServerCapabilities(t *testing.T) {
-	log.Debugln("---- DeleteTestServerCapabilities ----")
 
 	for _, sc := range testData.ServerCapabilities {
 		delResp, _, err := TOSession.DeleteServerCapability(sc.Name)

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -1696,6 +1696,14 @@
             "xmppPasswd": ""
         }
     ],
+    "serverCapabilities": [
+        {
+            "name": "foo"
+        },
+        {
+            "name": "bar"
+        }
+    ],
     "staticdnsentries": [
         {
             "address": "192.168.0.1",

--- a/traffic_ops/testing/api/v14/traffic_control.go
+++ b/traffic_ops/testing/api/v14/traffic_control.go
@@ -39,6 +39,7 @@ type TrafficControl struct {
 	Regions                        []tc.Region                        `json:"regions"`
 	Roles                          []tc.Role                          `json:"roles"`
 	Servers                        []tc.Server                        `json:"servers"`
+	ServerCapabilities             []tc.ServerCapability              `json:"serverCapabilities"`
 	Statuses                       []tc.StatusNullable                `json:"statuses"`
 	StaticDNSEntries               []tc.StaticDNSEntry                `json:"staticdnsentries"`
 	Tenants                        []tc.Tenant                        `json:"tenants"`

--- a/traffic_ops/testing/api/v14/withobjs.go
+++ b/traffic_ops/testing/api/v14/withobjs.go
@@ -52,6 +52,7 @@ const (
 	ProfileParameters
 	Regions
 	Roles
+	ServerCapabilities
 	ServerChecks
 	Servers
 	Statuses
@@ -86,6 +87,7 @@ var withFuncs = map[TCObj]TCObjFuncs{
 	ProfileParameters:              {CreateTestProfileParameters, DeleteTestProfileParameters},
 	Regions:                        {CreateTestRegions, DeleteTestRegions},
 	Roles:                          {CreateTestRoles, DeleteTestRoles},
+	ServerCapabilities:             {CreateTestServerCapabilities, DeleteTestServerCapabilities},
 	ServerChecks:                   {CreateTestServerChecks, DeleteTestServerChecks},
 	Servers:                        {CreateTestServers, DeleteTestServers},
 	Statuses:                       {CreateTestStatuses, DeleteTestStatuses},

--- a/traffic_ops/traffic_ops_golang/api/generic_crud.go
+++ b/traffic_ops/traffic_ops_golang/api/generic_crud.go
@@ -166,7 +166,7 @@ func GenericDelete(val GenericDeleter) (error, error, int) {
 	if rowsAffected, err := result.RowsAffected(); err != nil {
 		return nil, errors.New("deleting " + val.GetType() + ": getting rows affected: " + err.Error()), http.StatusInternalServerError
 	} else if rowsAffected < 1 {
-		return errors.New("no " + val.GetType() + " with that id found"), nil, http.StatusNotFound
+		return errors.New("no " + val.GetType() + " with that key found"), nil, http.StatusNotFound
 	} else if rowsAffected > 1 {
 		return nil, fmt.Errorf(val.GetType()+" delete affected too many rows: %d", rowsAffected), http.StatusInternalServerError
 	}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -68,6 +68,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/region"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/role"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/server"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/servercapability"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/servercheck"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/staticdnsentry"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/status"
@@ -264,6 +265,11 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPut, `servers/{id}$`, api.UpdateHandler(&server.TOServer{}), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `servers/?$`, api.CreateHandler(&server.TOServer{}), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodDelete, `servers/{id}$`, api.DeleteHandler(&server.TOServer{}), auth.PrivLevelOperations, Authenticated, nil},
+
+		//Server Capability
+		{1.4, http.MethodGet, `server_capabilities$`, api.ReadHandler(&servercapability.TOServerCapability{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.4, http.MethodPost, `server_capabilities$`, api.CreateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, Authenticated, nil},
+		{1.4, http.MethodDelete, `server_capabilities$`, api.DeleteHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Status: CRUD
 		{1.1, http.MethodGet, `statuses/?(\.json)?$`, api.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
+++ b/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
@@ -35,15 +35,41 @@ type TOServerCapability struct {
 }
 
 func (v *TOServerCapability) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
-func (v *TOServerCapability) InsertQuery() string           { return insertQuery() }
 func (v *TOServerCapability) NewReadObj() interface{}       { return &tc.ServerCapability{} }
-func (v *TOServerCapability) SelectQuery() string           { return selectQuery() }
+
+func (v *TOServerCapability) InsertQuery() string {
+	return `
+INSERT INTO server_capability (
+  name
+)
+VALUES (
+  :name
+)
+RETURNING last_updated
+`
+}
+
+func (v *TOServerCapability) SelectQuery() string {
+	return `
+SELECT
+  name,
+  last_updated
+FROM
+  server_capability sc
+`
+}
+
+func (v *TOServerCapability) DeleteQuery() string {
+	return `
+DELETE FROM server_capability WHERE name=:name
+`
+}
+
 func (v *TOServerCapability) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 	return map[string]dbhelpers.WhereColumnInfo{
 		"name": {"sc.name", nil},
 	}
 }
-func (v *TOServerCapability) DeleteQuery() string { return deleteQuery() }
 
 func (v TOServerCapability) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"name", api.GetStringKey}}
@@ -76,25 +102,3 @@ func (v *TOServerCapability) Validate() error {
 func (v *TOServerCapability) Read() ([]interface{}, error, error, int) { return api.GenericRead(v) }
 func (v *TOServerCapability) Create() (error, error, int)              { return api.GenericCreateNameBasedID(v) }
 func (v *TOServerCapability) Delete() (error, error, int)              { return api.GenericDelete(v) }
-
-func selectQuery() string {
-	return `SELECT
-name,
-last_updated
-FROM server_capability sc`
-}
-
-func insertQuery() string {
-	query := `INSERT INTO server_capability (
-name
-) VALUES (
-:name
-) RETURNING last_updated`
-	return query
-}
-
-func deleteQuery() string {
-	query := `DELETE FROM server_capability
-WHERE name=:name`
-	return query
-}

--- a/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
+++ b/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
@@ -49,7 +49,7 @@ func (v TOServerCapability) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"name", api.GetStringKey}}
 }
 
-//Implementation of the Identifier, Validator interface functions
+// Implementation of the Identifier, Validator interface functions
 func (v TOServerCapability) GetKeys() (map[string]interface{}, bool) {
 	return map[string]interface{}{"name": v.Name}, true
 }

--- a/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
+++ b/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
@@ -1,0 +1,100 @@
+package servercapability
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+type TOServerCapability struct {
+	api.APIInfoImpl `json:"-"`
+	tc.ServerCapability
+}
+
+func (v *TOServerCapability) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
+func (v *TOServerCapability) InsertQuery() string           { return insertQuery() }
+func (v *TOServerCapability) NewReadObj() interface{}       { return &tc.ServerCapability{} }
+func (v *TOServerCapability) SelectQuery() string           { return selectQuery() }
+func (v *TOServerCapability) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
+	return map[string]dbhelpers.WhereColumnInfo{
+		"name": {"sc.name", nil},
+	}
+}
+func (v *TOServerCapability) DeleteQuery() string { return deleteQuery() }
+
+func (v TOServerCapability) GetKeyFieldsInfo() []api.KeyFieldInfo {
+	return []api.KeyFieldInfo{{"name", api.GetStringKey}}
+}
+
+//Implementation of the Identifier, Validator interface functions
+func (v TOServerCapability) GetKeys() (map[string]interface{}, bool) {
+	return map[string]interface{}{"name": v.Name}, true
+}
+
+func (v *TOServerCapability) SetKeys(keys map[string]interface{}) {
+	v.Name, _ = keys["name"].(string)
+}
+
+func (v *TOServerCapability) GetAuditName() string {
+	return v.Name
+}
+
+func (v *TOServerCapability) GetType() string {
+	return "server capability"
+}
+
+func (v *TOServerCapability) Validate() error {
+	errs := validation.Errors{
+		"name": validation.Validate(v.Name, validation.Required),
+	}
+	return util.JoinErrs(tovalidate.ToErrors(errs))
+}
+
+func (v *TOServerCapability) Read() ([]interface{}, error, error, int) { return api.GenericRead(v) }
+func (v *TOServerCapability) Create() (error, error, int)              { return api.GenericCreateNameBasedID(v) }
+func (v *TOServerCapability) Delete() (error, error, int)              { return api.GenericDelete(v) }
+
+func selectQuery() string {
+	return `SELECT
+name,
+last_updated
+FROM server_capability sc`
+}
+
+func insertQuery() string {
+	query := `INSERT INTO server_capability (
+name
+) VALUES (
+:name
+) RETURNING last_updated`
+	return query
+}
+
+func deleteQuery() string {
+	query := `DELETE FROM server_capability
+WHERE name=:name`
+	return query
+}

--- a/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
+++ b/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
@@ -93,8 +93,9 @@ func (v *TOServerCapability) GetType() string {
 }
 
 func (v *TOServerCapability) Validate() error {
+	rule := validation.NewStringRule(tovalidate.IsAlphanumericUnderscoreDash, "must consist of only alphanumeric, dash, or underscore characters")
 	errs := validation.Errors{
-		"name": validation.Validate(v.Name, validation.Required),
+		"name": validation.Validate(v.Name, validation.Required, rule),
 	}
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Add a new API for creating, reading, and deleting (not updating) server capabilities:
```
POST /api/1.4/server_capabilities
GET /api/1.4/server_capabilities[?name=<name>]
DELETE /api/1.4/server_capabilities?name=<name>

expected POST body:
{"name": "bar"}

expected POST response:
{
  "alerts": [
    {
      "text": "server capability was created.",
      "level": "success"
    }
  ],
  "response": {
    "name": "bar",
    "lastUpdated": "2019-10-07 22:10:00+00"
  }
}

expected GET response (can use ?name=... qparam to filter by name):
{
  "response": [
    {
      "name": "bar",
      "lastUpdated": "2019-10-07 20:38:24+00"
    }
  ]
}

expected DELETE response:
{
  "alerts": [
    {
      "text": "server capability was deleted.",
      "level": "success"
    }
  ]
}
```

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Control Client (Go)
- Traffic Monitor
- Traffic Ops

Documentation will be done in a follow-up PR.

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Read the added TO API tests to verify they're sufficient, then run the TO API tests.

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
