### PR TITLE
TP: adds type query param to the state url definition.

### DIFF
--- a/traffic_portal/app/src/modules/private/deliveryServices/capabilities/index.js
+++ b/traffic_portal/app/src/modules/private/deliveryServices/capabilities/index.js
@@ -21,7 +21,7 @@ module.exports = angular.module('trafficPortal.private.deliveryServices.capabili
 	.config(function($stateProvider, $urlRouterProvider) {
 		$stateProvider
 			.state('trafficPortal.private.deliveryServices.capabilities', {
-				url: '/{deliveryServiceId}/required-server-capabilities',
+				url: '/{deliveryServiceId}/required-server-capabilities?type',
 				views: {
 					deliveryServicesContent: {
 						templateUrl: 'common/modules/table/deliveryServiceCapabilities/table.deliveryServiceCapabilities.tpl.html',


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Fixes a UI state definition that would result in unpredictable DS UI behavior. Specifically, the success/error message displayed when adding/removing required server capabilities would occasionally not display properly.

No need to update any documentation.
No need to write additional tests as the ds workflow is already covered under existing tests.
No need for a changelog.md entry for such a minor change.

- [x] This PR is not related to any Issue 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
Run the UI tests. Ensure that they pass.
Also, you can add or remove ds required server capabilities from a ds and ensure that the success message is displayed properly.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
