### PR TITLE
Rewrote /user/current to Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,6 @@ local.tar.gz
 .projectile
 *.bak
 *.iml
-# Traffic Ops binary
+# built local binaries
 ./traffic_ops_golang
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.1/federations/:id/users/:userID
   - /api/1.2/current_stats
   - /api/1.1/osversions
+  - /api/1.1/user/current `PUT`
 
 - Traffic Router: Added a tunable bounded queue to support DNS request processing.
 - Traffic Ops API Routing Blacklist: via the `routing_blacklist` field in `cdn.conf`, enable certain whitelisted Go routes to be handled by Perl instead (via the `perl_routes` list) in case a regression is found in the Go handler, and explicitly disable any routes via the `disabled_routes` list. Requests to disabled routes are immediately given a 503 response. Both fields are lists of Route IDs, and route information (ID, version, method, path, and whether or not it can bypass to Perl) can be found by running `./traffic_ops_golang --api-routes`. To disable a route or have it bypassed to Perl, find its Route ID using the previous command and put it in the `disabled_routes` or `perl_routes` list, respectively.

--- a/docs/source/api/user_current.rst
+++ b/docs/source/api/user_current.rst
@@ -21,7 +21,9 @@
 
 ``GET``
 =======
-Retrieves the profile for the authenticated user.
+.. caution:: As a username is needed to log in, any administrator or application must necessarily know the current username at any given time. Thus it's generally better to use the ``username`` query parameter of a ``GET`` request to :ref:`to-api-users` instead.
+
+Retrieves the details of the authenticated user.
 
 :Auth. Required: Yes
 :Roles Required: None
@@ -40,20 +42,20 @@ Response Structure
 :country:          The name of the country wherein the user resides
 :email:            The user's email address
 :fullName:         The user's full name, e.g. "John Quincy Adams"
-:gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
+:gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
 :publicSshKey:     The user's public key used for the SSH protocol
 :registrationSent: If the user was created using the :ref:`to-api-users-register` endpoint, this will be the date and time at which the registration email was sent - otherwise it will be ``null``
-:role:             The integral, unique identifier of the highest-privilege role assigned to this user
-:rolename:         The name of the highest-privilege role assigned to this user
+:role:             The integral, unique identifier of the highest-privilege :term:`Role` assigned to this user
+:rolename:         The name of the highest-privilege :term:`Role` assigned to this user
 :stateOrProvince:  The name of the state or province where this user resides
-:tenant:           The name of the tenant to which this user belongs
-:tenantId:         The integral, unique identifier of the tenant to which this user belongs
-:uid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX user ID of the user - now it is always ``null``
+:tenant:           The name of the :term:`Tenant` to which this user belongs
+:tenantId:         The integral, unique identifier of the :term:`Tenant` to which this user belongs
+:uid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX user ID of the user
 :username:         The user's username
 
 .. code-block:: http
@@ -98,8 +100,7 @@ Response Structure
 
 ``PUT``
 =======
-.. deprecated:: 1.4
-	Use the ``PUT`` method of the :ref:`to-api-users` instead.
+.. warning:: Assuming the current user's integral, unique identifier is known, it's generally better to use the ``PUT`` method of the :ref:`to-api-users` instead.
 
 .. warning:: Users that login via LDAP pass-back cannot be modified
 
@@ -107,34 +108,39 @@ Updates the date for the authenticated user.
 
 :Auth. Required: Yes
 :Roles Required: None
-:Response Type:  ``undefined``
+:Response Type:  Object
+
+	.. versionchanged:: ATCv4
+		Starting in ATC version 4, all API versions respond to this endpoint with the updated user information. Prior to that, no response object was returned at all.
+
 
 Request Structure
 -----------------
-:addressLine1:       An optional field which should contain the user's address - including street name and number
-:addressLine2:       An optional field which should contain an additional address field for e.g. apartment number
-:city:               An optional field which should contain the name of the city wherein the user resides
-:company:            An optional field which should contain the name of the company for which the user works
-:confirmLocalPasswd: The 'confirm' field in a new user's password specification - must match ``localPasswd``
-:country:            An optional field which should contain the name of the country wherein the user resides
-:email:              The user's email address
+:user: The entire request must be inside a top-level "user" key for legacy reasons
 
-	.. versionchanged:: 1.4
-		Prior to version 1.4, the email was validated using the `Email::Valid Perl package <https://metacpan.org/pod/Email::Valid>`_ but is now validated (circuitously) by `GitHub user asaskevich's regular expression <https://github.com/asaskevich/govalidator/blob/9a090521c4893a35ca9a228628abf8ba93f63108/patterns.go#L7>`_ . Note that neither method can actually distinguish a valid, deliverable, email address but merely ensure the email is in a commonly-found format.
+	:addressLine1:       The user's address - including street name and number
+	:addressLine2:       An additional address field for e.g. apartment number
+	:city:               The name of the city wherein the user resides
+	:company:            The name of the company for which the user works
+	:confirmLocalPasswd: The 'confirm' field in a new user's password specification - must match ``localPasswd``. This is optional; when ``localPasswd`` is not present in the request, this need not be present
+	:country:            The name of the country wherein the user resides
+	:email:              The user's email address\ [#notnull]_
 
