### PR TITLE
[Backport] Fix omitempty issue for ATS config metadata generation (#4306)

### DIFF
--- a/lib/go-tc/ats.go
+++ b/lib/go-tc/ats.go
@@ -44,8 +44,8 @@ type ATSConfigMetaDataInfo struct {
 type ATSConfigMetaDataConfigFile struct {
 	FileNameOnDisk string `json:"fnameOnDisk"`
 	Location       string `json:"location"`
-	APIURI         string `json:"apiUri, omitempty"`
-	URL            string `json:"url, omitempty"`
+	APIURI         string `json:"apiUri,omitempty"`
+	URL            string `json:"url,omitempty"`
 	Scope          string `json:"scope"`
 }
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
If empty, the 'url' and 'apiUri' fields should be omitted from the marshalled JSON, which is how Perl handled it. This fixes ORT's ability to use "URL" parameters which ORT fetches places them on the filesystem like config files. Without this fix, ORT requests `https://mytrafficops.example.com/` since `apiUri == ""` instead of the given URL in the parameter.

- [x] This PR fixes #4299 

## Which Traffic Control components are affected by this PR?
- Traffic Ops
- Traffic Ops ORT

No docs or changelog necessary since this just fixes a regression in the API.

## What is the best way to verify this PR?
Run the Go unit tests (`go test ./lib/... ./traffic_ops/traffic_ops_golang/... ./traffic_monitor/... ./traffic_stats/... ./grove/... ./traffic_ops/ort/atstccfg/...`) and make sure they all pass.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.0-RC1

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
