### PR TITLE
Added --hostname option to ORT.py

### DIFF
--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -207,6 +207,11 @@ Arguments and Flags
 	that :program:`traffic_ops_ort` cannot be run using the new call signature unless this value is
 	defined, either on the command line or in the execution environment.
 
+.. option:: --hostname HOSTNAME
+
+	Causes ORT to request configuration information for the server named ``HOSTNAME`` instead of
+	detecting the server's actual hostname. This is primarily useful for testing purposes.
+
 Environment Variables
 ---------------------
 .. envvar:: TO_URL
@@ -325,7 +330,7 @@ Module Contents
 ===============
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __author__  = "Brennan Fieck"
 
 import argparse
@@ -452,6 +457,9 @@ def main() -> int:
 	                    help="wait a random number between 0 and <dispersion> before starting.",
 	                    type=int,
 	                    default=300)
+	parser.add_argument("--hostname",
+	                    help="Pretend to be a server with the provided hostname instead of using "
+	                         "this server's actual hostname in communications with Traffic Ops")
 	parser.add_argument("--login_dispersion",
 	                    help="wait a random number between 0 and <login_dispersion> before login.",
 	                    type=int,

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/configuration.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/configuration.py
@@ -117,8 +117,12 @@ class Configuration():
 
 		logging.info("Distribution detected as: '%s'", DISTRO)
 
-		self.hostname = (platform.node().split('.')[0], platform.node())
-		logging.info("Hostname detected as: '%s'", self.fullHostname)
+		if not args.hostname:
+			self.hostname = (platform.node().split('.')[0], platform.node())
+			logging.info("Hostname detected as: '%s'", self.fullHostname)
+		else:
+			self.hostname = (args.hostname, args.hostname)
+			logging.info("Hostname set to: '%s'", self.fullHostname)
 
 		try:
 			self.mode = Configuration.Modes[args.Mode.upper()]


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Adds a `--hostname` option that allows you to run ORT as though you were a different server.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops ORT (Python)

## What is the best way to verify this PR?
Run CDN-in-a-Box (since that's the only place ORT.py is used - feel free to test in a real environment and let me know how it goes) and observe that it still works because these changes

## The following criteria are ALL met by this PR

- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**