### PR TITLE
removed non-existent parameters from CDN-in-a-Box and docs

### DIFF
--- a/docs/source/api/cdns_name_snapshot.rst
+++ b/docs/source/api/cdns_name_snapshot.rst
@@ -78,10 +78,6 @@ Response Structure
 			DNSSEC is used within this CDN
 
 	:domain_name:                        The Top-Level Domain Name (TLD) served by the CDN
-	:edge.dns.limit:                     This field is of unknown use, and may be remnants of a legacy system
-	:edge.dns.routing:                   This field is of unknown use, and may be remnants of a legacy system
-	:edge.http.limit:                    This field is of unknown use, and may be remnants of a legacy system
-	:edge.http.routing:                  This field is of unknown use, and may be remnants of a legacy system
 	:federationmapping.polling.interval: A string containing an integer which specifies the interval, in seconds, on which other Traffic Control components should check for new federation mappings
 	:federationmapping.polling.url:      The URL where Traffic Control components can request federation mappings
 	:geolocation.polling.interval:       A string containing an integer which specifies the interval, in seconds, on which other Traffic Control components should check for new IP-to-geographic-location mapping databases
@@ -368,10 +364,6 @@ Response Structure
 			"dnssec.dynamic.response.expiration": "300s",
 			"dnssec.enabled": "false",
 			"domain_name": "mycdn.ciab.test",
-			"edge.dns.limit": "6",
-			"edge.dns.routing": "true",
-			"edge.http.limit": "6",
-			"edge.http.routing": "true",
 			"federationmapping.polling.interval": "60000",
 			"federationmapping.polling.url": "https://${toHostname}/internal/api/1.3/federations.json",
 			"geolocation.polling.interval": "86400000",

--- a/docs/source/api/cdns_name_snapshot_new.rst
+++ b/docs/source/api/cdns_name_snapshot_new.rst
@@ -77,10 +77,6 @@ Response Structure
 			DNSSEC is used within this CDN
 
 	:domain_name:                        The Top-Level Domain Name (TLD) served by the CDN
-	:edge.dns.limit:                     This field is of unknown use, and may be remnants of a legacy system
-	:edge.dns.routing:                   This field is of unknown use, and may be remnants of a legacy system
-	:edge.http.limit:                    This field is of unknown use, and may be remnants of a legacy system
-	:edge.http.routing:                  This field is of unknown use, and may be remnants of a legacy system
 	:federationmapping.polling.interval: A string containing an integer which specifies the interval, in seconds, on which other Traffic Control components should check for new federation mappings
 	:federationmapping.polling.url:      The URL where Traffic Control components can request federation mappings
 	:geolocation.polling.interval:       A string containing an integer which specifies the interval, in seconds, on which other Traffic Control components should check for new IP-to-geographic-location mapping databases
@@ -365,10 +361,6 @@ Response Structure
 			"dnssec.dynamic.response.expiration": "300s",
 			"dnssec.enabled": "false",
 			"domain_name": "mycdn.ciab.test",
-			"edge.dns.limit": "6",
-			"edge.dns.routing": "true",
-			"edge.http.limit": "6",
-			"edge.http.routing": "true",
 			"federationmapping.polling.interval": "60000",
 			"federationmapping.polling.url": "https://${toHostname}/internal/api/1.3/federations.json",
 			"geolocation.polling.interval": "86400000",

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/040-CCR_CIAB.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/040-CCR_CIAB.json
@@ -159,26 +159,6 @@
       "configFile": "CRConfig.json",
       "name": "tld.ttls.SOA",
       "value": "86400"
-    },
-    {
-      "configFile": "CRConfig.json",
-      "name": "edge.dns.limit",
-      "value": "6"
-    },
-    {
-      "configFile": "CRConfig.json",
-      "name": "edge.http.limit",
-      "value": "6"
-    },
-    {
-      "configFile": "CRConfig.json",
-      "name": "edge.dns.routing",
-      "value": "true"
-    },
-    {
-      "configFile": "CRConfig.json",
-      "name": "edge.http.routing",
-      "value": "true"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

Removes some odd parameters from the CDN-in-a-Box Traffic Router profile. They aren't "real" parameters, meaning they don't do anything or have any meaning, but because CDN-in-a-Box was returning them in CDN Snapshots, it wound up being documented. Basically just by saying "idk what this is lol". So since they have no meaning or effect, this PR removes them, both from documentation and CDN-in-a-Box.

Specifically, they were:
- Name: `edge.dns.limit` Config File: `CRConfig.json`
- Name: `edge.dns.routing` Config File: `CRConfig.json`
- Name: `edge.http.limit` Config File: `CRConfig.json`
- Name: `edge.http.routing` Config File: `CRConfig.json`

and don't count on "Value" or "Secure" being anything in particular.

## Which Traffic Control components are affected by this PR?
- CDN-in-a-Box
- Documentation

## What is the best way to verify this PR?
Build CDN-in-a-Box and verify that routing and monitoring still work by e.g. marking caches as up/down, requesting Delivery Service content etc.

Build and read the documentation, make sure it accurately represents the `/cdns/{{name}}/snapshot` and `/cdns/{{name}}/snapshot/new` responses.

Make sure these parameters haven't been copy/pasted somewhere else via e.g. `grep`, <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> in Sublime Text etc.

## If this is a bug fix, what versions of Traffic Control are affected?
It's pretty harmless IMO, but:

- master
- 3.1.x

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**