### PR TITLE
Fixed wrong import order and Py3-incompatibility

### DIFF
--- a/misc/kickstart_create_network_line.py
+++ b/misc/kickstart_create_network_line.py
@@ -19,10 +19,10 @@
     network links in /sys/class/net/*, then emits a ks.cfg network line.
     '''
 
+from __future__ import print_function
 import os
 import re
 
-from __future__ import print_function
 
 global TO_LOG
 # This "logs" to stdout which is captured during kickstart
@@ -170,8 +170,7 @@ def useable_interfaces(net_devs, nc, iface_speed):
         #  if not it is anyway.
         # Thus we are doing a bond of some sort.
         # This gives us the fastest interfaces first:
-        speeds = net_devs.keys()
-        speeds.sort(reverse=True)
+        speeds = [k for k in sorted(net_devs.keys(), reverse=True)]
         fastest = speeds[0]
         # Walk through "speeds" and take the first one that has more than one
         # interface. This will only set iface_list if there are 2 or more interfaces:


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4285 

Changes the import order to be correct (`__future__` first) and fixes an incompatibility with Python 3 (tested CPython versions 3.8.1 and 2.7.17).

## Which Traffic Control components are affected by this PR?
 - Tools (`kickstart_create_network_line.py`)
No documentation because this tool is undocumented - and should (hopefully) be on its way out.

## What is the best way to verify this PR?
Try to run the script with a valid network.cfg file - if you don't have one it'll crash. If you don't have one that sets `BOND_DEVICE` and `BOND_OPTIONS` it'll crash. Probably others.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.0 (RC1)

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**