### PR TITLE
Change Traffic Ops middleware wrapper symbols to be public

### DIFF
--- a/lib/go-rfc/http.go
+++ b/lib/go-rfc/http.go
@@ -1,0 +1,49 @@
+package rfc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+const ApplicationJSON = "application/json"
+const Gzip = "gzip"
+const ContentType = "Content-Type"
+const ContentEncoding = "Content-Encoding"
+const ContentTypeTextPlain = "text/plain"
+const AcceptEncoding = "Accept-Encoding"
+
+// AcceptsGzip returns whether r accepts gzip encoding, per RFC7231§5.3.4.
+func AcceptsGzip(r *http.Request) bool {
+	encodingHeaders := r.Header[AcceptEncoding] // headers are case-insensitive, but Go promises to Canonical-Case requests
+	for _, encodingHeader := range encodingHeaders {
+		encodingHeader = util.StripAllWhitespace(encodingHeader)
+		encodings := strings.Split(encodingHeader, ",")
+		for _, encoding := range encodings {
+			if strings.ToLower(encoding) == Gzip { // encoding is case-insensitive, per the RFC7231§3.1.2.1.
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/lib/go-tc/alerts.go
+++ b/lib/go-tc/alerts.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 )
 
 // Alert represents an informational message, typically returned through the Traffic Ops API.
@@ -81,7 +82,7 @@ func GetHandleErrorsFunc(w http.ResponseWriter, r *http.Request) func(status int
 			fmt.Fprintf(w, http.StatusText(http.StatusInternalServerError))
 			return
 		}
-		w.Header().Set(ContentType, ApplicationJson)
+		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 
 		ctx := r.Context()
 		ctx = context.WithValue(ctx, StatusKey, status)

--- a/lib/go-util/http.go
+++ b/lib/go-util/http.go
@@ -1,0 +1,94 @@
+package util
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"net/http"
+)
+
+// Interceptor implements http.ResponseWriter.
+// It intercepts writes to w, and tracks the HTTP code and the count of bytes written, while still writing to w.
+type Interceptor struct {
+	W         http.ResponseWriter
+	Code      int
+	ByteCount int
+}
+
+// WriteHeader implements http.ResponseWriter.
+// It does the real write to Interceptor's internal ResponseWriter, while keeping track of the code.
+func (i *Interceptor) WriteHeader(rc int) {
+	i.W.WriteHeader(rc)
+	i.Code = rc
+}
+
+// Write implements http.ResponseWriter.
+// It does the real write to Interceptor's internal ResponseWriter, while keeping track of the count of bytes written.
+// It also sets Interceptor's tracked code to 200 if WriteHeader wasn't called (which is what the real http.ResponseWriter will write to the client).
+func (i *Interceptor) Write(b []byte) (int, error) {
+	wi, werr := i.W.Write(b)
+	i.ByteCount += wi
+	if i.Code == 0 {
+		i.Code = 200
+	}
+	return wi, werr
+}
+
+// Header implements http.ResponseWriter.
+// It returns Interceptor's internal ResponseWriter.Header, without modification or tracking.
+func (i *Interceptor) Header() http.Header {
+	return i.W.Header()
+}
+
+// BodyInterceptor fulfills the Writer interface, but records the body and doesn't actually write. This allows performing operations on the entire body written by a handler, for example, compressing or hashing. To actually write, call `RealWrite()`. Note this means `len(b)` and `nil` are always returned by `Write()`, any real write errors will be returned by `RealWrite()`.
+type BodyInterceptor struct {
+	W         http.ResponseWriter
+	BodyBytes []byte
+}
+
+// WriteHeader implements http.ResponseWriter.
+// It does the real write to Interceptor's internal ResponseWriter, without modification or tracking.
+func (i *BodyInterceptor) WriteHeader(rc int) {
+	i.W.WriteHeader(rc)
+}
+
+// Write implements http.ResponseWriter.
+// It writes the given bytes to BodyInterceptor's internal tracking bytes, and does not write them to the internal ResponseWriter.
+// To write the internal bytes, call BodyInterceptor.RealWrite.
+func (i *BodyInterceptor) Write(b []byte) (int, error) {
+	i.BodyBytes = append(i.BodyBytes, b...)
+	return len(b), nil
+}
+
+// Header implements http.ResponseWriter.
+// It returns BodyInterceptor's internal ResponseWriter.Header, without modification or tracking.
+func (i *BodyInterceptor) Header() http.Header {
+	return i.W.Header()
+}
+
+// RealWrite writes BodyInterceptor's internal bytes, which were stored by calls to Write.
+func (i *BodyInterceptor) RealWrite(b []byte) (int, error) {
+	wi, werr := i.W.Write(i.BodyBytes)
+	return wi, werr
+}
+
+// Body returns the internal bytes stored by calls to Write.
+func (i *BodyInterceptor) Body() []byte {
+	return i.BodyBytes
+}

--- a/lib/go-util/str.go
+++ b/lib/go-util/str.go
@@ -19,6 +19,11 @@ package util
  * under the License.
  */
 
+import (
+	"strings"
+	"unicode"
+)
+
 // RemoveStrDuplicates removes duplicates from strings, considering a map of already-seen duplicates.
 // Returns the strings which are unique, and not already present in seen; and a map of the unique strings in inputStrings and seenStrings.
 //
@@ -51,4 +56,14 @@ func ContainsStr(a []string, x string) bool {
 		}
 	}
 	return false
+}
+
+// StripAllWhitespace returns s with all whitespace removed, as defined by unicode.IsSpace.
+func StripAllWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/lib/go-util/util.go
+++ b/lib/go-util/util.go
@@ -1,4 +1,4 @@
-package tc
+package util
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,28 +19,20 @@ package tc
  * under the License.
  */
 
