### PR TITLE
Only allow changing of types based on useintable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Fix to traffic_ops_ort.pl to strip specific comment lines before checking if a file has changed.  Also promoted a changed file message from DEBUG to ERROR for report mode.
 - Fixed Traffic Portal regenerating CDN DNSSEC keys with the wrong effective date
+- Type mutation through the api is now restricted to only those types that apply to the "server" table
 - Updated The Traffic Ops Python, Go and Java clients to use API version 2.0 (when possible)
 - Updated CDN-in-a-Box scripts and enroller to use TO API version 2.0
 - Updated numerous, miscellaneous tools to use TO API version 2.0

--- a/docs/source/api/v1/types_id.rst
+++ b/docs/source/api/v1/types_id.rst
@@ -26,7 +26,7 @@
 
 :Auth. Required: Yes
 :Roles Required: None
-:Response Type:  Array
+:Response Type: Array
 
 Request Structure
 -----------------
@@ -82,3 +82,138 @@ Response Structure
 		}
 	]}
 
+=======
+
+``PUT``
+=======
+Updates a type
+
+:Auth. Required: Yes
+:Roles Required: None
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Request Path Parameters
+
+	+------+-------------------------------------------------------------+
+	| Name | Description                                                 |
+	+======+=============================================================+
+	|  ID  | The integral, unique identifier of the type being inspected |
+	+------+-------------------------------------------------------------+
+
+:description: A short description of this type
+:name:        The name of this type
+:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type.
+.. note:: Only types with useInTable set to 'server' are allowed to be updated.
+
+.. code-block:: http
+	:caption: Request Structure
+
+	PUT /api/2.0/type/3004
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+	Content-Length: 68
+	Content-Type: application/json
+
+	{
+		"name": "Example01",
+		"description": "Example2",
+		"useInServer": "server"
+	}
+
+Response Structure
+------------------
+:description: A short description of this type
+:id:          An integral, unique identifier for this type
+:lastUpdated: The date and time at which this type was last updated, in ISO format
+:name:        The name of this type
+:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: EH8jo8OrCu79Tz9xpgT3YRyKJ/p2NcTmbS3huwtqRByHz9H6qZLQjA59RIPaVSq3ZxsU6QhTaox5nBkQ9LPSAA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 26 Feb 2020 18:58:41 GMT
+	Content-Length: 172
+
+	{
+		"alerts": [
+		{
+			"text": "type was updated.",
+			"level": "success"
+		}],
+		"response": [
+		{
+			"id": 3004,
+			"lastUpdated": "2020-02-26 18:58:41+00",
+			"name": "Example02",
+			"description": "Example"
+			"useInTable": "server"
+		}]
+	}
+
+``DELETE``
+==========
+Deletes a type
+
+:Auth. Required: Yes
+:Roles Required: None
+:Response Type: Object
+
+Request Structure
+-----------------
+.. table:: Request Path Parameters
+
+	+------+-------------------------------------------------------------+
+	| Name | Description                                                 |
+	+======+=============================================================+
+	|  ID  | The integral, unique identifier of the type being inspected |
+	+------+-------------------------------------------------------------+
+
+.. note:: Only types with useInTable set to "server" are allowed to be deleted.
+
+.. code-block:: http
+	:caption: Request Structure
+
+	DELETE /api/2.0/type/3004
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+	Content-Length: 0
+
+Response Structure
+------------------
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: EH8jo8OrCu79Tz9xpgT3YRyKJ/p2NcTmbS3huwtqRByHz9H6qZLQjA59RIPaVSq3ZxsU6QhTaox5nBkQ9LPSAA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 26 Feb 2020 18:58:41 GMT
+	Content-Length: 84
+
+	{
+		"alerts": [
+		{
+			"text": "type was deleted.",
+			"level": "success"
+		}],
+	}

--- a/docs/source/api/v1/types_id.rst
+++ b/docs/source/api/v1/types_id.rst
@@ -111,7 +111,7 @@ Request Structure
 .. code-block:: http
 	:caption: Request Structure
 
-	PUT /api/2.0/type/3004
+	PUT /api/2.0/type/3004 HTTP/1.1
 	Host: trafficops.infra.ciab.test
 	User-Agent: curl/7.47.0
 	Accept: */*
@@ -172,6 +172,7 @@ Deletes a type
 :Roles Required: "admin" or "operations"
 :Response Type: Object
 
+
 Request Structure
 -----------------
 .. table:: Request Path Parameters
@@ -182,12 +183,12 @@ Request Structure
 	|  ID  | The integral, unique identifier of the type being inspected |
 	+------+-------------------------------------------------------------+
 
-	.. note:: Only types with useInTable set to "server" are allowed to be deleted.
+.. note:: Only types with useInTable set to "server" are allowed to be deleted.
 
 .. code-block:: http
 	:caption: Request Structure
 
-	DELETE /api/2.0/type/3004
+	DELETE /api/2.0/type/3004 HTTP/1.1
 	Host: trafficops.infra.ciab.test
 	User-Agent: curl/7.47.0
 	Accept: */*

