### PR TITLE
"updated" ORT to use API v2

### DIFF
--- a/traffic_ops/ort/traffic_ops_ort.pl
+++ b/traffic_ops/ort/traffic_ops_ort.pl
@@ -797,6 +797,8 @@ sub update_trops {
 sub send_update_to_trops {
 	my $status = shift;
 	my $reval_status = shift;
+
+	# TODO: this is a non-standard API endpoint that will be removed with the Perl; need to update it.
 	my $uri    = "/update/$hostname_short";
 	( $log_level >> $DEBUG ) && print "DEBUG Setting update flag in Traffic Ops to $status.\n";
 
@@ -817,7 +819,7 @@ sub get_print_current_client_connections {
 }
 
 sub get_update_status {
-	my $uri     = "/api/1.3/servers/$hostname_short/update_status";
+	my $uri     = "/api/2.0/servers/$hostname_short/update_status";
 	my $upd_ref = &lwp_get($uri);
 	if ($upd_ref eq '404') {
 		( $log_level >> $ERROR ) && printf("ERROR ORT version incompatible with current version of Traffic Ops. Please upgrade to Traffic Ops 2.2.\n");
@@ -833,7 +835,7 @@ sub get_update_status {
 
 	##Some versions of Traffic Ops had the 1.3 API but did not have the use_reval_pending field.  If this field is not present, exit.
 	if ( !defined( $upd_json->[0]->{'use_reval_pending'} ) ) {
-		my $info_uri = "/api/1.4/system/info.json";
+		my $info_uri = "/api/2.0/system/info";
 		my $info_ref = &lwp_get($info_uri);
 		if ($info_ref eq '404') {
 			( $log_level >> $ERROR ) && printf("ERROR Unable to get status of use_reval_pending parameter.  Stopping.\n");
@@ -892,7 +894,7 @@ sub check_revalidate_state {
 			( $log_level >> $ERROR ) && print "ERROR Traffic Ops is signaling that no revalidations are waiting to be applied.\n";
 		}
 
-		my $stj = &lwp_get("/api/1.4/statuses");
+		my $stj = &lwp_get("/api/2.0/statuses");
 		if ( $stj =~ m/^\d{3}$/ ) {
 			( $log_level >> $ERROR ) && print "Statuses URL: $uri returned $stj! Skipping creation of status file.\n";
 		}
@@ -982,7 +984,7 @@ sub check_syncds_state {
 						( $dispersion > 0 ) && &sleep_timer($dispersion);
 					}
 					($upd_json, $uri) = get_update_status();
-					
+
 					$parent_pending = ( defined( $upd_json->[0]->{'parent_pending'} ) ) ? $upd_json->[0]->{'parent_pending'} : undef;
 					if ( !defined($parent_pending) ) {
 						( $log_level >> $ERROR ) && print "ERROR Invalid JSON for $uri. Exiting, not sure what else to do.\n";
@@ -996,7 +998,7 @@ sub check_syncds_state {
 						( $log_level >> $DEBUG ) && print "DEBUG The update on my parents cleared; continuing.\n";
 					}
 				}
-			}			
+			}
 			else {
 				( $log_level >> $DEBUG ) && print "DEBUG Traffic Ops is signaling that my parents do not need an update, or wait_for_parents == 0.\n";
 			}
@@ -1009,7 +1011,7 @@ sub check_syncds_state {
 		else {
 			( $log_level >> $ERROR ) && print "ERROR Traffic Ops is signaling that no update is waiting to be applied.\n";
 		}
-		my $stj = &lwp_get("/api/1.4/statuses");
+		my $stj = &lwp_get("/api/2.0/statuses");
 		if ( $stj =~ m/^\d{3}$/ ) {
 			( $log_level >> $ERROR ) && print "Statuses URL: $uri returned $stj! Skipping creation of status file.\n";
 		}
@@ -1080,9 +1082,9 @@ sub sleep_rand {
 sub sleep_timer {
 	my $duration = shift;
 	my $reval_clock = $reval_wait_time;
-	
-	my $proper_script_mode = $script_mode; 
-	
+
+	my $proper_script_mode = $script_mode;
+
 	if ( $reval_in_use == 1 && $proper_script_mode != $BADASS ) {
 		( $log_level >> $WARN ) && print "WARN Performing a revalidation check before sleeping... \n";
 		&revalidate_while_sleeping();
@@ -1117,7 +1119,7 @@ sub sleep_timer {
 		}
 	}
 
-	$script_mode = $proper_script_mode; 
+	$script_mode = $proper_script_mode;
 
 	( $log_level >> $WARN ) && print "\n";
 }
@@ -1687,7 +1689,7 @@ sub get_cookie {
 		&sleep_rand($login_dispersion);
 	}
 
-	my $url = $to_host . "/api/1.3/user/login";
+	my $url = $to_host . "/api/2.0/user/login";
 	my $json = qq/{ "u": "$u", "p": "$p"}/;
 	my $response = $lwp_conn->post($url, Content => $json);
 
@@ -1845,7 +1847,7 @@ sub get_cfg_file_list {
 	my $cfg_files;
 	my $profile_name;
 	my $cdn_name;
-	my $uri = "/api/1.4/servers/$host_name/configfiles/ats";
+	my $uri = "/api/2.0/servers/$host_name/configfiles/ats"; #This doesn't actually exist in 2.0, but atstccfg doesn't care
 
 	my $result = &lwp_get($uri);
 
@@ -1856,7 +1858,7 @@ sub get_cfg_file_list {
 	}
 
 	my $ort_ref = decode_json($result);
-	
+
 	if ($api_in_use == 1) {
 		$to_rev_proxy_url = $ort_ref->{'info'}->{'toRevProxyUrl'};
 		if ( $to_rev_proxy_url && $rev_proxy_disable == 0 ) {
@@ -1956,7 +1958,7 @@ sub get_header_comment {
 	my $to_host = shift;
 	my $toolname;
 
-	my $uri    = "/api/1.4/system/info.json";
+	my $uri    = "/api/2.0/system/info";
 	my $result = &lwp_get($uri);
 
 	my $result_ref = decode_json($result);
@@ -2123,6 +2125,8 @@ sub process_packages {
 	my $tm_host   = shift;
 
 	my $proceed = 0;
+
+	# TODO: this is a non-standard API endpoint that will be removed with the Perl; need to update it.
 	my $uri     = "/ort/$host_name/packages";
 	my $result  = &lwp_get($uri);
 
@@ -2371,6 +2375,8 @@ sub process_chkconfig {
 	my $tm_host   = shift;
 
 	my $proceed = 0;
+
+	# TODO: this is a non-standard API endpoint that will be removed with the Perl; need to update it.
 	my $uri     = "/ort/$host_name/chkconfig";
 	my $result  = &lwp_get($uri);
 
@@ -2628,7 +2634,7 @@ sub validate_result {
 
 sub set_uri {
 	my $filename = shift;
-	
+
 	my $filepath = $cfg_file_tracker->{$filename}->{'location'};
 	my $URI;
 	if ( $api_in_use == 1 && defined($cfg_file_tracker->{$filename}->{'apiUri'}) ) {
@@ -2641,7 +2647,7 @@ sub set_uri {
 
 	return if (!defined($cfg_file_tracker->{$filename}->{'fname-in-TO'}));
 
-	return $URI; 
+	return $URI;
 }
 
 sub scrape_unencode_text {
@@ -2922,7 +2928,7 @@ sub adv_preprocessing_remap {
 
 	if ( 1 < $#file_lines ) { #header line is always present, so look for 2 lines or more
 		( $log_level >> $DEBUG ) && print "DEBUG Entering advanced pre-processing for remap.config.\n";
-		
+
 		# key on the FROM remap
 		my %override_hash=();
 
@@ -3057,7 +3063,7 @@ sub adv_processing_ssl {
 	my @db_file_lines = @{ $_[0] };
 	if (@db_file_lines > 1) { #header line is always present, so look for 2 lines or more
 		( $log_level >> $DEBUG ) && print "DEBUG Entering advanced processing for ssl_multicert.config.\n";
-		my $uri = "/api/1.4/cdns/name/$my_cdn_name/sslkeys.json";
+		my $uri = "/api/2.0/cdns/name/$my_cdn_name/sslkeys";
 		my $result = &lwp_get($uri);
 		if ( $result =~ m/^\d{3}$/ ) {
 			if ( $script_mode == $REPORT ) {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

Updates ORT to use the 2.0 API where it can. It still uses these three non-standard API endpoints:

- `/ort/{{Host Name}}/packages`
- `/ort/{{Host Name}}/chkconfig`
- `/update/{{Host Name}}`

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
~~How do you verify ORT? If you find out, let me know.~~

Probably just run it in badass mode on a server somewhere and if it can fetch everything it needs without crashing then it's probably fine. This was a comparatively small change, after all.

## The following criteria are ALL met by this PR
- [x] ORT tests don't exist/aren't currently possible
- [x] ORT is entirely undocumented
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**