### PR TITLE
Add missing deprecation notices to /user/current/jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /servercheck/aadata
   - /types/trimmed
   - /deliveryservice_user/:dsId/:userId
+  - /user/current/jobs
 
 ## [4.0.0] - 2019-12-16
 ### Added

--- a/docs/source/api/user_current_jobs.rst
+++ b/docs/source/api/user_current_jobs.rst
@@ -96,7 +96,13 @@ Response Structure
 	Date: Wed, 19 Jun 2019 13:23:18 GMT
 	Content-Length: 747
 
-	{ "response": [{
+	{ "alerts": [
+		{
+			"text": "This endpoint is deprecated, please use the 'userId' or 'createdBy' query parameters of a GET request to /jobs instead",
+			"level": "warning"
+		}
+	],
+	"response": [{
 		"agent": 1,
 		"assetType": "file",
 		"assetUrl": "http://origin.infra.ciab.test/.*",
@@ -185,15 +191,21 @@ Response Structure
 	Date: Wed, 19 Jun 2019 13:19:51 GMT
 	Content-Length: 235
 
-	{ "alerts": [{
-		"text": "Invalidation Job creation was successful.",
-		"level": "success"
-	}],
+	{ "alerts": [
+		{
+			"text": "This endpoint is deprecated, please use the POST method /jobs instead",
+			"level": "warning"
+		},
+		{
+			"text": "Invalidation Job creation was successful",
+			"level": "success"
+		}
+	],
 	"response": {
 		"assetUrl": "http://origin.infra.ciab.test/.*",
 		"createdBy": "admin",
 		"deliveryService": "demo1",
-		"id": 3,
+		"id": 1,
 		"keyword": "PURGE",
 		"parameters": "TTL:3h",
 		"startTime": "2019-06-21 00:00:00+00"

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -135,10 +135,10 @@ func HandleErr(w http.ResponseWriter, r *http.Request, tx *sql.Tx, statusCode in
 	handleSimpleErr(w, r, statusCode, userErr, sysErr)
 }
 
-// logErr handles the logging of errors and setting up possibly nil errors without actually writing anything to a
+// LogErr handles the logging of errors and setting up possibly nil errors without actually writing anything to a
 // http.ResponseWriter, unlike handleSimpleErr. It returns the userErr which will be initialized to the
 // http.StatusText of errCode if it was passed as nil - otherwise left alone.
-func logErr(r *http.Request, errCode int, userErr error, sysErr error) error {
+func LogErr(r *http.Request, errCode int, userErr error, sysErr error) error {
 	if sysErr != nil {
 		log.Errorf(r.RemoteAddr + " " + sysErr.Error())
 	}
@@ -153,7 +153,7 @@ func logErr(r *http.Request, errCode int, userErr error, sysErr error) error {
 // handleSimpleErr is a helper for HandleErr.
 // This exists to prevent exposing HandleErr calls in this file with nil transactions, which might be copy-pasted creating bugs.
 func handleSimpleErr(w http.ResponseWriter, r *http.Request, statusCode int, userErr error, sysErr error) {
-	userErr = logErr(r, statusCode, userErr, sysErr)
+	userErr = LogErr(r, statusCode, userErr, sysErr)
 
 	respBts, err := json.Marshal(tc.CreateErrorAlerts(userErr))
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -157,7 +157,7 @@ func DeprecatedReadHandler(reader Reader, alternative *string) http.HandlerFunc 
 
 		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
 		if userErr != nil || sysErr != nil {
-			userErr = logErr(r, http.StatusInternalServerError, userErr, sysErr)
+			userErr = LogErr(r, http.StatusInternalServerError, userErr, sysErr)
 			alerts.AddAlerts(tc.CreateErrorAlerts(userErr))
 			WriteAlerts(w, r, errCode, alerts)
 			return
@@ -165,7 +165,7 @@ func DeprecatedReadHandler(reader Reader, alternative *string) http.HandlerFunc 
 
 		interfacePtr := reflect.ValueOf(reader)
 		if interfacePtr.Kind() != reflect.Ptr {
-			userErr = logErr(r, http.StatusInternalServerError, nil, errors.New(" reflect: can only indirect from a pointer"))
+			userErr = LogErr(r, http.StatusInternalServerError, nil, errors.New(" reflect: can only indirect from a pointer"))
 			alerts.AddAlerts(tc.CreateErrorAlerts(userErr))
 			WriteAlerts(w, r, errCode, alerts)
 			return
@@ -177,7 +177,7 @@ func DeprecatedReadHandler(reader Reader, alternative *string) http.HandlerFunc 
 
 		results, userErr, sysErr, errCode := obj.Read()
 		if userErr != nil || sysErr != nil {
-			userErr = logErr(r, http.StatusInternalServerError, userErr, sysErr)
+			userErr = LogErr(r, http.StatusInternalServerError, userErr, sysErr)
 			alerts.AddAlerts(tc.CreateErrorAlerts(userErr))
 			WriteAlerts(w, r, errCode, alerts)
 			return

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/userinvalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/userinvalidationjobs.go
@@ -157,9 +157,6 @@ func GetUserJobs(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		userErr = api.LogErr(r, http.StatusInternalServerError, nil, fmt.Errorf("Fetching user jobs: %v", err))
 		alerts.AddNewAlert(tc.ErrorLevel, userErr.Error())
-		// if err := inf.Tx.Tx.Rollback(); err != nil && err != sql.ErrTxDone {
-		// 	log.Errorln("rolling back transaction: " + err.Error())
-		// }
 		api.WriteAlerts(w, r, http.StatusInternalServerError, alerts)
 		return
 	}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

The `/user/current/jobs` endpoint has been marked as deprecated in the documentation, and the "happy paths" had deprecation notices. However, in the event of an error no deprecation notice was output. This PR includes changes that ensure the notice is always output, and adds them to the Perl handlers as well - which used to never output the notice (this is important because the route is perl-bypass-able, so it's possible an API consumer never sees the notice depending on TO server configuration).

Finally, adds a "deprecated" entry for the endpoint in the CHANGELOG and updates API examples in the docs to show the new deprecation notices.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Run the existing unit and client/api integration tests, build and read the documentation, and make requests to `/user/current/jobs` and ensure the deprecation notice is output.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**