### PR TITLE
traffic_ops_ort: fix for syncds having too many header rewrite false …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Monitor health/stat time now includes full body download (like prior TM <=2.1 version)
 - Modified Traffic Router logging format to include an additional field for DNS log entries, namely `rhi`. This defaults to '-' and is only used when EDNS0 client subnet extensions are enabled and a client subnet is present in the request. When enabled and a subnet is present, the subnet appears in the `chi` field and the resolver address is in the `rhi` field.
 - Changed traffic_ops_ort.pl so that hdr_rw-<ds>.config files are compared with strict ordering and line duplication when detecting configuration changes.
+- Fix to traffic_ops_ort.pl to strip specific comment lines before checking if a file has changed.  Also promoted a changed file message from DEBUG to ERROR for report mode.
 - Traffic Ops (golang), Traffic Monitor, Traffic Stats are now compiled using Go version 1.11. Grove was already being compiled with this version which improves performance for TLS when RSA certificates are used.
 - Fixed issue #3497: TO API clients that don't specify the latest minor version will overwrite/default any fields introduced in later versions
 - Fixed permissions on DELETE /api/$version/deliveryservice_server/{dsid}/{serverid} endpoint


### PR DESCRIPTION
…positives

What does this PR (Pull Request) do?
This PR fixes an issue when canned comments aren't consistently stripped for header_rewrites, logs_xml.config or *.cer files.  Also promotes File changed message from DEBUG to ERROR for report mode.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT perl

## What is the best way to verify this PR?
Set up a test box with traffic_ops_ort.  Badass an initial EDGE configuration with some DS's that contain EDGE header rewrite rules.

First test:  Queue CDN.  Run syncds, WARN mode.  Old version the header_rewrite header file will trigger false positives. New version should not.  Edit a DS's header rewrite rule, queue, run syncds.  Only the edited header rewrite rule should update.

Next test: Edit header_rewrite for DS and queue.  Run report mode with WARN mode.  Ensure the changed accompanying header rewrite and only that one shows up as an ERROR message.

## If this is a bug fix, what versions of Traffic Control are affected?
- master (8e11e3db7f4e708e6ba42e7e766f9bb10387d750)
- 4.0.x (1523be3d2238243f0f2ca3ab9d3d93c69b9ae3c9)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
