### PR TITLE
Add top-level vendor dir to TO-Go and TM unit test containers

### DIFF
--- a/traffic_monitor/tests/Dockerfile-golangtest
+++ b/traffic_monitor/tests/Dockerfile-golangtest
@@ -17,6 +17,7 @@ ARG DIR=github.com/apache/trafficcontrol
 ADD traffic_monitor /go/src/$DIR/traffic_monitor
 ADD traffic_ops /go/src/$DIR/traffic_ops
 ADD lib /go/src/$DIR/lib
+ADD vendor /go/src/$DIR/vendor
 VOLUME ["/junit"]
 
 WORKDIR /go/src/$DIR/traffic_monitor

--- a/traffic_ops/app/bin/tests/Dockerfile-golangtest
+++ b/traffic_ops/app/bin/tests/Dockerfile-golangtest
@@ -17,6 +17,7 @@ ARG DIR=github.com/apache/trafficcontrol
 
 ADD traffic_ops /go/src/$DIR/traffic_ops
 ADD lib /go/src/$DIR/lib
+ADD vendor /go/src/$DIR/vendor
 
 WORKDIR /go/src/$DIR/traffic_ops/traffic_ops_golang
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
The TO-Go and TM unit test containers are failing to find the vendored
influxdb library after moving it to the top-level vendor dir. Fix the
containers to include the top-level vendor dir in the build.

- [x] This PR fixes is not related to any issue

## Which Traffic Control components are affected by this PR?

- Traffic Monitor (tests only)
- Traffic Ops (tests only)


## What is the best way to verify this PR?
Make sure both of these containers build successfully and the tests pass.
```
docker-compose -f traffic_monitor/tests/docker-compose.yml up --build
docker-compose -f traffic_ops/app/bin/tests/docker-compose.yml up --build unit_golang
```

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR fixes test container builds, no docs necessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

