### PR TITLE
TP: makes parameter row clickable to show parameter details

### DIFF
--- a/traffic_portal/app/src/common/modules/table/profileParameters/TableProfileParametersController.js
+++ b/traffic_portal/app/src/common/modules/table/profileParameters/TableProfileParametersController.js
@@ -54,7 +54,10 @@ var TableProfileParametersController = function(profile, parameters, $controller
 			);
 	};
 
-	$scope.confirmRemoveParam = function(parameter) {
+	$scope.confirmRemoveParam = function(parameter, $event) {
+		if ($event) {
+			$event.stopPropagation(); // this kills the click event so it doesn't trigger anything else
+		}
 		if (profile.type == 'DS_PROFILE') { // if this is a ds profile, then it is used by delivery service(s) so we'll fetch the ds count...
 			deliveryServiceService.getDeliveryServices({ profile: profile.id }).
 				then(function(result) {

--- a/traffic_portal/app/src/common/modules/table/profileParameters/table.profileParameters.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/profileParameters/table.profileParameters.tpl.html
@@ -43,12 +43,14 @@ under the License.
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="p in ::parameters" context-menu="contextMenuItems">
+            <tr ng-click="editParameter(p.id)" ng-repeat="p in ::parameters" context-menu="contextMenuItems">
                 <td data-search="^{{::p.name}}$">{{::p.name}}</td>
                 <td data-search="^{{::p.configFile}}$">{{::p.configFile}}</td>
                 <td data-search="^{{::p.value}}$">{{::p.value}}</td>
                 <td data-search="^{{::p.secure}}$">{{::p.secure}}</td>
-                <td><button type="button" class="btn btn-link" title="Unlink Parameter from Profile" ng-click="confirmRemoveParam(p)"><i class="fa fa-chain-broken"></i></button></td>
+                <td style="text-align: right;">
+                    <a class="link action-link" title="Unlink Parameter from Profile" ng-click="confirmRemoveParam(p, $event)"><i class="fa fa-sm fa-chain-broken"></i></a>
+                </td>
             </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Before: parameters in the profile parameters table (tp.domain.com/profiles/{id}/parameters) were NOT clickable. This made it difficult to see the details of a parameter.

After: parameters in the profile parameters table (tp.domain.com/profiles/{id}/parameters) ARE clickable.

No need to update documentation or tests or changelog.md.

- [x] This PR fixes is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
Navigate to tp.domain.com/profiles/{id}/parameters and click on a row to take you to the parameters details page.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
