### PR TITLE
Added deprecation notice to /hwinfo/dtdata

### DIFF
--- a/traffic_ops/app/lib/API/HwInfo.pm
+++ b/traffic_ops/app/lib/API/HwInfo.pm
@@ -119,7 +119,7 @@ sub data {
 	my %itotal_records = ( iTotalDisplayRecords => $total_records );
 	%data = %{ merge( \%data, \%itotal_records ) };
 
-	$self->render( json => \%data );
+	$self->deprecation_with_no_alternative(200, json => \%data );
 }
 
 1;

--- a/traffic_ops/app/lib/MojoPlugins/Response.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Response.pm
@@ -170,6 +170,23 @@ sub register {
 		}
 	);
 
+	$app->renderer->add_helper(
+		deprecation_with_no_alternative => sub {
+			my $self = shift || confess("Call on an instance of MojoPlugins::Response");
+			my $code = shift || confess("Please supply a response code e.g. 400");
+			my $response_object = shift;
+
+			my $builder ||= MojoPlugins::Response::Builder->new($self, @_);
+			my @alerts_response = ({$LEVEL_KEY => $WARNING_LEVEL, $TEXT_KEY => "This endpoint and its functionality is deprecated, and will be removed in the future"});
+
+			if (defined($response_object)) {
+				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response, $RESPONSE_KEY => $response_object } );
+			} else {
+				return $self->render( $STATUS_KEY => $code, $JSON_KEY => { $ALERTS_KEY => \@alerts_response } );
+			}
+		}
+	);
+
 	# Alerts (500)
 	$app->renderer->add_helper(
 		internal_server_error => sub {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #3799 (kinda)

This adds a new method to `MojoPlugins::Response` instances called `deprecate_with_no_alternative` for deprecation alerts when no alternative exists. It also changes the `/hwinfo/dtdata` handler to use it.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

Not adding documentation for a deprecated route.

## What is the best way to verify this PR?
You actually can't. The endpoint is currently broken in master, and I didn't want to fix an endpoint that's been broken for gods know how long, with no apparent purpose, and is already deprecated. This way, though, if it is ever fixed it'll have a deprecation notice. Plus I think the helper is still useful for other endpoints where there's no alternative to something that's deprecated.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**