### PR TITLE
deprecate /servercheck/aadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /stats_summary/create
   - /deliveryservices/:id/state
   - /cdns/configs
+  - /servercheck/aadata
 
 ## [4.0.0] - 2019-12-16
 ### Added

--- a/traffic_ops/app/lib/API/ServerCheck.pm
+++ b/traffic_ops/app/lib/API/ServerCheck.pm
@@ -55,7 +55,7 @@ sub aadata {
 		);
 		push( @{ $data{'aaData'} }, \@line );
 	}
-	return $self->render( json => \%data );
+	return $self->deprecation_with_no_alternative(200, \%data);
 }
 
 # read for not crazy Datatables


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3831
Adds a deprecation notice for `/servercheck/aadata`. The endpoint doesn't appear to do anything, and is undocumented, so there are no tests or documentation updates.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Build TO (Perl implementation) and observe deprecation notices in the responses to `/servercheck/aadata`.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**