### PR TITLE
Fix atstccfg hosting.config including inactive DS

### DIFF
--- a/traffic_ops/ort/atstccfg/cfgfile/hostingdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/hostingdotconfig.go
@@ -133,20 +133,24 @@ func GetConfigFileServerHostingDotConfig(cfg config.TCCfg, serverNameOrID string
 	}
 
 	hostingDSes := map[tc.DeliveryServiceName]tc.DeliveryServiceNullable{}
+
+	isMid := strings.HasPrefix(server.Type, tc.MidTypePrefix)
+
 	for _, ds := range dses {
 		if ds.Active == nil || ds.Type == nil || ds.XMLID == nil || ds.CDNID == nil || ds.ID == nil || ds.OrgServerFQDN == nil {
 			// some DSes have nil origins. I think MSO? TODO: verify
 			continue
 		}
 
-		if !ServerHostingDotConfigMidIncludeInactive && !*ds.Active {
+		if !*ds.Active && ((!isMid && !ServerHostingDotConfigEdgeIncludeInactive) || (isMid && !ServerHostingDotConfigMidIncludeInactive)) {
 			continue
 		}
+
 		if *ds.CDNID != server.CDNID {
 			continue
 		}
 
-		if strings.HasPrefix(server.Type, tc.MidTypePrefix) {
+		if isMid {
 			if !strings.HasSuffix(string(*ds.Type), tc.DSTypeLiveNationalSuffix) {
 				continue
 			}


### PR DESCRIPTION
Fixes atstccfg hosting.config generation to include inactive DSes for
edges, but not mids. Matches Perl behavior.

This is more important than it might appear, because a common Ops
procedure is to ORT "badass" new OFFLINE servers, to get their
proper config before setting them REPORTED.

No tests, because this is in the data loading and not the logic it can't reasonably be unit tested, and ORT doesn't have an integration test framework yet. I've manually tested, and verified all our production servers diff identical to the old Perl.
No docs, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?

Run ORT or `atstccfg` and verify OFFLINE edges are inserted into hosting.config.

## If this is a bug fix, what versions of Traffic Control are affected?
- master


## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

