### PR TITLE
Separate execution of required zone generation from optional priming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - Updated /api/1.1/cachegroups: Cache Group Fallbacks are included
   - Updated /api/1.1/cachegroups: fixed so fallbackToClosest can be set through API
     - Warning:  a PUT of an old Cache Group JSON without the fallbackToClosest field will result in a `null` value for that field
+- Traffic Router: fixed a bug which would cause `REFUSED` DNS answers if the zone priming execution did not complete within the configured `zonemanager.init.timeout` period.
 - Issue 2821: Fixed "Traffic Router may choose wrong certificate when SNI names overlap"
 - traffic_ops/app/bin/checks/ToDnssecRefresh.pl now requires "user" and "pass" parameters of an operations-level user! Update your scripts accordingly! This was necessary to move to an API endpoint with proper authentication, which may be safely exposed.
 - Traffic Monitor UI updated to support HTTP or HTTPS traffic.

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -23,6 +23,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,10 +33,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -171,6 +176,8 @@ public class ZoneManager extends Resolver {
 			}
 
 			final ExecutorService initExecutor = Executors.newFixedThreadPool(poolSize);
+			final List<Runnable> generationTasks = new ArrayList<>();
+			final BlockingQueue<Runnable> primingTasks = new LinkedBlockingQueue<>();
 
 			final ExecutorService ze = Executors.newFixedThreadPool(poolSize);
 			final ScheduledExecutorService me = Executors.newScheduledThreadPool(2); // 2 threads, one for static, one for dynamic, threads to refresh zones
