### PR TITLE
traffic_ops_ort: fix for syncds having too many header rewrite false …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.1/cachegroupparameters/{{cachegroupID}}/{{parameterID}} `(DELETE)`
 
 ### Changed
+- Fix to traffic_ops_ort.pl to strip specific comment lines before checking if a file has changed.  Also promoted a changed file message from DEBUG to ERROR for report mode.
 
 ### Deprecated/Removed
 - Traffic Ops API Endpoints


### PR DESCRIPTION
…positives

What does this PR (Pull Request) do?
This PR fixes an issue when canned comments aren't consistently stripped for header_rewrites, logs_xml.config or *.cer files.  Also promotes File changed message from DEBUG to ERROR for report mode.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT perl

## What is the best way to verify this PR?
Set up a test box with traffic_ops_ort.  Badass an initial EDGE configuration with some DS's that contain EDGE header rewrite rules.

First test:  Queue CDN.  Run syncds, WARN mode.  Old version the header_rewrite header file will trigger false positives. New version should not.  Edit a DS's header rewrite rule, queue, run syncds.  Only the edited header rewrite rule should update.

Next test: Edit header_rewrite for DS and queue.  Run report mode with WARN mode.  Ensure the changed accompanying header rewrite and only that one shows up as an ERROR message.

## If this is a bug fix, what versions of Traffic Control are affected?
- master (8e11e3db7f4e708e6ba42e7e766f9bb10387d750)
- 4.0.x (1523be3d2238243f0f2ca3ab9d3d93c69b9ae3c9)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
