### PR TITLE
TP: fixes bug where empty CG fallback could be added to the list of fallbacks

### DIFF
--- a/traffic_portal/app/src/common/modules/form/cacheGroup/FormCacheGroupController.js
+++ b/traffic_portal/app/src/common/modules/form/cacheGroup/FormCacheGroupController.js
@@ -128,7 +128,7 @@ var FormCacheGroupController = function(cacheGroup, types, cacheGroups, $scope, 
             cacheGroup.fallbacks = new Array();
         }
         // Add selected fallback to selected list if it is not already there
-        if (cacheGroup.fallbacks.indexOf($scope.fallbackSelected) === -1) {
+        if ($scope.fallbackSelected && cacheGroup.fallbacks.indexOf($scope.fallbackSelected) === -1) {
             cacheGroup.fallbacks.push($scope.fallbackSelected);
         }
         // Update list of available fallbacks so it does not include the newly selected fallback


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Prevents the addition of an empty cg fallback. i.e. can't add the "Add cachegroup fallback..." option as a fallback.

- [x] This PR fixes #3533 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
- Edit an EDGE_LOC cachegroup
- try to add the "Add Failover Cachegroup..." option as a cachegroup fallback. it won't be added to your list of fallbacks as it did before.

## If this is a bug fix, what versions of Traffic Control are affected?

- master (3d70e94)
- 3.0.2

## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