-:fullName:        The user's full name, e.g. "John Quincy Adams"
-:localPasswd:     The user's password
-:newUser:         An optional meta field with no apparent purpose - don't use this
-:phoneNumber:     An optional field which should contain the user's phone number
-:postalCode:      An optional field which should contain the user's postal code
-:publicSshKey:    An optional field which should contain the user's public encryption key used for the SSH protocol
-:role:            The number that corresponds to the highest permission role which will be permitted to the user
-:stateOrProvince: An optional field which should contain the name of the state or province in which the user resides
-:tenantId:        The integral, unique identifier of the tenant to which the new user shall belong
+		.. versionchanged:: ATCv4
+			Prior to version ATCv4, the email was validated using the `Email::Valid Perl package <https://metacpan.org/pod/Email::Valid>`_ but is now validated (circuitously) by `GitHub user asaskevich's regular expression <https://github.com/asaskevich/govalidator/blob/9a090521c4893a35ca9a228628abf8ba93f63108/patterns.go#L7>`_ . Note that neither method can actually distinguish a valid, deliverable, email address but merely ensure the email is in a commonly-found format.
 
-	.. note:: This field is optional if and only if tenancy is not enabled in Traffic Control
-
-:username: The user's new username
+	:fullName:        The user's full name, e.g. "John Quincy Adams"
+	:gid:             A legacy field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - please don't use this
+	:id:              The user's integral, unique, identifier - this cannot be changed\ [#notnull]_
+	:localPasswd:     Optionally, the user's password. This should never be given if it will not be changed. An empty string or ``null`` can be used to explicitly specify no change.
+	:phoneNumber:     The user's phone number
+	:postalCode:      The user's postal code
+	:publicSshKey:    The user's public encryption key used for the SSH protocol
+	:role:            The integral, unique identifier of the highest permission :term:`Role` which will be permitted to the user - this cannot be altered from the user's current :term:`Role`\ [#notnull]_
+	:stateOrProvince: The state or province in which the user resides
+	:tenantId:        The integral, unique identifier of the :term:`Tenant` to which the new user shall belong\ [#tenancy]_\ [#notnull]_
+	:uid:             A legacy field only kept for legacy compatibility reasons that used to contain the UNIX user ID of the user - please don't use this
+	:username:        The user's new username\ [#notnull]_
 
 .. code-block:: http
 	:caption: Request Example
@@ -144,49 +150,100 @@ Request Structure
 	User-Agent: curl/7.47.0
 	Accept: */*
 	Cookie: mojolicious=...
-	Content-Length: 483
+	Content-Length: 465
 	Content-Type: application/json
 
 	{ "user": {
-		"addressLine1": "not a real address",
-		"addressLine2": "not a real address either",
-		"city": "not a real city",
-		"company": "not a real company",
-		"country": "not a real country",
-		"email": "not@real.email",
-		"fullName": "Not a real fullName",
-		"phoneNumber": "not a real phone number",
-		"postalCode": "not a real postal code",
-		"publicSshKey": "not a real ssh key",
-		"stateOrProvince": "not a real state or province",
-		"tenantId": 1,
+		"addressLine1": null,
+		"addressLine2": null,
+		"city": null,
+		"company": null,
+		"country": null,
+		"email": "admin@infra.trafficops.ciab.test",
+		"fullName": null,
+		"gid": null,
+		"id": 2,
+		"phoneNumber": null,
+		"postalCode": null,
+		"publicSshKey": null,
 		"role": 1,
+		"stateOrProvince": null,
+		"tenantId": 1,
+		"uid": null,
 		"username": "admin"
 	}}
 
 Response Structure
 ------------------
+:addressLine1:     The user's address - including street name and number
+:addressLine2:     An additional address field for e.g. apartment number
+:city:             The name of the city wherein the user resides
+:company:          The name of the company for which the user works
+:country:          The name of the country wherein the user resides
+:email:            The user's email address
+:fullName:         The user's full name, e.g. "John Quincy Adams"
+:gid:              A legacy field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
+:id:               An integral, unique identifier for this user
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:newUser:          A meta field with no apparent purpose
+:phoneNumber:      The user's phone number
+:postalCode:       The postal code of the area in which the user resides
+:publicSshKey:     The user's public key used for the SSH protocol
+:registrationSent: If the user was created using the :ref:`to-api-users-register` endpoint, this will be the date and time at which the registration email was sent - otherwise it will be ``null``
+:role:             The integral, unique identifier of the highest-privilege :term:`Role` assigned to this user
+:rolename:         The name of the highest-privilege :term:`Role` assigned to this user
+:stateOrProvince:  The name of the state or province where this user resides
+:tenant:           The name of the :term:`Tenant` to which this user belongs
+:tenantId:         The integral, unique identifier of the :term:`Tenant` to which this user belongs
+:uid:              A legacy field only kept for legacy compatibility reasons that used to contain the UNIX user ID of the user
+:username:         The user's username
 
 .. code-block:: http
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
-	Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 	Content-Type: application/json
 	Date: Thu, 13 Dec 2018 21:05:49 GMT
-	Server: Mojolicious (Perl)
+	X-Server-Name: traffic_ops_golang/
 	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
 	Vary: Accept-Encoding
 	Whole-Content-Sha512: sHFqZQ4Cv7IIWaIejoAvM2Fr/HSupcX3D16KU/etjw+4jcK9EME3Bq5ohLC+eQ52BDCKW2Ra+AC3TfFtworJww==
-	Content-Length: 79
+	Content-Length: 478
 
 	{ "alerts": [
 		{
-			"level": "success",
-			"text": "User profile was successfully updated"
+			"text": "User profile was successfully updated",
+			"level": "success"
 		}
-	]}
+	],
+	"response": {
+		"addressLine1": null,
+		"addressLine2": null,
+		"city": null,
+		"company": null,
+		"country": null,
+		"email": "admin@infra.trafficops.ciab.test",
+		"fullName": null,
+		"gid": null,
+		"id": 2,
+		"lastUpdated": "2019-10-08 20:14:25+00",
+		"newUser": false,
+		"phoneNumber": null,
+		"postalCode": null,
+		"publicSshKey": null,
+		"registrationSent": null,
+		"role": 1,
+		"roleName": "admin",
+		"stateOrProvince": null,
+		"tenant": "root",
+		"tenantId": 1,
+		"uid": null,
+		"username": "admin"
+	}}
+
+.. [#notnull] This field cannot be ``null``.
+.. [#tenancy] This endpoint respects tenancy; a user cannot assign itself to a :term:`Tenant` that is not the same :term:`Tenant` to which it was previously assigned or a descendant thereof.

--- a/docs/source/api/user_current.rst
+++ b/docs/source/api/user_current.rst
@@ -122,7 +122,7 @@ Request Structure
 	:addressLine2:       An additional address field for e.g. apartment number
 	:city:               The name of the city wherein the user resides
 	:company:            The name of the company for which the user works
-	:confirmLocalPasswd: The 'confirm' field in a new user's password specification - must match ``localPasswd``. This is optional; when ``localPasswd`` is not present in the request, this need not be present
+	:confirmLocalPasswd: An optional 'confirm' field in a new user's password specification. This has no known effect and in fact *doesn't even need to match* ``localPasswd``
 	:country:            The name of the country wherein the user resides
 	:email:              The user's email address\ [#notnull]_
 

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -139,7 +139,7 @@ type CurrentUserUpdateRequestUser struct {
 	StateOrProvince    json.RawMessage `json:"stateOrProvince"`
 	TenantID           json.RawMessage `json:"tenantId"`
 	UID                json.RawMessage `json:"uid"`
-	Username           json.RawMessage         `json:"username"`
+	Username           json.RawMessage `json:"username"`
 }
 
 // ValidateAndUnmarshal validates the request and returns a User into which the request's information

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -142,10 +142,10 @@ type CurrentUserUpdateRequestUser struct {
 	Username           json.RawMessage `json:"username"`
 }
 
-// ValidateAndUnmarshal validates the request and returns a User into which the request's information
+// UnmarshalAndValidate validates the request and returns a User into which the request's information
 // has been unmarshalled. This allows many fields to be "null", but explicitly checks that they are
 // present in the JSON payload.
-func (u *CurrentUserUpdateRequestUser) ValidateAndUnmarshal(user *User) error {
+func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 	errs := []error{}
 	if u.AddressLine1 != nil {
 		if err := json.Unmarshal(u.AddressLine1, &user.AddressLine1); err != nil {

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -143,8 +143,7 @@ type CurrentUserUpdateRequestUser struct {
 }
 
 // UnmarshalAndValidate validates the request and returns a User into which the request's information
-// has been unmarshalled. This allows many fields to be "null", but explicitly checks that they are
-// present in the JSON payload.
+// has been unmarshalled.
 func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 	errs := []error{}
 	if u.AddressLine1 != nil {
@@ -171,15 +170,6 @@ func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 		}
 	}
 
-	if u.LocalPasswd != nil && *u.LocalPasswd != "" {
-		if u.ConfirmLocalPasswd == nil || *u.ConfirmLocalPasswd == "" {
-			errs = append(errs, errors.New("confirmLocalPasswd: required when changing password"))
-		} else if *u.LocalPasswd != *u.ConfirmLocalPasswd {
-			errs = append(errs, errors.New("localPasswd and confirmLocalPasswd do not match"))
-		}
-	} else if u.ConfirmLocalPasswd != nil && *u.ConfirmLocalPasswd != "" {
-		errs = append(errs, errors.New("localPasswd: required when changing password"))
-	}
 	user.ConfirmLocalPassword = u.ConfirmLocalPasswd
 	user.LocalPassword = u.LocalPasswd
 

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -273,7 +273,7 @@ func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 		if err := json.Unmarshal(u.Username, &user.Username); err != nil {
 			errs = append(errs, fmt.Errorf("username: %v"))
 		} else if user.Username == nil || *user.Username == "" {
-			errs = append(errs, errors.New("username: cannot be null of empty string"))
+			errs = append(errs, errors.New("username: cannot be null or empty string"))
 		}
 	}
 

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -20,10 +20,15 @@ package tc
  */
 
 import "database/sql"
+import "encoding/json"
 import "errors"
+import "fmt"
 
 import "github.com/apache/trafficcontrol/lib/go-rfc"
 import "github.com/apache/trafficcontrol/lib/go-util"
+
+import "github.com/go-ozzo/ozzo-validation"
+import "github.com/go-ozzo/ozzo-validation/is"
 
 // UserCredentials contains Traffic Ops login credentials
 type UserCredentials struct {
@@ -90,10 +95,11 @@ type commonUserFields struct {
 
 // User fields in v14 have been updated to be nullable
 type User struct {
-	Username         *string    `json:"username" db:"username"`
-	RegistrationSent *TimeNoMod `json:"registrationSent" db:"registration_sent"`
-	LocalPassword    *string    `json:"localPasswd,omitempty" db:"local_passwd"`
-	RoleName         *string    `json:"roleName,omitempty" db:"rolename"`
+	Username             *string    `json:"username" db:"username"`
+	RegistrationSent     *TimeNoMod `json:"registrationSent" db:"registration_sent"`
+	LocalPassword        *string    `json:"localPasswd,omitempty" db:"local_passwd"`
+	ConfirmLocalPassword *string    `json:"confirmLocalPasswd,omitempty" db:"confirm_local_passwd"`
+	RoleName             *string    `json:"roleName,omitempty" db:"-"`
 	commonUserFields
 }
 
@@ -103,6 +109,172 @@ type UserCurrent struct {
 	LocalUser *bool   `json:"localUser"`
 	RoleName  *string `json:"roleName"`
 	commonUserFields
+}
+
+// CurrentUserUpdateRequest differs from a regular User/UserCurrent in that many of its fields are
+// *parsed* but not *unmarshaled*. This allows a handler to distinguish between "null" and
+// "undefined" values.
+type CurrentUserUpdateRequest struct {
+	// User, for whatever reason, contains all of the actual data.
+	User CurrentUserUpdateRequestUser `json:"user"`
+}
+
+// CurrentUserUpdateRequestUser holds all of the actual data in a request to update the current user.
+type CurrentUserUpdateRequestUser struct {
+	AddressLine1       json.RawMessage `json:"addressLine1"`
+	AddressLine2       json.RawMessage `json:"addressLine2"`
+	City               json.RawMessage `json:"city"`
+	Company            json.RawMessage `json:"company"`
+	ConfirmLocalPasswd *string         `json:"confirmLocalPasswd"`
+	Country            json.RawMessage `json:"country"`
+	Email              json.RawMessage `json:"email"`
+	FullName           json.RawMessage `json:"fullName"`
+	GID                json.RawMessage `json:"gid"`
+	ID                 *uint64         `json:"id"`
+	LocalPasswd        *string         `json:"localPasswd"`
+	PhoneNumber        json.RawMessage `json:"phoneNumber"`
+	PostalCode         json.RawMessage `json:"postalCode"`
+	PublicSSHKey       json.RawMessage `json:"publicSshKey"`
+	Role               *uint64         `json:"role"`
+	StateOrProvince    json.RawMessage `json:"stateOrProvince"`
+	TenantID           *uint64         `json:"tenantId"`
+	UID                json.RawMessage `json:"uid"`
+	Username           *string         `json:"username"`
+}
+
+// ValidateAndUnmarshal validates the request and returns a User into which the request's information
+// has been unmarshalled. This allows many fields to be "null", but explicitly checks that they are
+// present in the JSON payload.
+func (u *CurrentUserUpdateRequestUser) ValidateAndUnmarshal() (User, error) {
+	var user User
+	errs := []error{}
+	if u.AddressLine1 == nil {
+		errs = append(errs, errors.New("addressLine1: required"))
+	} else if err := json.Unmarshal(u.AddressLine1, &user.AddressLine1); err != nil {
+		errs = append(errs, fmt.Errorf("addressLine1: %v", err))
+	}
+
+	if u.AddressLine2 == nil {
+		errs = append(errs, errors.New("addressLine2: required"))
+	} else if err := json.Unmarshal(u.AddressLine2, &user.AddressLine2); err != nil {
+		errs = append(errs, fmt.Errorf("addressLine2: %v", err))
+	}
+
+	if u.City == nil {
+		errs = append(errs, errors.New("city: required"))
+	} else if err := json.Unmarshal(u.City, &user.City); err != nil {
+		errs = append(errs, fmt.Errorf("city: %v", err))
+	}
+
+	if u.Company == nil {
+		errs = append(errs, errors.New("company: required"))
+	} else if err := json.Unmarshal(u.Company, &user.Company); err != nil {
+		errs = append(errs, fmt.Errorf("company: %v", err))
+	}
+
+	user.ConfirmLocalPassword = u.ConfirmLocalPasswd
+	user.LocalPassword = u.LocalPasswd
+
+	if u.LocalPasswd != nil && *u.LocalPasswd != "" {
+		if u.ConfirmLocalPasswd == nil || *u.ConfirmLocalPasswd == "" {
+			errs = append(errs, errors.New("confirmLocalPasswd: required when changing password"))
+		} else if *u.LocalPasswd != *u.ConfirmLocalPasswd {
+			errs = append(errs, errors.New("localPasswd and confirmLocalPasswd do not match"))
+		}
+	}
+
+	if u.Country == nil {
+		errs = append(errs, errors.New("country: required"))
+	} else if err := json.Unmarshal(u.Country, &user.Country); err != nil {
+		errs = append(errs, fmt.Errorf("country: %v", err))
+	}
+
+	if u.Email == nil {
+		errs = append(errs, errors.New("email: required"))
+	} else if err := json.Unmarshal(u.Email, &user.Email); err != nil {
+		errs = append(errs, fmt.Errorf("email: %v", err))
+	}
+	if user.Email != nil {
+		if err := validation.Validate(*user.Email, is.Email); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if u.FullName == nil {
+		errs = append(errs, errors.New("fullName: required"))
+	} else if err := json.Unmarshal(u.FullName, &user.FullName); err != nil {
+		errs = append(errs, fmt.Errorf("fullName: %v", err))
+	}
+
+	if u.GID == nil {
+		errs = append(errs, errors.New("gid: required"))
+	} else if err := json.Unmarshal(u.GID, &user.GID); err != nil {
+		errs = append(errs, fmt.Errorf("gid: %v", err))
+	}
+
+	if u.ID == nil {
+		errs = append(errs, errors.New("id: required (and can't be null)"))
+	} else {
+		id := int(*u.ID)
+		user.ID = &id
+	}
+
+	if u.PhoneNumber == nil {
+		errs = append(errs, errors.New("phoneNumber: required"))
+	} else if err := json.Unmarshal(u.PhoneNumber, &user.PhoneNumber); err != nil {
+		errs = append(errs, fmt.Errorf("phoneNumber: %v", err))
+	}
+
+	if u.PostalCode == nil {
+		errs = append(errs, errors.New("postalCode: required"))
+	} else if err := json.Unmarshal(u.PostalCode, &user.PostalCode); err != nil {
+		errs = append(errs, fmt.Errorf("postalCode: %v", err))
+	}
+
+	if u.PublicSSHKey == nil {
+		errs = append(errs, errors.New("publicSshKey: required"))
+	} else if err := json.Unmarshal(u.PublicSSHKey, &user.PublicSSHKey); err != nil {
+		errs = append(errs, fmt.Errorf("publicSshKey: %v", err))
+	}
+
+	if u.Role == nil {
+		errs = append(errs, errors.New("role: required (and can't be null)"))
+	} else {
+		role := int(*u.Role)
+		user.Role = &role
+	}
+
+	if u.StateOrProvince == nil {
+		errs = append(errs, errors.New("stateOrProvince: required"))
+	} else if err := json.Unmarshal(u.StateOrProvince, &user.StateOrProvince); err != nil {
+		errs = append(errs, fmt.Errorf("stateOrProvince: %v", err))
+	}
+
+	if u.TenantID == nil {
+		errs = append(errs, errors.New("tenantId: required"))
+	} else {
+		tenantID := int(*u.TenantID)
+		user.TenantID = &tenantID
+	}
+
+	if u.UID == nil {
+		errs = append(errs, errors.New("uid: required"))
+	} else if err := json.Unmarshal(u.UID, &user.UID); err != nil {
+		errs = append(errs, fmt.Errorf("uid: %v", err))
+	}
+
+	if u.Username == nil || *u.Username == "" {
+		errs = append(errs, errors.New("username: required (and cannot be null or blank)"))
+	} else {
+		uname := *u.Username
+		user.Username = &uname
+	}
+
+	var err error
+	if len(errs) > 0 {
+		err = util.JoinErrs(errs)
+	}
+	return user, err
 }
 
 // ------------------- Response structs -------------------- //

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -277,11 +277,7 @@ func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 		}
 	}
 
-	var err error
-	if len(errs) > 0 {
-		err = util.JoinErrs(errs)
-	}
-	return err
+	return util.JoinErrs(errs)
 }
 
 // ------------------- Response structs -------------------- //

--- a/traffic_control/clients/python/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/tosession.py
@@ -2447,6 +2447,17 @@ class TOSession(RestApiSession):
 		:raises: Union[LoginError, OperationError]
 		"""
 
+	@api_request(u'put', u'user/current', (u'1.1', u'1.2', u'1.3', u'1.4'))
+	def replace_authenticated_user(self, data=None):
+		"""
+		Updates the currently authenticated user.
+		:ref:`to-api-user-current`
+		:param data: The new user information which will replace the current user's user information.
+		:type data: Dict[str, Any]
+		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
+		:raises: Union[LoginError, OperationError]
+		"""
+
 	@api_request(u'get', u'user/current/jobs', (u'1.1', u'1.2', u'1.3',))
 	def get_authenticated_user_jobs(self):
 		"""

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -77,6 +77,28 @@ func (to *Session) GetUserCurrent() (*tc.UserCurrent, ReqInf, error) {
 	return &resp.Response, reqInf, nil
 }
 
+// UpdateCurrentUser replaces the current user data with the provided tc.User structure.
+func (to *Session) UpdateCurrentUser(user *tc.User) (*tc.UpdateUserResponse, ReqInf, error) {
+	var a net.Addr
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: a}
+
+	reqBody, err := json.Marshal(user)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	var resp *http.Response
+	resp, reqInf.RemoteAddr, err = to.request(http.MethodPut, apiBase+"/user/current", reqBody)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var clientResp tc.UpdateUserResponse
+	err = json.NewDecoder(resp.Body).Decode(&clientResp)
+	return &clientResp, reqInf, err
+}
+
 // CreateUser creates a user
 func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, error) {
 	if user.TenantID == nil && user.Tenant != nil {

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -78,10 +78,11 @@ func (to *Session) GetUserCurrent() (*tc.UserCurrent, ReqInf, error) {
 }
 
 // UpdateCurrentUser replaces the current user data with the provided tc.User structure.
-func (to *Session) UpdateCurrentUser(user *tc.User) (*tc.UpdateUserResponse, ReqInf, error) {
+func (to *Session) UpdateCurrentUser(u tc.User) (*tc.UpdateUserResponse, ReqInf, error) {
 	var a net.Addr
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: a}
 
+	user := struct{ User tc.User `json:"user"` }{ u }
 	reqBody, err := json.Marshal(user)
 	if err != nil {
 		return nil, reqInf, err

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -570,3 +570,14 @@ func GetGlobalParam(tx *sql.Tx, name string) (string, bool, error) {
 	}
 	return val, true, nil
 }
+
+// UsernameExists reports whether or not the the given username exists as a user in the database to
+// which the passed transaction refers. If anything goes wrong when checking the existence of said
+// user, the error is directly returned to the caller. Note that in that case, no real meaning
+// should be assigned to the returned boolean value.
+func UsernameExists(uname string, tx *sql.Tx) (bool, error) {
+	row := tx.QueryRow(`SELECT EXISTS(SELECT * FROM tm_user WHERE tm_user.username=$1)`, uname)
+	var exists bool
+	err := row.Scan(&exists);
+	return exists, err
+}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -244,7 +244,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(&user.TOUser{}), auth.PrivLevelOperations, Authenticated, nil, 876244816, noPerlBypass},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil, 1610701614, noPerlBypass},
-		{1.1, http.MethodPut, `user/current(/|\.json)?$`, user.ReplaceCurrent, auth.PrivLevelReadOnly, Authenticated, nil, 420, perlBypasss},
+		{1.1, http.MethodPut, `user/current(/|\.json)?$`, user.ReplaceCurrent, auth.PrivLevelReadOnly, Authenticated, nil, 420, perlBypass},
 
 		//Parameter: CRUD
 		{1.1, http.MethodGet, `parameters/?(\.json)?$`, api.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, Authenticated, nil, 2012554292, noPerlBypass},

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -244,6 +244,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPost, `users/?(\.json)?$`, api.CreateHandler(&user.TOUser{}), auth.PrivLevelOperations, Authenticated, nil, 876244816, noPerlBypass},
 
 		{1.1, http.MethodGet, `user/current/?(\.json)?$`, user.Current, auth.PrivLevelReadOnly, Authenticated, nil, 1610701614, noPerlBypass},
