### PR TITLE
Add atstccfg meta config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.1/roles `GET`
   - /api/1.4/cdns/name/:name/dnsseckeys `GET`
   - /api/1.4/user/login/oauth `POST`
+  - /api/1.1/servers/:name/configfiles/ats `GET`
   - /api/1.1/profiles/:name/configfiles/ats/* `GET`
   - /api/1.1/servers/:name/configfiles/ats/* `GET`
   - /api/1.1/cdns/:name/configfiles/ats/* `GET`
@@ -56,7 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added pagination support to some Traffic Ops endpoints via three new query parameters, limit and offset/page
 - Traffic Ops now supports a "sortOrder" query parameter on some endpoints to return API responses in descending order
 - Traffic Ops now uses a consistent format for audit logs across all Go endpoints
-- Added cache-side config generator, atstccfg, installed with ORT. Currently includes parent.config and all profile configs, proxies others to Traffic Ops.
+- Added cache-side config generator, atstccfg, installed with ORT. Includes all configs.
 - In Traffic Portal, all tables now include a 'CSV' link to enable the export of table data in CSV format.
 - Pylint configuration now enforced (present in [a file in the Python client directory](./traffic_control/clients/python/pylint.rc))
 - Added an optional SMTP server configuration to the TO configuration file, api now has unused abilitiy to send emails

--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -1,0 +1,175 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+type ConfigProfileParams struct {
+	FileNameOnDisk string
+	Location       string
+	URL            string
+	APIURI         string
+}
+
+// APIVersion is the Traffic Ops API version for config fiels.
+// This is used to generate the meta config, which has API paths.
+// Note the version in the meta config is not used by the atstccfg generator, which isn't actually an API.
+// TODO change the config system to not use old API paths, and remove this.
+const APIVersion = "1.4"
+
+func MakeMetaConfig(
+	serverHostName tc.CacheName,
+	server *ServerInfo,
+	tmURL string, // global tm.url Parameter
+	tmReverseProxyURL string, // global tm.rev_proxy.url Parameter
+	locationParams map[string]ConfigProfileParams, // map[configFile]params; 'location' and 'URL' Parameters on serverHostName's Profile
+	uriSignedDSes []tc.DeliveryServiceName,
+	scopeParams map[string]string, // map[configFileName]scopeParam
+) string {
+	if tmURL == "" {
+		log.Errorln("ats.GetConfigMetadata: global tm.url parameter missing or empty! Setting empty in meta config!")
+	}
+
+	atsData := tc.ATSConfigMetaData{
+		Info: tc.ATSConfigMetaDataInfo{
+			ProfileID:         int(server.ProfileID),
+			TOReverseProxyURL: tmReverseProxyURL,
+			TOURL:             tmURL,
+			ServerIPv4:        server.IP,
+			ServerPort:        server.Port,
+			ServerName:        server.HostName,
+			CDNID:             server.CDNID,
+			CDNName:           string(server.CDN),
+			ServerID:          server.ID,
+			ProfileName:       server.ProfileName,
+		},
+		ConfigFiles: []tc.ATSConfigMetaDataConfigFile{},
+	}
+
+	if locationParams["remap.config"].Location != "" {
+		configLocation := locationParams["remap.config"].Location
+		for _, ds := range uriSignedDSes {
+			cfgName := "uri_signing_" + string(ds) + ".config"
+			// If there's already a parameter for it, don't clobber it. The user may wish to override the location.
+			if _, ok := locationParams[cfgName]; !ok {
+				p := locationParams[cfgName]
+				p.FileNameOnDisk = cfgName
+				p.Location = configLocation
+				locationParams[cfgName] = p
+			}
+		}
+	}
+
+	for cfgFile, cfgParams := range locationParams {
+		atsCfg := tc.ATSConfigMetaDataConfigFile{
+			FileNameOnDisk: cfgParams.FileNameOnDisk,
+			Location:       cfgParams.Location,
+		}
+
+		scope := getServerScope(cfgFile, server.Type, scopeParams)
+
+		if cfgParams.URL != "" {
+			scope = tc.ATSConfigMetaDataConfigFileScopeCDNs
+			atsCfg.URL = cfgParams.URL
+		} else {
+			scopeID := ""
+			if scope == tc.ATSConfigMetaDataConfigFileScopeCDNs {
+				scopeID = string(server.CDN)
+			} else if scope == tc.ATSConfigMetaDataConfigFileScopeProfiles {
+				scopeID = server.ProfileName
+			} else { // ATSConfigMetaDataConfigFileScopeServers
+				scopeID = server.HostName
+			}
+			atsCfg.APIURI = "/api/" + APIVersion + "/" + string(scope) + "/" + scopeID + "/configfiles/ats/" + cfgFile
+		}
+
+		atsCfg.Scope = string(scope)
+
+		atsData.ConfigFiles = append(atsData.ConfigFiles, atsCfg)
+	}
+
+	bts, err := json.Marshal(atsData)
+	if err != nil {
+		// should never happen
+		log.Errorln("marshalling chkconfig NameVersions: " + err.Error())
+		bts = []byte("error encoding to json, see log for details")
+	}
+	return string(bts)
+}
+
+func getServerScope(cfgFile string, serverType string, scopeParams map[string]string) tc.ATSConfigMetaDataConfigFileScope {
+	switch {
+	case cfgFile == "cache.config" && tc.CacheTypeFromString(serverType) == tc.CacheTypeMid:
+		return tc.ATSConfigMetaDataConfigFileScopeServers
+	default:
+		return getScope(cfgFile, scopeParams)
+	}
+}
+
+const DefaultScope = tc.ATSConfigMetaDataConfigFileScopeServers
+
+// getScope returns the ATSConfigMetaDataConfigFileScope for the given config file, and potentially the given server. If the config is not a Server scope, i.e. was part of an endpoint which does not include a server name or id, the server may be nil.
+func getScope(cfgFile string, scopeParams map[string]string) tc.ATSConfigMetaDataConfigFileScope {
+	switch {
+	case cfgFile == "ip_allow.config",
+		cfgFile == "parent.config",
+		cfgFile == "hosting.config",
+		cfgFile == "packages",
+		cfgFile == "chkconfig",
+		cfgFile == "remap.config",
+		strings.HasPrefix(cfgFile, "to_ext_") && strings.HasSuffix(cfgFile, ".config"):
+		return tc.ATSConfigMetaDataConfigFileScopeServers
+	case cfgFile == "12M_facts",
+		cfgFile == "50-ats.rules",
+		cfgFile == "astats.config",
+		cfgFile == "cache.config",
+		cfgFile == "drop_qstring.config",
+		cfgFile == "logs_xml.config",
+		cfgFile == "logging.config",
+		cfgFile == "plugin.config",
+		cfgFile == "records.config",
+		cfgFile == "storage.config",
+		cfgFile == "volume.config",
+		cfgFile == "sysctl.conf",
+		strings.HasPrefix(cfgFile, "url_sig_") && strings.HasSuffix(cfgFile, ".config"),
+		strings.HasPrefix(cfgFile, "uri_signing_") && strings.HasSuffix(cfgFile, ".config"):
+		return tc.ATSConfigMetaDataConfigFileScopeProfiles
+	case cfgFile == "bg_fetch.config",
+		cfgFile == "regex_revalidate.config",
+		cfgFile == "ssl_multicert.config",
+		strings.HasPrefix(cfgFile, "cacheurl") && strings.HasSuffix(cfgFile, ".config"),
+		strings.HasPrefix(cfgFile, "hdr_rw_") && strings.HasSuffix(cfgFile, ".config"),
+		strings.HasPrefix(cfgFile, "regex_remap_") && strings.HasSuffix(cfgFile, ".config"),
+		strings.HasPrefix(cfgFile, "set_dscp_") && strings.HasSuffix(cfgFile, ".config"):
+		return tc.ATSConfigMetaDataConfigFileScopeCDNs
+	}
+
+	scope, ok := scopeParams[cfgFile]
+	if !ok {
+		scope = string(DefaultScope)
+	}
+	return tc.ATSConfigMetaDataConfigFileScope(scope)
+}

--- a/lib/go-atscfg/meta_test.go
+++ b/lib/go-atscfg/meta_test.go
@@ -1,0 +1,240 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestMakeMetaConfig(t *testing.T) {
+	serverHostName := tc.CacheName("myServer")
+	server := &ServerInfo{
+		CacheGroupID:                  42,
+		CDN:                           "mycdn",
+		CDNID:                         43,
+		DomainName:                    "myserverdomain.invalid",
+		HostName:                      "myserver",
+		HTTPSPort:                     443,
+		ID:                            44,
+		IP:                            "192.168.2.9",
+		ParentCacheGroupID:            45,
+		ParentCacheGroupType:          "MID_LOC",
+		ProfileID:                     46,
+		ProfileName:                   "myserverprofile",
+		Port:                          80,
+		SecondaryParentCacheGroupID:   47,
+		SecondaryParentCacheGroupType: "MID_LOC",
+		Type:                          "EDGE",
+	}
+
+	tmURL := "https://myto.invalid"
+	tmReverseProxyURL := "https://myrp.myto.invalid"
+	locationParams := map[string]ConfigProfileParams{
+		"remap.config": ConfigProfileParams{
+			FileNameOnDisk: "remap.config",
+			Location:       "/my/location/",
+		},
+		"regex_revalidate.config": ConfigProfileParams{
+			FileNameOnDisk: "regex_revalidate.config",
+			Location:       "/my/location/",
+			URL:            "http://myurl/remap.config", // cdn-scoped endpoint
+			APIURI:         "http://myapi/remap.config",
+		},
+		"cache.config": ConfigProfileParams{
+			FileNameOnDisk: "cache.config", // cache.config on mids is server-scoped
+			Location:       "/my/location/",
+		},
+		"ip_allow.config": ConfigProfileParams{
+			FileNameOnDisk: "ip_allow.config",
+			Location:       "/my/location/",
+		},
+		"volume.config": ConfigProfileParams{
+			FileNameOnDisk: "volume.config",
+			Location:       "/my/location/",
+		},
+		"ssl_multicert.config": ConfigProfileParams{
+			FileNameOnDisk: "ssl_multicert.config",
+			Location:       "/my/location/",
+		},
+		"uri_signing_mydsname.config": ConfigProfileParams{
+			FileNameOnDisk: "uri_signing_mydsname.config",
+			Location:       "/my/location/",
+		},
+		"unknown.config": ConfigProfileParams{
+			FileNameOnDisk: "unknown.config",
+			Location:       "/my/location/",
+		},
+		"custom.config": ConfigProfileParams{
+			FileNameOnDisk: "custom.config",
+			Location:       "/my/location/",
+		},
+	}
+	uriSignedDSes := []tc.DeliveryServiceName{"mydsname"}
+
+	scopeParams := map[string]string{"custom.config": string(tc.ATSConfigMetaDataConfigFileScopeProfiles)}
+
+	txt := MakeMetaConfig(serverHostName, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, scopeParams)
+
+	cfg := tc.ATSConfigMetaData{}
+	if err := json.Unmarshal([]byte(txt), &cfg); err != nil {
+		t.Fatalf("MakeMetaConfig returned invalid JSON: " + err.Error())
+	}
+
+	if cfg.Info.ProfileID != int(server.ProfileID) {
+		t.Errorf("expected Info.ProfileID %v actual %v", server.ProfileID, cfg.Info.ProfileID)
+	}
+
+	if cfg.Info.TOReverseProxyURL != tmReverseProxyURL {
+		t.Errorf("expected Info.TOReverseProxyURL %v actual %v", tmReverseProxyURL, cfg.Info.TOReverseProxyURL)
+	}
+
+	if cfg.Info.TOURL != tmURL {
+		t.Errorf("expected Info.TOURL %v actual %v", tmURL, cfg.Info.TOURL)
+	}
+
+	if server.IP != cfg.Info.ServerIPv4 {
+		t.Errorf("expected Info.ServerIP %v actual %v", server.IP, cfg.Info.ServerIPv4)
+	}
+
+	if server.Port != cfg.Info.ServerPort {
+		t.Errorf("expected Info.ServerPort %v actual %v", server.Port, cfg.Info.ServerPort)
+	}
+
+	if server.HostName != cfg.Info.ServerName {
+		t.Errorf("expected Info.ServerName %v actual %v", server.HostName, cfg.Info.ServerName)
+	}
+
+	if cfg.Info.CDNID != server.CDNID {
+		t.Errorf("expected Info.CDNID %v actual %v", server.CDNID, cfg.Info.CDNID)
+	}
+
+	if cfg.Info.CDNName != string(server.CDN) {
+		t.Errorf("expected Info.CDNName %v actual %v", server.CDN, cfg.Info.CDNName)
+	}
+	if cfg.Info.ServerID != server.ID {
+		t.Errorf("expected Info.ServerID %v actual %v", server.ID, cfg.Info.ServerID)
+	}
+	if cfg.Info.ProfileName != server.ProfileName {
+		t.Errorf("expected Info.ProfileName %v actual %v", server.ProfileName, cfg.Info.ProfileName)
+	}
+
+	expectedConfigs := map[string]func(cf tc.ATSConfigMetaDataConfigFile){
+		"cache.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeProfiles); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+		"ip_allow.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeServers); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+		"volume.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeProfiles); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+		"ssl_multicert.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeCDNs); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+		"uri_signing_mydsname.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeProfiles); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+		"unknown.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeServers); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+		"custom.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeProfiles); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+		"remap.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeServers); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+		"regex_revalidate.config": func(cf tc.ATSConfigMetaDataConfigFile) {
+			if expected := "/my/location/"; cf.Location != expected {
+				t.Errorf("expected location '%v', actual '%v'", expected, cf.Location)
+			}
+			if expected := string(tc.ATSConfigMetaDataConfigFileScopeCDNs); cf.Scope != expected {
+				t.Errorf("expected scope '%v', actual '%v'", expected, cf.Scope)
+			}
+		},
+	}
+
+	for _, cfgFile := range cfg.ConfigFiles {
+		if testF, ok := expectedConfigs[cfgFile.FileNameOnDisk]; !ok {
+			t.Errorf("unexpected config '" + cfgFile.FileNameOnDisk + "'")
+		} else {
+			testF(cfgFile)
+			delete(expectedConfigs, cfgFile.FileNameOnDisk)
+		}
+	}
+
+	server.Type = "MID"
+	txt = MakeMetaConfig(serverHostName, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, scopeParams)
+	cfg = tc.ATSConfigMetaData{}
+	if err := json.Unmarshal([]byte(txt), &cfg); err != nil {
+		t.Fatalf("MakeMetaConfig returned invalid JSON: " + err.Error())
+	}
+	for _, cfgFile := range cfg.ConfigFiles {
+		if cfgFile.FileNameOnDisk != "cache.config" {
+			continue
+		}
+		if expected := string(tc.ATSConfigMetaDataConfigFileScopeServers); cfgFile.Scope != expected {
+			t.Errorf("expected cache.config on a Mid to be scope '%v', actual '%v'", expected, cfgFile.Scope)
+		}
+		break
+	}
+}

--- a/traffic_ops/ort/atstccfg/meta.go
+++ b/traffic_ops/ort/atstccfg/meta.go
@@ -1,0 +1,229 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func GetConfigFileMeta(cfg TCCfg, serverNameOrID string) (string, error) {
+	servers, err := GetServers(cfg)
+	if err != nil {
+		return "", errors.New("getting servers: " + err.Error())
+	}
+
+	server := tc.Server{ID: atscfg.InvalidID}
+	if serverID, err := strconv.Atoi(serverNameOrID); err == nil {
+		for _, toServer := range servers {
+			if toServer.ID == serverID {
+				server = toServer
+				break
+			}
+		}
+	} else {
+		serverName := serverNameOrID
+		for _, toServer := range servers {
+			if toServer.HostName == serverName {
+				server = toServer
+				break
+			}
+		}
+	}
+	if server.ID == atscfg.InvalidID {
+		return "", errors.New("server '" + serverNameOrID + " not found in servers")
+	}
+
+	serverHostName := server.HostName
+
+	cacheGroups, err := GetCacheGroups(cfg)
+	if err != nil {
+		return "", errors.New("getting cachegroups: " + err.Error())
+	}
+
+	cgMap := map[string]tc.CacheGroupNullable{}
+	for _, cg := range cacheGroups {
+		if cg.Name == nil {
+			return "", errors.New("got cachegroup with nil name!'")
+		}
+		cgMap[*cg.Name] = cg
+	}
+
+	serverCG, ok := cgMap[server.Cachegroup]
+	if !ok {
+		return "", errors.New("server '" + serverNameOrID + "' cachegroup '" + server.Cachegroup + "' not found in CacheGroups")
+	}
+
+	parentCGID := -1
+	parentCGType := ""
+	if serverCG.ParentName != nil && *serverCG.ParentName != "" {
+		parentCG, ok := cgMap[*serverCG.ParentName]
+		if !ok {
+			return "", errors.New("server '" + serverNameOrID + "' cachegroup '" + server.Cachegroup + "' parent '" + *serverCG.ParentName + "' not found in CacheGroups")
+		}
+		if parentCG.ID == nil {
+			return "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
+		}
+		parentCGID = *parentCG.ID
+
+		if parentCG.Type == nil {
+			return "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
+		}
+		parentCGType = *parentCG.Type
+	}
+
+	secondaryParentCGID := -1
+	secondaryParentCGType := ""
+	if serverCG.SecondaryParentName != nil && *serverCG.SecondaryParentName != "" {
+		parentCG, ok := cgMap[*serverCG.SecondaryParentName]
+		if !ok {
+			return "", errors.New("server '" + serverNameOrID + "' cachegroup '" + server.Cachegroup + "' secondary parent '" + *serverCG.SecondaryParentName + "' not found in CacheGroups")
+		}
+
+		if parentCG.ID == nil {
+			return "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
+		}
+		secondaryParentCGID = *parentCG.ID
+		if parentCG.Type == nil {
+			return "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
+		}
+
+		secondaryParentCGType = *parentCG.Type
+	}
+
+	serverInfo := atscfg.ServerInfo{
+		CacheGroupID:                  server.CachegroupID,
+		CDN:                           tc.CDNName(server.CDNName),
+		CDNID:                         server.CDNID,
+		DomainName:                    server.DomainName,
+		HostName:                      server.HostName,
+		ID:                            server.ID,
+		IP:                            server.IPAddress,
+		ParentCacheGroupID:            parentCGID,
+		ParentCacheGroupType:          parentCGType,
+		ProfileID:                     atscfg.ProfileID(server.ProfileID),
+		ProfileName:                   server.Profile,
+		Port:                          server.TCPPort,
+		SecondaryParentCacheGroupID:   secondaryParentCGID,
+		SecondaryParentCacheGroupType: secondaryParentCGType,
+		Type:                          server.Type,
+	}
+
+	globalParams, err := GetGlobalParameters(cfg)
+	if err != nil {
+		return "", errors.New("getting global parameters: " + err.Error())
+	}
+
+	toReverseProxyURL := ""
+	toURL := ""
+	for _, param := range globalParams {
+		if param.Name == "tm.rev_proxy.url" {
+			toReverseProxyURL = param.Value
+		} else if param.Name == "tm.url" {
+			toURL = param.Value
+		}
+		if toReverseProxyURL != "" && toURL != "" {
+			break
+		}
+	}
+
+	scopeParamsRaw, err := GetParametersByName(cfg, "scope")
+	if err != nil {
+		return "", errors.New("getting scope parameters: " + err.Error())
+	}
+
+	scopeParams := map[string]string{}
+	for _, param := range scopeParamsRaw {
+		scopeParams[param.ConfigFile] = param.Value
+	}
+
+	serverProfileParameters, err := GetServerProfileParameters(cfg, server.Profile)
+	if err != nil {
+		return "", errors.New("getting server profile '" + server.Profile + "' parameters: " + err.Error())
+	}
+
+	locationParams := map[string]atscfg.ConfigProfileParams{}
+	for _, param := range serverProfileParameters {
+		if param.Name == "location" {
+			p := locationParams[param.ConfigFile]
+			p.FileNameOnDisk = param.ConfigFile
+			p.Location = param.Value
+			locationParams[param.ConfigFile] = p
+		} else if param.Name == "URL" {
+			p := locationParams[param.ConfigFile]
+			p.URL = param.Value
+			locationParams[param.ConfigFile] = p
+		}
+	}
+
+	deliveryServices, err := GetCDNDeliveryServices(cfg, server.CDNID)
+	if err != nil {
+		return "", errors.New("getting delivery services: " + err.Error())
+	}
+
+	dsIDs := []int{}
+	for _, ds := range deliveryServices {
+		if ds.SigningAlgorithm == nil || *ds.SigningAlgorithm != tc.SigningAlgorithmURISigning {
+			continue
+		}
+		if ds.ID == nil {
+			// TODO log error?
+			continue
+		}
+		dsIDs = append(dsIDs, *ds.ID)
+	}
+
+	serverIDs := []int{server.ID}
+
+	dsServers, err := GetDeliveryServiceServers(cfg, dsIDs, serverIDs)
+	if err != nil {
+		return "", errors.New("getting meta config delivery service servers: " + err.Error())
+	}
+
+	dssMap := map[int]struct{}{} // set of map[dsID]. We know we only asked for our own server, so we don't care about the servers returned.
+	for _, dss := range dsServers {
+		if dss.DeliveryService == nil {
+			continue // TODO log?
+		}
+		dssMap[*dss.DeliveryService] = struct{}{}
+	}
+
+	uriSignedDSes := []tc.DeliveryServiceName{}
+	for _, ds := range deliveryServices {
+		if ds.ID == nil {
+			continue
+		}
+		if ds.XMLID == nil {
+			continue // TODO log?
+		}
+		if ds.SigningAlgorithm == nil || *ds.SigningAlgorithm != tc.SigningAlgorithmURISigning {
+			continue
+		}
+		if _, ok := dssMap[*ds.ID]; !ok {
+			continue
+		}
+		uriSignedDSes = append(uriSignedDSes, tc.DeliveryServiceName(*ds.XMLID))
+	}
+
+	return atscfg.MakeMetaConfig(tc.CacheName(serverHostName), &serverInfo, toURL, toReverseProxyURL, locationParams, uriSignedDSes, scopeParams), nil
+}

--- a/traffic_ops/testing/api/v14/atsconfig_meta_test.go
+++ b/traffic_ops/testing/api/v14/atsconfig_meta_test.go
@@ -16,6 +16,7 @@ package v14
 */
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -50,7 +51,7 @@ func GetTestATSConfigMeta(t *testing.T) {
 	expected := tc.ATSConfigMetaDataConfigFile{
 		FileNameOnDisk: "hdr_rw_mid_anymap-ds.config",
 		Location:       "/remap/config/location/parameter",
-		APIURI:         "/api/1.2/cdns/cdn1/configfiles/ats/hdr_rw_mid_anymap-ds.config",
+		APIURI:         "cdns/cdn1/configfiles/ats/hdr_rw_mid_anymap-ds.config", // expected suffix; config gen doesn't care about API version
 		URL:            "",
 		Scope:          "cdns",
 	}
@@ -66,7 +67,16 @@ func GetTestATSConfigMeta(t *testing.T) {
 		t.Fatalf("Getting server '"+server.HostName+"' config list: expected: %+v actual: not found\n", expected.FileNameOnDisk)
 	}
 
-	if expected != *actual {
-		t.Fatalf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
+	if expected.FileNameOnDisk != actual.FileNameOnDisk {
+		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
+	}
+	if expected.Location != actual.Location {
+		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
+	}
+	if !strings.HasSuffix(actual.APIURI, expected.APIURI) {
+		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
+	}
+	if actual.Scope != expected.Scope {
+		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
 	}
 }

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/meta.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/meta.go
@@ -20,12 +20,10 @@ package atsserver
  */
 
 import (
-	"database/sql"
 	"errors"
 	"net/http"
-	"strings"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
@@ -59,24 +57,11 @@ func GetConfigMetaData(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("GetConfigMetaData getting tm.url parameter: "+err.Error()))
 		return
 	}
-	if tmParams.URL == "" {
-		log.Errorln("ats.GetConfigMetadata: global tm.url parameter missing or empty! Setting empty in meta config!")
-	}
 
-	atsData := tc.ATSConfigMetaData{
-		Info: tc.ATSConfigMetaDataInfo{
-			ProfileID:         int(server.ProfileID),
-			TOReverseProxyURL: tmParams.ReverseProxyURL,
-			TOURL:             tmParams.URL,
-			ServerIPv4:        server.IP,
-			ServerPort:        server.Port,
-			ServerName:        server.HostName,
-			CDNID:             server.CDNID,
-			CDNName:           string(server.CDN),
-			ServerID:          server.ID,
-			ProfileName:       server.ProfileName,
-		},
-		ConfigFiles: []tc.ATSConfigMetaDataConfigFile{},
+	scopeParams, err := ats.GetScopeParameters(inf.Tx.Tx)
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("GetConfigMetaData getting scope: "+err.Error()))
+		return
 	}
 
 	locationParams, err := ats.GetLocationParams(inf.Tx.Tx, int(server.ProfileID))