-type ErrorConstant string
-
-func (e ErrorConstant) Error() string { return string(e) }
-
-const DBError = ErrorConstant("database access error")
-const NilTenantError = ErrorConstant("tenancy is enabled but request tenantID is nil")
-const TenantUserNotAuthError = ErrorConstant("user not authorized for requested tenant")
-const TenantDSUserNotAuthError = ErrorConstant("user not authorized for requested delivery service tenant")
-
-type AlertLevel int
-
-const (
-	SuccessLevel AlertLevel = iota
-	InfoLevel
-	WarnLevel
-	ErrorLevel
+import (
+	"runtime"
 )
 
-var alertLevels = [4]string{"success", "info", "warning", "error"}
-
-func (a AlertLevel) String() string {
-	return alertLevels[a]
+// Stacktrace is a helper function which returns the current stacktrace.
+// It wraps runtime.Stack, which requires a sufficiently long buffer.
+func Stacktrace() []byte {
+	initialBufSize := 1024
+	buf := make([]byte, initialBufSize)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return buf[:n]
+		}
+		buf = make([]byte, len(buf)*2)
+	}
 }
-
-const CachegroupCoordinateNamePrefix = "from_cachegroup_"

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -147,7 +147,7 @@ func handleSimpleErr(w http.ResponseWriter, r *http.Request, statusCode int, use
 	}
 	log.Debugln(userErr.Error())
 	*r = *r.WithContext(context.WithValue(r.Context(), tc.StatusKey, statusCode))
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write(append(respBts, '\n'))
 }
 
@@ -190,7 +190,7 @@ func WriteRespAlert(w http.ResponseWriter, r *http.Request, level tc.AlertLevel,
 		handleSimpleErr(w, r, http.StatusInternalServerError, nil, errors.New("marshalling JSON: "+err.Error()))
 		return
 	}
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write(append(respBts, '\n'))
 }
 
@@ -215,7 +215,7 @@ func WriteRespAlertObj(w http.ResponseWriter, r *http.Request, level tc.AlertLev
 		handleSimpleErr(w, r, http.StatusInternalServerError, nil, errors.New("marshalling JSON: "+err.Error()))
 		return
 	}
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write(append(respBts, '\n'))
 }
 
@@ -231,7 +231,7 @@ func WriteAlerts(w http.ResponseWriter, r *http.Request, code int, alerts tc.Ale
 		handleSimpleErr(w, r, http.StatusInternalServerError, nil, fmt.Errorf("marshalling JSON: %v", err))
 		return
 	}
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.WriteHeader(code)
 	w.Write(append(resp, '\n'))
 }
@@ -255,7 +255,7 @@ func WriteAlertsObj(w http.ResponseWriter, r *http.Request, code int, alerts tc.
 		handleSimpleErr(w, r, http.StatusInternalServerError, nil, fmt.Errorf("marshalling JSON: %v", err))
 		return
 	}
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.WriteHeader(code)
 	w.Write(append(respBts, '\n'))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atscdn/atscdn.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/atscdn.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
@@ -79,7 +80,7 @@ type MakeCfgFunc func(tx *sql.Tx, cfg *config.Config, profile ats.ProfileData, f
 //
 func WithProfileData(w http.ResponseWriter, r *http.Request, makeCfg func(tx *sql.Tx, cfg *config.Config, profile ats.ProfileData, fileName string) (string, error)) {
 	addHdr := true
-	WithProfileDataHdr(w, r, addHdr, tc.ContentTypeTextPlain, makeCfg)
+	WithProfileDataHdr(w, r, addHdr, rfc.ContentTypeTextPlain, makeCfg)
 }
 
 func WithProfileDataHdr(w http.ResponseWriter, r *http.Request, addHdr bool, contentType string, makeCfg func(tx *sql.Tx, cfg *config.Config, profile ats.ProfileData, fileName string) (string, error)) {
@@ -137,7 +138,7 @@ func WithProfileDataHdr(w http.ResponseWriter, r *http.Request, addHdr bool, con
 	}
 
 	if contentType != "" {
-		w.Header().Set(tc.ContentType, contentType)
+		w.Header().Set(rfc.ContentType, contentType)
 	}
 	w.Write([]byte(hdr + text))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atscdn/bgfetch.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/bgfetch.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 )
@@ -52,6 +52,6 @@ func GetBGFetchDotConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txt := atscfg.MakeBGFetchDotConfig(cdnName, toToolName, toURL)
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atscdn/cacheurldotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/cacheurldotconfig.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
@@ -62,7 +63,7 @@ func GetCacheURLDotConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txt := atscfg.MakeCacheURLDotConfig(cdnName, toToolName, toURL, fullFileName, dses)
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }
 

