### PR TITLE
Block allowing requiring caps on ds that their servers dont have

### DIFF
--- a/docs/source/api/deliveryservices_required_capabilities.rst
+++ b/docs/source/api/deliveryservices_required_capabilities.rst
@@ -112,6 +112,8 @@ Associates a Server Capability to a :term:`Delivery Service`.
 :Roles Required: "admin" or "operations"
 :Response Type:  Object
 
+.. note:: A capability can only be made required on a :term:`Delivery Service` if its associates Servers already have that capability assigned.
+
 Request Structure
 -----------------
 :deliveryServiceID:   The :term:`Delivery Service`'s ID to associate

--- a/docs/source/api/deliveryservices_required_capabilities.rst
+++ b/docs/source/api/deliveryservices_required_capabilities.rst
@@ -112,7 +112,7 @@ Associates a Server Capability to a :term:`Delivery Service`.
 :Roles Required: "admin" or "operations"
 :Response Type:  Object
 
-.. note:: A capability can only be made required on a :term:`Delivery Service` if its associates Servers already have that capability assigned.
+.. note:: A capability can only be made required on a :term:`Delivery Service` if its associated Servers already have that capability assigned.
 
 Request Structure
 -----------------

--- a/traffic_ops/testing/api/v14/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservices_required_capabilities_test.go
@@ -203,16 +203,16 @@ func InvalidDeliveryServicesRequiredCapabilityAddition(t *testing.T) {
 
 	// Create new bogus server capability
 	_, _, err = TOSession.CreateServerCapability(tc.ServerCapability{
-		Name: "bogus",
+		Name: "newcap",
 	})
 	if err != nil {
-		t.Fatalf("cannot CREATE bogus server capability: %v\n", err)
+		t.Fatalf("cannot CREATE newcap server capability: %v\n", err)
 	}
 
 	// Attempt to assign to DS should fail
 	_, _, err = TOSession.CreateDeliveryServicesRequiredCapability(tc.DeliveryServicesRequiredCapability{
 		DeliveryServiceID:  dsID,
-		RequiredCapability: util.StrPtr("bogus"),
+		RequiredCapability: util.StrPtr("newcap"),
 	})
 	if err == nil {
 		t.Fatalf("expected error requiring a capability that is not associated on the delivery service's servers")
@@ -224,12 +224,20 @@ func InvalidDeliveryServicesRequiredCapabilityAddition(t *testing.T) {
 		t.Fatalf("could not DELETE the server %v from ds %v: %v\n", sID, *dsID, err)
 	}
 
+	// Remove server capabilities from server
 	for _, ssc := range serverCaps {
 		_, _, err := TOSession.DeleteServerServerCapability(*ssc.ServerID, *ssc.ServerCapability)
 		if err != nil {
 			t.Errorf("could not DELETE the server capability %v from server %v: %v\n", *ssc.ServerCapability, *ssc.Server, err)
 		}
 	}
+
+	// Delete server capability
+	_, _, err = TOSession.DeleteServerCapability("newcap")
+	if err != nil {
+		t.Fatalf("cannot DELETE newcap server capability: %v\n", err)
+	}
+
 }
 
 func DeleteTestDeliveryServicesRequiredCapabilities(t *testing.T) {

--- a/traffic_ops/testing/api/v14/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/testing/api/v14/deliveryservices_required_capabilities_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestDeliveryServicesRequiredCapabilities(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, ServerCapabilities, DeliveryServices, DeliveryServicesRequiredCapabilities}, func() {
+		InvalidDeliveryServicesRequiredCapabilityAddition(t)
 		GetTestDeliveryServicesRequiredCapabilities(t)
 	})
 }
@@ -122,7 +123,7 @@ func CreateTestDeliveryServicesRequiredCapabilities(t *testing.T) {
 		},
 	}
 
-	// Assign all required capability to delivery services listed in `tc-fixtrues.json`.
+	// Assign all required capability to delivery services listed in `tc-fixtures.json`.
 	for _, td := range testData.DeliveryServicesRequiredCapabilities {
 		var dsID int
 		if td.DeliveryServiceID != nil {
@@ -155,7 +156,80 @@ func CreateTestDeliveryServicesRequiredCapabilities(t *testing.T) {
 			}
 		})
 	}
+}
 
