### PR TITLE
Add atscfg logic for Server Capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an optional SMTP server configuration to the TO configuration file, api now has unused abilitiy to send emails
 - Traffic Monitor now has "gbps" calculated stat, allowing operators to monitor bandwidth in Gbps.
 - Added an API 1.4 endpoint, /api/1.4/deliveryservices_required_capabilities, to create, read, and delete associations between a delivery service and a required capability.
+- Added ATS config generation omitting parents without Delivery Service Required Capabilities.
 - In Traffic Portal, added the ability to create, view and delete server capabilities and associate those server capabilities with servers and delivery services. See [blueprint](./blueprints/server-capabilitites.md)
 
 ### Changed

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -34,6 +34,8 @@ const DefaultATSVersion = "5" // TODO Emulates Perl; change to 6? ATC no longer 
 
 const HeaderCommentDateFormat = "Mon Jan 2 15:04:05 MST 2006"
 
+type ServerCapability string
+
 type ServerInfo struct {
 	CacheGroupID                  int
 	CDN                           tc.CDNName

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -79,7 +79,7 @@ func TestMakeParentDotConfig(t *testing.T) {
 		ParentConfigParamQString:         "myQstringParam",
 	}
 
-	parentInfos := map[string][]ParentInfo{
+	parentInfos := map[OriginHost][]ParentInfo{
 		"ds1.example.net": []ParentInfo{
 			ParentInfo{
 				Host:            "my-parent-0",
@@ -107,5 +107,134 @@ func TestMakeParentDotConfig(t *testing.T) {
 	}
 	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
 		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	}
+}
+
+func TestMakeParentDotConfigCapabilities(t *testing.T) {
+	atsMajorVer := 7
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	parentConfigDSes := []ParentConfigDSTopLevel{
+		ParentConfigDSTopLevel{
+			ParentConfigDS: ParentConfigDS{
+				Name:            "ds0",
+				QStringIgnore:   tc.QStringIgnoreUseInCacheKeyAndPassUp,
+				OriginFQDN:      "http://ds0.example.net",
+				MultiSiteOrigin: false,
+				Type:            tc.DSTypeHTTP,
+				QStringHandling: "ds0qstringhandling",
+				RequiredCapabilities: map[ServerCapability]struct{}{
+					"FOO": {},
+				},
+			},
+		},
+	}
+
+	serverInfo := &ServerInfo{
+		CacheGroupID:                  42,
+		CDN:                           "myCDN",
+		CDNID:                         43,
+		DomainName:                    "serverdomain.example.net",
+		HostName:                      "myserver",
+		ID:                            44,
+		IP:                            "192.168.2.1",
+		ParentCacheGroupID:            45,
+		ParentCacheGroupType:          "myParentCGType",
+		ProfileID:                     46,
+		ProfileName:                   "MyProfileName",
+		Port:                          80,
+		SecondaryParentCacheGroupID:   47,
+		SecondaryParentCacheGroupType: "MySecondaryParentCGType",
+		Type:                          "EDGE",
+	}
+
+	serverParams := map[string]string{
+		ParentConfigParamQStringHandling: "myQStringHandlingParam",
+		ParentConfigParamAlgorithm:       tc.AlgorithmConsistentHash,
+		ParentConfigParamQString:         "myQstringParam",
+	}
+
+	parentInfos := map[OriginHost][]ParentInfo{
+		DeliveryServicesAllParentsKey: []ParentInfo{
+			ParentInfo{
+				Host:            "my-parent-nocaps",
+				Port:            80,
+				Domain:          "my-parent-nocaps-domain",
+				Weight:          "1",
+				UseIP:           false,
+				Rank:            1,
+				IP:              "192.168.2.1",
+				PrimaryParent:   true,
+				SecondaryParent: true,
+				Capabilities:    map[ServerCapability]struct{}{},
+			},
+			ParentInfo{
+				Host:            "my-parent-fooonly",
+				Port:            80,
+				Domain:          "my-parent-fooonly-domain",
+				Weight:          "1",
+				UseIP:           false,
+				Rank:            1,
+				IP:              "192.168.2.2",
+				PrimaryParent:   true,
+				SecondaryParent: true,
+				Capabilities: map[ServerCapability]struct{}{
+					"FOO": {},
+				},
+			},
+			ParentInfo{
+				Host:            "my-parent-foobar",
+				Port:            80,
+				Domain:          "my-parent-foobar-domain",
+				Weight:          "1",
+				UseIP:           false,
+				Rank:            1,
+				IP:              "192.168.2.2",
+				PrimaryParent:   true,
+				SecondaryParent: true,
+				Capabilities: map[ServerCapability]struct{}{
+					"FOO": {},
+					"BAR": {},
+				},
+			},
+		},
+	}
+
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	lines := strings.Split(txt, "\n")
+
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines (comment, ds, dot remap, and empty newline), actual: '%+v'", len(lines))
+	}
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue // skip empty newline
+		}
+		if strings.HasPrefix(line, `dest_domain=.`) {
+			continue // skip dot remap, which has all parents irrespective of capability
+		}
+		if strings.HasPrefix(line, `#`) {
+			continue // skip comment
+		}
+
+		if !strings.Contains(line, "dest_domain=ds0.example.net") {
+			t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", line)
+		}
+		if !strings.Contains(line, "foobar") {
+			t.Errorf("expected parent with all capabilities, actual: '%v'", line)
+		}
+		if !strings.Contains(line, "fooonly") {
+			t.Errorf("expected parent with required capabilities, actual: '%v'", line)
+		}
+		if strings.Contains(line, "nocaps") {
+			t.Errorf("expected not to contain parent with no capabilities, actual line: '%v'", line)
+		}
 	}
 }