--- a/docs/source/api/v1/types_id.rst
+++ b/docs/source/api/v1/types_id.rst
@@ -96,11 +96,11 @@ Request Structure
 -----------------
 .. table:: Request Path Parameters
 
-	+------+-------------------------------------------------------------+
-	| Name | Description                                                 |
-	+======+=============================================================+
-	|  ID  | The integral, unique identifier of the type being inspected |
-	+------+-------------------------------------------------------------+
+	+------+-----------------------------------------------------------+
+	| Name | Description                                               |
+	+======+===========================================================+
+	|  ID  | The integral, unique identifier of the type being updated |
+	+------+-----------------------------------------------------------+
 
 :description: A short description of this type
 :name:        The name of this type
@@ -177,11 +177,11 @@ Request Structure
 -----------------
 .. table:: Request Path Parameters
 
-	+------+-------------------------------------------------------------+
-	| Name | Description                                                 |
-	+======+=============================================================+
-	|  ID  | The integral, unique identifier of the type being inspected |
-	+------+-------------------------------------------------------------+
+	+------+-----------------------------------------------------------+
+	| Name | Description                                               |
+	+======+===========================================================+
+	|  ID  | The integral, unique identifier of the type being deleted |
+	+------+-----------------------------------------------------------+
 
 .. note:: Only types with useInTable set to "server" are allowed to be deleted.
 

--- a/docs/source/api/v1/types_id.rst
+++ b/docs/source/api/v1/types_id.rst
@@ -89,7 +89,7 @@ Response Structure
 Updates a type
 
 :Auth. Required: Yes
-:Roles Required: None
+:Roles Required: "admin" or "operations"
 :Response Type:  Object
 
 Request Structure
@@ -105,6 +105,7 @@ Request Structure
 :description: A short description of this type
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type.
+
 .. note:: Only types with useInTable set to 'server' are allowed to be updated.
 
 .. code-block:: http
@@ -121,7 +122,7 @@ Request Structure
 	{
 		"name": "Example01",
 		"description": "Example2",
-		"useInServer": "server"
+		"useInTable": "server"
 	}
 
 Response Structure
@@ -168,7 +169,7 @@ Response Structure
 Deletes a type
 
 :Auth. Required: Yes
-:Roles Required: None
+:Roles Required: "admin" or "operations"
 :Response Type: Object
 
 Request Structure
@@ -181,7 +182,7 @@ Request Structure
 	|  ID  | The integral, unique identifier of the type being inspected |
 	+------+-------------------------------------------------------------+
 
-.. note:: Only types with useInTable set to "server" are allowed to be deleted.
+	.. note:: Only types with useInTable set to "server" are allowed to be deleted.
 
 .. code-block:: http
 	:caption: Request Structure

--- a/docs/source/api/v2/types.rst
+++ b/docs/source/api/v2/types.rst
@@ -82,3 +82,77 @@ Response Structure
 			"useInTable": "cachegroup"
 		}
 	]}
+
+
+``POST``
+========
+Creates a type
+
+:Auth. Required: Yes
+:Roles Required: None
+:Response Type:  Object
+
+Request Structure
+-----------------
+:description: A short description of this type
+:name:        The name of this type
+:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type.
+.. note:: The only useInTable value that is allowed to be created dynamically is 'server'
+
+.. code-block:: http
+	:caption: Request Structure
+
+	POST /api/2.0/type
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+	Content-Length: 67
+	Content-Type: application/json
+
+	{
+		"name": "Example01",
+		"description": "Example",
+		"useInServer": "server"
+	}
+
+Response Structure
+------------------
+:description: A short description of this type
+:id:          An integral, unique identifier for this type
+:lastUpdated: The date and time at which this type was last updated, in ISO format
+:name:        The name of this type
+:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: EH8jo8OrCu79Tz9xpgT3YRyKJ/p2NcTmbS3huwtqRByHz9H6qZLQjA59RIPaVSq3ZxsU6QhTaox5nBkQ9LPSAA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 26 Feb 2020 18:58:41 GMT
+	Content-Length: 171
+
+	{
+		"alerts": [
+		{
+			"text": "type was created.",
+			"level": "success"
+		}],
+		"response": [
+		{
+			"id": 3004,
+			"lastUpdated": "2020-02-26 18:58:41+00",
+			"name": "Example01",
+			"description": "Example"
+			"useInTable": "server"
+		}]
+	}
+
+

--- a/docs/source/api/v2/types.rst
+++ b/docs/source/api/v2/types.rst
@@ -83,26 +83,27 @@ Response Structure
 		}
 	]}
 
-
 ``POST``
 ========
 Creates a type
 
 :Auth. Required: Yes
-:Roles Required: None
-:Response Type:  Object
+:Roles Required: "admin" or "operations"
+:Response Type: Object
 
 Request Structure
 -----------------
+
 :description: A short description of this type
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type.
-.. note:: The only useInTable value that is allowed to be created dynamically is 'server'
+
+	.. note:: The only useInTable value that is allowed to be created dynamically is 'server'
 
 .. code-block:: http
 	:caption: Request Structure
 
