### PR TITLE
Some tiny Python-client-related fixes

### DIFF
--- a/traffic_control/clients/README.md
+++ b/traffic_control/clients/README.md
@@ -4,15 +4,12 @@ There are two client libraries supported:
 
 ## Python
 * Supported TO API Versions
-  * 1.1
-  * 1.2
-* Documentation
-  * https://github.com/apache/trafficcontrol/tree/master/traffic_control/clients/python/trafficops
+	* 2.0
+* [Documentation](https://github.com/apache/trafficcontrol/tree/master/traffic_control/clients/python/trafficops)
 
 ## Golang
-### TO API v1.2 _(Deprecated)_
-* Documentation
-  * https://github.com/apache/trafficcontrol/tree/master/traffic_ops/client
-###TO API v1.3
-* Documentation
-  * https://github.com/apache/trafficcontrol/tree/master/traffic_ops/client/v13
+### TO API v1.5 _(Deprecated)_
+* [Documentation](https://github.com/apache/trafficcontrol/tree/master/traffic_ops/v1-client)
+
+### TO API v2.0
+* [Documentation](https://github.com/apache/trafficcontrol/tree/master/traffic_ops/client)

--- a/traffic_control/clients/python/setup.py
+++ b/traffic_control/clients/python/setup.py
@@ -29,9 +29,9 @@ if pyversion.major < 3:
 	sys.stderr.write("Python 2 is no longer supported\n")
 	sys.exit(1)
 
-elif pyversion.major == 3 and (pyversion.minor < 4 or pyversion.minor > 6):
+elif pyversion.major == 3 and (pyversion.minor < 6 or pyversion.minor > 8):
 	MSG = ('WARNING: This library may not work properly with Python {0.major}.{0.minor}.{0.micro}, '
-	       'as it is untested for this version. (3.4 <= version <=3.6 recommended)\n')
+	       'as it is untested for this version. (3.6 <= version <=3.8 recommended)\n')
 	sys.stderr.write(MSG.format(pyversion))
 
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/traffic_control/clients/python/to_access/__init__.py
+++ b/traffic_control/clients/python/to_access/__init__.py
@@ -78,6 +78,10 @@ Arguments and Flags
 	Request exactly :option:`PATH`; do not preface the request path with :file:`/api/{api_version}`.
 	This effectively means that :option:`--api-version` will have no effect. (Default: false)
 
+.. option:: -v, --version
+
+	Print version information and exit.
+
 .. option:: --request-headers
 
 	Output the request method line and any and all request headers. (Default: false)
@@ -180,10 +184,9 @@ import os
 import sys
 from urllib.parse import urlparse
 
-from future.utils import raise_from
-
 from trafficops.restapi import LoginError, OperationError, InvalidJSONError
 from trafficops.tosession import TOSession
+from trafficops.__version__ import __version__
 
 from requests.exceptions import RequestException
 
@@ -294,7 +297,11 @@ def parse_arguments(program):
 	                    action="store_true",
 	                    help=("Pretty-print payloads as JSON. "
 	                         "Note that this will make Content-Type headers \"wrong\", in general"))
-	parser.add_argument("PATH", help="The path to the resource being requested - omit '/api/1.x'")
+	parser.add_argument("-v", "--version",
+	                    action="version",
+	                    help="Print version information and exit",
+	                    version="%(prog)s v"+__version__)
+	parser.add_argument("PATH", help="The path to the resource being requested - omit '/api/2.x'")
 	parser.add_argument("DATA",
 	                    help=("An optional data string to pass with the request. If this is a "
 	                         "filename, the contents of the file will be sent instead."),
@@ -321,12 +328,12 @@ def parse_arguments(program):
 
 	to_host = to_host.hostname
 	if not to_host:
-		raise KeyError("Invalid URL/host for Traffic Ops: '%s'" % original_to_host)
+		raise KeyError(f"Invalid URL/host for Traffic Ops: '{original_to_host}'")
 
 	s = TOSession(to_host,
 	              host_port=to_port,
 	              ssl=useSSL,
-	              api_version="{.1f}".format(args.api_version),
+	              api_version=f"{args.api_version:.1f}",
 	              verify_cert=not args.insecure)
 
 	data = args.DATA

--- a/traffic_control/clients/python/trafficops/__version__.py
+++ b/traffic_control/clients/python/trafficops/__version__.py
@@ -27,4 +27,4 @@ this client will remain non-breaking for existing code using it until the next m
 released.
 """
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/traffic_control/clients/python/trafficops/__version__.py
+++ b/traffic_control/clients/python/trafficops/__version__.py
@@ -21,17 +21,10 @@ gives the version of this *Apache-TrafficControl package* and **not** the versio
 client to grow in a version-controlled manner without being tied to the release cadence of Apache
 Traffic Control as a whole.
 
-Version 1.0 is supported for use with Apache Traffic Control version 3.0 (release pending at the
+Version 2.0 is supported for use with Apache Traffic Control version 4.0 (release pending at the
 time of this writing). New functionality will be added as the :ref:`to-api` evolves, but changes to
 this client will remain non-breaking for existing code using it until the next major version is
 released.
-
-.. deprecated:: 1.0
-	The v1.0 release of this client deprecates support of Python2. Versions 2.0 and onward will
-	*only* support Python3 (v3.4+). Note that this release is expected either by the time Python2
-	reaches its end-of-life at the end of 2019, or with the release of Apache Traffic Control v4.0,
-	should that happen first. Users and developers are encouraged to switch to Python3 as soon as
-	possible.
 """
 
 __version__ = '2.0.0'

--- a/traffic_control/clients/python/trafficops/__version__.py
+++ b/traffic_control/clients/python/trafficops/__version__.py
@@ -21,7 +21,7 @@ gives the version of this *Apache-TrafficControl package* and **not** the versio
 client to grow in a version-controlled manner without being tied to the release cadence of Apache
 Traffic Control as a whole.
 
-Version 2.0 is supported for use with Apache Traffic Control version 4.0 (release pending at the
+Version 2.0 is supported for use with Apache Traffic Control version 4.1 (release pending at the
 time of this writing). New functionality will be added as the :ref:`to-api` evolves, but changes to
 this client will remain non-breaking for existing code using it until the next major version is
 released.


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

* Addresses inaccuracies, bad formatting in the clients/README.md file
* Fixed the warning in `setup.py` reporting that "3.4 <= version 3.6" being supported (3.4 isn't even receiving security fixes anymore)
* Removed an unused import from the toaccess scripts
* Added `-v`/`--version` support to the toaccess scripts
* Fixed a bug when formatting the API version that caused all toaccess scripts to be unusable (now using fstrings)
* Incremented micro version to account for bugfix
* Removed admonition about dropping support for Python 2 - that's been done and the package will now refuse to build for Python 2.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Client (Python) - but really mostly just toaccess

## What is the best way to verify this PR?
Install the client and try to use the toaccess scripts. I tried `toget -fkp ping` and got the expected output (my environment variables are set).

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Python client is untested
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**