--- a/traffic_ops/traffic_ops_golang/ats/atscdn/headerrewritedotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/headerrewritedotconfig.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
@@ -65,7 +66,7 @@ func GetEdgeHeaderRewriteDotConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txt := atscfg.MakeHeaderRewriteDotConfig(tc.CDNName(cdnName), toToolName, toURL, ds, assignedEdges)
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }
 
@@ -105,7 +106,7 @@ func GetMidHeaderRewriteDotConfig(w http.ResponseWriter, r *http.Request) {
 
 	txt := atscfg.MakeHeaderRewriteMidDotConfig(tc.CDNName(cdnName), toToolName, toURL, ds, assignedMids)
 
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }
 

--- a/traffic_ops/traffic_ops_golang/ats/atscdn/regexremapdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/regexremapdotconfig.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
@@ -63,7 +64,7 @@ func GetRegexRemapDotConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txt := atscfg.MakeRegexRemapDotConfig(cdnName, toToolName, toURL, fullFileName, dses)
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }
 

--- a/traffic_ops/traffic_ops_golang/ats/atscdn/regexrevalidatedotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/regexrevalidatedotconfig.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
@@ -79,7 +80,7 @@ func GetRegexRevalidateDotConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txt := atscfg.MakeRegexRevalidateDotConfig(tc.CDNName(cdnName), params, toToolName, toURL, jobs)
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }
 

--- a/traffic_ops/traffic_ops_golang/ats/atscdn/setdscpdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/setdscpdotconfig.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 )
@@ -54,6 +54,6 @@ func GetSetDSCPDotConfig(w http.ResponseWriter, r *http.Request) {
 	dscpNumStr := inf.Params["dscp"] // TODO verify is a number? Perl doesn't
 
 	txt := atscfg.MakeSetDSCPDotConfig(cdnName, toToolName, toURL, dscpNumStr)
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atscdn/sslmulticertdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/sslmulticertdotconfig.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
@@ -60,7 +61,7 @@ func GetSSLMultiCertDotConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txt := atscfg.MakeSSLMultiCertDotConfig(cdnName, toToolName, toURL, dses)
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }
 

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/astats.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/astats.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetAstats(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeAstats)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeAstats)
 }
 
 func makeAstats(tx *sql.Tx, cfg *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/atsdotrules.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/atsdotrules.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetATSDotRules(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeATSDotRules)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeATSDotRules)
 }
 
 func makeATSDotRules(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, fileName string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/cache.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/cache.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetCache(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeCache)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeCache)
 }
 
 func makeCache(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/dropqstring.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/dropqstring.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetDropQString(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeDropQString)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeDropQString)
 }
 
 func makeDropQString(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/facts.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/facts.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetFacts(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeFacts)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeFacts)
 }
 
 func makeFacts(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, fileName string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/logging.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/logging.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetLogging(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeLogging) // TODO change to Content-Type text/x-lua? Perl uses text/plain.
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeLogging) // TODO change to Content-Type text/x-lua? Perl uses text/plain.
 }
 
 func makeLogging(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/loggingyaml.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/loggingyaml.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetLoggingYAML(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeLoggingYAML) // TODO change to Content-Type text/yaml? Perl uses text/plain.
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeLoggingYAML) // TODO change to Content-Type text/yaml? Perl uses text/plain.
 }
 
 func makeLoggingYAML(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/logsxml.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/logsxml.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetLogsXML(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeLogsXML) // TODO change to Content-Type text/xml? Perl uses text/plain.
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeLogsXML) // TODO change to Content-Type text/xml? Perl uses text/plain.
 }
 
 func makeLogsXML(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/plugin.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/plugin.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetPlugin(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makePlugin)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makePlugin)
 }
 
 func makePlugin(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/profile.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/profile.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
@@ -79,7 +79,7 @@ func WithProfileData(w http.ResponseWriter, r *http.Request, contentType string,
 	}
 
 	if contentType != "" {
-		w.Header().Set(tc.ContentType, contentType)
+		w.Header().Set(rfc.ContentType, contentType)
 	}
 	w.Write([]byte(text))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/records.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/records.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetRecords(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeRecords)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeRecords)
 }
 
 func makeRecords(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/storage.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/storage.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
@@ -33,7 +33,7 @@ import (
 const StorageFileName = "storage.config"
 
 func GetStorage(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeStorage)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeStorage)
 }
 
 func makeStorage(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/sysctl.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/sysctl.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
@@ -34,7 +34,7 @@ const SysctlSeparator = " = "
 const SysctlFileName = "sysctl.conf"
 
 func GetSysctl(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeSysctl)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeSysctl)
 }
 
 func makeSysctl(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/unknown.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/unknown.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 )
@@ -71,7 +71,7 @@ func GetUnknown(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	w.Write([]byte(txt))
 }
 

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/urisigning.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/urisigning.go
@@ -26,14 +26,14 @@ import (
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/riaksvc"
 )
 
 func GetURISigning(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ApplicationJson, uriSigningDotConfig)
