### PR TITLE
Added deprecation notice to /divisions/name/{{name}}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Deprecated/Removed
 - Traffic Ops API Endpoints
   - /servers/totals
-  - /cachegroups/:parameterID/parameter/available 
+  - /cachegroups/:parameterID/parameter/available
   - /cachegroup/:parameterID/parameter
   - /api_capabilities/:id
   - /regions/:region_name/phys_locations
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /parameters/:id/unassigned_profiles
   - /parameters/:id/profiles
   - /cdns/:name/configs/routing
+  - /divisions/name/:name
+  - /hwinfo/dtdata
 
 ## [4.0.0] - 2019-12-16
 ### Added
@@ -103,7 +105,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added deep coverage zone routing percentage to the Traffic Portal dashboard.
 - Added a `traffic_ops/app/bin/osversions-convert.pl` script to convert the `osversions.cfg` file from Perl to JSON as part of the `/osversions` endpoint rewrite.
 - Added [Experimental] - Emulated Vault suppling a HTTP server mimicking RIAK behavior for usage as traffic-control vault.
-- Added Traffic Ops Client function that returns a Delivery Service Nullable Response when requesting for a Delivery Service by XMLID 
+- Added Traffic Ops Client function that returns a Delivery Service Nullable Response when requesting for a Delivery Service by XMLID
 
 ### Changed
 - Traffic Router:  TR will now allow steering DSs and steering target DSs to have RGB enabled. (fixes #3910)
@@ -123,7 +125,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Monitor UI updated to support HTTP or HTTPS traffic.
 - Traffic Monitor health/stat time now includes full body download (like prior TM <=2.1 version)
 - Modified Traffic Router logging format to include an additional field for DNS log entries, namely `rhi`. This defaults to '-' and is only used when EDNS0 client subnet extensions are enabled and a client subnet is present in the request. When enabled and a subnet is present, the subnet appears in the `chi` field and the resolver address is in the `rhi` field.
-- Changed traffic_ops_ort.pl so that hdr_rw-<ds>.config files are compared with strict ordering and line duplication when detecting configuration changes.
+- Changed traffic_ops_ort.pl so that hdr_rw-&lt;ds&gt;.config files are compared with strict ordering and line duplication when detecting configuration changes.
 - Traffic Ops (golang), Traffic Monitor, Traffic Stats are now compiled using Go version 1.11. Grove was already being compiled with this version which improves performance for TLS when RSA certificates are used.
 - Fixed issue #3497: TO API clients that don't specify the latest minor version will overwrite/default any fields introduced in later versions
 - Fixed permissions on DELETE /api/$version/deliveryservice_server/{dsid}/{serverid} endpoint

--- a/traffic_ops/app/lib/API/Division.pm
+++ b/traffic_ops/app/lib/API/Division.pm
@@ -7,9 +7,9 @@ package API::Division;
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -57,7 +57,7 @@ sub index_by_name {
 			}
 		);
 	}
-	$self->success( \@data );
+	$self->deprecation(200, "GET /divisions with the 'name' parameter", \@data );
 }
 
 
@@ -181,28 +181,30 @@ sub delete {
 
 sub delete_by_name {
 	my $self = shift;
-	my $name     = $self->param('name');
+	my $name = $self->param('name');
+
+	my $alt = "DELETE /divsions/{{ID}}";
 
 	if ( !&is_oper($self) ) {
-		return $self->forbidden();
+		return $self->with_deprecation("Forbidden", "error", 403, $alt);
 	}
 
 	my $division = $self->db->resultset('Division')->find( { name => $name } );
 	if ( !defined($division) ) {
-		return $self->not_found();
+		return $self->with_deprecation("Resource not found.", "error", 404, $alt);
 	}
 
 	my $regions = $self->db->resultset('Region')->find( { division => $division->id } );
 	if ( defined($regions) ) {
-		return $self->alert("This division is currently used by regions.");
+		return $self->with_deprecation("This division is currently used by regions.", "error", 400, $alt);
 	}
 
 
 	my $rs = $division->delete();
 	if ($rs) {
-		return $self->success_message("Division deleted.");
+		return $self->with_deprecation("Division deleted.", "success", 200, $alt);
 	} else {
-		return $self->alert( "Division delete failed." );
+		return $self->with_deprecation("Division delete failed.", "error", 400, $alt);
 	}
 }
 

--- a/traffic_ops/client/division.go
+++ b/traffic_ops/client/division.go
@@ -131,7 +131,9 @@ func (to *Session) DeleteDivisionByID(id int) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, nil
 }
 
