### PR TITLE
Traffic Ops client upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Fix to traffic_ops_ort.pl to strip specific comment lines before checking if a file has changed.  Also promoted a changed file message from DEBUG to ERROR for report mode.
+- Updated The Traffic Ops Python, Go and Java clients to use API version 2.0 (when possible)
+- Updated CDN-in-a-Box scripts and enroller to use TO API version 2.0
+- Updated numerous, miscellaneous tools to use TO API version 2.0
 
 ### Deprecated/Removed
+- Traffic Ops Python client no longer supports Python 2.
 - Traffic Ops API Endpoints
   - /api_capabilities/:id
   - /cachegroup/:parameterID/parameter

--- a/experimental/traffic-portal-angular8/src/app/services/api.service.ts
+++ b/experimental/traffic-portal-angular8/src/app/services/api.service.ts
@@ -84,7 +84,7 @@ export class APIService {
 	 * The current API version to use
 	 * @todo Get this from the environment
 	 */
-	public API_VERSION = '1.4';
+	public API_VERSION = '2.0';
 
 	private deliveryServiceTypes: Array<Type>;
 

--- a/infrastructure/cdn-in-a-box/edge/run.sh
+++ b/infrastructure/cdn-in-a-box/edge/run.sh
@@ -58,7 +58,7 @@ found=
 while [[ -z $found ]]; do
     echo 'waiting for enroller setup'
     sleep 3
-    found=$(to-get "api/1.3/cdns?name=$CDN_NAME" | jq -r '.response[].name')
+    found=$(to-get "api/2.0/cdns?name=$CDN_NAME" | jq -r '.response[].name')
 done
 
 to-enroll edge $CDN_NAME || (while true; do echo "enroll failed."; sleep 3 ; done)
@@ -69,7 +69,7 @@ while [[ -z "$(testenrolled)" ]]; do
 done
 
 # Wait for SSL keys to exist
-until to-get "api/1.3/cdns/name/$CDN_NAME/sslkeys" && [[ "$(to-get api/1.3/cdns/name/$CDN_NAME/sslkeys)" != '{"response":[]}' ]]; do
+until to-get "api/2.0/cdns/name/$CDN_NAME/sslkeys" && [[ "$(to-get api/2.0/cdns/name/$CDN_NAME/sslkeys)" != '{"response":[]}' ]]; do
 	echo 'waiting for SSL keys to exist'
 	sleep 3
 done

--- a/infrastructure/cdn-in-a-box/enroller/enroller.go
+++ b/infrastructure/cdn-in-a-box/enroller/enroller.go
@@ -764,7 +764,7 @@ func startWatching(watchDir string, toSession *session, dispatcher map[string]fu
 }
 
 func startServer(httpPort string, toSession *session, dispatcher map[string]func(*session, io.Reader) error) error {
-	baseEP := "/api/1.4/"
+	baseEP := "/api/2.0/"
 	for d, f := range dispatcher {
 		http.HandleFunc(baseEP+d, func(w http.ResponseWriter, r *http.Request) {
 			defer r.Body.Close()

--- a/infrastructure/cdn-in-a-box/mid/run.sh
+++ b/infrastructure/cdn-in-a-box/mid/run.sh
@@ -58,7 +58,7 @@ found=
 while [[ -z $found ]]; do
     echo 'waiting for enroller setup'
     sleep 3
-    found=$(to-get api/1.3/cdns?name="$CDN_NAME" | jq -r '.response[].name')
+    found=$(to-get api/2.0/cdns?name="$CDN_NAME" | jq -r '.response[].name')
 done
 
 to-enroll mid $CDN_NAME "CDN_in_a_Box_Mid" || (while true; do echo "enroll failed."; sleep 3 ; done)

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -36,6 +36,8 @@ class API(TOSession):
 	"""
 	This class extends :class:`trafficops.tosession.TOSession` to provide some ease-of-use
 	functionality for getting things needed by :term:`ORT`.
+
+	TODO: update to 2.0 if/when atstccfg support is integrated.
 	"""
 
 	#: This should always be the latest API version supported - note this breaks compatability with

--- a/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
@@ -89,7 +89,7 @@ export TO_PASSWORD=$TO_ADMIN_PASSWORD
 
 # There's a race condition with setting the TM credentials and TO actually creating
 # the TM user
-until to-get "api/1.3/users?username=$TM_USER" 2>/dev/null | jq -c -e '.response[].username|length'; do
+until to-get "api/2.0/users?username=$TM_USER" 2>/dev/null | jq -c -e '.response[].username|length'; do
 	echo "waiting for TM_USER creation..."
 	sleep 3
 done
@@ -102,7 +102,7 @@ export TO_USER=$TO_ADMIN_USER
 export TO_PASSWORD=$TO_ADMIN_PASSWORD
 
 # Do not start until there a valid Snapshot has been taken
-until [ $(to-get "/api/1.4/cdns/$CDN_NAME/snapshot" 2>/dev/null | jq -c -e '.response.config|length') -gt 0 ] ; do
+until [ $(to-get "/api/2.0/cdns/$CDN_NAME/snapshot" 2>/dev/null | jq -c -e '.response.config|length') -gt 0 ] ; do
 	echo "Waiting on valid Snapshot...";
   	sleep 3;
 done

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -74,10 +74,10 @@ to-enroll "to" ALL || (while true; do echo "enroll failed."; sleep 3 ; done)
 while true; do
   echo "Verifying that edge was associated to delivery service..."
 
-  edge_name="$(to-get 'api/1.3/servers/hostname/edge/details' 2>/dev/null | jq -r -c '.response|.hostName')"
-  ds_name=$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[] | select(.cdnName == "'"$CDN_NAME"'").xmlId')
-  ds_id=$(to-get 'api/1.3/deliveryservices' 2>/dev/null | jq -r -c '.response[] | select(.cdnName == "'"$CDN_NAME"'").id')
-  edge_verify=$(to-get "/api/1.2/deliveryservices/$ds_id/servers" | jq -r '.response[]|.hostName')
+  edge_name="$(to-get 'api/2.0/servers?hostName=edge' 2>/dev/null | jq -r -c '.response|.hostName')"
+  ds_name=$(to-get 'api/2.0/deliveryservices' 2>/dev/null | jq -r -c '.response[] | select(.cdnName == "'"$CDN_NAME"'").xmlId')
+  ds_id=$(to-get 'api/2.0/deliveryservices' 2>/dev/null | jq -r -c '.response[] | select(.cdnName == "'"$CDN_NAME"'").id')
+  edge_verify=$(to-get "/api/2.0/deliveryservices/$ds_id/servers" | jq -r '.response[]|.hostName')
 
   if [[ $edge_verify = $edge_name ]] ; then
     break

--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -305,7 +305,7 @@ to-add-sslkeys() {
 		json_response=$(to-post 'api/2.0/deliveryservices/sslkeys/add' "$json_request")
 		if [[ -n "$json_response" ]] ; then
 			sleep 3
-			cdn_sslkeys_response=$(to-get "api/2.0/cdns/name/$1/sslkeys.json" | jq '.response[] | length')
+			cdn_sslkeys_response=$(to-get "api/2.0/cdns/name/$1/sslkeys" | jq '.response[] | length')
 			if ((cdn_sslkeys_response>0)); then
 				break
 			else

--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -75,7 +75,7 @@ to-auth() {
 	# if cookiejar is current, nothing to do..
 	cookie_current $COOKIEJAR && return
 
-	local url=$TO_URL/api/1.4/user/login
+	local url=$TO_URL/api/2.0/user/login
 	local datatype='Accept: application/json'
 	cat >"$login" <<-CREDS
 { "u" : "$TO_USER", "p" : "$TO_PASSWORD" }
@@ -89,7 +89,7 @@ CREDS
 
 to-ping() {
 	# ping endpoint does not require authentication
-	curl $CURLAUTH $CURLOPTS -X GET "$TO_URL/api/1.4/ping"
+	curl $CURLAUTH $CURLOPTS -X GET "$TO_URL/api/2.0/ping"
 }
 
 to-get() {
@@ -140,21 +140,21 @@ to-delete() {
 #         MY_HTTPS_PORT - the tcp port, default is "443"
 to-enroll() {
 
-	# Force fflush() on /shared 
-	sync 
+	# Force fflush() on /shared
+	sync
 
 	# Wait for the initial data load to be copied
 	until [[ -f "$ENROLLER_DIR/initial-load-done" ]] ; do
 		echo "Waiting for enroller initial data load to complete...."
 		sleep 2
-		sync 
+		sync
 	done
 
 	# Wait for the Enroller servers directory to be created
-	until [[ -d "${ENROLLER_DIR}/servers" ]] ; do 
+	until [[ -d "${ENROLLER_DIR}/servers" ]] ; do
 		echo "Waiting for ${ENROLLER_DIR}/servers ..."
 		sleep 2
-		sync 
+		sync
 	done
 
 	# If the servers dir vanishes, the docker shared volume isn't working right
@@ -265,7 +265,7 @@ to-enroll() {
 
 # Tests that this server exists in Traffic Ops
 function testenrolled() {
-	local tmp="$(to-get	'api/1.3/servers?name='$MY_HOSTNAME'')"
+	local tmp="$(to-get	'api/2.0/servers?name='$MY_HOSTNAME'')"
 	tmp=$(echo $tmp | jq '.response[]|select(.hostName=="'"$MY_HOSTNAME"'")')
 	echo "$tmp"
 }
@@ -302,10 +302,10 @@ to-add-sslkeys() {
 	                 }")
 
 	while true; do
-		json_response=$(to-post 'api/1.4/deliveryservices/sslkeys/add' "$json_request")
+		json_response=$(to-post 'api/2.0/deliveryservices/sslkeys/add' "$json_request")
 		if [[ -n "$json_response" ]] ; then
 			sleep 3
-			cdn_sslkeys_response=$(to-get "api/1.3/cdns/name/$1/sslkeys.json" | jq '.response[] | length')
+			cdn_sslkeys_response=$(to-get "api/2.0/cdns/name/$1/sslkeys.json" | jq '.response[] | length')
 			if ((cdn_sslkeys_response>0)); then
 				break
 			else
@@ -329,7 +329,7 @@ to-auto-snapqueue() {
 		expected_servers_list=$(jq -r -n --argjson expected "$expected_servers_json" '$expected|join(",")')
 		expected_servers_total=$(jq -r -n --argjson expected "$expected_servers_json" '$expected|length')
 
-		current_servers_json=$(to-get 'api/1.4/servers' 2>/dev/null | jq -c -e '[.response[] | .xmppId] | sort')
+		current_servers_json=$(to-get 'api/2.0/servers' 2>/dev/null | jq -c -e '[.response[] | .xmppId] | sort')
 		[ -z "$current_servers_json" ] && current_servers_json='[]'
 		current_servers_list=$(jq -r -n --argjson current "$current_servers_json" '$current|join(",")')
 		current_servers_total=$(jq -r -n --argjson current "$current_servers_json" '$current|length')
@@ -346,11 +346,11 @@ to-auto-snapqueue() {
 			echo "AUTO-SNAPQUEUE - All expected servers enrolled."
 			sleep $AUTO_SNAPQUEUE_ACTION_WAIT
 			echo "AUTO-SNAPQUEUE - Do automatic snapshot..."
-			cdn_id=$(to-get "api/1.3/cdns?name=$2" |jq '.response[0].id')
-			to-put "api/1.3/cdns/$cdn_id/snapshot"
+			cdn_id=$(to-get "api/2.0/cdns?name=$2" |jq '.response[0].id')
+			to-put "api/2.0/cdns/$cdn_id/snapshot"
 			sleep $AUTO_SNAPQUEUE_ACTION_WAIT
 			echo "AUTO-SNAPQUEUE - Do queue updates..."
-			to-post "api/1.3/cdns/$cdn_id/queue_update" '{"action":"queue"}'
+			to-post "api/2.0/cdns/$cdn_id/queue_update" '{"action":"queue"}'
 			break
 		fi
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/trafficops-init.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/trafficops-init.sh
@@ -45,7 +45,7 @@ waitfor() {
     local value="$3"
 
     while true; do
-        v=$(to-get "api/1.4/$endpoint?$field=$value" | jq -r --arg field "$field" '.response[][$field]')
+        v=$(to-get "api/2.0/$endpoint?$field=$value" | jq -r --arg field "$field" '.response[][$field]')
         if [[ $v == $value ]]; then
             break
         fi

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/040-CCR_CIAB.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/040-CCR_CIAB.json
@@ -93,7 +93,7 @@
     {
       "configFile": "CRConfig.json",
       "name": "federationmapping.polling.url",
-      "value": "https://${toHostname}/internal/api/1.3/federations.json"
+      "value": "https://${toHostname}/internal/api/2.0/federations"
     },
     {
       "configFile": "CRConfig.json",

--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/run.sh
@@ -40,7 +40,7 @@ done
 source config.sh
 
 PGPASSWORD="$DB_USER_PASS" pg_dump --blobs --no-owner --format=c "--host=$DB_SERVER" "--port=$DB_PORT" "--username=$DB_USER" traffic_ops > dbdump.manual
-to-get api/1.4/dbdump > dbdump.api
+to-get api/2.0/dbdump > dbdump.api
 
 diff dbdump.api dbdump.manual && rm -f dbdump.api dbdump.manual
 

--- a/infrastructure/test/integration/README.md
+++ b/infrastructure/test/integration/README.md
@@ -33,7 +33,7 @@ To create a new integration test, create an executable file -- it can be a shell
 
 Your executable should:
 * Query Traffic Ops at localhost
-* Query any other components at their IPs, which can be queried from Traffic Ops at `https://localhost/api/1.2/servers`
+* Query any other components at their IPs, which can be queried from Traffic Ops at `https://localhost/api/2.0/servers`
   * If you're not using a Traffic Ops client, you'll need to send a login cookie; for an example of how to get the cookie, see https://github.com/apache/trafficcontrol/tree/master/infrastructure/docker/traffic_ops/run.sh
 * Return 0 and print nothing for success; return a nonzero code and print the error on failure
 

--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -38,7 +38,7 @@ type ConfigProfileParams struct {
 // This is used to generate the meta config, which has API paths.
 // Note the version in the meta config is not used by the atstccfg generator, which isn't actually an API.
 // TODO change the config system to not use old API paths, and remove this.
-const APIVersion = "1.4"
+const APIVersion = "2.0"
 
 func MakeMetaConfig(
 	serverHostName tc.CacheName,

--- a/test/astats_sim/ats_sim.js
+++ b/test/astats_sim/ats_sim.js
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,7 +23,7 @@ var myport = 80;
 var config_url = "https://traffic-ops.com/CRConfig-Snapshots/cdn-name/CRConfig.json";
 var to_user = "";
 var to_password = "";
-var to_login_api = "/api/1.2/user/login";
+var to_login_api = "/api/2.0/user/login";
 var simulator_ua = "ATS Simulator/node.js " + process.version;
 
 // first argument to follow node ats_sim.js
@@ -257,15 +257,15 @@ function getData(request) {
 	var miss_changed = (unixtime / 10000000) + int1;
 	var miss_client_no_cache = 0;
 	var aborts = (unixtime / 10000000) + int2 * 2;
-	var possible_aborts = 0; 
+	var possible_aborts = 0;
 	var connect_failed = (unixtime / 1000000) + int2 * 4 + int1 * 2;
 	var other = ((unixtime / 1000000) + int3) / 100;
-	var unclassified = 0; 
+	var unclassified = 0;
 	var write_bytes = unixtime + int4 * int5;
-	var current_client_connections = Math.round(int5 * Math.random()); 
+	var current_client_connections = Math.round(int5 * Math.random());
 	var bytes_used = write_bytes / 20 + int2 * int5;
 	var bytes_total = bytes_used + int10;
-	var v1_bytes_used = bytes_used; 
+	var v1_bytes_used = bytes_used;
 	var v1_bytes_total = bytes_total;
 	var load_avg_1 = (8 * Math.random()).toFixed(2);
 	var load_avg_5 = (load_avg_1 / 2).toFixed(2);
@@ -293,7 +293,7 @@ function getData(request) {
 	var ds_500s = {};
 
 	for (var i=1; i<=10; i++) {
-		var rand1 = rand(int1); 
+		var rand1 = rand(int1);
 		ds_bytes[i] = if_tbytes / 10;
 		ds_bytes_in[i] = if_rbytes / 10;
 		var tps = basetime / 10000;
@@ -326,15 +326,15 @@ function getData(request) {
 	ret.ats["proxy.process.http.transaction_counts.miss_changed"] = miss_changed;
 	ret.ats["proxy.process.http.transaction_counts.miss_client_no_cache"] = miss_client_no_cache;
 	ret.ats["proxy.process.http.transaction_counts.errors.aborts"] = aborts;
-	ret.ats["proxy.process.http.transaction_counts.errors.possible_aborts"] = possible_aborts; 
+	ret.ats["proxy.process.http.transaction_counts.errors.possible_aborts"] = possible_aborts;
 	ret.ats["proxy.process.http.transaction_counts.errors.connect_failed"] = connect_failed;
 	ret.ats["proxy.process.http.transaction_counts.errors.other"] = other;
-	ret.ats["proxy.process.http.transaction_counts.other.unclassified"] = unclassified; 
+	ret.ats["proxy.process.http.transaction_counts.other.unclassified"] = unclassified;
 	ret.ats["proxy.process.net.write_bytes"] = write_bytes;
-	ret.ats["proxy.process.http.current_client_connections"] = current_client_connections; 
+	ret.ats["proxy.process.http.current_client_connections"] = current_client_connections;
 	ret.ats["proxy.process.cache.bytes_used"] = bytes_used;
 	ret.ats["proxy.process.cache.bytes_total"] = bytes_total;
-	ret.ats["proxy.process.cache.volume_1.bytes_used"] = v1_bytes_used; 
+	ret.ats["proxy.process.cache.volume_1.bytes_used"] = v1_bytes_used;
 	ret.ats["proxy.process.cache.volume_1.bytes_total"] = v1_bytes_total;
 
 	if (cr_config && cr_config.contentServers && server_name in cr_config.contentServers) {

--- a/test/traffic_ops_cfg/cfg_test.pl
+++ b/test/traffic_ops_cfg/cfg_test.pl
@@ -235,7 +235,7 @@ sub get_crconfigs {
 	my $to_url = shift;
         my $outpath = shift;
 
-	my $to_cdn_url = $to_url . '/api/1.2/cdns.json';
+	my $to_cdn_url = $to_url . '/api/2.0/cdns';
 	my $result     = &curl_me($to_cdn_url);
 	my $cdn_json   = decode_json($result);
 
@@ -269,7 +269,7 @@ sub get_crconfigs {
                 }
                 my $to_url = shift;
 
-                my $to_server_url = $to_url . '/api/1.2/servers.json';
+                my $to_server_url = $to_url . '/api/2.0/servers';
                 my $result        = &curl_me($to_server_url);
                 my $server_json   = decode_json($result);
 

--- a/traffic_control/clients/java/trafficops/src/main/java/org/apache/trafficcontrol/client/trafficops/TOSession.java
+++ b/traffic_control/clients/java/trafficops/src/main/java/org/apache/trafficcontrol/client/trafficops/TOSession.java
@@ -41,27 +41,27 @@ import com.google.gson.GsonBuilder;
 @AutoValue
 public abstract class TOSession implements Closeable {
 	private static final Logger LOG = LoggerFactory.getLogger(TOSession.class);
-	
+
 	private static final String URL_FORMAT_STR = "/%s/%s/%s";
-	
+
 	public static final String DEFAULT_API_PATH = "api";
-	public static final String DEFAULT_API_VERSION = "1.2";
-	
+	public static final String DEFAULT_API_VERSION = "2.0";
+
 	public abstract RestApiSession restClient();
 	public abstract String host();
 	public abstract int port();
 	public abstract boolean ssl();
 	public abstract String apiVersion();
 	public abstract String apiBasePath();
-	
+
 	static final Gson gson = new GsonBuilder()
 			.create();
-	
+
 	private boolean isLoggedIn = false;
-	
+
 	protected URIBuilder newUriBuilder(final String path) {
 		final String _path = String.format(URL_FORMAT_STR, this.apiBasePath(), this.apiVersion(), path);
-		
+
 		return new URIBuilder()
 				.setScheme(this.ssl() ? "https" : "http")
 				.setHost(this.host())
@@ -77,25 +77,25 @@ public abstract class TOSession implements Closeable {
 		}
 		return Collections.emptyList();
 	}
-	
+
 	public void close() throws IOException {
 		this.restClient().close();
 	}
 	public boolean isLoggedIn() {
 		return isLoggedIn;
 	}
-	
+
 	public CompletableFuture<Boolean> login(final String username, final String password) {
 		URI uri;
 		try {
-			uri = this.newUriBuilder("user/login.json")
+			uri = this.newUriBuilder("user/login")
 					.build();
 		} catch (Throwable e) {
 			final CompletableFuture<Boolean> f = new CompletableFuture<>();
 			f.completeExceptionally(e);
 			return f;
 		}
-		
+
 		LOG.debug("Logging into: {}", uri);
 		return ResponseFuture.builder()
 			.setHandleException((f,t)-> {
@@ -116,7 +116,7 @@ public abstract class TOSession implements Closeable {
 	public CompletableFuture<Response.CollectionResponse> getServers(final Map<String, ?> filterParams){
 		URI uri;
 		try {
-			uri = this.newUriBuilder("servers.json")
+			uri = this.newUriBuilder("servers")
 					.setParameters(this.toPairs(filterParams))
 					.build();
 		} catch (Throwable e) {
@@ -130,14 +130,14 @@ public abstract class TOSession implements Closeable {
 				.setSession(this.restClient())
 				.build();
 	}
-	
+
 	public CompletableFuture<Response.CollectionResponse> getDeliveryServices(){
 		return this.getDeliveryServices(null);
 	}
 	public CompletableFuture<Response.CollectionResponse> getDeliveryServices(final Map<String, ?> filterParams){
 		URI uri;
 		try {
-			uri = this.newUriBuilder("deliveryservices.json")
+			uri = this.newUriBuilder("deliveryservices")
 					.setParameters(this.toPairs(filterParams))
 					.build();
 		} catch (Throwable e) {
@@ -152,21 +152,21 @@ public abstract class TOSession implements Closeable {
 				.setSession(this.restClient())
 				.build();
 	}
-	
-	
+
+
 	public static Builder builder() {
 		final Builder b = new AutoValue_TOSession.Builder()
 				.setApiBasePath(DEFAULT_API_PATH)
 				.setApiVersion(DEFAULT_API_VERSION);
-		
+
 		return b;
 	}
 	public abstract Builder toBuilder();
-	
+
 	@AutoValue.Builder
 	public abstract static class Builder {
 		public abstract TOSession build();
-		
+
 		public abstract Builder setRestClient(RestApiSession restClient);
 		public abstract RestApiSession.Builder restClientBuilder();
 
@@ -175,7 +175,7 @@ public abstract class TOSession implements Closeable {
 		public abstract Builder setApiVersion(String version);
 		public abstract Builder setApiBasePath(String version);
 		public abstract Builder setSsl(boolean ssl);
-		
+
 		public Builder fromURI(URI uri){
 			return this.setSsl(uri.getScheme().equals("http") ? false: true)
 					.setHost(uri.getHost())

--- a/traffic_ops/app/bin/checks/ToDSCPCheck.pl
+++ b/traffic_ops/app/bin/checks/ToDSCPCheck.pl
@@ -131,7 +131,7 @@ foreach my $ds ( @{$jdeliveryservices} ) {
 	$ds_info{ $ds->{id} } = $ds;
 
 	# Get the DS details and add the matchList
-	my $ds_details = $ext->get( '/api/1.2/deliveryservices/' . $ds->{id} );
+	my $ds_details = $ext->get( '/api/2.0/deliveryservices/' . $ds->{id} );
 
 	#DEBUG "Debug matchList before push: " . Dumper($ds_details->[0]{matchList});
 	# The matchList was removed at one point and now it's back.
@@ -146,7 +146,7 @@ if ( defined( $args{s} ) ) {
 
 	# TODO check for a successful return
 	# This returns a reference to a hash
-	$jdataserver = $ext->get( '/api/1.1/servers/hostname/' . $args{s} . '/details' );
+	$jdataserver = $ext->get( '/api/2.0/servers/hostname/' . $args{s} . '/details' );
 
 	# create an array
 	my @tmp = ();
@@ -167,7 +167,7 @@ else {
 }
 
 my %cdns  = ();
-my $jcdns = $ext->get('/api/1.1/cdns');
+my $jcdns = $ext->get('/api/2.0/cdns');
 
 # convert the cdns to a hash
 foreach my $cdn ( @{$jcdns} ) {
@@ -191,7 +191,7 @@ foreach my $server ( @{$jdataserver} ) {
 	my $protocol    = "http";
 	my $ip_protocol = "ipv4";
 	my $domain_name = undef;
-	my $details     = $ext->get( '/api/1.1/servers/hostname/' . $host_name . '/details' );
+	my $details     = $ext->get( '/api/2.0/servers/hostname/' . $host_name . '/details' );
 	my $successful  = 1;                                                                     # assume all is good
 
 	if ( ( defined( $ip_addrs[1] ) ) && ( $ip_addrs[1] =~ m/:/ ) ) {

--- a/traffic_ops/app/bin/checks/ToDnssecRefresh.pl
+++ b/traffic_ops/app/bin/checks/ToDnssecRefresh.pl
@@ -80,7 +80,7 @@ $ua->timeout(30);
 $ua->ssl_opts(verify_hostname => 0);
 $ua->cookie_jar( {} );
 
-my $login_url = "$b_url/api/1.2/user/login";
+my $login_url = "$b_url/api/2.0/user/login";
 TRACE "posting $login_url";
 my $req = HTTP::Request->new( 'POST', $login_url );
 $req->header( 'Content-Type' => 'application/json' );
@@ -92,7 +92,7 @@ if ( ! $login_response->is_success ) {
 	exit(1);
 }
 
-my $url       = "$b_url/api/1.4/cdns/dnsseckeys/refresh";
+my $url       = "$b_url/api/2.0/cdns/dnsseckeys/refresh";
 TRACE "getting $url";
 my $response = $ua->get($url);
 if ( $response->is_success ) {

--- a/traffic_ops/app/bin/checks/ToORTCheck.pl
+++ b/traffic_ops/app/bin/checks/ToORTCheck.pl
@@ -105,7 +105,7 @@ my $ext = Extensions::Helper->new( { base_url => $b_url, token => '91504CE6-8E4A
 
 my $jdataserver = $ext->get(Extensions::Helper::SERVERLIST_PATH);
 
-my $glbl_prms = $ext->get( '/api/1.1/parameters/profile/global.json' );
+my $glbl_prms = $ext->get( '/api/2.0/parameters/profile/global' );
 my $to_url;
 foreach my $p (@{$glbl_prms}) {
    if ($p->{name} eq 'tm.url') {

--- a/traffic_ops/app/bin/extensions
+++ b/traffic_ops/app/bin/extensions
@@ -6,7 +6,7 @@
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,11 +60,11 @@ elsif ( $args{a} eq 'add' ) {
 	open( FILE, $args{f} ) or die "Couldn't open file: $!";
 	my $json_text = <FILE>;
 	close FILE;
-	$econ->post_json( '/api/1.1/to_extensions', $json_text );
+	$econ->post_json( '/api/2.0/to_extensions', $json_text );
 }
 elsif ( $args{a} eq 'delete' ) {
 	my $json_text = encode_json( { id => $args{i} } );
-	$econ->post_json( '/api/1.1/to_extensions/delete', $json_text );
+	$econ->post_json( '/api/2.0/to_extensions/delete', $json_text );
 }
 else {
 	ERROR "Use -a list|add|delete";
@@ -74,7 +74,7 @@ my ( $f1_id, $f1_name, $f1_type, $f1_colnames, $f1_version );
 
 sub mainlist {
 	my $econ     = shift;
-	my $ext_list = $econ->get('/api/1.1/to_extensions.json');
+	my $ext_list = $econ->get('/api/2.0/to_extensions.json');
 	foreach my $extension ( @{$ext_list} ) {
 
 		$f1_id       = $extension->{id};

--- a/traffic_ops/app/script/update_riak_for_search.pl
+++ b/traffic_ops/app/script/update_riak_for_search.pl
@@ -71,7 +71,7 @@ sub get_cookie {
 	my $u = shift;
 	my $p = shift;
 
-	my $url = $to_host . "/api/1.2/user/login";
+	my $url = $to_host . "/api/2.0/user/login";
 	my $json = encode_json({u => $u, p => $p});
 	my $req = HTTP::Request->new( 'POST', $url );
 	$req->header( 'Content-Type' => 'application/json' );
@@ -101,7 +101,7 @@ sub get_deliveryservices {
 	my $to_host = shift;
 	my $ua = shift;
 
-	my $url = $to_host . "/api/1.2/deliveryservices.json";
+	my $url = $to_host . "/api/2.0/deliveryservices";
 	my $response = $ua->get( $url );
 
 	if(!$response->is_success() || $response->code() > 400) {
@@ -117,7 +117,7 @@ sub get_riak_record {
 	my $xml_id = shift;
 	my $to_url = shift;
 	my $ua = shift;
-	my $url = $to_url . "/api/1.2/deliveryservices/xmlId/$xml_id/sslkeys.json";
+	my $url = $to_url . "/api/2.0/deliveryservices/xmlId/$xml_id/sslkeys";
 	my $response = $ua->get( $url );
 
 	if(!$response->is_success() || $response->code() > 400) {
@@ -134,7 +134,7 @@ sub send_riak_record {
 	my $to_url = shift;
 	my $ua = shift;
 
-	my $url = $to_url . "/api/1.2/deliveryservices/sslkeys/add";
+	my $url = $to_url . "/api/2.0/deliveryservices/sslkeys/add";
 	my $req = HTTP::Request->new( 'POST', $url );
 	$req->header( 'Content-Type' => 'application/json' );
 	$req->content( encode_json($record) );

--- a/traffic_ops/testing/compare/compare.go
+++ b/traffic_ops/testing/compare/compare.go
@@ -79,7 +79,7 @@ func (to *Connect) login(creds Creds) error {
 	}
 
 	to.Client = &http.Client{Transport: tr}
-	url := to.URL + `/api/1.3/user/login`
+	url := to.URL + `/api/2.0/user/login`
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		return err

--- a/traffic_ops/testing/compare/genConfigRoutes.py
+++ b/traffic_ops/testing/compare/genConfigRoutes.py
@@ -90,8 +90,8 @@ def getCRConfigs(A:TOSession, B:TOSession) -> typing.Generator[str, None, None]:
 
 	for cdn in cdns:
 		yield "/CRConfig-Snapshots/%s/CRConfig.json" % cdn
-		yield "/api/1.3/cdns/%s/snapshot" % cdn
-		yield "/api/1.3/cdns/%s/snapshot/new" % cdn
+		yield "/api/2.0/cdns/%s/snapshot" % cdn
+		yield "/api/2.0/cdns/%s/snapshot/new" % cdn
 
 
 def consolidateVariables(kwargs:argparse.Namespace) -> typing.Tuple[str, str,

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -213,7 +213,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{2, 0}, http.MethodGet, `dbdump/?`, dbdump.DBDump, auth.PrivLevelAdmin, Authenticated, nil, 224016647, noPerlBypass},
 
 		//Division: CRUD
-		{api.Version{2, 0}, http.MethodGet, `divisions/??$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, Authenticated, nil, 2085181534, noPerlBypass},
+		{api.Version{2, 0}, http.MethodGet, `divisions/?$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, Authenticated, nil, 2085181534, noPerlBypass},
 		{api.Version{2, 0}, http.MethodGet, `divisions/{id}$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, Authenticated, nil, 2241497902, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPut, `divisions/{id}$`, api.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, Authenticated, nil, 206369140, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPost, `divisions/?$`, api.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, Authenticated, nil, 253713800, noPerlBypass},


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Updates various clients of the Traffic Ops API to use version 2.0.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?
This includes updates to all of the following components/systems/tools:

- experimental Traffic Portal in Angular 8
- CDN in a Box, including ORT.py (except for configuration file generation routes)
- The `astats` plugin simulator in `test/astats_sim/`
- The `test/traffic_ops_cfg/cfg_test.pl` script - which by the way can we remove that? Isn't it superseded by the `compare` tool?
- The `compare` tool and its companion `genConfigRoutes.py` script - the latter of which should be removed with API v1 anyway, since it will no longer be able to generate valid routes (because configuration file generation will be handled by `atstccfg` from now on).
- Traffic Ops Client (Java)
- Some of the 'checks' scripts in `traffic_ops/app/bin/checks/`
- The `traffic_ops/app/bin/extensions` script
- The `traffic_ops/app/script/update_riak_for_search.pl` script

This PR also removes API endpoints from clients when said endpoints don't exist in TO API v2.0.

It also fixes a typo in one of the TO route definitions and some improper formatting for the `--api-routes` option of `traffic_ops_golang`.

## What is the best way to verify this PR?
For tools/components/systems that support it, run the tests. For those that don't....  ¯\\\_(ツ)\_/¯

## The following criteria are ALL met by this PR
- [x] Tests will be added in #4374 
- [x] Documentation will be added in #4371 
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**