+	WithProfileData(w, r, rfc.ApplicationJSON, uriSigningDotConfig)
 }
 
 func uriSigningDotConfig(tx *sql.Tx, cfg *config.Config, _ ats.ProfileData, fileName string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/urlsig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/urlsig.go
@@ -25,14 +25,14 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/riaksvc"
 )
 
 func GetURLSig(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, urlSigDotConfig)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, urlSigDotConfig)
 }
 
 func urlSigDotConfig(tx *sql.Tx, cfg *config.Config, profile ats.ProfileData, fileName string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsprofile/volume.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsprofile/volume.go
@@ -25,13 +25,13 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 )
 
 func GetVolume(w http.ResponseWriter, r *http.Request) {
-	WithProfileData(w, r, tc.ContentTypeTextPlain, makeVolume)
+	WithProfileData(w, r, rfc.ContentTypeTextPlain, makeVolume)
 }
 
 func makeVolume(tx *sql.Tx, _ *config.Config, profile ats.ProfileData, _ string) (string, error) {

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/chkconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/chkconfig.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 )
 
@@ -53,6 +53,6 @@ func GetChkconfig(w http.ResponseWriter, r *http.Request) {
 
 	txt := atscfg.MakeChkconfig(params)
 
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(txt))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/meta.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/meta.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 )
@@ -77,6 +77,6 @@ func GetConfigMetaData(w http.ResponseWriter, r *http.Request) {
 	}
 
 	txt := atscfg.MakeMetaConfig(serverName, server, tmParams.URL, tmParams.ReverseProxyURL, locationParams, uriSignedDSes, scopeParams)
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(txt))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/packages.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/packages.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 )
 
@@ -53,6 +53,6 @@ func GetPackages(w http.ResponseWriter, r *http.Request) {
 
 	txt := atscfg.MakePackages(params)
 
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(txt))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/remapdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/remapdotconfig.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 )
@@ -88,6 +88,6 @@ func GetServerConfigRemap(w http.ResponseWriter, r *http.Request) {
 
 	txt := atscfg.MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
 
-	w.Header().Set(tc.ContentType, tc.ContentTypeTextPlain)
+	w.Header().Set(rfc.ContentType, rfc.ContentTypeTextPlain)
 	io.WriteString(w, txt)
 }

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/unknown.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/unknown.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/ats"
 )
@@ -65,6 +65,6 @@ func GetUnknown(w http.ResponseWriter, r *http.Request) {
 
 	txt := atscfg.MakeServerUnknown(serverName, serverDomain, toToolName, toURL, params)
 
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(txt))
 }

--- a/traffic_ops/traffic_ops_golang/crconfig/handler.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/handler.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice"
@@ -72,7 +73,7 @@ func SnapshotGetHandler(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("CDN not found"), nil)
 		return
 	}
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(`{"response":` + snapshot + `}`))
 }
 
@@ -94,7 +95,7 @@ func SnapshotGetMonitoringHandler(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("CDN not found"), nil)
 		return
 	}
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(`{"response":` + snapshot + `}`))
 }
 
@@ -116,7 +117,7 @@ func SnapshotOldGetHandler(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("CDN not found"), nil)
 		return
 	}
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(snapshot))
 }
 

--- a/traffic_ops/traffic_ops_golang/dbdump/dbdump.go
+++ b/traffic_ops/traffic_ops_golang/dbdump/dbdump.go
@@ -27,7 +27,7 @@ import "os/exec"
 import "time"
 
 import "github.com/apache/trafficcontrol/lib/go-log"
-import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/lib/go-rfc"
 
 import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 
@@ -91,7 +91,7 @@ func DBDump(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(tc.ContentType, "application/octet-stream;type=pg_dump-data")
+	w.Header().Set(rfc.ContentType, "application/octet-stream;type=pg_dump-data")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename()))
 	if out[len(out)-1] != '\n' {
 		out = append(out, '\n')

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
@@ -462,7 +463,7 @@ func ReplaceFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *h
 		return
 	}
 
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write(append(respBts, '\n'))
 }
 

--- a/traffic_ops/traffic_ops_golang/hwinfo/hwinfo.go
+++ b/traffic_ops/traffic_ops_golang/hwinfo/hwinfo.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 
@@ -96,7 +97,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write(append(respBts, '\n'))
 }
 

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -29,6 +29,7 @@ import "strings"
 import "time"
 
 import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/lib/go-rfc"
 import "github.com/apache/trafficcontrol/lib/go-log"
 import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
