### PR TITLE
Rewrite /federations to Go - POST/PUT/DELETE

### DIFF
--- a/docs/source/api/federations.rst
+++ b/docs/source/api/federations.rst
@@ -21,7 +21,7 @@
 
 ``GET``
 =======
-Retrieves a list of federation mappings (aka federation resolvers) for the current user.
+Retrieves a list of :term:`Federation` mappings (i.e. :term:`Federation` Resolvers) for the current user.
 
 :Auth. Required: Yes
 :Roles Required: "admin", "Federation", "operations", "Portal", or "Steering"
@@ -34,12 +34,12 @@ No parameters available.
 Response Structure
 ------------------
 :deliveryService: The ``xml_id`` that uniquely identifies the :term:`Delivery Service` that uses the federation mappings in ``mappings``
-:mappings:        An array of objects that represent the mapping of a federation's Canonical Name (CNAME) to one or more resolvers
+:mappings:        An array of objects that represent the mapping of a :term:`Federation`'s :abbr:`CNAME (Canonical Name)` to one or more Resolvers
 
-	:cname:    The actual CNAME used by the federation
-	:resolve4: An array of IPv4 addresses capable of resolving the federation's CNAME
-	:resolve6: An array of IPv6 addresses capable of resolving the federation's CNAME
-	:ttl:      The Time To Live (TTL) of the CNAME in hours
+	:cname:    The actual CNAME used by the :term:`Federation`
+	:resolve4: An array of IPv4 addresses (or subnets in :abbr:`CIDR (Classless Inter-Domain Routing)` notation) capable of resolving the :term:`Federation`'s CNAME
+	:resolve6: An array of IPv6 addresses (or subnets in :abbr:`CIDR (Classless Inter-Domain Routing)` notation) capable of resolving the :term:`Federation`'s CNAME
+	:ttl:      The :abbr:`TTL (Time To Live)` of the CNAME in hours
 
 .. code-block:: http
 	:caption: Response Example
@@ -77,9 +77,9 @@ Response Structure
 
 ``POST``
 ========
-Allows a user to create federation resolvers for :term:`Delivery Service`\ s, providing the :term:`Delivery Service` is within a CDN that has some associated federation.
+Allows a user to create :term:`Federation` Resolvers for :term:`Delivery Services`, providing the :term:`Delivery Service` is within a CDN that has some associated :term:`Federation`.
 
-.. warning:: Confusingly, this endpoint does **not** create a new federation; to do that, the :ref:`to-api-cdns-name-federations` endpoint must be used. Furthermore, the federation must properly be assigned to a :term:`Delivery Service` using the :ref:`to-api-federations-id-deliveryservices` and assigned to the user creating resolvers using :ref:`to-api-federations-id-users`.
+.. warning:: Confusingly, this method of this endpoint does **not** create a new :term:`Federation`; to do that, the :ref:`to-api-cdns-name-federations` endpoint must be used. Furthermore, the :term:`Federation` must properly be assigned to a :term:`Delivery Service` using the :ref:`to-api-federations-id-deliveryservices` and assigned to the user creating Resolvers using :ref:`to-api-federations-id-users`.
 
 .. seealso:: The :ref:`to-api-federations-id-federation_resolvers` endpoint duplicates this functionality.
 
@@ -89,32 +89,50 @@ Allows a user to create federation resolvers for :term:`Delivery Service`\ s, pr
 
 Request Structure
 -----------------
-:federations: The top-level key that must exist - an array of objects that each describe a set of resolvers for a :term:`Delivery Service`'s federation
+.. versionchanged:: 1.4
+	Prior to API version 1.4, the request body had to be wrapped in a top-level ``federations`` key, as can be seen in the :ref:`Legacy Request <legacy-post-request>` example. That behavior is still supported but no longer necessary.
 
-	:deliveryService: The 'xml_id' of the :term:`Delivery Service` which will use the federation resolvers specified in ``mappings``
-	:mappings:        An object containing two arrays of IP addresses to use as federation resolvers
+.. _legacy-post-request:
+.. code-block:: json
+	:caption: Legacy Request
 
