### PR TITLE
Fixed bad dependency pipeline failing on newer dependencies

### DIFF
--- a/tools/golang/Dockerfile
+++ b/tools/golang/Dockerfile
@@ -21,10 +21,6 @@ RUN apk --no-cache add gcc musl-dev git
 
 ARG DIR=github.com/apache/trafficcontrol
 
-# Add repo and perform go get
-# Needed since we have no dependency manager and go source is throughout
-ADD . /go/src/$DIR
-
 WORKDIR /go/src/github.com/apache/trafficcontrol
 
 RUN go get golang.org/x/crypto/ed25519\

--- a/tools/golang/Dockerfile
+++ b/tools/golang/Dockerfile
@@ -27,7 +27,12 @@ ADD . /go/src/$DIR
 
 WORKDIR /go/src/github.com/apache/trafficcontrol
 
-RUN go list -f {{.Deps}} ./... | tr -d '[]' | tr -s ' ' '\n' | sed -re 's/vendor\///g' | grep golang.org/x/ | grep -v chacha | sort | uniq | tr '_' '.' | xargs go get -v
+RUN go get golang.org/x/crypto/ed25519\
+           golang.org/x/crypto/scrypt\
+           golang.org/x/net/ipv4\
+           golang.org/x/net/ipv6\
+           golang.org/x/net/publicsuffix\
+           golang.org/x/sys/unix
 
 FROM base AS lint
 

--- a/tools/golang/docker-compose.yml
+++ b/tools/golang/docker-compose.yml
@@ -20,16 +20,16 @@ version: '2.3'
 services:
   lint:
     build:
-      context: ../..
-      dockerfile: tools/golang/Dockerfile
+      context: .
+      dockerfile: Dockerfile
       target: lint
     volumes:
       - ../..:/go/src/github.com/apache/trafficcontrol
 
   unit:
     build:
-      context: ../..
-      dockerfile: tools/golang/Dockerfile
+      context: .
+      dockerfile: Dockerfile
       target: unit
     volumes:
       - ../..:/go/src/github.com/apache/trafficcontrol


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Removes a pipeline from the unit testing container that used to try to do "smart" dependency resolution. It's been failing since newer dependencies were added to the project, so now the dockerfile just explicitly installs un-vendored (golang.org/x/\*) packages that we know we have dependencies on. *This means that if the un-vendored packages on which we depend ever change this testing container will need to be upgraded or it will break*.

## Which Traffic Control components are affected by this PR?
- [The unit testing service defined in `tools/golang`](./tools/golang/)

## What is the best way to verify this PR?
Run the unit-testing service.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Bug is not referenced in docs, so no update necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**