@@ -275,7 +276,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	if err := job.Validate(inf.Tx.Tx); err != nil {
 		response := tc.Alerts{
 			[]tc.Alert{
@@ -521,7 +522,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+	w.Header().Set(http.CanonicalHeaderKey("content-type"), rfc.ApplicationJSON)
 	w.Write(append(resp, '\n'))
 
 	api.CreateChangeLogRawTx(api.ApiChange, api.Updated+"content invalidation job: #"+strconv.FormatUint(*job.ID, 10), inf.User, inf.Tx.Tx)
@@ -607,7 +608,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+	w.Header().Set(http.CanonicalHeaderKey("content-type"), rfc.ApplicationJSON)
 	w.Write(append(resp, '\n'))
 
 	api.CreateChangeLogRawTx(api.ApiChange, api.Deleted+"content invalidation job: #"+strconv.FormatUint(*result.ID, 10), inf.User, inf.Tx.Tx)

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/userinvalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/userinvalidationjobs.go
@@ -27,6 +27,7 @@ import "strconv"
 import "time"
 
 import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/lib/go-rfc"
 import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 
 const userReadQuery = `
@@ -130,7 +131,7 @@ func CreateUserJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(tc.ContentType, tc.ApplicationJson)
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Header().Set(http.CanonicalHeaderKey("location"), inf.Config.URL.Scheme+"://"+r.Host+"/api/1.4/jobs?id="+strconv.FormatUint(uint64(*result.ID), 10))
 	w.WriteHeader(http.StatusOK)
 	w.Write(append(resp, '\n'))
@@ -208,6 +209,6 @@ func GetUserJobs(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("encoding user jobs response: %v", err))
 		return
 	}
-	w.Header().Set(http.CanonicalHeaderKey("content-type"), tc.ApplicationJson)
+	w.Header().Set(http.CanonicalHeaderKey("content-type"), rfc.ApplicationJSON)
 	w.Write(append(resp, '\n'))
 }

--- a/traffic_ops/traffic_ops_golang/login/login.go
+++ b/traffic_ops/traffic_ops_golang/login/login.go
@@ -166,7 +166,7 @@ func LoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 			handleErrs(http.StatusInternalServerError, err)
 			return
 		}
-		w.Header().Set(tc.ContentType, tc.ApplicationJson)
+		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 		if !authenticated {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
@@ -206,7 +206,7 @@ func TokenLoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set(tc.ContentType, tc.ApplicationJson)
+		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 		w.Write(append(respBts, '\n'))
 
 		// TODO: afaik, Perl never clears these tokens. They should be reset to NULL on login, I think.
@@ -357,7 +357,7 @@ func OauthLoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 			handleErrs(http.StatusInternalServerError, err)
 			return
 		}
-		w.Header().Set(tc.ContentType, tc.ApplicationJson)
+		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 		if !authenticated {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
@@ -503,7 +503,7 @@ func ResetPassword(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set(tc.ContentType, tc.ApplicationJson)
+		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 		w.Write(append(respBts, '\n'))
 	}
 }

--- a/traffic_ops/traffic_ops_golang/login/logout.go
+++ b/traffic_ops/traffic_ops_golang/login/logout.go
@@ -24,6 +24,7 @@ import "fmt"
 import "net/http"
 
 import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/lib/go-rfc"
 import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tocookie"
 
@@ -51,7 +52,7 @@ func LogoutHandler(secret string) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set(tc.ContentType, tc.ApplicationJson)
+		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 		w.Write(append(respBts, '\n'))
 	}
 }

--- a/traffic_ops/traffic_ops_golang/plugin/hello_middleware.go
+++ b/traffic_ops/traffic_ops_golang/plugin/hello_middleware.go
@@ -1,0 +1,49 @@
+package plugin
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/routing/middleware"
+)
+
+func init() {
+	AddPlugin(10000, Funcs{onRequest: helloMiddleware})
+}
+
+const HelloMiddlewarePath = "/_hello_middleware"
+
+func helloMiddleware(d OnRequestData) IsRequestHandled {
+	if !strings.HasPrefix(d.R.URL.Path, HelloPath) {
+		return RequestUnhandled
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("Hello, World!\n"))
+	}
+	requestTimeout := middleware.DefaultRequestTimeout
+	if d.AppCfg.RequestTimeout != 0 {
+		requestTimeout = time.Second * time.Duration(d.AppCfg.RequestTimeout)
+	}
+	mw := middleware.GetDefault(d.AppCfg.Secrets[0], requestTimeout)
+	handler = middleware.Use(handler, mw)
+	handler(d.W, d.R)
+
+	return RequestHandled
+}

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
@@ -1,4 +1,4 @@
-package routing
+package middleware
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
@@ -46,7 +46,7 @@ var debugLogging = flag.Bool("debug", false, "enable debug logging in test")
 // TestWrapHeaders checks that appropriate default headers are added to a request
 func TestWrapHeaders(t *testing.T) {
 	body := "We are here!!"
-	f := wrapHeaders(func(w http.ResponseWriter, r *http.Request) {
+	f := WrapHeaders(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(body))
 	})
 
@@ -85,12 +85,12 @@ func TestWrapHeaders(t *testing.T) {
 
 // TestWrapPanicRecover checks that a recovered panic returns a 500
 func TestWrapPanicRecover(t *testing.T) {
-	f := wrapPanicRecover(func(w http.ResponseWriter, r *http.Request) {
+	f := WrapPanicRecover(func(w http.ResponseWriter, r *http.Request) {
 		var foo *string
 		bar := *foo // will throw nil dereference panic
 		w.Write([]byte(bar))
 	})
-	f = wrapHeaders(f)
+	f = WrapHeaders(f)
 
 	w := httptest.NewRecorder()
 	r, err := http.NewRequest("", "/", nil)
@@ -120,7 +120,7 @@ func TestGzip(t *testing.T) {
 		t.Error("Error closing gzipper", err)
 	}
 
-	f := wrapHeaders(func(w http.ResponseWriter, r *http.Request) {
+	f := WrapHeaders(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(body))
 	})
 
@@ -182,7 +182,7 @@ func TestWrapAuth(t *testing.T) {
 			return
 		}
 
-		w.Header().Set(tc.ContentType, tc.ApplicationJson)
+		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 		fmt.Fprintf(w, "%s", respBts)
 	}
 

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -73,6 +73,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/profileparameter"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/region"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/role"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/routing/middleware"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/server"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/servercapability"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/servercheck"
@@ -170,8 +171,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `cdns/configs/?(\.json)?$`, cdn.GetConfigs, auth.PrivLevelReadOnly, Authenticated, nil, 1768437852, noPerlBypass},
 
 		{1.1, http.MethodGet, `cdns/domains/?(\.json)?$`, cdn.DomainsHandler, auth.PrivLevelReadOnly, Authenticated, nil, 296902560, noPerlBypass},
-		{1.1, http.MethodGet, `cdns/health$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}, 1443074329, noPerlBypass},
-		{1.1, http.MethodGet, `cdns/routing$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}, 66722982, noPerlBypass},
+		{1.1, http.MethodGet, `cdns/health$`, handlerToFunc(proxyHandler), 0, NoAuth, []middleware.Middleware{}, 1443074329, noPerlBypass},
+		{1.1, http.MethodGet, `cdns/routing$`, handlerToFunc(proxyHandler), 0, NoAuth, []middleware.Middleware{}, 66722982, noPerlBypass},
 
 		//CDN: CRUD
 		{1.1, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 1345914650, noPerlBypass},
@@ -297,10 +298,10 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		//Server
 		{1.1, http.MethodGet, `servers/status$`, server.GetServersStatusCountsHandler, auth.PrivLevelReadOnly, Authenticated, nil, 2052786293, perlBypass},
-		{1.1, http.MethodGet, `servers/totals$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}, 2037840835, noPerlBypass},
+		{1.1, http.MethodGet, `servers/totals$`, handlerToFunc(proxyHandler), 0, NoAuth, []middleware.Middleware{}, 2037840835, noPerlBypass},
 
 		//Serverchecks
