### PR TITLE
TP: unregisters resize event handler when navigating away from dashboard

### DIFF
--- a/traffic_portal/app/src/common/modules/chart/bps/ChartBPSController.js
+++ b/traffic_portal/app/src/common/modules/chart/bps/ChartBPSController.js
@@ -128,7 +128,11 @@ var ChartBPSController = function(deliveryService, $scope, $state, $timeout, $fi
 	};
 
 	var registerResizeListener = function() {
-		$(window).resize(plotChart);
+		$(window).bind("resize", plotChart);
+	};
+
+	var unregisterResizeListener = function() {
+		$(window).unbind("resize", plotChart);
 	};
 
 	var plotChart = function() {
@@ -147,6 +151,7 @@ var ChartBPSController = function(deliveryService, $scope, $state, $timeout, $fi
 
 	$scope.$on("$destroy", function() {
 		killIntervals();
+		unregisterResizeListener();
 	});
 
 	angular.element(document).ready(function () {

--- a/traffic_portal/app/src/common/modules/chart/httpStatus/ChartHttpStatusController.js
+++ b/traffic_portal/app/src/common/modules/chart/httpStatus/ChartHttpStatusController.js
@@ -160,7 +160,11 @@ var ChartHttpStatusController = function(deliveryService, $scope, $state, $timeo
 	};
 
 	var registerResizeListener = function() {
-		$(window).resize(plotChart);
+		$(window).bind("resize", plotChart);
+	};
+
+	var unregisterResizeListener = function() {
+		$(window).unbind("resize", plotChart);
 	};
 
 	var plotChart = function() {
@@ -180,6 +184,7 @@ var ChartHttpStatusController = function(deliveryService, $scope, $state, $timeo
 
 	$scope.$on("$destroy", function() {
 		killIntervals();
+		unregisterResizeListener();
 	});
 
 	angular.element(document).ready(function () {

--- a/traffic_portal/app/src/common/modules/chart/tps/ChartTPSController.js
+++ b/traffic_portal/app/src/common/modules/chart/tps/ChartTPSController.js
@@ -128,7 +128,11 @@ var ChartTPSController = function(deliveryService, $scope, $state, $timeout, $fi
 	};
 
 	var registerResizeListener = function() {
-		$(window).resize(plotChart);
+		$(window).bind("resize", plotChart);
+	};
+
+	var unregisterResizeListener = function() {
+		$(window).unbind("resize", plotChart);
 	};
 
 	var plotChart = function() {
@@ -147,6 +151,7 @@ var ChartTPSController = function(deliveryService, $scope, $state, $timeout, $fi
 
 	$scope.$on("$destroy", function() {
 		killIntervals();
+		unregisterResizeListener();
 	});
 
 	angular.element(document).ready(function () {

--- a/traffic_portal/app/src/common/modules/widget/cdnChart/WidgetCDNChartController.js
+++ b/traffic_portal/app/src/common/modules/widget/cdnChart/WidgetCDNChartController.js
@@ -168,7 +168,11 @@ var WidgetCDNChartController = function(cdn, $scope, $timeout, $filter, $q, $int
 	};
 
 	var registerResizeListener = function() {
-		$(window).resize(plotChart);
+		$(window).bind("resize", plotChart);
+	};
+
+	var unregisterResizeListener = function() {
+		$(window).unbind("resize", plotChart);
 	};
 
 	var plotChart = function() {
@@ -187,6 +191,7 @@ var WidgetCDNChartController = function(cdn, $scope, $timeout, $filter, $q, $int
 
 	$scope.$on("$destroy", function() {
 		killIntervals();
+		unregisterResizeListener();
 	});
 
 	angular.element(document).ready(function () {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This PR fixes an issue where the resize event handler attached to the window for the purpose of resizing dashboard charts is never removed. This causes errors in the browser console as the resize event continues to attempt to replot a chart that doesn't exist when you are not on the dashboard page. 

No tests, docs or changelog entry.

- [x] This PR fixes #4243 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
- Open the browser console
- Login to TP and navigate to the dashboard
- Resize the window and ensure the charts all resize
- Navigate away from the dashboard
- Resize the window and ensure no console errors appear in the browser console.

## If this is a bug fix, what versions of Traffic Control are affected?
- master (bbcf027)
- 3.1.0
- 4.0.0 (RC1)


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
