### PR TITLE
Deprecate GET cdns/name/:name & GET cdns/:id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /cachegroups/:parameterID/parameter/available
   - /cdns/:name/configs/routing
   - /cdns/configs
+  - /cdns/:id (GET)
+  - /cdns/name/:name (GET)
   - /cdns/usage/overview
   - /deliveryservice_user
   - /deliveryservice_user/:dsId/:userId

--- a/docs/source/api/v1/cdns.rst
+++ b/docs/source/api/v1/cdns.rst
@@ -31,25 +31,33 @@ Request Structure
 
 .. table:: Request Query Parameters
 
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| Parameter | Required | Description                                                                       |
-	+===========+==========+===================================================================================+
-	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the |
-	|           |          | objects in the ``response`` array                                                 |
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending   |
-	|           |          | ("desc")                                                                          |
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| limit     | no       | Choose the maximum number of results to return                                    |
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| offset    | no       | The number of results to skip before beginning to return results. Must use in     |
-	|           |          | conjunction with limit                                                            |
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this           |
-	|           |          | parameter, pages are ``limit`` long and the first page is 1. If ``offset`` was    |
-	|           |          | defined, this query parameter has no effect. ``limit`` must be defined to make    |
-	|           |          | use of ``page``.                                                                  |
-	+-----------+----------+-----------------------------------------------------------------------------------+
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| Parameter     | Required | Description                                                                       |
+	+===============+==========+===================================================================================+
+	| domainName    | no       | Return only the CDN that has this domain name                                     |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| dnssecEnabled | no       | Return only the CDNs that are either dnssec enabled or not                        |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| id            | no       | Return only the CDN that has this id                                              |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| name          | no       | Return only the CDN that has this name                                            |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| orderby       | no       | Choose the ordering of the results - must be the name of one of the fields of the |
+	|               |          | objects in the ``response`` array                                                 |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| sortOrder     | no       | Changes the order of sorting. Either ascending (default or "asc") or descending   |
+	|               |          | ("desc")                                                                          |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| limit         | no       | Choose the maximum number of results to return                                    |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| offset        | no       | The number of results to skip before beginning to return results. Must use in     |
+	|               |          | conjunction with limit                                                            |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| page          | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this           |
+	|               |          | parameter, pages are ``limit`` long and the first page is 1. If ``offset`` was    |
+	|               |          | defined, this query parameter has no effect. ``limit`` must be defined to make    |
+	|               |          | use of ``page``.                                                                  |
+	+---------------+----------+-----------------------------------------------------------------------------------+
 
 Response Structure
 ------------------

--- a/docs/source/api/v1/cdns_id.rst
+++ b/docs/source/api/v1/cdns_id.rst
@@ -21,6 +21,9 @@
 
 ``GET``
 =======
+.. deprecated:: ATCv4
+	Use the ``GET`` method of :ref:`to-api-v1-cdns` with the query parameter ``id`` instead.
+
 Extract information about a specific CDN.
 
 :Auth. Required: Yes
@@ -67,6 +70,12 @@ Response Structure
 			"id": 2,
 			"lastUpdated": "2018-11-14 18:21:14+00",
 			"name": "CDN-in-a-Box"
+		}
+	],
+	"alerts": [
+		{
+			"text": "This endpoint is deprecated, please use GET /cdns with query parameter id instead",
+			"level": "warning"
 		}
 	]}
 

--- a/docs/source/api/v1/cdns_name_name.rst
+++ b/docs/source/api/v1/cdns_name_name.rst
@@ -21,6 +21,9 @@
 
 ``GET``
 =======
+.. deprecated:: ATCv4
+	Use the ``GET`` method of :ref:`to-api-v1-cdns` with the query parameter ``name`` instead.
+
 Extract information about a CDN, identified by name.
 
 :Auth. Required: Yes
@@ -67,6 +70,12 @@ Response Structure
 			"id": 2,
 			"lastUpdated": "2018-11-14 18:21:14+00",
 			"name": "CDN-in-a-Box"
+		}
+	],
+	"alerts": [
+		{
+			"text": "This endpoint is deprecated, please use GET /cdns with query parameter name instead",
+			"level": "warning"
 		}
 	]}
 

