### PR TITLE
Fix atscfg errors to include DS name

### DIFF
--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -125,14 +125,14 @@ func GetServerConfigRemapDotConfigForMid(
 		}
 		if ds.CacheURL != nil && *ds.CacheURL != "" {
 			if hasCacheURL {
-				log.Errorln("DeliveryService qstring_ignore and cacheurl both add cacheurl, but ATS cacheurl doesn't work correctly with multiple entries! Adding anyway!")
+				log.Errorln("Making remap.config for Delivery Service '" + ds.Name + "': qstring_ignore and cacheurl both add cacheurl, but ATS cacheurl doesn't work correctly with multiple entries! Adding anyway!")
 			}
 			midRemap += ` @plugin=cacheurl.so @pparam=` + CacheURLConfigFileName(ds.Name)
 		}
 
 		if ds.ProfileID != nil && len(profilesCacheKeyConfigParams[*ds.ProfileID]) > 0 {
 			if hasCacheKey {
-				log.Errorln("DeliveryService qstring_ignore and cachekey params both add cachekey, but ATS cachekey doesn't work correctly with multiple entries! Adding anyway!")
+				log.Errorln("Making remap.config for Delivery Service '" + ds.Name + "': qstring_ignore and cachekey params both add cachekey, but ATS cachekey doesn't work correctly with multiple entries! Adding anyway!")
 			}
 			midRemap += ` @plugin=cachekey.so`
 			for name, val := range profilesCacheKeyConfigParams[*ds.ProfileID] {
@@ -240,7 +240,7 @@ func BuildRemapLine(cacheURLConfigParams map[string]string, atsMajorVersion int,
 			text += ` @plugin=regex_remap.so @pparam=` + dqsFile
 		} else if *ds.QStringIgnore == tc.QueryStringIgnoreIgnoreInCacheKeyAndPassUp {
 			if _, globalExists := cacheURLConfigParams["location"]; globalExists {
-				log.Warnln("qstring_ignore == 1, but global cacheurl.config param exists, so skipping remap rename config_file=cacheurl.config parameter")
+				log.Warnln("Making remap.config for Delivery Service '" + ds.Name + "': qstring_ignore == 1, but global cacheurl.config param exists, so skipping remap rename config_file=cacheurl.config parameter")
 			} else {
 				qstr, addedCacheURL, addedCacheKey := GetQStringIgnoreRemap(atsMajorVersion)
 				if addedCacheURL {
@@ -256,14 +256,14 @@ func BuildRemapLine(cacheURLConfigParams map[string]string, atsMajorVersion int,
 
 	if ds.CacheURL != nil && *ds.CacheURL != "" {
 		if hasCacheURL {
-			log.Errorln("DeliveryService qstring_ignore and cacheurl both add cacheurl, but ATS cacheurl doesn't work correctly with multiple entries! Adding anyway!")
+			log.Errorln("Making remap.config for Delivery Service '" + ds.Name + "': qstring_ignore and cacheurl both add cacheurl, but ATS cacheurl doesn't work correctly with multiple entries! Adding anyway!")
 		}
 		text += ` @plugin=cacheurl.so @pparam=` + CacheURLConfigFileName(ds.Name)
 	}
 
 	if len(cacheKeyConfigParams) > 0 {
 		if hasCacheKey {
-			log.Errorln("DeliveryService qstring_ignore and params both add cachekey, but ATS cachekey doesn't work correctly with multiple entries! Adding anyway!")
+			log.Errorln("Making remap.config for Delivery Service '" + ds.Name + "': qstring_ignore and params both add cachekey, but ATS cachekey doesn't work correctly with multiple entries! Adding anyway!")
 		}
 		text += ` @plugin=cachekey.so`
 


### PR DESCRIPTION
Will make debugging errors much easier.

- [x] This PR is not related to any other Issue

No new tests, unit tests already exist. Changes only affect error logs, which don't affect config generation.
No docs, no interface change.
No changelog, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests. Run `atstccfg` for remap.config, verify config generates as expected. Generate remap.config on CDN with both `qstring_ignore` and `cachekey` Parameters, verify error log contains the DS name and "remap.config."

## If this is a bug fix, what versions of Traffic Control are affected?

- 4.0.x (RC0)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information