-		:resolve4: An array of IPv4 addresses that can resolve the :term:`Delivery Service`'s federation
-		:resolve6: An array of IPv6 addresses that can resolve the :term:`Delivery Service`'s federation
+	{
+		"federations": [{
+			"deliveryService": "demo1",
+			"mappings": {
+				"resolve4": ["0.0.0.0"],
+				"resolve6": ["::1"]
+			}
+		}]
+	}
+
+The request payload is an array of objects that describe Delivery Service :term:`Federation` Resolver mappings. Each object in the array must be in the following format.
+
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` which will use the :term:`Federation` Resolvers specified in ``mappings``
+:mappings:        An object containing two arrays of IP addresses (or subnets in :abbr:`CIDR (Classless Inter-Domain Routing)` notation) to use as :term:`Federation` Resolvers
+
+	:resolve4: An array of IPv4 addresses (or subnets in :abbr:`CIDR (Classless Inter-Domain Routing)` notation) that can resolve the :term:`Delivery Service`'s :term:`Federation`
+	:resolve6: An array of IPv6 addresses (or subnets in :abbr:`CIDR (Classless Inter-Domain Routing)` notation) that can resolve the :term:`Delivery Service`'s :term:`Federation`
 
 .. code-block:: http
 	:caption: Request Example
 
-	POST /api/1.1/federations HTTP/1.1
+	POST /api/1.4/federations HTTP/1.1
 	Host: trafficops.infra.ciab.test
 	User-Agent: curl/7.47.0
 	Accept: */*
 	Cookie: mojolicious=...
-	Content-Length: 119
+	Content-Length: 118
 	Content-Type: application/json
 
-	{ "federations": [{
-		"deliveryService": "demo1",
-		"mappings": {
-			"resolve4": ["0.0.0.0"],
-			"resolve6": ["::"]
+
+	[{
+		"deliveryService":"demo1",
+		"mappings":{
+			"resolve4":["127.0.0.1", "0.0.0.0/32"],
+			"resolve6":["::1", "5efa::ff00/128"]
 		}
-	}]}
+	}]
 
 Response Structure
 ------------------
@@ -123,24 +141,29 @@ Response Structure
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
-	Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 	Content-Type: application/json
-	Date: Mon, 03 Dec 2018 17:00:29 GMT
-	Server: Mojolicious (Perl)
-	Set-Cookie: mojolicious=...; expires=Mon, 03 Dec 2018 21:00:29 GMT; path=/; HttpOnly
-	Vary: Accept-Encoding
-	Whole-Content-Sha512: dXg86uD2Un1AeBCeeBLSo2rsYgl6NOHHQEc5oMlpw1THOh2HwGdjwB3rPd/qoYIhOxcnnHoEstrEiHmucFev4A==
-	Content-Length: 63
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: B7TSUOYZPRPyi3mVy+CuxiXR5k/d0s07w4i6kYzpWS+YL79juEfkuSqfedaYG/kMA8O9XbjkWRjcBAdxOVrdTQ==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 23 Oct 2019 22:28:02 GMT
+	Content-Length: 152
 
-	{ "response": "admin successfully created federation resolvers." }
+	{ "alerts": [
+		{
+			"text": "admin successfully created federation resolvers.",
+			"level": "success"
+		}
+	],
+	"response": "admin successfully created federation resolvers."
+	}
 
 
 ``DELETE``
 ==========
-Deletes **all** federation resolvers associated with the logged-in user's federations.
+Deletes **all** :term:`Federation` Resolvers associated with the logged-in user's :term:`Federations`.
 
 :Auth. Required: Yes
 :Roles Required: "admin", "Federation", "operations", "Portal", or "Steering"
@@ -150,6 +173,15 @@ Request Structure
 -----------------
 No parameters available
 
+.. code-block:: http
+	:caption: Request Example
+
+	DELETE /api/1.4/federations HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+
 Response Structure
 ------------------
 .. code-block:: http
@@ -157,24 +189,28 @@ Response Structure
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
-	Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 	Content-Type: application/json
-	Date: Mon, 03 Dec 2018 17:55:10 GMT
-	Server: Mojolicious (Perl)
-	Set-Cookie: mojolicious=...; expires=Mon, 03 Dec 2018 21:55:10 GMT; path=/; HttpOnly
-	Vary: Accept-Encoding
-	Whole-Content-Sha512: b84HraJH6Kiqrz7i1L1juDBJWdkdYbbClnWM0lZDljvpSkVT9adFTTrHiv7Mjtt2RKquGdzFZ6tqt9s+ODxqsw==
-	Content-Length: 93
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: fd7P45mIiHuYqZZW6+8K+YjY1Pe504Aaw4J4Zp9AhrqLX72ERytTqWtAp1msutzNSRUdUSC72+odNPtpv3O8uw==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 23 Oct 2019 23:34:53 GMT
+	Content-Length: 184
 
-	{ "response": "admin successfully deleted all federation resolvers: [ 0.0.0.0/32, ::/128 ]." }
-
+	{ "alerts": [
+		{
+			"text": "admin successfully deleted all federation resolvers: [ 8.8.8.8 ]",
+			"level": "success"
+		}
+	],
+	"response": "admin successfully deleted all federation resolvers: [ 8.8.8.8 ]"
+	}
 
 ``PUT``
 =======
-Replaces **all** federations associated with a user's :term:`Delivery Service`\ (s) with those defined inside the request payload.
+Replaces **all** :term:`Federations` associated with a user's :term:`Delivery Service`\ (s) with those defined inside the request payload.
 
 :Auth. Required: Yes
 :Roles Required: "admin", "Federation", "operations", "Portal", or "Steering"
@@ -182,32 +218,48 @@ Replaces **all** federations associated with a user's :term:`Delivery Service`\ 
 
 Request Structure
 -----------------
-:federations: The top-level key that must exist - an array of objects that each describe a set of resolvers for a :term:`Delivery Service`'s federation
+.. versionchanged:: 1.4
+	Prior to API version 1.4, the request body had to be wrapped in a top-level ``federations`` key, as can be seen in the :ref:`legacy-put-request` example. That behavior is still supported but no longer necessary.
 
-	:deliveryService: The 'xml_id' of the :term:`Delivery Service` which will use the federation resolvers specified in ``mappings``
-	:mappings:        An object containing two arrays of IP addresses to use as federation resolvers
+.. _legacy-put-request:
+.. code-block:: json
+	:caption: Legacy Request
 
-		:resolve4: An array of IPv4 addresses that can resolve the :term:`Delivery Service`'s federation
-		:resolve6: An array of IPv6 addresses that can resolve the :term:`Delivery Service`'s federation
+	{
+		"federations": [{
+			"deliveryService": "demo1",
+			"mappings": {
+				"resolve4": ["0.0.0.0"],
+				"resolve6": ["::1"]
+			}
+		}]
+	}
+
+The request payload is an array of objects that describe Delivery Service :term:`Federation` Resolver mappings. Each object in the array must be in the following format.
+
+:deliveryService: The :ref:`ds-xmlid` of the :term:`Delivery Service` which will use the :term:`Federation` Resolvers specified in ``mappings``
+:mappings:        An object containing two arrays of IP addresses (or subnets in :abbr:`CIDR (Classless Inter-Domain Routing)` notation) to use as :term:`Federation` Resolvers
+
+	:resolve4: An array of IPv4 addresses (or subnets in :abbr:`CIDR (Classless Inter-Domain Routing)` notation) that can resolve the :term:`Delivery Service`'s :term:`Federation`
+	:resolve6: An array of IPv6 addresses (or subnets in :abbr:`CIDR (Classless Inter-Domain Routing)` notation) that can resolve the :term:`Delivery Service`'s :term:`Federation`
 
 .. code-block:: http
 	:caption: Request Example
 
 	PUT /api/1.4/federations HTTP/1.1
 	Host: trafficops.infra.ciab.test
-	User-Agent: curl/7.62.0
+	User-Agent: curl/7.47.0
 	Accept: */*
 	Cookie: mojolicious=...
-	Content-Length: 113
+	Content-Length: 95
 	Content-Type: application/json
 
-	{ "federations": [{
-		"deliveryService": "demo1",
-		"mappings": {
-			"resolve4": ["0.0.0.1"],
-			"resolve6": ["::1"]
-		}
-	}]}
+	[{ "mappings": {
+		"resolve4": ["8.8.8.8"],
+		"resolve6": []
+	},
+	"deliveryService":"demo1"
+	}]
 
 Response Structure
 ------------------
@@ -215,17 +267,28 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	access-control-allow-credentials: true
-	access-control-allow-headers: Origin, X-Requested-With, Content-Type, Accept
-	access-control-allow-methods: POST,GET,OPTIONS,PUT,DELETE
-	access-control-allow-origin: *
-	cache-control: no-cache, no-store, max-age=0, must-revalidate
-	content-type: application/json
-	date: Wed, 05 Dec 2018 00:52:31 GMT
-	server: Mojolicious (Perl)
-	set-cookie: mojolicious=...; expires=Wed, 05 Dec 2018 04:52:30 GMT; path=/; HttpOnly
-	vary: Accept-Encoding, Accept-Encoding
-	whole-content-sha512: dXg86uD2Un1AeBCeeBLSo2rsYgl6NOHHQEc5oMlpw1THOh2HwGdjwB3rPd/qoYIhOxcnnHoEstrEiHmucFev4A==
-	content-length: 63
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Set-Cookie: mojolicious=...; Path=/; HttpOnly
+	Whole-Content-Sha512: dQ5AvQULhc254zQwgUpBl1/CHbLr/clKtkbs0Ju9f1BM4xIfbbO3puFNN9zaEaZ1iz0lBvHFp/PgfUqisD3QHA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 23 Oct 2019 23:22:03 GMT
+	Content-Length: 258
+	Content-Type: application/json
 
-	{"response": "admin successfully created federation resolvers."}
+	{ "alerts": {
+		"alerts": [
+			{
+				"text": "admin successfully deleted all federation resolvers: [ 8.8.8.8 ]",
+				"level": "success"
+			},
+			{
+				"text": "admin successfully created federation resolvers.",
+				"level": "success"
+			}
+		]
+	},
+	"response": "admin successfully created federation resolvers."
+	}

--- a/docs/source/api/federations.rst
+++ b/docs/source/api/federations.rst
@@ -278,17 +278,15 @@ Response Structure
 	Content-Length: 258
 	Content-Type: application/json
 
-	{ "alerts": {
-		"alerts": [
-			{
-				"text": "admin successfully deleted all federation resolvers: [ 8.8.8.8 ]",
-				"level": "success"
-			},
-			{
-				"text": "admin successfully created federation resolvers.",
-				"level": "success"
-			}
-		]
-	},
+	{ "alerts": [
+		{
+			"text": "admin successfully deleted all federation resolvers: [ 8.8.8.8 ]",
+			"level": "success"
+		},
+		{
+			"text": "admin successfully created federation resolvers.",
+			"level": "success"
+		}
+	],
 	"response": "admin successfully created federation resolvers."
 	}

--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -294,28 +294,28 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 				return nil
 			})),
 		validation.Field(&details.HasNegativeCachingCustomization, validation.By(
-			func (h interface{}) error {
+			func(h interface{}) error {
 				if h == nil {
 					return errors.New("hasNegativeCachingCustomization: required")
 				}
 				return nil
 			})),
 		validation.Field(&details.HasOriginACLWhitelist, validation.By(
-			func (h interface{}) error {
+			func(h interface{}) error {
 				if h == nil {
 					return errors.New("hasNegativeCachingCustomization: required")
 				}
 				return nil
 			})),
 		validation.Field(&details.HasOriginDynamicRemap, validation.By(
-			func (h interface{}) error {
+			func(h interface{}) error {
 				if h == nil {
 					return errors.New("hasNegativeCachingCustomization: required")
 				}
 				return nil
 			})),
 		validation.Field(&details.HasSignedURLs, validation.By(
-			func (h interface{}) error {
+			func(h interface{}) error {
 				if h == nil {
 					return errors.New("hasNegativeCachingCustomization: required")
 				}
@@ -323,7 +323,7 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 			})),
 		validation.Field(&details.MaxLibrarySizeEstimate, validation.Required),
 		validation.Field(&details.OriginHeaders, validation.By(
-			func (h interface{}) error {
+			func(h interface{}) error {
 				if h == nil {
 					return nil
 				}
@@ -340,7 +340,7 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 		validation.Field(&details.RangeRequestHandling, validation.Required),
 		validation.Field(&details.RoutingName, validation.Required),
 		validation.Field(&details.RoutingType, validation.By(
-			func (t interface{}) error {
+			func(t interface{}) error {
 				if t == nil || *(t.(*DSType)) == "" {
 					return errors.New("routingType: required")
 				}

--- a/lib/go-tc/federation.go
+++ b/lib/go-tc/federation.go
@@ -115,7 +115,7 @@ func (r *ResolverMapping) Validate(tx *sql.Tx) error {
 			continue
 		}
 
-		if ip,_,err := net.ParseCIDR(res); err != nil || ip.To4() == nil {
+		if ip, _, err := net.ParseCIDR(res); err != nil || ip.To4() == nil {
 			errs = append(errs, fmt.Errorf("[ %s ] is not a valid ip address.", res))
 		}
 	}
@@ -129,7 +129,7 @@ func (r *ResolverMapping) Validate(tx *sql.Tx) error {
 			continue
 		}
 
-		if ip,_,err := net.ParseCIDR(res); err != nil || ip.To16() == nil {
+		if ip, _, err := net.ParseCIDR(res); err != nil || ip.To16() == nil {
 			errs = append(errs, fmt.Errorf("[ %s ] is not a valid ip address.", res))
 		}
 	}
@@ -143,8 +143,8 @@ func (r *ResolverMapping) Validate(tx *sql.Tx) error {
 // Federation.
 type FederationResolverMapping struct {
 	// TTL is the Time-to-Live of a DNS response to a request to resolve this Federation's CNAME
-	TTL      *int     `json:"ttl"`
-	CName    *string  `json:"cname"`
+	TTL   *int    `json:"ttl"`
+	CName *string `json:"cname"`
 	ResolverMapping
 }
 
@@ -156,7 +156,7 @@ type IAllFederation interface {
 
 // FederationDSPost is the format of a request to associate a Federation with any number of Delivery Services.
 type FederationDSPost struct {
-	DSIDs   []int `json:"dsIds"`
+	DSIDs []int `json:"dsIds"`
 	// Replace indicates whether existing Federation-to-Delivery Service associations should be
 	// replaced by the ones defined by this request, or otherwise merely augmented with them.
 	Replace *bool `json:"replace"`
@@ -187,8 +187,8 @@ func (f *FederationUserPost) Validate(tx *sql.Tx) error {
 }
 
 type DeliveryServiceFederationResolverMapping struct {
-	DeliveryService string `json:"deliveryService"`
-	Mappings ResolverMapping `json:"mappings"`
+	DeliveryService string          `json:"deliveryService"`
+	Mappings        ResolverMapping `json:"mappings"`
 }
 
 func (d *DeliveryServiceFederationResolverMapping) Validate(tx *sql.Tx) error {

--- a/lib/go-tc/federation.go
+++ b/lib/go-tc/federation.go
@@ -21,22 +21,35 @@ package tc
 
 import (
 	"database/sql"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/apache/trafficcontrol/lib/go-util"
 )
 
+// CDNFederationResponse represents a Traffic Ops API response to a request for one or more of a CDN's
+// Federations.
 type CDNFederationResponse struct {
 	Response []CDNFederation `json:"response"`
 }
 
+// CreateCDNFederationResponse represents a Traffic Ops API response to a request to
+// create a new Federation for a CDN.
 type CreateCDNFederationResponse struct {
 	Response CDNFederation `json:"response"`
 	Alerts
 }
 
+// UpdateCDNFederationResponse represents a Traffic Ops API response to a request to replace a
+// Federation of a CDN with the one provided in the request body.
 type UpdateCDNFederationResponse struct {
 	Response CDNFederation `json:"response"`
 	Alerts
 }
 
+// DeleteCDNFederationResponse represents a Traffic Ops API response to a request to remove a
+// Federation from a CDN.
 type DeleteCDNFederationResponse struct {
 	Alerts
 }
@@ -67,26 +80,72 @@ type FederationMapping struct {
 	TTL   int    `json:"ttl"`
 }
 
-// AllFederation is the JSON object returned by /api/1.x/federations?all
-type AllFederation struct {
-	Mappings        []AllFederationMapping `json:"mappings"`
-	DeliveryService DeliveryServiceName    `json:"deliveryService"`
+// AllDeliveryServiceFederationsMapping is a structure that contains identifying information for a
+// Delivery Service as well as any and all Federation Resolver mapping assigned to it (or all those
+// getting assigned to it).
+type AllDeliveryServiceFederationsMapping struct {
+	Mappings        []FederationResolverMapping `json:"mappings"`
+	DeliveryService DeliveryServiceName         `json:"deliveryService"`
 }
 
-func (a AllFederation) IsAllFederations() bool { return true }
+// IsAllFederations implements the IAllFederation interface. Always returns true.
+func (a AllDeliveryServiceFederationsMapping) IsAllFederations() bool { return true }
 
 // AllFederation is the JSON object returned by /api/1.x/federations?all&cdnName=my-cdn-name
 type AllFederationCDN struct {
 	CDNName *CDNName `json:"cdnName"`
 }
 
+// IsAllFederations implements the IAllFederation interface. Always returns true.
 func (a AllFederationCDN) IsAllFederations() bool { return true }
 
-type AllFederationMapping struct {
-	TTL      *int     `json:"ttl"`
-	CName    *string  `json:"cname"`
+type ResolverMapping struct {
 	Resolve4 []string `json:"resolve4,omitempty"`
 	Resolve6 []string `json:"resolve6,omitempty"`
+}
+
+func (r *ResolverMapping) Validate(tx *sql.Tx) error {
+	errs := []error{}
+	for _, res := range r.Resolve4 {
+		ip := net.ParseIP(res)
+		if ip != nil {
+			if ip.To4() == nil {
+				errs = append(errs, fmt.Errorf("[ %s ] is not a valid ip address.", res))
+			}
+			continue
+		}
+
+		if ip,_,err := net.ParseCIDR(res); err != nil || ip.To4() == nil {
+			errs = append(errs, fmt.Errorf("[ %s ] is not a valid ip address.", res))
+		}
+	}
+
+	for _, res := range r.Resolve6 {
+		ip := net.ParseIP(res)
+		if ip != nil {
+			if ip.To16() == nil {
+				errs = append(errs, fmt.Errorf("[ %s ] is not a valid ip address.", res))
+			}
+			continue
+		}
+
+		if ip,_,err := net.ParseCIDR(res); err != nil || ip.To16() == nil {
+			errs = append(errs, fmt.Errorf("[ %s ] is not a valid ip address.", res))
+		}
+	}
+	if len(errs) > 0 {
+		return util.JoinErrs(errs)
+	}
+	return nil
+}
+
+// FederationResolverMapping is the set of all resolvers - both IPv4 and IPv6 - for a specific
+// Federation.
+type FederationResolverMapping struct {
+	// TTL is the Time-to-Live of a DNS response to a request to resolve this Federation's CNAME
+	TTL      *int     `json:"ttl"`
+	CName    *string  `json:"cname"`
+	ResolverMapping
 }
 
 // IAllFederation is an interface for the disparate objects returned by /api/1.x/federations?all.
@@ -95,8 +154,11 @@ type IAllFederation interface {
 	IsAllFederations() bool
 }
 
+// FederationDSPost is the format of a request to associate a Federation with any number of Delivery Services.
 type FederationDSPost struct {
 	DSIDs   []int `json:"dsIds"`
+	// Replace indicates whether existing Federation-to-Delivery Service associations should be
+	// replaced by the ones defined by this request, or otherwise merely augmented with them.
 	Replace *bool `json:"replace"`
 }
 
@@ -121,5 +183,54 @@ type FederationUserPost struct {
 }
 // Validate validates FederationUserPost
 func (f *FederationUserPost) Validate(tx *sql.Tx) error {
+	return nil
+}
+
+type DeliveryServiceFederationResolverMapping struct {
+	DeliveryService string `json:"deliveryService"`
+	Mappings ResolverMapping `json:"mappings"`
+}
+
+func (d *DeliveryServiceFederationResolverMapping) Validate(tx *sql.Tx) error {
+	return d.Mappings.Validate(tx)
+}
+
+// LegacyDeliveryServiceFederationResolverMappingRequest is the legacy format for a request to
+// create (or modify) the Federation Resolver mappings of one or more Delivery Services. Use this
+// for compatibility with API versions 1.3 and older.
+type LegacyDeliveryServiceFederationResolverMappingRequest struct {
+	Federations []DeliveryServiceFederationResolverMapping `json:"federations"`
+}
+
+// Validate implements the github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator
+// interface.
+func (req *LegacyDeliveryServiceFederationResolverMappingRequest) Validate(tx *sql.Tx) error {
+	if len(req.Federations) < 1 {
+		return errors.New("federations: required")
+	}
+	r := DeliveryServiceFederationResolverMappingRequest(req.Federations)
+	return (&r).Validate(tx)
+}
+
+// DeliveryServiceFederationResolverMappingRequest is the format of a request to create (or
+// modify) the Federation Resolver mappings of one or more Delivery Services. Use this when working
+// only with API versions 1.4 and newer.
+type DeliveryServiceFederationResolverMappingRequest []DeliveryServiceFederationResolverMapping
+
+// Validate implements the github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator
+// interface.
+func (req *DeliveryServiceFederationResolverMappingRequest) Validate(tx *sql.Tx) error {
+	if len(*req) < 1 {
+		return errors.New("must specify at least one Delivery Service/Federation Resolver(s) mapping")
+	}
+	errs := []error{}
+	for _, m := range *req {
+		if err := m.Validate(tx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return util.JoinErrs(errs)
+	}
 	return nil
 }

--- a/traffic_ops/client/federation.go
+++ b/traffic_ops/client/federation.go
@@ -143,3 +143,69 @@ func (to *Session) DeleteFederationUser(federationID, userID int) (tc.Alerts, Re
 	}
 	return alerts, reqInf, nil
 }
+
+// AddFederationResolverMappingsForCurrentUser adds Federation Resolver mappings to one or more
+// Delivery Services for the current user.
+func (to *Session) AddFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, ReqInf, error) {
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+	var alerts tc.Alerts
+
+	bts, err := json.Marshal(mappings)
+	if err != nil {
+		return alerts, reqInf, err
+	}
+
+	resp, remoteAddr, err := to.request(http.MethodPost, apiBase + "/federations", bts)
+	reqInf.RemoteAddr = remoteAddr
+	if err != nil {
+		return alerts, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, err
+}
+
+// DeleteFederationResolverMappingsForCurrentUser removes ALL Federation Resolver mappings for ALL
+// Federations assigned to the currently authenticated user, as well as deleting ALL of the
+// Federation Resolvers themselves.
+func (to *Session) DeleteFederationResolverMappingsForCurrentUser() (tc.Alerts, ReqInf, error) {
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+	var alerts tc.Alerts
+
+	resp, remoteAddr, err := to.request(http.MethodDelete, apiBase + "/federations", nil)
+	reqInf.RemoteAddr = remoteAddr
+	if err != nil {
+		return alerts, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, err
+}
+
+// ReplaceFederationResolverMappingsForCurrentUser replaces any and all Federation Resolver mappings
+// on all Federations assigned to the currently authenticated user. This will first remove ALL
+// Federation Resolver mappings for ALL Federations assigned to the currently authenticated user, as
+// well as deleting ALL of the Federation Resolvers themselves. In other words, calling this is
+// equivalent to a call to DeleteFederationResolverMappingsForCurrentUser followed by a call to
+// AddFederationResolverMappingsForCurrentUser .
+func (to *Session) ReplaceFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, ReqInf, error) {
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+	var alerts tc.Alerts
+
+	bts, err := json.Marshal(mappings)
+	if err != nil {
+		return alerts, reqInf, err
+	}
+
+	resp, remoteAddr, err := to.request(http.MethodPut, apiBase + "/federations", bts)
+	reqInf.RemoteAddr = remoteAddr
+	if err != nil {
+		return alerts, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, err
+}

--- a/traffic_ops/client/federation.go
+++ b/traffic_ops/client/federation.go
@@ -25,25 +25,25 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
-func (to *Session) Federations() ([]tc.AllFederation, ReqInf, error) {
+func (to *Session) Federations() ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
 	type FederationResponse struct {
-		Response []tc.AllFederation `json:"response"`
+		Response []tc.AllDeliveryServiceFederationsMapping `json:"response"`
 	}
 	data := FederationResponse{}
 	inf, err := get(to, apiBase+"/federations", &data)
 	return data.Response, inf, err
 }
 
-func (to *Session) AllFederations() ([]tc.AllFederation, ReqInf, error) {
+func (to *Session) AllFederations() ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
 	type FederationResponse struct {
-		Response []tc.AllFederation `json:"response"`
+		Response []tc.AllDeliveryServiceFederationsMapping `json:"response"`
 	}
 	data := FederationResponse{}
 	inf, err := get(to, apiBase+"/federations/all", &data)
 	return data.Response, inf, err
 }
 
-func (to *Session) AllFederationsForCDN(cdnName string) ([]tc.AllFederation, ReqInf, error) {
+func (to *Session) AllFederationsForCDN(cdnName string) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
 	// because the Federations JSON array is heterogeneous (array members may be a AllFederation or AllFederationCDN), we have to try decoding each separately.
 	type FederationResponse struct {
 		Response []json.RawMessage `json:"response"`
@@ -54,9 +54,9 @@ func (to *Session) AllFederationsForCDN(cdnName string) ([]tc.AllFederation, Req
 		return nil, inf, err
 	}
 
-	feds := []tc.AllFederation{}
+	feds := []tc.AllDeliveryServiceFederationsMapping{}
 	for _, raw := range data.Response {
-		fed := tc.AllFederation{}
+		fed := tc.AllDeliveryServiceFederationsMapping{}
 		if err := json.Unmarshal([]byte(raw), &fed); err != nil {
 			// we don't actually need the CDN, but we want to return an error if we got something unexpected
 			cdnFed := tc.AllFederationCDN{}

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -86,7 +86,7 @@ func WriteRespRaw(w http.ResponseWriter, r *http.Request, v interface{}) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(bts)
+	w.Write(append(bts, '\n'))
 }
 
 // WriteRespVals is like WriteResp, but also takes a map of root-level values to write. The API most commonly needs these for meta-parameters, like size, limit, and orderby.

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
@@ -182,7 +182,7 @@ func TestReadHandler(t *testing.T) {
 	readFunc(w, r)
 
 	//verifies the body is in the expected format
-	body := `{"response":[{"ID":1}]}`
+	body := "{\"response\":[{\"ID\":1}]}\n"
 	if w.Body.String() != body {
 		t.Error("Expected body", body, "got", w.Body.String())
 	}

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -42,55 +42,6 @@ const BaseOrderBy = "\nORDER BY"
 const BaseLimit = "\nLIMIT"
 const BaseOffset = "\nOFFSET"
 
-const UserIDHasAccessToDeliveryServiceXMLIDQuery = `
-WITH RECURSIVE
-	user_tenant_id AS (
-		SELECT tm_user.tenant_id AS v
-		FROM tm_user
-		WHERE tm_user.id = $1
-	),
-	resource_tenant_id AS (
-		SELECT deliveryservice.tenant_id AS v
-		FROM deliveryservice
-		WHERE deliveryservice.xml_id = $2
-	),
-	user_tenant_parents AS (
-			SELECT active, parent_id
-			FROM tenant
-			WHERE id = (
-				SELECT v
-				FROM user_tenant_id
-			)
-		UNION
-			SELECT t.active, t.parent_id
-			FROM tenant t
-			JOIN user_tenant_parents ON user_tenant_parents.parent_id = t.id
-	),
-	q AS (
-			SELECT id, active
-			FROM tenant
-			WHERE id = (
-				SELECT v
-				FROM user_tenant_id
-			)
-		UNION
-			SELECT t.id, t.active
-			FROM tenant t
-			JOIN q ON q.id = t.parent_id
-	)
-SELECT id, (
-	SELECT bool_and(active)
-	FROM user_tenant_parents
-) AS active
-FROM q
-WHERE id = (
-	SELECT v
-	FROM resource_tenant_id
-)
-UNION ALL SELECT -1, false
-FETCH FIRST 1 ROW ONLY;
-`
-
 const getDSTenantIDFromXMLIDQuery = `
 SELECT deliveryservice.tenant_id
 FROM deliveryservice

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -42,6 +42,75 @@ const BaseOrderBy = "\nORDER BY"
 const BaseLimit = "\nLIMIT"
 const BaseOffset = "\nOFFSET"
 