--- a/docs/source/api/v2/cdns.rst
+++ b/docs/source/api/v2/cdns.rst
@@ -31,25 +31,33 @@ Request Structure
 
 .. table:: Request Query Parameters
 
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| Parameter | Required | Description                                                                       |
-	+===========+==========+===================================================================================+
-	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the |
-	|           |          | objects in the ``response`` array                                                 |
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending   |
-	|           |          | ("desc")                                                                          |
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| limit     | no       | Choose the maximum number of results to return                                    |
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| offset    | no       | The number of results to skip before beginning to return results. Must use in     |
-	|           |          | conjunction with limit                                                            |
-	+-----------+----------+-----------------------------------------------------------------------------------+
-	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this           |
-	|           |          | parameter, pages are ``limit`` long and the first page is 1. If ``offset`` was    |
-	|           |          | defined, this query parameter has no effect. ``limit`` must be defined to make    |
-	|           |          | use of ``page``.                                                                  |
-	+-----------+----------+-----------------------------------------------------------------------------------+
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| Parameter     | Required | Description                                                                       |
+	+===============+==========+===================================================================================+
+	| domainName    | no       | Return only the CDN that has this domain name                                     |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| dnssecEnabled | no       | Return only the CDNs that are either dnssec enabled or not                        |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| id            | no       | Return only the CDN that has this id                                              |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| name          | no       | Return only the CDN that has this name                                            |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| orderby       | no       | Choose the ordering of the results - must be the name of one of the fields of the |
+	|               |          | objects in the ``response`` array                                                 |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| sortOrder     | no       | Changes the order of sorting. Either ascending (default or "asc") or descending   |
+	|               |          | ("desc")                                                                          |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| limit         | no       | Choose the maximum number of results to return                                    |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| offset        | no       | The number of results to skip before beginning to return results. Must use in     |
+	|               |          | conjunction with limit                                                            |
+	+---------------+----------+-----------------------------------------------------------------------------------+
+	| page          | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this           |
+	|               |          | parameter, pages are ``limit`` long and the first page is 1. If ``offset`` was    |
+	|               |          | defined, this query parameter has no effect. ``limit`` must be defined to make    |
+	|               |          | use of ``page``.                                                                  |
+	+---------------+----------+-----------------------------------------------------------------------------------+
 
 Response Structure
 ------------------

--- a/docs/source/api/v2/cdns_id.rst
+++ b/docs/source/api/v2/cdns_id.rst
@@ -19,58 +19,6 @@
 ``cdns/{{ID}}``
 ***************
 
-``GET``
-=======
-Extract information about a specific CDN.
-
-:Auth. Required: Yes
-:Roles Required: None
-:Response Type:  Array
-
-Request Structure
------------------
-.. table:: Request Path Parameters
-
-	+------+----------------------------------------------------+
-	| Name |                Description                         |
-	+======+====================================================+
-	|  ID  | Integral, unique identifier for the CDN to inspect |
-	+------+----------------------------------------------------+
-
-Response Structure
-------------------
-:dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
-:domainName:    Top Level Domain name within which this CDN operates
-:id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
-:name:          The name of the CDN
-
-.. code-block:: http
-	:caption: Response Example
-
-	HTTP/1.1 200 OK
-	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-	Access-Control-Allow-Origin: *
-	Content-Type: application/json
-	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-	Whole-Content-Sha512: bTz86xdnGfbKhxnneb4geXohaw3lhG+h5wc21/ncHFATwp1h80h+txxySCIVfa0hgBrJHEdpGZQsH5w5IknsrQ==
-	X-Server-Name: traffic_ops_golang/
-	Date: Wed, 14 Nov 2018 20:59:34 GMT
-	Content-Length: 137
-
-	{ "response": [
-		{
-			"dnssecEnabled": false,
-			"domainName": "mycdn.ciab.test",
-			"id": 2,
-			"lastUpdated": "2018-11-14 18:21:14+00",
-			"name": "CDN-in-a-Box"
-		}
-	]}
-
-
 ``PUT``
 =======
 Allows a user to edit a specific CDN

--- a/docs/source/api/v2/cdns_name_name.rst
+++ b/docs/source/api/v2/cdns_name_name.rst
@@ -19,57 +19,6 @@
 ``cdns/name/{{name}}``
 **********************
 
