### PR TITLE
Fix atstccfg logging non-errors

### DIFF
--- a/traffic_ops/ort/atstccfg/cfgfile/cacheurldotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cacheurldotconfig.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/toreq"
@@ -62,8 +61,6 @@ func GetConfigFileCDNCacheURL(cfg config.TCCfg, cdnNameOrID string, fileName str
 		return "", errors.New("getting delivery service servers: " + err.Error())
 	}
 
-	log.Errorf("gcfccu dss: %v\n", len(dss))
-
 	dssMap := map[int][]int{} // map[dsID]serverID
 	for _, dss := range dss {
 		if dss.Server == nil || dss.DeliveryService == nil {
@@ -76,6 +73,10 @@ func GetConfigFileCDNCacheURL(cfg config.TCCfg, cdnNameOrID string, fileName str
 	for _, ds := range dses {
 		if ds.ID == nil {
 			continue // TODO warn
+		}
+		// ANY_MAP and STEERING DSes don't have origins, and thus can't be put into the cacheurl config.
+		if ds.Type != nil && (*ds.Type == tc.DSTypeAnyMap || *ds.Type == tc.DSTypeSteering) {
+			continue
 		}
 		if len(dssMap[*ds.ID]) == 0 {
 			continue

--- a/traffic_ops/ort/atstccfg/cfgfile/sslmulticertdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/sslmulticertdotconfig.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/toreq"
 )
@@ -48,7 +49,16 @@ func GetConfigFileCDNSSLMultiCertDotConfig(cfg config.TCCfg, cdnNameOrID string)
 		return "", errors.New("getting delivery services: " + err.Error())
 	}
 
-	cfgDSes := atscfg.DeliveryServicesToSSLMultiCertDSes(dses)
+	filteredDSes := []tc.DeliveryServiceNullable{}
+	for _, ds := range dses {
+		// ANY_MAP and STEERING DSes don't have origins, and thus can't be put into the ssl config.
+		if ds.Type != nil && (*ds.Type == tc.DSTypeAnyMap || *ds.Type == tc.DSTypeSteering) {
+			continue
+		}
+		filteredDSes = append(filteredDSes, ds)
+	}
+
+	cfgDSes := atscfg.DeliveryServicesToSSLMultiCertDSes(filteredDSes)
 
 	txt := atscfg.MakeSSLMultiCertDotConfig(cdnName, toToolName, toURL, cfgDSes)
 	return txt, nil


### PR DESCRIPTION
Fixes atstccfg logging errors that weren't errors.

Unit tests exist, verifying behavior of atscfg. ORT doesn't have an integration testing framework, so the atstccfg side can't have tests yet. I manually tested and verified all appropriate DSes were still present in generated files, and no incorrect errors were logged.
No changelog, no interface change.
No docs, no interface change.
 
- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT or atstccfg, check atstccfg logs (atstccfg is configurable; ORT puts them in /tmp/ort/), verify no spurious errors are logged, verify affected files (ssl_multicert.config and cacheurl.config) generate correctly.

## If this is a bug fix, what versions of Traffic Control are affected?
- 4.0.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information