### PR TITLE
Backport 4.0.x: Fix ip_allow config generation for mids to include rascal servers 

### DIFF
--- a/lib/go-util/net_test.go
+++ b/lib/go-util/net_test.go
@@ -17,6 +17,7 @@ package util
 // When adding symbols, document the RFC and section they correspond to.
 
 import (
+	"fmt"
 	"net"
 	"testing"
 )
@@ -188,5 +189,53 @@ func TestLastIP(t *testing.T) {
 		if expected != actual {
 			t.Errorf("expected: '" + expected + "' actual '" + actual + "'")
 		}
+	}
+}
+
+func TestIP4ToNum(t *testing.T) {
+	var tests = []struct {
+		ip     string
+		number uint32
+	}{
+		{"127.0.0.1", uint32(2130706433)},
+		{"127.0.0.4", uint32(2130706436)},
+		{"127.255.255.255", uint32(2147483647)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			n, err := IP4ToNum(tt.ip)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+
+			}
+			if n != tt.number {
+				t.Errorf("got %v, want %v", n, tt.number)
+			}
+		})
+	}
+}
+
+func TestIP4InRange(t *testing.T) {
+	var tests = []struct {
+		ip      string
+		ipRange string
+		inRange bool
+	}{
+		{"111.0.0.1", "127.0.0.0-127.255.255.255", false},
+		{"128.0.0.1", "127.0.0.0-127.255.255.255", false},
+		{"127.0.0.1", "127.0.0.0-127.255.255.255", true},
+		{"127.0.0.1", "127.0.0.1", true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v in range %v", tt.ip, tt.inRange), func(t *testing.T) {
+			exists, err := IP4InRange(tt.ip, tt.ipRange)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+
+			}
+			if exists != tt.inRange {
+				t.Errorf("got %v, want %v", exists, tt.inRange)
+			}
+		})
 	}
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/ipallowdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/ipallowdotconfig.go
@@ -22,6 +22,7 @@ package cfgfile
 import (
 	"errors"
 	"strconv"
+	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -110,10 +111,10 @@ func GetConfigFileServerIPAllowDotConfig(cfg config.TCCfg, serverNameOrID string
 
 	childServers := map[tc.CacheName]atscfg.IPAllowServer{}
 	for _, sv := range servers {
-		if _, ok := childCGs[sv.Cachegroup]; !ok {
-			continue
+		_, ok := childCGs[sv.Cachegroup]
+		if ok || (strings.HasPrefix(string(serverType), tc.MidTypePrefix) && string(sv.Type) == tc.MonitorTypeName) {
+			childServers[tc.CacheName(sv.HostName)] = atscfg.IPAllowServer{IPAddress: sv.IPAddress, IP6Address: sv.IP6Address}
 		}
-		childServers[tc.CacheName(sv.HostName)] = atscfg.IPAllowServer{IPAddress: sv.IPAddress, IP6Address: sv.IP6Address}
 	}
 
 	txt := atscfg.MakeIPAllowDotConfig(serverName, serverType, toToolName, toURL, fileParams, childServers)

--- a/traffic_ops/testing/api/v14/ip_allow_dot_config_test.go
+++ b/traffic_ops/testing/api/v14/ip_allow_dot_config_test.go
@@ -1,0 +1,125 @@
+package v14
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-util"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const ipAllow = "ip_allow.config"
+
+var (
+	expectedRules = []string{
+		"src_ip=127.0.0.1 action=ip_allow method=ALL\n",
+		"src_ip=::1 action=ip_allow method=ALL\n",
+	}
+	midExpectedRules = []string{
+		"src_ip=10.0.0.0-10.255.255.255 action=ip_allow method=ALL\n",
+		"src_ip=172.16.0.0-172.31.255.255 action=ip_allow method=ALL\n",
+		"src_ip=192.168.0.0-192.168.255.255 action=ip_allow method=ALL\n",
+		"src_ip=::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff action=ip_deny method=ALL\n",
+		"src_ip=::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff action=ip_deny method=ALL\n",
+	}
+	edgeExpectedRules = []string{
+		"src_ip=0.0.0.0-255.255.255.255 action=ip_deny method=PUSH|PURGE|DELETE\n",
+		"src_ip=::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff action=ip_deny method=PUSH|PURGE|DELETE\n",
+	}
+	rascalServerIP = ""
+	rascalRule     = "src_ip=%v action=ip_allow method=ALL"
+)
+
+func TestIPAllowDotConfig(t *testing.T) {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		rascalServerIP = getServer(t, "RASCAL").IPAddress
+		// rascalRule = fmt.Sprintf("src_ip=%v action=ip_allow method=ALL", rascalServer.IPAddress)
+		GetTestIPAllowDotConfig(t)
+		GetTestIPAllowMidDotConfig(t)
+	})
+}
+
+func GetTestIPAllowDotConfig(t *testing.T) {
+	// Get edge server
+	s := getServer(t, "EDGE")
+	output, _, err := TOSession.GetATSServerConfig(s.ID, ipAllow)
+	if err != nil {
+		t.Fatalf("cannot GET server %v config %v: %v", s.HostName, ipAllow, err)
+	}
+	for _, r := range append(expectedRules, edgeExpectedRules...) {
+		if !strings.Contains(output, r) {
+			t.Errorf("expected rule %v not found in ip_allow config", r)
+		}
+	}
+	// Make sure edge does not contain rule for rascal server
+	exists, ipRange := getIPRule(output, rascalServerIP)
+	rascalRule := fmt.Sprintf(rascalRule, ipRange)
+	if exists && strings.Contains(output, rascalRule) {
+		t.Errorf("rascal IP was not supposed to be in an allowed rule: %v", rascalRule)
+	}
+}
+
+func GetTestIPAllowMidDotConfig(t *testing.T) {
+	// Get mid server
+	s := getServer(t, "MID")
+	output, _, err := TOSession.GetATSServerConfig(s.ID, ipAllow)
+	if err != nil {
+		t.Errorf("cannot GET server %v config %v: %v", s.HostName, ipAllow, err)
+	}
+	for _, r := range append(expectedRules, midExpectedRules...) {
+		if !strings.Contains(output, r) {
+			t.Errorf("expected rule %v not found in ip_allow config", r)
+		}
+	}
+
+	// Make sure mid contains an allowed rule that includes the rascal server
+	exists, ipRange := getIPRule(output, rascalServerIP)
+	rascalRule := fmt.Sprintf(rascalRule, ipRange)
+	if !(exists && strings.Contains(output, rascalRule)) {
+		t.Errorf("expected rascal to be include as allowed in mid ip allow config")
+	}
+}
+
+func getServer(t *testing.T, serverType string) tc.Server {
+	v := url.Values{}
+	v.Add("type", serverType)
+	servers, _, err := TOSession.GetServersByType(v)
+	if err != nil {
+		t.Fatalf("cannot GET Server by type %v: %v", serverType, err)
+	}
+	if len(servers) == 0 {
+		t.Fatalf("cannot find any Servers by type %v", serverType)
+	}
+	return servers[0]
+}
+
+// getIPRuleRange returns if the given IP is included in the set of rules and which ip range it is included in
+func getIPRule(rules, ip string) (bool, string) {
+	for _, r := range strings.Split(rules, "\n")[1:] {
+		if !strings.Contains(r, "src_ip") {
+			continue
+		}
+		ipRange := r[7:strings.IndexAny(r, " ")]
+		if exists, _ := util.IP4InRange(ip, ipRange); exists {
+			return true, ipRange
+		}
+	}
+	return false, ""
+}

--- a/traffic_ops/testing/api/v14/tc-fixtures.json
+++ b/traffic_ops/testing/api/v14/tc-fixtures.json
@@ -1828,7 +1828,7 @@
             "routerPortName": "",
             "status": "REPORTED",
             "tcpPort": 81,
-            "type": "TRAFFIC_MONITOR",
+            "type": "RASCAL",
             "updPending": false,
             "xmppId": "",
             "xmppPasswd": "X"
@@ -2301,7 +2301,7 @@
         {
             "description": "Traffic Monitor (Rascal)",
             "lastUpdated": "2018-03-02T19:13:46.832327+00:00",
-            "name": "TRAFFIC_MONITOR",
+            "name": "RASCAL",
             "useInTable": "server"
         }
     ],

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/ipallowdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/ipallowdotconfig.go
@@ -86,7 +86,7 @@ FROM
   JOIN type tp on tp.id = s.type
   JOIN cachegroup cg on cg.id = s.cachegroup
 WHERE