-// DELETE a Division by Division name
+// DELETE a Division by Division name.
+//
+// Deprecated: This will be removed in the near(-ish) future. Use Session.DeleteDivisionByID instead.
 func (to *Session) DeleteDivisionByName(name string) (tc.Alerts, ReqInf, error) {
 	route := fmt.Sprintf("%s/name/%s", API_v13_Divisions, name)
 	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -144,6 +144,65 @@ func ReadHandler(reader Reader) http.HandlerFunc {
 	}
 }
 
+// DeprecatedReadHandler creates a net/http.HandlerFunc for the passed Reader object, and adds a deprecation
+// notice, optionally with a passed alternative route suggestion.
+func DeprecatedReadHandler(reader Reader, alternative *string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var alerts tc.Alerts
+		if alternative != nil {
+			alerts = tc.CreateAlerts(tc.WarnLevel, fmt.Sprintf("This endpoint is deprecated, please use %s instead", *alternative))
+		} else {
+			alerts = tc.CreateAlerts(tc.WarnLevel, "This endpoint is deprecated, and will be removed in the future")
+		}
+
+		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
+		if userErr != nil || sysErr != nil {
+			if sysErr != nil {
+				log.Errorf(r.RemoteAddr + " " + sysErr.Error())
+			}
+			if userErr == nil {
+				userErr = errors.New(http.StatusText(errCode))
+			}
+			alerts.AddAlerts(tc.CreateErrorAlerts(userErr))
+			WriteAlerts(w, r, errCode, alerts)
+			log.Debugln(userErr.Error())
+			*r = *r.WithContext(context.WithValue(r.Context(), tc.StatusKey, errCode))
+			return
+		}
+
+		interfacePtr := reflect.ValueOf(reader)
+		if interfacePtr.Kind() != reflect.Ptr {
+			log.Errorf(r.RemoteAddr + " reflect: can only indirect from a pointer")
+			errCode = http.StatusInternalServerError
+			alerts.AddAlerts(tc.CreateErrorAlerts(errors.New(http.StatusText(errCode))))
+			WriteAlerts(w, r, errCode, alerts)
+			log.Debugln(userErr.Error())
+			*r = *r.WithContext(context.WithValue(r.Context(), tc.StatusKey, errCode))
+			return
+		}
+
+		objectType := reflect.Indirect(interfacePtr).Type()
+		obj := reflect.New(objectType).Interface().(Reader)
+		obj.SetInfo(inf)
+
+		results, userErr, sysErr, errCode := obj.Read()
+		if userErr != nil || sysErr != nil {
+			if sysErr != nil {
+				log.Errorf(r.RemoteAddr + " " + sysErr.Error())
+			}
+			if userErr == nil {
+				userErr = errors.New(http.StatusText(errCode))
+			}
+			alerts.AddAlerts(tc.CreateErrorAlerts(userErr))
+			WriteAlerts(w, r, errCode, alerts)
+			log.Debugln(userErr.Error())
+			*r = *r.WithContext(context.WithValue(r.Context(), tc.StatusKey, errCode))
+			return
+		}
+		WriteAlertsObj(w, r, http.StatusOK, alerts, results)
+	}
+}
+
 // UpdateHandler creates a handler function from the pointer to a struct implementing the Updater interface
 //   this generic handler encapsulates the logic for handling:
 //   *fetching the id from the path parameter

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/about"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/apicapability"
@@ -216,7 +217,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPut, `divisions/{id}$`, api.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, Authenticated, nil, 306369140, noPerlBypass},
 		{1.1, http.MethodPost, `divisions/?$`, api.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, Authenticated, nil, 553713800, noPerlBypass},
 		{1.1, http.MethodDelete, `divisions/{id}$`, api.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, Authenticated, nil, 1325382237, noPerlBypass},
-		{1.1, http.MethodGet, `divisions/name/{name}/?(\.json)?$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, Authenticated, nil, 1211408769, noPerlBypass},
+		{1.1, http.MethodGet, `divisions/name/{name}/?(\.json)?$`, api.DeprecatedReadHandler(&division.TODivision{}, util.StrPtr("GET /divisions with the 'name' parameter")), auth.PrivLevelReadOnly, Authenticated, nil, 1211408769, noPerlBypass},
 
 		{1.1, http.MethodGet, `logs/?(\.json)?$`, logs.Get, auth.PrivLevelReadOnly, Authenticated, nil, 848340550, perlBypass},
 		{1.1, http.MethodGet, `logs/{days}/days/?(\.json)?$`, logs.Get, auth.PrivLevelReadOnly, Authenticated, nil, 1192414145, perlBypass},


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #3789

Adds a deprecation notice to API responses for `/divisions/name/{{name}}` handlers, and adds one to the GoDoc for the client method that uses that route.

Not documenting deprecated route.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Make requests to `/divisions/name/{{name}}` and observe that the deprecation notice always appears. It supports `GET` and `DELETE`, which both do pretty much what you'd expect.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**