### PR TITLE
Fix TO API test failure when starting from a fresh `db/admin reset`

### DIFF
--- a/traffic_ops/testing/api/v14/todb.go
+++ b/traffic_ops/testing/api/v14/todb.go
@@ -250,9 +250,9 @@ INSERT INTO job (id, agent, object_type, object_name, keyword, parameters, asset
 func SetupTypes(db *sql.DB) error {
 
 	sqlStmt := `
-INSERT INTO type (id, name, description, use_in_table) VALUES (1, 'CHECK_EXTENSION_BOOL', 'Extension for checkmark in Server Check', 'to_extension');
-INSERT INTO type (id, name, description, use_in_table) VALUES (2, 'CHECK_EXTENSION_NUM', 'Extension for int value in Server Check', 'to_extension');
-INSERT INTO type (id, name, description, use_in_table) VALUES (3, 'CHECK_EXTENSION_OPEN_SLOT', 'Open slot for check in Server Status', 'to_extension');
+INSERT INTO type (name, description, use_in_table) VALUES ('CHECK_EXTENSION_BOOL', 'Extension for checkmark in Server Check', 'to_extension');
+INSERT INTO type (name, description, use_in_table) VALUES ('CHECK_EXTENSION_NUM', 'Extension for int value in Server Check', 'to_extension');
+INSERT INTO type (name, description, use_in_table) VALUES ('CHECK_EXTENSION_OPEN_SLOT', 'Open slot for check in Server Status', 'to_extension');
 `
 	err := execSQL(db, sqlStmt, "type")
 	if err != nil {
@@ -265,8 +265,8 @@ INSERT INTO type (id, name, description, use_in_table) VALUES (3, 'CHECK_EXTENSI
 func SetupToExtensions(db *sql.DB) error {
 
 	sqlStmt := `
-INSERT INTO to_extension (name, version, info_url, isactive, script_file, servercheck_column_name, type) VALUES ('OPEN', '1.0.0', '-', false, '', 'aa', 3);
-INSERT INTO to_extension (name, version, info_url, isactive, script_file, servercheck_column_name, type) VALUES ('OPEN', '1.0.0', '-', false, '', 'ab', 3);
+INSERT INTO to_extension (name, version, info_url, isactive, script_file, servercheck_column_name, type) VALUES ('OPEN', '1.0.0', '-', false, '', 'aa', (SELECT id FROM type WHERE name = 'CHECK_EXTENSION_OPEN_SLOT'));
+INSERT INTO to_extension (name, version, info_url, isactive, script_file, servercheck_column_name, type) VALUES ('OPEN', '1.0.0', '-', false, '', 'ab', (SELECT id FROM type WHERE name = 'CHECK_EXTENSION_OPEN_SLOT'));
 	`
 	err := execSQL(db, sqlStmt, "to_extension")
 	if err != nil {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
This PR fixes an issue that causes the TO API tests to fail when being run against a freshly reset TODB (i.e. `db/admin --env=test reset`).

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- TO API tests

## What is the best way to verify this PR?
On `master`, run `db/admin --env=test reset` on your test environment to reset the test DB. Then run the TO API tests, and observe the test failure (type already exists).
Follow the same steps on this PR, and observe the test success.

## The following criteria are ALL met by this PR

- [x] This PR fixes a testing issue
- [x] ^ no docs necessary
- [x] ^ no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)