-  (tp.name = '` + tc.MonitorTypeName + `' OR tp.name LIKE '` + tc.EdgeTypePrefix + `%')
+  (tp.name = '` + tc.MonitorTypeName + `' OR ( tp.name LIKE '` + tc.EdgeTypePrefix + `%')
   AND cg.id IN (
     SELECT
       cg2.id
@@ -94,7 +94,7 @@ WHERE
      server s2
      JOIN cachegroup cg2 ON (cg2.parent_cachegroup_id = s2.cachegroup OR cg2.secondary_parent_cachegroup_id = s2.cachegroup)
     WHERE
-      s2.host_name = $1
+      s2.host_name = $1 )
   )
 `
 	rows, err := tx.Query(qry, serverName)


### PR DESCRIPTION
(cherry picked from #4296)
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

Currently in ip_allow.config generation for mids it does not include rascal server IPs causing them to be blocked on attempting to pull astats.

The behavior in the perl implementation is that it would include all servers of type Rascal as well as EDGEs that are in either parent/secondary cachegroup of the mid. https://github.com/apache/trafficcontrol/blob/master/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm#L2210-L2228

### TO GO API Bug
In the go TO implementation it checks the parent/secondary cachegroup on both Rascal AND Edge servers which is a mismatch of logic.

Going from `is rascal OR (is edge AND edge.cg in (mid parent cg, mid secondary cg)` to `is rascal OR edge AND s.cg in (mid parent cg, mid secondary cg)`

### atstccfg Bug
In the atstccfg cfg it does not attempt to include rascal servers 

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops
- atstccfg

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Generate the ip_allow.cfg for a mid and ensure the rascal servers are included via TO API and atstccfg

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master
- 4.0.0 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

