### PR TITLE
Added documentation for atstccfg

### DIFF
--- a/docs/source/tools/atstccfg.rst
+++ b/docs/source/tools/atstccfg.rst
@@ -22,6 +22,8 @@ atstccfg
 ********
 :program:`atstccfg` is a tool for generating configuration files server-side on :abbr:`ATC (Apache Traffic Control)` cache servers. It stores its generated/cached files in ``/tmp/atstccfg_cache/`` for re-use.
 
+.. warning:: :program:`atstccfg` does not have a stable command-line interface, it can and will change without warning. Scripts should avoid calling it for the time being.
+
 The source code for :program:`atstccfg` may be found in :atc-file:`traffic_ops/ort/atstccfg`, and the Go module reference is :atc-godoc:`traffic_ops/ort/atstccfg`.
 
 Usage

--- a/docs/source/tools/atstccfg.rst
+++ b/docs/source/tools/atstccfg.rst
@@ -72,7 +72,7 @@ Options
 
 	If given, SSL certificate errors will be ignored when communicating with Traffic Ops.
 
-	.. caution:: For (hopefully) obvious reasons, the use of this option in production environments is discouraged.
+	.. caution:: The use of this option in production environments is discouraged.
 
 .. option:: -t TIMEOUT, --traffic-ops-timeout-milliseconds TIMEOUT
 

--- a/docs/source/tools/atstccfg.rst
+++ b/docs/source/tools/atstccfg.rst
@@ -22,13 +22,13 @@ atstccfg
 ********
 :program:`atstccfg` is a tool for generating configuration files server-side on :abbr:`ATC (Apache Traffic Control)` cache servers. It stores its generated/cached files in ``/tmp/atstccfg_cache/`` for re-use.
 
-.. warning:: :program:`atstccfg` does not have a stable command-line interface, it can and will change without warning. Scripts should avoid calling it for the time being.
+.. warning:: :program:`atstccfg` does not have a stable command-line interface, it can and will change without warning. Scripts should avoid calling it for the time being, as its only intended caller is :term:`ORT`.
 
 The source code for :program:`atstccfg` may be found in :atc-file:`traffic_ops/ort/atstccfg`, and the Go module reference is :atc-godoc:`traffic_ops/ort/atstccfg`.
 
 Usage
 =====
-``atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l]``
+``atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l] [-h] [-v]``
 
 Options
 -------
@@ -47,6 +47,10 @@ Options
 .. option:: -i INFO_LOCATION, --log-location-info INFO_LOCATION
 
 	The file location to which to log information messages. Respects the special string constants of :atc-godoc:`lib/go-log`. Default: 'stderr'
+
+.. option:: -h, --help
+
+	Print usage information and exit.
 
 .. option:: -l, --list-plugins
 

