### PR TITLE
Add TM dir to TO-Go unit test container

### DIFF
--- a/traffic_ops/app/bin/tests/Dockerfile-golangtest
+++ b/traffic_ops/app/bin/tests/Dockerfile-golangtest
@@ -17,6 +17,7 @@ ARG DIR=github.com/apache/trafficcontrol
 
 ADD traffic_ops /go/src/$DIR/traffic_ops
 ADD lib /go/src/$DIR/lib
+ADD traffic_monitor /go/src/$DIR/traffic_monitor
 ADD vendor /go/src/$DIR/vendor
 
 WORKDIR /go/src/$DIR/traffic_ops/traffic_ops_golang


### PR DESCRIPTION
## What does this PR (Pull Request) do?
A newly re-written TO API route uses structs from the TM packages, so the TM dir needs to be added to the TO-Go unit test container.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- TO test container

## What is the best way to verify this PR?
```docker-compose -f traffic_ops/app/bin/tests/docker-compose.yml up --build unit_golang``` and verify the container builds successfully and UTs pass.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