+		{1.1, http.MethodPut, `user/current(/|\.json)?$`, user.ReplaceCurrent, auth.PrivLevelReadOnly, Authenticated, nil, 420, perlBypasss},
 
 		//Parameter: CRUD
 		{1.1, http.MethodGet, `parameters/?(\.json)?$`, api.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, Authenticated, nil, 2012554292, noPerlBypass},

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -214,7 +214,8 @@ func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 		errCode = http.StatusInternalServerError
 		api.HandleErr(w, r, tx, errCode, nil, sysErr)
 		return
-	} else if !exists {
+	}
+	if !exists {
 		sysErr = fmt.Errorf("Current user (#%d) doesn't exist... ??", inf.User.ID)
 		errCode = http.StatusInternalServerError
 		api.HandleErr(w, r, tx, errCode, nil, sysErr)

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -310,23 +310,7 @@ func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := struct {
-		tc.Alerts
-		Response tc.User `json:"response"`
-	}{
-		tc.CreateAlerts(tc.SuccessLevel, "User profile was successfully updated"),
-		user,
-	}
-
-	respBts, err := json.Marshal(resp)
-	if err != nil {
-		errCode = http.StatusInternalServerError
-		sysErr = fmt.Errorf("Marshalling response: %v", err)
-		api.HandleErr(w, r, tx, errCode, nil, sysErr)
-		return
-	}
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
-	w.Write(append(respBts, '\n'))
+	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "User profile was successfully updated", user)
 }
 
 func updateUser(u *tc.User, tx *sql.Tx, cp bool) error {

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -21,13 +21,72 @@ package user
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
 )