--- a/traffic_ops/traffic_ops_golang/ats/db.go
+++ b/traffic_ops/traffic_ops_golang/ats/db.go
@@ -945,3 +945,67 @@ func GetCDNNameFromNameOrID(tx *sql.Tx, cdnNameOrID string) (string, error, erro
 	}
 	return cdnName, nil, nil, http.StatusOK
 }
+
+// GetServerCapabilities returns the list of capabilities assigned to the given servers.
+func GetServerCapabilitiesByID(tx *sql.Tx, serverIDs []int) (map[int]map[atscfg.ServerCapability]struct{}, error) {
+	qry := `
+SELECT
+  sc.server,
+  sc.server_capability
+FROM
+  server_server_capability sc
+WHERE
+  sc.server = ANY($1)
+`
+	rows, err := tx.Query(qry, pq.Array(serverIDs))
+	if err != nil {
+		return nil, errors.New("querying: " + err.Error())
+	}
+	defer rows.Close()
+
+	serverCaps := map[int]map[atscfg.ServerCapability]struct{}{}
+	for rows.Next() {
+		id := 0
+		cap := atscfg.ServerCapability("")
+		if err := rows.Scan(&id, &cap); err != nil {
+			return nil, errors.New("scanning: " + err.Error())
+		}
+		if _, ok := serverCaps[id]; !ok {
+			serverCaps[id] = map[atscfg.ServerCapability]struct{}{}
+		}
+		serverCaps[id][cap] = struct{}{}
+	}
+	return serverCaps, nil
+}
+
+// GetDeliveryServiceRequiredCapabilities returns the list of required capabilities assigned to the given delivery services.
+func GetDeliveryServiceRequiredCapabilities(tx *sql.Tx, dses []int) (map[int]map[atscfg.ServerCapability]struct{}, error) {
+	qry := `
+SELECT
+  dsc.deliveryservice_id,
+  dsc.required_capability
+FROM
+  deliveryservices_required_capability dsc
+WHERE
+  dsc.deliveryservice_id = ANY($1)
+`
+	rows, err := tx.Query(qry, pq.Array(dses))
+	if err != nil {
+		return nil, errors.New("querying: " + err.Error())
+	}
+	defer rows.Close()
+
+	dsCaps := map[int]map[atscfg.ServerCapability]struct{}{}
+	for rows.Next() {
+		id := 0
+		cap := atscfg.ServerCapability("")
+		if err := rows.Scan(&id, &cap); err != nil {
+			return nil, errors.New("scanning: " + err.Error())
+		}
+		if _, ok := dsCaps[id]; !ok {
+			dsCaps[id] = map[atscfg.ServerCapability]struct{}{}
+		}
+		dsCaps[id][cap] = struct{}{}
+	}
+	return dsCaps, nil
+}


### PR DESCRIPTION
Adds parent.config omitting parents which lack server capabilities required by Delivery Services.

- [x] This PR is not related to any other Issue

Includes changelog.
Includes unit tests for config generation.
Documentation already exists for Server Capabilities; ATS config generation details are not currently documented.

## Which Traffic Control components are affected by this PR?
- Traffic Ops
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests.

Create a DS with Required Capabilities, ensure servers exist which lack those Capabilities, verify parent.config (both at the old TO endpoint, and by `atstccfg`) don't contain those servers. Verify parent.config DSes with Required Capabilities do contain servers which have the Required Capabilities.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
