### PR TITLE
Hotfix for broken docs link

### DIFF
--- a/docs/source/api/staticdnsentries.rst
+++ b/docs/source/api/staticdnsentries.rst
@@ -142,7 +142,7 @@ Request Structure
 
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the :abbr:`FQDN (Fully Qualified Domain Name)` which shall resolve to ``address``
-:ttl:               The :term:`TTL (Time To Live)` of this static DNS entry in seconds
+:ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
 
 .. code-block:: http


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

One of my earlier PRs (I think #4154) introduced a broken link in the docs for `/staticdnsentries` - this fixes it.


## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Build the docs, verify the warning `term not in glossary: ttl (time to live)` does not appear in the output (but also should have no errors or warnings).

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.0 RC1

## The following criteria are ALL met by this PR

- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**