### PR TITLE
TR: Send reason-phrase for HTTP API responses

### DIFF
--- a/traffic_router/core/src/main/conf/server.xml
+++ b/traffic_router/core/src/main/conf/server.xml
@@ -38,7 +38,8 @@
 				   connectionTimeout="10000" mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="Port"
 					sendReasonPhrase="true"/>
 		<Connector port="3333" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
-				   connectionTimeout="10000" mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="ApiPort"/>
+				   connectionTimeout="10000" mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="ApiPort"
+				   sendReasonPhrase="true"/>
 		<Connector port="3443" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
 				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" connectionTimeout="10000"
 				   mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="SecureApiPort" sendReasonPhrase="true"


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
Reason-phrases are sent for routing over HTTP, routing over HTTPS, and the API over HTTPS, but not for the API over HTTP. This PR adds reason-phrases for the API over HTTP.

As @ocket8888 [noted](https://github.com/apache/trafficcontrol/pull/4074#discussion_r342164277) in #4074, Pygments needs reason-phrases for HTTP responses (of any HTTP version).


- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR does not include tests because
* The only component that depends on reason-phrases as far as I know is the documentation.
* HTTP/2 responses have no reason-phrases.
* If documentation ever stops failing to build due to no reason-phrase in a documented HTTP response, there is no reason to send one anymore, so building the documentation is a de facto test.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Router

## What is the best way to verify this PR?

In the CDN-in-a-box directory,

```shell
docker-compose exec trafficrouter curl -I http://trafficrouter:3333/crs/stats
```

<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master (1c2ebee4)
- 3.1.0

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] I have explained why tests are unnecessary
- [x] This PR does not need documentation because expected behavior does not change
- [x] This PR does not include an update to CHANGELOG.md, such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