--- a/docs/source/tools/atstccfg.rst
+++ b/docs/source/tools/atstccfg.rst
@@ -1,0 +1,104 @@
+..
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. program: atstccfg
+
+.. _atstccfg:
+
+********
+atstccfg
+********
+:program:`atstccfg` is a tool for generating configuration files server-side on :abbr:`ATC (Apache Traffic Control)` cache servers. It stores its generated/cached files in ``/tmp/atstccfg_cache/`` for re-use.
+
+The source code for :program:`atstccfg` may be found in :atc-file:`traffic_ops/ort/atstccfg`, and the Go module reference is :atc-godoc:`traffic_ops/ort/atstccfg`.
+
+Usage
+=====
+``atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l]``
+
+Options
+-------
+.. option:: -a AGE, --cache-file-max-age-seconds AGE
+
+	Sets the maximum age - in seconds - a cached response can be in order to be considered "fresh" - older files will be re-generated and cached. Default: 60
+
+.. option:: -e ERROR_LOCATION, --log-location-error ERROR_LOCATION
+
+	The file location to which to log errors. Respects the special string constants of :atc-godoc:`lib/go-log`. Default: 'stderr'
+
+.. option:: -g, --print-generated-files
+
+	If given, the names of files generated (and not proxied to Traffic Ops) will be printed to stdout, then :program:`atstccfg` will exit.
+
+.. option:: -i INFO_LOCATION, --log-location-info INFO_LOCATION
+
+	The file location to which to log information messages. Respects the special string constants of :atc-godoc:`lib/go-log`. Default: 'stderr'
+
+.. option:: -l, --list-plugins
+
+	List the loaded plugins and then exit.
+
+.. option:: -n, --no-cache
+
+	If given, existing cache files will not be used. Cache files will still be created, existing ones just won't be used.
+
+.. option:: -P TO_PASSWORD, --traffic-ops-password TO_PASSWORD
+
+	Authenticate using this password - if not given, atstccfg will attempt to use the value of the :envvar:`TO_PASS` environment variable.
+
+.. option:: -r N, --num-retries N
+
+	The number of times to retry getting a file if it fails. Default: 5
+
+.. option:: -s, --traffic-ops-insecure
+
+	If given, SSL certificate errors will be ignored when communicating with Traffic Ops.
+
+	.. caution:: For (hopefully) obvious reasons, the use of this option in production environments is discouraged.
+
+.. option:: -t TIMEOUT, --traffic-ops-timeout-milliseconds TIMEOUT
+
+	Sets the timeout - in milliseconds - for requests made to Traffic Ops. Default: 10000
+
+.. option:: -u TO_URL, --traffic-ops-url TO_URL
+
+	Request this URL, e.g. ``https://trafficops.infra.ciab.test/servers/edge/configfiles/ats``. If not given, :program:`atstccfg` will attempt to use the value of the :envvar:`TO_URL` environment variable.
+
+.. option:: -U TO_USER, --traffic-ops-user TO_USER
+
+	Authenticate as the user ``TO_USER`` - if not given, :program:`atstccfg` will attempt to use the value of the :envvar:`TO_USER` environment variable.
+
+.. option:: -v, --version
+
+	Print version information and exit.
+
+.. option:: -w WARNING_LOCATION, --log-location-warning WARNING_LOCATION
+
+	The file location to which to log warnings. Respects the special string constants of :atc-godoc:`lib/go-log`. Default: 'stderr'
+
+Environment Variables
+---------------------
+
+.. envvar:: TO_USER
+
+	Defines the user as whom to authenticate with Traffic Ops. This is only used if :option:`-U`/:option:`--traffic-ops-user` is not given.
+
+.. envvar:: TO_PASS
+
+	Defines the password to use when authenticating with Traffic Ops. This is only used if :option:`-P`/:option:`--traffic-ops-password` is not given.
+
+.. envvar:: TO_URL
+
+	Defines the *full* URL to be requested. This is only used if :option:`-u`/:option:`--traffic-ops-url` is not given.

--- a/docs/source/tools/index.rst
+++ b/docs/source/tools/index.rst
@@ -22,8 +22,6 @@ This is a living list of tools used to interact with, test, and develop for the 
 
 .. toctree::
 	:maxdepth: 2
+	:glob:
 
-	compare
-	python_client
-	traffic_vault_util
-	toaccess
+	*

--- a/traffic_ops/ort/atstccfg/.gitignore
+++ b/traffic_ops/ort/atstccfg/.gitignore
@@ -1,0 +1,1 @@
+atstccfg

--- a/traffic_ops/ort/atstccfg/README.md
+++ b/traffic_ops/ort/atstccfg/README.md
@@ -1,0 +1,43 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+# atstccfg
+atstccfg is a tool for generating configuration files server-side on ATC cache servers.
+
+## Usage
+```
+atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l]
+```
+The available options are:
+```
+-a, --cache-file-max-age-seconds                                Sets the maximum age - in seconds - a cached response can be in order to be considered "fresh" - older files will be re-generated and cached. Default: 60
+-e ERROR_LOCATION, --log-location-error ERROR_LOCATION          The file location to which to log errors. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
+-g, --print-generated-files                                     If given, the names of files generated (and not proxied to Traffic Ops) will be printed to stdout, then atstccfg will exit.
+-i INFO_LOCATION, --log-location-info INFO_LOCATION             The file location to which to log information messages. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
+-l, --list-plugins                                              List the loaded plugins and then exit.
+-n, --no-cache                                                  If given, existing cache files will not be used. Cache files will still be created, existing ones just won't be used.
+-P TO_PASSWORD                                                  Authenticate using this password - if not given, atstccfg will attempt to use the value of the TO_PASS environment variable
+-r N, --num-retries N                                           The number of times to retry getting a file if it fails. Default: 5
+-s, --traffic-ops-insecure                                      If given, SSL certificate errors will be ignored when communicating with Traffic Ops. NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS.
+-t, --traffic-ops-timeout-milliseconds                          Sets the timeout - in milliseconds - for requests made to Traffic Ops. Default: 10000
+-u TO_URL                                                       Request this URL, e.g. 'https://trafficops.infra.ciab.test/servers/edge/configfiles/ats'
+-U TO_USER                                                      Authenticate as the user TO_USER - if not given, atstccfg will attempt to use the value of the TO_USER environment variable
+-v, --version                                                   Print version information and exit.
+-w WARNING_LOCATION, --log-location-warning WARNING_LOCATION    The file location to which to log warnings. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
+```
+atstccfg caches generated files in /tmp/atstccfg_cache/ for re-use.

