### PR TITLE
Rewrote deliveryservices/{{ID}/safe to Go

### DIFF
--- a/docs/source/api/deliveryservices_id_safe.rst
+++ b/docs/source/api/deliveryservices_id_safe.rst
@@ -31,11 +31,11 @@ Request Structure
 -----------------
 .. table:: Request Path Parameters
 
-	+------+-----------------------------------------------------------------+
-	| Name | Description                                                     |
-	+======+=================================================================+
-	|  ID  | The :ref:`ds-id` of the :term:`Delivery Service` being modified |
-	+------+-----------------------------------------------------------------+
+	+------+--------------------------------------------------------------------------------+
+	| Name | Description                                                                    |
+	+======+================================================================================+
+	|  ID  | The integral, unique identifier of the :term:`Delivery Service` being modified |
+	+------+--------------------------------------------------------------------------------+
 
 :displayName: A string that is the :ref:`ds-display-name`
 :infoUrl:     An optional\ [#optional]_ string containing the :ref:`ds-info-url`

--- a/docs/source/api/deliveryservices_id_safe.rst
+++ b/docs/source/api/deliveryservices_id_safe.rst
@@ -31,39 +31,33 @@ Request Structure
 -----------------
 .. table:: Request Path Parameters
 
-	+------+--------------------------------------------------------------------------------+
-	| Name |                      Description                                               |
-	+======+================================================================================+
-	|  ID  | The integral, unique identifier of the :term:`Delivery Service` being modified |
-	+------+--------------------------------------------------------------------------------+
+	+------+-----------------------------------------------------------------+
+	| Name | Description                                                     |
+	+======+=================================================================+
+	|  ID  | The :ref:`ds-id` of the :term:`Delivery Service` being modified |
+	+------+-----------------------------------------------------------------+
 
-:displayName: The :ref:`ds-display-name`
-:infoUrl:     An :ref:`ds-info-url`
-:longDesc:    The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:   The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:   The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-
-.. note:: All of these fields are optional; this ``PUT`` behaves more like a ``PATCH``
+:displayName: A string that is the :ref:`ds-display-name`
+:infoUrl:     An optional\ [#optional]_ string containing the :ref:`ds-info-url`
+:longDesc:    An optional\ [#optional]_ string containing the :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:   An optional\ [#optional]_ string containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
 
 .. code-block:: http
 	:caption: Request Example
 
-	PUT /api/1.4/deliveryservices/1/safe HTTP/1.1
-	Host: trafficops.infra.ciab.test
-	User-Agent: curl/7.47.0
+	PUT /api/1.5/deliveryservices/1/safe HTTP/1.1
+	User-Agent: python-requests/2.22.0
+	Accept-Encoding: gzip, deflate
 	Accept: */*
+	Connection: keep-alive
 	Cookie: mojolicious=...
-	Content-Length: 165
-	Content-Type: application/x-www-form-urlencoded
+	Content-Length: 132
 
 	{
-		"displayName": "demo",
-		"infoUrl": "www.info.com",
-		"longDesc": "A Delivery Service created for the CDN-in-a-Box project",
-		"longDesc1": null,
-		"longDesc2": null
+		"displayName": "test",
+		"infoUrl": "this is not even a real URL",
+		"longDesc": "longDesc1 is implicitly set to null in this example
 	}
-
 
 Response Structure
 ------------------
@@ -98,7 +92,7 @@ Response Structure
 :dscp:              A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
 :ecsEnabled:        A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 
-	.. versionadded:: 1.4
+	.. versionadded:: 1.5
 
 :edgeHeaderRewrite: A set of :ref:`ds-edge-header-rw-rules`
 :exampleURLs:       An array of :ref:`ds-example-urls`
@@ -174,98 +168,102 @@ Response Structure
 	:caption: Response Example
 
 	HTTP/1.1 200 OK
-	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
 	Content-Type: application/json
-	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-	Whole-Content-Sha512: mCLMjvACRKHNGP/OSx4javkOtxxzyiDdQzsV78IamUhVmvyKyKaCeOKRmpsG69w+nhh3OkPZ6e9MMeJpcJSKcA==
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 10 Feb 2020 16:33:03 GMT; Max-Age=3600; HttpOnly
 	X-Server-Name: traffic_ops_golang/
-	Date: Thu, 15 Nov 2018 19:04:29 GMT
-	Transfer-Encoding: chunked
+	Date: Mon, 10 Feb 2020 15:33:03 GMT
+	Content-Length: 853
 
-	{ "response": [{
-		"active": true,
-		"anonymousBlockingEnabled": false,
-		"cacheurl": null,
-		"ccrDnsTtl": null,
-		"cdnId": 2,
-		"cdnName": "CDN-in-a-Box",
-		"checkPath": null,
-		"displayName": "demo",
-		"dnsBypassCname": null,
-		"dnsBypassIp": null,
-		"dnsBypassIp6": null,
-		"dnsBypassTtl": null,
-		"dscp": 0,
-		"edgeHeaderRewrite": null,
-		"geoLimit": 0,
-		"geoLimitCountries": null,
-		"geoLimitRedirectURL": null,
-		"geoProvider": 0,
-		"globalMaxMbps": null,
-		"globalMaxTps": null,
-		"httpBypassFqdn": null,
-		"id": 1,
-		"infoUrl": "www.info.com",
-		"initialDispersion": 1,
-		"ipv6RoutingEnabled": true,
-		"lastUpdated": "2019-05-15 14:32:05+00",
-		"logsEnabled": true,
-		"longDesc": "A Delivery Service created for the CDN-in-a-Box project",
-		"longDesc1": null,
-		"longDesc2": null,
-		"matchList": [
-			{
-				"type": "HOST_REGEXP",
-				"setNumber": 0,
-				"pattern": ".*\\.demo1\\..*"
-			}
-		],
-		"maxDnsAnswers": null,
-		"midHeaderRewrite": null,
-		"missLat": 42,
-		"missLong": -88,
-		"multiSiteOrigin": false,
-		"originShield": null,
-		"orgServerFqdn": "http://origin.infra.ciab.test",
-		"profileDescription": null,
-		"profileId": null,
-		"profileName": null,
-		"protocol": 2,
-		"qstringIgnore": 0,
-		"rangeRequestHandling": 0,
-		"regexRemap": null,
-		"regionalGeoBlocking": false,
-		"remapText": null,
-		"routingName": "video",
-		"signed": false,
-		"sslKeyVersion": null,
-		"tenantId": 1,
-		"type": "HTTP",
-		"typeId": 1,
-		"xmlId": "demo1",
-		"exampleURLs": [
-			"http://video.demo1.mycdn.ciab.test",
-			"https://video.demo1.mycdn.ciab.test"
-		],
-		"deepCachingType": "NEVER",
-		"fqPacingRate": null,
-		"signingAlgorithm": null,
-		"tenant": "root",
-		"trResponseHeaders": null,
-		"trRequestHeaders": null,
-		"consistentHashRegex": null,
-		"consistentHashQueryParams": [
-			"abc",
-			"pdq",
-			"xxx",
-			"zyx"
-		],
-		"maxOriginConnections": 0,
-		"ecsEnabled": false
-	}]}
-
+	{ "alerts": [
+		{
+			"text": "Delivery Service safe update successful.",
+			"level": "success"
+		}
+	],
+	"response": [
+		{
+			"active": true,
+			"anonymousBlockingEnabled": false,
+			"cacheurl": null,
+			"ccrDnsTtl": null,
+			"cdnId": 2,
+			"cdnName": "CDN-in-a-Box",
+			"checkPath": null,
+			"displayName": "test",
+			"dnsBypassCname": null,
+			"dnsBypassIp": null,
+			"dnsBypassIp6": null,
+			"dnsBypassTtl": null,
+			"dscp": 0,
+			"edgeHeaderRewrite": null,
+			"geoLimit": 0,
+			"geoLimitCountries": null,
+			"geoLimitRedirectURL": null,
+			"geoProvider": 0,
+			"globalMaxMbps": null,
+			"globalMaxTps": null,
+			"httpBypassFqdn": null,
+			"id": 1,
+			"infoUrl": "this is not even a real URL",
+			"initialDispersion": 1,
+			"ipv6RoutingEnabled": true,
+			"lastUpdated": "2020-02-10 15:33:03+00",
+			"logsEnabled": true,
+			"longDesc": "longDesc1 is implicitly set to null in this example",
+			"longDesc1": null,
+			"longDesc2": null,
+			"matchList": [
+				{
+					"type": "HOST_REGEXP",
+					"setNumber": 0,
+					"pattern": ".*\\.demo1\\..*"
+				}
+			],
+			"maxDnsAnswers": null,
+			"midHeaderRewrite": null,
+			"missLat": 42,
+			"missLong": -88,
+			"multiSiteOrigin": false,
+			"originShield": null,
+			"orgServerFqdn": "http://origin.infra.ciab.test",
+			"profileDescription": null,
+			"profileId": null,
+			"profileName": null,
+			"protocol": 2,
+			"qstringIgnore": 0,
+			"rangeRequestHandling": 0,
+			"regexRemap": null,
+			"regionalGeoBlocking": false,
+			"remapText": null,
+			"routingName": "video",
+			"signed": false,
+			"sslKeyVersion": 1,
+			"tenantId": 1,
+			"type": "HTTP",
+			"typeId": 1,
+			"xmlId": "demo1",
+			"exampleURLs": [
+				"http://video.demo1.mycdn.ciab.test",
+				"https://video.demo1.mycdn.ciab.test"
+			],
+			"deepCachingType": "NEVER",
+			"fqPacingRate": null,
+			"signingAlgorithm": null,
+			"tenant": "root",
+			"trResponseHeaders": null,
+			"trRequestHeaders": null,
+			"consistentHashRegex": null,
+			"consistentHashQueryParams": [
+				"abc",
+				"pdq",
+				"xxx",
+				"zyx"
+			],
+			"maxOriginConnections": 0,
+			"ecsEnabled": false
+		}
+	]}
 
 .. [#tenancy] Only those :term:`Delivery Services` assigned to :term:`Tenants` that are the requesting user's :term:`Tenant` or children thereof may be modified with this endpoint.
+.. [#optional] If these fields are not present in the request body they are *implicitly set to* ``null``.

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -607,3 +607,18 @@ type AssignedDsResponse struct {
 	DSIds    []int `json:"dsIds"`
 	Replace  bool  `json:"replace"`
 }
+
+// DeliveryServiceSafeUpdateRequest represents a request to update the "safe" fields of a
+// Delivery Service.
+type DeliveryServiceSafeUpdateRequest struct {
+	DisplayName *string `json:"displayName`
+	InfoURL *string `json:"infoUrl"`
+	LongDesc *string `json:"longDesc"`
+	LongDesc1 *string `json:"longDesc1`
+}
+
+// Validate implements the github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator
+// interface.
+func (*DeliveryServiceSafeUpdateRequest) Validate(*sql.Tx) error {
+	return nil
+}

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -612,9 +612,9 @@ type AssignedDsResponse struct {
 // Delivery Service.
 type DeliveryServiceSafeUpdateRequest struct {
 	DisplayName *string `json:"displayName`
-	InfoURL *string `json:"infoUrl"`
-	LongDesc *string `json:"longDesc"`
-	LongDesc1 *string `json:"longDesc1`
+	InfoURL     *string `json:"infoUrl"`
+	LongDesc    *string `json:"longDesc"`
+	LongDesc1   *string `json:"longDesc1`
 }
 
 // Validate implements the github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -619,6 +619,19 @@ type DeliveryServiceSafeUpdateRequest struct {
 
 // Validate implements the github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator
 // interface.
-func (*DeliveryServiceSafeUpdateRequest) Validate(*sql.Tx) error {
+func (r *DeliveryServiceSafeUpdateRequest) Validate(*sql.Tx) error {
+	if r.DisplayName == nil {
+		return errors.New("displayName: cannot be null/missing")
+	}
 	return nil
+}
+
+// DeliveryServiceSafeUpdateResponse represents Traffic Ops's response to a PUT request to its
+// /deliveryservices/{{ID}}/safe endpoint.
+type DeliveryServiceSafeUpdateResponse struct {
+	Alerts
+	// Response contains the representation of the Delivery Service after it has been updated.
+	// Note that this should be "cast" to the appropriate version of Delivery Service, reflecting
+	// the API version that was called.
+	Response []DeliveryServiceNullable `json:"response"`
 }

--- a/traffic_control/clients/python/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/tosession.py
@@ -977,12 +977,12 @@ class TOSession(RestApiSession):
 		:raises: Union[LoginError, OperationError]
 		"""
 
-	@api_request(u'put', u'deliveryservices/{delivery_service_id:d}/safe', (u'1.1', u'1.2', u'1.3',))
+	@api_request(u'put', u'deliveryservices/{delivery_service_id:d}/safe', (u'1.1', u'1.2', u'1.3', u'1.4', u'1.5'))
 	def update_deliveryservice_safe(self, delivery_service_id=None, data=None):
 		"""
-		Allows a user to edit limited fields of an assigned delivery service.
+		Allows a user to edit limited fields of a Delivery Service.
 		:ref:`to-api-deliveryservices-id-safe`
-		:param delivery_service_id: The delivery service Id
+		:param delivery_service_id: The Delivery Service Id
 		:type delivery_service_id: int
 		:param data: The request data structure for the API request
 		:type data: Dict[str, Any]

--- a/traffic_ops/client/deliveryservice.go
+++ b/traffic_ops/client/deliveryservice.go
@@ -465,3 +465,25 @@ func (to *Session) GetDeliveryServiceURISigningKeys(dsName string) ([]byte, ReqI
 	}
 	return []byte(data), reqInf, nil
 }
+
+// UpdateDeliveryServiceSafe updates the given Delivery Service identified by 'id' with the given "safe" fields.
+func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUpdateRequest) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+	path := apiBase + `/deliveryservices/` + strconv.Itoa(id) + `/safe`
+
+	var reqInf ReqInf
+	var resp tc.DeliveryServiceSafeUpdateResponse
+
+	req, err := json.Marshal(ds)
+	if err != nil {
+		return resp.Response, reqInf, err
+	}
+
+	if reqInf, err = put(to, path, req, &resp); err != nil {
+		return resp.Response, reqInf, err
+	}
+
+	if len(resp.Response) < 1 {
+		err = errors.New("Traffic Ops returned success, but response was missing the Delivery Service")
+	}
+	return resp.Response, reqInf, err
+}

--- a/traffic_ops/testing/api/v1/deliveryservice_safe_update.go
+++ b/traffic_ops/testing/api/v1/deliveryservice_safe_update.go
@@ -1,0 +1,101 @@
+package v1
+
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+func TestPutDeliveryServiceSafe(t *testing.T) {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		UpdateTestDeliveryServiceSafe(t)
+	})
+}
+
+func UpdateTestDeliveryServiceSafe(t *testing.T) {
+	if (len(testData.DeliveryServices) < 1) {
+		t.Fatalf("Need at least one test Delivery Service to test safe update")
+	}
+	firstDS := testData.DeliveryServices[0]
+
+	dses, _, err := TOSession.GetDeliveryServiceByXMLIDNullable(first.XMLID)
+	if err != nil {
+		t.Fatalf("cannot GET Delivery Service by XMLID '%s': %v", first.XMLID, err)
+	} else if len(dses) != 1 {
+		t.Fatalf("expected exactly one Delivery Service by XMLID '%s', got %d", fist.XMLID, len(dses))
+	} else if dses[0].XMLID == nil {
+		t.Fatalf("requested Delivery Service with XMLID '%s', but response contained Delivery Service with null/missing XMLID", first.XMLID)
+	} else if *dses[0].XMLID != first.XMLID {
+		t.Fatalf("requested Delivery Service with XMLID '%s', got '%s'", first.XMLID, *dses[0].XMLID)
+	} else if dses[0].ID == nil {
+		t.Fatalf("requested Delivery Service with XMLID '%s', response contained Delivery Service with null/missing ID", first.XMLID)
+	}
+
+	remoteDS := dses[0]
+
+	req := tc.DeliveryServiceSafeUpdateRequest{
+		DisplayName: util.StrPtr("safe update display name"),
+		InfoURL:     util.StrPtr("safe update info URL"),
+		LongDesc:    util.StrPtr("safe update long desc"),
+		LongDesc1:   util.StrPtr("safe update long desc one"),
+	}
+
+	resp _, err := TOSession.UpdateDeliveryServiceSafe(*remoteDS.ID, req)
+	err != nil {
+		t.Fatalf("unexpected error from PUT /deliveryservices/%d/safe: %v", *remoteDS.ID, err)
+	} else if len(resp) != 1 {
+		t.Fatalf("expected exactly one Delivery Service in response to PUT /deliveryservices/%d/safe, got %d", *remoteDS.ID, len(resp))
+	}
+
+	dses, _, err := TOSession.GetDeliveryServiceByXMLIDNullable(first.XMLID)
+	if err != nil {
+		t.Fatalf("cannot GET Delivery Service by ID: id %v xmlid '%v' - %v", remoteDS.ID, remoteDS.XMLID, err)
+	} else if len(dses) != 1 {
+		t.Fatalf("expected exactly one Delivery Service by XMLID '%s', got %d", fist.XMLID, len(dses))
+	} else if dses[0].XMLID == nil {
+		t.Fatalf("requested Delivery Service with XMLID '%s', but response contained Delivery Service with null/missing XMLID", first.XMLID)
+	} else if *dses[0].XMLID != first.XMLID {
+		t.Fatalf("requested Delivery Service with XMLID '%s', got '%s'", first.XMLID, *dses[0].XMLID)
+	} else if dses[0].DisplayName == nil {
+		t.Fatalf("requested Delivery Service with XMLID '%s', response contained Delivery Service with null/missing Display Name", first.XMLID)
+	} else if dses[0].InfoURL == nil {
+		t.Fatalf("requested Delivery Service with XMLID '%s', response contained Delivery Service with null/missing Info URL", first.XMLID)
+	} else if dses[0].LongDesc == nil {
+		t.Fatalf("requested Delivery Service with XMLID '%s', response contained Delivery Service with null/missing Long Description", first.XMLID)
+	} else if dses[0].LongDesc1 == nil {
+		t.Fatalf("requested Delivery Service with XMLID '%s', response contained Delivery Service with null/missing Long Description 1", first.XMLID)
+	}
+
+	remoteDS = dses[0]
+
+	if *req.DisplayName != *remoteDS.DisplayName || *req.InfoURL != *remoteDS.InfoURL || *req.LongDesc != *remoteDS.LongDesc || *req.LongDesc1 != *remoteDS.LongDesc1 {
+		t.Fatalf(`Safe update succeeded, but resulting Delivery Service didn't match. expected:
+	{
+		"displayName": "%s",
+		"infoUrl": "%s",
+		"longDesc": "%s",
+		"longDesc1": "%s"
+	}
+	actual:
+	{
+		"displayName": "%s",
+		"infoUrl": "%s",
+		"longDesc": "%s",
+		"longDesc1": "%s"
+	}`, *req.DisplayName, *req.InfoURL, *req.LongDesc, *req.LongDesc1, *remoteDS.DisplayName, *remoteDS.InfoURL, *remoteDS.LongDesc, *remoteDS.LongDesc1)
+	}
+}

--- a/traffic_ops/testing/api/v1/deliveryservice_safe_update_test.go
+++ b/traffic_ops/testing/api/v1/deliveryservice_safe_update_test.go
@@ -13,7 +13,6 @@ package v1
 */
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -30,13 +29,13 @@ func UpdateTestDeliveryServiceSafe(t *testing.T) {
 	if (len(testData.DeliveryServices) < 1) {
 		t.Fatalf("Need at least one test Delivery Service to test safe update")
 	}
-	firstDS := testData.DeliveryServices[0]
+	first := testData.DeliveryServices[0]
 
 	dses, _, err := TOSession.GetDeliveryServiceByXMLIDNullable(first.XMLID)
 	if err != nil {
 		t.Fatalf("cannot GET Delivery Service by XMLID '%s': %v", first.XMLID, err)
 	} else if len(dses) != 1 {
-		t.Fatalf("expected exactly one Delivery Service by XMLID '%s', got %d", fist.XMLID, len(dses))
+		t.Fatalf("expected exactly one Delivery Service by XMLID '%s', got %d", first.XMLID, len(dses))
 	} else if dses[0].XMLID == nil {
 		t.Fatalf("requested Delivery Service with XMLID '%s', but response contained Delivery Service with null/missing XMLID", first.XMLID)
 	} else if *dses[0].XMLID != first.XMLID {
@@ -54,18 +53,18 @@ func UpdateTestDeliveryServiceSafe(t *testing.T) {
 		LongDesc1:   util.StrPtr("safe update long desc one"),
 	}
 
-	resp _, err := TOSession.UpdateDeliveryServiceSafe(*remoteDS.ID, req)
-	err != nil {
+	resp, _, err := TOSession.UpdateDeliveryServiceSafe(*remoteDS.ID, req)
+	if err != nil {
 		t.Fatalf("unexpected error from PUT /deliveryservices/%d/safe: %v", *remoteDS.ID, err)
 	} else if len(resp) != 1 {
 		t.Fatalf("expected exactly one Delivery Service in response to PUT /deliveryservices/%d/safe, got %d", *remoteDS.ID, len(resp))
 	}
 
-	dses, _, err := TOSession.GetDeliveryServiceByXMLIDNullable(first.XMLID)
+	dses, _, err = TOSession.GetDeliveryServiceByXMLIDNullable(first.XMLID)
 	if err != nil {
 		t.Fatalf("cannot GET Delivery Service by ID: id %v xmlid '%v' - %v", remoteDS.ID, remoteDS.XMLID, err)
 	} else if len(dses) != 1 {
-		t.Fatalf("expected exactly one Delivery Service by XMLID '%s', got %d", fist.XMLID, len(dses))
+		t.Fatalf("expected exactly one Delivery Service by XMLID '%s', got %d", first.XMLID, len(dses))
 	} else if dses[0].XMLID == nil {
 		t.Fatalf("requested Delivery Service with XMLID '%s', but response contained Delivery Service with null/missing XMLID", first.XMLID)
 	} else if *dses[0].XMLID != first.XMLID {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -1,0 +1,124 @@
+package deliveryservice
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
+)
+
+const safeUpdateQuery = `
+UPDATE deliveryservice
+SET display_name=$1,
+    info_url=$2,
+    long_desc=$3,
+    long_desc_1=$4
+WHERE id = $5
+RETURNING id
+`
+
+// UpdateSafe is the handler for PUT requests to /deliveryservices/{{ID}}/safe.
+//
+// The only fields which are "safe" to modify are the displayName, infoURL, longDesc, and longDesc1.
+func UpdateSafe(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	tx := inf.Tx.Tx
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	dsID := inf.IntParams["id"]
+
+	userErr, sysErr, errCode = tenant.CheckID(tx, inf.User, dsID)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+
+	var dsr tc.DeliveryServiceSafeUpdateRequest
+	if err := api.Parse(r.Body, tx, &dsr); err != nil {
+		api.HandleErr(w, r, tx, http.StatusBadRequest, fmt.Errorf("decoding: %s", err), nil)
+		return
+	}
+
+	if ok, err := updateDSSafe(tx, dsID, dsr); err != nil {
+		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, fmt.Errorf("Updating Delivery Service (safe): %s", err))
+		return
+	} else if !ok {
+		userErr = fmt.Errorf("No Delivery Service exists by ID '%d'", dsID)
+		api.HandleErr(w, r, tx, http.StatusNotFound, userErr, nil)
+		return
+	}
+
+	dses, userErr, sysErr, errCode := readGetDeliveryServices(inf.Params, inf.Tx, inf.User)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
+	}
+	if len(dses) != 1 {
+		sysErr = fmt.Errorf("Updating Delivery Service (safe): expected one Delivery Service returned from read, got %v", len(dses))
+		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
+		return
+	}
+
+	ds := dses[0]
+
+	alertMsg := "Delivery Service safe update successful."
+	if inf.Version != nil && inf.Version.Major == 1 && inf.Version.Minor < 5 {
+		switch (inf.Version.Minor) {
+		case 4:
+			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, ds.DeliveryServiceNullableV14)
+		case 3:
+			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, ds.DeliveryServiceNullableV13)
+		default:
+			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, ds.DeliveryServiceNullableV12)
+		}
+	} else {
+		api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, ds)
+	}
+
+	api.CreateChangeLogRawTx(api.ApiChange, fmt.Sprintf("DS: %s, ID: %d, ACTION: Updated safe fields", *ds.XMLID, *ds.ID), inf.User, tx)
+}
+
+// updateDSSafe updates the given delivery service in the database. Returns whether the DS existed, and any error.
+func updateDSSafe(tx *sql.Tx, dsID int, ds tc.DeliveryServiceSafeUpdateRequest) (bool, error) {
+	res, err := tx.Exec(safeUpdateQuery, ds.DisplayName, ds.InfoURL, ds.LongDesc, ds.LongDesc1, dsID)
+	if err != nil {
+		return false, err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("Checking rows affected: %s", err)
+	}
+	if rowsAffected < 1 {
+		return false, nil
+	}
+	if rowsAffected > 1 {
+		return false, fmt.Errorf("Too many rows affected: %v", rowsAffected)
+	}
+	return true, nil
+}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -91,14 +91,14 @@ func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 	if inf.Version != nil && inf.Version.Major == 1 && inf.Version.Minor < 5 {
 		switch (inf.Version.Minor) {
 		case 4:
-			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, ds.DeliveryServiceNullableV14)
+			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullableV14{ds.DeliveryServiceNullableV14})
 		case 3:
-			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, ds.DeliveryServiceNullableV13)
+			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullableV13{ds.DeliveryServiceNullableV13})
 		default:
