### PR TITLE
TP: ensures that the DS view state is not reloaded until the DS update is complete

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -202,10 +202,13 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, type, 
 				if (options.status.id == $scope.COMPLETE) {
 					createDeliveryServiceUpdateRequest(dsRequest, options.comment, true).then(
 						function() {
-							deliveryServiceService.updateDeliveryService(deliveryService);
-						}).then(function() {
-							$state.reload(); // reloads all the resolves for the view
-							messageModel.setMessages([ { level: 'success', text: 'Delivery Service [ ' + deliveryService.xmlId + ' ] updated' } ], false);
+							deliveryServiceService.updateDeliveryService(deliveryService).
+								then(
+									function() {
+										$state.reload(); // reloads all the resolves for the view
+										messageModel.setMessages([ { level: 'success', text: 'Delivery Service [ ' + deliveryService.xmlId + ' ] updated' } ], false);
+									}
+								);
 						}).catch(function(fault) {
 							$anchorScroll(); // scrolls window to top
 							messageModel.setMessages(fault.data.alerts, false);


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4269

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?

- Turn dsRequests on in traffic_portal_properties.json
- Set the overrideRole in traffic_portal_properties.json (i.e. admin)
- Login to TP as a user with the overrideRole
- Update an existing delivery service. For example, change the routing name.
- Fulfill the ds request immediately
- Notice that the routing name has changed in the Delivery Service URL(s) section

## If this is a bug fix, what versions of Traffic Control are affected?

- master (0c04aac)
- 4.0.0 (RC1)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
