### PR TITLE
Fixed incorrect /cachegroupparameters docs, added caveat

### DIFF
--- a/docs/source/api/cachegroupparameters.rst
+++ b/docs/source/api/cachegroupparameters.rst
@@ -68,7 +68,7 @@ Response Structure
 
 ``POST``
 ========
-Assign :term:`Parameter`\ (s) to :term:`Cache Group`\ (s).
+Assign :term:`Parameter`\ (s) to :term:`Cache Group`\ (s). :term:`Parameters` already assigned to one or more :term:`Profiles` cannot be assigned to :term:`Cache Groups`.
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"
@@ -93,15 +93,14 @@ The request data can take the form of either a single object or an array of one 
 	Content-Type: application/json
 
 	{
-		"cachegroupId": 8,
+		"cacheGroupId": 8,
 		"parameterId": 124
 	}
 
 Response Structure
 ------------------
-:cachegroup:   A string containing the :ref:`cache-group-name` of the :term:`Cache Group`
-:last_updated: Date and time of last modification in an ISO-like format
-:parameter:    An integer that is the :term:`Parameter`'s :ref:`parameter-id`
+:cacheGroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` to which a :term:`Parameter` has been assigned
+:parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
  	:caption: Response Example


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes is not related to any Issue

The docs for `/cachegroupparameters` had a typo in the POST-method request example, and incorrect field descriptions for the response example. This fixes that, and also adds documentation for the restriction that Parameters assigned to Profiles cannot be assigned to Cache Groups.

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Build the documentation, verify its accuracy and that it properly renders.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0 (RC2)

## The following criteria are ALL met by this PR

- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**