-			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, ds.DeliveryServiceNullableV12)
+			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullableV12{ds.DeliveryServiceNullableV12})
 		}
 	} else {
-		api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, ds)
+		api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullable{ds})
 	}
 
 	api.CreateChangeLogRawTx(api.ApiChange, fmt.Sprintf("DS: %s, ID: %d, ACTION: Updated safe fields", *ds.XMLID, *ds.ID), inf.User, tx)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -89,7 +89,7 @@ func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 
 	alertMsg := "Delivery Service safe update successful."
 	if inf.Version != nil && inf.Version.Major == 1 && inf.Version.Minor < 5 {
-		switch (inf.Version.Minor) {
+		switch inf.Version.Minor {
 		case 4:
 			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullableV14{ds.DeliveryServiceNullableV14})
 		case 3:

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -564,6 +564,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.4, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV14, auth.PrivLevelOperations, Authenticated, nil, 1766567526, noPerlBypass},
 		{1.3, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV13, auth.PrivLevelOperations, Authenticated, nil, 1559124565, noPerlBypass},
 		{1.1, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV12, auth.PrivLevelOperations, Authenticated, nil, 597160536, noPerlBypass},
+		{1.1, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateSafe, auth.PrivLevelOperations, Authenticated, nil, 547210931, perlBypass},
+
 
 		{1.1, http.MethodDelete, `deliveryservices/{id}/?(\.json)?$`, api.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, Authenticated, nil, 242642074, noPerlBypass},
 

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -564,7 +564,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.4, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV14, auth.PrivLevelOperations, Authenticated, nil, 1766567526, noPerlBypass},
 		{1.3, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV13, auth.PrivLevelOperations, Authenticated, nil, 1559124565, noPerlBypass},
 		{1.1, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV12, auth.PrivLevelOperations, Authenticated, nil, 597160536, noPerlBypass},