@@ -85,136 +70,13 @@ func GetConfigMetaData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if locationParams["remap.config"].Location != "" {
-		configLocation := locationParams["remap.config"].Location
-		uriSignedDSes, err := ats.GetServerURISignedDSes(inf.Tx.Tx, server.HostName, server.Port)
-		if err != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("GetConfigMetaData getting server uri-signed dses: "+err.Error()))
-			return
-		}
-		for _, ds := range uriSignedDSes {
-			cfgName := "uri_signing_" + string(ds) + ".config"
-			// If there's already a parameter for it, don't clobber it. The user may wish to override the location.
-			if _, ok := locationParams[cfgName]; !ok {
-				p := locationParams[cfgName]
-				p.FileNameOnDisk = cfgName
-				p.Location = configLocation
-			}
-		}
-	}
-
-	for cfgFile, cfgParams := range locationParams {
-		atsCfg := tc.ATSConfigMetaDataConfigFile{
-			FileNameOnDisk: cfgParams.FileNameOnDisk,
-			Location:       cfgParams.Location,
-		}
-
-		scope, err := getServerScope(inf.Tx.Tx, cfgFile, server.Type)
-		if err != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("GetConfigMetaData getting scope: "+err.Error()))
-			return
-		}
-
-		if cfgParams.URL != "" {
-			scope = tc.ATSConfigMetaDataConfigFileScopeCDNs
-			atsCfg.URL = cfgParams.URL
-		} else {
-			scopeID := ""
-			if scope == tc.ATSConfigMetaDataConfigFileScopeCDNs {
-				scopeID = string(server.CDN)
-			} else if scope == tc.ATSConfigMetaDataConfigFileScopeProfiles {
-				scopeID = server.ProfileName
-			} else { // ATSConfigMetaDataConfigFileScopeServers
-				scopeID = server.HostName
-			}
-			atsCfg.APIURI = "/api/1.2/" + string(scope) + "/" + scopeID + "/configfiles/ats/" + cfgFile
-		}
-
-		atsCfg.Scope = string(scope)
-
-		atsData.ConfigFiles = append(atsData.ConfigFiles, atsCfg)
-	}
-
-	api.WriteRespRaw(w, r, atsData)
-}
-
-func getServerScope(tx *sql.Tx, cfgFile string, serverType string) (tc.ATSConfigMetaDataConfigFileScope, error) {
-	switch {
-	case cfgFile == "cache.config" && tc.CacheTypeFromString(serverType) == tc.CacheTypeMid:
-		return tc.ATSConfigMetaDataConfigFileScopeServers, nil
-	default:
-		return getScope(tx, cfgFile)
-	}
-}
-
-// getScope returns the ATSConfigMetaDataConfigFileScope for the given config file, and potentially the given server. If the config is not a Server scope, i.e. was part of an endpoint which does not include a server name or id, the server may be nil.
-func getScope(tx *sql.Tx, cfgFile string) (tc.ATSConfigMetaDataConfigFileScope, error) {
-	switch {
-	case cfgFile == "ip_allow.config":
-		fallthrough
-	case cfgFile == "parent.config":
-		fallthrough
-	case cfgFile == "hosting.config":
-		fallthrough
-	case cfgFile == "packages":
-		fallthrough
-	case cfgFile == "chkconfig":
-		fallthrough
-	case cfgFile == "remap.config":
-		fallthrough
-	case strings.HasPrefix(cfgFile, "to_ext_") && strings.HasSuffix(cfgFile, ".config"):
-		return tc.ATSConfigMetaDataConfigFileScopeServers, nil
-	case cfgFile == "12M_facts":
-		fallthrough
-	case cfgFile == "50-ats.rules":
-		fallthrough
-	case cfgFile == "astats.config":
-		fallthrough
-	case cfgFile == "cache.config":
-		fallthrough
-	case cfgFile == "drop_qstring.config":
-		fallthrough
-	case cfgFile == "logs_xml.config":
-		fallthrough
-	case cfgFile == "logging.config":
-		fallthrough
-	case cfgFile == "plugin.config":
-		fallthrough
-	case cfgFile == "records.config":
-		fallthrough
-	case cfgFile == "storage.config":
-		fallthrough
-	case cfgFile == "volume.config":
-		fallthrough
-	case cfgFile == "sysctl.conf":
-		fallthrough
-	case strings.HasPrefix(cfgFile, "url_sig_") && strings.HasSuffix(cfgFile, ".config"):
-		fallthrough
-	case strings.HasPrefix(cfgFile, "uri_signing_") && strings.HasSuffix(cfgFile, ".config"):
-		return tc.ATSConfigMetaDataConfigFileScopeProfiles, nil
-
-	case cfgFile == "bg_fetch.config":
-		fallthrough
-	case cfgFile == "regex_revalidate.config":
-		fallthrough
-	case cfgFile == "ssl_multicert.config":
-		fallthrough
-	case strings.HasPrefix(cfgFile, "cacheurl") && strings.HasSuffix(cfgFile, ".config"):
-		fallthrough
-	case strings.HasPrefix(cfgFile, "hdr_rw_") && strings.HasSuffix(cfgFile, ".config"):
-		fallthrough
-	case strings.HasPrefix(cfgFile, "regex_remap_") && strings.HasSuffix(cfgFile, ".config"):
-		fallthrough
-	case strings.HasPrefix(cfgFile, "set_dscp_") && strings.HasSuffix(cfgFile, ".config"):
-		return tc.ATSConfigMetaDataConfigFileScopeCDNs, nil
-	}
-
-	scope, ok, err := ats.GetFirstScopeParameter(tx, cfgFile)
+	uriSignedDSes, err := ats.GetServerURISignedDSes(inf.Tx.Tx, server.HostName, server.Port)
 	if err != nil {
-		return tc.ATSConfigMetaDataConfigFileScopeInvalid, errors.New("getting scope parameter: " + err.Error())
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("GetConfigMetaData getting server uri-signed dses: "+err.Error()))
+		return
 	}