-	POST /api/2.0/type
+	POST /api/2.0/type HTTP/1.1
 	Host: trafficops.infra.ciab.test
 	User-Agent: curl/7.47.0
 	Accept: */*
@@ -113,11 +114,12 @@ Request Structure
 	{
 		"name": "Example01",
 		"description": "Example",
-		"useInServer": "server"
+		"useInTable": "server"
 	}
 
 Response Structure
 ------------------
+
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
 :lastUpdated: The date and time at which this type was last updated, in ISO format

--- a/docs/source/api/v2/types_id.rst
+++ b/docs/source/api/v2/types_id.rst
@@ -1,0 +1,156 @@
+..
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _to-api-types-id:
+
+****************
+``types/{{ID}}``
+****************
+
+``PUT``
+=======
+Updates a type
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Request Path Parameters
+
+	+------+-----------------------------------------------------------+
+	| Name | Description                                               |
+	+======+===========================================================+
+	|  ID  | The integral, unique identifier of the type being updated |
+	+------+-----------------------------------------------------------+
+
+:description: A short description of this type
+:name:        The name of this type
+:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type.
+
+.. note:: Only types with useInTable set to 'server' are allowed to be updated.
+
+.. code-block:: http
+	:caption: Request Structure
+
+	PUT /api/2.0/type/3004 HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+	Content-Length: 68
+	Content-Type: application/json
+
+	{
+		"name": "Example01",
+		"description": "Example2",
+		"useInTable": "server"
+	}
+
+Response Structure
+------------------
+:description: A short description of this type
+:id:          An integral, unique identifier for this type
+:lastUpdated: The date and time at which this type was last updated, in ISO format
+:name:        The name of this type
+:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: EH8jo8OrCu79Tz9xpgT3YRyKJ/p2NcTmbS3huwtqRByHz9H6qZLQjA59RIPaVSq3ZxsU6QhTaox5nBkQ9LPSAA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 26 Feb 2020 18:58:41 GMT
+	Content-Length: 172
+
+	{
+		"alerts": [
+		{
+			"text": "type was updated.",
+			"level": "success"
+		}],
+		"response": [
+		{
+			"id": 3004,
+			"lastUpdated": "2020-02-26 18:58:41+00",
+			"name": "Example02",
+			"description": "Example"
+			"useInTable": "server"
+		}]
+	}
+
+``DELETE``
+==========
+Deletes a type
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Response Type: Object
+
+
+Request Structure
+-----------------
+.. table:: Request Path Parameters
+
+	+------+-----------------------------------------------------------+
+	| Name | Description                                               |
+	+======+===========================================================+
+	|  ID  | The integral, unique identifier of the type being deleted |
+	+------+-----------------------------------------------------------+
+
+.. note:: Only types with useInTable set to "server" are allowed to be deleted.
+
+.. code-block:: http
+	:caption: Request Structure
+
+	DELETE /api/2.0/type/3004 HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+	Content-Length: 0
+
+Response Structure
+------------------
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: EH8jo8OrCu79Tz9xpgT3YRyKJ/p2NcTmbS3huwtqRByHz9H6qZLQjA59RIPaVSq3ZxsU6QhTaox5nBkQ9LPSAA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 26 Feb 2020 18:58:41 GMT
+	Content-Length: 84
+
+	{
+		"alerts": [
+		{
+			"text": "type was deleted.",
+			"level": "success"
+		}],
+	}

--- a/traffic_ops/testing/api/v1/types_test.go
+++ b/traffic_ops/testing/api/v1/types_test.go
@@ -52,7 +52,6 @@ func CreateTestTypes(t *testing.T) {
 		}
 
 		if typ.UseInTable != "server" {
-			t.Log(fmt.Sprintf(dbQueryTemplate, typ.Name, typ.Description, typ.UseInTable))
 			err = execSQL(db, fmt.Sprintf(dbQueryTemplate, typ.Name, typ.Description, typ.UseInTable), "type")
 		} else {
 			_, _, err = TOSession.CreateType(typ)

--- a/traffic_ops/testing/api/v1/types_test.go
+++ b/traffic_ops/testing/api/v1/types_test.go
@@ -47,7 +47,7 @@ func CreateTestTypes(t *testing.T) {
 	for _, typ := range testData.Types {
 		foundTypes, _, err := TOSession.GetTypeByName(typ.Name)
 		if err == nil && len(foundTypes) > 0 {
-			t.Logf("Type %v already exists (%v matche(s))", typ.Name, len(foundTypes))
+			t.Logf("Type %v already exists (%v match(es))", typ.Name, len(foundTypes))
 			continue
 		}
 

--- a/traffic_ops/testing/api/v1/types_test.go
+++ b/traffic_ops/testing/api/v1/types_test.go
@@ -16,7 +16,6 @@ package v1
 */
 
 import (
-	"fmt"
 	"testing"
 
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
@@ -32,78 +31,50 @@ func TestTypes(t *testing.T) {
 func CreateTestTypes(t *testing.T) {
 	t.Log("---- CreateTestTypes ----")
 
-	db, err := OpenConnection()
-	if err != nil {
-		t.Fatal("cannot open db")
-	}
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Errorf("unable to close connection to db, error: %v", err.Error())
-		}
-	}()
-	dbQueryTemplate := "INSERT INTO type (name, description, use_in_table) VALUES ('%v', '%v', '%v');"
-
 	for _, typ := range testData.Types {
-		foundTypes, _, err := TOSession.GetTypeByName(typ.Name)
-		if err == nil && len(foundTypes) > 0 {
-			t.Logf("Type %v already exists (%v match(es))", typ.Name, len(foundTypes))
-			continue
-		}
-
-		if typ.UseInTable != "server" {
-			err = execSQL(db, fmt.Sprintf(dbQueryTemplate, typ.Name, typ.Description, typ.UseInTable), "type")
-		} else {
-			_, _, err = TOSession.CreateType(typ)
-		}
-
+		resp, _, err := TOSession.CreateType(typ)
 		if err != nil {
 			t.Errorf("could not CREATE types: %v", err)
 		}
+		t.Log("Response: ", resp)
 	}
 
 }
 
 func UpdateTestTypes(t *testing.T) {
 	t.Log("---- UpdateTestTypes ----")
-	expectedTypeName := "testType%v"
 
-	for i, typ := range testData.Types {
-		expectedTypeName = fmt.Sprintf(expectedTypeName, i)
-		originalType := typ
-		resp, _, err := TOSession.GetTypeByName(originalType.Name)
-		if err != nil {
-			t.Fatalf("cannot GET Type by name: %v - %v", originalType.Name, err)
-		}
-		remoteType := resp[0]
-		remoteType.Name = expectedTypeName
-		var alert tc.Alerts
-		alert, _, err = TOSession.UpdateTypeByID(remoteType.ID, remoteType)
-		if remoteType.UseInTable != "server"  {
-			if err == nil {
-				t.Fatalf("expected UPDATE on type %v to fail", remoteType.ID)
-			}
-			continue
-		} else if err != nil {
-			t.Fatalf("cannot UPDATE Type by id: %v - %v", err, alert)
-		}
+	firstType := testData.Types[0]
+	// Retrieve the Type by name so we can get the id for the Update
+	resp, _, err := TOSession.GetTypeByName(firstType.Name)
+	if err != nil {
+		t.Errorf("cannot GET Type by name: %v - %v", firstType.Name, err)
+	}
+	remoteType := resp[0]
+	expectedTypeName := "testType1"
+	remoteType.Name = expectedTypeName
+	var alert tc.Alerts
+	alert, _, err = TOSession.UpdateTypeByID(remoteType.ID, remoteType)
+	if err != nil {
+		t.Errorf("cannot UPDATE Type by id: %v - %v", err, alert)
+	}
 
-		// Retrieve the Type to check Type name got updated
-		resp, _, err = TOSession.GetTypeByID(remoteType.ID)
-		if err != nil {
-			t.Fatalf("cannot GET Type by ID: %v - %v", originalType.ID, err)
-		}
-		respType := resp[0]
-		if respType.Name != expectedTypeName {
-			t.Fatalf("results do not match actual: %s, expected: %s", respType.Name, expectedTypeName)
-		}
+	// Retrieve the Type to check Type name got updated
+	resp, _, err = TOSession.GetTypeByID(remoteType.ID)
+	if err != nil {
+		t.Errorf("cannot GET Type by name: %v - %v", firstType.Name, err)
+	}
+	respType := resp[0]
+	if respType.Name != expectedTypeName {
+		t.Errorf("results do not match actual: %s, expected: %s", respType.Name, expectedTypeName)
+	}
 
-		// Revert name change
-		respType.Name = originalType.Name
-		alert, _, err = TOSession.UpdateTypeByID(respType.ID, respType)
-		if err != nil {
-			t.Fatalf("cannot restore UPDATE Type by id: %v - %v", err, alert)
-		}
+	t.Log("Response Type: ", respType)
+
+	respType.Name = firstType.Name
+	alert, _, err = TOSession.UpdateTypeByID(respType.ID, respType)
+	if err != nil {
+		t.Errorf("cannot restore UPDATE Type by id: %v - %v", err, alert)
 	}
 }
 
@@ -124,36 +95,17 @@ func GetTestTypes(t *testing.T) {
 func DeleteTestTypes(t *testing.T) {
 	t.Log("---- DeleteTestTypes ----")
 
-	db, err := OpenConnection()
-	if err != nil {
-		t.Fatal("cannot open db")
-	}
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Errorf("unable to close connection to db, error: %v", err.Error())
-		}
-	}()
-	dbDeleteTemplate := "DELETE FROM type WHERE name='%v';"
-
 	for _, typ := range testData.Types {
 		// Retrieve the Type by name so we can get the id for the Update
 		resp, _, err := TOSession.GetTypeByName(typ.Name)
 		if err != nil || len(resp) == 0 {
-			t.Fatalf("cannot GET Type by name: %v - %v", typ.Name, err.Error())
+			t.Errorf("cannot GET Type by name: %v - %v", typ.Name, err)
 		}
 		respType := resp[0]
 
-		if respType.UseInTable != "server" {
-			err := execSQL(db, fmt.Sprintf(dbDeleteTemplate, respType.Name), "type")
-			if  err != nil {
-				t.Fatalf("cannot DELETE Type by name: %v", err.Error())
-			}
-		} else {
-			delResp, _, err := TOSession.DeleteTypeByID(respType.ID)
-			if err != nil {
-				t.Fatalf("cannot DELETE Type by name: %v - %v", err, delResp)
-			}
+		delResp, _, err := TOSession.DeleteTypeByID(respType.ID)
+		if err != nil {
+			t.Errorf("cannot DELETE Type by name: %v - %v", err, delResp)
 		}
 
 		// Retrieve the Type to see if it got deleted

--- a/traffic_ops/testing/api/v2/types_test.go
+++ b/traffic_ops/testing/api/v2/types_test.go
@@ -66,10 +66,9 @@ func CreateTestTypes(t *testing.T) {
 
 func UpdateTestTypes(t *testing.T) {
 	t.Log("---- UpdateTestTypes ----")
-	expectedTypeName := "testType%v"
 
 	for i, typ := range testData.Types {
-		expectedTypeName = fmt.Sprintf(expectedTypeName, i)
+		expectedTypeName := fmt.Sprintf("testType%v", i)
 		originalType := typ
 		resp, _, err := TOSession.GetTypeByName(originalType.Name)
 		if err != nil {
@@ -79,7 +78,7 @@ func UpdateTestTypes(t *testing.T) {
 		remoteType.Name = expectedTypeName
 		var alert tc.Alerts
 		alert, _, err = TOSession.UpdateTypeByID(remoteType.ID, remoteType)
-		if remoteType.UseInTable != "server"  {
+		if remoteType.UseInTable != "server" {
 			if err == nil {
 				t.Fatalf("expected UPDATE on type %v to fail", remoteType.ID)
 			}
@@ -146,7 +145,7 @@ func DeleteTestTypes(t *testing.T) {
 
 		if respType.UseInTable != "server" {
 			err := execSQL(db, fmt.Sprintf(dbDeleteTemplate, respType.Name), "type")
-			if  err != nil {
+			if err != nil {
 				t.Fatalf("cannot DELETE Type by name: %v", err.Error())
 			}
 		} else {

--- a/traffic_ops/testing/api/v2/types_test.go
+++ b/traffic_ops/testing/api/v2/types_test.go
@@ -1,4 +1,4 @@
-package v1
+package v2
 
 /*
 

--- a/traffic_ops/testing/api/v2/types_test.go
+++ b/traffic_ops/testing/api/v2/types_test.go
@@ -1,4 +1,4 @@
-package v2
+package v1
 
 /*
 
@@ -16,6 +16,7 @@ package v2
 */
 
 import (
+	"fmt"
 	"testing"
 
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
@@ -31,50 +32,78 @@ func TestTypes(t *testing.T) {
 func CreateTestTypes(t *testing.T) {
 	t.Log("---- CreateTestTypes ----")
 
+	db, err := OpenConnection()
+	if err != nil {
+		t.Fatal("cannot open db")
+	}
+	defer func() {
+		err := db.Close()
+		if err != nil {
+			t.Errorf("unable to close connection to db, error: %v", err.Error())
+		}
+	}()
+	dbQueryTemplate := "INSERT INTO type (name, description, use_in_table) VALUES ('%v', '%v', '%v');"
+
 	for _, typ := range testData.Types {
-		resp, _, err := TOSession.CreateType(typ)
+		foundTypes, _, err := TOSession.GetTypeByName(typ.Name)
+		if err == nil && len(foundTypes) > 0 {
+			t.Logf("Type %v already exists (%v match(es))", typ.Name, len(foundTypes))
+			continue
+		}
+
+		if typ.UseInTable != "server" {
+			err = execSQL(db, fmt.Sprintf(dbQueryTemplate, typ.Name, typ.Description, typ.UseInTable), "type")
+		} else {
+			_, _, err = TOSession.CreateType(typ)
+		}
+
 		if err != nil {
 			t.Errorf("could not CREATE types: %v", err)
 		}
-		t.Log("Response: ", resp)
 	}
 
 }
 
 func UpdateTestTypes(t *testing.T) {
 	t.Log("---- UpdateTestTypes ----")
+	expectedTypeName := "testType%v"
 
-	firstType := testData.Types[0]
-	// Retrieve the Type by name so we can get the id for the Update
-	resp, _, err := TOSession.GetTypeByName(firstType.Name)
-	if err != nil {
-		t.Errorf("cannot GET Type by name: %v - %v", firstType.Name, err)
-	}
-	remoteType := resp[0]
-	expectedTypeName := "testType1"
-	remoteType.Name = expectedTypeName
-	var alert tc.Alerts
-	alert, _, err = TOSession.UpdateTypeByID(remoteType.ID, remoteType)
-	if err != nil {
-		t.Errorf("cannot UPDATE Type by id: %v - %v", err, alert)
-	}
+	for i, typ := range testData.Types {
+		expectedTypeName = fmt.Sprintf(expectedTypeName, i)
+		originalType := typ
+		resp, _, err := TOSession.GetTypeByName(originalType.Name)
+		if err != nil {
+			t.Fatalf("cannot GET Type by name: %v - %v", originalType.Name, err)
+		}
+		remoteType := resp[0]
+		remoteType.Name = expectedTypeName
+		var alert tc.Alerts
+		alert, _, err = TOSession.UpdateTypeByID(remoteType.ID, remoteType)
+		if remoteType.UseInTable != "server"  {
+			if err == nil {
+				t.Fatalf("expected UPDATE on type %v to fail", remoteType.ID)
+			}
+			continue
+		} else if err != nil {
+			t.Fatalf("cannot UPDATE Type by id: %v - %v", err, alert)
+		}
 
-	// Retrieve the Type to check Type name got updated
-	resp, _, err = TOSession.GetTypeByID(remoteType.ID)
-	if err != nil {
-		t.Errorf("cannot GET Type by name: %v - %v", firstType.Name, err)
-	}
-	respType := resp[0]
-	if respType.Name != expectedTypeName {
-		t.Errorf("results do not match actual: %s, expected: %s", respType.Name, expectedTypeName)
-	}
+		// Retrieve the Type to check Type name got updated
+		resp, _, err = TOSession.GetTypeByID(remoteType.ID)
+		if err != nil {
+			t.Fatalf("cannot GET Type by ID: %v - %v", originalType.ID, err)
+		}
+		respType := resp[0]
+		if respType.Name != expectedTypeName {
+			t.Fatalf("results do not match actual: %s, expected: %s", respType.Name, expectedTypeName)
+		}
 
-	t.Log("Response Type: ", respType)
-
-	respType.Name = firstType.Name
-	alert, _, err = TOSession.UpdateTypeByID(respType.ID, respType)
-	if err != nil {
-		t.Errorf("cannot restore UPDATE Type by id: %v - %v", err, alert)
+		// Revert name change
+		respType.Name = originalType.Name
+		alert, _, err = TOSession.UpdateTypeByID(respType.ID, respType)
+		if err != nil {
+			t.Fatalf("cannot restore UPDATE Type by id: %v - %v", err, alert)
+		}
 	}
 }
 
@@ -95,17 +124,36 @@ func GetTestTypes(t *testing.T) {
 func DeleteTestTypes(t *testing.T) {
 	t.Log("---- DeleteTestTypes ----")
 
+	db, err := OpenConnection()
+	if err != nil {
+		t.Fatal("cannot open db")
+	}
+	defer func() {
+		err := db.Close()
+		if err != nil {
+			t.Errorf("unable to close connection to db, error: %v", err.Error())
+		}
+	}()
+	dbDeleteTemplate := "DELETE FROM type WHERE name='%v';"
+
 	for _, typ := range testData.Types {
 		// Retrieve the Type by name so we can get the id for the Update
 		resp, _, err := TOSession.GetTypeByName(typ.Name)
 		if err != nil || len(resp) == 0 {
-			t.Errorf("cannot GET Type by name: %v - %v", typ.Name, err)
+			t.Fatalf("cannot GET Type by name: %v - %v", typ.Name, err.Error())
 		}
 		respType := resp[0]
 
-		delResp, _, err := TOSession.DeleteTypeByID(respType.ID)
-		if err != nil {
-			t.Errorf("cannot DELETE Type by name: %v - %v", err, delResp)
+		if respType.UseInTable != "server" {
+			err := execSQL(db, fmt.Sprintf(dbDeleteTemplate, respType.Name), "type")
+			if  err != nil {
+				t.Fatalf("cannot DELETE Type by name: %v", err.Error())
+			}
+		} else {
+			delResp, _, err := TOSession.DeleteTypeByID(respType.ID)
+			if err != nil {
+				t.Fatalf("cannot DELETE Type by name: %v - %v", err, delResp)
+			}
 		}
 
 		// Retrieve the Type to see if it got deleted

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -20,6 +20,8 @@ package types
  */
 
 import (
+	"errors"
+	"net/http"
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -96,8 +98,21 @@ func (typ *TOType) Validate() error {
 
 func (tp *TOType) Read() ([]interface{}, error, error, int) { return api.GenericRead(tp) }
 func (tp *TOType) Update() (error, error, int)              { return api.GenericUpdate(tp) }
-func (tp *TOType) Create() (error, error, int)              { return api.GenericCreate(tp) }
 func (tp *TOType) Delete() (error, error, int)              { return api.GenericDelete(tp) }
+
+func (tp *TOType) Create() (error, error, int)              {
+	if !usedInServerTable(tp) {
+		return nil, errors.New("can not create type"), http.StatusBadRequest
+	}
+	return api.GenericCreate(tp)
+}
+
+func usedInServerTable(tp *TOType) bool {
+	if tp.UseInTable == nil || *tp.UseInTable != "server" {
+		return false
+	}
+	return true
+}
 
 func selectQuery() string {
 	return `SELECT

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -98,7 +98,13 @@ func (typ *TOType) Validate() error {
 }
 
 func (tp *TOType) Read() ([]interface{}, error, error, int) { return api.GenericRead(tp) }
-func (tp *TOType) Update() (error, error, int)              { return api.GenericUpdate(tp) }
+
+func (tp *TOType) Update() (error, error, int) {
+	if !usedInServerTable(tp.UseInTable) {
+		return nil, errors.New("can not update type"), http.StatusBadRequest
+	}
+	return api.GenericUpdate(tp)
+}
 
 func (tp *TOType) Delete() (error, error, int) {
 	if tp.UseInTable == nil {

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -107,16 +107,14 @@ func (tp *TOType) Update() (error, error, int) {
 }
 
 func (tp *TOType) Delete() (error, error, int) {
-	if tp.UseInTable == nil {
-		if tp.ID != nil {
-			query := `SELECT use_in_table from type where id=$1`
-			err := tp.ReqInfo.Tx.Tx.QueryRow(query, tp.ID).Scan(&tp.UseInTable)
-			if err != nil {
-				return api.ParseDBError(err)
-			}
-		} else {
-			return nil, errors.New("no type with that key found"), http.StatusNotFound
+	if tp.ID != nil {
+		query := `SELECT use_in_table from type where id=$1`
+		err := tp.ReqInfo.Tx.Tx.QueryRow(query, tp.ID).Scan(&tp.UseInTable)
+		if err != nil {
+			return api.ParseDBError(err)
 		}
+	} else {
+		return errors.New("no type with that key found"), nil, http.StatusNotFound
 	}
 	if !tp.AllowMutation() {
 		return nil, errors.New(fmt.Sprintf("can not delete type")), http.StatusBadRequest

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -101,7 +101,7 @@ func (tp *TOType) Read() ([]interface{}, error, error, int) { return api.Generic
 
 func (tp *TOType) Update() (error, error, int) {
 	if !tp.AllowMutation() {
-		return nil, errors.New("can not update type"), http.StatusBadRequest
+		return errors.New("can not update type"), nil, http.StatusBadRequest
 	}
 	return api.GenericUpdate(tp)
 }
@@ -117,14 +117,14 @@ func (tp *TOType) Delete() (error, error, int) {
 		return errors.New("no type with that key found"), nil, http.StatusNotFound
 	}
 	if !tp.AllowMutation() {
-		return nil, errors.New(fmt.Sprintf("can not delete type")), http.StatusBadRequest
+		return errors.New(fmt.Sprintf("can not delete type")), nil, http.StatusBadRequest
 	}
 	return api.GenericDelete(tp)
 }
 
 func (tp *TOType) Create() (error, error, int) {
 	if !tp.AllowMutation() {
-		return nil, errors.New("can not create type"), http.StatusBadRequest
+		return errors.New("can not create type"), nil, http.StatusBadRequest
 	}
 	return api.GenericCreate(tp)
 }

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -110,10 +110,12 @@ func (tp *TOType) Delete() (error, error, int) {
 	if tp.UseInTable == nil {
 		if tp.ID != nil {
 			query := `SELECT use_in_table from type where id=$1`
-			err := tp.ReqInfo.Tx.Tx.QueryRow( query, tp.ID).Scan(&tp.UseInTable)
+			err := tp.ReqInfo.Tx.Tx.QueryRow(query, tp.ID).Scan(&tp.UseInTable)
 			if err != nil {
-				tp.UseInTable = nil
+				return api.ParseDBError(err)
 			}
+		} else {
+			return nil, errors.New("no type with that key found"), http.StatusNotFound
 		}
 	}
 	if !tp.AllowMutation() {
@@ -122,7 +124,7 @@ func (tp *TOType) Delete() (error, error, int) {
 	return api.GenericDelete(tp)
 }
 
-func (tp *TOType) Create() (error, error, int)              {
+func (tp *TOType) Create() (error, error, int) {
 	if !tp.AllowMutation() {
 		return nil, errors.New("can not create type"), http.StatusBadRequest
 	}

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -124,9 +124,8 @@ func TestInterfaces(t *testing.T) {
 	}
 }
 
-func TestCreateType(t *testing.T) {
-	field := "test"
-	p := TOType{
+func createDummyType(field string) *TOType {
+	return &TOType{
 		TypeNullable: tc.TypeNullable{
 			Name: &field,
 			Description: &field,
@@ -134,12 +133,29 @@ func TestCreateType(t *testing.T) {
 		},
 	}
 
-	_, err, statusCode := p.Create()
+}
+
+func TestCreateInvalidType(t *testing.T) {
+	invalidCreateType := createDummyType("test")
+
+	_, err, statusCode := invalidCreateType.Create()
 	if err == nil {
 		t.Errorf("expected create type to have an error")
 	}
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("expected create type to return a 400 error")
+	}
+}
+
+func TestDeleteInvalidType(t *testing.T) {
+	invalidDeleteType := createDummyType("other")
+
+	_, err, statusCode := invalidDeleteType.Delete()
+	if err == nil {
+		t.Errorf("expected delete type to have an error")
+	}
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("expected delete type to return a 400 error")
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -125,14 +125,23 @@ func TestInterfaces(t *testing.T) {
 }
 
 func createDummyType(field string) *TOType {
+	version := api.Version{
+		Major: 2,
+		Minor: 0,
+	}
+	apiInfo := api.APIInfo{
+		Version:  &version,
+	}
 	return &TOType{
 		TypeNullable: tc.TypeNullable{
 			Name: &field,
 			Description: &field,
 			UseInTable: &field,
 		},
+		APIInfoImpl: api.APIInfoImpl{
+			ReqInfo: &apiInfo,
+		},
 	}
-
 }
 
 func TestUpdateInvalidType(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -135,15 +135,28 @@ func createDummyType(field string) *TOType {
 
 }
 
+func TestUpdateInvalidType(t *testing.T) {
+	invalidUpdateType := createDummyType("test")
+
+	_, err, statusCode := invalidUpdateType.Update()
+	if err == nil {
+		t.Fatalf("expected update type tp have an error")
+	}
+	if statusCode != http.StatusBadRequest {
+		t.Fatalf("expected update to return a 400 error")
+	}
+}
+
+
 func TestCreateInvalidType(t *testing.T) {
 	invalidCreateType := createDummyType("test")
 
 	_, err, statusCode := invalidCreateType.Create()
 	if err == nil {
-		t.Errorf("expected create type to have an error")
+		t.Fatalf("expected create type to have an error")
 	}
 	if statusCode != http.StatusBadRequest {
-		t.Errorf("expected create type to return a 400 error")
+		t.Fatalf("expected create type to return a 400 error")
 	}
 }
 
@@ -152,10 +165,10 @@ func TestDeleteInvalidType(t *testing.T) {
 
 	_, err, statusCode := invalidDeleteType.Delete()
 	if err == nil {
-		t.Errorf("expected delete type to have an error")
+		t.Fatalf("expected delete type to have an error")
 	}
 	if statusCode != http.StatusBadRequest {
-		t.Errorf("expected delete type to return a 400 error")
+		t.Fatalf("expected delete type to return a 400 error")
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -21,6 +21,7 @@ package types
 
 import (
 	"errors"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -120,6 +121,25 @@ func TestInterfaces(t *testing.T) {
 	}
 	if _, ok := i.(api.Identifier); !ok {
 		t.Errorf("Type must be Identifier")
+	}
+}
+
+func TestCreateType(t *testing.T) {
+	field := "test"
+	p := TOType{
+		TypeNullable: tc.TypeNullable{
+			Name: &field,
+			Description: &field,
+			UseInTable: &field,
+		},
+	}
+
+	_, err, statusCode := p.Create()
+	if err == nil {
+		t.Errorf("expected create type to have an error")
+	}
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("expected create type to return a 400 error")
 	}
 }
 

--- a/traffic_portal/app/src/common/modules/form/type/FormTypeController.js
+++ b/traffic_portal/app/src/common/modules/form/type/FormTypeController.js
@@ -22,8 +22,8 @@ var FormTypeController = function(type, $scope, $location, formUtils, stringUtil
     $scope.type = type;
 
     $scope.props = [
-        { name: 'name', type: 'text', required: true, maxLength: 45 },
-        { name: 'useInTable', type: 'text', required: true, maxLength: 45 }
+        { name: 'name', type: 'text', required: true, maxLength: 45},
+        { name: 'useInTable', type: 'text', required: false, maxLength: 45, disabled: true, defaultValue: "server" }
     ];
 
     $scope.labelize = stringUtils.labelize;

--- a/traffic_portal/app/src/common/modules/form/type/form.type.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/type/form.type.tpl.html
@@ -37,7 +37,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(typeForm[prop.name]), 'has-feedback': hasError(typeForm[prop.name])}" ng-repeat="prop in props">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">{{labelize(prop.name)}} <span ng-show="prop.required">*</span></label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="{{prop.name}}" name="{{prop.name}}" type="{{prop.type}}" class="form-control" ng-model="type[prop.name]" ng-readonly="prop.readonly" ng-required="prop.required" ng-maxlength="prop.maxLength" autofocus>
+                    <input id="{{prop.name}}" name="{{prop.name}}" type="{{prop.type}}" class="form-control" ng-disabled="prop.disabled" ng-model="type[prop.name]" ng-readonly="prop.readonly" ng-required="prop.required" ng-maxlength="prop.maxLength" autofocus ng-value="type[prop.name] != null ? type[prop.name] : prop.defaultValue" />
                     <small class="input-error" ng-show="hasPropertyError(typeForm[prop.name], 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(typeForm[prop.name], 'maxlength')">Too Long</small>
                     <span ng-show="hasError(typeForm[prop.name])" class="form-control-feedback"><i class="fa fa-times"></i></span>

--- a/traffic_portal/app/src/common/modules/form/type/new/FormNewTypeController.js
+++ b/traffic_portal/app/src/common/modules/form/type/new/FormNewTypeController.js
@@ -30,6 +30,7 @@ var FormNewTypeController = function(type, $scope, $controller, typeService) {
     };
 
     $scope.save = function(type) {
+        type.useInTable = "server";
         typeService.createType(type);
     };
 


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

Only types used in the server table are actually mutable. Change types to only allow deleting/updating/creating types that belongs to the server table.


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
Run API tests and verify they pass.

<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
