### PR TITLE
Fixed '/deliveryservices' not working with API 2.0

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -407,7 +407,7 @@ func (ds *TODeliveryService) Read() ([]interface{}, error, error, int) {
 	if version == nil {
 		return nil, nil, errors.New("TODeliveryService.Read called with nil API version"), http.StatusInternalServerError
 	}
-	if version.Major != 1 || version.Minor < 1 {
+	if version.Major == 1 && version.Minor < 1 {
 		return nil, nil, fmt.Errorf("TODeliveryService.Read called with invalid API version: %d.%d", version.Major, version.Minor), http.StatusInternalServerError
 	}
 
@@ -425,7 +425,7 @@ func (ds *TODeliveryService) Read() ([]interface{}, error, error, int) {
 	for _, ds := range dses {
 		switch {
 		// NOTE: it's required to handle minor version cases in a descending >= manner
-		case version.Minor >= 5:
+		case version.Major > 1 || version.Minor >= 5:
 			returnable = append(returnable, ds)
 		case version.Minor >= 4:
 			returnable = append(returnable, ds.DeliveryServiceNullableV14)


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4398 

This fixes the version-checking logic of the handler for GET requests to `/deliveryservices` to allow API versions >= 2.0.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Make a GET request to `/deliveryservices` and observe that no internal server error occurs.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Tests will be added by #4374 
- [x] Documentation will be added by #4371 
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**