### PR TITLE
TR code coverage with Jacoco

### DIFF
--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -33,6 +33,7 @@
 		         command line -->
 			<java.library.path>must be passed on the Maven commandline</java.library.path>
 			<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+			<jacoco.version>0.8.2</jacoco.version>
     </properties>
 	<repositories>
 		<repository>
@@ -215,6 +216,20 @@
 								<include>**/*.java</include>
 							</includes>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.2</version>
+				<executions>
+					<execution>
+						<id>default</id>
+						<goals>
+							<goal>prepare-agent</goal>
+							<goal>report</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -182,7 +182,8 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19.1</version>
 				<configuration>
-					<argLine>-XX:-UseSplitVerifier -Djava.library.path=${java.library.path}</argLine>
+					<!-- Commenting SplitVerifier since it is deprecated with Java 8-->
+					<!--<argLine>-XX:-UseSplitVerifier -Djava.library.path=${java.library.path}</argLine>-->
 					<excludedGroups>com.comcast.cdn.traffic_control.traffic_router.core.util.IntegrationTest,com.comcast.cdn.traffic_control.traffic_router.core.util.ExternalTest</excludedGroups>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
Code Coverage For TR

- [x] This PR is not related to any Issue.  Exposes the code coverage for Traffic Router Component.

## Which Traffic Control components are affected by this PR?
This doesn't affect the functionality of the any component. Just exposes the unit test coverage for TR component. Testing, documentation, changelog is not required.

## What is the best way to verify this PR?
Jenkins job should show coverage information by func
![image](https://user-images.githubusercontent.com/56312239/66569257-ca158b80-eb88-11e9-9740-a4da2577a436.png)


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [ ] This PR includes any and all required license headers
- [ ] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [ ] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
