### PR TITLE
Fix atscfg typo in MSO with secondary parents

### DIFF
--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -431,9 +431,9 @@ func getMSOParentStrs(ds ParentConfigDSTopLevel, parentInfos []ParentInfo, atsMa
 	parents := ""
 	secondaryParents := ""
 
-	if atsMajorVer >= 6 && ds.MSOAlgorithm == "consistent_hash" && len(secondaryParents) > 0 {
+	if atsMajorVer >= 6 && ds.MSOAlgorithm == "consistent_hash" && len(secondaryParentStr) > 0 {
 		parents = `parent="` + strings.Join(parentInfo, "") + `"`
-		secondaryParents = `" secondary_parent="` + secondaryParentStr + `"`
+		secondaryParents = ` secondary_parent="` + secondaryParentStr + `"`
 	} else {
 		parents = `parent="` + strings.Join(parentInfo, "") + secondaryParentStr + `"`
 	}


### PR DESCRIPTION
Fix atscfg typo in MSO with secondary parents.

Includes unit tests.
No documentation, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?

Run unit tests.
Create a MSO DS with Secondary Parents, and run `atstccfg`, verify the secondary parent is placed in a `secondary_parents=` field in `parent.config`.

## If this is a bug fix, what versions of Traffic Control are affected?
- master 

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
