### PR TITLE
deprecates the /cdns/usage/overview endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /types/trimmed
   - /deliveryservice_user/:dsId/:userId
   - /user/current/jobs
+  - /cdns/usage/overview
 
 ## [4.0.0] - 2019-12-16
 ### Added

--- a/docs/source/api/cdns_usage_overview.rst
+++ b/docs/source/api/cdns_usage_overview.rst
@@ -21,6 +21,9 @@
 
 .. versionadded:: 1.2
 
+.. deprecated:: ATCv4
+	This endpoint and its functionality is deprecated, and will be removed in the future.
+
 ``GET``
 =======
 Retrieves the high-level CDN usage metrics from Traffic Stats
@@ -46,10 +49,18 @@ Response Structure
 .. code-block:: json
 	:caption: Response Example
 
-	{ "response": {
-		"currentGbps": 975.920621333333,
-		"source": "TrafficStats",
-		"tps": 0,
-		"version": "1.2",
-		"maxGbps": 12085
-	}}
+	{
+		"alerts": [
+			{
+				"level": "warning",
+				"text": "This endpoint and its functionality is deprecated, and will be removed in the future"
+			}
+		],
+		"response": {
+			"currentGbps": 975.920621333333,
+			"source": "TrafficStats",
+			"tps": 0,
+			"version": "1.2",
+			"maxGbps": 12085
+		}
+	}

--- a/traffic_ops/app/lib/Extensions/TrafficStats/API/CdnStats.pm
+++ b/traffic_ops/app/lib/Extensions/TrafficStats/API/CdnStats.pm
@@ -52,10 +52,10 @@ sub get_usage_overview {
 
 	my ( $rc, $result ) = $cstats->get_usage_overview();
 	if ( $rc == SUCCESS ) {
-		return $self->success($result);
+		return $self->deprecation_with_no_alternative(200, $result);
 	}
 	else {
-		return $self->alert($result);
+		return $self->deprecation_with_no_alternative(400, $result);
 	}
 }
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Adds deprecation notices for /cdns/usage/overview to response and documentation.

- [x] This PR fixes #3850 

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Run unit and API tests
Make a call to GET /cdns/usage/overview and notice the deprecation alert
Build the docs and review the /cdns/usage/overview api endpoint documentation

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
