### PR TITLE
Add lib/go-rfc GoDoc comments

### DIFF
--- a/lib/go-rfc/http.go
+++ b/lib/go-rfc/http.go
@@ -26,12 +26,12 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 )
 
-const ApplicationJSON = "application/json"
-const Gzip = "gzip"
-const ContentType = "Content-Type"
-const ContentEncoding = "Content-Encoding"
-const ContentTypeTextPlain = "text/plain"
-const AcceptEncoding = "Accept-Encoding"
+const ApplicationJSON = "application/json" // RFC4627§6
+const Gzip = "gzip"                        // RFC7230§4.2.3
+const ContentType = "Content-Type"         // RFC7231§3.1.1.5
+const ContentEncoding = "Content-Encoding" // RFC7231§3.1.2.2
+const ContentTypeTextPlain = "text/plain"  // RFC2046§4.1
+const AcceptEncoding = "Accept-Encoding"   // RFC7231§5.3.4
 
 // AcceptsGzip returns whether r accepts gzip encoding, per RFC7231§5.3.4.
 func AcceptsGzip(r *http.Request) bool {

--- a/lib/go-rfc/rfc.go
+++ b/lib/go-rfc/rfc.go
@@ -1,0 +1,29 @@
+// Package rfc provides symbols for specifications, primarily IETF RFCs.
+//
+// This includes strings, such as header names, as well as logic functions, such as cache control rules.
+//
+// All symbols in this package should document the precise RFC and ideally the exact section where they are defined, to allow readers to easily verify correctness.
+//
+// This is primarily intended for IETF HTTP RFCs, but may include other specifications as well (e.g. ANSI, W3C, WHATWG, etc).
+// If a symbol documents simply "RFC" then it refers to an IETF RFC. If the symbol is an RFC from a different organization, it should document the organization or project, e.g. "Rust RFC 2436" or "ISO/IEC 23009."
+//
+package rfc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */


### PR DESCRIPTION
Adds GoDoc comments as to which IETF RFC symbols are from, as well as
a package comment.

Is documentation.
No tests, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?

Read the comments, verify they're correct.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information