-		{1.1, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateSafe, auth.PrivLevelOperations, Authenticated, nil, 547210931, perlBypass},
+		{1.1, http.MethodPut, `deliveryservices/{id}/safe/?(\.json)?$`, deliveryservice.UpdateSafe, auth.PrivLevelOperations, Authenticated, nil, 547210931, perlBypass},
 
 
 		{1.1, http.MethodDelete, `deliveryservices/{id}/?(\.json)?$`, api.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, Authenticated, nil, 242642074, noPerlBypass},

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -566,7 +566,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPut, `deliveryservices/{id}/?(\.json)?$`, deliveryservice.UpdateV12, auth.PrivLevelOperations, Authenticated, nil, 597160536, noPerlBypass},
 		{1.1, http.MethodPut, `deliveryservices/{id}/safe/?(\.json)?$`, deliveryservice.UpdateSafe, auth.PrivLevelOperations, Authenticated, nil, 547210931, perlBypass},
 
-
 		{1.1, http.MethodDelete, `deliveryservices/{id}/?(\.json)?$`, api.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, Authenticated, nil, 242642074, noPerlBypass},
 
 		{1.1, http.MethodGet, `deliveryservices/{id}/servers/eligible/?(\.json)?$`, deliveryservice.GetServersEligible, auth.PrivLevelReadOnly, Authenticated, nil, 474761584, noPerlBypass},


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3786 and supersedes/replaces #2455  

Rewrites `/deliveryservices/{{ID}}/safe` to Go with special handling for the new Delivery Service fields in API v1.3, 1.4 and 1.5. Also adds client methods, fixes some inaccurate documentation, adds integration tests, and updates the Python Client to support newer API versions for this endpoint.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Client (Python)
- Traffic Ops Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Run the associated client/api integration tests (`TestPutDeliveryServiceSafe`), build and read the documentation, make a `PUT` request to `/api/1.5/deliveryservices/{{ID}}/safe` - that doesn't need to succeed or even correspond to a real ID, just make sure the routing works.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**