### PR TITLE
Fixed /api/2.0/roles always returning empty array

### DIFF
--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -165,15 +165,11 @@ func (role *TORole) Read() ([]interface{}, error, error, int) {
 		return nil, userErr, sysErr, errCode
 	}
 
-	if version.Major > 1 {
-		return vals, nil, nil, http.StatusOK
-	}
-
 	returnable := []interface{}{}
 	for _, val := range vals {
 		rl := val.(*TORole)
 		switch {
-		case version.Minor >= 3:
+		case version.Major > 1 || version.Minor >= 3:
 			caps := ([]string)(*rl.PQCapabilities)
 			rl.Capabilities = &caps
 			returnable = append(returnable, rl)

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -164,6 +164,11 @@ func (role *TORole) Read() ([]interface{}, error, error, int) {
 	if userErr != nil || sysErr != nil {
 		return nil, userErr, sysErr, errCode
 	}
+
+	if version.Major > 1 {
+		return vals, nil, nil, http.StatusOK
+	}
+
 	returnable := []interface{}{}
 	for _, val := range vals {
 		rl := val.(*TORole)


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

The `/roles` endpoint when called in API version 2.0 is always returning an empty array because of how it handles the new v1.3 fields. This fixes that.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Build and run, make a GET request to `/roles`, verify the resulting array of roles is not empty.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Tests are being added in #4374 
- [x] Documentation is being added in #4371 
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**