### PR TITLE
Servers/checks go

### DIFF
--- a/docs/source/api/servers_checks.rst
+++ b/docs/source/api/servers_checks.rst
@@ -1,0 +1,85 @@
+..
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _to-api-servers-checks:
+
+******************
+``servers/checks``
+******************
+Deals with the various checks associated with certain types of servers.
+
+.. seealso:: :ref:`to-check-ext`
+
+``GET``
+=======
+Fetches identifying and meta information as well as "check" values regarding all servers that have a :term:`Type` with a name beginning with "EDGE" or "MID" (ostensibly this is equivalent to all :term:`cache servers`).
+
+:Auth. Required: Yes
+:Roles Required: None
+:Response Type:  Array
+
+Request Structure
+-----------------
+No parameters available.
+
+Response Structure
+------------------
+:adminState:   The name of the server's :term:`Status` - called "adminState" for legacy reasons
+:cacheGroup:   The name of the :term:`Cache Group` to which the server belongs
+:checks:       An optionally present map of the names of "checks" to their values. Only numeric and boolean checks are represented, and boolean checks are represented as integers with ``0`` meaning "false" and ``1`` meaning "true". Will not appear if the server in question has no valued "checks".
+:hostName:     The (short) hostname of the server
+:id:           The server's integral, unique identifier
+:profile:      The name of the :term:`Profile` used by the server
+:revalPending: A boolean that indicates whether or not the server has pending revalidations
+:type:         The name of the server's :term:`Type`
+:updPending:   A boolean that indicates whether or not the server has pending updates
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Thu, 23 Jan 2020 20:00:19 GMT; Max-Age=3600; HttpOnly
+	X-Server-Name: traffic_ops_golang/
+	Date: Thu, 23 Jan 2020 19:00:19 GMT
+	Content-Length: 202
+
+	{ "response": [
+		{
+			"adminState": "REPORTED",
+			"cacheGroup": "CDN_in_a_Box_Edge",
+			"id": 12,
+			"hostName": "edge",
+			"revalPending": false,
+			"profile": "ATS_EDGE_TIER_CACHE",
+			"type": "EDGE",
+			"updPending": false
+		},
+		{
+			"adminState": "REPORTED",
+			"cacheGroup": "CDN_in_a_Box_Mid",
+			"id": 11,
+			"hostName": "mid",
+			"revalPending": false,
+			"profile": "ATS_MID_TIER_CACHE",
+			"type": "MID",
+			"updPending": false
+		}
+	]}

--- a/lib/go-tc/serverchecks.go
+++ b/lib/go-tc/serverchecks.go
@@ -178,7 +178,7 @@ type GenericServerCheck struct {
 
 	// Checks maps arbitrary checks - up to one per "column" (whatever those mean)
 	// done on the server to their values.
-	Checks map[string]int `json:"checks,omitempty"`
+	Checks map[string]*int `json:"checks,omitempty"`
 }
 
 // ServerCheckColumns is a collection of columns associated with a particular

--- a/lib/go-tc/serverchecks.go
+++ b/lib/go-tc/serverchecks.go
@@ -35,35 +35,41 @@ type ServerchecksResponse struct {
 	Response []Servercheck `json:"response"`
 }
 
