### PR TITLE
Fixed improperly labeled 'httpRoute' field in api_capabilities responses

### DIFF
--- a/docs/source/api/api_capabilities.rst
+++ b/docs/source/api/api_capabilities.rst
@@ -18,7 +18,7 @@
 ********************
 ``api_capabilities``
 ********************
-Deals with the capabilities that may be associated with API endpoints and methods. These capabilities are assigned to "roles", of which a user may have one or more. Capabilities support "wildcarding" or "globbing" using asterisks to group multiple routes into a single capability
+Deals with the capabilities that may be associated with API endpoints and methods. These capabilities are assigned to :term:`Roles`, of which a user may have one or more. Capabilities support "wildcarding" or "globbing" using asterisks to group multiple routes into a single capability
 
 ``GET``
 =======

--- a/lib/go-tc/api_capabilities.go
+++ b/lib/go-tc/api_capabilities.go
@@ -23,7 +23,7 @@ package tc
 type APICapability struct {
 	ID          int       `json:"id" db:"id"`
 	HTTPMethod  string    `json:"httpMethod" db:"http_method"`
-	Route       string    `json:"route" db:"route"`
+	Route       string    `json:"httpRoute" db:"route"`
 	Capability  string    `json:"capability" db:"capability"`
 	LastUpdated TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4244

Also includes a single-word edit of the documentation.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Ensure all existing unit and API/client integration tests still pass, ensure the docs build without warnings.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR

- [x] I have explained why tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**