### PR TITLE
deprecate 'servers/totals'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [unreleased]
+### Added
+
+### Changed
+
+### Deprecated/Removed
+- The TO API `servers/totals` endpoint is now deprecated
+
 ## [4.0.0] - 2019-12-16
 ### Added
 - Traffic Router: TR now generates a self-signed certificate at startup and uses it as the default TLS cert.

--- a/docs/source/api/servers_totals.rst
+++ b/docs/source/api/servers_totals.rst
@@ -18,6 +18,7 @@
 ******************
 ``servers/totals``
 ******************
+.. deprecated:: 1.1
 
 ``GET``
 =======
@@ -53,7 +54,12 @@ Response Structure
 	Whole-Content-Sha512: J4wy8zf+LX44/qWIbvziWHCcDZpUJ9GOpOVUVqPbVHUCh1V19o8FnE7T+V0639n9Xyw9k10NcaGIqASA+O9Rzg==
 	Content-Length: 305
 
-	{ "response": [
+	{	"alerts": [
+		{
+			"level": "warning",
+			"text": "This endpoint is deprecated"
+		}],
+		"response": [
 		{
 			"count": 1,
 			"type": "EDGE"

--- a/traffic_ops/app/lib/API/Server.pm
+++ b/traffic_ops/app/lib/API/Server.pm
@@ -784,7 +784,7 @@ sub totals {
 		);
 	}
 
-	return $self->success( \@data );
+	return $self->success_deprecate( \@data );
 
 }
 

--- a/traffic_ops/app/lib/MojoPlugins/Response.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Response.pm
@@ -119,6 +119,19 @@ sub register {
 		}
 	);
 
+	# Success (200) - With a JSON response and a deprecated message
+	$app->renderer->add_helper(
+		success_deprecate => sub {
+			my $self    = shift || confess("Call on an instance of MojoPlugins::Response");
+			my $data    = shift || confess("Please supply a response body hash.");
+
+			my $builder ||= MojoPlugins::Response::Builder->new($self, @_);
+			my @alerts_response = ({$LEVEL_KEY => $WARNING_LEVEL, $TEXT_KEY => "This endpoint is deprecated"});
+
+			return $self->render( $STATUS_KEY => 200, $JSON_KEY => { $ALERTS_KEY => \@alerts_response, $RESPONSE_KEY => $data } );
+		}
+	);
+
 	$app->renderer->add_helper(
 		deprecation => sub {
 			my $self = shift || confess("Call on an instance of MojoPlugins::Response");


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3825 

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Manually test the TO-PERL `servers/totals` endpoint to see the deprecation warning

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