--- a/traffic_ops/ort/atstccfg/README.md
+++ b/traffic_ops/ort/atstccfg/README.md
@@ -20,7 +20,7 @@
 atstccfg is a tool for generating configuration files server-side on ATC cache servers.
 
 !!! Warning !!!
-    atstccfg does not have a stable command-line interface, it can and will change without warning. Scripts should avoid calling it for the time being.
+    <strong>atstccfg does not have a stable command-line interface, it can and will change without warning. Scripts should avoid calling it for the time being.</strong>
 
 ## Usage
 ```

--- a/traffic_ops/ort/atstccfg/README.md
+++ b/traffic_ops/ort/atstccfg/README.md
@@ -31,6 +31,7 @@ The available options are:
 -a, --cache-file-max-age-seconds                                Sets the maximum age - in seconds - a cached response can be in order to be considered "fresh" - older files will be re-generated and cached. Default: 60
 -e ERROR_LOCATION, --log-location-error ERROR_LOCATION          The file location to which to log errors. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
 -g, --print-generated-files                                     If given, the names of files generated (and not proxied to Traffic Ops) will be printed to stdout, then atstccfg will exit.
+-h, --help                                                      Print usage information and exit.
 -i INFO_LOCATION, --log-location-info INFO_LOCATION             The file location to which to log information messages. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
 -l, --list-plugins                                              List the loaded plugins and then exit.
 -n, --no-cache                                                  If given, existing cache files will not be used. Cache files will still be created, existing ones just won't be used.

--- a/traffic_ops/ort/atstccfg/README.md
+++ b/traffic_ops/ort/atstccfg/README.md
@@ -19,6 +19,9 @@
 # atstccfg
 atstccfg is a tool for generating configuration files server-side on ATC cache servers.
 
+!!! Warning !!!
+    atstccfg does not have a stable command-line interface, it can and will change without warning. Scripts should avoid calling it for the time being.
+
 ## Usage
 ```
 atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l]

--- a/traffic_ops/ort/atstccfg/atstccfg.go
+++ b/traffic_ops/ort/atstccfg/atstccfg.go
@@ -4,13 +4,14 @@
 //
 // Usage:
 //
-// 	atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l]
+// 	atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l] [-v] [-h]
 //
 // The available options are:
 //
 // 	-a, --cache-file-max-age-seconds                                Sets the maximum age - in seconds - a cached response can be in order to be considered "fresh" - older files will be re-generated and cached. Default: 60
 // 	-e ERROR_LOCATION, --log-location-error ERROR_LOCATION          The file location to which to log errors. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
 // 	-g, --print-generated-files                                     If given, the names of files generated (and not proxied to Traffic Ops) will be printed to stdout, then atstccfg will exit.
+// 	-h, --help                                                      Print usage information and exit.
 // 	-i INFO_LOCATION, --log-location-info INFO_LOCATION             The file location to which to log information messages. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
 // 	-l, --list-plugins                                              List the loaded plugins and then exit.
 // 	-n, --no-cache                                                  If given, existing cache files will not be used. Cache files will still be created, existing ones just won't be used.