+// CommonCheckFields is a structure containing all of the fields common to both
+// Serverchecks and GenericServerChecks.
+type CommonCheckFields struct {
+
+	// AdminState is the server's status - called "AdminState" for legacy reasons.
+	AdminState string `json:"adminState"`
+
+	// CacheGroup is the name of the Cache Group to which the server belongs.
+	CacheGroup string `json:"cacheGroup"`
+
+	// ID is the integral, unique identifier of the server.
+	ID int `json:"id"`
+
+	// HostName of the checked server.
+	HostName string `json:"hostName"`
+
+	// RevalPending is a flag that indicates if revalidations are pending for the checked server.
+	RevalPending bool `json:"revalPending"`
+
+	// Profile is the name of the Profile used by the checked server.
+	Profile string `json:"profile"`
+
+	// Type is the name of the server's Type.
+	Type string `json:"type"`
+
+	// UpdPending is a flag that indicates if updates are pending for the checked server.
+	UpdPending bool `json:"updPending"`
+
+}
+
 // Servercheck is a single Servercheck struct for GET response.
 // swagger:model Servercheck
 type Servercheck struct {
 
-	// The Servercheck response data
-	//
-	// Admin state of the checked server
-	AdminState string `json:"adminState"`
-
-	// Cache group the checked server belongs to
-	CacheGroup string `json:"cacheGroup"`
-
-	// ID number of the checked server
-	ID int `json:"id"`
-
-	// Hostname of the checked server
-	HostName string `json:"hostName"`
-
-	// Reval pending flag for checked server
-	RevalPending bool `json:"revalPending"`
-
-	// Profile name of checked server
-	Profile string `json:"profile"`
-
-	// Traffic Control type of the checked server
-	Type string `json:"type"`
-
-	// Update pending flag for the checked server
-	UpdPending bool `json:"updPending"`
+	CommonCheckFields
 
 	// Various check types
 	Checks struct {
@@ -160,4 +166,59 @@ func (scp ServercheckRequestNullable) Validate(tx *sql.Tx) error {
 // ServercheckPostResponse is the response to a Servercheck POST request.
 type ServercheckPostResponse struct {
 	Alerts []Alert `json:"alerts"`
+}
+
+
+// GenericServerCheck represents a server with some associated meta data presented
+// along with its arbitrary "checks". This is unlike a Servercheck in that the
+// represented checks are not known before the time a request is made, and checks
+// with no value are not presented.
+type GenericServerCheck struct {
+	CommonCheckFields
+
+	// Checks maps arbitrary checks - up to one per "column" (whatever those mean)
+	// done on the server to their values.
+	Checks map[string]int `json:"checks,omitempty"`
+}
+
+// ServerCheckColumns is a collection of columns associated with a particular
+// server's "checks". The meaning of the column names is unknown.
+type ServerCheckColumns struct {
+	// ID uniquely identifies a servercheck columns row.
+	ID int `db:"id"`
+
+	// Server is the ID of the server which is associated with these checks.
+	Server int `db:"server"`
+
+	AA *int `db:"aa"`
+	AB *int `db:"ab"`
+	AC *int `db:"ac"`
+	AD *int `db:"ad"`
+	AE *int `db:"ae"`
+	AF *int `db:"af"`
+	AG *int `db:"ag"`
+	AH *int `db:"ah"`
+	AI *int `db:"ai"`
+	AJ *int `db:"aj"`
+	AK *int `db:"ak"`
+	AL *int `db:"al"`
+	AM *int `db:"am"`
+	AN *int `db:"an"`
+	AO *int `db:"ao"`
+	AP *int `db:"ap"`
+	AQ *int `db:"aq"`
+	AR *int `db:"ar"`
+	AT *int `db:"at"`
+	AU *int `db:"au"`
+	AV *int `db:"av"`
+	AW *int `db:"aw"`
+	AX *int `db:"ax"`
+	AY *int `db:"ay"`
+	AZ *int `db:"az"`
+	BA *int `db:"ba"`
+	BB *int `db:"bb"`
+	BC *int `db:"bc"`
+	BD *int `db:"bd"`
+	BE *int `db:"be"`
+	BF *int `db:"bf"`
 }

--- a/traffic_ops/testing/api/v1/serverchecks_test.go
+++ b/traffic_ops/testing/api/v1/serverchecks_test.go
@@ -102,20 +102,34 @@ func UpdateTestServerChecks(t *testing.T) {
 func GetTestServerChecks(t *testing.T) {
 	hostname := testData.Serverchecks[0].HostName
 	// Get server checks
-	serverChecksResp, _, err := TOSession.GetServerChecks()
+	serverChecksResp, alerts, _, err := TOSession.GetServersChecks()
 	if err != nil {
-		t.Fatalf("could not GET serverchecks: %v", err)
+		t.Fatalf("could not GET serverchecks: %v (alerts: %+v)", err, alerts)
 	}
 	found := false
-	for _, sc := range serverChecksResp.Response {
+	for _, sc := range serverChecksResp {
 		if sc.HostName == *hostname {
 			found = true
-			if sc.Checks.ORT != 12 {
-				t.Errorf("%v returned for ORT value servercheck - expected 12", sc.Checks.ORT)
+
+			if sc.Checks == nil {
+				t.Errorf("server %s had no checks - expected it to have at least two", *hostname)
+				break
 			}
 
-			if sc.Checks.ILO != 0 {
-				t.Errorf("%v returned for ILO value servercheck - expected 1", sc.Checks.ILO)
+			if ort, ok := sc.Checks["ORT"]; !ok {
+				t.Error("no 'ORT' servercheck exists - expected it to exist")
+			} else if ort == nil {
+				t.Error("'null' returned for ORT value servercheck - expected pointer to 12")
+			} else if *ort != 12 {
+				t.Errorf("%v returned for ORT value servercheck - expected 12", *ort)
+			}
+
+			if ilo, ok := sc.Checks["ILO"]; !ok {
+				t.Error("no 'ILO' servercheck exists - expected it to exist")
+			} else if ilo == nil {
+				t.Error("'null' returned for ILO value servercheck - expected pointer to 0")
+			} else if *ilo != 0 {
+				t.Errorf("%v returned for ILO value servercheck - expected 0", *ilo)
 			}
 			break
 		}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -314,7 +314,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `servers/totals$`, handlerToFunc(proxyHandler), 0, NoAuth, []middleware.Middleware{}, 2037840835, noPerlBypass},
 
 		//Serverchecks
-		{1.1, http.MethodGet, `servers/checks$`, handlerToFunc(proxyHandler), 0, NoAuth, []middleware.Middleware{}, 1796112922, noPerlBypass},
+		{1.1, http.MethodGet, `servers/checks(/|\.json)?$`, servercheck.ReadServersChecks, auth.PrivLevelReadOnly, Authenticated, nil, 1796112922, perlBypass},
 		{1.1, http.MethodPost, `servercheck/?(\.json)?$`, servercheck.CreateUpdateServercheck, auth.PrivLevelInvalid, Authenticated, nil, 1764281568, perlBypass},
 
 		//Server Details

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -233,7 +233,7 @@ func ReadServersChecks(w http.ResponseWriter, r *http.Request) {
 	columns := make(map[int]tc.ServerCheckColumns)
 	for colRows.Next() {
 		var cols tc.ServerCheckColumns
-		if err = colRows.StructScan(cols); err != nil {
+		if err = colRows.StructScan(&cols); err != nil {
 			sysErr = fmt.Errorf("scanning server checks columns: %v", err)
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
 			return

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -47,8 +47,8 @@ LEFT JOIN profile ON server.profile = profile.id
 LEFT JOIN status ON server.status = status.id
 LEFT JOIN cachegroup ON server.cachegroup = cachegroup.id
 LEFT JOIN type ON server.type = type.id
-WHERE typename LIKE 'MID%' OR type.name LIKE 'EDGE%'
-ORDER BY hostName ASCENDING
+WHERE type.name LIKE 'MID%' OR type.name LIKE 'EDGE%'
+ORDER BY hostName ASC
 `
 
 const serverChecksQuery = `
@@ -215,7 +215,7 @@ func ReadServersChecks(w http.ResponseWriter, r *http.Request) {
 	for extRows.Next() {
 		var shortName string
 		var columnName string
-		if err = extRows.Scan(shortName, columnName); err != nil {
+		if err = extRows.Scan(&shortName, &columnName); err != nil {
 			sysErr = fmt.Errorf("scanning extension: %v", err)
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
 			return
@@ -252,7 +252,7 @@ func ReadServersChecks(w http.ResponseWriter, r *http.Request) {
 	data := []tc.GenericServerCheck{}
 	for serverRows.Next() {
 		var serverInfo tc.GenericServerCheck
-		if err = serverRows.Scan(serverInfo.HostName, serverInfo.ID, serverInfo.Profile, serverInfo.AdminState, serverInfo.CacheGroup, serverInfo.Type, serverInfo.UpdPending, serverInfo.RevalPending); err != nil {
+		if err = serverRows.Scan(&serverInfo.HostName, &serverInfo.ID, &serverInfo.Profile, &serverInfo.AdminState, &serverInfo.CacheGroup, &serverInfo.Type, &serverInfo.UpdPending, &serverInfo.RevalPending); err != nil {
 			sysErr = fmt.Errorf("scanning server info for checks: %v", err)
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
 			return

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -214,13 +214,13 @@ func ReadServersChecks(w http.ResponseWriter, r *http.Request) {
 	}
 	for extRows.Next() {
 		var shortName string
-		var columnName string
-		if err = extRows.Scan(&shortName, &columnName); err != nil {
+		var checkName string
+		if err = extRows.Scan(&shortName, &checkName); err != nil {
 			sysErr = fmt.Errorf("scanning extension: %v", err)
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
 			return
 		}
-		extensions[columnName] = shortName
+		extensions[shortName] = checkName
 	}
 
 	colRows, err := inf.Tx.Queryx(serverChecksQuery)
@@ -260,7 +260,7 @@ func ReadServersChecks(w http.ResponseWriter, r *http.Request) {
 
 		serverCheckCols, ok := columns[serverInfo.ID]
 		if ok {
-			serverInfo.Checks = make(map[string]int)
+			serverInfo.Checks = make(map[string]*int)
 		} else {
 			data = append(data, serverInfo)
 			continue
@@ -269,129 +269,67 @@ func ReadServersChecks(w http.ResponseWriter, r *http.Request) {
 		for colName, checkName := range extensions {
 			switch (colName) {
 			case "aa":
-				if (serverCheckCols.AA != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AA
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AA
 			case "ab":
-				if (serverCheckCols.AB != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AB
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AB
 			case "ac":
-				if (serverCheckCols.AC != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AC
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AC
 			case "ad":
-				if (serverCheckCols.AD != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AD
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AD
 			case "ae":
-				if (serverCheckCols.AE != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AE
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AE
 			case "af":
-				if (serverCheckCols.AF != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AF
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AF
 			case "ag":
-				if (serverCheckCols.AG != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AG
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AG
 			case "ah":
-				if (serverCheckCols.AH != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AH
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AH
 			case "ai":
-				if (serverCheckCols.AI != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AI
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AI
 			case "aj":
-				if (serverCheckCols.AJ != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AJ
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AJ
 			case "ak":
-				if (serverCheckCols.AK != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AK
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AK
 			case "al":
-				if (serverCheckCols.AL != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AL
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AL
 			case "am":
-				if (serverCheckCols.AM != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AM
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AM
 			case "an":
-				if (serverCheckCols.AN != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AN
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AN
 			case "ao":
-				if (serverCheckCols.AO != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AO
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AO
 			case "ap":
-				if (serverCheckCols.AP != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AP
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AP
 			case "aq":
-				if (serverCheckCols.AQ != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AQ
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AQ
 			case "ar":
-				if (serverCheckCols.AR != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AR
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AR
 			case "at":
-				if (serverCheckCols.AT != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AT
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AT
 			case "au":
-				if (serverCheckCols.AU != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AU
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AU
 			case "av":
-				if (serverCheckCols.AV != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AV
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AV
 			case "aw":
-				if (serverCheckCols.AW != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AW
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AW
 			case "ax":
-				if (serverCheckCols.AX != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AX
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AX
 			case "ay":
-				if (serverCheckCols.AY != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AY
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AY
 			case "az":
-				if (serverCheckCols.AZ != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.AZ
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.AZ
 			case "ba":
-				if (serverCheckCols.BA != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.BA
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.BA
 			case "bb":
-				if (serverCheckCols.BB != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.BB
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.BB
 			case "bc":
-				if (serverCheckCols.BC != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.BC
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.BC
 			case "bd":
-				if (serverCheckCols.BD != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.BD
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.BD
 			case "be":
-				if (serverCheckCols.BE != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.BE
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.BE
 			case "bf":
-				if (serverCheckCols.BF != nil) {
-					serverInfo.Checks[checkName] = *serverCheckCols.BF
-				}
+				serverInfo.Checks[checkName] = serverCheckCols.BF
 			}
 		}
 

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -33,6 +33,72 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 )
 
+const serverInfoQuery = `
+SELECT server.host_name AS hostName,
+       server.id AS id,
+       profile.name AS profile,
+       status.name AS adminState,
+       cachegroup.name AS cacheGroup,
+       type.name AS type,
+       server.upd_pending AS updPending,
+       server.reval_pending AS revalPending
+FROM server
+LEFT JOIN profile ON server.profile = profile.id
+LEFT JOIN status ON server.status = status.id
+LEFT JOIN cachegroup ON server.cachegroup = cachegroup.id
+LEFT JOIN type ON server.type = type.id
+WHERE typename LIKE 'MID%' OR type.name LIKE 'EDGE%'
+ORDER BY hostName ASCENDING
+`
+
+const serverChecksQuery = `
+SELECT servercheck.id,
+       servercheck.server,
+       servercheck.aa,
+       servercheck.ab,
+       servercheck.ac,
+       servercheck.ad,
+       servercheck.ae,
+       servercheck.af,
+       servercheck.ag,
+       servercheck.ah,
+       servercheck.ai,
+       servercheck.aj,
+       servercheck.ak,
+       servercheck.al,
+       servercheck.am,
+       servercheck.an,
+       servercheck.ao,
+       servercheck.ap,
+       servercheck.aq,
+       servercheck.ar,
+       servercheck.bf,
+       servercheck.at,
+       servercheck.au,
+       servercheck.av,
+       servercheck.aw,
+       servercheck.ax,
+       servercheck.ay,
+       servercheck.az,
+       servercheck.ba,
+       servercheck.bb,
+       servercheck.bc,
+       servercheck.bd,
+       servercheck.be
+FROM servercheck
+`
+
+const extensionsQuery = `
+SELECT to_extension.servercheck_column_name,
+       to_extension.servercheck_short_name
+FROM to_extension
+LEFT JOIN type ON type.id = to_extension.type
+WHERE (type.name = 'CHECK_EXTENSION_BOOL' OR
+      type.name = 'CHECK_EXTENSION_NUM') AND
+      to_extension.servercheck_short_name IS NOT NULL AND
+      to_extension.servercheck_column_name IS NOT NULL
+`
+
 // CreateUpdateServercheck handles creating or updating an existing servercheck
 func CreateUpdateServercheck(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
@@ -110,8 +176,8 @@ func createUpdateServerCheck(sid int, colName string, value int, tx *sql.Tx) err
 
 	insertUpdateQuery := fmt.Sprintf(`
 INSERT INTO servercheck (server, %[1]s)
-VALUES ($1, $2) 
-ON CONFLICT (server) 
+VALUES ($1, $2)
+ON CONFLICT (server)
 DO UPDATE SET %[1]s = EXCLUDED.%[1]s`, colName)
 
 	result, err := tx.Exec(insertUpdateQuery, sid, value)
@@ -127,4 +193,210 @@ DO UPDATE SET %[1]s = EXCLUDED.%[1]s`, colName)
 	}
 
 	return nil
+}
+
+// ReadServersChecks is the handler for GET requests for /servers/checks
+func ReadServersChecks(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	tx := inf.Tx.Tx
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	extensions := make(map[string]string)
+	extRows, err := tx.Query(extensionsQuery)
+	if err != nil {
+		sysErr = fmt.Errorf("querying for extensions: %v", err)
+		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
+		return
+	}
+	for extRows.Next() {
+		var shortName string
+		var columnName string
+		if err = extRows.Scan(shortName, columnName); err != nil {
+			sysErr = fmt.Errorf("scanning extension: %v", err)
+			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
+			return
+		}
+		extensions[columnName] = shortName
+	}
+
+	colRows, err := inf.Tx.Queryx(serverChecksQuery)
+	if err != nil {
+		sysErr = fmt.Errorf("Querying server checks columns: %v", err)
+		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
+		return
+	}
+
+	columns := make(map[int]tc.ServerCheckColumns)
+	for colRows.Next() {
+		var cols tc.ServerCheckColumns
+		if err = colRows.StructScan(cols); err != nil {
+			sysErr = fmt.Errorf("scanning server checks columns: %v", err)
+			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
+			return
+		}
+
+		columns[cols.Server] = cols
+	}
+
+	serverRows, err := tx.Query(serverInfoQuery)
+	if err != nil {
+		sysErr = fmt.Errorf("Querying server info for checks: %v", err)
+		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
+		return
+	}
+
+	data := []tc.GenericServerCheck{}
+	for serverRows.Next() {
+		var serverInfo tc.GenericServerCheck
+		if err = serverRows.Scan(serverInfo.HostName, serverInfo.ID, serverInfo.Profile, serverInfo.AdminState, serverInfo.CacheGroup, serverInfo.Type, serverInfo.UpdPending, serverInfo.RevalPending); err != nil {
+			sysErr = fmt.Errorf("scanning server info for checks: %v", err)
+			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
+			return
+		}
+
+		serverCheckCols, ok := columns[serverInfo.ID]
+		if ok {
+			serverInfo.Checks = make(map[string]int)
+		} else {
+			data = append(data, serverInfo)
+			continue
+		}
+
+		for colName, checkName := range extensions {
+			switch (colName) {
+			case "aa":
+				if (serverCheckCols.AA != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AA
+				}
+			case "ab":
+				if (serverCheckCols.AB != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AB
+				}
+			case "ac":
+				if (serverCheckCols.AC != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AC
+				}
+			case "ad":
+				if (serverCheckCols.AD != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AD
+				}
+			case "ae":
+				if (serverCheckCols.AE != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AE
+				}
+			case "af":
+				if (serverCheckCols.AF != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AF
+				}
+			case "ag":
+				if (serverCheckCols.AG != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AG
+				}
+			case "ah":
+				if (serverCheckCols.AH != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AH
+				}
+			case "ai":
+				if (serverCheckCols.AI != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AI
+				}
+			case "aj":
+				if (serverCheckCols.AJ != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AJ
+				}
+			case "ak":
+				if (serverCheckCols.AK != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AK
+				}
+			case "al":
+				if (serverCheckCols.AL != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AL
+				}
+			case "am":
+				if (serverCheckCols.AM != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AM
+				}
+			case "an":
+				if (serverCheckCols.AN != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AN
+				}
+			case "ao":
+				if (serverCheckCols.AO != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AO
+				}
+			case "ap":
+				if (serverCheckCols.AP != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AP
+				}
+			case "aq":
+				if (serverCheckCols.AQ != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AQ
+				}
+			case "ar":
+				if (serverCheckCols.AR != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AR
+				}
+			case "at":
+				if (serverCheckCols.AT != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AT
+				}
+			case "au":
+				if (serverCheckCols.AU != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AU
+				}
+			case "av":
+				if (serverCheckCols.AV != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AV
+				}
+			case "aw":
+				if (serverCheckCols.AW != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AW
+				}
+			case "ax":
+				if (serverCheckCols.AX != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AX
+				}
+			case "ay":
+				if (serverCheckCols.AY != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AY
+				}
+			case "az":
+				if (serverCheckCols.AZ != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.AZ
+				}
+			case "ba":
+				if (serverCheckCols.BA != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.BA
+				}
+			case "bb":
+				if (serverCheckCols.BB != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.BB
+				}
+			case "bc":
+				if (serverCheckCols.BC != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.BC
+				}
+			case "bd":
+				if (serverCheckCols.BD != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.BD
+				}
+			case "be":
+				if (serverCheckCols.BE != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.BE
+				}
+			case "bf":
+				if (serverCheckCols.BF != nil) {
+					serverInfo.Checks[checkName] = *serverCheckCols.BF
+				}
+			}
+		}
+
+		data = append(data, serverInfo)
+	}
+
+	api.WriteResp(w, r, data)
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #3827

Rewrites `/servers/checks` to Go and provides all associated documentation and tests.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Run the tests it came with, manually create server checks and then request `/servers/checks`, build and read the documentation.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**