### PR TITLE
TP: delivery service widget - changes search to ds xmlId rather than display name

### DIFF
--- a/traffic_portal/app/src/common/modules/widget/deliveryServices/widget.deliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/widget/deliveryServices/widget.deliveryServices.tpl.html
@@ -35,7 +35,7 @@ under the License.
                     </div>
                     <div class="input-group delivery-services-search-form">
                         <input type="text" class="filter-input form-control" placeholder="Filter delivery services..."
-                               ng-model="search.displayName">
+                               ng-model="search.xmlId">
                         <span class="filter-input-group-btn input-group-btn">
                                 <button class="btn btn-default" type="button"><i class="fa fa-search"></i></button>
                         </span>
@@ -49,8 +49,8 @@ under the License.
                         <a class="delivery-services-health list-group-item widgetTable"
                            ng-repeat="ds in deliveryServices | filter:search:strict | offsetFilter:(currentDeliveryServicesPage-1)*deliveryServicesPerPage | limitTo:deliveryServicesPerPage track by $index"
                            ng-click="getChartData(ds, ds.idx)">
-                            <div class="col-lg-6 col-md-5 col-sm-5 col-xs-4 whitespace" style="float:left;" title="{{ds.displayName}} ({{ds.xmlId}})">{{ds.displayName}}
-                                <small>({{ds.xmlId}})<br>{{ds.tenant}}</small>
+                            <div class="col-lg-6 col-md-5 col-sm-5 col-xs-4 whitespace" style="float:left;" title="{{ds.xmlId}}">{{ds.xmlId}}<br>
+                                <small>{{ds.displayName}}</small>
                             </div>
                             <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 whitespace" style="float:left;" title="{{ds.type}}">{{ds.type}}</div>
                             <div class="col-lg-2 col-md-3 col-sm-3 col-xs-4 whitespace" style="margin-top:8px; float:left;">
@@ -65,9 +65,9 @@ under the License.
         <div class="col-lg-7 col-md-6 col-sm-12 col-xs-12">
             <div ng-show="!isRequested">Select a Delivery Service to view bandwidth chart.</div>
             <div class="alert alert-info" ng-show="isLoading">Loading data
-                for {{selectedDeliveryService.displayName}}</div>
+                for {{selectedDeliveryService.xmlId}}</div>
             <div ng-show="!isLoading" class="dsWidgetMessages">
-                <div class="pull-left">{{selectedDeliveryService.displayName}} - Bandwidth Per Second <br>
+                <div class="pull-left">{{selectedDeliveryService.xmlId}} - Bandwidth Per Second <br>
                     <small>{{dateRangeText}}</small>
                 </div>
                 <div class="pull-right dsWidgetButtonAlignFix" role="group">


### PR DESCRIPTION
## What does this PR (Pull Request) do?

xmlId is more widely used to identify a ds, therefore, switching the search to xmlId rather than display name.

This widget is not currently under test nor documented. Too small of a change to warrant a changelog.md entry.

- [x] This PR fixes #3753 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
