### PR TITLE
Fix atstccfg caching

### DIFF
--- a/traffic_ops/ort/atstccfg/toreq/caching.go
+++ b/traffic_ops/ort/atstccfg/toreq/caching.go
@@ -77,7 +77,7 @@ func WriteCacheJSON(tempDir string, cacheFileName string, obj interface{}) {
 
 	objPath := filepath.Join(tempDir, cacheFileName)
 	// Use os.OpenFile, not os.Create, in order to set perms to 0600 - cookies allow login, therefore the file MUST only allow access by the current user, for security reasons
-	objFile, err := os.OpenFile(objPath, os.O_RDWR|os.O_CREATE, 0600)
+	objFile, err := os.OpenFile(objPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		log.Errorln("creating object cache file '" + objPath + "': " + err.Error())
 		return
@@ -116,6 +116,7 @@ func GetJSONObjFromFile(tempDir string, cacheFileName string, cacheFileMaxAge ti
 	}
 
 	if err := json.Unmarshal(bts, obj); err != nil {
+		log.Errorln("GetJSONObjFromFile loaded '" + cacheFileName + "' but failed to parse JSON: " + err.Error())
 		return errors.New("unmarshalling object from file '" + objPath + "':" + err.Error())
 	}
 

--- a/traffic_ops/ort/atstccfg/toreq/caching_test.go
+++ b/traffic_ops/ort/atstccfg/toreq/caching_test.go
@@ -1,0 +1,68 @@
+package toreq
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriteCacheJSON(t *testing.T) {
+	type Obj struct {
+		S string `json:"s"`
+	}
+
+	fileName := "TestWriteCacheJSON.json"
+	tmpDir := os.TempDir()
+	filePath := filepath.Join(tmpDir, fileName)
+	defer os.Remove(filePath)
+
+	{
+		largeObj := Obj{
+			S: `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+    Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris. Integer in mauris eu nibh euismod gravida. Duis ac tellus et risus vulputate vehicula. Donec lobortis risus a elit. Etiam tempor. Ut ullamcorper, ligula eu tempor congue, eros est euismod turpis, id tincidunt sapien risus a quam. Maecenas fermentum consequat mi. Donec fermentum. Pellentesque malesuada nulla a mi. Duis sapien sem, aliquet nec, commodo eget, consequat quis, neque. Aliquam faucibus, elit ut dictum aliquet, felis nisl adipiscing sapien, sed malesuada diam lacus eget erat. Cras mollis scelerisque nunc. Nullam arcu. Aliquam consequat. Curabitur augue lorem, dapibus quis, laoreet et, pretium ac, nisi. Aenean magna nisl, mollis quis, molestie eu, feugiat in, orci. In hac habitasse platea dictumst.
+`,
+		}
+
+		WriteCacheJSON(tmpDir, fileName, largeObj)
+		loadedLargeObj := Obj{}
+		if err := GetJSONObjFromFile(tmpDir, fileName, time.Hour, &loadedLargeObj); err != nil {
+			t.Fatalf("GetJSONObjFromFile large error expected nil, actual: " + err.Error())
+		} else if largeObj.S != loadedLargeObj.S {
+			t.Fatalf("GetJSONObjFromFile expected %+v actual %+v\n", largeObj.S, loadedLargeObj.S)
+		}
+	}
+
+	{
+		// Write a smaller object to the same file, to make sure it properly truncates, and doesn't leave old text lying around (resulting in malformed json)
+		smallObj := Obj{S: `foo`}
+		WriteCacheJSON(tmpDir, fileName, smallObj)
+		loadedSmallObj := Obj{}
+		if err := GetJSONObjFromFile(tmpDir, fileName, time.Hour, &loadedSmallObj); err != nil {
+			t.Fatalf("GetJSONObjFromFile small error expected nil, actual: " + err.Error())
+		} else if smallObj.S != loadedSmallObj.S {
+			t.Fatalf("GetJSONObjFromFile expected %+v actual %+v\n", smallObj.S, loadedSmallObj.S)
+		}
+	}
+}


### PR DESCRIPTION
Fixes atstccfg caching, which was breaking when the new cache file
was smaller than the old, because it wasn't truncating the file.

Also changes deliveryservice_server to always fetch all Servers and
Delivery Services and cache them, because it's faster for an ORT
run to reuse and cache them all.

Testing a complete `badass` on a largeish CDN, old Perl ORT against Perl TO takes ~4m, atstccfg without fixed caching takes ~5m, with this fix takes ~2.5m. So, this probably isn't a huge deal. But good to fix.

Includes unit tests.
No docs, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?

Run unit tests. Run ORT, verify it's still correct and faster than without this PR.

## If this is a bug fix, what versions of Traffic Control are affected?

It's in master, but it's not really a "bug" in that it still produces the right output, just not as fast as it could.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information