### PR TITLE
Fixed segfault in DS Request validation

### DIFF
--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -275,7 +275,7 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 		validation.Field(&details.Customer, validation.Required),
 		validation.Field(&details.DeepCachingType, validation.By(
 			func(t interface{}) error {
-				if t == nil {
+				if t == (*DeepCachingType)(nil) {
 					return errors.New("deepCachingType: required")
 				}
 				if *t.(*DeepCachingType) == DeepCachingTypeInvalid {
@@ -285,7 +285,7 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 			})),
 		validation.Field(&details.DeliveryProtocol, validation.By(
 			func(p interface{}) error {
-				if p == nil {
+				if p == (*Protocol)(nil) {
 					return errors.New("deliveryProtocol: required")
 				}
 				if *p.(*Protocol) == ProtocolInvalid {
@@ -295,28 +295,28 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 			})),
 		validation.Field(&details.HasNegativeCachingCustomization, validation.By(
 			func(h interface{}) error {
-				if h == nil {
+				if h == (*bool)(nil) {
 					return errors.New("hasNegativeCachingCustomization: required")
 				}
 				return nil
 			})),
 		validation.Field(&details.HasOriginACLWhitelist, validation.By(
 			func(h interface{}) error {
-				if h == nil {
+				if h == (*bool)(nil) {
 					return errors.New("hasNegativeCachingCustomization: required")
 				}
 				return nil
 			})),
 		validation.Field(&details.HasOriginDynamicRemap, validation.By(
 			func(h interface{}) error {
-				if h == nil {
+				if h == (*bool)(nil) {
 					return errors.New("hasNegativeCachingCustomization: required")
 				}
 				return nil
 			})),
 		validation.Field(&details.HasSignedURLs, validation.By(
 			func(h interface{}) error {
-				if h == nil {
+				if h == (*bool)(nil) {
 					return errors.New("hasNegativeCachingCustomization: required")
 				}
 				return nil
@@ -324,7 +324,7 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 		validation.Field(&details.MaxLibrarySizeEstimate, validation.Required),
 		validation.Field(&details.OriginHeaders, validation.By(
 			func(h interface{}) error {
-				if h == nil {
+				if h == (*OriginHeaders)(nil) {
 					return nil
 				}
 				if len(*h.(*OriginHeaders)) < 1 {
@@ -341,7 +341,7 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 		validation.Field(&details.RoutingName, validation.Required),
 		validation.Field(&details.RoutingType, validation.By(
 			func(t interface{}) error {
-				if t == nil || *(t.(*DSType)) == "" {
+				if t == (*DSType)(nil) || *(t.(*DSType)) == "" {
 					return errors.New("routingType: required")
 				}
 				*t.(*DSType) = DSTypeFromString(string(*t.(*DSType)))


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4215

Fixes a segfault in the validation of DS Request requests where fields are `nil` but are not equal to `nil` for typing reasons.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Run associated tests, make requests to the `deliveryservices/request` endpoint with e.g. an empty request object (`{}`) and observe that no internal server error is returned (unless SMTP isn't enabled in your environment in which case you'll need to look at the TO logs to be sure that the error is because SMTP isn't enabled and not because there was a segmentation fault).

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**