+func InvalidDeliveryServicesRequiredCapabilityAddition(t *testing.T) {
+	// Tests that a capability cannot be made required if the DS's services do not have it assigned
+
+	// Get Delivery Capability for a DS
+	capabilities, _, err := TOSession.GetDeliveryServicesRequiredCapabilities(nil, util.StrPtr("ds1"), nil)
+	if err != nil {
+		t.Fatalf("cannot GET delivery service required capabilities: %v\n", err)
+	}
+	if len(capabilities) == 0 {
+		t.Fatalf("delivery service ds1 needs at least one capability required")
+	}
+
+	// First assign current capabilities to edge server so we can assign it to the DS
+	servers, _, err := TOSession.GetServerByHostName("atlanta-edge-01")
+	if err != nil {
+		t.Fatalf("cannot GET Server by hostname: %v\n", err)
+	}
+	if len(servers) < 1 {
+		t.Fatal("need at least one server to test invalid ds required capability assignment")
+	}
+
+	dsID := capabilities[0].DeliveryServiceID
+	sID := servers[0].ID
+	serverCaps := []tc.ServerServerCapability{}
+
+	for _, cap := range capabilities {
+		sCap := tc.ServerServerCapability{
+			ServerID:         &sID,
+			ServerCapability: cap.RequiredCapability,
+		}
+		_, _, err := TOSession.CreateServerServerCapability(sCap)
+		if err != nil {
+			t.Errorf("could not POST the server capability %v to server %v: %v\n", *cap.RequiredCapability, sID, err)
+		}
+		serverCaps = append(serverCaps, sCap)
+	}
+
+	// Assign server to ds
+	_, err = TOSession.CreateDeliveryServiceServers(*dsID, []int{sID}, false)
+	if err != nil {
+		t.Fatalf("cannot CREATE server delivery service assignement: %v\n", err)
+	}
+
+	// Create new bogus server capability
+	_, _, err = TOSession.CreateServerCapability(tc.ServerCapability{
+		Name: "bogus",
+	})
+	if err != nil {
+		t.Fatalf("cannot CREATE bogus server capability: %v\n", err)
+	}
+
+	// Attempt to assign to DS should fail
+	_, _, err = TOSession.CreateDeliveryServicesRequiredCapability(tc.DeliveryServicesRequiredCapability{
+		DeliveryServiceID:  dsID,
+		RequiredCapability: util.StrPtr("bogus"),
+	})
+	if err == nil {
+		t.Fatalf("expected error requiring a capability that is not associated on the delivery service's servers")
+	}
+
+	// Disassociate server from DS
+	_, _, err = TOSession.DeleteDeliveryServiceServer(*dsID, sID)
+	if err != nil {
+		t.Fatalf("could not DELETE the server %v from ds %v: %v\n", sID, *dsID, err)
+	}
+
+	for _, ssc := range serverCaps {
+		_, _, err := TOSession.DeleteServerServerCapability(*ssc.ServerID, *ssc.ServerCapability)
+		if err != nil {
+			t.Errorf("could not DELETE the server capability %v from server %v: %v\n", *ssc.ServerCapability, *ssc.Server, err)
+		}
+	}
 }
 
 func DeleteTestDeliveryServicesRequiredCapabilities(t *testing.T) {

--- a/traffic_ops/testing/api/v14/serverservercapability_test.go
+++ b/traffic_ops/testing/api/v14/serverservercapability_test.go
@@ -172,7 +172,7 @@ func DeleteTestServerServerCapabilities(t *testing.T) {
 		// Assign server to ds
 		_, err = TOSession.CreateDeliveryServiceServers(*dsReqCap.DeliveryServiceID, []int{*ssc.ServerID}, false)
 		if err != nil {
-			t.Fatalf("cannot CREATE server delivery service assignement: %v\n", err)
+			t.Fatalf("cannot CREATE server delivery service assignment: %v\n", err)
 		}
 		dsServers = append(dsServers, tc.DeliveryServiceServer{
 			Server:          ssc.ServerID,

--- a/traffic_ops/testing/api/v14/todb.go
+++ b/traffic_ops/testing/api/v14/todb.go
@@ -280,6 +280,8 @@ INSERT INTO to_extension (name, version, info_url, isactive, script_file, server
 func Teardown(db *sql.DB) error {
 
 	sqlStmt := `
+	DELETE FROM deliveryservices_required_capability;
+	DELETE FROM server_server_capability;
 	DELETE FROM server_server_capability;
 	DELETE FROM server_capability;
 	DELETE FROM to_extension;

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
@@ -20,9 +20,12 @@ package deliveryservice
  */
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
@@ -31,6 +34,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
 	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/lib/pq"
 )
 
 const (
@@ -237,6 +241,11 @@ func (rc *RequiredCapability) Create() (error, error, int) {
 		return errors.New("not authorized on this tenant"), nil, http.StatusForbidden
 	}
 
+	usrErr, sysErr, rCode := rc.ensureDSServerCap()
+	if usrErr != nil || sysErr != nil {
+		return usrErr, sysErr, rCode
+	}
+
 	rows, err := rc.APIInfo().Tx.NamedQuery(rcInsertQuery(), rc)
 	if err != nil {
 		return api.ParseDBError(err)
@@ -257,6 +266,62 @@ func (rc *RequiredCapability) Create() (error, error, int) {
 	}
 
 	return nil, nil, http.StatusOK
+}
+
+func (rc *RequiredCapability) ensureDSServerCap() (error, error, int) {
+	tx := rc.APIInfo().Tx
+
+	// Get assigned DS server IDs
+	dsServerIDs := []int64{}
+	if err := tx.Tx.QueryRow(`
+	SELECT ARRAY(
+		SELECT server 
+		FROM deliveryservice_server 
+		WHERE deliveryservice=$1
+	)`, rc.DeliveryServiceID).Scan(pq.Array(&dsServerIDs)); err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("reading delivery service %v servers: %v", *rc.DeliveryServiceID, err), http.StatusInternalServerError
+	}
+
+	if len(dsServerIDs) == 0 { // no attached servers can return success right away
+		return nil, nil, http.StatusOK
+	}
+
+	// Get servers IDs that have the new capability
+	capServerIDs := []int64{}
+	if err := tx.QueryRow(`
+	SELECT ARRAY(
+		SELECT server
+		FROM server_server_capability 
+		WHERE server IN (
+			SELECT server 
+			FROM deliveryservice_server 
+			WHERE deliveryservice=$1
+		)
+		AND server_capability=$2
+	)`, rc.DeliveryServiceID, rc.RequiredCapability).Scan(pq.Array(&capServerIDs)); err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("reading servers that have server capability %v attached: %v", *rc.RequiredCapability, err), http.StatusInternalServerError
+	}
+
+	vIDs := getViolatingServerIDs(dsServerIDs, capServerIDs)
+	if len(vIDs) > 0 {
+		return fmt.Errorf("capability %v cannot be made required on the delivery service %v as it has the associated servers %v that do not have the capability assigned", *rc.RequiredCapability, *rc.DeliveryServiceID, strings.Join(vIDs, ",")), nil, http.StatusBadRequest
+	}
+
+	return nil, nil, http.StatusOK
+}
+
+func getViolatingServerIDs(dsServerIDs, capServerIDs []int64) []string {
+	capServerIDsMap := map[int64]struct{}{}
+	for _, id := range capServerIDs {
+		capServerIDsMap[id] = struct{}{}
+	}
+	vIDs := []string{}
+	for _, id := range dsServerIDs {
+		if _, found := capServerIDsMap[id]; !found {
+			vIDs = append(vIDs, strconv.FormatInt(id, 10))
+		}
+	}
+	return vIDs
 }
 
 func (rc *RequiredCapability) isTenantAuthorized() (bool, error) {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
@@ -77,6 +77,9 @@ func TestCreateDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mockTenantID(t, mock, 1)
 
+	arrayRows := sqlmock.NewRows([]string{"array"})
+	mock.ExpectQuery("SELECT server FROM deliveryservice_server").WillReturnRows(arrayRows)
+
 	rows := sqlmock.NewRows([]string{"required_capability", "deliveryservice_id", "last_updated"}).AddRow(
 		util.StrPtr("mem"),
 		util.IntPtr(1),


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR adds the validation that capabilities can not be made required on DSs when that DS's associated servers do not have that capability assigned 

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Documentation
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Automated - Run API tests

Manual - Create a DS with servers assigned to it. Attempt to require a new capability to that DS and it should be blocked.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR does not include an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
