### PR TITLE
TP: Provides the ability to view all users for a given role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a boolean to delivery service in Traffic Portal and Traffic Ops to enable EDNS0 client subnet at the delivery service level and include it in the cr-config.
 - Updated Traffic Router to read new EDSN0 client subnet field and route accordingly only for enabled delivery services. When enabled and a subnet is present in the request, the subnet appears in the `chi` field and the resolver address is in the `rhi` field.
 - Added an optimistic quorum feature to Traffic Monitor to prevent false negative states from propagating to downstream components in the event of network isolation.
+- Added the ability to fetch users by role
 - Traffic Ops Golang Endpoints
   - /api/1.1/cachegroupparameters/{{cachegroupID}}/{{parameterID}} `(DELETE)`
   - /api/1.5/to_extensions/:id `(DELETE)`

--- a/docs/source/api/users.rst
+++ b/docs/source/api/users.rst
@@ -31,8 +31,6 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-.. versionadded:: ATCv4.1 The ``role`` query parameter was added in version 4.1 of :abbr:`ATC (Apache Traffic Control)`.
-
 	+-----------+----------+------------------------------------------------------------------------------------------+
 	| Name      | Required | Description                                                                              |
 	+===========+==========+==========================================================================================+
@@ -59,8 +57,9 @@ Request Structure
 	|           |          | parameter has no effect. ``limit`` must be defined to make use of ``page``.              |
 	+-----------+----------+------------------------------------------------------------------------------------------+
 
-.. versionadded:: 1.4
-	The ``id`` and ``username`` query parameters were added in the 1.4 API.
+.. versionadded:: ATCv4.1 The ``role`` query parameter was added in version 4.1 of :abbr:`ATC (Apache Traffic Control)`.
+
+.. versionadded:: ATCv4.0 The ``id`` and ``username`` query parameters were added in version 4.0 of :abbr:`ATC (Apache Traffic Control)`.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/users.rst
+++ b/docs/source/api/users.rst
@@ -31,6 +31,8 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
+.. versionadded:: ATCv4.1 The ``role`` query parameter was added in version 4.1 of :abbr:`ATC (Apache Traffic Control)`.
+
 	+-----------+----------+------------------------------------------------------------------------------------------+
 	| Name      | Required | Description                                                                              |
 	+===========+==========+==========================================================================================+

--- a/docs/source/api/users.rst
+++ b/docs/source/api/users.rst
@@ -38,6 +38,8 @@ Request Structure
 	+-----------+----------+------------------------------------------------------------------------------------------+
 	| tenant    | no       | Return only users belonging to the :term:`Tenant` identified by tenant name              |
 	+-----------+----------+------------------------------------------------------------------------------------------+
