### PR TITLE
Fix Traffic Ops Perl endpoints to always be numbers

### DIFF
--- a/traffic_ops/app/lib/API/ServerCheck.pm
+++ b/traffic_ops/app/lib/API/ServerCheck.pm
@@ -74,7 +74,7 @@ sub read {
 	my @data;
 	while ( my $server = $rs->next ) {
 		my $v;
-		$v->{id}		= $server->id;
+		$v->{id}		= $server->id + 0;
 		$v->{hostName}		= $server->host_name;
 		$v->{profile}		= $server->profile->name;
 		$v->{adminState}	= $server->status->name;
@@ -84,7 +84,11 @@ sub read {
 		$v->{revalPending}	= \$server->reval_pending;
 		foreach my $col (qw/aa ab ac ad ae af ag ah ai aj ak al am an ao ap aq ar at au av aw ax ay az ba bb bc bd be bf/) {
 			if ( defined( $mapping{$col} ) && defined( $server->servercheck ) ) {
-				$v->{checks}->{ $mapping{$col} } = $server->servercheck->$col();
+				my $server_check_val = $server->servercheck->$col();
+				if ( defined($server_check_val) ) {
+					$server_check_val = $server_check_val + 0; # coerce to a number, if it's not null
+				}
+				$v->{checks}->{ $mapping{$col} } = $server_check_val;
 			}
 		}
 		push( @data, $v );

--- a/traffic_ops/app/lib/API/ToExtension.pm
+++ b/traffic_ops/app/lib/API/ToExtension.pm
@@ -30,7 +30,7 @@ sub index {
 		next unless ( $row->type->name ne 'CHECK_EXTENSION_OPEN_SLOT' );    # Open slots are not in the list
 		push(
 			@data, {
-				id                     => $row->id,
+				id                     => $row->id + 0,
 				name                   => $row->name,
 				version                => $row->version,
 				info_url               => $row->info_url,
@@ -62,7 +62,7 @@ sub index {
 
 		push(
 			@data, {
-				id                     => $row->id,
+				id                     => $row->id + 0,
 				name                   => $info->{name},
 				version                => $info->{version},
 				info_url               => $info->{info_url},


### PR DESCRIPTION
Fixes the serverchecks and to_extensions endpoints to always return
numbers, as they should.

Apparently, certain versions of Perl or its libraries sometimes turn
the numbers into strings. This forces it to always be a number.

These two endpoints are specifically used in the API tests. This
makes the API tests pass correctly.

We should probably make all numbers in all endpoints do this; but
because Perl is going away, that may not be worth it. But these two
at least let devs verify all API tests pass, instead of potentially
having to ignore failures and hope their code changes didn't cause
other failures in the same tests.

- [x] This PR is not related to any other Issue

No new tests, tests already exist, and the entire purpose of this PR is to fix them.
No docs, no interface change.
No changelog, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?

Run API tests. Request serverchecks and to_extensions endpoints, verify response is still correct.

## If this is a bug fix, what versions of Traffic Control are affected?

- everything ever. But it's only a bug if the user has certain versions of Perl installed, and it's unclear what causes those versions to be installed or when or which versions. Probably.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information