### PR TITLE
Fix atscfg gen to print date as UTC

### DIFF
--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -61,7 +61,7 @@ func (s *ServerInfo) IsTopLevelCache() bool {
 }
 
 func HeaderCommentWithTOVersionStr(name string, nameVersionStr string) string {
-	return "# DO NOT EDIT - Generated for " + name + " by " + nameVersionStr + " on " + time.Now().Format(HeaderCommentDateFormat) + "\n"
+	return "# DO NOT EDIT - Generated for " + name + " by " + nameVersionStr + " on " + time.Now().UTC().Format(HeaderCommentDateFormat) + "\n"
 }
 
 func GetNameVersionStringFromToolNameAndURL(toolName string, url string) string {

--- a/lib/go-atscfg/atscfg_test.go
+++ b/lib/go-atscfg/atscfg_test.go
@@ -233,3 +233,14 @@ func TestGetConfigFile(t *testing.T) {
 		t.Errorf("Expected %s.   Got %s", expected, cfgFile)
 	}
 }
+
+func TestHeaderCommentUTC(t *testing.T) {
+	objName := "foo"
+	toolName := "bar"
+	toURL := "url"
+
+	txt := GenericHeaderComment(objName, toolName, toURL)
+	if !strings.Contains(txt, " UTC ") {
+		t.Error("Expected header comment to print time in UTC, actual '" + txt + "'")
+	}
+}


### PR DESCRIPTION

## What does this PR (Pull Request) do?

Fix atscfg gen to print date as UTC. Matches old Perl config file generation. The fix is in the library used by both `atstccfg` and `traffic_ops_golang`, and therefore fixes both.

Includes unit tests.
No documentation, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue


## Which Traffic Control components are affected by this PR?

- Traffic Ops
- Traffic Ops ORT

## What is the best way to verify this PR?

Run unit tests.
Generate any config file on a machine whose local time zone is not UTC, verify header time is in UTC.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information