### PR TITLE
TP: fixes bug that surfaces when trying to compare profiles without params

### DIFF
--- a/traffic_portal/app/src/common/service/utils/CollectionUtils.js
+++ b/traffic_portal/app/src/common/service/utils/CollectionUtils.js
@@ -20,6 +20,9 @@
 var CollectionUtils = function() {
 
 	this.uniqArray = function(array1, array2, key) {
+		array1 = array1 || [];
+		array2 = array2 || [];
+
 		const keys = new Set();
 		const uniq = new Array();
 		array1.concat(array2).forEach(function(item) {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
This PR fixes a bug highlighted by a failing UI test. When comparing 2 profiles, if one or both of the profiles has no params, then the comparison page fails to load.

- [x] This PR is not related to any Issue

- No tests as this is a scenario covered by a current UI test
- No documentation as this is simply a bug fix
- No changelog.md entry as this bug was not released with any TC release

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
- In TP, navigate to the profiles view - tp.domain.com/#!/profiles
- Select 2 profiles to compare. Ensure that at least one of those profiles has ZERO params associated with it
- Ensure that the profile diff page is displayed correctly.

## If this is a bug fix, what versions of Traffic Control are affected?
- master (0974c74)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
