### PR TITLE
Pin Go builds to 1.11.13

### DIFF
--- a/infrastructure/docker/build/Dockerfile-grove
+++ b/infrastructure/docker/build/Dockerfile-grove
@@ -33,9 +33,13 @@ RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 ### grove specific requirements
 RUN	yum -y install \
 		git \
-		golang \
 		rpm-build && \
 	yum -y clean all
+
+RUN curl -LO https://dl.google.com/go/go1.11.13.linux-amd64.tar.gz && \
+    tar -C /usr/local -xvzf go1.11.13.linux-amd64.tar.gz && \
+    ln -s /usr/local/go/bin/go /usr/bin/go && \
+    rm go1.11.13.linux-amd64.tar.gz
 
 ###
 

--- a/infrastructure/docker/build/Dockerfile-grovetccfg
+++ b/infrastructure/docker/build/Dockerfile-grovetccfg
@@ -33,9 +33,13 @@ RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 ### grovetccfg specific requirements
 RUN	yum -y install \
 		git \
-		golang \
 		rpm-build && \
 	yum -y clean all
+
+RUN curl -LO https://dl.google.com/go/go1.11.13.linux-amd64.tar.gz && \
+    tar -C /usr/local -xvzf go1.11.13.linux-amd64.tar.gz && \
+    ln -s /usr/local/go/bin/go /usr/bin/go && \
+    rm go1.11.13.linux-amd64.tar.gz
 
 ###
 

--- a/infrastructure/docker/build/Dockerfile-traffic_monitor
+++ b/infrastructure/docker/build/Dockerfile-traffic_monitor
@@ -33,9 +33,13 @@ RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 ### traffic_monitor specific requirements
 RUN	yum -y install \
 		git \
-		golang \
 		rpm-build && \
 	yum -y clean all
+
+RUN curl -LO https://dl.google.com/go/go1.11.13.linux-amd64.tar.gz && \
+    tar -C /usr/local -xvzf go1.11.13.linux-amd64.tar.gz && \
+    ln -s /usr/local/go/bin/go /usr/bin/go && \
+    rm go1.11.13.linux-amd64.tar.gz
 
 ###
 

--- a/infrastructure/docker/build/Dockerfile-traffic_stats
+++ b/infrastructure/docker/build/Dockerfile-traffic_stats
@@ -33,9 +33,13 @@ RUN	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 ### traffic_stats specific requirements
 RUN	yum -y install \
 		git  \
-		golang \
 		rpm-build && \
 	yum -y clean all
+
+RUN curl -LO https://dl.google.com/go/go1.11.13.linux-amd64.tar.gz && \
+    tar -C /usr/local -xvzf go1.11.13.linux-amd64.tar.gz && \
+    ln -s /usr/local/go/bin/go /usr/bin/go && \
+    rm go1.11.13.linux-amd64.tar.gz
 
 ###
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
TO was recently pinned to 1.11 due to issues communicating with Riak at
the Go version provided by EPEL (1.13 currently). Since 1.13 isn't
really "vetted" yet, pin the rest of the Go components to 1.11 as well.
Builds should be deterministic, and advancing Go versions should be a
very intentional process with thorough testing.

Also note, the previous version of the `golang` package provided by EPEL was 1.11, which is what these components were being built with until that package was upgraded to 1.13.

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
- Grove
- Traffic Monitor
- Traffic Stats
- build (doc updates and new tests not necessary)

## What is the best way to verify this PR?
Run `sudo ./pkg -v` to run the build, verify it builds successfully. Take the resulting rpms, use them to build CIAB, and verify that CIAB starts up successfully.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)