-``GET``
-=======
-Extract information about a CDN, identified by name.
-
-:Auth. Required: Yes
-:Roles Required: None
-:Response Type:  Array
-
-Request Structure
------------------
-.. table:: Request Path Parameters
-
-	+------+---------------------------------------------+
-	| Name |                Description                  |
-	+======+=============================================+
-	| name | The name of the CDN to be inspected         |
-	+------+---------------------------------------------+
-
-Response Structure
-------------------
-:dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
-:domainName:    Top Level Domain name within which this CDN operates
-:id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
-:name:          The name of the CDN
-
-.. code-block:: http
-	:caption: Response Example
-
-	HTTP/1.1 200 OK
-	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-	Access-Control-Allow-Origin: *
-	Content-Type: application/json
-	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-	Whole-Content-Sha512: bTz86xdnGfbKhxnneb4geXohaw3lhG+h5wc21/ncHFATwp1h80h+txxySCIVfa0hgBrJHEdpGZQsH5w5IknsrQ==
-	X-Server-Name: traffic_ops_golang/
-	Date: Wed, 14 Nov 2018 21:22:16 GMT
-	Content-Length: 137
-
-	{ "response": [
-		{
-			"dnssecEnabled": false,
-			"domainName": "mycdn.ciab.test",
-			"id": 2,
-			"lastUpdated": "2018-11-14 18:21:14+00",
-			"name": "CDN-in-a-Box"
-		}
-	]}
-
 ``DELETE``
 ==========
 Allows a user to delete a CDN by name

--- a/traffic_control/clients/python/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/tosession.py
@@ -497,33 +497,13 @@ class TOSession(RestApiSession):
 	# CDN
 	#
 	@api_request('get', 'cdns', ('2.0',))
