### PR TITLE
Deprecate types/trimmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /deliveryservices/:id/state
   - /cdns/configs
   - /servercheck/aadata
+  - /types/trimmed
 
 ## [4.0.0] - 2019-12-16
 ### Added

--- a/docs/source/api/types_trimmed.rst
+++ b/docs/source/api/types_trimmed.rst
@@ -55,7 +55,7 @@ Response Structure
 	{ "alerts": [
 		{
 			"level": "warning",
-			"text": "This endpoint is deprecated"
+			"text": "This endpoint is deprecated, please use '/types' instead"
 		}
 	],
 	"response": [

--- a/docs/source/api/types_trimmed.rst
+++ b/docs/source/api/types_trimmed.rst
@@ -18,6 +18,8 @@
 *****************
 ``types/trimmed``
 *****************
+.. deprecated:: ATCv4
+	This endpoint and all of its functionality is deprecated. All of the information it can return can be more completely obtained with :ref:`to-api-types`.
 
 ``GET``
 =======
@@ -41,26 +43,167 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Connection: keep-alive
-	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
-	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-	Whole-Content-SHA512: Wh4z9VkNcOI8UzSTM77N+JFx5bP8yxRR4rg1fZIH40DI+0suOD36YhePUMMqMl6DIlIWjrnkj+iojuQ09oTzeg==
 	Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-	Date: Wed, 12 Dec 2018 23:37:01 GMT
-	Access-Control-Allow-Origin: *
-	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-	Content-Length: 1104
+	Content-Encoding: gzip
+	Content-Length: 389
 	Content-Type: application/json
+	Date: Fri, 31 Jan 2020 18:09:29 GMT
 	Server: Mojolicious (Perl)
+	Set-Cookie: mojolicious=...; expires=Fri, 31 Jan 2020 22:09:29 GMT; path=/; HttpOnly
+	Vary: Accept-Encoding
 
-	{ "response": [
+	{ "alerts": [
+		{
+			"level": "warning",
+			"text": "This endpoint is deprecated"
+		}
+	],
+	"response": [
 		{
 			"name": "AAAA_RECORD"
 		},
 		{
 			"name": "ANY_MAP"
+		},
+		{
+			"name": "A_RECORD"
+		},
+		{
+			"name": "BIND"
+		},
+		{
+			"name": "CCR"
+		},
+		{
+			"name": "CHECK_EXTENSION_BOOL"
+		},
+		{
+			"name": "CHECK_EXTENSION_NUM"
+		},
+		{
+			"name": "CHECK_EXTENSION_OPEN_SLOT"
+		},
+		{
+			"name": "CLIENT_STEERING"
+		},
+		{
+			"name": "CNAME_RECORD"
+		},
+		{
+			"name": "CONFIG_EXTENSION"
+		},
+		{
+			"name": "DNS"
+		},
+		{
+			"name": "DNS_LIVE"
+		},
+		{
+			"name": "DNS_LIVE_NATNL"
+		},
+		{
+			"name": "EDGE"
+		},
+		{
+			"name": "EDGE_LOC"
+		},
+		{
+			"name": "ENROLLER"
+		},
+		{
+			"name": "GRAFANA"
+		},
+		{
+			"name": "HEADER_REGEXP"
+		},
+		{
+			"name": "HOST_REGEXP"
+		},
+		{
+			"name": "HTTP"
+		},
+		{
+			"name": "HTTP_LIVE"
+		},
+		{
+			"name": "HTTP_LIVE_NATNL"
+		},
+		{
+			"name": "HTTP_NO_CACHE"
+		},
+		{
+			"name": "INFLUXDB"
+		},
+		{
+			"name": "MID"
+		},
+		{
+			"name": "MID_LOC"
+		},
+		{
+			"name": "ORG"
+		},
+		{
+			"name": "ORG_LOC"
+		},
+		{
+			"name": "PATH_REGEXP"
+		},
+		{
+			"name": "RASCAL"
+		},
+		{
+			"name": "RESOLVE4"
+		},
+		{
+			"name": "RESOLVE6"
+		},
+		{
+			"name": "RIAK"
+		},
+		{
+			"name": "STATISTIC_EXTENSION"
+		},
+		{
+			"name": "STEERING"
+		},
+		{
+			"name": "STEERING_GEO_ORDER"
+		},
+		{
+			"name": "STEERING_GEO_WEIGHT"
+		},
+		{
+			"name": "STEERING_ORDER"
+		},
+		{
+			"name": "STEERING_REGEXP"
+		},
+		{
+			"name": "STEERING_WEIGHT"
+		},
+		{
+			"name": "TC_LOC"
+		},
+		{
+			"name": "TRAFFIC_ANALYTICS"
+		},
+		{
+			"name": "TRAFFIC_OPS"
+		},
+		{
+			"name": "TRAFFIC_OPS_DB"
+		},
+		{
+			"name": "TRAFFIC_PORTAL"
+		},
+		{
+			"name": "TRAFFIC_STATS"
+		},
+		{
+			"name": "TR_LOC"
+		},
+		{
+			"name": "TXT_RECORD"
 		}
 	]}
-
-.. note:: The response example for this endpoint has been truncated to only the first two elements of the resulting array, as the output was hundreds of lines long.

--- a/traffic_ops/app/lib/API/Types.pm
+++ b/traffic_ops/app/lib/API/Types.pm
@@ -62,7 +62,7 @@ sub index_trimmed {
 			}
 		);
 	}
-	$self->success_deprecate( \@data );
+	$self->deprecate( 200, "/types", \@data );
 }
 
 sub show {

--- a/traffic_ops/app/lib/API/Types.pm
+++ b/traffic_ops/app/lib/API/Types.pm
@@ -62,7 +62,7 @@ sub index_trimmed {
 			}
 		);
 	}
-	$self->success( \@data );
+	$self->success_deprecate( \@data );
 }
 
 sub show {

--- a/traffic_ops/app/lib/API/Types.pm
+++ b/traffic_ops/app/lib/API/Types.pm
@@ -62,7 +62,7 @@ sub index_trimmed {
 			}
 		);
 	}
-	$self->deprecate( 200, "/types", \@data );
+	$self->deprecation( 200, "/types", \@data );
 }
 
 sub show {

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -361,6 +361,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodGet, `system/info/?(\.json)?$`, systeminfo.Get, auth.PrivLevelReadOnly, Authenticated, nil, 211047475, noPerlBypass},
 
 		//Type: CRUD
+		{1.1, http.MethodGet, `types/trimmed/?(\.json)?$`, handlerToFunc(proxyHandler), 0, NoAuth, []middleware.Middleware{}, 666, noPerlBypass},
 		{1.1, http.MethodGet, `types/?(\.json)?$`, api.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, Authenticated, nil, 2026701823, noPerlBypass},
 		{1.1, http.MethodGet, `types/{id}$`, api.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, Authenticated, nil, 86037256, noPerlBypass},
 		{1.1, http.MethodPut, `types/{id}$`, api.UpdateHandler(&types.TOType{}), auth.PrivLevelOperations, Authenticated, nil, 68860115, noPerlBypass},


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3834 and fixes #3114
Adds deprecation notices for `/types/trimmed` to endpoint output and documentation, and fixes broken routing that rendered the endpoint unreachable through Go.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Run the existing unit and client/API integration tests, make a GET request to `/types/trimmed` and observe the deprecation notice in the output, and build and read the documentation to make sure it is thorough, accurate, well-formatted, and builds without errors/warnings.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0 (RC3)

## The following criteria are ALL met by this PR

- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**