### PR TITLE
Fix user current update required email

### DIFF
--- a/docs/source/api/user_current.rst
+++ b/docs/source/api/user_current.rst
@@ -124,7 +124,7 @@ Request Structure
 	:company:            The name of the company for which the user works
 	:confirmLocalPasswd: An optional 'confirm' field in a new user's password specification. This has no known effect and in fact *doesn't even need to match* ``localPasswd``
 	:country:            The name of the country wherein the user resides
-	:email:              The user's email address\ [#notnull]_
+	:email:              The user's email address - cannot be an empty string\ [#notnull]_
 
 		.. versionchanged:: ATCv4
 			Prior to version ATCv4, the email was validated using the `Email::Valid Perl package <https://metacpan.org/pod/Email::Valid>`_ but is now validated (circuitously) by `GitHub user asaskevich's regular expression <https://github.com/asaskevich/govalidator/blob/9a090521c4893a35ca9a228628abf8ba93f63108/patterns.go#L7>`_ . Note that neither method can actually distinguish a valid, deliverable, email address but merely ensure the email is in a commonly-found format.

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -182,6 +182,8 @@ func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 	if u.Email != nil {
 		if err := json.Unmarshal(u.Email, &user.Email); err != nil {
 			errs = append(errs, fmt.Errorf("email: %v", err))
+		} else if *user.Email == "" {
+			errs = append(errs, errors.New("email: cannot be an empty string"))
 		} else if err = validation.Validate(*user.Email, is.Email); err != nil {
 			errs = append(errs, err)
 		}

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -182,8 +182,8 @@ func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 	if u.Email != nil {
 		if err := json.Unmarshal(u.Email, &user.Email); err != nil {
 			errs = append(errs, fmt.Errorf("email: %v", err))
-		} else if *user.Email == "" {
-			errs = append(errs, errors.New("email: cannot be an empty string"))
+		} else if user.Email == nil || *user.Email == "" {
+			errs = append(errs, errors.New("email: cannot be null or an empty string"))
 		} else if err = validation.Validate(*user.Email, is.Email); err != nil {
 			errs = append(errs, err)
 		}
@@ -194,7 +194,7 @@ func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 			errs = append(errs, fmt.Errorf("fullName: %v", err))
 		} else if user.FullName == nil || *user.FullName == "" {
 			// Perl enforced this
-			errs = append(errs, fmt.Errorf("fullName: cannot be set to 'null' or empty string"))
+			errs = append(errs, errors.New("fullName: cannot be set to 'null' or empty string"))
 		}
 	}
 

--- a/traffic_ops/testing/api/v1/user_test.go
+++ b/traffic_ops/testing/api/v1/user_test.go
@@ -218,6 +218,30 @@ func UserSelfUpdateTest(t *testing.T) {
 	} else if *resp2[0].Email != "operator@example.com" {
 		t.Errorf("Expected Email to be restored to 'operator@example.com', but it was '%s'", *resp2[0].Email)
 	}
+
+	// now test using an invalid email address
+	currentEmail := *user.Email
+	user.Email = new(string);
+	updateResp, _, err = TOSession.UpdateCurrentUser(user)
+	if err == nil {
+		t.Fatal("error was expected updating user with email: '' - got none")
+	}
+
+	// Ensure it wasn't actually updated
+	resp2, _, err = TOSession.GetUserByID(*user.ID)
+	if err != nil {
+		t.Fatalf("error getting user #%d: %v", *user.ID, err)
+	}
+
+	if len(resp2) < 1 {
+		t.Fatalf("no user returned when requesting user #%d", *user.ID)
+	}
+
+	if resp2[0].Email == nil {
+		t.Errorf("Email missing or null after update")
+	} else if *resp2[0].Email != currentEmail {
+		t.Errorf("Expected Email to still be '%s', but it was '%s'", currentEmail, *resp2[0].Email)
+	}
 }
 
 func UserUpdateOwnRoleTest(t *testing.T) {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4240

Adds a constraint that disallows setting the user's email address to an empty string in the PUT handler for `/user/current`.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Run the client/api integration tests. I added a case that checks for empty string emails. Other than that, try submitting a PUT request to `/user/current` and verifying that the response indicates the error.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0 (RC2 - I *think*)

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**