### PR TITLE
Fixed inconsistent indentation in API docs

### DIFF
--- a/docs/source/api/profiles_id_export.rst
+++ b/docs/source/api/profiles_id_export.rst
@@ -77,23 +77,21 @@ Response Structure
 	Transfer-Encoding: gzip
 
 
-	{
-	  "profile": {
-        "name": "GLOBAL",
-        "description": "Global Traffic Ops profile",
-        "cdn": "ALL",
-        "type": "UNK_PROFILE"
-      },
-	  "parameters": [
-        {
-            "config_file": "global",
-            "name": "tm.instance_name",
-            "value": "Traffic Ops CDN"
-        },
-        {
-            "config_file": "global",
-            "name": "tm.toolname",
-            "value": "Traffic Ops"
-        }
-	  ]
-	}
+	{ "profile": {
+		"name": "GLOBAL",
+		"description": "Global Traffic Ops profile",
+		"cdn": "ALL",
+		"type": "UNK_PROFILE"
+	},
+	"parameters": [
+		{
+			"config_file": "global",
+			"name": "tm.instance_name",
+			"value": "Traffic Ops CDN"
+		},
+		{
+			"config_file": "global",
+			"name": "tm.toolname",
+			"value": "Traffic Ops"
+		}
+	]}

--- a/docs/source/api/profiles_import.rst
+++ b/docs/source/api/profiles_import.rst
@@ -56,26 +56,24 @@ Request Structure
 	Cookie: mojolicious=...
 	Content-Type: application/json
 
-	{
-	  "profile": {
-        "name": "GLOBAL",
-        "description": "Global Traffic Ops profile",
-        "cdn": "ALL",
-        "type": "UNK_PROFILE"
-      },
-	  "parameters": [
-        {
-            "config_file": "global",
-            "name": "tm.instance_name",
-            "value": "Traffic Ops CDN"
-        },
-        {
-            "config_file": "global",
-            "name": "tm.toolname",
-            "value": "Traffic Ops"
-        }
-	  ]
-	}
+	{ "profile": {
+		"name": "GLOBAL",
+		"description": "Global Traffic Ops profile",
+		"cdn": "ALL",
+		"type": "UNK_PROFILE"
+	},
+	"parameters": [
+		{
+			"config_file": "global",
+			"name": "tm.instance_name",
+			"value": "Traffic Ops CDN"
+		},
+		{
+			"config_file": "global",
+			"name": "tm.toolname",
+			"value": "Traffic Ops"
+		}
+	]}
 
 Response Structure
 ------------------
@@ -101,18 +99,16 @@ Response Structure
 	Transfer-Encoding: gzip
 
 
-	{
-      "alerts": [
-        {
-            "level": "success",
-            "text": "Profile imported [ Global ] with 2 new and 0 existing parameters"
-        }
-      ],
-      "response": {
-        "cdn": "ALL",
-        "name": "Global",
-        "id": 18,
-        "type": "UNK_PROFILE",
-        "description": "Global Traffic Ops profile"
-      }
-	}
+	{ "alerts": [
+		{
+			"level": "success",
+			"text": "Profile imported [ Global ] with 2 new and 0 existing parameters"
+		}
+	],
+	"response": {
+		"cdn": "ALL",
+		"name": "Global",
+		"id": 18,
+		"type": "UNK_PROFILE",
+		"description": "Global Traffic Ops profile"
+	}}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Fixes some inconsistent indentation in the request and response examples in the documentation for the `/profiles/import` and `/profiles/{{ID}}/export` endpoints.

So far as I know this has no complications with our officially supported versions of Sphinx and Pygments, but it causes rendering issues and therefore broken highlighting in some older versions. Plus, it's inconsistent!

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Build the documentation, observe there's no warnings or errors, check the generated output for `/profiles/import` and `/profiles/{{ID}}/export` and verify that syntax is properly highlighted in all request and response examples.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0 (RC2)

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**