--- a/traffic_ops/ort/atstccfg/atstccfg.go
+++ b/traffic_ops/ort/atstccfg/atstccfg.go
@@ -1,3 +1,28 @@
+// atstccfg is a tool for generating configuration files server-side on ATC cache servers.
+//
+// Usage:
+//
+// 	atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l]
+//
+// The available options are:
+//
+// 	-a, --cache-file-max-age-seconds                                Sets the maximum age - in seconds - a cached response can be in order to be considered "fresh" - older files will be re-generated and cached. Default: 60
+// 	-e ERROR_LOCATION, --log-location-error ERROR_LOCATION          The file location to which to log errors. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
+// 	-g, --print-generated-files                                     If given, the names of files generated (and not proxied to Traffic Ops) will be printed to stdout, then atstccfg will exit.
+// 	-i INFO_LOCATION, --log-location-info INFO_LOCATION             The file location to which to log information messages. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
+// 	-l, --list-plugins                                              List the loaded plugins and then exit.
+// 	-n, --no-cache                                                  If given, existing cache files will not be used. Cache files will still be created, existing ones just won't be used.
+// 	-P TO_PASSWORD                                                  Authenticate using this password - if not given, atstccfg will attempt to use the value of the TO_PASS environment variable
+// 	-r N, --num-retries N                                           The number of times to retry getting a file if it fails. Default: 5
+// 	-s, --traffic-ops-insecure                                      If given, SSL certificate errors will be ignored when communicating with Traffic Ops. NOT RECOMMENDED FOR PRODUCTION ENVIRONMENTS.
+// 	-t, --traffic-ops-timeout-milliseconds                          Sets the timeout - in milliseconds - for requests made to Traffic Ops. Default: 10000
+// 	-u TO_URL                                                       Request this URL, e.g. 'https://trafficops.infra.ciab.test/servers/edge/configfiles/ats'
+// 	-U TO_USER                                                      Authenticate as the user TO_USER - if not given, atstccfg will attempt to use the value of the TO_USER environment variable
+// 	-v, --version                                                   Print version information and exit.
+// 	-w WARNING_LOCATION, --log-location-warning WARNING_LOCATION    The file location to which to log warnings. Respects the special string constants of github.com/apache/trafficcontrol/lib/go-log. Default: 'stderr'
+//
+// atstccfg caches generated files in /tmp/atstccfg_cache/ for re-use.
+
 package main
 
 /*

--- a/traffic_ops/ort/atstccfg/atstccfg.go
+++ b/traffic_ops/ort/atstccfg/atstccfg.go
@@ -1,5 +1,7 @@
 // atstccfg is a tool for generating configuration files server-side on ATC cache servers.
 //
+// Warning: atstccfg does not have a stable command-line interface, it can and will change without warning. Scripts should avoid calling it for the time being.
+//
 // Usage:
 //
 // 	atstccfg [-u TO_URL] [-U TO_USER] [-P TO_PASSWORD] [-n] [-r N] [-e ERROR_LOCATION] [-w WARNING_LOCATION] [-i INFO_LOCATION] [-g] [-s] [-t TIMEOUT] [-a MAX_AGE] [-l]

--- a/traffic_ops/ort/atstccfg/config/config.go
+++ b/traffic_ops/ort/atstccfg/config/config.go
@@ -98,11 +98,15 @@ func GetCfg() (Cfg, error) {
 	cacheFileMaxAgeSecondsPtr := flag.IntP("cache-file-max-age-seconds", "a", 60, "Maximum age to use cached files.")
 	versionPtr := flag.BoolP("version", "v", false, "Print version information and exit.")
 	listPluginsPtr := flag.BoolP("list-plugins", "l", false, "Print the list of plugins.")
+	helpPtr := flag.BoolP("help", "h", false, "Print usage information and exit")
 
 	flag.Parse()
 
 	if *versionPtr {
 		fmt.Println(AppName + " v" + Version)
+		os.Exit(0)
+	} else if *helpPtr {
+		flag.PrintDefaults()
 		os.Exit(0)
 	} else if *printGeneratedFilesPtr {
 		return Cfg{PrintGeneratedFiles: true}, nil

--- a/traffic_ops/ort/atstccfg/config/config.go
+++ b/traffic_ops/ort/atstccfg/config/config.go
@@ -21,6 +21,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"net/url"
 	"os"
@@ -95,12 +96,15 @@ func GetCfg() (Cfg, error) {
 	toInsecurePtr := flag.BoolP("traffic-ops-insecure", "s", false, "Whether to ignore HTTPS certificate errors from Traffic Ops. It is HIGHLY RECOMMENDED to never use this in a production environment, but only for debugging.")
 	toTimeoutMSPtr := flag.IntP("traffic-ops-timeout-milliseconds", "t", 10000, "Timeout in seconds for Traffic Ops requests.")
 	cacheFileMaxAgeSecondsPtr := flag.IntP("cache-file-max-age-seconds", "a", 60, "Maximum age to use cached files.")
-
+	versionPtr := flag.BoolP("version", "v", false, "Print version information and exit.")
 	listPluginsPtr := flag.BoolP("list-plugins", "l", false, "Print the list of plugins.")
 
 	flag.Parse()
 
-	if *printGeneratedFilesPtr {
+	if *versionPtr {
+		fmt.Println(AppName + " v" + Version)
+		os.Exit(0)
+	} else if *printGeneratedFilesPtr {
 		return Cfg{PrintGeneratedFiles: true}, nil
 	} else if *listPluginsPtr {
 		return Cfg{ListPlugins: true}, nil


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Adds a documentation page for atstccfg under "Tools", adds a README markdown file to the atstccfg directory, and adds usage documentation to the atstccfg package's GoDoc. Also adds the `-v`/`--version` option which causes it to print out the version and then exit.

### Edit
Also added the `-h`/`--help` option which used to sort-of function using the `flag` package's bultin behavior. Basically, the option is now shown in usage output, and when used causes the exit code to be a success instead of a failure. Still prints to stderr.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops ORT (`atstccfg`)

## What is the best way to verify this PR?
Build and read the documentation to make sure it renders right and is accurate. Build godoc documentation to be sure it renders right and is accurate. Check out the rendered markdown to make sure it renders right and is accurate.
## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**