@@ -184,10 +191,17 @@ public class ZoneManager extends Resolver {
 
 			try {
 				LOGGER.info("Generating zone data");
-				generateZones(tr, zc, dzc, initExecutor);
-				initExecutor.shutdown();
-				initExecutor.awaitTermination(initTimeout, TimeUnit.MINUTES);
+				generateZones(tr, zc, dzc, generationTasks, primingTasks);
+				initExecutor.invokeAll(generationTasks.stream().map(Executors::callable).collect(Collectors.toList()));
 				LOGGER.info("Zone generation complete");
+				final Instant primingStart = Instant.now();
+				final List<Future<Object>> futures = initExecutor.invokeAll(primingTasks.stream().map(Executors::callable).collect(Collectors.toList()), initTimeout, TimeUnit.MINUTES);
+				final Instant primingEnd = Instant.now();
+				if (futures.stream().anyMatch(Future::isCancelled)) {
+					LOGGER.warn(String.format("Priming zone cache exceeded time limit of %d minute(s); continuing", initTimeout));
+				} else {
+					LOGGER.info(String.format("Priming zone cache completed in %s", Duration.between(primingStart, primingEnd).toString()));
+				}
 
 				me.scheduleWithFixedDelay(getMaintenanceRunnable(dzc, ZoneCacheType.DYNAMIC, maintenanceInterval), 0, maintenanceInterval, TimeUnit.SECONDS);
 				me.scheduleWithFixedDelay(getMaintenanceRunnable(zc, ZoneCacheType.STATIC, maintenanceInterval), 0, maintenanceInterval, TimeUnit.SECONDS);
@@ -217,8 +231,9 @@ public class ZoneManager extends Resolver {
 				if (tdzc != null) {
 					tdzc.invalidateAll();
 				}
+				LOGGER.info("Initialization of zone data completed");
 			} catch (final InterruptedException ex) {
-				LOGGER.warn(String.format("Initialization of zone data exceeded time limit of %d minute(s); continuing", initTimeout), ex);
+				LOGGER.warn(String.format("Initialization of zone data was interrupted, timeout of %d minute(s); continuing", initTimeout), ex);
 			} catch (IOException ex) {
 				LOGGER.fatal("Caught fatal exception while generating zone data!", ex);
 			}
@@ -344,7 +359,7 @@ public class ZoneManager extends Resolver {
 		return zone;
 	}
 
-	private static void generateZones(final TrafficRouter tr, final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final ExecutorService initExecutor) throws IOException {
+	private static void generateZones(final TrafficRouter tr, final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final List<Runnable> generationTasks, final BlockingQueue<Runnable> primingTasks) throws IOException {
 		final CacheRegister data = tr.getCacheRegister();
 		final Map<String, List<Record>> zoneMap = new HashMap<String, List<Record>>();
 		final Map<String, DeliveryService> dsMap = new HashMap<String, DeliveryService>();
@@ -371,8 +386,8 @@ public class ZoneManager extends Resolver {
 		}
 
 		final Map<String, List<Record>> superDomains = populateZoneMap(zoneMap, dsMap, data);
-		final List<Record> superRecords = fillZones(zoneMap, dsMap, tr, zc, dzc, initExecutor);
-		final List<Record> upstreamRecords = fillZones(superDomains, dsMap, tr, superRecords, zc, dzc, initExecutor);
+		final List<Record> superRecords = fillZones(zoneMap, dsMap, tr, zc, dzc, generationTasks, primingTasks);
+		final List<Record> upstreamRecords = fillZones(superDomains, dsMap, tr, superRecords, zc, dzc, generationTasks, primingTasks);
 
 		for (final Record record : upstreamRecords) {
 			if (record.getType() == Type.DS) {
@@ -381,12 +396,12 @@ public class ZoneManager extends Resolver {
 		}
 	}
 
-	private static List<Record> fillZones(final Map<String, List<Record>> zoneMap, final Map<String, DeliveryService> dsMap, final TrafficRouter tr, final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final ExecutorService initExecutor)
+	private static List<Record> fillZones(final Map<String, List<Record>> zoneMap, final Map<String, DeliveryService> dsMap, final TrafficRouter tr, final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final List<Runnable> generationTasks, final BlockingQueue<Runnable> primingTasks)
 			throws IOException {
-		return fillZones(zoneMap, dsMap, tr, null, zc, dzc, initExecutor);
+		return fillZones(zoneMap, dsMap, tr, null, zc, dzc, generationTasks, primingTasks);
 	}
 
-	private static List<Record> fillZones(final Map<String, List<Record>> zoneMap, final Map<String, DeliveryService> dsMap, final TrafficRouter tr, final List<Record> superRecords, final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final ExecutorService initExecutor)
+	private static List<Record> fillZones(final Map<String, List<Record>> zoneMap, final Map<String, DeliveryService> dsMap, final TrafficRouter tr, final List<Record> superRecords, final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final List<Runnable> generationTasks, final BlockingQueue<Runnable> primingTasks)
 			throws IOException {
 		final String hostname = InetAddress.getLocalHost().getHostName().replaceAll("\\..*", "");
 
@@ -397,7 +412,7 @@ public class ZoneManager extends Resolver {
 				zoneMap.get(domain).addAll(superRecords);
 			}
 
-			records.addAll(createZone(domain, zoneMap, dsMap, tr, zc, dzc, initExecutor, hostname));
+			records.addAll(createZone(domain, zoneMap, dsMap, tr, zc, dzc, generationTasks, primingTasks, hostname));
 		}
 
 		return records;
@@ -405,7 +420,7 @@ public class ZoneManager extends Resolver {
 
 	@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
 	private static List<Record> createZone(final String domain, final Map<String, List<Record>> zoneMap, final Map<String, DeliveryService> dsMap, 
-			final TrafficRouter tr, final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final ExecutorService initExecutor, final String hostname) throws IOException {
+			final TrafficRouter tr, final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final List<Runnable> generationTasks, final BlockingQueue<Runnable> primingTasks, final String hostname) throws IOException {
 		final DeliveryService ds = dsMap.get(domain);
 		final CacheRegister data = tr.getCacheRegister();
 		final JsonNode trafficRouters = data.getTrafficRouters();
@@ -441,65 +456,86 @@ public class ZoneManager extends Resolver {
 			final long maxTTL = ZoneUtils.getMaximumTTL(list);
 			records.addAll(signatureManager.generateDSRecords(name, maxTTL));
 			list.addAll(signatureManager.generateDNSKEYRecords(name, maxTTL));
-			initExecutor.execute(new Runnable() {
-				@Override
-				public void run() {
-					try {
-						final Zone zone = zc.get(signatureManager.generateZoneKey(name, list)); // cause the zone to be loaded into the new cache
-						final boolean primeDynCache = JsonUtils.optBoolean(config, "dynamic.cache.primer.enabled", true);
-						final int primerLimit = JsonUtils.optInt(config, "dynamic.cache.primer.limit", DEFAULT_PRIMER_LIMIT);
-
-						// prime the dynamic zone cache
-						if (primeDynCache && ds != null && ds.isDns()) {
-							final DNSRequest request = new DNSRequest();
-							final Name edgeName = newName(ds.getRoutingName(), domain);
-							request.setHostname(edgeName.toString(true)); // Name.toString(true) - omit the trailing dot
-
-							for (final CacheLocation cacheLocation : data.getCacheLocations()) {
-								final List<Cache> caches = tr.selectCachesByCZ(ds, cacheLocation);
-
-								if (caches == null) {
-									continue;
-								}
-
-								// calculate number of permutations if maxDnsIpsForLocation > 0 and we're not using consistent DNS routing
-								int p = 1;
-
-								if (ds.getMaxDnsIps() > 0 && !tr.isConsistentDNSRouting() && caches.size() > ds.getMaxDnsIps()) {
-									for (int c = caches.size(); c > (caches.size() - ds.getMaxDnsIps()); c--) {
-										p *= c;
-									}
-								}
-
-								final Set<List<InetRecord>> pset = new HashSet<List<InetRecord>>();
-
-								for (int i = 0; i < primerLimit; i++) {
-									final List<InetRecord> records = tr.inetRecordsFromCaches(ds, caches, request);
-
-									if (!pset.contains(records)) {
-										fillDynamicZone(dzc, zone, edgeName, records, signatureManager.isDnssecEnabled());
-										pset.add(records);
-										LOGGER.debug("Primed " + ds.getId() + " @ " + cacheLocation.getId() + "; permutation " + pset.size() + "/" + p);
-									}
-
-									if (pset.size() == p) {
-										break;
-									}
-								}
-							}
-						}
-					} catch (ExecutionException ex) {
-						LOGGER.fatal("Unable to load zone into cache: " + ex.getMessage(), ex);
-					} catch (TextParseException ex) { // only occurs due to newName above
-						LOGGER.fatal("Unable to prime dynamic zone " + domain, ex);
-					}
-				}
-			});
 		} catch (NoSuchAlgorithmException ex) {
 			LOGGER.fatal("Unable to create zone: " + ex.getMessage(), ex);
 		}
 
+		primeZoneCache(domain, name, list, tr, zc, dzc, generationTasks, primingTasks, ds);
+
 		return records;
+	}
+
+	@SuppressWarnings("PMD.CyclomaticComplexity")
+	private static void primeZoneCache(final String domain, final Name name, final List<Record> list, final TrafficRouter tr,
+			final LoadingCache<ZoneKey, Zone> zc, final LoadingCache<ZoneKey, Zone> dzc, final List<Runnable> generationTasks,
+			final BlockingQueue<Runnable> primingTasks, final DeliveryService ds) {
+		generationTasks.add(() -> {
+			try {
+				final Zone zone = zc.get(signatureManager.generateZoneKey(name, list)); // cause the zone to be loaded into the new cache
+				final CacheRegister data = tr.getCacheRegister();
+				final JsonNode config = data.getConfig();
+				final boolean primeDynCache = JsonUtils.optBoolean(config, "dynamic.cache.primer.enabled", true);
+
+				// prime the dynamic zone cache
+				if (primeDynCache && ds != null && ds.isDns()) {
+					primingTasks.add(() -> {
+						try {
+							primeDNSDeliveryServices(domain, tr, dzc, zone, ds, data);
+						} catch (TextParseException ex) {
+							LOGGER.fatal("Unable to prime dynamic zone " + domain, ex);
+						}
+					});
+				}
+			} catch (ExecutionException ex) {
+				LOGGER.fatal("Unable to load zone into cache: " + ex.getMessage(), ex);
+			}
+		});
+	}
+
+	@SuppressWarnings("PMD.CyclomaticComplexity")
+	private static void primeDNSDeliveryServices(final String domain, final TrafficRouter tr, final LoadingCache<ZoneKey, Zone> dzc,
+			final Zone zone, final DeliveryService ds, final CacheRegister data) throws TextParseException {
+		final Name edgeName = newName(ds.getRoutingName(), domain);
+		final JsonNode config = data.getConfig();
+		final int primerLimit = JsonUtils.optInt(config, "dynamic.cache.primer.limit", DEFAULT_PRIMER_LIMIT);
+
+		LOGGER.info("Priming " + edgeName);
+
+		final DNSRequest request = new DNSRequest();
+		request.setHostname(edgeName.toString(true)); // Name.toString(true) - omit the trailing dot
+
+		for (final CacheLocation cacheLocation : data.getCacheLocations()) {
+			final List<Cache> caches = tr.selectCachesByCZ(ds, cacheLocation);
+
+			if (caches == null) {
+				continue;
+			}
+
+			// calculate number of permutations if maxDnsIpsForLocation > 0 and we're not using consistent DNS routing
+			int p = 1;
+
+			if (ds.getMaxDnsIps() > 0 && !tr.isConsistentDNSRouting() && caches.size() > ds.getMaxDnsIps()) {
+				for (int c = caches.size(); c > (caches.size() - ds.getMaxDnsIps()); c--) {
+					p *= c;
+				}
+			}
+
+			final Set<List<InetRecord>> pset = new HashSet<>();
+
+			for (int i = 0; i < primerLimit; i++) {
+				final List<InetRecord> records = tr.inetRecordsFromCaches(ds, caches, request);
+
+				if (!pset.contains(records)) {
+					fillDynamicZone(dzc, zone, edgeName, records, signatureManager.isDnssecEnabled());
+					pset.add(records);
+					LOGGER.debug("Primed " + ds.getId() + " @ " + cacheLocation.getId() + "; permutation " + pset.size() + "/" + p);
+				}
+
+				if (pset.size() == p) {
+					break;
+				}
+			}
+		}
 	}
 
 	@SuppressWarnings("PMD.CyclomaticComplexity")


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Generating zones is a required step that cannot be timed out safely.
Priming those zones can be timed out safely. Separate the execution of
these two operations so that only the priming execution can be timed
out.

- [x] This PR is not related to any Issue


## Which Traffic Control components are affected by this PR?

- Traffic Router

## What is the best way to verify this PR?
Set the TR profile parameters `zonemanager.init.timeout` to 1, `keystore.maintenance.interval` to 30, snapshot, wait 10 minutes, create a new delivery service, snapshot, and observe TR's behavior while sending it valid DNS requests. Without this PR, you will most likely see TR return a lot of `REFUSED` answers. With this PR, you shouldn't see `REFUSED` answers for valid requests.

## If this is a bug fix, what versions of Traffic Control are affected?
- since at least 2.2.x


## The following criteria are ALL met by this PR
- [x] writing tests for this would be more complex than I have time for right now
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
