### PR TITLE
Turn off TLSv1 in Traffic Portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed Traffic Ops Golang POST servers/id/deliveryservice continuing erroneously after a database error.
 - Fixed Traffic Ops Golang POST servers/id/deliveryservice double-logging errors.
 - Issue #4131 - The "Clone Delivery Service Assignments" menu item is hidden on a cache when the cache has zero delivery service assignments to clone.
+- Traffic Router - Turn off TLSv1
 
 ### Deprecated/Removed
 - The TO API `cachegroup_fallbacks` endpoint is now deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed Traffic Ops Golang POST servers/id/deliveryservice continuing erroneously after a database error.
 - Fixed Traffic Ops Golang POST servers/id/deliveryservice double-logging errors.
 - Issue #4131 - The "Clone Delivery Service Assignments" menu item is hidden on a cache when the cache has zero delivery service assignments to clone.
-- Traffic Router - Turn off TLSv1
+- Traffic Portal - Turn off TLSv1
 
 ### Deprecated/Removed
 - The TO API `cachegroup_fallbacks` endpoint is now deprecated

--- a/traffic_portal/server.js
+++ b/traffic_portal/server.js
@@ -109,7 +109,7 @@ if (useSSL) {
     // from the list of supported protocols that SSLv23_method supports.
     //
     var sslOptions = {};
-    sslOptions['secureOptions'] = constants.SSL_OP_NO_SSLv3;
+    sslOptions['secureOptions'] = constants.SSL_OP_NO_TLSv1;
 
     sslOptions['key'] = fs.readFileSync(config.ssl.key);
     sslOptions['cert'] = fs.readFileSync(config.ssl.cert);


### PR DESCRIPTION
## What does this PR (Pull Request) do?

It turns off TLSv1 in Traffic Portal

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?

`docker run -it drwetter/testssl.sh:latest -p <server>`

## If this is a bug fix, what versions of Traffic Control are affected?

Not a bug fix.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [ ] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
