### PR TITLE
TP: fetches tenant users with the proper query param and removes tenantId…

### DIFF
--- a/docs/source/api/users.rst
+++ b/docs/source/api/users.rst
@@ -38,9 +38,6 @@ Request Structure
 	+-----------+----------+------------------------------------------------------------------------------------------+
 	| tenant    | no       | Return only users belonging to the :term:`Tenant` identified by tenant name              |
 	+-----------+----------+------------------------------------------------------------------------------------------+
-	| tenantId  | no       | Return only users belonging to the :term:`Tenant` identified by this integral, unique    |
-	|           |          | identifier                                                                               |
-	+-----------+----------+------------------------------------------------------------------------------------------+
 	| username  | no       | Return only the user with this username                                                  |
 	+-----------+----------+------------------------------------------------------------------------------------------+
 	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the        |

--- a/traffic_portal/app/src/modules/private/tenants/users/index.js
+++ b/traffic_portal/app/src/modules/private/tenants/users/index.js
@@ -31,7 +31,7 @@ module.exports = angular.module('trafficPortal.private.tenants.users', [])
 								return tenantService.getTenant($stateParams.tenantId);
 							},
 							tenantUsers: function(tenant, userService) {
-								return userService.getUsers({ tenantId: tenant.id });
+								return userService.getUsers({ tenant: tenant.name });
 							}
 						}
 					}


### PR DESCRIPTION
… from the list of supported query params in the docs

## What does this PR (Pull Request) do?
When TP fetches the users of a certain tenant, an unsupported query param (?tenantId=tenant.id) was being used, therefore a tenant filter was not being applied and all users were being returned. Changed it to use ?tenant=tenant.name and now only users for that tenant are returned.

- [x] This PR fixes #4056 

No need for a changelog.md entry as this bug is so small
The users test flow is not current under test. will add in subsequent PR.

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Portal

## What is the best way to verify this PR?
- Launch TP
- Navigate to tp.domain.com/#!/tenants/{tenant-id}/users
- Ensure only users assigned to that tenant are displayed

## If this is a bug fix, what versions of Traffic Control are affected?

- master (102372c)
- 3.0.2
- 2.2

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
