### PR TITLE
ORT Speed Improvements (#4419) (4.0.x Backport)

### DIFF
--- a/traffic_ops/ort/atstccfg/config/config.go
+++ b/traffic_ops/ort/atstccfg/config/config.go
@@ -94,8 +94,7 @@ func GetCfg() (Cfg, error) {
 	printGeneratedFilesPtr := flag.BoolP("print-generated-files", "g", false, "Whether to print a list of files which are generated (and not proxied to Traffic Ops).")
 	toInsecurePtr := flag.BoolP("traffic-ops-insecure", "s", false, "Whether to ignore HTTPS certificate errors from Traffic Ops. It is HIGHLY RECOMMENDED to never use this in a production environment, but only for debugging.")
 	toTimeoutMSPtr := flag.IntP("traffic-ops-timeout-milliseconds", "t", 10000, "Timeout in seconds for Traffic Ops requests.")
-	cacheFileMaxAgeSecondsPtr := flag.IntP("cache-file-max-age-seconds", "a", 60, "Maximum age to use cached files.")
-
+	cacheFileMaxAgeSecondsPtr := flag.IntP("cache-file-max-age-seconds", "a", 900, "Maximum age to use cached files.")
 	listPluginsPtr := flag.BoolP("list-plugins", "l", false, "Print the list of plugins.")
 
 	flag.Parse()

--- a/traffic_ops/ort/atstccfg/routing.go
+++ b/traffic_ops/ort/atstccfg/routing.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/cfgfile"
@@ -37,6 +38,11 @@ var scopeConfigFileFuncs = map[string]func(cfg config.TCCfg, resource string, fi
 }
 
 func GetConfigFile(cfg config.TCCfg) (string, int, error) {
+	start := time.Now()
+	defer func() {
+		log.Infof("GetConfigFile %v took %v\n", cfg.TOURL.Path, time.Since(start).Round(time.Millisecond))
+	}()
+
 	pathParts := strings.Split(cfg.TOURL.Path, "/")
 
 	if len(pathParts) == 7 && pathParts[1] == `api` && pathParts[3] == `servers` && pathParts[5] == `configfiles` && pathParts[6] == `ats` {

--- a/traffic_ops/ort/atstccfg/toreq/caching.go
+++ b/traffic_ops/ort/atstccfg/toreq/caching.go
@@ -20,30 +20,53 @@ package toreq
  */
 
 import (
+	"bufio"
+	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-// GetCachedJSON attempts to get the given object from tempDir/cacheFileName.
+// DefaultCacheFormat is the encoder, decoder, and file extension to use for caching.
+// This may be changed at compile-time. See CacheFormatJSON.
+// Note this is not used for all cache files. Notably, Delivery Service Servers use a custom CSV format, which is faster than gob.
+var DefaultCacheFormat = CacheFormatGob
+
+// GetCached attempts to get the given object from tempDir/cacheFileName.
 // If the cache file doesn't exist, is too old, or is malformed, it uses getter to get the object, and stores it in cacheFileName.
-// The object is placed in obj (which must be a pointer to the type of object to decode from JSON), and the error from getter is returned.
-func GetCachedJSON(cfg config.TCCfg, cacheFileName string, obj interface{}, getter func(obj interface{}) error) error {
-	err := GetJSONObjFromFile(cfg.TempDir, cacheFileName, cfg.CacheFileMaxAge, obj)
+// The object is placed in obj (which must be a pointer to the type of object to decode), and the error from getter is returned.
+// The cache format is defined by CacheEncoder and CacheDecoder, which may be changed at compile-time.
+func GetCached(cfg config.TCCfg, cacheFileName string, obj interface{}, getter func(obj interface{}) error) error {
+	return GetCachedWithFormat(cfg, cacheFileName, obj, getter, DefaultCacheFormat)
+}
+
+// GetCachedDSS is like GetCached, but optimized for Delivery Service Servers, which is massive.
+func GetCachedDSS(cfg config.TCCfg, cacheFileName string, obj *[]tc.DeliveryServiceServer, getter func(obj interface{}) error) error {
+	return GetCachedWithFormat(cfg, cacheFileName, obj, getter, CacheFormatDSS)
+}
+
+func GetCachedWithFormat(cfg config.TCCfg, cacheFileName string, obj interface{}, getter func(obj interface{}) error, cacheFormat CacheFormat) error {
+	cacheFileName += cacheFormat.Extension
+	start := time.Now()
+	err := ReadCache(cacheFormat.Decoder, cfg.TempDir, cacheFileName, cfg.CacheFileMaxAge, obj)
 	if err == nil {
+		log.Infof("ReadCache %v (hit) took %v\n", cacheFileName, time.Since(start).Round(time.Millisecond))
 		return nil
 	}
 
-	log.Infoln("GetCachedJSON failed to get object from '" + cfg.TempDir + "/" + cacheFileName + "', calling getter: " + err.Error())
+	log.Infoln("ReadCache failed to get object from '" + cfg.TempDir + "/" + cacheFileName + "', calling getter: " + err.Error())
 
 	currentRetry := 0
 	for {
@@ -51,7 +74,10 @@ func GetCachedJSON(cfg config.TCCfg, cacheFileName string, obj interface{}, gett
 		if err == nil {
 			break
 		}
-
+		if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			// if the server returned a 404, retrying won't help
+			return errors.New("getting uncached: " + err.Error())
+		}
 		if currentRetry == cfg.NumRetries {
 			return errors.New("getting uncached: " + err.Error())
 		}
@@ -62,16 +88,16 @@ func GetCachedJSON(cfg config.TCCfg, cacheFileName string, obj interface{}, gett
 		time.Sleep(time.Second * time.Duration(sleepSeconds)) // TODO make backoff configurable?
 	}
 
-	WriteCacheJSON(cfg.TempDir, cacheFileName, obj)
+	WriteCache(cacheFormat.Encoder, cfg.TempDir, cacheFileName, obj)
+	log.Infof("GetCachedJSON %v (miss) took %v\n", cacheFileName, time.Since(start).Round(time.Millisecond))
 	return nil
 }
 
-// WriteCacheJSON attempts to write obj to tempDir/cacheFileName.
+// WriteCache attempts to write obj to tempDir/cacheFileName.
 // If there is an error, it is written to stderr but not returned.
-func WriteCacheJSON(tempDir string, cacheFileName string, obj interface{}) {
-	objBts, err := json.Marshal(obj)
-	if err != nil {
-		log.Errorln("serializing object '" + cacheFileName + "' to JSON: " + err.Error())
+func WriteCache(encode EncodeFunc, tempDir string, cacheFileName string, obj interface{}) {
+	if encode == nil {
+		log.Errorln("object '" + cacheFileName + "': nil encode func! Should never happen! Can't write file!")
 		return
 	}
 
@@ -84,17 +110,19 @@ func WriteCacheJSON(tempDir string, cacheFileName string, obj interface{}) {
 	}
 	defer objFile.Close()
 
-	if _, err := objFile.Write(objBts); err != nil {
-		log.Errorln("writing object cache file '" + objPath + "': " + err.Error())
+	if err := encode(objFile, obj); err != nil {
+		log.Errorln("writing '" + cacheFileName + "': " + err.Error())
 		return
 	}
 }
 
-// GetJSONObjFromFile gets obj from tempDir/cacheFileName, if it exists and isn't older than CacheFileMaxAge.
-// Just like with json.Unmarshal, obj must be a non-nil pointer to the object to decode into.
-func GetJSONObjFromFile(tempDir string, cacheFileName string, cacheFileMaxAge time.Duration, obj interface{}) error {
+// ReadCache gets obj from tempDir/cacheFileName, if it exists and isn't older than CacheFileMaxAge.
+// The obj must be a non-nil pointer to the object to decode into.
+func ReadCache(decode DecodeFunc, tempDir string, cacheFileName string, cacheFileMaxAge time.Duration, obj interface{}) error {
+	if decode == nil {
+		return errors.New("nil decode func")
+	}
 	objPath := filepath.Join(tempDir, cacheFileName)
-
 	objFile, err := os.Open(objPath)
 	if err != nil {
 		return errors.New("opening object file '" + objPath + "':" + err.Error())
@@ -105,23 +133,41 @@ func GetJSONObjFromFile(tempDir string, cacheFileName string, cacheFileMaxAge ti
 	if err != nil {
 		return errors.New("getting object file info '" + objPath + "':" + err.Error())
 	}
-
 	if objFileAge := time.Now().Sub(objFileInfo.ModTime()); objFileAge > cacheFileMaxAge {
 		return fmt.Errorf("object file too old, max age %dms less than file age %dms", int(cacheFileMaxAge/time.Millisecond), int(objFileAge/time.Millisecond))
 	}
-
-	bts, err := ioutil.ReadAll(objFile)
-	if err != nil {
-		return errors.New("reading object from file '" + objPath + "':" + err.Error())
-	}
-
-	if err := json.Unmarshal(bts, obj); err != nil {
+	if err := decode(objFile, obj); err != nil {
 		log.Errorln("GetJSONObjFromFile loaded '" + cacheFileName + "' but failed to parse JSON: " + err.Error())
 		return errors.New("unmarshalling object from file '" + objPath + "':" + err.Error())
 	}
-
 	return nil
 }
+
+type CacheFormat struct {
+	Encoder   EncodeFunc
+	Decoder   DecodeFunc
+	Extension string
+}
+
+var CacheFormatGob = CacheFormat{GobEncode, GobDecode, GobExtension}
+var CacheFormatJSON = CacheFormat{JSONEncode, JSONDecode, JSONExtension}
+
+// CacheFormatDSS is a special format encoder/decoder optimized for Delivery Service Servers.
+// The encoder and decoder both return errors if obj is not a *[]tc.DeliveryServiceServer.
+var CacheFormatDSS = CacheFormat{DSSEncode, DSSDecode, DSSExtension}
+
+type EncodeFunc func(w io.Writer, obj interface{}) error
+type DecodeFunc func(r io.Reader, obj interface{}) error
+
+const JSONExtension = ".json"
+
+func JSONDecode(r io.Reader, obj interface{}) error { return json.NewDecoder(r).Decode(obj) }
+func JSONEncode(w io.Writer, obj interface{}) error { return json.NewEncoder(w).Encode(obj) }
+
+const GobExtension = ".gob"
+
+func GobDecode(r io.Reader, obj interface{}) error { return gob.NewDecoder(r).Decode(obj) }
+func GobEncode(w io.Writer, obj interface{}) error { return gob.NewEncoder(w).Encode(obj) }
 
 func StringToCookies(cookiesStr string) []*http.Cookie {
 	hdr := http.Header{}
@@ -176,4 +222,66 @@ func GetCookiesFromFile(tempDir string, cacheFileMaxAge time.Duration) (string, 
 		return "", errors.New("reading cookies from file '" + cookiePath + "':" + err.Error())
 	}
 	return string(bts), nil
+}
+
+// DSSExtension is the file extension for the format read and written by DSSEncode and DSSDecode.
+const DSSExtension = ".csv"
+
+// DSSEncode is an EncodeFunc optimized for Delivery Service Servers.
+// If iObj is not a *[]tc.DeliveryServiceServer it immediately returns an error.
+func DSSEncode(w io.Writer, iObj interface{}) error {
+	// Please don't change this to use encoding/csv unless you benchmark and prove it's at least as fast. DSS is massive, and performance is important.
+	obj, ok := iObj.(*[]tc.DeliveryServiceServer)
+	if !ok {
+		return fmt.Errorf("object is '%T' must be a *[]tc.DeliveryServiceServer\n", iObj)
+	}
+	for _, dss := range *obj {
+		if dss.DeliveryService == nil || dss.Server == nil {
+			continue // TODO warn?
+		}
+		if _, err := io.WriteString(w, strconv.Itoa(*dss.DeliveryService)+`,`+strconv.Itoa(*dss.Server)+"\n"); err != nil {
+			return fmt.Errorf("writing object cache file: " + err.Error())
+		}
+	}
+	return nil
+}
+
+// DSSDecode is a DecodeFunc optimized for Delivery Service Servers.
+// If iObj is not a *[]tc.DeliveryServiceServer it immediately returns an error.
+func DSSDecode(r io.Reader, iObj interface{}) error {
+	// Please don't change this to use encoding/csv unless you benchmark and prove it's at least as fast. DSS is massive, and performance is important.
+	obj, ok := iObj.(*[]tc.DeliveryServiceServer)
+	if !ok {
+		return fmt.Errorf("object is '%T' must be a *[]tc.DeliveryServiceServer\n", iObj)
+	}
+	objFileReader := bufio.NewReader(r)
+	for {
+		dsStr, err := objFileReader.ReadString(',')
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return errors.New("malformed object file:" + err.Error())
+		}
+		dsStr = dsStr[:len(dsStr)-1] // ReadString(',') includes the comma; remove it
+
+		ds, err := strconv.Atoi(dsStr)
+		if err != nil {
+			return errors.New("malformed object file: first field should be ds id, but is not an integer: '" + dsStr + "'")
+		}
+		svStr, err := objFileReader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return errors.New("malformed object file: final line had ds but not server, or file is missing a trailing newline")
+			}
+			return errors.New("malformed object file:" + err.Error())
+		}
+		svStr = svStr[:len(svStr)-1] // ReadString('\n') includes the newline; remove it
+		sv, err := strconv.Atoi(svStr)
+		if err != nil {
+			return errors.New("malformed object file: second field should be server id, but is not an integer: '" + svStr + "'")
+		}
+		*obj = append(*obj, tc.DeliveryServiceServer{DeliveryService: &ds, Server: &sv})
+	}
+	return nil
 }

--- a/traffic_ops/ort/atstccfg/toreq/caching_test.go
+++ b/traffic_ops/ort/atstccfg/toreq/caching_test.go
@@ -45,24 +45,65 @@ func TestWriteCacheJSON(t *testing.T) {
 `,
 		}
 
-		WriteCacheJSON(tmpDir, fileName, largeObj)
+		WriteCache(CacheFormatJSON.Encoder, tmpDir, fileName, largeObj)
 		loadedLargeObj := Obj{}
-		if err := GetJSONObjFromFile(tmpDir, fileName, time.Hour, &loadedLargeObj); err != nil {
-			t.Fatalf("GetJSONObjFromFile large error expected nil, actual: " + err.Error())
+		if err := ReadCache(CacheFormatJSON.Decoder, tmpDir, fileName, time.Hour, &loadedLargeObj); err != nil {
+			t.Fatalf("ReadCache large error expected nil, actual: " + err.Error())
 		} else if largeObj.S != loadedLargeObj.S {
-			t.Fatalf("GetJSONObjFromFile expected %+v actual %+v\n", largeObj.S, loadedLargeObj.S)
+			t.Fatalf("ReadCache expected %+v actual %+v\n", largeObj.S, loadedLargeObj.S)
 		}
 	}
 
 	{
 		// Write a smaller object to the same file, to make sure it properly truncates, and doesn't leave old text lying around (resulting in malformed json)
 		smallObj := Obj{S: `foo`}
-		WriteCacheJSON(tmpDir, fileName, smallObj)
+		WriteCache(CacheFormatJSON.Encoder, tmpDir, fileName, smallObj)
 		loadedSmallObj := Obj{}
-		if err := GetJSONObjFromFile(tmpDir, fileName, time.Hour, &loadedSmallObj); err != nil {
+		if err := ReadCache(CacheFormatJSON.Decoder, tmpDir, fileName, time.Hour, &loadedSmallObj); err != nil {
 			t.Fatalf("GetJSONObjFromFile small error expected nil, actual: " + err.Error())
 		} else if smallObj.S != loadedSmallObj.S {
 			t.Fatalf("GetJSONObjFromFile expected %+v actual %+v\n", smallObj.S, loadedSmallObj.S)
+		}
+	}
+}
+
+func TestWriteCacheGob(t *testing.T) {
+	type Obj struct {
+		S string `json:"s"`
+	}
+
+	fileName := "TestWriteCacheGob.gob"
+	tmpDir := os.TempDir()
+	filePath := filepath.Join(tmpDir, fileName)
+	defer os.Remove(filePath)
+
+	{
+		largeObj := Obj{
+			S: `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+    Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris. Integer in mauris eu nibh euismod gravida. Duis ac tellus et risus vulputate vehicula. Donec lobortis risus a elit. Etiam tempor. Ut ullamcorper, ligula eu tempor congue, eros est euismod turpis, id tincidunt sapien risus a quam. Maecenas fermentum consequat mi. Donec fermentum. Pellentesque malesuada nulla a mi. Duis sapien sem, aliquet nec, commodo eget, consequat quis, neque. Aliquam faucibus, elit ut dictum aliquet, felis nisl adipiscing sapien, sed malesuada diam lacus eget erat. Cras mollis scelerisque nunc. Nullam arcu. Aliquam consequat. Curabitur augue lorem, dapibus quis, laoreet et, pretium ac, nisi. Aenean magna nisl, mollis quis, molestie eu, feugiat in, orci. In hac habitasse platea dictumst.
+`,
+		}
+
+		WriteCache(CacheFormatGob.Encoder, tmpDir, fileName, largeObj)
+		loadedLargeObj := Obj{}
+		if err := ReadCache(CacheFormatGob.Decoder, tmpDir, fileName, time.Hour, &loadedLargeObj); err != nil {
+			t.Fatalf("ReadCache large error expected nil, actual: " + err.Error())
+		} else if largeObj.S != loadedLargeObj.S {
+			t.Fatalf("ReadCache expected %+v actual %+v\n", largeObj.S, loadedLargeObj.S)
+		}
+	}
+
+	{
+		// Write a smaller object to the same file, to make sure it properly truncates, and doesn't leave old text lying around (resulting in malformed gob)
+		smallObj := Obj{S: `foo`}
+		WriteCache(CacheFormatGob.Encoder, tmpDir, fileName, smallObj)
+		loadedSmallObj := Obj{}
+		if err := ReadCache(CacheFormatGob.Decoder, tmpDir, fileName, time.Hour, &loadedSmallObj); err != nil {
+			t.Fatalf("ReadCache small error expected nil, actual: " + err.Error())
+		} else if smallObj.S != loadedSmallObj.S {
+			t.Fatalf("ReadCache expected %+v actual %+v\n", smallObj.S, loadedSmallObj.S)
 		}
 	}
 }

--- a/traffic_ops/ort/atstccfg/toreq/toreq.go
+++ b/traffic_ops/ort/atstccfg/toreq/toreq.go
@@ -34,7 +34,7 @@ import (
 
 func GetProfile(cfg config.TCCfg, profileID int) (tc.Profile, error) {
 	profile := tc.Profile{}
-	err := GetCachedJSON(cfg, "profile_"+strconv.Itoa(profileID)+".json", &profile, func(obj interface{}) error {
+	err := GetCached(cfg, "profile_"+strconv.Itoa(profileID), &profile, func(obj interface{}) error {
 		toProfiles, reqInf, err := (*cfg.TOClient).GetProfileByID(profileID)
 		if err != nil {
 			return errors.New("getting profile '" + strconv.Itoa(profileID) + "' from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -55,7 +55,7 @@ func GetProfile(cfg config.TCCfg, profileID int) (tc.Profile, error) {
 
 func GetProfileByName(cfg config.TCCfg, profileName string) (tc.Profile, error) {
 	profile := tc.Profile{}
-	err := GetCachedJSON(cfg, "profile_"+profileName+".json", &profile, func(obj interface{}) error {
+	err := GetCached(cfg, "profile_"+profileName, &profile, func(obj interface{}) error {
 		toProfiles, reqInf, err := (*cfg.TOClient).GetProfileByName(profileName)
 		if err != nil {
 			return errors.New("getting profile '" + profileName + "' from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -76,7 +76,7 @@ func GetProfileByName(cfg config.TCCfg, profileName string) (tc.Profile, error) 
 
 func GetProfileParameters(cfg config.TCCfg, profileName string) ([]tc.Parameter, error) {
 	profileParameters := []tc.Parameter{}
-	err := GetCachedJSON(cfg, "profile_"+profileName+"_parameters.json", &profileParameters, func(obj interface{}) error {
+	err := GetCached(cfg, "profile_"+profileName+"_parameters", &profileParameters, func(obj interface{}) error {
 		toParams, reqInf, err := (*cfg.TOClient).GetParametersByProfileName(profileName)
 		if err != nil {
 			return errors.New("getting profile '" + profileName + "' parameters from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -93,7 +93,7 @@ func GetProfileParameters(cfg config.TCCfg, profileName string) ([]tc.Parameter,
 
 func GetGlobalParameters(cfg config.TCCfg) ([]tc.Parameter, error) {
 	globalParams := []tc.Parameter{}
-	err := GetCachedJSON(cfg, "profile_global_parameters.json", &globalParams, func(obj interface{}) error {
+	err := GetCached(cfg, "profile_global_parameters", &globalParams, func(obj interface{}) error {
 		toParams, reqInf, err := (*cfg.TOClient).GetParametersByProfileName(config.GlobalProfileName)
 		if err != nil {
 			return errors.New("getting global profile '" + config.GlobalProfileName + "' parameters from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -142,7 +142,7 @@ func GetTOToolNameAndURLFromTO(cfg config.TCCfg) (string, string, error) {
 
 func GetServers(cfg config.TCCfg) ([]tc.Server, error) {
 	servers := []tc.Server{}
-	err := GetCachedJSON(cfg, "servers.json", &servers, func(obj interface{}) error {
+	err := GetCached(cfg, "servers", &servers, func(obj interface{}) error {
 		toServers, reqInf, err := (*cfg.TOClient).GetServers()
 		if err != nil {
 			return errors.New("getting servers from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -159,7 +159,7 @@ func GetServers(cfg config.TCCfg) ([]tc.Server, error) {
 
 func GetServerByHostName(cfg config.TCCfg, serverHostName string) (tc.Server, error) {
 	server := tc.Server{}
-	err := GetCachedJSON(cfg, "server-name-"+serverHostName+".json", &server, func(obj interface{}) error {
+	err := GetCached(cfg, "server-name-"+serverHostName, &server, func(obj interface{}) error {
 		toServers, reqInf, err := (*cfg.TOClient).GetServerByHostName(serverHostName)
 		if err != nil {
 			return errors.New("getting server name '" + serverHostName + "' from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -178,7 +178,7 @@ func GetServerByHostName(cfg config.TCCfg, serverHostName string) (tc.Server, er
 
 func GetServerByID(cfg config.TCCfg, serverID int) (tc.Server, error) {
 	server := tc.Server{}
-	err := GetCachedJSON(cfg, "server-id-"+strconv.Itoa(serverID)+".json", &server, func(obj interface{}) error {
+	err := GetCached(cfg, "server-id-"+strconv.Itoa(serverID), &server, func(obj interface{}) error {
 		toServers, reqInf, err := (*cfg.TOClient).GetServerByID(serverID)
 		if err != nil {
 			return fmt.Errorf("getting server id %v from Traffic Ops '%v': %v", serverID, MaybeIPStr(reqInf), err)
@@ -197,7 +197,7 @@ func GetServerByID(cfg config.TCCfg, serverID int) (tc.Server, error) {
 
 func GetCacheGroups(cfg config.TCCfg) ([]tc.CacheGroupNullable, error) {
 	cacheGroups := []tc.CacheGroupNullable{}
-	err := GetCachedJSON(cfg, "cachegroups.json", &cacheGroups, func(obj interface{}) error {
+	err := GetCached(cfg, "cachegroups", &cacheGroups, func(obj interface{}) error {
 		toCacheGroups, reqInf, err := (*cfg.TOClient).GetCacheGroupsNullable()
 		if err != nil {
 			return errors.New("getting cachegroups from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -236,7 +236,7 @@ func GetDeliveryServiceServers(cfg config.TCCfg, dsIDs []int, serverIDs []int) (
 	}
 
 	dsServers := []tc.DeliveryServiceServer{}
-	err := GetCachedJSON(cfg, "deliveryservice_servers_s"+serverIDsStr+"_d_"+dsIDsStr+".json", &dsServers, func(obj interface{}) error {
+	err := GetCachedDSS(cfg, "deliveryservice_servers_s"+serverIDsStr+"_d_"+dsIDsStr, &dsServers, func(obj interface{}) error {
 		const noLimit = 999999 // TODO add "no limit" param to DSS endpoint
 		toDSS, reqInf, err := (*cfg.TOClient).GetDeliveryServiceServersWithLimits(noLimit, dsIDsToFetch, sIDsToFetch)
 		if err != nil {
@@ -284,7 +284,7 @@ func GetDeliveryServiceServers(cfg config.TCCfg, dsIDs []int, serverIDs []int) (
 
 func GetServerProfileParameters(cfg config.TCCfg, profileName string) ([]tc.Parameter, error) {
 	serverProfileParameters := []tc.Parameter{}
-	err := GetCachedJSON(cfg, "profile_"+profileName+"_parameters.json", &serverProfileParameters, func(obj interface{}) error {
+	err := GetCached(cfg, "profile_"+profileName+"_parameters", &serverProfileParameters, func(obj interface{}) error {
 		toParams, reqInf, err := (*cfg.TOClient).GetParametersByProfileName(profileName)
 		if err != nil {
 			return errors.New("getting server profile '" + profileName + "' parameters from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -301,7 +301,7 @@ func GetServerProfileParameters(cfg config.TCCfg, profileName string) ([]tc.Para
 
 func GetCDNDeliveryServices(cfg config.TCCfg, cdnID int) ([]tc.DeliveryServiceNullable, error) {
 	deliveryServices := []tc.DeliveryServiceNullable{}
-	err := GetCachedJSON(cfg, "cdn_"+strconv.Itoa(cdnID)+"_deliveryservices"+".json", &deliveryServices, func(obj interface{}) error {
+	err := GetCached(cfg, "cdn_"+strconv.Itoa(cdnID)+"_deliveryservices", &deliveryServices, func(obj interface{}) error {
 		toDSes, reqInf, err := (*cfg.TOClient).GetDeliveryServicesByCDNID(cdnID)
 		if err != nil {
 			return errors.New("getting delivery services from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -318,7 +318,7 @@ func GetCDNDeliveryServices(cfg config.TCCfg, cdnID int) ([]tc.DeliveryServiceNu
 
 func GetConfigFileParameters(cfg config.TCCfg, configFile string) ([]tc.Parameter, error) {
 	params := []tc.Parameter{}
-	err := GetCachedJSON(cfg, "config_file_"+configFile+"_parameters"+".json", &params, func(obj interface{}) error {
+	err := GetCached(cfg, "config_file_"+configFile+"_parameters", &params, func(obj interface{}) error {
 		toParams, reqInf, err := (*cfg.TOClient).GetParameterByConfigFile(configFile)
 		if err != nil {
 			return errors.New("getting delivery services from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -335,7 +335,7 @@ func GetConfigFileParameters(cfg config.TCCfg, configFile string) ([]tc.Paramete
 
 func GetCDN(cfg config.TCCfg, cdnName tc.CDNName) (tc.CDN, error) {
 	cdn := tc.CDN{}
-	err := GetCachedJSON(cfg, "cdn_"+string(cdnName)+".json", &cdn, func(obj interface{}) error {
+	err := GetCached(cfg, "cdn_"+string(cdnName), &cdn, func(obj interface{}) error {
 		toCDNs, reqInf, err := (*cfg.TOClient).GetCDNByName(string(cdnName))
 		if err != nil {
 			return errors.New("getting cdn from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -355,7 +355,7 @@ func GetCDN(cfg config.TCCfg, cdnName tc.CDNName) (tc.CDN, error) {
 
 func GetCDNByID(cfg config.TCCfg, cdnID int) (tc.CDN, error) {
 	cdn := tc.CDN{}
-	err := GetCachedJSON(cfg, "cdn_id_"+strconv.Itoa(cdnID)+".json", &cdn, func(obj interface{}) error {
+	err := GetCached(cfg, "cdn_id_"+strconv.Itoa(cdnID), &cdn, func(obj interface{}) error {
 		toCDNs, reqInf, err := (*cfg.TOClient).GetCDNByID(cdnID)
 		if err != nil {
 			return errors.New("getting cdn from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -375,7 +375,7 @@ func GetCDNByID(cfg config.TCCfg, cdnID int) (tc.CDN, error) {
 
 func GetURLSigKeys(cfg config.TCCfg, dsName string) (tc.URLSigKeys, error) {
 	keys := tc.URLSigKeys{}
-	err := GetCachedJSON(cfg, "urlsigkeys_"+string(dsName)+".json", &keys, func(obj interface{}) error {
+	err := GetCached(cfg, "urlsigkeys_"+string(dsName), &keys, func(obj interface{}) error {
 		toKeys, reqInf, err := (*cfg.TOClient).GetDeliveryServiceURLSigKeys(dsName)
 		if err != nil {
 			return errors.New("getting url sig keys from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -392,7 +392,7 @@ func GetURLSigKeys(cfg config.TCCfg, dsName string) (tc.URLSigKeys, error) {
 
 func GetURISigningKeys(cfg config.TCCfg, dsName string) ([]byte, error) {
 	keys := []byte{}
-	err := GetCachedJSON(cfg, "urisigningkeys_"+string(dsName)+".json", &keys, func(obj interface{}) error {
+	err := GetCached(cfg, "urisigningkeys_"+string(dsName), &keys, func(obj interface{}) error {
 		toKeys, reqInf, err := (*cfg.TOClient).GetDeliveryServiceURISigningKeys(dsName)
 		if err != nil {
 			return errors.New("getting url sig keys from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -410,7 +410,7 @@ func GetURISigningKeys(cfg config.TCCfg, dsName string) ([]byte, error) {
 
 func GetParametersByName(cfg config.TCCfg, paramName string) ([]tc.Parameter, error) {
 	params := []tc.Parameter{}
-	err := GetCachedJSON(cfg, "parameters_name_"+paramName+".json", &params, func(obj interface{}) error {
+	err := GetCached(cfg, "parameters_name_"+paramName, &params, func(obj interface{}) error {
 		toParams, reqInf, err := (*cfg.TOClient).GetParameterByName(paramName)
 		if err != nil {
 			return errors.New("getting parameters name '" + paramName + "' from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -427,7 +427,7 @@ func GetParametersByName(cfg config.TCCfg, paramName string) ([]tc.Parameter, er
 
 func GetCacheGroupParameters(cfg config.TCCfg, cacheGroupID int) ([]tc.Parameter, error) {
 	params := []tc.Parameter{}
-	err := GetCachedJSON(cfg, "cachegroup_parameters_id_"+strconv.Itoa(cacheGroupID)+".json", &params, func(obj interface{}) error {
+	err := GetCached(cfg, "cachegroup_parameters_id_"+strconv.Itoa(cacheGroupID), &params, func(obj interface{}) error {
 		toParams, reqInf, err := (*cfg.TOClient).GetCacheGroupParameters(cacheGroupID)
 		if err != nil {
 			return errors.New("getting cachegroup parameters id '" + strconv.Itoa(cacheGroupID) + "' from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -451,11 +451,9 @@ func GetCacheGroupParameters(cfg config.TCCfg, cacheGroupID int) ([]tc.Parameter
 	return params, nil
 }
 
-// func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.CacheGroupParameter, ReqInf, error) {
-
 func GetDeliveryServiceRegexes(cfg config.TCCfg) ([]tc.DeliveryServiceRegexes, error) {
 	regexes := []tc.DeliveryServiceRegexes{}
-	err := GetCachedJSON(cfg, "ds_regexes.json", &regexes, func(obj interface{}) error {
+	err := GetCached(cfg, "ds_regexes", &regexes, func(obj interface{}) error {
 		toRegexes, reqInf, err := (*cfg.TOClient).GetDeliveryServiceRegexes()
 		if err != nil {
 			return errors.New("getting ds regexes from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -472,7 +470,7 @@ func GetDeliveryServiceRegexes(cfg config.TCCfg) ([]tc.DeliveryServiceRegexes, e
 
 func GetJobs(cfg config.TCCfg) ([]tc.Job, error) {
 	jobs := []tc.Job{}
-	err := GetCachedJSON(cfg, "jobs.json", &jobs, func(obj interface{}) error {
+	err := GetCached(cfg, "jobs", &jobs, func(obj interface{}) error {
 		toJobs, reqInf, err := (*cfg.TOClient).GetJobs(nil, nil)
 		if err != nil {
 			return errors.New("getting jobs from Traffic Ops '" + MaybeIPStr(reqInf) + "': " + err.Error())
@@ -486,6 +484,7 @@ func GetJobs(cfg config.TCCfg) ([]tc.Job, error) {
 	}
 	return jobs, nil
 }
+
 func GetServerCapabilitiesByID(cfg config.TCCfg, serverIDs []int) (map[int]map[atscfg.ServerCapability]struct{}, error) {
 	serverIDsStr := ""
 	if len(serverIDs) > 0 {
@@ -494,7 +493,7 @@ func GetServerCapabilitiesByID(cfg config.TCCfg, serverIDs []int) (map[int]map[a
 	}
 
 	serverCaps := map[int]map[atscfg.ServerCapability]struct{}{}
-	err := GetCachedJSON(cfg, "server_capabilities_s_"+serverIDsStr+".json", &serverCaps, func(obj interface{}) error {
+	err := GetCached(cfg, "server_capabilities_s_"+serverIDsStr, &serverCaps, func(obj interface{}) error {
 		// TODO add list of IDs to API+Client
 		toServerCaps, reqInf, err := (*cfg.TOClient).GetServerServerCapabilities(nil, nil, nil)
 		if err != nil {
@@ -530,7 +529,7 @@ func GetDeliveryServiceRequiredCapabilitiesByID(cfg config.TCCfg, dsIDs []int) (
 	}
 
 	dsCaps := map[int]map[atscfg.ServerCapability]struct{}{}
-	err := GetCachedJSON(cfg, "ds_capabilities_d_"+dsIDsStr+".json", &dsCaps, func(obj interface{}) error {
+	err := GetCached(cfg, "ds_capabilities_d_"+dsIDsStr, &dsCaps, func(obj interface{}) error {
 		// TODO add list of IDs to API+Client
 		toDSCaps, reqInf, err := (*cfg.TOClient).GetDeliveryServicesRequiredCapabilities(nil, nil, nil)
 		if err != nil {

--- a/traffic_ops/ort/traffic_ops_ort.pl
+++ b/traffic_ops/ort/traffic_ops_ort.pl
@@ -46,6 +46,7 @@ my $override_hostname_short = '';
 my $override_hostname_full = '';
 my $override_domainname = '';
 my $use_cache = 1;
+my $cache_max_age_seconds = 900;
 
 GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "retries=i"          => \$retries,
@@ -57,6 +58,7 @@ GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "override_hostname_full=s" => \$override_hostname_full,
             "override_domainname=s" => \$override_domainname,
             "use_cache=i" => \$use_cache,
+            "cache_max_age_seconds=i" => \$cache_max_age_seconds,
           );
 
 if ( $#ARGV < 1 ) {
@@ -157,6 +159,7 @@ my $CFG_FILE_ALREADY_PROCESSED = 4;
 #### LWP globals
 my $api_in_use = 1;
 my $rev_proxy_in_use = 0;
+my $atstccfg_cache_cleared = 0;
 my $lwp_conn                   = &setup_lwp();
 my $unixtime       = time();
 my $hostname_short = `/bin/hostname -s`;
@@ -359,6 +362,7 @@ sub usage {
 	print "\t   override_hostname_full=<text>  => override the full hostname of the OS for config generation. Default = ''.\n";
 	print "\t   override_domainname=<text>     => override the domainname of the OS for config generation. Default = ''.\n";
 	print "\t   use_cache=<0|1>                => whether to use cached Traffic Ops data for config generation. Default = 1, use cache.\n";
+	print "\t   cache_max_age_seconds=<time>   => the max time in seconds to use cache files. Default = 900 (15 minutes).\n";
 	print "====-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-====\n";
 	exit 1;
 }
@@ -1508,12 +1512,22 @@ sub lwp_get {
 
 	my ( $TO_USER, $TO_PASS ) = split( /:/, $TM_LOGIN );
 
+	# atstccfg_cache_cleared is a global variable we use to clear the atstccfg cache on the first atstccfg call.
+	# Telling atstccfg to use-cache=false will cause it to delete the cache directory
+	# Which is what we want: when ORT starts to run, delete the cache. We only want to use the atstccfg cache within the same ORT run, not across different runs.
+
 	my $no_cache_arg = '';
-	if ( $use_cache == 0 ) {
+	if ( $use_cache == 0 || $atstccfg_cache_cleared == 0 ) {
+		$atstccfg_cache_cleared = 1;
 		$no_cache_arg = '--no-cache';
 	}
 
-	$response_content = `$atstccfg_cmd $no_cache_arg --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$request' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null 2>$atstccfg_log_path`;
+	my $cache_age_arg='';
+	if (length $cache_max_age_seconds > 0) {
+		$cache_age_arg = "--cache-file-max-age-seconds=$cache_max_age_seconds";
+	}
+
+	$response_content = `$atstccfg_cmd $no_cache_arg $cache_age_arg --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$request' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null 2>$atstccfg_log_path`;
 
 	my $atstccfg_exit_code = $?;
 	$atstccfg_exit_code = atstccfg_code_to_http_code($atstccfg_exit_code);


### PR DESCRIPTION
* Change atstccfg to use gob,csv caching

Changes atstccfg caching to use gob by default, with a custom csv
format for delivery service servers which is huge and slow.

It also abstracts the cache reading and writing, so it's easy
to change to another format.

It also leaves in a const to easily change it to JSON at compile
time.

On a large ORT run, this cuts the time down to about 1/3 what
it was with JSON.

* Change atstccfg default cache time to 15mins.

Default was 1min, which was far too short for an ORT run.
It's configurable, so users passing the flag won't be changed.

* Add atstccfg time info log.

* Add ort flag for cache time, rm cache dir on start

* Add atstccfg err not panic for nil en/decode

* Add atstccfg more informative error msg

* Change ort atstccfg cache clearing to variable

(cherry picked from commit 9f9d58c4e1ca341e84fc06ba3e77e721ad26ba70)

<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [ ] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- Documentation
- Grove
- Traffic Control Client <!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Monitor
- Traffic Ops
- Traffic Ops ORT
- Traffic Portal
- Traffic Router
- Traffic Stats
- Traffic Vault

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [ ] This PR includes any and all required license headers
- [ ] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [ ] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