+const UserIDHasAccessToDeliveryServiceXMLIDQuery = `
+WITH RECURSIVE
+	user_tenant_id AS (
+		SELECT tm_user.tenant_id AS v
+		FROM tm_user
+		WHERE tm_user.id = $1
+	),
+	resource_tenant_id AS (
+		SELECT deliveryservice.tenant_id AS v
+		FROM deliveryservice
+		WHERE deliveryservice.xml_id = $2
+	),
+	user_tenant_parents AS (
+			SELECT active, parent_id
+			FROM tenant
+			WHERE id = (
+				SELECT v
+				FROM user_tenant_id
+			)
+		UNION
+			SELECT t.active, t.parent_id
+			FROM tenant t
+			JOIN user_tenant_parents ON user_tenant_parents.parent_id = t.id
+	),
+	q AS (
+			SELECT id, active
+			FROM tenant
+			WHERE id = (
+				SELECT v
+				FROM user_tenant_id
+			)
+		UNION
+			SELECT t.id, t.active
+			FROM tenant t
+			JOIN q ON q.id = t.parent_id
+	)
+SELECT id, (
+	SELECT bool_and(active)
+	FROM user_tenant_parents
+) AS active
+FROM q
+WHERE id = (
+	SELECT v
+	FROM resource_tenant_id
+)
+UNION ALL SELECT -1, false
+FETCH FIRST 1 ROW ONLY;
+`
+
+const getDSTenantIDFromXMLIDQuery = `
+SELECT deliveryservice.tenant_id
+FROM deliveryservice
+WHERE deliveryservice.xml_id = $1
+`
+
+const getFederationIDForUserIDByXMLIDQuery = `
+SELECT federation_deliveryservice.federation
+FROM federation_deliveryservice
+WHERE federation_deliveryservice.deliveryservice IN (
+	SELECT deliveryservice.id
+	FROM deliveryservice
+	WHERE deliveryservice.xml_id = $1
+) AND federation_deliveryservice.federation IN (
+	SELECT federation_tmuser.federation
+	FROM federation_tmuser
+	WHERE federation_tmuser.tm_user = $2
+)
+`
+
 func BuildWhereAndOrderByAndPagination(parameters map[string]string, queryParamsToSQLCols map[string]WhereColumnInfo) (string, string, string, map[string]interface{}, []error) {
 	whereClause := BaseWhere
 	orderBy := BaseOrderBy
@@ -215,6 +284,21 @@ func GetDSNameFromID(tx *sql.Tx, id int) (tc.DeliveryServiceName, bool, error) {
 	return name, true, nil
 }
 
+// GetDSTenantIDFromXMLID fetches the ID of the Tenant to whom the Delivery Service identified by the
+// the provided XMLID belongs. It returns, in order, the requested ID (if one could be found), a
+// boolean indicating whether or not a Delivery Service with the provided xmlid could be found, and
+// an error for logging in case something unexpected goes wrong.
+func GetDSTenantIDFromXMLID(tx *sql.Tx, xmlid string) (int, bool, error) {
+	var id int
+	if err := tx.QueryRow(getDSTenantIDFromXMLIDQuery, xmlid).Scan(&id); err != nil {
+		if err == sql.ErrNoRows {
+			return -1, false, nil
+		}
+		return -1, false, fmt.Errorf("Fetching Tenant ID for DS %s: %v", xmlid, err)
+	}
+	return id, true, nil
+}
+
 // GetProfileNameFromID returns the profile's name, whether a profile with ID exists, or any error.
 func GetProfileNameFromID(id int, tx *sql.Tx) (string, bool, error) {
 	name := ""
@@ -345,4 +429,18 @@ func GetCacheGroupNameFromID(tx *sql.Tx, id int64) (tc.CacheGroupName, bool, err
 		return "", false, errors.New("querying cachegroup ID: " + err.Error())
 	}
 	return tc.CacheGroupName(name), true, nil
+}
+
+// GetFederationIDForUserIDByXMLID retrieves the ID of the Federation assigned to the user defined by
+// userID on the Delivery Service identified by xmlid. If no such federation exists, the boolean
+// returned will be 'false', while the error indicates unexpected errors that occurred when querying.
+func GetFederationIDForUserIDByXMLID(tx *sql.Tx, userID int, xmlid string) (uint, bool, error) {
+	var id uint
+	if err := tx.QueryRow(getFederationIDForUserIDByXMLIDQuery, xmlid, userID).Scan(&id); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("Getting Federation ID for user #%d by DS XMLID '%s': %v", userID, xmlid, err)
+	}
+	return id, true, nil
 }

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -239,10 +239,10 @@ func AddFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *http.
 	}
 
 	msg := fmt.Sprintf("%s successfully created federation resolvers.", inf.User.UserName)
