### PR TITLE
Rewrite users/register to Go

### DIFF
--- a/docs/source/api/users_register.rst
+++ b/docs/source/api/users_register.rst
@@ -34,10 +34,22 @@ Request Structure
 	.. versionchanged:: 1.4
 		Prior to version 1.4, the email was validated using the `Email::Valid Perl package <https://metacpan.org/pod/Email::Valid>`_ but is now validated (circuitously) by `GitHub user asaskevich's regular expression <https://github.com/asaskevich/govalidator/blob/9a090521c4893a35ca9a228628abf8ba93f63108/patterns.go#L7>`_ . Note that neither method can actually distinguish a valid, deliverable, email address but merely ensure the email is in a commonly-found format.
 
-:role:     The integral, unique identifier of the highest permissions role which will be afforded to the new user
-:tenantId: An optional field containing the integral, unique identifier of the tenant to which the new user will belong
+:role:     The integral, unique identifier of the highest permissions :term:`Role` which will be afforded to the new user
 
-	.. note:: This field is optional if and only if tenancy is not enabled in Traffic Ops.
+	.. versionchanged:: ACTv4.0
+		Prior to ATC version 4.0, this endpoint allowed for the registration of users with arbitrary
+		:term:`Roles`. It now restricts the allowed values to identifiers for :term:`Roles` with at
+		most the same permissions level as the requesting user.
+
+:tenantId: An optional field containing the integral, unique identifier of the :term:`Tenant` to which the new user will belong
+
+	.. versionchanged:: ACTv4.0
+		Prior to ATC version 4.0, this endpoint allowed for the registration of users with arbitrary
+		:term:`Tenants`. It now restricts the allowed values to identifiers for :term:`Tenants`
+		within the requesting user's :term:`Tenant`'s permissions.
+
+	.. versionchanged:: ATCv4.0
+		As tenancy is no longer truly optional, this field is no longer optional.
 
 .. code-block:: http
 	:caption: Request Example

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -155,7 +155,7 @@ type UserRegistrationRequest struct {
 
 // Validate implements the
 // github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator interface.
-func (urr UserRegistrationRequest) Validate(tx *sql.Tx) error {
+func (urr *UserRegistrationRequest) Validate(tx *sql.Tx) error {
 	var errs = []error{}
 	if urr.Role == 0 {
 		errs = append(errs, errors.New("role: required and cannot be zero."))

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -19,7 +19,10 @@ package tc
  * under the License.
  */
 
+import "database/sql"
+
 import "github.com/apache/trafficcontrol/lib/go-rfc"
+import "github.com/apache/trafficcontrol/lib/go-util"
 
 // UserCredentials contains Traffic Ops login credentials
 type UserCredentials struct {
@@ -138,4 +141,28 @@ type UserDeliveryServiceDeleteResponse struct {
 
 type UserPasswordResetRequest struct {
 	Email rfc.EmailAddress `json:"email"`
+}
+
+// UserRegistrationRequest is the request submitted by operators when they want to register a new
+// user.
+type UserRegistrationRequest struct {
+	Email rfc.EmailAddress `json:"email"`
+	// Role - despite being named "Role" - is actually merely the *ID* of a Role to give the new user.
+	Role uint `json:"role"`
+	TenantID uint `json:"tenantId"`
+}
+
+// Validate implements the
+// github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator interface.
+func (urr *UserRegistrationRequest) Validate (tx *sql.Tx) (error) {
+	var errs = []error{}
+	if urr.Role == 0 {
+		errs = append(errs, errors.New("role: required and cannot be zero."))
+	}
+
+	if urr.TenantID == 0 {
+		errs = append(errs, errors.New("role: required and cannot be zero."))
+	}
+
+	return util.JoinErrs(errs)
 }

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -93,7 +93,7 @@ type User struct {
 	Username         *string    `json:"username" db:"username"`
 	RegistrationSent *TimeNoMod `json:"registrationSent" db:"registration_sent"`
 	LocalPassword    *string    `json:"localPasswd,omitempty" db:"local_passwd"`
-	RoleName         *string    `json:"roleName,omitempty" db:"-"`
+	RoleName         *string    `json:"roleName,omitempty" db:"rolename"`
 	commonUserFields
 }
 
@@ -163,6 +163,12 @@ func (urr *UserRegistrationRequest) Validate(tx *sql.Tx) error {
 
 	if urr.TenantID == 0 {
 		errs = append(errs, errors.New("tenantId: required and cannot be zero."))
+	}
+
+	// This can only happen if an email isn't present in the request; the JSON parse handles actually
+	// invalid email addresses.
+	if Email.Address.Address == "" {
+		errs = append(errs, errors.New("email: required"))
 	}
 
 	return util.JoinErrs(errs)

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -20,6 +20,7 @@ package tc
  */
 
 import "database/sql"
+import "errors"
 
 import "github.com/apache/trafficcontrol/lib/go-rfc"
 import "github.com/apache/trafficcontrol/lib/go-util"
@@ -154,7 +155,7 @@ type UserRegistrationRequest struct {
 
 // Validate implements the
 // github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator interface.
-func (urr *UserRegistrationRequest) Validate (tx *sql.Tx) (error) {
+func (urr UserRegistrationRequest) Validate (tx *sql.Tx) (error) {
 	var errs = []error{}
 	if urr.Role == 0 {
 		errs = append(errs, errors.New("role: required and cannot be zero."))

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -149,13 +149,13 @@ type UserPasswordResetRequest struct {
 type UserRegistrationRequest struct {
 	Email rfc.EmailAddress `json:"email"`
 	// Role - despite being named "Role" - is actually merely the *ID* of a Role to give the new user.
-	Role uint `json:"role"`
+	Role     uint `json:"role"`
 	TenantID uint `json:"tenantId"`
 }
 
 // Validate implements the
 // github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator interface.
-func (urr UserRegistrationRequest) Validate (tx *sql.Tx) (error) {
+func (urr UserRegistrationRequest) Validate(tx *sql.Tx) error {
 	var errs = []error{}
 	if urr.Role == 0 {
 		errs = append(errs, errors.New("role: required and cannot be zero."))

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -167,7 +167,7 @@ func (urr *UserRegistrationRequest) Validate(tx *sql.Tx) error {
 
 	// This can only happen if an email isn't present in the request; the JSON parse handles actually
 	// invalid email addresses.
-	if Email.Address.Address == "" {
+	if urr.Email.Address.Address == "" {
 		errs = append(errs, errors.New("email: required"))
 	}
 

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -162,7 +162,7 @@ func (urr UserRegistrationRequest) Validate(tx *sql.Tx) error {
 	}
 
 	if urr.TenantID == 0 {
-		errs = append(errs, errors.New("role: required and cannot be zero."))
+		errs = append(errs, errors.New("tenantId: required and cannot be zero."))
 	}
 
 	return util.JoinErrs(errs)

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -23,8 +23,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 // Users gets an array of Users.
@@ -165,9 +165,9 @@ func (to *Session) RegisterNewUser(tenantID uint, roleID uint, email rfc.EmailAd
 	var alerts tc.Alerts
 
 	reqBody, err := json.Marshal(tc.UserRegistrationRequest{
-		Email: email,
+		Email:    email,
 		TenantID: tenantID,
-		Role: roleID,
+		Role:     roleID,
 	})
 	if err != nil {
 		return alerts, reqInf, err

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -39,6 +39,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tocookie"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
 
 	influx "github.com/influxdata/influxdb/client/v2"
 	"github.com/jmoiron/sqlx"
@@ -435,6 +436,13 @@ func (inf *APIInfo) Close() {
 // SendMail is a convenience method used to call SendMail using an APIInfo structure's configuration.
 func (inf *APIInfo) SendMail(to rfc.EmailAddress, msg []byte) (int, error, error) {
 	return SendMail(to, msg, inf.Config)
+}
+
+// IsResourceAuthorizedToCurrentUser is a convenience method used to call
+// github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant.IsResourceAuthorizedToUserTx
+// using an APIInfo structure to provide the current user and database transaction.
+func (inf *APIInfo) IsResourceAuthorizedToCurrentUser(resourceTenantID int) (bool, error) {
+	return tenant.IsResourceAuthorizedToUserTx(resourceTenantID, inf.User, inf.Tx.Tx)
 }
 
 // SendMail sends an email msg to the address identified by to. The msg parameter should be an

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -38,8 +38,8 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tocookie"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tocookie"
 
 	influx "github.com/influxdata/influxdb/client/v2"
 	"github.com/jmoiron/sqlx"

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -65,7 +65,7 @@ WHERE federation_deliveryservice.deliveryservice IN (
 
 const getUserByEmailQuery = `
 SELECT u.id,
-       u.username as username,
+       u.username,
        u.public_ssh_key,
        u.role,
        r.name as rolename,

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -85,9 +85,9 @@ SELECT u.id,
        t.name as tenant,
        u.last_updated
 FROM tm_user u
-WHERE u.email=$1
 LEFT JOIN tenant t ON u.tenant_id = t.id
 LEFT JOIN role r ON u.role = r.id
+WHERE u.email=$1
 `
 
 func BuildWhereAndOrderByAndPagination(parameters map[string]string, queryParamsToSQLCols map[string]WhereColumnInfo) (string, string, string, map[string]interface{}, []error) {

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -550,7 +550,7 @@ func GetFederationIDForUserIDByXMLID(tx *sql.Tx, userID int, xmlid string) (uint
 // returned will be 'false', while the error indicates unexpected errors that occurred when querying.
 func GetUserByEmail(tx *sqlx.Tx, email string) (tc.User, bool, error) {
 	var u tc.User
-	if err := tx.QueryRow(getUserByEmailQuery, email).StructScan(&u); err != nil {
+	if err := tx.QueryRowx(getUserByEmailQuery, email).StructScan(&u); err != nil {
 		if err == sql.ErrNoRows {
 			return u, false, nil
 		}

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 )
 
@@ -60,6 +61,33 @@ WHERE federation_deliveryservice.deliveryservice IN (
 	FROM federation_tmuser
 	WHERE federation_tmuser.tm_user = $2
 )
+`
+
+const getUserByEmailQuery = `
+SELECT u.id,
+       u.username as username,
+       u.public_ssh_key,
+       u.role,
+       r.name as rolename,
+       u.company,
+       u.email,
+       u.full_name,
+       u.new_user,
+       u.address_line1,
+       u.address_line2,
+       u.city,
+       u.state_or_province,
+       u.phone_number,
+       u.postal_code,
+       u.country,
+       u.registration_sent,
+       u.tenant_id,
+       t.name as tenant,
+       u.last_updated
+FROM tm_user u
+WHERE u.email=$1
+LEFT JOIN tenant t ON u.tenant_id = t.id
+LEFT JOIN role r ON u.role = r.id
 `
 
 func BuildWhereAndOrderByAndPagination(parameters map[string]string, queryParamsToSQLCols map[string]WhereColumnInfo) (string, string, string, map[string]interface{}, []error) {
@@ -516,4 +544,17 @@ func GetFederationIDForUserIDByXMLID(tx *sql.Tx, userID int, xmlid string) (uint
 		return 0, false, fmt.Errorf("Getting Federation ID for user #%d by DS XMLID '%s': %v", userID, xmlid, err)
 	}
 	return id, true, nil
+}
+
+// GetUserByEmail retrieves the user with the given email. If no such user exists, the boolean
+// returned will be 'false', while the error indicates unexpected errors that occurred when querying.
+func GetUserByEmail(tx *sqlx.Tx, email string) (tc.User, bool, error) {
+	var u tc.User
+	if err := tx.QueryRow(getUserByEmailQuery, email).StructScan(&u); err != nil {
+		if err == sql.ErrNoRows {
+			return u, false, nil
+		}
+		return u, false, err
+	}
+	return u, true, nil
 }

--- a/traffic_ops/traffic_ops_golang/login/login.go
+++ b/traffic_ops/traffic_ops_golang/login/login.go
@@ -393,8 +393,8 @@ func VerifyUrlOnWhiteList(urlString string, whiteListedUrls []string) (bool, err
 	return false, nil
 }
 
-func setToken(addr rfc.EmailAddress, tx *sql.Tx) (string, error) {
-	t := make([]byte, 16)
+func generateToken() (string, error) {
+	var t = make([]byte, 16)
 	_, err := rand.Read(t)
 	if err != nil {
 		return "", err
@@ -402,12 +402,19 @@ func setToken(addr rfc.EmailAddress, tx *sql.Tx) (string, error) {
 	t[6] = (t[6] & 0x0f) | 0x40
 	t[8] = (t[8] & 0x3f) | 0x80
 
-	token := fmt.Sprintf("%x-%x-%x-%x-%x", t[0:4], t[4:6], t[6:8], t[8:10], t[10:])
+	return fmt.Sprintf("%x-%x-%x-%x-%x", t[0:4], t[4:6], t[6:8], t[8:10], t[10:]), nil
+}
+
+func setToken(addr rfc.EmailAddress, tx *sql.Tx) (string, error) {
+	token, err := generateToken()
+	if err != nil {
+		return "", err
+	}
 
 	if _, err = tx.Exec(setTokenQuery, token, addr.Address.Address); err != nil {
 		return "", err
 	}
-	return string(token), nil
+	return token, nil
 }
 
 func createMsg(addr rfc.EmailAddress, t string, db *sqlx.DB, c config.ConfigPortal) ([]byte, error) {

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -1,0 +1,257 @@
+package login
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "fmt"
+import "html/template"
+import "net/http"
+
+import "github.com/apache/trafficcontrol/lib/go-rfc"
+import "github.com/apache/trafficcontrol/lib/go-tc"
+
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
+import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
+
+type registrationEmailFormatter struct {
+	From rfc.EmailAddress
+	InstanceName string
+	RegisterURL string
+	To rfc.EmailAddress
+	Token string
+}
+
+const registerUserQuery = `
+INSERT INTO tm_user (tm_user.email,
+                     tm_user.new_user,
+                     tm_user.registration_sent,
+                     tm_user.role,
+                     tm_user.tenant_id,
+                     tm_user.token,
+                     tm_user.username)
+VALUES ($1,
+        TRUE,
+        NOW(),
+        $2,
+        $3,
+        $4,
+        $4)
+RETURNING (
+	SELECT role.name
+	FROM role
+	WHERE id=tm_user.role
+) AS role,
+(
+	SELECT tenant.name
+	WHERE tenant.id=tm_user.tenant_id
+) AS tenant
+`
+
+const renewRegistrationQuery = `
+UPDATE tm_user
+SET registration_sent = now(),
+    role = $1,
+    tenant_id = $2,
+    token = $3
+WHERE email = $4
+RETURNING (
+	SELECT role.name
+	FROM role
+	WHERE id=tm_user.role
+) AS role,
+(
+	SELECT tenant.name
+	WHERE tenant.id=tm_user.tenant_id
+) AS tenant
+`
+
+var registrationEmailTemplate = template.Must(template.New("Registration Email").Parse("From: {{.From.Address.Address}}\r" + `
+To: {{.To.Address.Address}}` + "\r" + `
+Content-Type: text/html` + "\r" + `
+Subject: {{.InstanceName}} New User Registration` + "\r\n\r" + `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>{{.InstanceName}} New User Registration</title>
+	<meta charset="utf-8"/>
+	<style>
+		.button_link {
+			display: block;
+			width: 130px;
+			height: 35px;
+			background: #2682AF;
+			padding: 5px;
+			text-align: center;
+			border-radius: 5px;
+			color: white;
+			font-weight: bold;
+			text-decoration: none;
+			cursor: pointer;
+		}
+	</style>
+</head>
+<body>
+	<main>
+		<p>A new account has been created for you on the {{.InstanceName}} Portal. In the
+		{{.InstanceName}} Portal, you'll find a dashboard that provides access to all of your
+		Delivery Services.</p>
+		<p><a class="button_link" href="{{.RegisterURL}}?token={{.Token}}" target="_blank">Click here to finish your registration</a></p>
+	</main>
+	<footer>
+		<p>Thank you,<br/>
+		The {{.InstanceName}} Team</p>
+	</footer>
+</body>
+</html>
+`))
+
+func createRegistrationMsg(addr rfc.EmailAddress, t string, tx *sql.Tx, c config.ConfigPortal) ([]byte, error) {
+	var instanceName string
+	if err := tx.QueryRow(instanceNameQuery).Scan(&instanceName); err != nil {
+		return nil, err
+	}
+
+	var f = registrationEmailFormatter {
+		From: c.EmailFrom,
+		InstanceName: instanceName,
+		RegisterURL: c.BaseURL.String() + c.UserRegisterPath,
+		To: addr,
+		Token: t,
+	}
+
+	var tmpl bytes.Buffer
+	if err := registrationEmailTemplate.Execute(&tmpl, &f); err != nil {
+		return nil, err
+	}
+	return tmpl.Bytes(), nil
+}
+
+func RegisterUser (w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	var tx = inf.Tx.Tx
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+	defer r.Body.Close()
+
+	var req tc.UserRegistrationRequest
+	if userErr = api.Parse(r.Body, tx, req); userErr != nil {
+		api.HandleErr(w, r, tx, http.StatusBadRequest, userErr, nil)
+		return
+	}
+
+	if ok, err := inf.IsResourceAuthorizedToCurrentUser(req.TenantID); err != nil {
+		sysErr = fmt.Errorf("Checking tenancy permissions of current user (%+v) on tenant #%d", inf.User, req.TenantID)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, tx, errCode, nil, sysErr)
+		return
+	} else if !ok {
+		sysErr = fmt.Errorf("User %s requested unauthorized access to tenant #%d to register new user", inf.User.UserName, req.TenantID)
+		userErr = errors.New("not authorized on this tenant")
+		errCode = http.StatusForbidden
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+
+	t, err := generateToken()
+	if err != nil {
+		errCode = http.StatusInternalServerError
+		sysErr = fmt.Errorf("Failed to generate token: %v", err)
+		api.HandleErr(w, r, tx, errCode, nil, sysErr)
+		return
+	}
+
+	var role string
+	var tenant string
+	user, exists, err := dbhelpers.GetUserByEmail(inf.Tx, req.Email.Address.Address)
+	if err != nil {
+		errCode = http.StatusInternalServerError
+		sysErr = fmt.Errorf("Checking for existing user with email %s: %v", req.Email, err)
+		api.HandleErr(w, r, tx, errCode, nil, sysErr)
+		return
+	}
+	if exists {
+		if user.NewUser == nil || !*user.NewUser {
+			userErr = errors.New("User already exists and has completed registration.")
+			errCode = http.StatusConflict
+			api.HandleErr(w, r, tx, errCode, userErr, nil)
+			return
+		}
+
+		role, tenant, err = renewRegistration(tx, req, t, user)
+	} else {
+		role, tenant, err = newRegistration(tx, req, t)
+	}
+
+	if err != nil {
+		userErr, sysErr, errCode = api.ParseDBError(err)
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+
+	msg, err := createRegistrationMsg(req.Email, token, tx, inf.Config.ConfigPortal)
+	if err != nil {
+		sysErr = fmt.Errorf("Failed to create email message: %v", err)
+		errCode = http.StatusInternalServerError
+		api.HandleErr(w, r, tx, errCode, nil, sysErr)
+		return
+	}
+
+	log.Debugf("Sending password reset email to %s", req.Email)
+
+	if errCode, userErr, sysErr = inf.SendMail(req.Email, msg); userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+
+	var alert = "Sent user registration to %s with the following permissions [ role: %s | tenant: %s ]"
+	alert = fmt.Sprintf(alert, req.Email, role, tenant)
+	api.WriteRespAlert(w, r, tc.SuccessLevel, alert)
+
+	var changeLog = "USER: %s, EMAIL: %s, ACTION: registration sent with role %s and tenant %s"
+	changeLog = fmt.Sprintf(changeLog, req.Email, req.Email, role, tenant)
+	api.CreateChangeLogRawTx(api.ApiChange, changeLog, inf.User, tx)
+}
+
+func renewRegistration(tx *sql.Tx, req tc.UserRegistrationRequest, t string, u tc.User) (string, string, error) {
+	var role string
+	var tenant string
+
+	var row = tx.QueryRow(renewRegistrationQuery, req.Role, req.TenantID, t, *u.Email)
+	if err := row.Scan(&role, &tenant); err != nil {
+		return "", "", err
+	}
+
+	return role, tenant, nil
+}
+
+func newRegistration(tx *sql.Tx, req tc.UserRegistrationRequest, t string) (string, string, error) {
+	var role string
+	var tenant string
+
+	var row = tx.QueryRow(registerUserQuery, req.Email.Address.Address, req.Role, req.TenantID, t)
+	if err := row.Scan(&role, &tenant); err != nil {
+		return "", "", err
+	}
+
+	return role, tenant, nil
+}

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -43,13 +43,13 @@ type registrationEmailFormatter struct {
 }
 
 const registerUserQuery = `
-INSERT INTO tm_user (tm_user.email,
-                     tm_user.new_user,
-                     tm_user.registration_sent,
-                     tm_user.role,
-                     tm_user.tenant_id,
-                     tm_user.token,
-                     tm_user.username)
+INSERT INTO tm_user (email,
+                     new_user,
+                     registration_sent,
+                     role,
+                     tenant_id,
+                     token,
+                     username)
 VALUES ($1,
         TRUE,
         NOW(),
@@ -64,6 +64,7 @@ RETURNING (
 ) AS role,
 (
 	SELECT tenant.name
+	FROM tenant
 	WHERE tenant.id=tm_user.tenant_id
 ) AS tenant
 `
@@ -82,6 +83,7 @@ RETURNING (
 ) AS role,
 (
 	SELECT tenant.name
+	FROM tenant
 	WHERE tenant.id=tm_user.tenant_id
 ) AS tenant
 `
@@ -227,6 +229,7 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
+		log.Errorf("Bare error: %v", err)
 		userErr, sysErr, errCode = api.ParseDBError(err)
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -243,7 +243,7 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf("Sending password reset email to %s", req.Email)
+	log.Debugf("Sending registration email to %s", req.Email)
 
 	if errCode, userErr, sysErr = inf.SendMail(req.Email, msg); userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -158,7 +158,7 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	var req tc.UserRegistrationRequest
-	if userErr = api.Parse(r.Body, tx, req); userErr != nil {
+	if userErr = api.Parse(r.Body, tx, &req); userErr != nil {
 		api.HandleErr(w, r, tx, http.StatusBadRequest, userErr, nil)
 		return
 	}

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -56,7 +56,7 @@ VALUES ($1,
         $2,
         $3,
         $4,
-        $4)
+        'registration_' || (SELECT md5(random()::text)))
 RETURNING (
 	SELECT role.name
 	FROM role

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -35,11 +35,11 @@ import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 type registrationEmailFormatter struct {
-	From rfc.EmailAddress
+	From         rfc.EmailAddress
 	InstanceName string
-	RegisterURL string
-	To rfc.EmailAddress
-	Token string
+	RegisterURL  string
+	To           rfc.EmailAddress
+	Token        string
 }
 
 const registerUserQuery = `
@@ -131,12 +131,12 @@ func createRegistrationMsg(addr rfc.EmailAddress, t string, tx *sql.Tx, c config
 		return nil, err
 	}
 
-	var f = registrationEmailFormatter {
-		From: c.EmailFrom,
+	var f = registrationEmailFormatter{
+		From:         c.EmailFrom,
 		InstanceName: instanceName,
-		RegisterURL: c.BaseURL.String() + c.UserRegisterPath,
-		To: addr,
-		Token: t,
+		RegisterURL:  c.BaseURL.String() + c.UserRegisterPath,
+		To:           addr,
+		Token:        t,
 	}
 
 	var tmpl bytes.Buffer
@@ -146,7 +146,7 @@ func createRegistrationMsg(addr rfc.EmailAddress, t string, tx *sql.Tx, c config
 	return tmpl.Bytes(), nil
 }
 
-func RegisterUser (w http.ResponseWriter, r *http.Request) {
+func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
 	var tx = inf.Tx.Tx
 	if userErr != nil || sysErr != nil {

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -146,6 +146,7 @@ func createRegistrationMsg(addr rfc.EmailAddress, t string, tx *sql.Tx, c config
 	return tmpl.Bytes(), nil
 }
 
+// RegisterUser is the handler for /users/register. It sends registration through Email.
 func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
 	var tx = inf.Tx.Tx

--- a/traffic_ops/traffic_ops_golang/login/register_test.go
+++ b/traffic_ops/traffic_ops_golang/login/register_test.go
@@ -29,22 +29,22 @@ func TestRegistrationTemplateRender(t *testing.T) {
 	to := rfc.EmailAddress{
 		mail.Address{
 			Address: "em@i.l",
-			Name: "",
+			Name:    "",
 		},
 	}
 	from := rfc.EmailAddress{
 		mail.Address{
 			Address: "no-reply@test.quest",
-			Name: "",
+			Name:    "",
 		},
 	}
 
 	f := registrationEmailFormatter{
-		From: from,
+		From:         from,
 		InstanceName: "test",
-		RegisterURL: "http://localhost/#!/user",
-		To: to,
-		Token: "token",
+		RegisterURL:  "http://localhost/#!/user",
+		To:           to,
+		Token:        "token",
 	}
 
 	var tmpl bytes.Buffer

--- a/traffic_ops/traffic_ops_golang/login/register_test.go
+++ b/traffic_ops/traffic_ops_golang/login/register_test.go
@@ -1,0 +1,58 @@
+package login
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "bytes"
+import "net/mail"
+import "testing"
+
+import "github.com/apache/trafficcontrol/lib/go-rfc"
+
+func TestRegistrationTemplateRender(t *testing.T) {
+	to := rfc.EmailAddress{
+		mail.Address{
+			Address: "em@i.l",
+			Name: "",
+		},
+	}
+	from := rfc.EmailAddress{
+		mail.Address{
+			Address: "no-reply@test.quest",
+			Name: "",
+		},
+	}
+
+	f := registrationEmailFormatter{
+		From: from,
+		InstanceName: "test",
+		RegisterURL: "http://localhost/#!/user",
+		To: to,
+		Token: "token",
+	}
+
+	var tmpl bytes.Buffer
+	if err := registrationEmailTemplate.Execute(&tmpl, &f); err != nil {
+		t.Fatalf("Failed to render email template: %v", err)
+	}
+	if tmpl.Len() <= 0 {
+		t.Fatalf("Template buffer empty after execution")
+	}
+	t.Logf("%s", tmpl.String())
+}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -229,6 +229,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.4, http.MethodPost, `user/login/oauth/?$`, login.OauthLoginHandler(d.DB, d.Config), 0, NoAuth, nil, 1415886009, noPerlBypass},
 		{1.1, http.MethodPost, `user/login/token(/|\.json)?$`, login.TokenLoginHandler(d.DB, d.Config), 0, NoAuth, nil, 402408841, perlBypass},
 		{1.1, http.MethodPost, `user/reset_password(/|\.json)?$`, login.ResetPassword(d.DB, d.Config), 0, NoAuth, nil, 2092914630, perlBypass},
+		{1.1, http.MethodPost, `users/register(/|\.json)?$`, login.RegisterUser, auth.PrivLevelOperations, Authenticated, nil, 1337, perlBypass},
 
 		//ISO
 		{1.1, http.MethodGet, `osversions(/|\.json)?$`, iso.GetOSVersions, auth.PrivLevelReadOnly, Authenticated, nil, 576088657, perlBypass},


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3835

Rewrites `/users/register` to Go. As opposed to the Perl, in this PR:

- `tenantID` is required, as tenancy is no longer optional.
- `tenantID` can no longer be a tenant to which the requesting user has no access
- `role` can no longer be a Role with a higher privilege level than the requesting user
- when new users are created, instead of using their login token as a username (?!?!?) a 32-character random string is generated and then appended to `registration_`.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Start up Traffic Ops from this branch in an environment with access to a mail server (which is properly configured in the TO configuration file) and attempt to register users using `/users/register`.

There are no unit or integration tests because this requires access to a mail server, which isn't built into the testing. There is, however, a test to ensure the email template renders given adequate input.

## The following criteria are ALL met by this PR
- [x] I have explained why tests are impossible/impractical
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**