### PR TITLE
Set Content-Length header in Traffic Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,7 +212,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated `t3c-apply` to reduce mutable state in `TrafficOpsReq` struct.
 - Updated Golang dependencies
 - [#6506](https://github.com/apache/trafficcontrol/pull/6506) - Updated `jackson-databind` and `jackson-annotations` Traffic Router dependencies to version 2.13.1
-- Traffic Router now includes a `Content-Length` header in each response.
 
 ### Deprecated
 - Deprecated the endpoints and docs associated with `/api_capability` and `/capabilities`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7158](https://github.com/apache/trafficcontrol/issues/7158) *Traffic Vault* Fix the `reencrypt` utility to uniquely reencrypt each version of the SSL Certificates.
 - [#7137](https://github.com/apache/trafficcontrol/pull/7137) *Cache Config* parent.config simulate topology for non topo delivery services.
 - Adds an extra T3C check for validity of an ssl cert (crash fix).
+- Traffic Router now always includes a `Content-Length` header in the response.
 
 ## [7.0.0] - 2022-07-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated `t3c-apply` to reduce mutable state in `TrafficOpsReq` struct.
 - Updated Golang dependencies
 - [#6506](https://github.com/apache/trafficcontrol/pull/6506) - Updated `jackson-databind` and `jackson-annotations` Traffic Router dependencies to version 2.13.1
+- Traffic Router now includes a `Content-Length` header in each response.
 
 ### Deprecated
 - Deprecated the endpoints and docs associated with `/api_capability` and `/capabilities`.

--- a/docs/source/development/traffic_router/traffic_router_api.rst
+++ b/docs/source/development/traffic_router/traffic_router_api.rst
@@ -79,6 +79,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 1214
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -162,6 +163,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Connection: close
 	Content-Disposition: inline;filename=f.txt
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 131
@@ -205,6 +207,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 35
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -235,6 +238,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 278
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -291,6 +295,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 253
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -418,6 +423,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 828
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -568,6 +574,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 137
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -609,6 +616,7 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
+	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 163
 	Date: Mon, 04 Nov 2019 19:48:04 GMT

--- a/docs/source/development/traffic_router/traffic_router_api.rst
+++ b/docs/source/development/traffic_router/traffic_router_api.rst
@@ -79,7 +79,6 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 1214
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -163,7 +162,6 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: close
 	Content-Disposition: inline;filename=f.txt
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 131
@@ -207,7 +205,6 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 35
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -238,7 +235,6 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 278
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -295,7 +291,6 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 253
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -423,7 +418,6 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 828
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -574,7 +568,6 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 137
 	Date: Mon, 04 Nov 2019 19:48:04 GMT
@@ -616,7 +609,6 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: close
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 163
 	Date: Mon, 04 Nov 2019 19:48:04 GMT

--- a/docs/source/development/traffic_router/traffic_router_api.rst
+++ b/docs/source/development/traffic_router/traffic_router_api.rst
@@ -70,24 +70,24 @@ Request Structure
 
 	GET /crs/stats HTTP/1.1
 	Host: trafficrouter.infra.ciab.test
-	User-Agent: curl/7.47.0
+	User-Agent: curl/7.52.1
 	Accept: */*
 
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example
+	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 200
 	Content-Type: application/json;charset=UTF-8
-	Transfer-Encoding: chunked
-	Date: Tue, 15 Jan 2019 21:02:09 GMT
+	Content-Length: 1213
+	Date: Sun, 03 Nov 2019 05:57:17 GMT
 
 	{ "app": {
-		"buildTimestamp": "2019-01-10",
+		"buildTimestamp": "2019-11-03",
 		"name": "traffic_router",
 		"deploy-dir": "/opt/traffic_router",
-		"git-revision": "437e9df81",
+		"git-revision": "3ebc920b7",
 		"version": "3.0.0"
 	},
 	"stats": {
@@ -95,7 +95,7 @@ Response Structure
 		"httpMap": {
 			"video.demo1.mycdn.ciab.test": {
 				"czCount": 0,
-				"geoCount": 0,
+				"geoCount": 1,
 				"deepCzCount": 0,
 				"missCount": 0,
 				"dsrCount": 0,
@@ -107,29 +107,29 @@ Response Structure
 			}
 		},
 		"totalDnsCount": 0,
-		"totalHttpCount": 1,
-		"totalDsMissCount": 0,
-		"appStartTime": 1547584831677,
-		"averageDnsTime": 0,
-		"averageHttpTime": 1547584863270,
+		"totalHttpCount": 2,
+		"totalDsMissCount": 1,
+		"appStartTime": 1572759663457,
+		"averageHttpTime": 786379849939,
 		"updateTracker": {
-			"lastHttpsCertificatesCheck": 1547586068932,
-			"lastGeolocationDatabaseUpdaterUpdate": 1547584858917,
-			"lastCacheStateCheck": 1547586128932,
-			"lastCacheStateChange": 1547584867102,
-			"lastNetworkUpdaterUpdate": 1547584857484,
-			"lastHttpsCertificatesUpdate": 1547586071079,
-			"lastSteeringWatcherUpdate": 1547584923514,
-			"lastConfigCheck": 1547586127344,
-			"lastConfigChange": 1547584863406,
-			"lastNetworkUpdaterCheck": 1547584857465,
-			"lastGeolocationDatabaseUpdaterCheck": 1547584858906,
-			"lastFederationsWatcherUpdate": 1547584863433,
-			"lastHttpsCertificatesFetchSuccess": 1547586069070,
-			"lastSteeringWatcherCheck": 1547586124630,
-			"lastFederationsWatcherCheck": 1547586124584,
-			"lastHttpsCertificatesFetchAttempt": 1547586068932
-		}
+			"lastHttpsCertificatesCheck": 1572760605162,
+			"lastGeolocationDatabaseUpdaterUpdate": 1572759695064,
+			"lastCacheStateCheck": 1572760637365,
+			"lastCacheStateChange": 1572759703763,
+			"lastNetworkUpdaterUpdate": 1572759694009,
+			"lastHttpsCertificatesUpdate": 1572760607280,
+			"lastSteeringWatcherUpdate": 1572759760062,
+			"lastConfigCheck": 1572760633918,
+			"lastConfigChange": 1572759699962,
+			"lastNetworkUpdaterCheck": 1572759693998,
+			"lastGeolocationDatabaseUpdaterCheck": 1572759695056,
+			"lastFederationsWatcherUpdate": 1572759699998,
+			"lastHttpsCertificatesFetchSuccess": 1572760605275,
+			"lastSteeringWatcherCheck": 1572760601104,
+			"lastFederationsWatcherCheck": 1572760601085,
+			"lastHttpsCertificatesFetchAttempt": 1572760605162
+		},
+		"averageDnsTime": 0
 	}}
 
 .. _tr-api-crs-stats-ip-ip:
@@ -153,19 +153,19 @@ Request Structure
 
 	GET /crs/stats/ip/255.255.255.255 HTTP/1.1
 	Host: trafficrouter.infra.ciab.test
-	User-Agent: curl/7.47.0
+	User-Agent: curl/7.52.1
 	Accept: */*
 
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example
+	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 200
 	Content-Disposition: inline;filename=f.txt
 	Content-Type: application/json;charset=UTF-8
-	Transfer-Encoding: chunked
-	Date: Tue, 15 Jan 2019 21:06:09 GMT
+	Content-Length: 131
+	Date: Sun, 03 Nov 2019 06:06:26 GMT
 
 	{ "locationByGeo": {
 		"city": "Woodridge",
@@ -194,7 +194,7 @@ Request Structure
 
 	GET /crs/locations HTTP/1.1
 	Host: trafficrouter.infra.ciab.test
-	User-Agent: curl/7.47.0
+	User-Agent: curl/7.52.1
 	Accept: */*
 
 Response Structure
@@ -202,12 +202,12 @@ Response Structure
 :locations: An array of strings that are the :ref:`Names of Cache Groups <cache-group-name>` to which this Traffic Router is capable of routing client traffic
 
 .. code-block:: http
-	:caption: Response Example
+	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 200
 	Content-Type: application/json;charset=UTF-8
-	Transfer-Encoding: chunked
-	Date: Tue, 15 Jan 2019 21:12:17 GMT
+	Content-Length: 35
+	Date: Sun, 03 Nov 2019 06:12:41 GMT
 
 	{ "locations": [
 		"CDN_in_a_Box_Edge"
@@ -226,18 +226,18 @@ Request Structure
 
 	GET /crs/locations/caches HTTP/1.1
 	Host: trafficrouter.infra.ciab.test
-	User-Agent: curl/7.47.0
+	User-Agent: curl/7.52.1
 	Accept: */*
 
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example
+	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 200
 	Content-Type: application/json;charset=UTF-8
-	Transfer-Encoding: chunked
-	Date: Tue, 15 Jan 2019 21:15:53 GMT
+	Content-Length: 278
+	Date: Sun, 03 Nov 2019 06:21:06 GMT
 
 	{ "locations": {
 		"CDN_in_a_Box_Edge": [
@@ -245,8 +245,8 @@ Response Structure
 				"cacheId": "edge",
 				"fqdn": "edge.infra.ciab.test",
 				"ipAddresses": [
-					"172.16.239.100",
-					"fc01:9400:1000:8:0:0:0:100"
+					"172.16.239.4",
+					"fc01:9400:1000:8:0:0:0:4"
 				],
 				"port": 0,
 				"adminStatus": null,
@@ -282,26 +282,26 @@ Request Structure
 
 	GET /crs/locations/CDN_in_a_Box_Edge/caches HTTP/1.1
 	Host: trafficrouter.infra.ciab.test
-	User-Agent: curl/7.47.0
+	User-Agent: curl/7.52.1
 	Accept: */*
 
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example
+	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 200
 	Content-Type: application/json;charset=UTF-8
-	Transfer-Encoding: chunked
-	Date: Tue, 15 Jan 2019 21:18:25 GMT
+	Content-Length: 253
+	Date: Sun, 03 Nov 2019 06:23:20 GMT
 
 	{ "caches": [
 		{
 			"cacheId": "edge",
 			"fqdn": "edge.infra.ciab.test",
 			"ipAddresses": [
-				"172.16.239.100",
-				"fc01:9400:1000:8:0:0:0:100"
+				"172.16.239.4",
+				"fc01:9400:1000:8:0:0:0:4"
 			],
 			"port": 0,
 			"adminStatus": null,
@@ -409,18 +409,18 @@ Request Structure
 
 	GET /crs/consistenthash/deliveryservice?deliveryServiceId=demo1&requestPath=/ HTTP/1.1
 	Host: trafficrouter.infra.ciab.test
-	User-Agent: curl/7.47.0
+	User-Agent: curl/7.52.1
 	Accept: */*
 
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example
+	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 200
 	Content-Type: application/json;charset=UTF-8
-	Transfer-Encoding: chunked
-	Date: Tue, 15 Jan 2019 21:40:51 GMT
+	Content-Length: 828
+	Date: Sun, 03 Nov 2019 06:26:30 GMT
 
 	{ "id": "demo1",
 	"coverageZoneOnly": false,
@@ -429,8 +429,8 @@ Response Structure
 	"geoRedirectUrlType": "INVALID_URL",
 	"routingName": "video",
 	"missLocation": {
-		"latitude": 42,
-		"longitude": -88,
+		"latitude": 42.0,
+		"longitude": -88.0,
 		"postalCode": null,
 		"city": null,
 		"countryCode": null,
@@ -458,6 +458,13 @@ Response Structure
 	"sslEnabled": true,
 	"acceptHttp": true,
 	"deepCache": "NEVER",
+	"consistentHashRegex": "",
+	"consistentHashQueryParams": [
+		"abc",
+		"zyx",
+		"xxx",
+		"pdq"
+	],
 	"dns": false,
 	"locationLimit": 0,
 	"maxDnsIps": 0,
@@ -552,23 +559,22 @@ Request Structure
 
 	GET /crs/consistenthash/patternbased/regex?regex=%2F.*%3F%28%2F.*%3F%2F%29.*%3F%28%5C.m3u8%29&requestPath=%2Ftext1234%2Fname%2Fasset.m3u8 HTTP/1.1
 	Host: localhost:3333
-	User-Agent: curl/7.54.0
+	User-Agent: curl/7.52.1
 	Accept: */*
 
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example
+	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 200
 	Content-Type: application/json;charset=UTF-8
-	Transfer-Encoding: chunked
-	Date: Fri, 15 Feb 2019 22:06:53 GMT
+	Content-Length: 137
+	Date: Sun, 03 Nov 2019 06:36:28 GMT
 
-	{
-	"resultingPathToConsistentHash":"/name/.m3u8",
-	"consistentHashRegex":"/.*?(/.*?/).*?(\\.m3u8)",
-	"requestPath":"/text1234/name/asset.m3u8"
+	{ "resultingPathToConsistentHash": "/name/.m3u8",
+	"consistentHashRegex": "/.*?(/.*?/).*?(\\.m3u8)",
+	"requestPath": "/text1234/name/asset.m3u8"
 	}
 
 .. _tr-api-crs-consistenthash-patternbased-deliveryservice:
@@ -592,25 +598,24 @@ Request Structure
 .. code-block:: http
 	:caption: Request Example
 
-	GET /crs/consistenthash/patternbased/deliveryservice?deliveryServiceId=asdf&requestPath=%2Fsometext1234%2Fstream_name%2Fasset_name.m3u8 HTTP/1.1
+	GET /crs/consistenthash/patternbased/deliveryservice?deliveryServiceId=demo1&requestPath=%2Fsometext1234%2Fstream_name%2Fasset_name.m3u8 HTTP/1.1
 	Host: localhost:3333
-	User-Agent: curl/7.54.0
+	User-Agent: curl/7.52.1
 	Accept: */*
 
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example
+	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 200
 	Content-Type: application/json;charset=UTF-8
-	Transfer-Encoding: chunked
-	Date: Fri, 15 Feb 2019 22:12:38 GMT
+	Content-Length: 163
+	Date: Sun, 03 Nov 2019 06:45:07 GMT
 
-	{
-	"resultingPathToConsistentHash":"/sometext1234/stream_name/asset_name.m3u8",
-	"deliveryServiceId":"asdf",
-	"requestPath":"/sometext1234/stream_name/asset_name.m3u8"
+	{ "resultingPathToConsistentHash": "/sometext1234/stream_name/asset_name.m3u8",
+	"deliveryServiceId": "demo1",
+	"requestPath": "/sometext1234/stream_name/asset_name.m3u8"
 	}
 
 .. _tr-api-crs-consistenthash-cache-coveragezone-steering:

--- a/docs/source/development/traffic_router/traffic_router_api.rst
+++ b/docs/source/development/traffic_router/traffic_router_api.rst
@@ -78,16 +78,16 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200
+	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
-	Content-Length: 1213
-	Date: Sun, 03 Nov 2019 05:57:17 GMT
+	Content-Length: 1214
+	Date: Mon, 04 Nov 2019 19:48:04 GMT
 
 	{ "app": {
-		"buildTimestamp": "2019-11-03",
+		"buildTimestamp": "2019-11-04",
 		"name": "traffic_router",
 		"deploy-dir": "/opt/traffic_router",
-		"git-revision": "3ebc920b7",
+		"git-revision": "eabc2b82e",
 		"version": "3.0.0"
 	},
 	"stats": {
@@ -95,7 +95,7 @@ Response Structure
 		"httpMap": {
 			"video.demo1.mycdn.ciab.test": {
 				"czCount": 0,
-				"geoCount": 1,
+				"geoCount": 0,
 				"deepCzCount": 0,
 				"missCount": 0,
 				"dsrCount": 0,
@@ -107,29 +107,29 @@ Response Structure
 			}
 		},
 		"totalDnsCount": 0,
-		"totalHttpCount": 2,
-		"totalDsMissCount": 1,
-		"appStartTime": 1572759663457,
-		"averageHttpTime": 786379849939,
+		"totalHttpCount": 1,
+		"totalDsMissCount": 0,
+		"appStartTime": 1572895915703,
+		"averageDnsTime": 0,
+		"averageHttpTime": 1572895947202,
 		"updateTracker": {
-			"lastHttpsCertificatesCheck": 1572760605162,
-			"lastGeolocationDatabaseUpdaterUpdate": 1572759695064,
-			"lastCacheStateCheck": 1572760637365,
-			"lastCacheStateChange": 1572759703763,
-			"lastNetworkUpdaterUpdate": 1572759694009,
-			"lastHttpsCertificatesUpdate": 1572760607280,
-			"lastSteeringWatcherUpdate": 1572759760062,
-			"lastConfigCheck": 1572760633918,
-			"lastConfigChange": 1572759699962,
-			"lastNetworkUpdaterCheck": 1572759693998,
-			"lastGeolocationDatabaseUpdaterCheck": 1572759695056,
-			"lastFederationsWatcherUpdate": 1572759699998,
-			"lastHttpsCertificatesFetchSuccess": 1572760605275,
-			"lastSteeringWatcherCheck": 1572760601104,
-			"lastFederationsWatcherCheck": 1572760601085,
-			"lastHttpsCertificatesFetchAttempt": 1572760605162
-		},
-		"averageDnsTime": 0
+			"lastHttpsCertificatesCheck": 1572896852436,
+			"lastGeolocationDatabaseUpdaterUpdate": 1572895942543,
+			"lastCacheStateCheck": 1572896884465,
+			"lastCacheStateChange": 1572895951089,
+			"lastNetworkUpdaterUpdate": 1572895941407,
+			"lastHttpsCertificatesUpdate": 1572896854512,
+			"lastSteeringWatcherUpdate": 1572896007369,
+			"lastConfigCheck": 1572896881213,
+			"lastConfigChange": 1572895947297,
+			"lastNetworkUpdaterCheck": 1572895941392,
+			"lastGeolocationDatabaseUpdaterCheck": 1572895942533,
+			"lastFederationsWatcherUpdate": 1572895947336,
+			"lastHttpsCertificatesFetchSuccess": 1572896852506,
+			"lastSteeringWatcherCheck": 1572896848090,
+			"lastFederationsWatcherCheck": 1572896848067,
+			"lastHttpsCertificatesFetchAttempt": 1572896852436
+		}
 	}}
 
 .. _tr-api-crs-stats-ip-ip:
@@ -161,11 +161,11 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200
+	HTTP/1.1 200 OK
 	Content-Disposition: inline;filename=f.txt
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 131
-	Date: Sun, 03 Nov 2019 06:06:26 GMT
+	Date: Mon, 04 Nov 2019 19:48:04 GMT
 
 	{ "locationByGeo": {
 		"city": "Woodridge",
@@ -204,10 +204,10 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200
+	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 35
-	Date: Sun, 03 Nov 2019 06:12:41 GMT
+	Date: Mon, 04 Nov 2019 19:48:04 GMT
 
 	{ "locations": [
 		"CDN_in_a_Box_Edge"
@@ -234,10 +234,10 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200
+	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 278
-	Date: Sun, 03 Nov 2019 06:21:06 GMT
+	Date: Mon, 04 Nov 2019 19:48:04 GMT
 
 	{ "locations": {
 		"CDN_in_a_Box_Edge": [
@@ -290,10 +290,10 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200
+	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 253
-	Date: Sun, 03 Nov 2019 06:23:20 GMT
+	Date: Mon, 04 Nov 2019 19:48:04 GMT
 
 	{ "caches": [
 		{
@@ -417,10 +417,10 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200
+	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 828
-	Date: Sun, 03 Nov 2019 06:26:30 GMT
+	Date: Mon, 04 Nov 2019 19:48:04 GMT
 
 	{ "id": "demo1",
 	"coverageZoneOnly": false,
@@ -567,10 +567,10 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200
+	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 137
-	Date: Sun, 03 Nov 2019 06:36:28 GMT
+	Date: Mon, 04 Nov 2019 19:48:04 GMT
 
 	{ "resultingPathToConsistentHash": "/name/.m3u8",
 	"consistentHashRegex": "/.*?(/.*?/).*?(\\.m3u8)",
@@ -608,10 +608,10 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example (JSON expanded)
 
-	HTTP/1.1 200
+	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
 	Content-Length: 163
-	Date: Sun, 03 Nov 2019 06:45:07 GMT
+	Date: Mon, 04 Nov 2019 19:48:04 GMT
 
 	{ "resultingPathToConsistentHash": "/sometext1234/stream_name/asset_name.m3u8",
 	"deliveryServiceId": "demo1",

--- a/docs/source/development/traffic_router/traffic_router_api.rst
+++ b/docs/source/development/traffic_router/traffic_router_api.rst
@@ -76,7 +76,7 @@ Request Structure
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example (JSON expanded)
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
@@ -159,7 +159,7 @@ Request Structure
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example (JSON expanded)
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Content-Disposition: inline;filename=f.txt
@@ -202,7 +202,7 @@ Response Structure
 :locations: An array of strings that are the :ref:`Names of Cache Groups <cache-group-name>` to which this Traffic Router is capable of routing client traffic
 
 .. code-block:: http
-	:caption: Response Example (JSON expanded)
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
@@ -232,7 +232,7 @@ Request Structure
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example (JSON expanded)
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
@@ -288,7 +288,7 @@ Request Structure
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example (JSON expanded)
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
@@ -415,7 +415,7 @@ Request Structure
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example (JSON expanded)
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
@@ -565,7 +565,7 @@ Request Structure
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example (JSON expanded)
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8
@@ -606,7 +606,7 @@ Request Structure
 Response Structure
 ------------------
 .. code-block:: http
-	:caption: Response Example (JSON expanded)
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Content-Type: application/json;charset=UTF-8

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/api/controllers/LocationController.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/api/controllers/LocationController.java
@@ -35,7 +35,7 @@ public class LocationController {
 	@Autowired
 	private DataExporter dataExporter;
 
-	@RequestMapping(value = "/{locID}/caches", method = RequestMethod.GET)
+	@RequestMapping(value = "/{locID}/caches", method = {RequestMethod.GET, RequestMethod.HEAD})
 	public @ResponseBody
 	Map<String, List<CacheModel>> getCaches(@PathVariable("locID") final String locId) {
 		final Map<String, List<CacheModel>> map = new HashMap<String, List<CacheModel>>();
@@ -43,17 +43,17 @@ public class LocationController {
 		return map;
 	}
 
-	@RequestMapping(value = "", method = RequestMethod.GET)
+	@RequestMapping(value = "", method = {RequestMethod.GET, RequestMethod.HEAD})
 	public @ResponseBody
-	Map<String,List<String>> getLocations() {
-		final Map<String, List<String >> locations = new HashMap<String, List<String>>();
+	Map<String, List<String>> getLocations() {
+		final Map<String, List<String>> locations = new HashMap<String, List<String>>();
 		locations.put("locations", dataExporter.getLocations());
 		return locations;
 	}
 
-	@RequestMapping(value = "/caches", method = RequestMethod.GET)
+	@RequestMapping(value = "/caches", method = {RequestMethod.GET, RequestMethod.HEAD})
 	public @ResponseBody
-	Map<String,Map<String, List<CacheModel>>> getCaches() {
+	Map<String, Map<String, List<CacheModel>>> getCaches() {
 		final Map<String, Map<String, List<CacheModel>>> map = new HashMap<String, Map<String, List<CacheModel>>>();
 		final Map<String, List<CacheModel>> innerMap = new HashMap<String, List<CacheModel>>();
 

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponse.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.traffic_control.traffic_router.core.http;
+
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class BufferedResponse extends ContentCachingResponseWrapper {
+	protected int contentLength;
+	protected ServletResponse response;
+
+	public BufferedResponse(final HttpServletResponse response) {
+		super(response);
+		this.response = response;
+	}
+
+	@Override
+	public void setContentLength(final int len) {
+		contentLength = len;
+		super.setContentLength(len);
+	}
+
+	@Override
+	public void setContentLengthLong(final long len) {
+		contentLength = (int) len;
+		super.setContentLengthLong(len);
+	}
+
+	@Override
+	public void copyBodyToResponse() throws IOException {
+		if (this.getContentSize() == 0) {
+			response.setContentLength(contentLength);
+		} else {
+			// When the content size is greater than 0, copyBodyToResponse()
+			// will set Content-Length.
+			super.copyBodyToResponse();
+		}
+	}
+}

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponseFilter.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponseFilter.java
@@ -15,47 +15,25 @@
 
 package org.apache.traffic_control.traffic_router.core.http;
 
+import com.google.common.net.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 public class BufferedResponseFilter extends OncePerRequestFilter {
 	public static final Logger LOGGER = LogManager.getLogger(BufferedResponseFilter.class);
 
 	public void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) throws IOException, ServletException {
-		final ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+		final BufferedResponse responseWrapper = new BufferedResponse(response);
 
 		chain.doFilter(request, responseWrapper);
 
-		if (responseWrapper.getContentSize() == 0) {
-			int contentLength = 0;
-
-			try {
-				final Field contentLengthField = responseWrapper.getClass().getDeclaredField("contentLength");
-				contentLengthField.setAccessible(true);
-				final Object contentLengthObject = contentLengthField.get(responseWrapper);
-				/* E.g., a HEAD request whose corresponding GET request has a non-empty body */
-				if (contentLengthObject != null) {
-					contentLength = (Integer) contentLengthObject;
-				}
-			} catch (ReflectiveOperationException e) {
-				LOGGER.error("Encountered a " + e.getClass() + "exception in " + this.getClass() + ": " + e.getMessage());
-			} finally {
-				response.setContentLength(contentLength);
-			}
-		} else {
-			/* When the content size is greater than 0, copyBodyToResponse()
-			 * will set Content-Length.
-			 */
-			responseWrapper.copyBodyToResponse();
-		}
+		responseWrapper.copyBodyToResponse();
 	}
 }

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponseFilter.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponseFilter.java
@@ -31,17 +31,7 @@ public class BufferedResponseFilter extends OncePerRequestFilter {
 
 	public void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) throws IOException, ServletException {
 		final BufferedResponse responseWrapper = new BufferedResponse(response);
-
 		chain.doFilter(request, responseWrapper);
-
-		// Close the connection without waiting for the 10-second connect timeout,
-		// in case the client does not close the connection. Even though this is
-		// the only case for which we are interested in sending Connection: close,
-		// sending it sometimes means we must always send it. From RFC 2616:
-		// > HTTP/1.1 applications that do not support persistent connections MUST
-		// > include the "close" connection option in every message.
-		response.addHeader(HttpHeaders.CONNECTION, "close");
-
 		responseWrapper.copyBodyToResponse();
 	}
 }

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponseFilter.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponseFilter.java
@@ -34,6 +34,14 @@ public class BufferedResponseFilter extends OncePerRequestFilter {
 
 		chain.doFilter(request, responseWrapper);
 
+		// Close the connection without waiting for the 10-second connect timeout,
+		// in case the client does not close the connection. Even though this is
+		// the only case for which we are interested in sending Connection: close,
+		// sending it sometimes means we must always send it. From RFC 2616:
+		// > HTTP/1.1 applications that do not support persistent connections MUST
+		// > include the "close" connection option in every message.
+		response.addHeader(HttpHeaders.CONNECTION, "close");
+
 		responseWrapper.copyBodyToResponse();
 	}
 }

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponseFilter.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/BufferedResponseFilter.java
@@ -1,0 +1,61 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.traffic_control.traffic_router.core.http;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+public class BufferedResponseFilter extends OncePerRequestFilter {
+	public static final Logger LOGGER = LogManager.getLogger(BufferedResponseFilter.class);
+
+	public void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) throws IOException, ServletException {
+		final ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+		chain.doFilter(request, responseWrapper);
+
+		if (responseWrapper.getContentSize() == 0) {
+			int contentLength = 0;
+
+			try {
+				final Field contentLengthField = responseWrapper.getClass().getDeclaredField("contentLength");
+				contentLengthField.setAccessible(true);
+				final Object contentLengthObject = contentLengthField.get(responseWrapper);
+				/* E.g., a HEAD request whose corresponding GET request has a non-empty body */
+				if (contentLengthObject != null) {
+					contentLength = (Integer) contentLengthObject;
+				}
+			} catch (ReflectiveOperationException e) {
+				LOGGER.error("Encountered a " + e.getClass() + "exception in " + this.getClass() + ": " + e.getMessage());
+			} finally {
+				response.setContentLength(contentLength);
+			}
+		} else {
+			/* When the content size is greater than 0, copyBodyToResponse()
+			 * will set Content-Length.
+			 */
+			responseWrapper.copyBodyToResponse();
+		}
+	}
+}

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/RouterFilter.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/RouterFilter.java
@@ -42,7 +42,6 @@ import java.util.Set;
 public class RouterFilter extends OncePerRequestFilter {
 	private static final Logger ACCESS = LogManager.getLogger("org.apache.traffic_control.traffic_router.core.access");
 	public static final String REDIRECT_QUERY_PARAM = "trred";
-	private static final String HEAD = "HEAD";
 
 	@Autowired
 	private TrafficRouterManager trafficRouterManager;
@@ -144,11 +143,9 @@ public class RouterFilter extends OncePerRequestFilter {
 
 		final String redirect = httpServletRequest.getParameter(REDIRECT_QUERY_PARAM);
 
-		if (!HEAD.equals(httpServletRequest.getMethod())) {
-			response.setContentType("application/json");
-			response.getWriter().println(routeResult.toMultiLocationJSONString());
-			httpAccessRecordBuilder.responseURLs(routeResult.getUrls());
-		}
+		response.setContentType("application/json");
+		response.getWriter().println(routeResult.toMultiLocationJSONString());
+		httpAccessRecordBuilder.responseURLs(routeResult.getUrls());
 
 		// don't actually parse the boolean value; trred would always be false unless the query param is "true"
 		if ("false".equalsIgnoreCase(redirect)) {
@@ -177,20 +174,14 @@ public class RouterFilter extends OncePerRequestFilter {
 		}
 
 		if ("false".equalsIgnoreCase(redirect)) {
-			if (!HEAD.equals(httpServletRequest.getMethod())) {
-				response.setContentType("application/json");
-				response.getWriter().println(routeResult.toMultiLocationJSONString());
-				httpAccessRecordBuilder.responseURLs(routeResult.getUrls());
-			}
-
+			response.setContentType("application/json");
+			response.getWriter().println(routeResult.toMultiLocationJSONString());
+			httpAccessRecordBuilder.responseURLs(routeResult.getUrls());
 			httpAccessRecordBuilder.responseCode(HttpServletResponse.SC_OK);
 		} else if ("json".equals(format)) {
-			if (!HEAD.equals(httpServletRequest.getMethod())) {
-				response.setContentType("application/json");
-				response.getWriter().println(routeResult.toLocationJSONString());
-				httpAccessRecordBuilder.responseURL(location);
-			}
-
+			response.setContentType("application/json");
+			response.getWriter().println(routeResult.toLocationJSONString());
+			httpAccessRecordBuilder.responseURL(location);
 			httpAccessRecordBuilder.responseCode(HttpServletResponse.SC_OK);
 		} else {
 			response.setHeader(HttpHeaders.LOCATION, location.toString());

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/RouterFilter.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/http/RouterFilter.java
@@ -25,6 +25,7 @@ import org.apache.traffic_control.traffic_router.geolocation.GeolocationExceptio
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -154,7 +155,7 @@ public class RouterFilter extends OncePerRequestFilter {
 			response.setStatus(HttpServletResponse.SC_OK);
 			httpAccessRecordBuilder.responseCode(HttpServletResponse.SC_OK);
 		} else {
-			response.setHeader("Location", routeResult.getUrl().toString());
+			response.setHeader(HttpHeaders.LOCATION, routeResult.getUrl().toString());
 			response.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
 			httpAccessRecordBuilder.responseCode(HttpServletResponse.SC_MOVED_TEMPORARILY);
 			httpAccessRecordBuilder.responseURL(routeResult.getUrl());
@@ -192,7 +193,8 @@ public class RouterFilter extends OncePerRequestFilter {
 
 			httpAccessRecordBuilder.responseCode(HttpServletResponse.SC_OK);
 		} else {
-			response.sendRedirect(location.toString());
+			response.setHeader(HttpHeaders.LOCATION, location.toString());
+			response.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
 			httpAccessRecordBuilder.responseCode(HttpServletResponse.SC_MOVED_TEMPORARILY);
 			httpAccessRecordBuilder.responseURL(location);
 		}

--- a/traffic_router/core/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/traffic_router/core/src/main/webapp/WEB-INF/applicationContext.xml
@@ -351,6 +351,9 @@
 		</property>
 	</bean>
 
+	<bean name="bufferedResponseFilter" class="com.comcast.cdn.traffic_control.traffic_router.core.http.BufferedResponseFilter">
+	</bean>
+
 	<util:list id="staticContentWhiteList" value-type="java.lang.String">
 		<value>/crossdomain.xml</value>
 		<value>/clientaccesspolicy.xml</value>

--- a/traffic_router/core/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/traffic_router/core/src/main/webapp/WEB-INF/applicationContext.xml
@@ -351,7 +351,7 @@
 		</property>
 	</bean>
 
-	<bean name="bufferedResponseFilter" class="com.comcast.cdn.traffic_control.traffic_router.core.http.BufferedResponseFilter">
+	<bean name="bufferedResponseFilter" class="org.apache.traffic_control.traffic_router.core.http.BufferedResponseFilter">
 	</bean>
 
 	<util:list id="staticContentWhiteList" value-type="java.lang.String">

--- a/traffic_router/core/src/main/webapp/WEB-INF/web.xml
+++ b/traffic_router/core/src/main/webapp/WEB-INF/web.xml
@@ -36,6 +36,20 @@
     </servlet>
 
     <filter>
+        <filter-name>bufferedResponseFilter</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+        <init-param>
+            <param-name>targetBeanName</param-name>
+            <param-value>bufferedResponseFilter</param-value>
+        </init-param>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>bufferedResponseFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter>
         <filter-name>routerFilter</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
         <init-param>

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
@@ -42,10 +42,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
 
 @Category(ExternalTest.class)
 public class BufferedResponseTest {

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
@@ -100,7 +100,7 @@ public class BufferedResponseTest {
 			}
 
 			assertThat(contentLengths.size(), equalTo(2));
-			assertThat("Expected HEAD and GET requests for " + path + "to have the same Content-Length", contentLengths.get(0), equalTo(contentLengths.get(1)));
+			assertThat("Expected HEAD and GET requests for " + path + " to have the same Content-Length", contentLengths.get(0), equalTo(contentLengths.get(1)));
 		}
 	}
 
@@ -168,7 +168,7 @@ public class BufferedResponseTest {
 			}
 
 			assertThat(contentLengths.size(), equalTo(2));
-			assertThat("Expected HEAD and GET requests for " + testHostName + path + "to have the same Content-Length", contentLengths.get(0), equalTo(contentLengths.get(1)));
+			assertThat("Expected HEAD and GET requests for " + testHostName + path + " to have the same Content-Length", contentLengths.get(0), equalTo(contentLengths.get(1)));
 		}
 	}
 }

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
@@ -66,15 +66,11 @@ public class BufferedResponseTest {
 	public void itSetsContentLengthHeaderFor404() throws IOException {
 		final String encodedUrl = URLEncoder.encode("http://trafficrouter01.somedeliveryservice.somecdn.domain.foo/stuff", StandardCharsets.UTF_8);
 		final HttpGet httpGet = new HttpGet("http://localhost:3333/crs/deliveryservices?url=" + encodedUrl);
-		CloseableHttpResponse response = null;
 
-		try {
-			response = httpClient.execute(httpGet);
+		try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
 			assertThat(response.getStatusLine().getStatusCode(), equalTo(404));
 			assertThat(response.getFirstHeader(HttpHeaders.TRANSFER_ENCODING), nullValue());
 			assertThat(response.getFirstHeader(HttpHeaders.CONTENT_LENGTH), notNullValue());
-		} finally {
-			if (response != null) response.close();
 		}
 	}
 
@@ -93,17 +89,13 @@ public class BufferedResponseTest {
 			final List<Integer> contentLengths = new ArrayList<>();
 
 			for (final HttpRequestBase request : requests) {
-				CloseableHttpResponse response = null;
 
-				try {
-					response = httpClient.execute(request);
+				try (CloseableHttpResponse response = httpClient.execute(request)) {
 					final Header contentLengthHeader = response.getFirstHeader(HttpHeaders.CONTENT_LENGTH);
 
 					assertThat(response.getFirstHeader(HttpHeaders.TRANSFER_ENCODING), nullValue());
 					assertThat(contentLengthHeader, notNullValue());
 					contentLengths.add(Integer.parseInt(contentLengthHeader.getValue()));
-				} finally {
-					if (response != null) response.close();
 				}
 			}
 
@@ -163,18 +155,15 @@ public class BufferedResponseTest {
 			final List<Integer> contentLengths = new ArrayList<>();
 
 			for (final HttpRequestBase request : requests) {
-				CloseableHttpResponse response = null;
+
 				request.setConfig(config);
 				request.addHeader("Host", testHostName);
-
-				try {
-					response = httpClient.execute(request);
+				try (CloseableHttpResponse response = httpClient.execute(request)) {
 					final Header contentLengthHeader = response.getFirstHeader(HttpHeaders.CONTENT_LENGTH);
+
 					assertThat(response.getFirstHeader(HttpHeaders.TRANSFER_ENCODING), nullValue());
 					assertThat(contentLengthHeader, notNullValue());
 					contentLengths.add(Integer.parseInt(contentLengthHeader.getValue()));
-				} finally {
-					if (response != null) response.close();
 				}
 			}
 

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
@@ -1,0 +1,176 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.traffic_control.traffic_router.core.external;
+
+import org.apache.traffic_control.traffic_router.core.http.RouterFilter;
+import org.apache.traffic_control.traffic_router.core.util.ExternalTest;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.catalina.LifecycleException;
+import org.apache.http.Header;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+@Category(ExternalTest.class)
+public class BufferedResponseTest {
+	final private String routerHttpPort = System.getProperty("routerHttpPort", "8888");
+	private CloseableHttpClient httpClient;
+
+	@Before
+	public void before() throws LifecycleException {
+		httpClient = HttpClientBuilder.create().build();
+	}
+
+	@After
+	public void after() throws Exception {
+		if (httpClient != null) httpClient.close();
+	}
+
+	@Test
+	public void itSetsContentLengthHeaderFor404() throws IOException {
+		final String encodedUrl = URLEncoder.encode("http://trafficrouter01.somedeliveryservice.somecdn.domain.foo/stuff", "utf-8");
+		final HttpGet httpGet = new HttpGet("http://localhost:3333/crs/deliveryservices?url=" + encodedUrl);
+		CloseableHttpResponse response = null;
+
+		try {
+			response = httpClient.execute(httpGet);
+			assertThat(response.getStatusLine().getStatusCode(), equalTo(404));
+			assertThat(response.getFirstHeader("Transfer-Encoding"), nullValue());
+			assertThat(response.getFirstHeader("Content-Length"), notNullValue());
+		} finally {
+			if (response != null) response.close();
+		}
+	}
+
+	@Test
+	public void itSetsTheSameContentLengthForHeadAndGet() throws IOException {
+		final List<String> paths = new ArrayList<>();
+		paths.add("http://localhost:3333/crs/stats");
+		paths.add("http://localhost:3333/crs/locations/caches");
+		paths.add("http://localhost:3333/crs/consistenthash/deliveryservice?deliveryServiceId=csd-target-1&requestPath=/");
+
+		for (final String path : paths) {
+			final List<HttpRequestBase> requests = new ArrayList<>();
+			requests.add(new HttpHead(path));
+			requests.add(new HttpGet(path));
+
+			final List<Integer> contentLengths = new ArrayList<>();
+
+			for (final HttpRequestBase request : requests) {
+				CloseableHttpResponse response = null;
+
+				try {
+					response = httpClient.execute(request);
+					final Header contentLengthHeader = response.getFirstHeader("Content-Length");
+
+					assertThat(response.getFirstHeader("Transfer-Encoding"), nullValue());
+					assertThat(contentLengthHeader, notNullValue());
+					contentLengths.add(Integer.parseInt(contentLengthHeader.getValue()));
+				} finally {
+					if (response != null) response.close();
+				}
+			}
+
+			assertThat(contentLengths.size(), equalTo(2));
+			assertThat("Expected HEAD and GET requests for " + path + "to have the same Content-Length", contentLengths.get(0), equalTo(contentLengths.get(1)));
+		}
+	}
+
+	@Test
+	public void itSetsAnAccurateContentLengthForGet() throws IOException {
+		final List<String> paths = new ArrayList<>();
+		paths.add("http://localhost:3333/crs/stats");
+		paths.add("http://localhost:3333/crs/locations/caches");
+		paths.add("http://localhost:3333/crs/consistenthash/deliveryservice?deliveryServiceId=csd-target-1&requestPath=/");
+
+		for (final String path : paths) {
+			CloseableHttpResponse response = null;
+
+			try {
+				final HttpGet httpGet = new HttpGet(path);
+				response = httpClient.execute(httpGet);
+
+				final ObjectMapper objectMapper = new ObjectMapper(new JsonFactory());
+				final String json = EntityUtils.toString(response.getEntity());
+				final Header contentLengthHeader = response.getFirstHeader("Content-Length");
+
+				/* If the content length is too low and cuts off the response
+				 * body, objectMapper.readTree(json) will likely throw a
+				 * JsonProcessingException.
+				 */
+				objectMapper.readTree(json);
+				assertThat(response.getFirstHeader("Transfer-Encoding"), nullValue());
+				assertThat(contentLengthHeader, notNullValue());
+				assertThat(Integer.parseInt(contentLengthHeader.getValue()), equalTo(json.length()));
+			} finally {
+				if (response != null) response.close();
+			}
+		}
+	}
+
+	@Test
+	public void itSetsContentLengthHeaderForDeliveryServiceSteering() throws IOException {
+		final String testHostName = "tr.client-steering-test-1.thecdn.example.com";
+		final RequestConfig config = RequestConfig.custom().setRedirectsEnabled(false).build();
+		final List<String> paths = new ArrayList<>();
+		paths.add("/qwerytuiop/asdfghjkl?fakeClientIpAddress=12.34.56.78");
+		paths.add("/qwerytuiop/asdfghjkl?fakeClientIpAddress=12.34.56.78&format=json");
+		paths.add("/qwerytuiop/asdfghjkl?fakeClientIpAddress=12.34.56.78&" + RouterFilter.REDIRECT_QUERY_PARAM + "=false");
+		paths.add("/qwerytuiop/asdfghjkl?fakeClientIpAddress=12.34.56.78&" + RouterFilter.REDIRECT_QUERY_PARAM + "=true");
+
+
+		for (final String path : paths) {
+			final List<HttpRequestBase> requests = new ArrayList<>();
+			requests.add(new HttpHead("http://localhost:" + routerHttpPort + path));
+			requests.add(new HttpGet("http://localhost:" + routerHttpPort + path));
+
+			for (final HttpRequestBase request : requests) {
+				CloseableHttpResponse response = null;
+				request.setConfig(config);
+				request.addHeader("Host", testHostName);
+
+				try {
+					response = httpClient.execute(request);
+
+					assertThat(response.getFirstHeader("Transfer-Encoding"), nullValue());
+					assertThat(response.getFirstHeader("Content-Length"), notNullValue());
+				} finally {
+					if (response != null) response.close();
+				}
+			}
+		}
+	}
+}

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/BufferedResponseTest.java
@@ -157,6 +157,8 @@ public class BufferedResponseTest {
 			requests.add(new HttpHead("http://localhost:" + routerHttpPort + path));
 			requests.add(new HttpGet("http://localhost:" + routerHttpPort + path));
 
+			final List<Integer> contentLengths = new ArrayList<>();
+
 			for (final HttpRequestBase request : requests) {
 				CloseableHttpResponse response = null;
 				request.setConfig(config);
@@ -164,13 +166,18 @@ public class BufferedResponseTest {
 
 				try {
 					response = httpClient.execute(request);
+					final Header contentLengthHeader = response.getFirstHeader("Content-Length");
 
 					assertThat(response.getFirstHeader("Transfer-Encoding"), nullValue());
-					assertThat(response.getFirstHeader("Content-Length"), notNullValue());
+					assertThat(contentLengthHeader, notNullValue());
+					contentLengths.add(Integer.parseInt(contentLengthHeader.getValue()));
 				} finally {
 					if (response != null) response.close();
 				}
 			}
+
+			assertThat(contentLengths.size(), equalTo(2));
+			assertThat("Expected HEAD and GET requests for " + testHostName + path + "to have the same Content-Length", contentLengths.get(0), equalTo(contentLengths.get(1)));
 		}
 	}
 }

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/LocationsTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/LocationsTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.traffic_control.traffic_router.core.external;
 
+import org.apache.http.HttpHeaders;
 import org.apache.traffic_control.traffic_router.core.util.ExternalTest;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
@@ -173,6 +175,7 @@ public class LocationsTest {
 			try {
 				response = closeableHttpClient.execute(httpHead);
 				assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+				assertThat(response.getFirstHeader(HttpHeaders.CONTENT_LENGTH), notNullValue());
 			} finally {
 				if (response != null) response.close();
 			}


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- This PR fixes #3965 by making the Traffic Router API and routing responses include a `Content-Length` header with every response
- Exposes LocationController endpoints to HEAD requests
- HEAD requests for routing responses return the same `Content-Type` and `Content-Length` as GET requests

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Router

## What is the best way to verify this PR?

Run the following external tests:
* org.apache.traffic_control.traffic_router.core.external.BufferedResponseTest
* org.apache.traffic_control.traffic_router.core.external.LocationsTest

## If this is a bug fix, what versions of Traffic Control are affected?

- master (c65ee2eb43)
- 6.0.0

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)