-	if !ok {
-		scope = string(tc.ATSConfigMetaDataConfigFileScopeServers)
-	}
-	return tc.ATSConfigMetaDataConfigFileScope(scope), nil
+
+	txt := atscfg.MakeMetaConfig(serverName, server, tmParams.URL, tmParams.ReverseProxyURL, locationParams, uriSignedDSes, scopeParams)
+	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Write([]byte(txt))
 }

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -434,6 +434,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		// ATS config files
 		{1.1, http.MethodGet, `servers/{server-name-or-id}/configfiles/ats/?(\.json)?$`, atsserver.GetConfigMetaData, auth.PrivLevelOperations, Authenticated, nil},
+
 		{1.1, http.MethodGet, `cdns/{cdn-name-or-id}/configfiles/ats/regex_revalidate.config/?(\.json)?$`, atscdn.GetRegexRevalidateDotConfig, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodGet, `cdns/{cdn-name-or-id}/configfiles/ats/hdr_rw_mid_{xml-id}.config/?(\.json)?$`, atscdn.GetMidHeaderRewriteDotConfig, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodGet, `cdns/{cdn-name-or-id}/configfiles/ats/hdr_rw_{xml-id}.config/?(\.json)?$`, atscdn.GetEdgeHeaderRewriteDotConfig, auth.PrivLevelOperations, Authenticated, nil},
@@ -464,7 +465,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `profiles/{profile-name-or-id}/configfiles/ats/volume.config/?$`, atsprofile.GetVolume, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodGet, `profiles/{profile-name-or-id}/configfiles/ats/{file}/?$`, atsprofile.GetUnknown, auth.PrivLevelOperations, Authenticated, nil},
 
-		{1.1, http.MethodGet, `servers/{server-name-or-id}/configfiles/ats/?(\.json)?$`, atsserver.GetConfigMetaData, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodGet, `servers/{server-name-or-id}/configfiles/ats/parent.config/?(\.json)?$`, atsserver.GetParentDotConfig, auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodGet, `servers/{server-name-or-id}/configfiles/ats/remap.config/?(\.json)?$`, atsserver.GetServerConfigRemap, auth.PrivLevelOperations, Authenticated, nil},
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Adds meta config to atstccfg config generator.

- [x] This PR is not related to any other Issue

Includes tests.
Includes changelog.
No documentation, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Ops
- Traffic Ops ORT

## What is the best way to verify this PR?

Run unit tests.

Run `atstccfg` with request to the meta config endpoint, verify response is identical to Go and old Perl endpoints.

## If this is a bug fix, what versions of Traffic Control are affected?

Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