+
+const replaceCurrentQuery = `
+UPDATE tm_user
+SET address_line1=$1,
+    address_line2=$2,
+    city=$3,
+    company=$4,
+    confirm_local_passwd=$5,
+    country=$6,
+    email=$7,
+    full_name=$8,
+    gid=$9,
+    local_passwd=$10,
+    new_user=FALSE,
+    phone_number=$11,
+    postal_code=$12,
+    public_ssh_key=$13,
+    state_or_province=$14,
+    tenant_id=$15,
+    token=NULL,
+    uid=$16,
+    username=$17
+WHERE id=$18
+RETURNING address_line1,
+          address_line2,
+          city,
+          company,
+          country,
+          email,
+          full_name,
+          gid,
+          id,
+          last_updated,
+          new_user,
+          phone_number,
+          postal_code,
+          public_ssh_key,
+          role,
+          (
+          	SELECT role.name
+          	FROM role
+          	WHERE role.id=tm_user.role
+          ) AS role_name,
+          state_or_province,
+          (
+          	SELECT tenant.name
+          	FROM tenant
+          	WHERE tenant.id=tm_user.tenant_id
+          ) AS tenant,
+          tenant_id,
+          uid,
+          username
+`
 
 func Current(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
@@ -79,4 +138,167 @@ WHERE u.id=$1
 	}
 	u.LocalUser = util.BoolPtr(localPassword.Valid)
 	return u, nil