+	| role      | no       | Return only users belonging to the :term:`Role` identified by role name                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
 	| username  | no       | Return only the user with this username                                                  |
 	+-----------+----------+------------------------------------------------------------------------------------------+
 	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the        |

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -40,6 +40,7 @@ func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
 	route := apiBase + "/users"
 	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -55,20 +56,10 @@ func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
 
 // GetUsersByRole returns all users accessible from current user for a given role
 func (to *Session) GetUsersByRole(roleName string) ([]tc.User, ReqInf, error) {
-	route := apiBase + "/users?role=" + url.QueryEscape(roleName)
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
-	var data tc.UsersResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	data := tc.UsersResponse{}
+	route := fmt.Sprintf("%s/users?role=%s", apiBase, url.QueryEscape(roleName))
+	inf, err := get(to, route, &data)
+	return data.Response, inf, err
 }
 
 func (to *Session) GetUserByID(id int) ([]tc.User, ReqInf, error) {

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -37,21 +37,10 @@ func (to *Session) Users() ([]tc.User, error) {
 
 // GetUsers returns all users accessible from current user
 func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
-	route := apiBase + "/users"
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
-	var data tc.UsersResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	data := tc.UsersResponse{}
+	route := fmt.Sprintf("%s/users", apiBase)
+	inf, err := get(to, route, &data)
+	return data.Response, inf, err
 }
 
 // GetUsersByRole returns all users accessible from current user for a given role

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-rfc"
@@ -36,8 +37,26 @@ func (to *Session) Users() ([]tc.User, error) {
 
 // GetUsers returns all users accessible from current user
 func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
-	route := apiBase + "/users.json"
-	resp, remoteAddr, err := to.request("GET", route, nil)
+	route := apiBase + "/users"
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.UsersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GetUsersByRole returns all users accessible from current user for a given role
+func (to *Session) GetUsersByRole(roleName string) ([]tc.User, ReqInf, error) {
+	route := apiBase + "/users?role=" + url.QueryEscape(roleName)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
 		return nil, reqInf, err

--- a/traffic_ops/testing/api/v1/user_test.go
+++ b/traffic_ops/testing/api/v1/user_test.go
@@ -296,8 +296,8 @@ func GetTestUsers(t *testing.T) {
 
 func GetTestAdminUsers(t *testing.T) {
 	adminUsers, _, err := TOSession.GetUsersByRole("admin")
-	if err != nil {
-		t.Errorf("cannot GET users by role: %v", err)
+	if err != nil || len(adminUsers) == 0 || adminUsers[0].RoleName == nil {
+		t.Errorf("cannot GET admin users by role: %v", err)
 	}
 	if *adminUsers[0].RoleName != "admin" {
 		t.Errorf("users get: RoleName expected %v actual %v", "admin", *adminUsers[0].RoleName)
@@ -306,8 +306,8 @@ func GetTestAdminUsers(t *testing.T) {
 
 func GetTestOperationsUsers(t *testing.T) {
 	opsUsers, _, err := TOSession.GetUsersByRole("operations")
-	if err != nil {
-		t.Errorf("cannot GET users by role: %v", err)
+	if err != nil || len(opsUsers) == 0 || opsUsers[0].RoleName == nil {
+		t.Errorf("cannot GET operations users by role: %v", err)
 	}
 	if *opsUsers[0].RoleName != "operations" {
 		t.Errorf("users get: RoleName expected %v actual %v", "operations", *opsUsers[0].RoleName)

--- a/traffic_ops/testing/api/v1/user_test.go
+++ b/traffic_ops/testing/api/v1/user_test.go
@@ -297,7 +297,7 @@ func GetTestUsers(t *testing.T) {
 func GetTestAdminUsers(t *testing.T) {
 	adminUsers, _, err := TOSession.GetUsersByRole("admin")
 	if err != nil {
-		t.Errorf("cannot GET users: %v", err)
+		t.Errorf("cannot GET users by role: %v", err)
 	}
 	if *adminUsers[0].RoleName != "admin" {
 		t.Errorf("users get: RoleName expected %v actual %v", "admin", *adminUsers[0].RoleName)
@@ -307,7 +307,7 @@ func GetTestAdminUsers(t *testing.T) {
 func GetTestOperationsUsers(t *testing.T) {
 	opsUsers, _, err := TOSession.GetUsersByRole("operations")
 	if err != nil {
-		t.Errorf("cannot GET users: %v", err)
+		t.Errorf("cannot GET users by role: %v", err)
 	}
 	if *opsUsers[0].RoleName != "operations" {
 		t.Errorf("users get: RoleName expected %v actual %v", "operations", *opsUsers[0].RoleName)

--- a/traffic_ops/testing/api/v1/user_test.go
+++ b/traffic_ops/testing/api/v1/user_test.go
@@ -36,6 +36,8 @@ func TestUsers(t *testing.T) {
 		UserSelfUpdateTest(t)
 		UserUpdateOwnRoleTest(t)
 		GetTestUsers(t)
+		GetTestAdminUsers(t)
+		GetTestOperationsUsers(t)
 		GetTestUserCurrent(t)
 		UserTenancyTest(t)
 	})
@@ -289,6 +291,26 @@ func GetTestUsers(t *testing.T) {
 	_, _, err := TOSession.GetUsers()
 	if err != nil {
 		t.Errorf("cannot GET users: %v", err)
+	}
+}
+
+func GetTestAdminUsers(t *testing.T) {
+	adminUsers, _, err := TOSession.GetUsersByRole("admin")
+	if err != nil {
+		t.Errorf("cannot GET users: %v", err)
+	}
+	if *adminUsers[0].RoleName != "admin" {
+		t.Errorf("users get: RoleName expected %v actual %v", "admin", *adminUsers[0].RoleName)
+	}
+}
+
+func GetTestOperationsUsers(t *testing.T) {
+	adminUsers, _, err := TOSession.GetUsersByRole("operations")
+	if err != nil {
+		t.Errorf("cannot GET users: %v", err)
+	}
+	if *adminUsers[0].RoleName != "operations" {
+		t.Errorf("users get: RoleName expected %v actual %v", "admin", *adminUsers[0].RoleName)
 	}
 }
 

--- a/traffic_ops/testing/api/v1/user_test.go
+++ b/traffic_ops/testing/api/v1/user_test.go
@@ -310,7 +310,7 @@ func GetTestOperationsUsers(t *testing.T) {
 		t.Errorf("cannot GET users: %v", err)
 	}
 	if *opsUsers[0].RoleName != "operations" {
-		t.Errorf("users get: RoleName expected %v actual %v", "admin", *opsUsers[0].RoleName)
+		t.Errorf("users get: RoleName expected %v actual %v", "operations", *opsUsers[0].RoleName)
 	}
 }
 

--- a/traffic_ops/testing/api/v1/user_test.go
+++ b/traffic_ops/testing/api/v1/user_test.go
@@ -296,20 +296,26 @@ func GetTestUsers(t *testing.T) {
 
 func GetTestAdminUsers(t *testing.T) {
 	adminUsers, _, err := TOSession.GetUsersByRole("admin")
-	if err != nil || len(adminUsers) == 0 || adminUsers[0].RoleName == nil {
-		t.Errorf("cannot GET admin users by role: %v", err)
-	}
-	if *adminUsers[0].RoleName != "admin" {
+	if err != nil {
+		t.Errorf("users get: Cannot GET admin users by role: %v", err)
+	} else if len(adminUsers) == 0 {
+		t.Errorf("users get: No admin users found")
+	} else if adminUsers[0].RoleName == nil {
+		t.Errorf("users get: RoleName property doesn't exist")
+	} else if *adminUsers[0].RoleName != "admin" {
 		t.Errorf("users get: RoleName expected %v actual %v", "admin", *adminUsers[0].RoleName)
 	}
 }
 
 func GetTestOperationsUsers(t *testing.T) {
 	opsUsers, _, err := TOSession.GetUsersByRole("operations")
-	if err != nil || len(opsUsers) == 0 || opsUsers[0].RoleName == nil {
-		t.Errorf("cannot GET operations users by role: %v", err)
-	}
-	if *opsUsers[0].RoleName != "operations" {
+	if err != nil {
+		t.Errorf("users get: Cannot GET operations users by role: %v", err)
+	} else if len(opsUsers) == 0 {
+		t.Errorf("users get: No operations users found")
+	} else if opsUsers[0].RoleName == nil {
+		t.Errorf("users get: RoleName property doesn't exist")
+	} else if *opsUsers[0].RoleName != "operations" {
 		t.Errorf("users get: RoleName expected %v actual %v", "operations", *opsUsers[0].RoleName)
 	}
 }

--- a/traffic_ops/testing/api/v1/user_test.go
+++ b/traffic_ops/testing/api/v1/user_test.go
@@ -305,12 +305,12 @@ func GetTestAdminUsers(t *testing.T) {
 }
 
 func GetTestOperationsUsers(t *testing.T) {
-	adminUsers, _, err := TOSession.GetUsersByRole("operations")
+	opsUsers, _, err := TOSession.GetUsersByRole("operations")
 	if err != nil {
 		t.Errorf("cannot GET users: %v", err)
 	}
-	if *adminUsers[0].RoleName != "operations" {
-		t.Errorf("users get: RoleName expected %v actual %v", "admin", *adminUsers[0].RoleName)
+	if *opsUsers[0].RoleName != "operations" {
+		t.Errorf("users get: RoleName expected %v actual %v", "admin", *opsUsers[0].RoleName)
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -83,6 +83,7 @@ func (user *TOUser) NewReadObj() interface{} {
 func (user *TOUser) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 	return map[string]dbhelpers.WhereColumnInfo{
 		"id":       dbhelpers.WhereColumnInfo{"u.id", api.IsInt},
+		"role":     dbhelpers.WhereColumnInfo{"r.name", nil},
 		"tenant":   dbhelpers.WhereColumnInfo{"t.name", nil},
 		"username": dbhelpers.WhereColumnInfo{"u.username", nil},
 	}

--- a/traffic_portal/app/src/common/modules/form/role/FormRoleController.js
+++ b/traffic_portal/app/src/common/modules/form/role/FormRoleController.js
@@ -17,9 +17,13 @@
  * under the License.
  */
 
-var FormRoleController = function(roles, $scope, formUtils, locationUtils) {
+var FormRoleController = function(roles, $scope, $location, formUtils, locationUtils) {
 
 	$scope.role = roles[0];
+
+	$scope.viewUsers = function() {
+		$location.path($location.path() + '/users');
+	};
 
 	$scope.navigateToPath = locationUtils.navigateToPath;
 
@@ -29,5 +33,5 @@ var FormRoleController = function(roles, $scope, formUtils, locationUtils) {
 
 };
 
-FormRoleController.$inject = ['roles', '$scope', 'formUtils', 'locationUtils'];
+FormRoleController.$inject = ['roles', '$scope', '$location', 'formUtils', 'locationUtils'];
 module.exports = FormRoleController;

--- a/traffic_portal/app/src/common/modules/form/role/form.role.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/role/form.role.tpl.html
@@ -25,7 +25,7 @@ under the License.
         </ol>
         <div class="pull-right" role="group" ng-show="!settings.isNew">
             <button class="btn btn-primary" title="View Capabilities" ng-show="enforceCapabilities" ng-click="viewCapabilities()">View Capabilities</button>
-            <!--<button class="btn btn-primary" title="View Users" ng-click="viewUsers()">View Users</button>-->
+            <button class="btn btn-primary" title="View Users" ng-click="viewUsers()">View Users</button>
         </div>
         <div class="clearfix"></div>
     </div>

--- a/traffic_portal/app/src/common/modules/form/role/form.role.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/role/form.role.tpl.html
@@ -24,8 +24,8 @@ under the License.
             <li class="active">{{roleName}}</li>
         </ol>
         <div class="pull-right" role="group" ng-show="!settings.isNew">
-            <button class="btn btn-primary" title="View Capabilities" ng-show="enforceCapabilities" ng-click="viewCapabilities()">View Capabilities</button>
-            <button class="btn btn-primary" title="View Users" ng-click="viewUsers()">View Users</button>
+            <button type="button" class="btn btn-primary" title="View Capabilities" ng-show="enforceCapabilities" ng-click="viewCapabilities()">View Capabilities</button>
+            <button type="button" class="btn btn-primary" title="View Users" ng-click="viewUsers()">View Users</button>
         </div>
         <div class="clearfix"></div>
     </div>

--- a/traffic_portal/app/src/modules/private/roles/users/index.js
+++ b/traffic_portal/app/src/modules/private/roles/users/index.js
@@ -30,8 +30,8 @@ module.exports = angular.module('trafficPortal.private.roles.users', [])
 							roles: function($stateParams, roleService) {
 								return roleService.getRoles({ id: $stateParams.roleId });
 							},
-							roleUsers: function($stateParams, userService) {
-								return userService.getUsers({ roleId: $stateParams.roleId });
+							roleUsers: function(roles, userService) {
+								return userService.getUsers({ role: roles[0].name });
 							}
 						}
 					}


### PR DESCRIPTION
## What does this PR (Pull Request) do?

1. allows the result of GET /api/users to be filtered by role
2. Provides a view in TP to view users of a specific role

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?

1. Run the TO API tests and ensure they all pass
2. Launch TP and navigate to `User Admin > Roles > Role` and then select `View Users` and ensure that only users of the selected role are displayed.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