-	def get_cdns(self):
+	def get_cdns(self, query_params=None):
 		"""
 		Get all CDNs.
 		:ref:`to-api-cdns`
+		:param query_params: See API page for more information on accepted parameters
+		:type query_params: Dict[str, Any]
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
-		:raises: Union[LoginError, OperationError]
-		"""
-
-	@api_request('get', 'cdns/{cdn_id:d}', ('2.0',))
-	def get_cdn_by_id(self, cdn_id=None):
-		"""
-		Get a CDN by Id.
-		:ref:`to-api-cdns-id`
-		:param cdn_id: The CDN id
-		:type cdn_id: str
-		:rtype: Tuple[Dict[str, Any], requests.Response]
-		:raises: Union[LoginError, OperationError]
-		"""
-
-	@api_request('get', 'cdns/name/{cdn_name}', ('2.0',))
-	def get_cdn_by_name(self, cdn_name=None):
-		"""
-		Get a CDN by name.
-		:ref:`to-api-cdns-name-name`
-		:param cdn_name: The CDN name
-		:type cdn_name: str
-		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
 

--- a/traffic_ops/client/cdn.go
+++ b/traffic_ops/client/cdn.go
@@ -84,7 +84,7 @@ func (to *Session) GetCDNs() ([]tc.CDN, ReqInf, error) {
 
 // GetCDNByID a CDN by the CDN ID.
 func (to *Session) GetCDNByID(id int) ([]tc.CDN, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_CDNS, id)
+	route := fmt.Sprintf("%s?id=%v", API_CDNS, id)
 	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -594,6 +594,11 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		//CDN: CRUD
 		{api.Version{1, 1}, http.MethodGet, `cdns/name/{name}/?(\.json)?$`, api.DeprecatedReadHandler(&cdn.TOCDN{}, util.StrPtr("GET /cdns with query parameter name")), auth.PrivLevelReadOnly, Authenticated, nil, 2135233288, noPerlBypass},
 		{api.Version{1, 1}, http.MethodDelete, `cdns/name/{name}$`, cdn.DeleteName, auth.PrivLevelOperations, Authenticated, nil, 408804959, noPerlBypass},
+		{api.Version{1, 1}, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 1345914650, noPerlBypass},
+		{api.Version{1, 1}, http.MethodGet, `cdns/{id}$`, api.DeprecatedReadHandler(&cdn.TOCDN{}, util.StrPtr("GET /cdns with query parameter id")), auth.PrivLevelReadOnly, Authenticated, nil, 2122954075, noPerlBypass},
+		{api.Version{1, 1}, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 549326357, noPerlBypass},
+		{api.Version{1, 1}, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 24013912, noPerlBypass},
+		{api.Version{1, 1}, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 1595587002, noPerlBypass},
 
 		//CDN: queue updates
 		{api.Version{1, 1}, http.MethodPost, `cdns/{id}/queue_update$`, cdn.Queue, auth.PrivLevelOperations, Authenticated, nil, 271515980, noPerlBypass},
@@ -783,13 +788,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{1, 3}, http.MethodPut, `asns/?$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil, 2064172317, noPerlBypass},
 		{api.Version{1, 3}, http.MethodPost, `asns/?$`, api.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil, 859114392, noPerlBypass},
 		{api.Version{1, 3}, http.MethodDelete, `asns/?$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, Authenticated, nil, 680204898, noPerlBypass},
-
-		//CDN generic handlers:
-		{api.Version{1, 3}, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 1230318621, noPerlBypass},
-		{api.Version{1, 3}, http.MethodGet, `cdns/{id}$`, api.DeprecatedReadHandler(&cdn.TOCDN{}, util.StrPtr("GET /cdns with query parameter id")), auth.PrivLevelReadOnly, Authenticated, nil, 632290057, noPerlBypass},
-		{api.Version{1, 3}, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 1311178934, noPerlBypass},
-		{api.Version{1, 3}, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 1160505289, noPerlBypass},
-		{api.Version{1, 3}, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 2007694657, noPerlBypass},
 
 		//Delivery service requests
 		{api.Version{1, 3}, http.MethodGet, `deliveryservice_requests/?(\.json)?$`, api.ReadHandler(&dsrequest.TODeliveryServiceRequest{}), auth.PrivLevelReadOnly, Authenticated, nil, 1681163935, noPerlBypass},

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -196,7 +196,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{2, 0}, http.MethodGet, `cdns/routing$`, crstats.GetCDNRouting, auth.PrivLevelReadOnly, Authenticated, nil, 26722982, noPerlBypass},
 
 		//CDN: CRUD
-		{api.Version{2, 0}, http.MethodGet, `cdns/name/{name}/?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 2235233288, noPerlBypass},
 		{api.Version{2, 0}, http.MethodDelete, `cdns/name/{name}$`, cdn.DeleteName, auth.PrivLevelOperations, Authenticated, nil, 208804959, noPerlBypass},
 
 		//CDN: queue updates
@@ -371,7 +370,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		//CDN generic handlers:
 		{api.Version{2, 0}, http.MethodGet, `cdns/?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 2230318621, noPerlBypass},
-		{api.Version{2, 0}, http.MethodGet, `cdns/{id}$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 232290057, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 2311178934, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 2160505289, noPerlBypass},
 		{api.Version{2, 0}, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 227694657, noPerlBypass},
@@ -594,12 +592,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{1, 1}, http.MethodGet, `cdns/routing$`, crstats.GetCDNRouting, auth.PrivLevelReadOnly, Authenticated, nil, 66722982, perlBypass},
 
 		//CDN: CRUD
-		{api.Version{1, 1}, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 1345914650, noPerlBypass},
-		{api.Version{1, 1}, http.MethodGet, `cdns/{id}$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 2122954075, noPerlBypass},
-		{api.Version{1, 1}, http.MethodGet, `cdns/name/{name}/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 2135233288, noPerlBypass},
-		{api.Version{1, 1}, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 549326357, noPerlBypass},
-		{api.Version{1, 1}, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 24013912, noPerlBypass},
-		{api.Version{1, 1}, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 1595587002, noPerlBypass},
+		{api.Version{1, 1}, http.MethodGet, `cdns/name/{name}/?(\.json)?$`, api.DeprecatedReadHandler(&cdn.TOCDN{}, util.StrPtr("GET /cdns with query parameter name")), auth.PrivLevelReadOnly, Authenticated, nil, 2135233288, noPerlBypass},
 		{api.Version{1, 1}, http.MethodDelete, `cdns/name/{name}$`, cdn.DeleteName, auth.PrivLevelOperations, Authenticated, nil, 408804959, noPerlBypass},
 
 		//CDN: queue updates
@@ -793,7 +786,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 
 		//CDN generic handlers:
 		{api.Version{1, 3}, http.MethodGet, `cdns/?(\.json)?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 1230318621, noPerlBypass},
-		{api.Version{1, 3}, http.MethodGet, `cdns/{id}$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, Authenticated, nil, 632290057, noPerlBypass},
+		{api.Version{1, 3}, http.MethodGet, `cdns/{id}$`, api.DeprecatedReadHandler(&cdn.TOCDN{}, util.StrPtr("GET /cdns with query parameter id")), auth.PrivLevelReadOnly, Authenticated, nil, 632290057, noPerlBypass},
 		{api.Version{1, 3}, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 1311178934, noPerlBypass},
 		{api.Version{1, 3}, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 1160505289, noPerlBypass},
 		{api.Version{1, 3}, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, Authenticated, nil, 2007694657, noPerlBypass},


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Documentation
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run traffic ops and make sure you can not hit the endpoint in API 2.0 and when performing a GET on it in 1.x you receive a deprecation message back in the returned alerts. 

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