+}
+
+func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	tx := inf.Tx.Tx
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	var userRequest tc.CurrentUserUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&userRequest); err != nil {
+		errCode = http.StatusBadRequest
+		userErr = fmt.Errorf("Couldn't parse request: %v", err)
+		api.HandleErr(w, r, tx, errCode, userErr, nil)
+		return
+	}
+
+	user, err := userRequest.User.ValidateAndUnmarshal()
+	if err != nil {
+		errCode = http.StatusBadRequest
+		userErr = fmt.Errorf("Couldn't parse request: %v", err)
+		api.HandleErr(w, r, tx, errCode, userErr, nil)
+		return
+	}
+
+	// obfuscate passwords (ValidateAndUnmarshal checks for equality with ConfirmLocalPassword)
+	// TODO: check for valid password via bad password list like Perl did? User creation doesn't...
+	if user.LocalPassword != nil && *user.LocalPassword != "" {
+		hashPass, err := auth.DerivePassword(*user.LocalPassword)
+		if err != nil {
+			sysErr = fmt.Errorf("Hashing new password: %v", err)
+			errCode = http.StatusInternalServerError
+			api.HandleErr(w, r, tx, errCode, nil, sysErr)
+			return
+		}
+
+		user.LocalPassword = util.StrPtr(hashPass)
+		user.ConfirmLocalPassword = util.StrPtr(hashPass)
+	}
+
+	if *user.ID != inf.User.ID {
+		userErr = errors.New("You cannot change your user ID!")
+		errCode = http.StatusBadRequest
+		api.HandleErr(w, r, tx, errCode, userErr, nil)
+		return
+	}
+
+	if *user.Role != inf.User.Role {
+		userErr = errors.New("You cannot change your permissions role!")
+		errCode = http.StatusBadRequest
+		api.HandleErr(w, r, tx, errCode, userErr, nil)
+		return
+	}
+
+	if ok, err := tenant.IsResourceAuthorizedToUserTx(*user.TenantID, inf.User, tx); err != nil {
+		if err == sql.ErrNoRows {
+			userErr = errors.New("No such tenant!")
+			errCode = http.StatusConflict
+		} else {
+			sysErr = fmt.Errorf("Checking user %s permissions on tenant #%d: %v", inf.User.UserName, *user.TenantID, err)
+			errCode = http.StatusInternalServerError
+		}
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	} else if !ok {
+		// unlike Perl, this endpoint will not disclose the existence of tenants over which the current
+		// user has no permission - in keeping with the behavior of the '/tenants' endpoint.
+		userErr = errors.New("No such tenant!")
+		errCode = http.StatusConflict
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+
+	if *user.Username != inf.User.UserName {
+
+		if ok, err := dbhelpers.UsernameExists(*user.Username, tx); err != nil {
+			sysErr = fmt.Errorf("Checking existence of user %s: %v", *user.Username, err)
+			errCode = http.StatusInternalServerError
+			api.HandleErr(w, r, tx, errCode, nil, sysErr)
+			return
+		} else if ok {
+			// TODO users are tenanted, so theoretically I should be hiding the existence of the
+			// conflicting user - but then how do I tell the client how to fix their request?
+			userErr = fmt.Errorf("Username %s already exists!", *user.Username)
+			errCode = http.StatusConflict
+			api.HandleErr(w, r, tx, errCode, userErr, nil)
+			return
+		}
+	}
+
+	row := tx.QueryRow(replaceCurrentQuery,
+		user.AddressLine1,
+		user.AddressLine2,
+		user.City,
+		user.Company,
+		user.ConfirmLocalPassword,
+		user.Country,
+		user.Email,
+		user.FullName,
+		user.GID,
+		user.LocalPassword,
+		user.PhoneNumber,
+		user.PostalCode,
+		user.PublicSSHKey,
+		user.StateOrProvince,
+		user.TenantID,
+		user.UID,
+		user.Username,
+		inf.User.ID,
+	)
+
+	err = row.Scan(&user.AddressLine1,
+		&user.AddressLine2,
+		&user.City,
+		&user.Company,
+		&user.Country,
+		&user.Email,
+		&user.FullName,
+		&user.GID,
+		&user.ID,
+		&user.LastUpdated,
+		&user.NewUser,
+		&user.PhoneNumber,
+		&user.PostalCode,
+		&user.PublicSSHKey,
+		&user.Role,
+		&user.RoleName,
+		&user.StateOrProvince,
+		&user.Tenant,
+		&user.TenantID,
+		&user.UID,
+		&user.Username,
+	)
+	if err != nil {
+		errCode = http.StatusInternalServerError
+		sysErr = fmt.Errorf("Updating user: %v", err)
+		api.HandleErr(w, r, tx, errCode, nil, sysErr)
+		return
+	}
+
+	// Hide the password fields
+	user.LocalPassword = nil
+	user.ConfirmLocalPassword = nil
+
+	resp := struct {
+		tc.Alerts
+		Response tc.User `json:"response"`
+	}{
+		tc.CreateAlerts(tc.SuccessLevel, "User profile was successfully updated"),
+		user,
+	}
+
+	respBts, err := json.Marshal(resp)
+	if err != nil {
+		errCode = http.StatusInternalServerError
+		sysErr = fmt.Errorf("Marshalling response: %v", err)
+		api.HandleErr(w, r, tx, errCode, nil, sysErr)
+		return
+	}
+	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Write(append(respBts, '\n'))
 }

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -268,7 +268,7 @@ func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "User profile was successfully updated", user)
 }
 
