### PR TITLE
[Backport 4.0.x] Fix TO atscfg missing max origin conns (#4344)

### DIFF
--- a/traffic_ops/traffic_ops_golang/ats/atscdn/headerrewritedotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atscdn/headerrewritedotconfig.go
@@ -137,11 +137,12 @@ SELECT
   s.host_name,
   s.domain_name,
   s.tcp_port,
-  s.status
+  st.name
 FROM
   server s
   JOIN deliveryservice_server dss ON dss.server = s.id
   JOIN deliveryservice ds ON ds.id = dss.deliveryservice
+  JOIN status st on st.id = s.status
 WHERE
   ds.xml_id = $1
 `
@@ -154,7 +155,7 @@ WHERE
 	servers := []atscfg.HeaderRewriteServer{}
 	for rows.Next() {
 		s := atscfg.HeaderRewriteServer{}
-		if err := rows.Scan(&s.Status, &s.HostName, &s.DomainName, &s.Port); err != nil {
+		if err := rows.Scan(&s.HostName, &s.DomainName, &s.Port, &s.Status); err != nil {
 			return nil, errors.New("scanning: " + err.Error())
 		}
 		s.Status = tc.CacheStatusFromString(string(s.Status))
@@ -170,9 +171,10 @@ SELECT
   s.host_name,
   s.domain_name,
   s.tcp_port,
-  s.status
+  st.name
 FROM
   server s
+  JOIN status st on st.id = s.status
 WHERE s.cachegroup IN (
   SELECT
     cg.parent_cachegroup_id
@@ -194,7 +196,7 @@ WHERE s.cachegroup IN (
 	servers := []atscfg.HeaderRewriteServer{}
 	for rows.Next() {
 		s := atscfg.HeaderRewriteServer{}
-		if err := rows.Scan(&s.Status, &s.HostName, &s.DomainName, &s.Port); err != nil {
+		if err := rows.Scan(&s.HostName, &s.DomainName, &s.Port, &s.Status); err != nil {
 			return nil, errors.New("scanning: " + err.Error())
 		}
 		s.Status = tc.CacheStatusFromString(string(s.Status))


### PR DESCRIPTION
Fixes a misordered SQL scan, which caused the Server Status to be
missing, causing the config gen to think there were no online servers,
and thus not create the max_origin_connections entry.

Note this is only in the old TO endpoints, not the config generator. The `atstccfg` generator doesn't have this issue.

- [x] This PR is not related to any other Issue

Includes TO API (Integration) tests.
No docs, no interface change.
No changelog, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?

Run TO API Tests.
Set Max Origin Connections on a DS, request the header rewrite endpoint for that DS, verify it includes a max_origin_connections entry.

## If this is a bug fix, what versions of Traffic Control are affected?
- master 
- 4.0.0 RC2

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information