-		{1.1, http.MethodGet, `servers/checks$`, handlerToFunc(proxyHandler), 0, NoAuth, []Middleware{}, 1796112922, noPerlBypass},
+		{1.1, http.MethodGet, `servers/checks$`, handlerToFunc(proxyHandler), 0, NoAuth, []middleware.Middleware{}, 1796112922, noPerlBypass},
 		{1.1, http.MethodPost, `servercheck/?(\.json)?$`, servercheck.CreateUpdateServercheck, auth.PrivLevelInvalid, Authenticated, nil, 1764281568, perlBypass},
 
 		//Server Details
@@ -663,7 +664,7 @@ func rootHandler(d ServerData) http.Handler {
 
 	log.Debugf("our reverseProxy: %++v\n", rp)
 	log.Debugf("our reverseProxy's transport: %++v\n", tr)
-	loggingProxyHandler := wrapAccessLog(d.Secrets[0], rp)
+	loggingProxyHandler := middleware.WrapAccessLog(d.Secrets[0], rp)
 
 	managerHandler := CreateThrottledHandler(loggingProxyHandler, d.BackendMaxConnections["mojolicious"])
 	return managerHandler

--- a/traffic_ops/traffic_ops_golang/routing/routing.go
+++ b/traffic_ops/traffic_ops_golang/routing/routing.go
@@ -34,15 +34,13 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/plugin"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/routing/middleware"
 
 	"github.com/jmoiron/sqlx"
 )
 
 // RoutePrefix ...
 const RoutePrefix = "^api" // TODO config?