-func updateUser(u *tc.User, tx *sql.Tx, cp bool) error {
+func updateUser(u *tc.User, tx *sql.Tx, changePassword bool) error {
 	row := tx.QueryRow(replaceCurrentQuery,
 		u.AddressLine1,
 		u.AddressLine2,
@@ -314,7 +314,7 @@ func updateUser(u *tc.User, tx *sql.Tx, cp bool) error {
 		return err
 	}
 
-	if cp {
+	if changePassword {
 		_, err = tx.Exec(replacePasswordQuery, u.ConfirmLocalPassword, u.LocalPassword, u.ID)
 		if err != nil {
 			return fmt.Errorf("resetting password: %v", err)

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -222,7 +222,7 @@ func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := userRequest.User.ValidateAndUnmarshal(&user); err != nil {
+	if err := userRequest.User.UnmarshalAndValidate(&user); err != nil {
 		errCode = http.StatusBadRequest
 		userErr = fmt.Errorf("Couldn't parse request: %v", err)
 		api.HandleErr(w, r, tx, errCode, userErr, nil)
@@ -231,7 +231,7 @@ func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 
 	changePasswd := false
 
-	// obfuscate passwords (ValidateAndUnmarshal checks for equality with ConfirmLocalPassword)
+	// obfuscate passwords (UnmarshalAndValidate checks for equality with ConfirmLocalPassword)
 	// TODO: check for valid password via bad password list like Perl did? User creation doesn't...
 	if user.LocalPassword != nil && *user.LocalPassword != "" {
 		hashPass, err := auth.DerivePassword(*user.LocalPassword)

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -133,7 +133,7 @@ u.tenant_id,
 u.username
 FROM tm_user as u
 LEFT JOIN role as r ON r.id = u.role
-LEFT JOIN tenant as t ON t.id = u.tenant_id
+INNER JOIN tenant as t ON t.id = u.tenant_id
 WHERE u.id=$1
 `
 	u := tc.UserCurrent{}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3838 

This rewrites the previously unimplemented PUT handler of `/user/current` into Go. It adds support in both the Go and Python clients, with some associated testing as well as documentation updates.

~This differs from the way the endpoint was handled in Perl - in Perl, every field in the request was optional (under the top-level "user" object, obviously) and only those included would be updated - as though it were a PATCH request. This instead demands a full representation of a user as is proper for PUT. Additionally, the Perl returned only a success message, this handler returns a representation of the user as it exists following the update.~

Pursuant to a [mailing list discussion](https://mail-archives.apache.org/mod_mbox/trafficcontrol-dev/201910.mbox/%3CCAMAKGdA5TL6c%3DXJXpB%2BbVj4%3D5gqjUhokqCBFZk20BoUCxYHSxg%40mail.gmail.com%3E) changing this endpoint's behavior - albeit for the better - was shot down, and I re-rewrote it to implement Perl-style PATCH-like behavior.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Client (Python)
- Traffic Control Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Build a TO RPM, start Traffic Ops, make a `PUT` request to `/user/current`, run the Go client/API integration tests, build and read the documentation.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**