-	if inf.Version.Major > 1 || inf.Version.Minor > 3 {
-		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)
-	} else {
+	if inf.Version.Major <= 1 || inf.Version.Minor <= 3 {
 		api.WriteResp(w, r, msg)
+	} else {
+		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)
 	}
 }
 
@@ -359,10 +359,10 @@ func RemoveFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *ht
 	changelogMsg := fmt.Sprintf("USER: %s, ID: %d, ACTION: %s", inf.User.UserName, inf.User.ID, msg)
 	api.CreateChangeLogRawTx(api.ApiChange, changelogMsg, inf.User, tx)
 
-	if inf.Version.Major > 1 || inf.Version.Minor > 3 {
-		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)
-	} else {
+	if inf.Version.Major <= 1 || inf.Version.Minor <= 3 {
 		api.WriteResp(w, r, msg)
+	} else {
+		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)
 	}
 }
 
@@ -429,7 +429,7 @@ func ReplaceFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *h
 	}
 
 	createdMsg := fmt.Sprintf("%s successfully created federation resolvers.", inf.User.UserName)
-	if inf.Version.Major < 2 && inf.Version.Minor <= 3 {
+	if inf.Version.Major <= 1 && inf.Version.Minor <= 3 {
 		api.WriteResp(w, r, createdMsg)
 		return
 	}
@@ -476,7 +476,7 @@ func getMappingsFromRequestBody(v api.Version, body io.ReadCloser) (tc.DeliveryS
 		return mappings, errors.New("Couldn't read request"), fmt.Errorf("Reading request body: %v", err)
 	}
 
-	if v.Minor <= 3 {
+	if v.Major <=1 && v.Minor <= 3 {
 		var req tc.LegacyDeliveryServiceFederationResolverMappingRequest
 		if err := json.Unmarshal(b, &req); err != nil {
 			return mappings, fmt.Errorf("parsing request: %v", err), nil

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -239,7 +239,7 @@ func AddFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *http.
 	}
 
 	msg := fmt.Sprintf("%s successfully created federation resolvers.", inf.User.UserName)
-	if inf.Version.Major <= 1 || inf.Version.Minor <= 3 {
+	if inf.Version.Major <= 1 && inf.Version.Minor <= 3 {
 		api.WriteResp(w, r, msg)
 	} else {
 		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)
@@ -359,7 +359,7 @@ func RemoveFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *ht
 	changelogMsg := fmt.Sprintf("USER: %s, ID: %d, ACTION: %s", inf.User.UserName, inf.User.ID, msg)
 	api.CreateChangeLogRawTx(api.ApiChange, changelogMsg, inf.User, tx)
 
-	if inf.Version.Major <= 1 || inf.Version.Minor <= 3 {
+	if inf.Version.Major <= 1 && inf.Version.Minor <= 3 {
 		api.WriteResp(w, r, msg)
 	} else {
 		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -21,16 +21,40 @@ package federations
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
 
 	"github.com/lib/pq"
 )
+
+const insertResolverQuery = `
+INSERT INTO federation_resolver (ip_address, type)
+VALUES ($1, (
+	SELECT type.id
+	FROM type
+	WHERE type.name = $2
+))
+ON CONFLICT DO NOTHING
+RETURNING federation_resolver.ip_address, federation_resolver.id
+`
+
+const associateFederationWithResolverQuery = `
+INSERT INTO federation_federation_resolver (federation, federation_resolver)
+VALUES ($1, $2)
+ON CONFLICT DO NOTHING
+`
 
 func Get(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
@@ -55,9 +79,9 @@ func Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func addResolvers(allFederations []tc.IAllFederation, feds []FedInfo, fedsResolvers map[int][]FedResolverInfo) []tc.IAllFederation {
-	dsFeds := map[tc.DeliveryServiceName][]tc.AllFederationMapping{}
+	dsFeds := map[tc.DeliveryServiceName][]tc.FederationResolverMapping{}
 	for _, fed := range feds {
-		mapping := tc.AllFederationMapping{}
+		mapping := tc.FederationResolverMapping{}
 		mapping.TTL = util.IntPtr(fed.TTL)
 		mapping.CName = util.StrPtr(fed.CName)
 		for _, resolver := range fedsResolvers[fed.ID] {
@@ -74,7 +98,7 @@ func addResolvers(allFederations []tc.IAllFederation, feds []FedInfo, fedsResolv
 	}
 
 	for ds, mappings := range dsFeds {
-		allFederations = append(allFederations, tc.AllFederation{DeliveryService: ds, Mappings: mappings})
+		allFederations = append(allFederations, tc.AllDeliveryServiceFederationsMapping{DeliveryService: ds, Mappings: mappings})
 	}
 	return allFederations
 }
@@ -166,4 +190,155 @@ ORDER BY
 		feds = append(feds, f)
 	}
 	return feds, nil
+}
+
+// AddFederationResorverMappingsForCurrentUser is the handler for a POST request to /federations.
+// Confusingly, it does not create a federation, but is instead used to manipulate the resolvers
+// used by one or more particular Delivery Services for one or more particular Federations.
+func AddFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	tx := inf.Tx.Tx
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		userErr = errors.New("Couldn't read request")
+		sysErr = fmt.Errorf("Reading request body: %v", err)
+		errCode = http.StatusBadRequest
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+
+	var mappings tc.DeliveryServiceFederationResolverMappingRequest
+	if inf.Version.Minor <= 3 {
+		var req tc.LegacyDeliveryServiceFederationResolverMappingRequest
+		if err := json.Unmarshal(b, &req); err != nil {
+			errCode = http.StatusBadRequest
+			userErr = fmt.Errorf("parsing request: %v", err)
+			api.HandleErr(w, r, tx, errCode, userErr, nil)
+			return
+		}
+		mappings = req.Federations
+	} else {
+		var req tc.DeliveryServiceFederationResolverMappingRequest
+
+		// fall back on legacy behavior
+		if err := json.Unmarshal(b, &req); err != nil {
+			var request tc.LegacyDeliveryServiceFederationResolverMappingRequest
+			if err = json.Unmarshal(b, &request); err != nil {
+				errCode = http.StatusBadRequest
+				userErr = fmt.Errorf("parsing request: %v", err)
+				api.HandleErr(w, r, tx, errCode, userErr, nil)
+				return
+			}
+			req = request.Federations
+		}
+		mappings = req
+	}
+
+	if err := mappings.Validate(tx); err != nil {
+		errCode = http.StatusBadRequest
+		userErr = fmt.Errorf("validating request: %v", err)
+		api.HandleErr(w, r, tx, errCode, userErr, nil)
+		return
+	}
+
+	userErr, sysErr, errCode = addFederationResolverMappingsForCurrentUser(inf.User, tx, mappings)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+
+	msg := fmt.Sprintf("%s successfully created federation resolvers.", inf.User.UserName)
+	if inf.Version.Minor <= 3 {
+		api.WriteResp(w, r, msg)
+	} else {
+		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)
+	}
+}
+
+// handles the main logic of the POST handler, separated out for convenience
+func addFederationResolverMappingsForCurrentUser(u *auth.CurrentUser, tx *sql.Tx, mappings []tc.DeliveryServiceFederationResolverMapping) (error, error, int) {
+	for _, fed := range mappings {
+		dsTenant, ok, err := dbhelpers.GetDSTenantIDFromXMLID(tx, fed.DeliveryService)
+		if err != nil {
+			return nil, err, http.StatusInternalServerError
+		} else if !ok {
+			return fmt.Errorf("'%s' - no such Delivery Service", fed.DeliveryService), nil, http.StatusBadRequest
+		}
+
+		if ok, err = tenant.IsResourceAuthorizedToUserTx(dsTenant, u, tx); err != nil {
+			err = fmt.Errorf("Checking user #%d tenancy permissions on DS '%s' (tenant #%d)", u.ID, fed.DeliveryService, dsTenant)
+			return nil, err, http.StatusInternalServerError
+		} else if !ok {
+			userErr := fmt.Errorf("'%s' - no such Delivery Service", fed.DeliveryService)
+			sysErr := fmt.Errorf("User '%s' requested unauthorized federation resolver mapping modification on the '%s' Delivery Service", u.UserName, fed.DeliveryService)
+			return userErr, sysErr, http.StatusConflict
+		}
+
+		fedID, ok, err := dbhelpers.GetFederationIDForUserIDByXMLID(tx, u.ID, fed.DeliveryService)
+		if err != nil {
+			return nil, fmt.Errorf("Getting Federation ID: %v", err), http.StatusInternalServerError
+		} else if !ok {
+			err = fmt.Errorf("No federation(s) found for user %s on delivery service '%s'.", u.UserName, fed.DeliveryService)
+			return err, nil, http.StatusConflict
+		}
+
+		inserted, err := addFederationResolverMappingsToFederation(fed.Mappings, fed.DeliveryService, fedID, tx)
+		if err != nil {
+			err = fmt.Errorf("Adding federation resolver mapping(s) to federation: %v", err)
+			return nil, err, http.StatusInternalServerError
+		}
+
+		changelogMsg := "FEDERATION DELIVERY SERVICE: %s, ID: %d, ACTION: User %s successfully added federation resolvers [ %s ]"
+		changelogMsg = fmt.Sprintf(changelogMsg, fed.DeliveryService, fedID, u.UserName, inserted)
+		api.CreateChangeLogRawTx(api.ApiChange, changelogMsg, u, tx)
+	}
+	return nil, nil, http.StatusOK
+}
+
+// adds federation resolver mappings for a particular delivery service to a given federation, creating said resolvers if
+// they don't already exist.
+func addFederationResolverMappingsToFederation(res tc.ResolverMapping, xmlid string, fed uint, tx *sql.Tx) (string, error) {
+	var resp string
+	if len(res.Resolve4) > 0 {
+		inserted, err := addFederationResolver(res.Resolve4, tc.FederationResolverType4, fed, tx)
+		if err != nil {
+			return "", err
+		}
+		resp = strings.Join(inserted, ", ")
+	}
+	if len(res.Resolve6) > 0 {
+		inserted, err := addFederationResolver(res.Resolve6, tc.FederationResolverType6, fed, tx)
+		if err != nil {
+			return "", err
+		}
+		resp += strings.Join(inserted, ", ")
+	}
+	return resp, nil
+}
+
+// adds federation resolvers of a specific type to the given federation
+func addFederationResolver(res []string, t tc.FederationResolverType, fedID uint, tx *sql.Tx) ([]string, error) {
+	inserted := []string{}
+	for _, r := range res {
+		var ip string
+		var id uint
+		if err := tx.QueryRow(insertResolverQuery, r, t).Scan(&ip, &id); err != nil && err != sql.ErrNoRows {
+			return nil, err
+		}
+		if ip != "" && id > 0 {
+			inserted = append(inserted, ip)
+			if _, err := tx.Exec(associateFederationWithResolverQuery, fedID, id); err != nil {
+				return nil, err
+			}
+		}
+
+	}
+
+	return inserted, nil
 }

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -447,7 +447,7 @@ func ReplaceFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *h
 		},
 	}
 	resp := struct {
-		Alerts   tc.Alerts `json:"alerts"`
+		tc.Alerts
 		Response string    `json:"response"`
 	}{
 		alerts,

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -239,10 +239,10 @@ func AddFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *http.
 	}
 
 	msg := fmt.Sprintf("%s successfully created federation resolvers.", inf.User.UserName)
-	if inf.Version.Minor <= 3 {
-		api.WriteResp(w, r, msg)
-	} else {
+	if inf.Version.Major > 1 || inf.Version.Minor > 3 {
 		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)
+	} else {
+		api.WriteResp(w, r, msg)
 	}
 }
 
@@ -359,10 +359,10 @@ func RemoveFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *ht
 	changelogMsg := fmt.Sprintf("USER: %s, ID: %d, ACTION: %s", inf.User.UserName, inf.User.ID, msg)
 	api.CreateChangeLogRawTx(api.ApiChange, changelogMsg, inf.User, tx)
 
-	if inf.Version.Minor <= 3 {
-		api.WriteResp(w, r, msg)
-	} else {
+	if inf.Version.Major > 1 || inf.Version.Minor > 3 {
 		api.WriteRespAlertObj(w, r, tc.SuccessLevel, msg, msg)
+	} else {
+		api.WriteResp(w, r, msg)
 	}
 }
 
@@ -429,7 +429,7 @@ func ReplaceFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *h
 	}
 
 	createdMsg := fmt.Sprintf("%s successfully created federation resolvers.", inf.User.UserName)
