### PR TITLE
[Backport 4.0.x] Fix atstccfg Delivery Service Server caching. (#4387)

### DIFF
--- a/traffic_ops/ort/traffic_ops_ort.pl
+++ b/traffic_ops/ort/traffic_ops_ort.pl
@@ -45,6 +45,7 @@ my $skip_os_check = 0;
 my $override_hostname_short = '';
 my $override_hostname_full = '';
 my $override_domainname = '';
+my $use_cache = 1;
 
 GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "retries=i"          => \$retries,
@@ -55,6 +56,7 @@ GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "override_hostname_short=s" => \$override_hostname_short,
             "override_hostname_full=s" => \$override_hostname_full,
             "override_domainname=s" => \$override_domainname,
+            "use_cache=i" => \$use_cache,
           );
 
 if ( $#ARGV < 1 ) {
@@ -356,6 +358,7 @@ sub usage {
 	print "\t   override_hostname_short=<text> => override the short hostname of the OS for config generation. Default = ''.\n";
 	print "\t   override_hostname_full=<text>  => override the full hostname of the OS for config generation. Default = ''.\n";
 	print "\t   override_domainname=<text>     => override the domainname of the OS for config generation. Default = ''.\n";
+	print "\t   use_cache=<0|1>                => whether to use cached Traffic Ops data for config generation. Default = 1, use cache.\n";
 	print "====-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-====\n";
 	exit 1;
 }
@@ -1505,7 +1508,12 @@ sub lwp_get {
 
 	my ( $TO_USER, $TO_PASS ) = split( /:/, $TM_LOGIN );
 
-	$response_content = `$atstccfg_cmd --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$request' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null 2>$atstccfg_log_path`;
+	my $no_cache_arg = '';
+	if ( $use_cache == 0 ) {
+		$no_cache_arg = '--no-cache';
+	}
+
+	$response_content = `$atstccfg_cmd $no_cache_arg --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$request' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null 2>$atstccfg_log_path`;
 
 	my $atstccfg_exit_code = $?;
 	$atstccfg_exit_code = atstccfg_code_to_http_code($atstccfg_exit_code);


### PR DESCRIPTION
Fixes atstccfg Delivery Service Server caching.
    
Fixses an inconsistent ORT bug with files, noticably parent.config,
not having all lines. Bug was filtering before saving the cache file.

DSS gets everything, and then filters. It was filtering before saving
the cache file, causing subsequent ORT calls under the cache age which
had more DSSes to be missing them.

This fixes it to filter after saving/loading the cache file, instead
of before.

Also adds a flag to ORT to disable caching. Caching is hard, and we've had similar bugs before. This will allow users to disable it in ORT without having to modify ORT (atstccfg already had a flag, it just wasn't exposed), which will reduce the severity of caching issues in the future.

ORT doesn't have an Integration Test framework yet, and the bug requires TO requests to test. I've manually verified full ORT calls place the full config files, where without the fix parent.config is missing most values. Also manually verified the new ORT --use_cache flag works as expected, by running ORT and verifying cache usage in atstccfg log.
No changelog, no docs, no interface change, and bug does not exist prior to 4.0.x.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT, verify full files are placed, specifically parent.config. Run atstccfg for a mid header rewrite file (which will only request a single DS), inspect DSS cache file `deliveryservice_servers_s_d_.json` and verify it contains all DSes, not just 1.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.x


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information