-
-// Middleware ...
-type Middleware func(handlerFunc http.HandlerFunc) http.HandlerFunc
 
 // Route ...
 type Route struct {
@@ -53,7 +51,7 @@ type Route struct {
 	Handler           http.HandlerFunc
 	RequiredPrivLevel int
 	Authenticated     bool
-	Middlewares       []Middleware
+	Middlewares       []middleware.Middleware
 	ID                int  // unique ID for referencing this Route
 	CanBypassToPerl   bool // if true, this Route can be passed through to Perl
 }
@@ -70,11 +68,7 @@ type RawRoute struct {
 	Handler           http.HandlerFunc
 	RequiredPrivLevel int
 	Authenticated     bool
-	Middlewares       []Middleware
-}
-
-func getDefaultMiddleware(secret string, requestTimeout time.Duration) []Middleware {
-	return []Middleware{getWrapAccessLog(secret), timeOutWrapper(requestTimeout), wrapHeaders, wrapPanicRecover}
+	Middlewares       []middleware.Middleware
 }
 
 // ServerData ...
@@ -113,10 +107,10 @@ type PathHandler struct {
 
 // CreateRouteMap returns a map of methods to a slice of paths and handlers; wrapping the handlers in the appropriate middleware. Uses Semantic Versioning: routes are added to every subsequent minor version, but not subsequent major versions. For example, a 1.2 route is added to 1.3 but not 2.1. Also truncates '2.0' to '2', creating succinct major versions.
 // Returns the map of routes, and a map of API versions served.
-func CreateRouteMap(rs []Route, rawRoutes []RawRoute, perlRouteIDs, disabledRouteIDs []int, perlHandler http.HandlerFunc, authBase AuthBase, reqTimeOutSeconds int) (map[string][]PathHandler, map[float64]struct{}) {
+func CreateRouteMap(rs []Route, rawRoutes []RawRoute, perlRouteIDs, disabledRouteIDs []int, perlHandler http.HandlerFunc, authBase middleware.AuthBase, reqTimeOutSeconds int) (map[string][]PathHandler, map[float64]struct{}) {
 	// TODO strong types for method, path
 	versions := getSortedRouteVersions(rs)
-	requestTimeout := time.Second * time.Duration(60)
+	requestTimeout := middleware.DefaultRequestTimeout
 	if reqTimeOutSeconds > 0 {
 		requestTimeout = time.Second * time.Duration(reqTimeOutSeconds)
 	}
@@ -139,16 +133,16 @@ func CreateRouteMap(rs []Route, rawRoutes []RawRoute, perlRouteIDs, disabledRout
 			if isPerlRoute {
 				m[r.Method] = append(m[r.Method], PathHandler{Path: path, Handler: perlHandler})
 			} else if isDisabledRoute {
-				m[r.Method] = append(m[r.Method], PathHandler{Path: path, Handler: wrapAccessLog(authBase.secret, DisabledRouteHandler())})
+				m[r.Method] = append(m[r.Method], PathHandler{Path: path, Handler: middleware.WrapAccessLog(authBase.Secret, middleware.DisabledRouteHandler())})
 			} else {
-				m[r.Method] = append(m[r.Method], PathHandler{Path: path, Handler: use(r.Handler, middlewares)})
+				m[r.Method] = append(m[r.Method], PathHandler{Path: path, Handler: middleware.Use(r.Handler, middlewares)})
 			}
 			log.Infof("adding route %v %v\n", r.Method, path)
 		}
 	}
 	for _, r := range rawRoutes {
 		middlewares := getRouteMiddleware(r.Middlewares, authBase, r.Authenticated, r.RequiredPrivLevel, requestTimeout)
-		m[r.Method] = append(m[r.Method], PathHandler{Path: r.Path, Handler: use(r.Handler, middlewares)})
+		m[r.Method] = append(m[r.Method], PathHandler{Path: r.Path, Handler: middleware.Use(r.Handler, middlewares)})
 		log.Infof("adding raw route %v %v\n", r.Method, r.Path)
 	}
 
@@ -160,9 +154,9 @@ func CreateRouteMap(rs []Route, rawRoutes []RawRoute, perlRouteIDs, disabledRout
 	return m, versionSet
 }
 
-func getRouteMiddleware(middlewares []Middleware, authBase AuthBase, authenticated bool, privLevel int, requestTimeout time.Duration) []Middleware {
+func getRouteMiddleware(middlewares []middleware.Middleware, authBase middleware.AuthBase, authenticated bool, privLevel int, requestTimeout time.Duration) []middleware.Middleware {
 	if middlewares == nil {
-		middlewares = getDefaultMiddleware(authBase.secret, requestTimeout)
+		middlewares = middleware.GetDefault(authBase.Secret, requestTimeout)
 	}
 	if authenticated { // a privLevel of zero is an unauthenticated endpoint.
 		authWrapper := authBase.GetWrapper(privLevel)
@@ -255,7 +249,7 @@ func Handler(
 	}
 
 	if IsRequestAPIAndUnknownVersion(r, versions) {
-		h := wrapAccessLog(cfg.Secrets[0], NotImplementedHandler())
+		h := middleware.WrapAccessLog(cfg.Secrets[0], middleware.NotImplementedHandler())
 		h.ServeHTTP(w, r)
 		return
 	}
@@ -293,21 +287,15 @@ func RegisterRoutes(d ServerData) error {
 		return err
 	}
 
-	authBase := AuthBase{secret: d.Config.Secrets[0], override: nil} //we know d.Config.Secrets is a slice of at least one or start up would fail.
+	authBase := middleware.AuthBase{Secret: d.Config.Secrets[0], Override: nil} //we know d.Config.Secrets is a slice of at least one or start up would fail.
 	routes, versions := CreateRouteMap(routeSlice, rawRoutes, d.PerlRoutes, d.DisabledRoutes, handlerToFunc(catchall), authBase, d.RequestTimeout)
+
 	compiledRoutes := CompileRoutes(routes)
 	getReqID := nextReqIDGetter()
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		Handler(compiledRoutes, versions, catchall, d.DB, &d.Config, getReqID, d.Plugins, w, r)
 	})
 	return nil
-}
-
-func use(h http.HandlerFunc, middlewares []Middleware) http.HandlerFunc {
-	for i := len(middlewares) - 1; i >= 0; i-- { //apply them in reverse order so they are used in a natural order.
-		h = middlewares[i](h)
-	}
-	return h
 }
 
 // nextReqIDGetter returns a function for getting incrementing identifiers. The returned func is safe for calling with multiple goroutines. Note the returned identifiers will not be unique after the max uint64 value.

--- a/traffic_ops/traffic_ops_golang/routing/routing_test.go
+++ b/traffic_ops/traffic_ops_golang/routing/routing_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/routing/middleware"
 )
 
 type key int
@@ -134,7 +135,7 @@ func TestCompileRoutes(t *testing.T) {
 		t.Error("error fetching routes: ", err.Error())
 	}
 
-	authBase := AuthBase{secret: d.Secrets[0], override: nil}
+	authBase := middleware.AuthBase{Secret: d.Secrets[0], Override: nil}
 	routes, versions := CreateRouteMap(routeSlice, nil, nil, nil, nil, authBase, 1)
 	if len(routes) == 0 {
 		t.Error("no routes handler defined")
@@ -189,7 +190,7 @@ func TestRoutes(t *testing.T) {
 }
 
 func TestCreateRouteMap(t *testing.T) {
-	authBase := AuthBase{"secret", func(handlerFunc http.HandlerFunc) http.HandlerFunc {
+	authBase := middleware.AuthBase{"secret", func(handlerFunc http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			ctx := context.WithValue(r.Context(), AuthWasCalled, "true")
 			handlerFunc(w, r.WithContext(ctx))
@@ -228,9 +229,9 @@ func TestCreateRouteMap(t *testing.T) {
 	routes := []Route{
 		{1.2, http.MethodGet, `path1`, PathOneHandler, auth.PrivLevelReadOnly, true, nil, 0, false},
 		{1.2, http.MethodGet, `path2`, PathTwoHandler, 0, false, nil, 1, false},
-		{1.2, http.MethodGet, `path3`, PathThreeHandler, 0, false, []Middleware{}, 2, false},
-		{1.2, http.MethodGet, `path4`, PathFourHandler, 0, false, []Middleware{}, 3, true},
-		{1.2, http.MethodGet, `path5`, PathFiveHandler, 0, false, []Middleware{}, 4, false},
+		{1.2, http.MethodGet, `path3`, PathThreeHandler, 0, false, []middleware.Middleware{}, 2, false},
+		{1.2, http.MethodGet, `path4`, PathFourHandler, 0, false, []middleware.Middleware{}, 3, true},
+		{1.2, http.MethodGet, `path5`, PathFiveHandler, 0, false, []middleware.Middleware{}, 4, false},
 	}
 
 	perlRoutesIDs := []int{3}

--- a/traffic_ops/traffic_ops_golang/trafficstats/cache.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/cache.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	influx "github.com/influxdata/influxdb/client/v2"
@@ -178,9 +179,9 @@ func GetCacheStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.Unix {
-		w.Header().Set(tc.ContentType, jsonWithUnixTimestamps.String())
+		w.Header().Set(rfc.ContentType, jsonWithUnixTimestamps.String())
 	} else {
-		w.Header().Set(tc.ContentType, jsonWithRFCTimestamps.String())
+		w.Header().Set(rfc.ContentType, jsonWithRFCTimestamps.String())
 	}
 	w.Header().Set(http.CanonicalHeaderKey("vary"), http.CanonicalHeaderKey("Accept"))
 	w.Write(append(respBts, '\n'))

--- a/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
 
@@ -244,9 +245,9 @@ func GetDSStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.Unix {
-		w.Header().Set(tc.ContentType, jsonWithUnixTimestamps.String())
+		w.Header().Set(rfc.ContentType, jsonWithUnixTimestamps.String())
 	} else {
-		w.Header().Set(tc.ContentType, jsonWithRFCTimestamps.String())
+		w.Header().Set(rfc.ContentType, jsonWithRFCTimestamps.String())
 	}
 	w.Header().Set(http.CanonicalHeaderKey("vary"), http.CanonicalHeaderKey("Accept"))
 	w.Write(append(respBts, '\n'))

--- a/traffic_ops/traffic_ops_golang/trafficstats/util_test.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/util_test.go
@@ -24,6 +24,7 @@ import "testing"
 import "time"
 
 import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/lib/go-rfc"
 import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 
 func TestTSConfigFromRequest(t *testing.T) {
@@ -54,7 +55,7 @@ func TestTSConfigFromRequest(t *testing.T) {
 	if e != nil {
 		t.Fatalf("Failed to build test request: %v", e)
 	}
-	r.Header.Add(tc.ContentType, tc.ApplicationJson)
+	r.Header.Add(rfc.ContentType, rfc.ApplicationJSON)
 
 	cfg, code, err := tsConfigFromRequest(r, &inf)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
+++ b/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/riaksvc"
@@ -202,7 +203,7 @@ func SaveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	api.CreateChangeLogRawTx(api.ApiChange, "DS: "+xmlID+", ID: "+strconv.Itoa(dsID)+", ACTION: Stored URI signing keys to a delivery service", inf.User, inf.Tx.Tx)
-	w.Header().Set("Content-Type", tc.ApplicationJson)
+	w.Header().Set("Content-Type", rfc.ApplicationJSON)
 	w.Write(data)
 }
 


### PR DESCRIPTION
Changes Traffic Ops middleware wrapper symbols to be public.

The primary goal of this is to make them accessible to plugins,
which will almost always want to add the access control, checksum,
server, and gzip headers.

To that end, this also includes an example plugin using middleware.

This doesn't change any code, it only moves and capitalizes existing symbols.

No new tests, no interface change and not a bug fix.
No documentation, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?

Run unit and API tests, verify they still pass.
Make some requests, verify things work as expected, still return middleware headers appropriately.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information