-	if inf.Version.Minor <= 3 {
+	if inf.Version.Major < 2 && inf.Version.Minor <= 3 {
 		api.WriteResp(w, r, createdMsg)
 		return
 	}

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -438,17 +438,17 @@ func ReplaceFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *h
 		[]tc.Alert{
 			tc.Alert{
 				Level: tc.SuccessLevel.String(),
-				Text: deletedMsg,
+				Text:  deletedMsg,
 			},
 			tc.Alert{
 				Level: tc.SuccessLevel.String(),
-				Text: createdMsg,
+				Text:  createdMsg,
 			},
 		},
 	}
-	resp := struct{
-		Alerts tc.Alerts `json:"alerts"`
-		Response string `json:"response"`
+	resp := struct {
+		Alerts   tc.Alerts `json:"alerts"`
+		Response string    `json:"response"`
 	}{
 		alerts,
 		createdMsg,
@@ -467,7 +467,7 @@ func ReplaceFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *h
 }
 
 // retrieves mappings from the given request body using the rules of the given api Version
-func getMappingsFromRequestBody(v api.Version, body io.ReadCloser) (tc.DeliveryServiceFederationResolverMappingRequest, error, error){
+func getMappingsFromRequestBody(v api.Version, body io.ReadCloser) (tc.DeliveryServiceFederationResolverMappingRequest, error, error) {
 	defer body.Close()
 	var mappings tc.DeliveryServiceFederationResolverMappingRequest
 
@@ -475,7 +475,6 @@ func getMappingsFromRequestBody(v api.Version, body io.ReadCloser) (tc.DeliveryS
 	if err != nil {
 		return mappings, errors.New("Couldn't read request"), fmt.Errorf("Reading request body: %v", err)
 	}
-
 
 	if v.Minor <= 3 {
 		var req tc.LegacyDeliveryServiceFederationResolverMappingRequest

--- a/traffic_ops/traffic_ops_golang/federations/federations_test.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations_test.go
@@ -1,0 +1,336 @@
+package federations
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "database/sql"
+import "io/ioutil"
+import "net/http"
+import "strings"
+import "testing"
+
+import "github.com/apache/trafficcontrol/lib/go-tc"
+
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+
+import "gopkg.in/DATA-DOG/go-sqlmock.v1"
+
+func TestAddFederationResolverMappingsForCurrentUser(t *testing.T) {
+	t.Run("add Federation Resolver Mappings for the current user", positiveTestAddFederationResolverMappingsForCurrentUser)
+	t.Run("add Federation Resolver Mappings for the current user when no federations exist/are assigned to them", testAddFederationResolverMappingsForCurrentUserWithoutFederations)
+	t.Run("add Federation Resolver Mappings for a DS unauthorized to the current user's tenant", testUnauthorizedDSOnResolverAdd)
+}
+
+func positiveTestAddFederationResolverMappingsForCurrentUser(t *testing.T) {
+	u := auth.CurrentUser{
+		UserName: "test",
+		ID: 1,
+		PrivLevel: 100,
+		TenantID: 1,
+		Role: 1,
+	}
+
+	mappings := []tc.DeliveryServiceFederationResolverMapping{
+		tc.DeliveryServiceFederationResolverMapping{
+			DeliveryService: "test",
+			Mappings: tc.ResolverMapping {
+				Resolve4: []string{"0.0.0.0", "127.0.0.1/12"},
+				Resolve6: []string{"abcd:ef01:2345:6789::", "f1d0::f00d/127"},
+			},
+		},
+	}
+
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+
+	dsTenantIDRows := sqlmock.NewRows([]string{"tenant_id"})
+	dsTenantIDRows.AddRow(1)
+	authorizedRows := sqlmock.NewRows([]string{"id", "active"})
+	authorizedRows.AddRow(1, true)
+	fedIDRows := sqlmock.NewRows([]string{"federation"})
+	fedIDRows.AddRow(1)
+	insertFirstResolverRows := sqlmock.NewRows([]string{"ip_address", "id"})
+	insertFirstResolverRows.AddRow(mappings[0].Mappings.Resolve4[0], 1)
+	insertSecondResolverRows := sqlmock.NewRows([]string{"ip_address", "id"})
+	insertSecondResolverRows.AddRow(mappings[0].Mappings.Resolve4[1], 2)
+	insertThirdResolverRows := sqlmock.NewRows([]string{"ip_address", "id"})
+	insertThirdResolverRows.AddRow(mappings[0].Mappings.Resolve6[0], 3)
+	insertFourthResolverRows := sqlmock.NewRows([]string{"ip_address", "id"})
+	insertFourthResolverRows.AddRow(mappings[0].Mappings.Resolve6[1], 4)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT deliveryservice.tenant_id").WillReturnRows(dsTenantIDRows)
+	mock.ExpectQuery("WITH RECURSIVE").WillReturnRows(authorizedRows)
+	mock.ExpectQuery("SELECT federation_deliveryservice.federation").WillReturnRows(fedIDRows)
+	mock.ExpectQuery("INSERT INTO federation_resolver").WillReturnRows(insertFirstResolverRows)
+	mock.ExpectExec("INSERT INTO federation_federation_resolver").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("INSERT INTO federation_resolver").WillReturnRows(insertSecondResolverRows)
+	mock.ExpectExec("INSERT INTO federation_federation_resolver").WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectQuery("INSERT INTO federation_resolver").WillReturnRows(insertThirdResolverRows)
+	mock.ExpectExec("INSERT INTO federation_federation_resolver").WillReturnResult(sqlmock.NewResult(3, 1))
+	mock.ExpectQuery("INSERT INTO federation_resolver").WillReturnRows(insertFourthResolverRows)
+	mock.ExpectExec("INSERT INTO federation_federation_resolver").WillReturnResult(sqlmock.NewResult(4, 1))
+	mock.ExpectCommit()
+
+	tx, err := mockDB.Begin()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when beginning a mock transaction", err)
+	}
+
+	userErr, sysErr, errCode := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
+	if userErr != nil {
+		t.Errorf("Unexpected user error: %v", userErr)
+	}
+	if sysErr != nil {
+		t.Errorf("Unexpected system error: %v", sysErr)
+	}
+	if errCode != http.StatusOK {
+		t.Errorf("Expected response code %d, got %d", http.StatusOK, errCode)
+	}
+}
+
+func testAddFederationResolverMappingsForCurrentUserWithoutFederations(t *testing.T) {
+	u := auth.CurrentUser{
+		UserName: "test",
+		ID: 1,
+		PrivLevel: 100,
+		TenantID: 1,
+		Role: 1,
+	}
+
+	mappings := []tc.DeliveryServiceFederationResolverMapping{
+		tc.DeliveryServiceFederationResolverMapping{
+			DeliveryService: "test",
+			Mappings: tc.ResolverMapping {
+				Resolve4: []string{"0.0.0.0"},
+				Resolve6: []string{},
+			},
+		},
+	}
+
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+
+	dsTenantIDRows := sqlmock.NewRows([]string{"tenant_id"})
+	dsTenantIDRows.AddRow(1)
+	authorizedRows := sqlmock.NewRows([]string{"id", "active"})
+	authorizedRows.AddRow(1, true)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT deliveryservice.tenant_id").WillReturnRows(dsTenantIDRows)
+	mock.ExpectQuery("WITH RECURSIVE").WillReturnRows(authorizedRows)
+	mock.ExpectQuery("SELECT federation_deliveryservice.federation").WillReturnError(sql.ErrNoRows)
+	mock.ExpectCommit()
+
+	tx, err := mockDB.Begin()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when beginning a mock transaction", err)
+	}
+
+	userErr, sysErr, errCode := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
+	if userErr == nil {
+		t.Errorf("Unexpected a user error, but didn't get one")
+	} else {
+		t.Logf("Got expected user error: %v", userErr)
+	}
+	if sysErr != nil {
+		t.Errorf("Unexpected system error: %v", sysErr)
+	}
+	if errCode != http.StatusConflict {
+		t.Errorf("Expected response code %d, got %d", http.StatusConflict, errCode)
+	}
+}
+
+func testUnauthorizedDSOnResolverAdd(t *testing.T) {
+	u := auth.CurrentUser {
+		UserName: "test",
+		ID: 1,
+		PrivLevel: 100,
+		TenantID: 1,
+		Role: 1,
+	}
+
+	mappings := []tc.DeliveryServiceFederationResolverMapping{
+		tc.DeliveryServiceFederationResolverMapping{
+			DeliveryService: "test",
+			Mappings: tc.ResolverMapping {
+				Resolve4: []string{},
+				Resolve6: []string{},
+			},
+		},
+	}
+
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+
+	dsTenantIDRows := sqlmock.NewRows([]string{"tenant_id"})
+	dsTenantIDRows.AddRow(1)
+	authorizedRows := sqlmock.NewRows([]string{"id", "active"})
+	authorizedRows.AddRow(1, false) // unauthorized because tenant is inactive
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT deliveryservice.tenant_id").WillReturnRows(dsTenantIDRows)
+	mock.ExpectQuery("WITH RECURSIVE").WillReturnRows(authorizedRows)
+	mock.ExpectCommit()
+
+	tx, err := mockDB.Begin()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when beginning a mock transaction", err)
+	}
+
+	userErr, sysErr, errCode := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
+	if userErr == nil {
+		t.Errorf("Unexpected a user error, but didn't get one")
+	} else {
+		t.Logf("Got expected user error: %v", userErr)
+	}
+	if sysErr == nil {
+		t.Errorf("Unexpected a system error, but didn't get one")
+	} else {
+		t.Logf("Got expected system error: %v", sysErr)
+	}
+	if errCode != http.StatusConflict {
+		t.Errorf("Expected response code %d, got %d", http.StatusConflict, errCode)
+	}
+}
+
+func TestGetMappingsFromRequestBody(t *testing.T) {
+	data := `{"federations":[{"deliveryService":"test","mappings":{"resolve4":[], "resolve6":[]}}]}`
+	buf := strings.NewReader(data)
+
+	legacyVersion := api.Version {
+		Major: 1,
+		Minor: 3,
+	}
+
+	version := api.Version {
+		Major: 1,
+		Minor: 4,
+	}
+
+	_, userErr, sysErr := getMappingsFromRequestBody(legacyVersion, ioutil.NopCloser(buf))
+	if userErr != nil {
+		t.Errorf("Unexpected user error legacy parsing '%s': %v", data, userErr)
+	}
+	if sysErr != nil {
+		t.Errorf("Unexpected system error legacy parsing '%s': %v", data, sysErr)
+	}
+
+	buf = strings.NewReader(data)
+
+	_, userErr, sysErr = getMappingsFromRequestBody(version, ioutil.NopCloser(buf))
+	if userErr != nil {
+		t.Errorf("Unexpected user error parsing '%s': %v", data, userErr)
+	}
+	if sysErr != nil {
+		t.Errorf("Unexpected system error parsing '%s': %v", data, sysErr)
+	}
+
+	data = `[{"deliveryService":"test","mappings":{"resolve4":[], "resolve6":[]}}]`
+	buf = strings.NewReader(data)
+
+	_, userErr, sysErr = getMappingsFromRequestBody(legacyVersion, ioutil.NopCloser(buf))
+	if userErr == nil {
+		t.Errorf("Expected user error legacy parsing '%s' but didn't get one", data)
+	} else {
+		t.Logf("Got expected user error legacy parsing '%s': %v", data, userErr)
+	}
+	if sysErr != nil {
+		t.Errorf("Unexpected system error legacy parsing '%s': %v", data, sysErr)
+	}
+
+	buf = strings.NewReader(data)
+
+	_, userErr, sysErr = getMappingsFromRequestBody(version, ioutil.NopCloser(buf))
+	if userErr != nil {
+		t.Errorf("Unexpected user error parsing '%s': %v", data, userErr)
+	}
+	if sysErr != nil {
+		t.Errorf("Unexpected system error parsing '%s': %v", data, sysErr)
+	}
+}
+
+func TestRemoveFederationResolverMappingsForCurrentUser(t *testing.T) {
+	u := auth.CurrentUser{
+		UserName: "test",
+		ID: 1,
+		PrivLevel: 100,
+		TenantID: 1,
+		Role: 1,
+	}
+
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+
+	ips := []string{
+		"0.0.0.0",
+		"127.0.0.1/32",
+		"::1",
+		"::1/64",
+	}
+
+	rows := sqlmock.NewRows([]string{"ip_address"})
+	rows.AddRow(ips[0])
+	rows.AddRow(ips[1])
+	rows.AddRow(ips[2])
+	rows.AddRow(ips[3])
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("DELETE").WillReturnRows(rows)
+	mock.ExpectCommit()
+
+	tx, err := mockDB.Begin()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when beginning a mock transaction", err)
+	}
+
+	returnedIPs, userErr, sysErr, errCode := removeFederationResolverMappingsForCurrentUser(tx, &u)
+	if userErr != nil {
+		t.Errorf("Unexpected user error removing resolvers: %v", userErr)
+	}
+	if sysErr != nil {
+		t.Errorf("Unexpected system error removing resolvers: %v", sysErr)
+	}
+	if errCode != http.StatusOK {
+		t.Errorf("Expected return code %d when removing resolvers, but got %d", http.StatusOK, errCode)
+	}
+
+	if len(returnedIPs) != len(ips) {
+		t.Fatalf("Length of returned IP array (%d) does not match expected length (%d)", len(returnedIPs), len(ips))
+	}
+
+	for i, ip := range ips {
+		if returnedIPs[i] != ip {
+			t.Errorf("Returned IP #%d was '%s', but '%s' was expected", i, returnedIPs[i], ip)
+		}
+	}
+}

--- a/traffic_ops/traffic_ops_golang/federations/federations_test.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations_test.go
@@ -40,17 +40,17 @@ func TestAddFederationResolverMappingsForCurrentUser(t *testing.T) {
 
 func positiveTestAddFederationResolverMappingsForCurrentUser(t *testing.T) {
 	u := auth.CurrentUser{
-		UserName: "test",
-		ID: 1,
+		UserName:  "test",
+		ID:        1,
 		PrivLevel: 100,
-		TenantID: 1,
-		Role: 1,
+		TenantID:  1,
+		Role:      1,
 	}
 
 	mappings := []tc.DeliveryServiceFederationResolverMapping{
 		tc.DeliveryServiceFederationResolverMapping{
 			DeliveryService: "test",
-			Mappings: tc.ResolverMapping {
+			Mappings: tc.ResolverMapping{
 				Resolve4: []string{"0.0.0.0", "127.0.0.1/12"},
 				Resolve6: []string{"abcd:ef01:2345:6789::", "f1d0::f00d/127"},
 			},
@@ -111,17 +111,17 @@ func positiveTestAddFederationResolverMappingsForCurrentUser(t *testing.T) {
 
 func testAddFederationResolverMappingsForCurrentUserWithoutFederations(t *testing.T) {
 	u := auth.CurrentUser{
-		UserName: "test",
-		ID: 1,
+		UserName:  "test",
+		ID:        1,
 		PrivLevel: 100,
-		TenantID: 1,
-		Role: 1,
+		TenantID:  1,
+		Role:      1,
 	}
 
 	mappings := []tc.DeliveryServiceFederationResolverMapping{
 		tc.DeliveryServiceFederationResolverMapping{
 			DeliveryService: "test",
-			Mappings: tc.ResolverMapping {
+			Mappings: tc.ResolverMapping{
 				Resolve4: []string{"0.0.0.0"},
 				Resolve6: []string{},
 			},
@@ -165,18 +165,18 @@ func testAddFederationResolverMappingsForCurrentUserWithoutFederations(t *testin
 }
 
 func testUnauthorizedDSOnResolverAdd(t *testing.T) {
-	u := auth.CurrentUser {
-		UserName: "test",
-		ID: 1,
+	u := auth.CurrentUser{
+		UserName:  "test",
+		ID:        1,
 		PrivLevel: 100,
-		TenantID: 1,
-		Role: 1,
+		TenantID:  1,
+		Role:      1,
 	}
 
 	mappings := []tc.DeliveryServiceFederationResolverMapping{
 		tc.DeliveryServiceFederationResolverMapping{
 			DeliveryService: "test",
-			Mappings: tc.ResolverMapping {
+			Mappings: tc.ResolverMapping{
 				Resolve4: []string{},
 				Resolve6: []string{},
 			},
@@ -224,12 +224,12 @@ func TestGetMappingsFromRequestBody(t *testing.T) {
 	data := `{"federations":[{"deliveryService":"test","mappings":{"resolve4":[], "resolve6":[]}}]}`
 	buf := strings.NewReader(data)
 
-	legacyVersion := api.Version {
+	legacyVersion := api.Version{
 		Major: 1,
 		Minor: 3,
 	}
 
-	version := api.Version {
+	version := api.Version{
 		Major: 1,
 		Minor: 4,
 	}
@@ -278,11 +278,11 @@ func TestGetMappingsFromRequestBody(t *testing.T) {
 
 func TestRemoveFederationResolverMappingsForCurrentUser(t *testing.T) {
 	u := auth.CurrentUser{
-		UserName: "test",
-		ID: 1,
+		UserName:  "test",
+		ID:        1,
 		PrivLevel: 100,
-		TenantID: 1,
-		Role: 1,
+		TenantID:  1,
+		Role:      1,
 	}
 
 	mockDB, mock, err := sqlmock.New()

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -477,6 +477,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `federations/?(\.json)?$`, federations.Get, auth.PrivLevelFederation, Authenticated, nil},
 		{1.1, http.MethodPost, `federations(/|\.json)?$`, federations.AddFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, Authenticated, nil},
 		{1.1, http.MethodDelete, `federations(/|\.json)?$`, federations.RemoveFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, Authenticated, nil},
+		{1.1, http.MethodPut, `federations(/|\.json)?$`, federations.ReplaceFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, Authenticated, nil},
 		{1.1, http.MethodPost, `federations/{id}/deliveryservices?(\.json)?$`, federations.PostDSes, auth.PrivLevelAdmin, Authenticated, nil},
 		{1.1, http.MethodGet, `federations/{id}/deliveryservices?(\.json)?$`, api.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?(\.json)?$`, api.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -476,7 +476,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.4, http.MethodGet, `federations/all/?(\.json)?$`, federations.GetAll, auth.PrivLevelAdmin, Authenticated, nil},
 		{1.1, http.MethodGet, `federations/?(\.json)?$`, federations.Get, auth.PrivLevelFederation, Authenticated, nil},
 		{1.1, http.MethodPost, `federations(/|\.json)?$`, federations.AddFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, Authenticated, nil},
-		// {1.4, http.MethodPost, `federations(/|\.json)?$`, federations.CreateV14, auth.PrivLevelFederation, Authenticated, nil},
+		{1.1, http.MethodDelete, `federations(/|\.json)?$`, federations.RemoveFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, Authenticated, nil},
 		{1.1, http.MethodPost, `federations/{id}/deliveryservices?(\.json)?$`, federations.PostDSes, auth.PrivLevelAdmin, Authenticated, nil},
 		{1.1, http.MethodGet, `federations/{id}/deliveryservices?(\.json)?$`, api.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?(\.json)?$`, api.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -475,6 +475,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		// Federations
 		{1.4, http.MethodGet, `federations/all/?(\.json)?$`, federations.GetAll, auth.PrivLevelAdmin, Authenticated, nil},
 		{1.1, http.MethodGet, `federations/?(\.json)?$`, federations.Get, auth.PrivLevelFederation, Authenticated, nil},
+		{1.1, http.MethodPost, `federations(/|\.json)?$`, federations.AddFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, Authenticated, nil},
+		// {1.4, http.MethodPost, `federations(/|\.json)?$`, federations.CreateV14, auth.PrivLevelFederation, Authenticated, nil},
 		{1.1, http.MethodPost, `federations/{id}/deliveryservices?(\.json)?$`, federations.PostDSes, auth.PrivLevelAdmin, Authenticated, nil},
 		{1.1, http.MethodGet, `federations/{id}/deliveryservices?(\.json)?$`, api.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.1, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?(\.json)?$`, api.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/tenant/tenancy.go
+++ b/traffic_ops/traffic_ops_golang/tenant/tenancy.go
@@ -79,7 +79,9 @@ func Check(user *auth.CurrentUser, XMLID string, tx *sql.Tx) (error, error, int)
 	return nil, nil, http.StatusOK
 }
 
-// CheckID checks that the given user has access to the given delivery service. Returns a user error, a system error, and an HTTP error code. If both the user and system error are nil, the error code should be ignored.
+// CheckID checks that the given user has access to the given delivery service. Returns a user error,
+// a system error, and an HTTP error code. If both the user and system error are nil, the error
+// code should be ignored.
 func CheckID(tx *sql.Tx, user *auth.CurrentUser, dsID int) (error, error, int) {
 	dsTenantID, ok, err := getDSTenantIDByIDTx(tx, dsID)
 	if err != nil {

--- a/traffic_portal/conf/config.js
+++ b/traffic_portal/conf/config.js
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3790 

Rewrites `/federations` to Go. This also adds API version 1.4 specific logic that
- Adds the messages normally returned as the "response" object as alerts (doesn't replace `response`, much as I'd like to)
- Allows POST request bodies that don't use the redundant top-level "federations" key (still backward-compatible; just gives clients the choice)

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Run the unit tests and API/Go client integration tests. 

### Test Manually (CDN-in-a-Box)
1. Build and start CDN-in-a-Box
2. In Traffic Portal, go to <kbd>CDNs</kbd>&#8594;<kbd>CDN-in-a-Box</kbd>&#8594;<kbd>More</kbd>&#8594;<kbd>Manage Federations</kbd>
3. Click on the "+" button
4. Fill out the form - make sure to assign the user to `admin` (since I assume that's the user as whom you've logged in) and hit "Submit" to create a new Federation
5. Make a `POST` request to `/federations`, then a `PUT` then a `DELETE` (afaik there's no mechanism for this in Traffic Portal, so use `curl` or the `toaccess` scripts or something).

### Test Manually (Locally-run servers)
1. Build and start Traffic Ops
2. Assuming you already have a CDN, a Delivery Service, and a user as whom to sign in, make a new Federation using the `POST` method of `/cdns/{{your CDN name here}}/federations`.
3. Assign your federation to a Delivery Service (within your user's Tenant - I don't know if this will check) using the `POST` method of `/federations/{{ID of the federation you just created - probably 1}}/deliveryservices`
4. Assign the Federation to your user using the `POST` method of `/federations/{{same ID again}}/users`
5. Make a `POST` request to `/federations`, then a `PUT` then a `DELETE`

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**