### PR TITLE
Implement GET /api/1.1/roles handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.1/deliveryservices/xmlId/:xmlid/sslkeys/delete `GET`
   - /api/1.4/cdns/dnsseckeys/refresh `GET`
   - /api/1.1/cdns/name/:name/dnsseckeys `GET`
+  - /api/1.1/roles `GET`
   - /api/1.4/cdns/name/:name/dnsseckeys `GET`
   - /api/1.4/user/login/oauth `POST`
   - /api/1.1/profiles/:name/configfiles/ats/* `GET`

--- a/lib/go-tc/roles.go
+++ b/lib/go-tc/roles.go
@@ -37,6 +37,16 @@ type RoleResponse struct {
 
 // Role ...
 type Role struct {
+	RoleV11
+
+	// Capabilities associated with the Role
+	//
+	// required: true
+	Capabilities *[]string `json:"capabilities" db:"-"`
+}
+
+// RoleV11 ...
+type RoleV11 struct {
 	// ID of the Role
 	//
 	// required: true
@@ -56,9 +66,4 @@ type Role struct {
 	//
 	// required: true
 	PrivLevel *int `json:"privLevel" db:"priv_level"`
-
-	// Capabilities associated with the Role
-	//
-	// required: true
-	Capabilities *[]string `json:"capabilities" db:"-"`
 }

--- a/traffic_ops/testing/api/v14/roles_test.go
+++ b/traffic_ops/testing/api/v14/roles_test.go
@@ -16,6 +16,7 @@ package v14
 */
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -31,9 +32,10 @@ const (
 )
 
 func TestRoles(t *testing.T) {
-	WithObjs(t, []TCObj{Parameters, Roles}, func() {
+	WithObjs(t, []TCObj{Roles}, func() {
 		UpdateTestRoles(t)
 		GetTestRoles(t)
+		GetTestRolesV11(t)
 		VerifyGetRolesOrder(t)
 	})
 }
@@ -104,6 +106,18 @@ func GetTestRoles(t *testing.T) {
 		t.Errorf("cannot GET Role by role: %v - %v\n", err, resp)
 	}
 
+}
+
+func GetTestRolesV11(t *testing.T) {
+	data := tc.RolesResponse{}
+	if err := makeV11Request(http.MethodGet, "/roles", nil, &data); err != nil {
+		t.Errorf("cannot GET 1.1 roles: %s", err.Error())
+	}
+	for _, role := range data.Response {
+		if role.Capabilities != nil {
+			t.Errorf("expected GET 1.1 roles to have nil Capabilities, actual: %v", *role.Capabilities)
+		}
+	}
 }
 
 func VerifyGetRolesOrder(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -160,12 +160,6 @@ func (role *TORole) deleteRoleCapabilityAssociations(tx *sqlx.Tx) (error, error,
 
 func (role *TORole) Read() ([]interface{}, error, error, int) {
 	version := role.APIInfo().Version
-	if version == nil {
-		return nil, nil, errors.New("TORole.Read called with nil API version"), http.StatusInternalServerError
-	}
-	if version.Major != 1 || version.Minor < 1 {
-		return nil, nil, fmt.Errorf("TORole.Read called with invalid API version: %d.%d", version.Major, version.Minor), http.StatusInternalServerError
-	}
 	vals, userErr, sysErr, errCode := api.GenericRead(role)
 	if userErr != nil || sysErr != nil {
 		return nil, userErr, sysErr, errCode
@@ -180,8 +174,6 @@ func (role *TORole) Read() ([]interface{}, error, error, int) {
 			returnable = append(returnable, rl)
 		case version.Minor >= 1:
 			returnable = append(returnable, rl.RoleV11)
-		default:
-			return nil, nil, fmt.Errorf("TORole.Read called with invalid API version: %d.%d", version.Major, version.Minor), http.StatusInternalServerError
 		}
 	}
 	return returnable, nil, nil, http.StatusOK

--- a/traffic_ops/traffic_ops_golang/role/roles_test.go
+++ b/traffic_ops/traffic_ops_golang/role/roles_test.go
@@ -38,24 +38,6 @@ func intAddr(i int) *int {
 	return &i
 }
 
-func getTestRoles() []tc.Role {
-	roles := []tc.Role{
-		{
-			ID:          intAddr(1),
-			Name:        stringAddr("role1"),
-			Description: stringAddr("the first role"),
-			PrivLevel:   intAddr(30),
-		},
-		{
-			ID:          intAddr(2),
-			Name:        stringAddr("role2"),
-			Description: stringAddr("the second role"),
-			PrivLevel:   intAddr(10),
-		},
-	}
-	return roles
-}
-
 //removed sqlmock based ReadRoles test due to sqlmock / pq.Array() type incompatibility issue.
 
 func TestFuncs(t *testing.T) {
@@ -98,9 +80,11 @@ func TestValidate(t *testing.T) {
 	// invalid name, empty domainname
 	n := "not_a_valid_role"
 	reqInfo := api.APIInfo{}
+	role := tc.Role{}
+	role.Name = &n
 	r := TORole{
 		APIInfoImpl: api.APIInfoImpl{&reqInfo},
-		Role:        tc.Role{Name: &n},
+		Role:        role,
 	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(r.Validate())))
 
@@ -114,13 +98,13 @@ func TestValidate(t *testing.T) {
 	}
 
 	//  name,  domainname both valid
+	role = tc.Role{}
+	role.Name = stringAddr("this is a valid name")
+	role.Description = stringAddr("this is a description")
+	role.PrivLevel = intAddr(30)
 	r = TORole{
 		APIInfoImpl: api.APIInfoImpl{&reqInfo},
-		Role: tc.Role{
-			Name:        stringAddr("this is a valid name"),
-			Description: stringAddr("this is a description"),
-			PrivLevel:   intAddr(30),
-		},
+		Role:        role,
 	}
 	err := r.Validate()
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -49,11 +49,11 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crconfig"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbdump"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservicerequests"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice/consistenthash"
 	dsrequest "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice/request"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice/request/comment"
 	dsserver "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice/servers"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservicerequests"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservicesregexes"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/division"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/federations"
@@ -372,7 +372,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.3, http.MethodDelete, `origins/?$`, api.DeleteHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, Authenticated, nil},
 
 		//Roles
-		{1.3, http.MethodGet, `roles/?(\.json)?$`, api.ReadHandler(&role.TORole{}), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodGet, `roles/?(\.json)?$`, api.ReadHandler(&role.TORole{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.3, http.MethodPut, `roles/?$`, api.UpdateHandler(&role.TORole{}), auth.PrivLevelAdmin, Authenticated, nil},
 		{1.3, http.MethodPost, `roles/?$`, api.CreateHandler(&role.TORole{}), auth.PrivLevelAdmin, Authenticated, nil},
 		{1.3, http.MethodDelete, `roles/?$`, api.DeleteHandler(&role.TORole{}), auth.PrivLevelAdmin, Authenticated, nil},


### PR DESCRIPTION


## What does this PR (Pull Request) do?
Modify the 1.3 GET handler to also handle requests at 1.1 (the only
difference is the addition of the "capabilities" field in 1.3).

- [x] This PR fixes #3820

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
1. Run the TO API tests
2. `GET /api/1.1/roles` and `GET /api/1.2/roles`, verify that the `capabilities` field **does not exist** in the result.
3. `GET /api/1.3/roles` and `GET /api/1.4/roles`, verify that the `capabilities` field **does exist** in the result.

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] Documentation already exists for /api/1.1/roles
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
