### PR TITLE
Fix atscfg strings.ReplaceAll to Replace

### DIFF
--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -318,7 +318,7 @@ func TestMakeParentDotConfigMSOSecondaryParent(t *testing.T) {
 
 	testComment(t, txt, serverName, toolName, toURL)
 
-	txt = strings.ReplaceAll(txt, " ", "")
+	txt = strings.Replace(txt, " ", "", -1)
 
 	if !strings.Contains(txt, `secondary_parent="my-parent-1.my-parent-1-domain`) {
 		t.Errorf("expected secondary parent 'my-parent-1.my-parent-1-domain', actual: '%v'", txt)


### PR DESCRIPTION
Fix atscfg strings.ReplaceAll to Replace.

The strings.ReplaceAll func doesn't exist in our current pinned
version of Go, 1.11.

Is a unit test.
No docs, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?

`go test`

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information