### PR TITLE
TP: navigation to the ds request page needs to wait until the update is complete

### DIFF
--- a/traffic_portal/app/src/modules/private/deliveryServiceRequests/edit/FormEditDeliveryServiceRequestController.js
+++ b/traffic_portal/app/src/modules/private/deliveryServiceRequests/edit/FormEditDeliveryServiceRequestController.js
@@ -100,6 +100,7 @@ var FormEditDeliveryServiceRequestController = function(deliveryServiceRequest, 
 		promises.push(deliveryServiceRequestService.assignDeliveryServiceRequest($scope.dsRequest.id, userModel.user.id));
 		// set the status to 'pending'
 		promises.push(deliveryServiceRequestService.updateDeliveryServiceRequestStatus($scope.dsRequest.id, 'pending'));
+		return promises;
 	};
 
 	$scope.fulfillRequest = function(ds) {
@@ -166,9 +167,13 @@ var FormEditDeliveryServiceRequestController = function(deliveryServiceRequest, 
 					deliveryServiceService.deleteDeliveryService(ds).
 						then(
 							function() {
-								updateDeliveryServiceRequest(); // after a successful delete, update the ds request, assignee and status and navigate to ds requests page
-								messageModel.setMessages([ { level: 'success', text: 'Delivery service [ ' + ds.xmlId + ' ] deleted' } ], true);
-								locationUtils.navigateToPath('/delivery-service-requests');
+								let promises = updateDeliveryServiceRequest(); // after a successful delete, update the ds request, assignee and status and navigate to ds requests page
+								$q.all(promises)
+									.then(
+										function() {
+											messageModel.setMessages([ { level: 'success', text: 'Delivery service [ ' + ds.xmlId + ' ] deleted' } ], true);
+											locationUtils.navigateToPath('/delivery-service-requests');
+										});
 							},
 							function(fault) {
 								$anchorScroll(); // scrolls window to top


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #3217 

TP now waits until the DSR update is complete before navigating to the ds request page. The bug described in #3217 was because of a timing issue.

- tests: ds requests are not currently under test
- docs: no change required as we don't document bugs
- changelog: too small to justify a changelog entry

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
- turn on ds requests in traffic_portal_properties.json
- delete a delivery service (which will create a ds request)
- fulfill the delivery service request which will delete the ds behind the scenes and navigate the user back to the ds requests page.
- ensure that the ds request has been assigned (to the fulfiller) and the 'complete' link is displayed

## If this is a bug fix, what versions of Traffic Control are affected?

- master (eb68cb0)
- 3.0.2

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
