### PR TITLE
Fix broken ORT caching resulting in malformed config files

### DIFF
--- a/.dependency_license
+++ b/.dependency_license
@@ -113,6 +113,8 @@ traffic_portal/app/src/assets/css/colReorder.dataTables\..*, MIT
 traffic_portal/app/src/assets/js/colReorder.dataTables\..*, MIT
 traffic_portal/app/src/assets/js/dataTables.buttons\..*, MIT
 traffic_portal/app/src/assets/js/buttons.html5\..*, MIT
+traffic_ops/ort/atstccfg/vendor/github\.com/fxamacker/cbor/.*, MIT
+traffic_ops/ort/atstccfg/vendor/github\.com/x448/float16/.*, MIT
 traffic_ops/traffic_ops_golang/vendor/github\.com/dgrijalva/.*, MIT
 traffic_ops/traffic_ops_golang/vendor/github\.com/lestrrat-go/.*, MIT
 

--- a/LICENSE
+++ b/LICENSE
@@ -456,3 +456,11 @@ For the errors (commit 27936f6) component:
 For the go-acme/lego (version 2.7.2) component:
 @traffic_ops/traffic_ops_golang/vendor/github.com/go-acme/lego/*
 ./traffic_ops/traffic_ops_golang/vendor/github.com/go-acme/lego/LICENSE
+
+For the fxamacker/cbor (commit e84e0b6) component:
+@traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/*
+./traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/LICENSE
+
+For the x448/float16 (commit e05feda) component:
+@traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/*
+./traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/LICENSE

--- a/build/functions.sh
+++ b/build/functions.sh
@@ -193,7 +193,7 @@ function createDocsTarball() {
 }
 
 # ----------------------------------------
-# verify if the go compiler is version 1.11 or higher, returns 0 if if not. returns 1 if it is.
+# verify if the go compiler is version 1.12 or higher, returns 0 if if not. returns 1 if it is.
 # 
 function verify_and_set_go_version () {
   GO_VERSION="none"
@@ -206,7 +206,7 @@ function verify_and_set_go_version () {
     
     go_version=`$g version | awk '{print $3}'`
 
-    if [[ $go_version =~ go([1-9])\.([1-9]+) ]] && [[ ${BASH_REMATCH[1]} -ge 1 ]] && [[ ${BASH_REMATCH[2]} -ge 11 ]]; then
+    if [[ $go_version =~ go([1-9])\.([1-9]+) ]] && [[ ${BASH_REMATCH[1]} -ge 1 ]] && [[ ${BASH_REMATCH[2]} -ge 12 ]]; then
       GO_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"; export GO_VERSION
       GO=$g; export GO
       PATH=`dirname $g`:$PATH; export PATH
@@ -223,7 +223,7 @@ function verify_and_set_go_version () {
   done
 
   if [[ $GO == none ]]; then
-    echo "ERROR: this build needs go 1.11 or greater and no usable go compiler was found, found GO_VERSION: $GO_VERSION"
+    echo "ERROR: this build needs go 1.12 or greater and no usable go compiler was found, found GO_VERSION: $GO_VERSION"
     return 0
   fi
 }

--- a/infrastructure/docker/build/Dockerfile-traffic_ops
+++ b/infrastructure/docker/build/Dockerfile-traffic_ops
@@ -43,10 +43,10 @@ RUN	yum -y install \
 		tar && \
 	yum -y clean all
 
-RUN curl -LO https://dl.google.com/go/go1.11.13.linux-amd64.tar.gz && \
-    tar -C /usr/local -xvzf go1.11.13.linux-amd64.tar.gz && \
+RUN curl -LO https://dl.google.com/go/go1.12.17.linux-amd64.tar.gz && \
+    tar -C /usr/local -xvzf go1.12.17.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
-    rm go1.11.13.linux-amd64.tar.gz
+    rm go1.12.17.linux-amd64.tar.gz
 
 ###
 

--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -33,7 +33,7 @@ URL:              https://github.com/apache/trafficcontrol/
 Vendor:           Apache Software Foundation
 Packager:         daniel_kirkwood at Cable dot Comcast dot com
 AutoReqProv:      no
-Requires:         cpanminus, expat-devel, gcc-c++, golang >= 1.11, libcurl, libpcap-devel, mkisofs, tar
+Requires:         cpanminus, expat-devel, gcc-c++, golang >= 1.12, libcurl, libpcap-devel, mkisofs, tar
 Requires:         openssl-devel, perl, perl-core, perl-DBD-Pg, perl-DBI, perl-Digest-SHA1
 Requires:         libidn-devel, libcurl-devel, libcap
 Requires:         postgresql96 >= 9.6.2 , postgresql96-devel >= 9.6.2

--- a/traffic_ops/ort/atstccfg/toreq/caching.go
+++ b/traffic_ops/ort/atstccfg/toreq/caching.go
@@ -21,7 +21,6 @@ package toreq
 
 import (
 	"bufio"
-	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,12 +36,14 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
+
+	"github.com/fxamacker/cbor"
 )
 
 // DefaultCacheFormat is the encoder, decoder, and file extension to use for caching.
 // This may be changed at compile-time. See CacheFormatJSON.
-// Note this is not used for all cache files. Notably, Delivery Service Servers use a custom CSV format, which is faster than gob.
-var DefaultCacheFormat = CacheFormatGob
+// Note this is not used for all cache files. Notably, Delivery Service Servers use a custom CSV format, which is faster than cbor.
+var DefaultCacheFormat = CacheFormatCBOR
 
 // GetCached attempts to get the given object from tempDir/cacheFileName.
 // If the cache file doesn't exist, is too old, or is malformed, it uses getter to get the object, and stores it in cacheFileName.
@@ -149,7 +150,7 @@ type CacheFormat struct {
 	Extension string
 }
 
-var CacheFormatGob = CacheFormat{GobEncode, GobDecode, GobExtension}
+var CacheFormatCBOR = CacheFormat{CBOREncode, CBORDecode, CBORExtension}
 var CacheFormatJSON = CacheFormat{JSONEncode, JSONDecode, JSONExtension}
 
 // CacheFormatDSS is a special format encoder/decoder optimized for Delivery Service Servers.
@@ -164,10 +165,10 @@ const JSONExtension = ".json"
 func JSONDecode(r io.Reader, obj interface{}) error { return json.NewDecoder(r).Decode(obj) }
 func JSONEncode(w io.Writer, obj interface{}) error { return json.NewEncoder(w).Encode(obj) }
 
-const GobExtension = ".gob"
+const CBORExtension = ".cbor"
 
-func GobDecode(r io.Reader, obj interface{}) error { return gob.NewDecoder(r).Decode(obj) }
-func GobEncode(w io.Writer, obj interface{}) error { return gob.NewEncoder(w).Encode(obj) }
+func CBORDecode(r io.Reader, obj interface{}) error { return cbor.NewDecoder(r).Decode(obj) }
+func CBOREncode(w io.Writer, obj interface{}) error { return cbor.NewEncoder(w).Encode(obj) }
 
 func StringToCookies(cookiesStr string) []*http.Cookie {
 	hdr := http.Header{}

--- a/traffic_ops/ort/atstccfg/toreq/caching_test.go
+++ b/traffic_ops/ort/atstccfg/toreq/caching_test.go
@@ -20,10 +20,15 @@ package toreq
  */
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 )
 
 func TestWriteCacheJSON(t *testing.T) {
@@ -67,12 +72,12 @@ func TestWriteCacheJSON(t *testing.T) {
 	}
 }
 
-func TestWriteCacheGob(t *testing.T) {
+func TestWriteCacheCBOR(t *testing.T) {
 	type Obj struct {
 		S string `json:"s"`
 	}
 
-	fileName := "TestWriteCacheGob.gob"
+	fileName := "TestWriteCacheCBOR"
 	tmpDir := os.TempDir()
 	filePath := filepath.Join(tmpDir, fileName)
 	defer os.Remove(filePath)
@@ -86,9 +91,9 @@ func TestWriteCacheGob(t *testing.T) {
 `,
 		}
 
-		WriteCache(CacheFormatGob.Encoder, tmpDir, fileName, largeObj)
+		WriteCache(CacheFormatCBOR.Encoder, tmpDir, fileName, largeObj)
 		loadedLargeObj := Obj{}
-		if err := ReadCache(CacheFormatGob.Decoder, tmpDir, fileName, time.Hour, &loadedLargeObj); err != nil {
+		if err := ReadCache(CacheFormatCBOR.Decoder, tmpDir, fileName, time.Hour, &loadedLargeObj); err != nil {
 			t.Fatalf("ReadCache large error expected nil, actual: " + err.Error())
 		} else if largeObj.S != loadedLargeObj.S {
 			t.Fatalf("ReadCache expected %+v actual %+v\n", largeObj.S, loadedLargeObj.S)
@@ -96,14 +101,104 @@ func TestWriteCacheGob(t *testing.T) {
 	}
 
 	{
-		// Write a smaller object to the same file, to make sure it properly truncates, and doesn't leave old text lying around (resulting in malformed gob)
+		// Write a smaller object to the same file, to make sure it properly truncates, and doesn't leave old text lying around (resulting in malformed cbor)
 		smallObj := Obj{S: `foo`}
-		WriteCache(CacheFormatGob.Encoder, tmpDir, fileName, smallObj)
+		WriteCache(CacheFormatCBOR.Encoder, tmpDir, fileName, smallObj)
 		loadedSmallObj := Obj{}
-		if err := ReadCache(CacheFormatGob.Decoder, tmpDir, fileName, time.Hour, &loadedSmallObj); err != nil {
+		if err := ReadCache(CacheFormatCBOR.Decoder, tmpDir, fileName, time.Hour, &loadedSmallObj); err != nil {
 			t.Fatalf("ReadCache small error expected nil, actual: " + err.Error())
 		} else if smallObj.S != loadedSmallObj.S {
 			t.Fatalf("ReadCache expected %+v actual %+v\n", smallObj.S, loadedSmallObj.S)
 		}
+	}
+}
+
+func TestDefaultCacheFormatIsomorphic(t *testing.T) {
+	// Test whether DefaultCacheFormat is isomorphic.
+	// That is, whether serializing and deserializing produces the original object.
+	// This might seem silly, but encoding/gob is not isomorphic and fails this test.
+	// We requires an isomorphic cache format, or config files will be wrong.
+
+	// Delivery Service is one of TC's most complex objects, so use an array of it to test.
+	// It's important to test null pointers, as well as pointers to default values (a common failure).
+
+	dsMatchPtr := []tc.DeliveryServiceMatch{
+		tc.DeliveryServiceMatch{
+			Type:      tc.DSMatchTypeHostRegex,
+			SetNumber: 0,
+			Pattern:   "foo",
+		},
+		tc.DeliveryServiceMatch{
+			Type:      tc.DSMatchTypeInvalid,
+			SetNumber: 42,
+			Pattern:   "",
+		},
+	}
+	dsTypeInvalidPtr := tc.DSTypeInvalid
+
+	ds1 := tc.DeliveryServiceNullable{}
+	ds1.Active = util.BoolPtr(false)
+	ds1.AnonymousBlockingEnabled = nil
+	ds1.CacheURL = util.StrPtr("")
+	ds1.CCRDNSTTL = util.IntPtr(0)
+	ds1.CDNID = nil
+	ds1.CDNName = nil
+	ds1.CheckPath = util.StrPtr("foo")
+	ds1.DisplayName = util.StrPtr("")
+	ds1.DSCP = nil
+	ds1.LogsEnabled = util.BoolPtr(true)
+	// ds1.MatchList = &dsMatchPtr
+	ds1.MissLat = nil
+	ds1.MissLong = util.FloatPtr(0)
+	ds1.Signed = false
+	ds1.Type = &dsTypeInvalidPtr
+	// ds1.ExampleURLs = []string{"foo", ""}
+
+	ds2 := tc.DeliveryServiceNullable{}
+	ds2.Active = nil
+	ds2.AnonymousBlockingEnabled = util.BoolPtr(false)
+	ds2.CacheURL = util.StrPtr("")
+	ds2.CCRDNSTTL = util.IntPtr(0)
+	ds2.CDNID = nil
+	ds2.CDNName = nil
+	ds2.CheckPath = util.StrPtr("foo")
+	ds2.DisplayName = util.StrPtr("")
+	ds2.DSCP = nil
+	ds2.LogsEnabled = util.BoolPtr(true)
+	ds2.MatchList = &dsMatchPtr
+	ds2.MissLat = util.FloatPtr(0)
+	ds2.MissLong = util.FloatPtr(42)
+	ds2.Signed = true
+	ds2.Type = nil
+	ds2.ExampleURLs = nil
+
+	dses := []tc.DeliveryServiceNullable{ds1, ds2}
+
+	fileName := "TestDefaultCacheFormatIsomorphic"
+
+	tmpDir := os.TempDir()
+	filePath := filepath.Join(tmpDir, fileName)
+	defer os.Remove(filePath)
+
+	WriteCache(DefaultCacheFormat.Encoder, tmpDir, fileName, dses)
+
+	readDSes := []tc.DeliveryServiceNullable{}
+	if err := ReadCache(DefaultCacheFormat.Decoder, tmpDir, fileName, time.Hour, &readDSes); err != nil {
+		t.Fatalf("ReadCache error expected nil, actual: " + err.Error())
+	}
+	if len(readDSes) != 2 {
+		t.Fatalf("ReadCache error expected 2 dses, actual: %v", len(readDSes))
+	}
+
+	if !reflect.DeepEqual(dses[0], readDSes[0]) {
+		dsj, _ := json.MarshalIndent(dses[0], "", " ")
+		dsrj, _ := json.MarshalIndent(readDSes[0], "", " ")
+		t.Errorf("ReadCache expected %+v actual %+v\n", string(dsj), string(dsrj))
+	}
+
+	if !reflect.DeepEqual(dses[1], readDSes[1]) {
+		dsj, _ := json.MarshalIndent(dses[1], "", " ")
+		dsrj, _ := json.MarshalIndent(readDSes[1], "", " ")
+		t.Errorf("ReadCache expected %+v actual %+v\n", string(dsj), string(dsrj))
 	}
 }

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/.golangci.yml
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/.golangci.yml
@@ -1,0 +1,86 @@
+# Do not delete linter settings. Linters like gocritic can be enabled on the command line.
+
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - paramTypeCombine
+      - whyNoLint
+      - wrapperFunc    
+  gofmt:
+    simplify: false    
+  goimports:
+    local-prefixes: github.com/fxamacker/cbor
+  golint:
+    min-confidence: 0
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - govet
+    - ineffassign
+    - maligned
+    - misspell
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+
+
+issues:
+  # max-issues-per-linter default is 50.  Set to 0 to disable limit.
+  max-issues-per-linter: 0
+  # max-same-issues default is 3.  Set to 0 to disable limit.
+  max-same-issues: 0
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - goconst
+        - dupl
+        - gomnd
+        - lll        
+    - path: doc\.go
+      linters:
+        - goimports
+        - gomnd
+        - lll
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.23.x # use the fixed version to not introduce new linters unexpectedly

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/CBOR_BENCHMARKS.md
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/CBOR_BENCHMARKS.md
@@ -1,0 +1,264 @@
+# CBOR Benchmarks for fxamacker/cbor 
+
+See [bench_test.go](bench_test.go).
+
+Benchmarks on Jan. 12, 2020 with cbor v1.5.0:
+* [Go builtin types](#go-builtin-types)
+* [Go structs](#go-structs)
+* [Go structs with "keyasint" struct tag](#go-structs-with-keyasint-struct-tag)
+* [Go structs with "toarray" struct tag](#go-structs-with-toarray-struct-tag)
+* [COSE data](#cose-data)
+* [CWT claims data](#cwt-claims-data)
+* [SenML data](#SenML-data)
+
+## Go builtin types
+
+Benchmarks use data representing the following values:
+
+* Boolean: `true`
+* Positive integer: `18446744073709551615`
+* Negative integer: `-1000`
+* Float: `-4.1`
+* Byte string: `h'0102030405060708090a0b0c0d0e0f101112131415161718191a'`
+* Text string: `"The quick brown fox jumps over the lazy dog"`
+* Array: `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]`
+* Map: `{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}}`
+
+Decoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkUnmarshal/CBOR_bool_to_Go_interface_{}-2 | 114 ns/op | 16 B/op | 1 allocs/op
+BenchmarkUnmarshal/CBOR_bool_to_Go_bool-2 | 101 ns/op | 1 B/op | 1 allocs/op
+BenchmarkUnmarshal/CBOR_positive_int_to_Go_interface_{}-2 | 141 ns/op | 24 B/op | 2 allocs/op
+BenchmarkUnmarshal/CBOR_positive_int_to_Go_uint64-2 | 120 ns/op | 8 B/op | 1 allocs/op
+BenchmarkUnmarshal/CBOR_negative_int_to_Go_interface_{}-2 | 141 ns/op | 24 B/op | 2 allocs/op
+BenchmarkUnmarshal/CBOR_negative_int_to_Go_int64-2 | 120 ns/op | 8 B/op | 1 allocs/op
+BenchmarkUnmarshal/CBOR_float_to_Go_interface_{}-2 | 143 ns/op | 24 B/op | 2 allocs/op
+BenchmarkUnmarshal/CBOR_float_to_Go_float64-2 | 121 ns/op | 8 B/op | 1 allocs/op
+BenchmarkUnmarshal/CBOR_bytes_to_Go_interface_{}-2 | 182 ns/op | 80 B/op | 3 allocs/op
+BenchmarkUnmarshal/CBOR_bytes_to_Go_[]uint8-2 | 201 ns/op | 64 B/op | 2 allocs/op
+BenchmarkUnmarshal/CBOR_text_to_Go_interface_{}-2 | 213 ns/op | 80 B/op | 3 allocs/op
+BenchmarkUnmarshal/CBOR_text_to_Go_string-2 | 196 ns/op | 64 B/op | 2 allocs/op
+BenchmarkUnmarshal/CBOR_array_to_Go_interface_{}-2 |1094 ns/op | 672 B/op | 29 allocs/op
+BenchmarkUnmarshal/CBOR_array_to_Go_[]int-2 | 1102 ns/op | 272 B/op | 3 allocs/op
+BenchmarkUnmarshal/CBOR_map_to_Go_interface_{}-2 | 2966 ns/op | 1420 B/op | 30 allocs/op
+BenchmarkUnmarshal/CBOR_map_to_Go_map[string]interface_{}-2 | 3754 ns/op | 964 B/op | 19 allocs/op
+BenchmarkUnmarshal/CBOR_map_to_Go_map[string]string-2 | 2621 ns/op | 740 B/op | 5 allocs/op
+
+Encoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkMarshal/Go_bool_to_CBOR_bool-2 | 88.1 ns/op	| 1 B/op | 1 allocs/op
+BenchmarkMarshal/Go_uint64_to_CBOR_positive_int-2 | 97.3 ns/op | 16 B/op | 1 allocs/op
+BenchmarkMarshal/Go_int64_to_CBOR_negative_int-2 | 91.2 ns/op | 3 B/op | 1 allocs/op
+BenchmarkMarshal/Go_float64_to_CBOR_float-2 | 100 ns/op	| 16 B/op | 1 allocs/op
+BenchmarkMarshal/Go_[]uint8_to_CBOR_bytes-2 | 123 ns/op | 32 B/op	| 1 allocs/op
+BenchmarkMarshal/Go_string_to_CBOR_text-2 | 118 ns/op | 48 B/op | 1 allocs/op
+BenchmarkMarshal/Go_[]int_to_CBOR_array-2 | 528 ns/op | 32 B/op	| 1 allocs/op
+BenchmarkMarshal/Go_map[string]string_to_CBOR_map-2 | 2096 ns/op | 576 B/op | 28 allocs/op
+
+## Go structs
+
+Benchmarks use struct and map[string]interface{} representing the following value:
+
+```
+{
+    "T":    true,
+    "Ui":   uint(18446744073709551615),
+    "I":    -1000,
+    "F":    -4.1,
+    "B":    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+    "S":    "The quick brown fox jumps over the lazy dog",
+    "Slci": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+    "Mss":  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
+}
+```
+
+Decoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkUnmarshal/CBOR_map_to_Go_map[string]interface{}-2 | 6260 ns/op | 2621 B/op | 73 allocs/op
+BenchmarkUnmarshal/CBOR_map_to_Go_struct-2 | 4481 ns/op | 1172 B/op | 10 allocs/op
+
+Encoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkMarshal/Go_map[string]interface{}_to_CBOR_map-2 | 4462 ns/op | 1072 B/op | 45 allocs/op
+BenchmarkMarshal/Go_struct_to_CBOR_map-2 | 2891 ns/op | 720 B/op | 28 allocs/op
+
+## Go structs with "keyasint" struct tag
+
+Benchmarks use struct (with keyasint struct tag) and map[int]interface{} representing the following value:
+
+```
+{
+    1: true,
+    2: uint(18446744073709551615),
+    3: -1000,
+    4: -4.1,
+    5: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+    6: "The quick brown fox jumps over the lazy dog",
+    7: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+    8: map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
+}
+```
+
+Struct type with keyasint struct tag is used to handle CBOR map with integer keys.
+
+```
+type T struct {
+	T    bool              `cbor:"1,keyasint"`
+	Ui   uint              `cbor:"2,keyasint"`
+	I    int               `cbor:"3,keyasint"`
+	F    float64           `cbor:"4,keyasint"`
+	B    []byte            `cbor:"5,keyasint"`
+	S    string            `cbor:"6,keyasint"`
+	Slci []int             `cbor:"7,keyasint"`
+	Mss  map[string]string `cbor:"8,keyasint"`
+}
+```
+
+Decoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkUnmarshal/CBOR_map_to_Go_map[int]interface{}-2| 6070 ns/op | 2517 B/op | 70 allocs/op
+BenchmarkUnmarshal/CBOR_map_to_Go_struct_keyasint-2 | 4355 ns/op | 1173 B/op | 10 allocs/op
+
+Encoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkMarshal/Go_map[int]interface{}_to_CBOR_map-2 | 4318 ns/op | 992 B/op | 45 allocs/op
+BenchmarkMarshal/Go_struct_keyasint_to_CBOR_map-2 | 2879 ns/op | 704 B/op | 28 allocs/op
+
+## Go structs with "toarray" struct tag
+
+Benchmarks use struct (with toarray struct tag) and []interface{} representing the following value:
+
+```
+[
+    true,
+    uint(18446744073709551615),
+    -1000,
+    -4.1,
+    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+    "The quick brown fox jumps over the lazy dog",
+    []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+    map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}
+]
+```
+
+Struct type with toarray struct tag is used to handle CBOR array.
+
+```
+type T struct {
+	_    struct{} `cbor:",toarray"`
+	T    bool
+	Ui   uint
+	I    int
+	F    float64
+	B    []byte
+	S    string
+	Slci []int
+	Mss  map[string]string
+}
+```
+
+Decoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkUnmarshal/CBOR_array_to_Go_[]interface{}-2 | 4968 ns/op | 2404 B/op | 67 allocs/op
+BenchmarkUnmarshal/CBOR_array_to_Go_struct_toarray-2 | 4205 ns/op | 1164 B/op | 9 allocs/op
+
+Encoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkMarshal/Go_[]interface{}_to_CBOR_map-2 | 3272 ns/op | 704 B/op | 28 allocs/op
+BenchmarkMarshal/Go_struct_toarray_to_CBOR_array-2 | 2840 ns/op | 704 B/op | 28 allocs/op
+
+## COSE data
+
+Benchmarks use COSE data from https://tools.ietf.org/html/rfc8392#appendix-A section A.2
+
+```
+// 128-Bit Symmetric COSE_Key
+{
+    / k /   -1: h'231f4c4d4d3051fdc2ec0a3851d5b383'
+    / kty /  1: 4 / Symmetric /,
+    / kid /  2: h'53796d6d6574726963313238' / 'Symmetric128' /,
+    / alg /  3: 10 / AES-CCM-16-64-128 /
+}
+// 256-Bit Symmetric COSE_Key 
+{
+    / k /   -1: h'403697de87af64611c1d32a05dab0fe1fcb715a86ab435f1
+                ec99192d79569388'
+    / kty /  1: 4 / Symmetric /,
+    / kid /  4: h'53796d6d6574726963323536' / 'Symmetric256' /,
+    / alg /  3: 4 / HMAC 256/64 /
+}
+// ECDSA 256-Bit COSE Key
+{
+    / d /   -4: h'6c1382765aec5358f117733d281c1c7bdc39884d04a45a1e
+                6c67c858bc206c19',
+    / y /   -3: h'60f7f1a780d8a783bfb7a2dd6b2796e8128dbbcef9d3d168
+                db9529971a36e7b9',
+    / x /   -2: h'143329cce7868e416927599cf65a34f3ce2ffda55a7eca69
+                ed8919a394d42f0f',
+    / crv / -1: 1 / P-256 /,
+    / kty /  1: 2 / EC2 /,
+    / kid /  2: h'4173796d6d657472696345434453413
+                23536' / 'AsymmetricECDSA256' /,
+    / alg /  3: -7 / ECDSA 256 /
+}
+```
+
+Decoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkUnmarshalCOSE/128-Bit_Symmetric_Key-2 | 578 ns/op | 240 B/op | 4 allocs/op
+BenchmarkUnmarshalCOSE/256-Bit_Symmetric_Key-2 | 586 ns/op | 256 B/op | 4 allocs/op
+BenchmarkUnmarshalCOSE/ECDSA_P256_256-Bit_Key-2 | 989 ns/op | 360 B/op | 7 allocs/op
+
+Encoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkMarshalCOSE/128-Bit_Symmetric_Key-2 | 535 ns/op | 224 B/op | 2 allocs/op
+BenchmarkMarshalCOSE/256-Bit_Symmetric_Key-2 | 543 ns/op | 240 B/op | 2 allocs/op
+BenchmarkMarshalCOSE/ECDSA_P256_256-Bit_Key-2 | 681 ns/op | 320 B/op | 2 allocs/op
+
+## CWT claims data
+
+Benchmarks use CTW claims data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
+
+```
+{
+    / iss / 1: "coap://as.example.com",
+    / sub / 2: "erikw",
+    / aud / 3: "coap://light.example.com",
+    / exp / 4: 1444064944,
+    / nbf / 5: 1443944944,
+    / iat / 6: 1443944944,
+    / cti / 7: h'0b71'
+}
+```
+
+Decoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkUnmarshalCWTClaims-2 | 796 ns/op | 176 B/op | 6 allocs/op
+
+Encoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkMarshalCWTClaims-2 | 466 ns/op | 176 B/op | 2 allocs/op
+
+## SenML data
+
+Benchmarks use SenML data from https://tools.ietf.org/html/rfc8428#section-6
+
+```
+[
+    {-2: "urn:dev:ow:10e2073a0108006:", -3: 1276020076.001, -4: "A", -1: 5, 0: "voltage", 1: "V", 2: 120.1},
+    {0: "current", 6: -5, 2: 1.2}, 
+    {0: "current", 6: -4, 2: 1.3},
+    {0: "current", 6: -3, 2: 1.4}, 
+    {0: "current", 6: -2, 2: 1.5},
+    {0: "current", 6: -1, 2: 1.6}, 
+    {0: "current", 6: 0, 2: 1.7}
+]
+```
+
+Decoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkUnmarshalSenML-2 | 3146 ns/op | 1544 B/op | 18 allocs/op
+
+Encoding Benchmark | Time | Memory | Allocs 
+--- | ---: | ---: | ---:
+BenchmarkMarshalSenML-2 | 2968 ns/op | 272 B/op	| 2 allocs/op

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/CBOR_GOLANG.md
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/CBOR_GOLANG.md
@@ -1,0 +1,32 @@
+👉  [Comparisons](https://github.com/fxamacker/cbor#comparisons) • [Status](https://github.com/fxamacker/cbor#current-status) • [Design Goals](https://github.com/fxamacker/cbor#design-goals) • [Features](https://github.com/fxamacker/cbor#features) • [Standards](https://github.com/fxamacker/cbor#standards) • [Fuzzing](https://github.com/fxamacker/cbor#fuzzing-and-code-coverage) • [Usage](https://github.com/fxamacker/cbor#usage) • [Security Policy](https://github.com/fxamacker/cbor#security-policy) • [License](https://github.com/fxamacker/cbor#license)
+
+# CBOR
+[CBOR](https://en.wikipedia.org/wiki/CBOR) is a data format designed to allow small code size and small message size. CBOR is defined in [RFC 7049 Concise Binary Object Representation](https://tools.ietf.org/html/rfc7049), an [IETF](http://ietf.org/) Internet Standards Document.
+
+CBOR is also designed to be stable for decades, be extensible without need for version negotiation, and not require a schema.
+
+While JSON uses text, CBOR uses binary. CDDL can be used to express CBOR (and JSON) in an easy and unambiguous way.  CDDL is defined in (RFC 8610 Concise Data Definition Language).
+
+## CBOR in Golang (Go)
+[Golang](https://golang.org/) is a nickname for the Go programming language.  Go is specified in [The Go Programming Language Specification](https://golang.org/ref/spec).
+
+__[fxamacker/cbor](https://github.com/fxamacker/cbor)__ is a library (written in Go) that encodes and decodes CBOR. The API design of fxamacker/cbor is based on Go's [`encoding/json`](https://golang.org/pkg/encoding/json/).  The design and reliability of fxamacker/cbor makes it ideal for encoding and decoding COSE.
+
+## COSE
+COSE is a protocol using CBOR for basic security services. COSE is defined in ([RFC 8152 CBOR Object Signing and Encryption](https://tools.ietf.org/html/rfc8152)).
+
+COSE describes how to create and process signatures, message authentication codes, and encryption using CBOR for serialization.  COSE specification also describes how to represent cryptographic keys using CBOR.  COSE is used by WebAuthn.
+
+## CWT
+CBOR Web Token (CWT) is defined in [RFC 8392](http://tools.ietf.org/html/rfc8392).  CWT is based on COSE and was derived in part from JSON Web Token (JWT).  CWT is a compact way to securely represent claims to be transferred between two parties.
+
+## WebAuthn
+[WebAuthn](https://en.wikipedia.org/wiki/WebAuthn) (Web Authentication) is a web standard for authenticating users to web-based apps and services. It's a core component of FIDO2, the successor of FIDO U2F legacy protocol.
+
+__[fxamacker/webauthn](https://github.com/fxamacker/webauthn)__ is a library (written in Go) that performs server-side authentication for clients using FIDO2 keys, legacy FIDO U2F keys, tpm, and etc.
+
+Copyright (c) Faye Amacker and contributors.
+
+<hr>
+
+👉  [Comparisons](https://github.com/fxamacker/cbor#comparisons) • [Status](https://github.com/fxamacker/cbor#current-status) • [Design Goals](https://github.com/fxamacker/cbor#design-goals) • [Features](https://github.com/fxamacker/cbor#features) • [Standards](https://github.com/fxamacker/cbor#standards) • [Fuzzing](https://github.com/fxamacker/cbor#fuzzing-and-code-coverage) • [Usage](https://github.com/fxamacker/cbor#usage) • [Security Policy](https://github.com/fxamacker/cbor#security-policy) • [License](https://github.com/fxamacker/cbor#license)

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/CODE_OF_CONDUCT.md
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at faye.github@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/CONTRIBUTING.md
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# How to contribute
+
+This project started because I needed an easy, small, and crash-proof CBOR library for my [WebAuthn (FIDO2) server library](https://github.com/fxamacker/webauthn). I believe this was the first and still only standalone CBOR library (in Go) that is fuzz tested as of November 10, 2019.
+
+To my surprise, Stefan Tatschner (rumpelsepp) submitted the first 2 issues when I didn't expect this project to be noticed.  So I decided to make it more full-featured for others by announcing releases and asking for feedback. Even this document exists because Montgomery Edwards⁴⁴⁸ (x448) opened [issue #22](https://github.com/fxamacker/cbor/issues/22).  In other words, you can contribute by opening an issue that helps the project improve. Especially in the early stages.
+
+When I announced v1.2 on Go Forum, Jakob Borg (calmh) responded with a thumbs up and encouragement.  Another project of equal priority needed my time and Jakob's kind words tipped the scale for me to work on this one (speedups for [milestone v1.3](https://github.com/fxamacker/cbor/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.3.0).) So words of appreciation or encouragement is nice way to contribute to open source projects.
+
+Another way is by using this library in your project. It can lead to features that benefit both projects, which is what happened when oasislabs/oasis-core switched to this CBOR libary -- thanks Yawning Angel (yawning) for requesting BinaryMarshaler/BinaryUnmarshaler and Jernej Kos (kostco) for requesting RawMessage!
+
+If you'd like to contribute code or send CBOR data, please read on (it can save you time!)
+
+## Private reports
+Usually, all issues are tracked publicly on [GitHub](https://github.com/fxamacker/cbor/issues). 
+
+To report security vulnerabilities, please email faye.github@gmail.com and allow time for the problem to be resolved before disclosing it to the public.  For more info, see [Security Policy](https://github.com/fxamacker/cbor#security-policy).
+
+Please do not send data that might contain personally identifiable information, even if you think you have permission.  That type of support requires payment and a contract where I'm indemnified, held harmless, and defended for any data you send to me.
+
+## Prerequisites to pull requests
+Please [create an issue](https://github.com/fxamacker/cbor/issues/new/choose), if one doesn't already exist, and describe your concern. You'll need a [GitHub account](https://github.com/signup/free) to do this.
+
+If you submit a pull request without creating an issue and getting a response, you risk having your work unused because the bugfix or feature was already done by others and being reviewed before reaching Github.
+
+## Describe your issue
+Clearly describe the issue:
+* If it's a bug, please provide: **version of this library** and **Go** (`go version`), **unmodified error message**, and describe **how to reproduce it**.  Also state **what you expected to happen** instead of the error.
+* If you propose a change or addition, try to give an example how the improved code could look like or how to use it.
+* If you found a compilation error, please confirm you're using a supported version of Go. If you are, then provide the output of `go version` first, followed by the complete error message.
+
+## Please don't
+Please don't send data containing personally identifiable information, even if you think you have permission.  That type of support requires payment and a contract where I'm indemnified, held harmless, and defended for any data you send to me.
+
+Please don't send CBOR data larger than 512 bytes. If you want to send crash-producing CBOR data > 512 bytes, please get my permission before sending it to me.
+
+## Wanted
+* Opening issues that are helpful to the project
+* Using this library in your project and letting me know
+* Sending well-formed CBOR data (<= 512 bytes) that causes crashes (none found yet).
+* Sending malformed CBOR data (<= 512 bytes) that causes crashes (none found yet, but bad actors are better than me at breaking things).
+* Sending tests or data for unit tests that increase code coverage (currently at 97.8% for v1.2.)
+* Pull requests with small changes that are well-documented and easily understandable.
+* Sponsors, donations, bounties, subscriptions: I'd like to run uninterrupted fuzzing between releases on a server with dedicated CPUs (after v1.3 or v1.4.)
+
+## Credits
+This guide used nlohmann/json contribution guidelines for inspiration as suggested in issue #22.
+

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/LICENSE
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 - present Faye Amacker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/README.md
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/README.md
@@ -1,0 +1,874 @@
+[![CBOR Library - Slideshow and Latest Docs.](https://github.com/fxamacker/images/raw/master/cbor/v2.1.0/cbor_slides.gif)](https://github.com/fxamacker/cbor/blob/master/README.md)
+
+# CBOR library in Go
+[__`fxamacker/cbor`__](https://github.com/fxamacker/cbor) is a CBOR encoder and decoder in [Go](https://golang.org).  It has a standard API, CBOR tags, 16/32/64-bit floats, options for duplicate map keys and more.  Each release passes 375+ tests and 250+ million execs fuzzing.
+
+[![](https://github.com/fxamacker/cbor/workflows/ci/badge.svg)](https://github.com/fxamacker/cbor/actions?query=workflow%3Aci)
+[![](https://github.com/fxamacker/cbor/workflows/cover%20%E2%89%A598%25/badge.svg)](https://github.com/fxamacker/cbor/actions?query=workflow%3A%22cover+%E2%89%A598%25%22)
+[![](https://github.com/fxamacker/cbor/workflows/linters/badge.svg)](https://github.com/fxamacker/cbor/actions?query=workflow%3Alinters)
+[![Go Report Card](https://goreportcard.com/badge/github.com/fxamacker/cbor)](https://goreportcard.com/report/github.com/fxamacker/cbor)
+[![Release](https://img.shields.io/github/release/fxamacker/cbor.svg?style=flat-square)](https://github.com/fxamacker/cbor/releases)
+[![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/fxamacker/cbor/master/LICENSE)
+
+__What is CBOR__?  [CBOR](CBOR_GOLANG.md) ([RFC 7049](https://tools.ietf.org/html/rfc7049)) is a binary data format inspired by JSON and MessagePack.  CBOR is used in [IETF](https://www.ietf.org) Internet Standards such as COSE ([RFC 8152](https://tools.ietf.org/html/rfc8152)) and CWT ([RFC 8392 CBOR Web Token](https://tools.ietf.org/html/rfc8392)). WebAuthn also uses CBOR.
+
+This CBOR library is safe and fast. Here's how it compares to another library using test data from RFC 8392 A.1.
+
+|     | fxamacker/cbor 2.1 | ugorji/go 1.1.7 |
+| --- | ------------------ | --------------- |
+| Encode CWT claims | 457 ns/op, 176 B/op, 2 allocs/op | 995 ns/op, 1424 B/op, 4 allocs/op | 
+| Decode CWT claims | 796 ns/op, 176 B/op, 6 allocs/op | 1105 ns/op, 568 B/op, 6 allocs/op |
+
+Speed is only one factor. There are more important factors.
+
+|     | fxamacker/cbor 2.1 | ugorji/go 1.1.7 |
+| --- | ------------------ | --------------- |
+| Malformed data #1 | 57.4 ns/op, 32 B/op, 1 allocs/op | ⚠️ fatal error: out of memory |
+| Malformed data #2 | 67.7 ns/op, 32 B/op, 1 allocs/op | ⚠️ runtime: out of memory: cannot allocate |
+
+Benchmarks used Go 1.12, linux_amd64, and default options for each CBOR library.
+
+<hr>
+
+⚓  [Installation](#installation) • [System Requirements](#system-requirements) • [Quick Start Guide](#quick-start)
+
+__Why this CBOR library?__ It doesn't crash and it has well-balanced qualities: small, fast, safe and easy. It also has a standard API, CBOR tags (built-in and user-defined), 16/32/64-bit floats, and duplicate map key options.
+
+* __Standard API__. Codec functions with signatures identical to [`encoding/json`](https://golang.org/pkg/encoding/json/) include:  
+`Marshal`, `Unmarshal`, `NewEncoder`, `NewDecoder`, `encoder.Encode`, and `decoder.Decode`.
+
+* __Customizable__. Standard interfaces are provided to allow user-implemented encoding or decoding:  
+`BinaryMarshaler`, `BinaryUnmarshaler`, `Marshaler`, and `Unmarshaler`.
+
+* __Small apps__.  Same programs are 4-9 MB smaller by switching to this library.  No code gen and the only imported pkg is [x448/float16](https://github.com/x448/float16) which is maintained by the same team as this library.
+
+* __Small data__.  The `toarray`, `keyasint`, and `omitempty` struct tags shrink size of Go structs encoded to CBOR.  Integers encode to smallest form that fits.  Floats can shrink from float64 -> float32 -> float16 if values fit.
+
+* __Fast__. v1.3 became faster than a well-known library that uses `unsafe` optimizations and code gen.  Faster libraries will always exist, but speed is only one factor.  This library doesn't use `unsafe` optimizations or code gen.  
+
+* __Safe__ and reliable. It prevents crashes on malicious CBOR data by using extensive tests, coverage-guided fuzzing, data validation, and avoiding Go's [`unsafe`](https://golang.org/pkg/unsafe/) pkg. Nested levels for CBOR arrays, maps, and tags are limited to 32.
+
+* __Easy__ and saves time. Simple (no param) functions return preset `EncOptions` so you don't have to know the differences between Canonical CBOR and CTAP2 Canonical CBOR to use those standards.
+
+💡 Struct tags are a Go language feature.  CBOR tags relate to a CBOR data type (major type 6).
+
+Struct tags for CBOR and JSON like `` `cbor:"name,omitempty"` `` and `` `json:"name,omitempty"` `` are supported so you can leverage your existing code.  If both `cbor:` and `json:` tags exist then it will use `cbor:`.
+
+New struct tags like __`keyasint`__ and __`toarray`__ make compact CBOR data such as COSE, CWT, and SenML easier to use. 
+
+<hr>
+
+[![CBOR API](https://github.com/fxamacker/images/raw/master/cbor/v2.1.0/cbor_api_struct_tags.png)](#usage)
+
+<hr>
+
+⚓  [Quick Start](#quick-start) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Installation
+
+👉 If Go modules aren't used, delete or modify example_test.go  
+from `"github.com/fxamacker/cbor/v2"` to `"github.com/fxamacker/cbor"`
+
+Using Go modules is recommended.
+```
+$ GO111MODULE=on go get github.com/fxamacker/cbor/v2
+```
+
+```
+import (
+	"github.com/fxamacker/cbor/v2" // imports as package "cbor"
+)
+```
+
+[Released versions](https://github.com/fxamacker/cbor/releases) benefit from longer fuzz tests.
+
+## System Requirements
+
+Using Go modules is recommended but not required. 
+
+* Go 1.12 (or newer).
+* amd64, arm64, ppc64le and s390x. Other architectures may also work but they are not tested as frequently. 
+
+If Go modules feature isn't used, please see [Installation](#installation) about deleting or modifying example_test.go.
+
+## Quick Start
+🛡️ Use Go's `io.LimitReader` to limit size when decoding very large or indefinite size data.
+
+Functions with identical signatures to encoding/json include:  
+`Marshal`, `Unmarshal`, `NewEncoder`, `NewDecoder`, `encoder.Encode`, `decoder.Decode`.
+
+__Default Mode__  
+
+If default options are acceptable, package level functions can be used for encoding and decoding.
+```
+b, err := cbor.Marshal(v)
+
+err := cbor.Unmarshal(b, &v)
+
+encoder := cbor.NewEncoder(w)
+
+decoder := cbor.NewDecoder(r)
+```
+
+__Modes__
+
+If you need to use options or CBOR tags, then you'll want to create a mode.
+
+"Mode" means defined way of encoding or decoding -- it links the standard API to your CBOR options and CBOR tags.  This way, you don't pass around options and the API remains identical to `encoding/json`.
+
+EncMode and DecMode are interfaces created from EncOptions or DecOptions structs.  
+For example, `em, err := cbor.EncOptions{...}.EncMode()` or `em, err := cbor.CanonicalEncOptions().EncMode()`.
+
+EncMode and DecMode use immutable options so their behavior won't accidentally change at runtime.  Modes are reusable, safe for concurrent use, and allow fast parallelism.
+
+__Creating and Using Encoding Modes__
+
+💡 Avoid using init().  For best performance, reuse EncMode and DecMode after creating them.
+
+Most apps will probably create one EncMode and DecMode before init().  However, there's no limit and each can use different options.
+
+```
+// Create EncOptions using either struct literal or a function.
+opts := cbor.CanonicalEncOptions()
+
+// If needed, modify encoding options
+opts.Time = cbor.TimeUnix
+
+// Create reusable EncMode interface with immutable options, safe for concurrent use.
+em, err := opts.EncMode()   
+
+// Use EncMode like encoding/json, with same function signatures.
+b, err := em.Marshal(v)
+// or
+encoder := em.NewEncoder(w)
+err := encoder.Encode(v)
+```
+
+__Creating Modes With CBOR Tags__
+
+A TagSet is used to specify CBOR tags.
+ 
+```
+em, err := opts.EncMode()                  // no tags
+em, err := opts.EncModeWithTags(ts)        // immutable tags
+em, err := opts.EncModeWithSharedTags(ts)  // mutable shared tags
+```
+
+TagSet and all modes using it are safe for concurrent use.  Equivalent API is available for DecMode.
+
+__Predefined Encoding Options__
+
+```
+func CanonicalEncOptions() EncOptions     // settings for RFC 7049 Canonical CBOR
+func CTAP2EncOptions() EncOptions         // settings for FIDO2 CTAP2 Canonical CBOR
+func CoreDetEncOptions() EncOptions       // modern settings from a draft RFC (subject to change)
+func PreferredUnsortedEncOptions() EncOptions  // modern settings from a draft RFC (subject to change)
+```
+
+__Struct Tags (keyasint, toarray, omitempty)__
+
+The `keyasint`, `toarray`, and `omitempty` struct tags make it easy to use compact CBOR message formats.  Internet standards often use CBOR arrays and CBOR maps with int keys to save space.
+
+__More Info About API, Options, and Usage__
+
+Options are listed in the Features section: [Encoding Options](#encoding-options) and [Decoding Options](#decoding-options)
+
+For more details about each setting, see [Options](#options) section.
+
+For additional API and usage examples, see [API](#api) and [Usage](#usage) sections.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Current Status
+Latest version is v2.x, which has:
+
+* __Stable API__ –  Six codec function signatures will never change.  No breaking API changes for other funcs in same major version.  And these two functions are subject to change until the draft RFC is approved by IETF (est. in 2020):
+  * CoreDetEncOptions() is subject to change because it uses draft standard.
+  * PreferredUnsortedEncOptions() is subject to change because it uses draft standard.
+* __Passed all tests__ – v2.x passed all 375+ tests on amd64, arm64, ppc64le and s390x with linux.
+* __Passed fuzzing__ – v2.1 passed 361+ million execs in coverage-guided fuzzing on Feb 17, 2020.
+
+__Why v2.x?__:
+
+v1 required breaking API changes to support new features like CBOR tags, detection of duplicate map keys, and having more functions with identical signatures to `encoding/json`.
+
+v2.1 is roughly 26% faster and uses 57% fewer allocs than v1.x when decoding COSE and CWT using default options.
+
+__Recent Activity__:
+
+* Release v2.1 (Feb. 17, 2020) 
+   - [x] CBOR tags (major type 6) for encoding and decoding.
+   - [x] Decoding options for duplicate map key detection: `DupMapKeyQuiet` (default) and `DupMapKeyEnforcedAPF`
+   - [x] Decoding optimizations. Structs using keyasint tag (like COSE and CWT) is  
+   24-28% faster and 53-61% fewer allocs than both v1.5 and v2.0.1.
+
+__Roadmap__:
+
+* Milestone v2.2
+   - [ ] CBOR BSTR <--> Go byte array. In the meantime, use CBOR BSTR with Go byte slice.   
+   - [ ] If time allows, add more CBOR tags as default or optional built-in tags.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Design Goals 
+This library is designed to be a generic CBOR encoder and decoder.  It was initially created for a [WebAuthn (FIDO2) server library](https://github.com/fxamacker/webauthn), because existing CBOR libraries (in Go) didn't meet certain criteria in 2019.
+
+This library is designed to be:
+
+* __Easy__ – API is like `encoding/json` plus `keyasint` and `toarray` struct tags.
+* __Small__ – Programs in cisco/senml are 4 MB smaller by switching to this library. In extreme cases programs can be smaller by 9+ MB. No code gen and the only imported pkg is x448/float16 which is maintained by the same team.
+* __Safe and reliable__ – No `unsafe` pkg, coverage >95%, coverage-guided fuzzing, and data validation to avoid crashes on malformed or malicious data.
+
+Competing factors are balanced:
+
+* __Speed__ vs __safety__ vs __size__ – to keep size small, avoid code generation. For safety, validate data and avoid Go's `unsafe` pkg.  For speed, use safe optimizations such as caching struct metadata. v1.4 is faster than a well-known library that uses `unsafe` and code gen.
+* __Standards compliance__ – CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049)) with minor [limitations](#limitations).
+  * Encoder supports options for sorting, floating-point conversions, and more.  Predefined options are also available so you can use "CTAP2 Canonical CBOR", etc. without knowing individual settings.  
+  * Decoder checks for well-formedness, validates data, and limits nested levels to defend against attacks. Decoder has options to handle duplicate map keys.  
+  * Both encoder and decoder supports CBOR tags (built-in and user-defined), and more. See [Standards](#standards).
+
+v2.0 decoupled options from CBOR encoding & decoding functions:
+
+* More encoding/decoding function signatures are identical to encoding/json.
+* More function signatures can remain stable forever.
+* More flexibility for evolving internal data types, optimizations, and concurrency.
+* Features like CBOR tags can be added without more breaking API changes.
+* Options to handle duplicate map keys can be added without more breaking API changes.
+
+Avoiding `unsafe` package has benefits.  The `unsafe` package [warns](https://golang.org/pkg/unsafe/):
+
+> Packages that import unsafe may be non-portable and are not protected by the Go 1 compatibility guidelines.
+
+All releases prioritize reliability to avoid crashes on decoding malformed CBOR data. See [Fuzzing and Coverage](#fuzzing-and-code-coverage).
+
+Features not in Go's standard library are usually not added.  However, the __`toarray`__ struct tag in __ugorji/go__ was too useful to ignore. It was added in v1.3 when a project mentioned they were using it with CBOR to save disk space.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Features
+
+### Standard API
+
+Many function signatures are identical to encoding/json, including:  
+`Marshal`, `Unmarshal`, `NewEncoder`, `NewDecoder`, `encoder.Encode`, `decoder.Decode`.
+
+`RawMessage` can be used to delay CBOR decoding or precompute CBOR encoding, like `encoding/json`.
+
+Standard interfaces allow user-defined types to have custom CBOR encoding and decoding.  They include:  
+`BinaryMarshaler`, `BinaryUnmarshaler`, `Marshaler`, and `Unmarshaler`.
+
+`Marshaler` and `Unmarshaler` interfaces are satisfied by `MarshalCBOR` and `UnmarshalCBOR` functions using same params and return types as Go's MarshalJSON and UnmarshalJSON.
+
+### Struct Tags
+
+Support "cbor" and "json" keys in Go's struct tags. If both are specified, then "cbor" is used.
+
+* `toarray` struct tag allows named struct fields for elements of CBOR arrays.
+* `keyasint` struct tag allows named struct fields for elements of CBOR maps with int keys.
+* `omitempty` struct tag excludes empty field values from being encoded.
+
+See [Usage](#usage).
+
+### CBOR Tags (New in v2.1)
+
+There are three broad categories of CBOR tags:
+
+* __Default built-in CBOR tags__ currently include tag numbers 0 and 1 (Time).  Additional default built-in tags in future releases may include tag numbers 2 and 3 (Bignum).  
+
+* __Optional built-in CBOR tags__ may be provided in the future via build flags or optional package(s) to help reduce bloat.
+
+* __User-defined CBOR tags__ are easy by using TagSet to associate tag numbers to user-defined Go types.
+
+### Preferred Serialization
+
+Preferred serialization encodes integers and floating-point values using the fewest bytes possible.
+
+* Integers are always encoded using the fewest bytes possible.
+* Floating-point values can optionally encode from float64->float32->float16 when values fit.
+
+### Compact Data Size
+
+The combination of preferred serialization and struct tags (toarray, keyasint, omitempty) allows very compact data size.
+
+### Predefined Encoding Options
+
+Easy-to-use functions (no params) return preset EncOptions struct:  
+`CanonicalEncOptions`, `CTAP2EncOptions`, `CoreDetEncOptions`, `PreferredUnsortedEncOptions`
+
+### Encoding Options
+
+Integers always encode to the shortest form that preserves value.  By default, time values are encoded without tags.
+
+Encoding of other data types and map key sort order are determined by encoder options.
+
+| Encoding Option | Available Settings (defaults in bold, aliases in italics) |
+| --------------- | --------------------------------------------------------- |
+| EncOptions.Sort | __`SortNone`__, `SortLengthFirst`, `SortBytewiseLexical`, _`SortCanonical`_, _`SortCTAP2`_, _`SortCoreDeterministic`_ |
+| EncOptions.Time | __`TimeUnix`__, `TimeUnixMicro`, `TimeUnixDynamic`, `TimeRFC3339`, `TimeRFC3339Nano` |
+| EncOptions.TimeTag | __`EncTagNone`__, `EncTagRequired` |
+| EncOptions.ShortestFloat | __`ShortestFloatNone`__, `ShortestFloat16` |
+| EncOptions.InfConvert | __`InfConvertFloat16`__, `InfConvertNone` |
+| EncOptions.NaNConvert | __`NaNConvert7e00`__, `NaNConvertNone`, `NaNConvertQuiet`, `NaNConvertPreserveSignal` |
+
+See [Options](#options) section for details about each setting.
+
+### Decoding Options
+
+| Decoding Option | Available Settings (defaults in bold, aliases in italics) |
+| --------------- | --------------------------------------------------------- |
+| DecOptions.TimeTag | __`DecTagIgnored`__, `DecTagOptional`, `DecTagRequired` |
+| DecOptions.DupMapKey | __`DupMapKeyQuiet`__, `DupMapKeyEnforcedAPF` |
+
+See [Options](#options) section for details about each setting.
+
+### Additional Features
+
+* Decoder always checks for invalid UTF-8 string errors.
+* Decoder always decodes in-place to slices, maps, and structs.
+* Decoder tries case-sensitive first and falls back to case-insensitive field name match when decoding to structs. 
+* Both encoder and decoder support indefinite length CBOR data (["streaming"](https://tools.ietf.org/html/rfc7049#section-2.2)).
+* Both encoder and decoder correctly handles nil slice, map, pointer, and interface values.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Standards
+This library is a small, fast, safe, and full-featured generic CBOR [(RFC 7049)](https://tools.ietf.org/html/rfc7049) encoder and decoder.  Notable features include:
+
+* CBOR tags (API supports built-in and user-defined) for both encoder and decoder
+* Definite and indefinite length data for both encoder and decoder
+* Encoder option for preferred serialization, including IEEE 754 binary16
+* Encoder option for sorting map keys: length-first (Canonical CBOR) and bytewise-lexical (CTAP2 & 7049bis)
+* Encoder options for floating-point shortest form, NaN, and Infinity
+* Decoder option to detect and reject duplicate map keys
+* Decoder checks for well-formedness and validates data
+* Decoder doesn't crash and avoids resource exhaustion from malformed/malicious CBOR data
+
+Known limitations are noted in the [Limitations section](#limitations). 
+
+Integers always encode to the shortest form that preserves value. Floats can optionally encode to shortest form:  
+float64 -> float32 -> float16 when values can be preserved.
+
+Go nil values for slices, maps, pointers, etc. are encoded as CBOR null.  Empty slices, maps, etc. are encoded as empty CBOR arrays and maps.
+
+Decoder checks for all required well-formedness errors, including all "subkinds" of syntax errors and too little data.
+
+After well-formedness is verified, basic validity errors are handled as follows:
+
+* Invalid UTF-8 string: Decoder always checks and returns invalid UTF-8 string error.
+* Duplicate keys in a map: Decoder has options to ignore or enforce rejection of duplicate map keys.
+
+When decoding well-formed CBOR arrays and maps, decoder saves the first error it encounters and continues with the next item.  Options to handle this differently may be added in the future.
+
+See [Options](#options) section for detailed settings or [Features](#features) section for a summary of options.
+
+__Duplicate Map Key Options__
+
+This library provides options for fast detection and rejection of duplicate map keys based on applying a Go-specific data model to CBOR's extended generic data model in order to determine duplicate vs distinct map keys. Detection relies on whether the CBOR map key would be a duplicate "key" when decoded and applied to the user-provided Go map or struct. 
+
+`DupMapKeyQuiet` turns off detection of duplicate map keys. It tries to use a "keep fastest" method by choosing either "keep first" or "keep last" depending on the Go data type.
+
+`DupMapKeyEnforcedAPF` enforces detection and rejection of duplidate map keys. Decoding stops immediately and returns `DupMapKeyError` when the first duplicate key is detected. The error includes the duplicate map key and the index number. 
+
+APF suffix means "Allow Partial Fill" so the destination map or struct can contain some decoded values at the time of error. It is the caller's responsibility to respond to the `DupMapKeyError` by discarding the partially filled result if that's required by their protocol. 
+
+## Limitations
+
+* Nested levels for CBOR arrays, maps, and tags are intentionally limited to 32 to quickly reject potentially malicious data.  This limit may be turned into a user-configurable setting in a future release.
+* CBOR negative int (type 1) that cannot fit into Go's int64 are not supported, such as RFC 7049 example -18446744073709551616.  Decoding these values returns `cbor.UnmarshalTypeError` like Go's `encoding/json`. However, this may be resolved in a future release by adding support for `big.Int`. Until then, users can use the API for custom encoding and decoding.
+* CBOR `Undefined` (0xf7) value decodes to Go's `nil` value.  CBOR `Null` (0xf6) more closely matches Go's `nil`.
+* CBOR map keys with data types not supported by Go for map keys are ignored and an error is returned after continuing to decode remaining items.  
+* When using io.Reader interface to read very large or indefinite length CBOR data, Go's `io.LimitReader` should be used to limit size.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## API
+Many function signatures are identical to Go's encoding/json, such as:  
+`Marshal`, `Unmarshal`, `NewEncoder`, `NewDecoder`, `encoder.Encode`, and `decoder.Decode`.
+
+Interfaces identical or comparable to Go's encoding, encoding/json, or encoding/gob include:  
+`Marshaler`, `Unmarshaler`, `BinaryMarshaler`, and `BinaryUnmarshaler`.
+
+Like `encoding/json`, `RawMessage` can be used to delay CBOR decoding or precompute CBOR encoding.
+
+"Mode" in this API means defined way of encoding or decoding -- it links the standard API to CBOR options and CBOR tags.
+
+EncMode and DecMode are interfaces created from EncOptions or DecOptions structs.  
+For example, `em, err := cbor.EncOptions{...}.EncMode()` or `em, err := cbor.CanonicalEncOptions().EncMode()`.
+
+EncMode and DecMode use immutable options so their behavior won't accidentally change at runtime.  Modes are intended to be reused and are safe for concurrent use.
+
+__API for Default Mode__
+
+If default options are acceptable, then you don't need to create EncMode or DecMode.
+```
+Marshal(v interface{}) ([]byte, error)
+NewEncoder(w io.Writer) *Encoder
+
+Unmarshal(data []byte, v interface{}) error
+NewDecoder(r io.Reader) *Decoder
+```
+
+__API for Creating & Using Encoding Modes__
+```
+// EncMode interface uses immutable options and is safe for concurrent use.
+type EncMode interface {
+	Marshal(v interface{}) ([]byte, error)
+	NewEncoder(w io.Writer) *Encoder
+	EncOptions() EncOptions  // returns copy of options
+}
+
+// EncOptions specifies encoding options.
+type EncOptions struct {
+...
+}
+
+// EncMode returns an EncMode interface created from EncOptions.
+func (opts EncOptions) EncMode() (EncMode, error) 
+
+// EncModeWithTags returns EncMode with options and tags that are both immutable. 
+func (opts EncOptions) EncModeWithTags(tags TagSet) (EncMode, error)
+
+// EncModeWithSharedTags returns EncMode with immutable options and mutable shared tags. 
+func (opts EncOptions) EncModeWithSharedTags(tags TagSet) (EncMode, error)
+```
+
+__API for Predefined Encoding Options__
+```
+func CanonicalEncOptions() EncOptions     // settings for RFC 7049 Canonical CBOR
+func CTAP2EncOptions() EncOptions         // settings for FIDO2 CTAP2 Canonical CBOR
+func CoreDetEncOptions() EncOptions       // modern settings from a draft RFC (subject to change)
+func PreferredUnsortedEncOptions() EncOptions  // modern settings from a draft RFC (subject to change)
+```
+
+__API for Creating & Using Decoding Modes__
+```
+// DecMode interface uses immutable options and is safe for concurrent use.
+type DecMode interface {
+	Unmarshal(data []byte, v interface{}) error
+	NewDecoder(r io.Reader) *Decoder
+	DecOptions() DecOptions  // returns copy of options
+}
+
+// DecOptions specifies decoding options.
+type DecOptions struct {
+...
+}
+
+// DecMode returns a DecMode interface created from DecOptions.
+func (opts DecOptions) DecMode() (DecMode, error)
+
+// DecModeWithTags returns DecMode with options and tags that are both immutable. 
+func (opts DecOptions) DecModeWithTags(tags TagSet) (DecMode, error)
+
+// DecModeWithSharedTags returns DecMode with immutable options and mutable shared tags. 
+func (opts DecOptions) DecModeWithSharedTags(tags TagSet) (DecMode, error)
+```
+
+__API for Using CBOR Tags__
+
+`TagSet` can be used to associate user-defined Go type(s) to tag number(s).  It's also used to create EncMode or DecMode. For example, `em := EncOptions{...}.EncModeWithTags(ts)` or `em := EncOptions{...}.EncModeWithSharedTags(ts)`. This allows every standard API exported by em (like `Marshal` and `NewEncoder`) to use the specified tags automatically.
+
+`Tag` and `RawTag` can be used to encode/decode a tag number with a Go value, but `TagSet` is generally recommended.
+
+```
+type TagSet interface {
+    // Add adds given tag number(s), content type, and tag options to TagSet.
+    Add(opts TagOptions, contentType reflect.Type, num uint64, nestedNum ...uint64) error
+
+    // Remove removes given tag content type from TagSet.
+    Remove(contentType reflect.Type)    
+}
+```
+
+`Tag` and `RawTag` types can also be used to encode/decode tag number with Go value.
+```
+type Tag struct {
+    Number  uint64
+    Content interface{}
+}
+
+type RawTag struct {
+    Number  uint64
+    Content RawMessage
+}
+```
+
+See [API docs (godoc.org)](https://godoc.org/github.com/fxamacker/cbor) for more details and more functions.  See [Usage section](#usage) for usage and code examples.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Options
+
+Options for the decoding and encoding are listed here.
+
+### Decoding Options
+
+| DecOptions.TimeTag | Description |
+| ------------------ | ----------- |
+| DecTagIgnored (default) | Tag numbers are ignored (if present) for time values. |
+| DecTagOptional | Tag numbers are only checked for validity if present for time values. |
+| DecTagRequired | Tag numbers must be provided for time values except for CBOR Null and CBOR Undefined. |
+
+CBOR Null and CBOR Undefined are silently treated as Go's zero time instant.  Go's `time` package provides `IsZero` function, which reports whether t represents the zero time instant, January 1, year 1, 00:00:00 UTC. 
+
+__Duplicate Map Key Options__
+
+| DecOptions.DupMapKey | Description |
+| -------------------- | ----------- |
+| DupMapKeyQuiet (default) | turns off detection of duplicate map keys. It uses a "keep fastest" method by choosing either "keep first" or "keep last" depending on the Go data type. |
+| DupMapKeyEnforcedAPF | enforces detection and rejection of duplidate map keys. Decoding stops immediately and returns `DupMapKeyError` when the first duplicate key is detected. The error includes the duplicate map key and the index number. |
+
+`DupMapKeyEnforcedAPF` uses "Allow Partial Fill" so the destination map or struct can contain some decoded values at the time of error.  Users can respond to the `DupMapKeyError` by discarding the partially filled result if that's required by their protocol.
+
+### Encoding Options
+
+__Integers always encode to the shortest form that preserves value__.  Encoding of other data types and map key sort order are determined by encoding options.
+
+These functions are provided to create and return a modifiable EncOptions struct with predefined settings.
+
+| Predefined EncOptions | Description |
+| --------------------- | ----------- |
+| CanonicalEncOptions() |[Canonical CBOR (RFC 7049 Section 3.9)](https://tools.ietf.org/html/rfc7049#section-3.9). |
+| CTAP2EncOptions() |[CTAP2 Canonical CBOR (FIDO2 CTAP2)](https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#ctap2-canonical-cbor-encoding-form). |
+| PreferredUnsortedEncOptions() |Unsorted, encode float64->float32->float16 when values fit, NaN values encoded as float16 0x7e00. |
+| CoreDetEncOptions() |PreferredUnsortedEncOptions() + map keys are sorted bytewise lexicographic. |
+
+🌱 CoreDetEncOptions() and PreferredUnsortedEncOptions() are subject to change until the draft RFC they used is approved by IETF.
+
+| EncOptions.Sort | Description |
+| --------------- | ----------- |
+| SortNone (default) |No sorting for map keys. |
+| SortLengthFirst |Length-first map key ordering. |
+| SortBytewiseLexical |Bytewise lexicographic map key ordering |
+| SortCanonical |(alias) Same as SortLengthFirst [(RFC 7049 Section 3.9)](https://tools.ietf.org/html/rfc7049#section-3.9) |
+| SortCTAP2 |(alias) Same as SortBytewiseLexical [(CTAP2 Canonical CBOR)](https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#ctap2-canonical-cbor-encoding-form). |
+| SortCoreDeterministic |(alias) Same as SortBytewiseLexical. |
+
+| EncOptions.Time | Description |
+| --------------- | ----------- |
+| TimeUnix (default) | (seconds) Encode as integer. |
+| TimeUnixMicro | (microseconds) Encode as floating-point.  ShortestFloat option determines size. |
+| TimeUnixDynamic | (seconds or microseconds) Encode as integer if time doesn't have fractional seconds, otherwise encode as floating-point rounded to microseconds. |
+| TimeRFC3339 | (seconds) Encode as RFC 3339 formatted string. |
+| TimeRFC3339Nano | (nanoseconds) Encode as RFC3339 formatted string. |
+
+| EncOptions.TimeTag | Description |
+| ------------------ | ----------- |
+| EncTagNone (default) | Tag number will not be encoded for time values. |
+| EncTagRequired | Tag number (0 or 1) will be encoded unless time value is undefined/zero-instant. |
+
+__Undefined Time Values__
+
+By default, undefined (zero instant) time values will encode as CBOR Null without tag number for both EncTagNone and EncTagRequired.  Although CBOR Undefined might be technically more correct for EncTagRequired, CBOR Undefined might not be supported by other generic decoders and it isn't supported by JSON.
+
+Go's `time` package provides `IsZero` function, which reports whether t represents the zero time instant, January 1, year 1, 00:00:00 UTC. 
+
+__Floating-Point Options__
+
+Encoder has 3 types of options for floating-point data: ShortestFloatMode, InfConvertMode, and NaNConvertMode.
+
+| EncOptions.ShortestFloat | Description |
+| ------------------------ | ----------- |
+| ShortestFloatNone (default) | No size conversion. Encode float32 and float64 to CBOR floating-point of same bit-size. |
+| ShortestFloat16 | Encode float64 -> float32 -> float16 ([IEEE 754 binary16](https://en.wikipedia.org/wiki/Half-precision_floating-point_format)) when values fit. |
+
+Conversions for infinity and NaN use InfConvert and NaNConvert settings.
+
+| EncOptions.InfConvert | Description |
+| --------------------- | ----------- |
+| InfConvertFloat16 (default) | Convert +- infinity to float16 since they always preserve value (recommended) |
+| InfConvertNone |Don't convert +- infinity to other representations -- used by CTAP2 Canonical CBOR |
+
+
+| EncOptions.NaNConvert | Description |
+| --------------------- | ----------- |
+| NaNConvert7e00 (default) | Encode to 0xf97e00 (CBOR float16 = 0x7e00) -- used by RFC 7049 Canonical CBOR. |
+| NaNConvertNone | Don't convert NaN to other representations -- used by CTAP2 Canonical CBOR. |
+| NaNConvertQuiet | Force quiet bit = 1 and use shortest form that preserves NaN payload. |
+| NaNConvertPreserveSignal | Convert to smallest form that preserves value (quit bit unmodified and NaN payload preserved). |
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Usage
+🛡️ Use Go's `io.LimitReader` to limit size when decoding very large or indefinite size data.
+
+Functions with identical signatures to encoding/json include:  
+`Marshal`, `Unmarshal`, `NewEncoder`, `NewDecoder`, `encoder.Encode`, `decoder.Decode`.
+
+__Default Mode__  
+
+If default options are acceptable, package level functions can be used for encoding and decoding.
+```
+b, err := cbor.Marshal(v)
+
+err := cbor.Unmarshal(b, &v)
+
+encoder := cbor.NewEncoder(w)
+
+decoder := cbor.NewDecoder(r)
+```
+
+__Modes__
+
+If you need to use options or CBOR tags, then you'll want to create a mode.
+
+"Mode" means defined way of encoding or decoding -- it links the standard API to your CBOR options and CBOR tags.  This way, you don't pass around options and the API remains identical to `encoding/json`.
+
+EncMode and DecMode are interfaces created from EncOptions or DecOptions structs.  
+For example, `em, err := cbor.EncOptions{...}.EncMode()` or `em, err := cbor.CanonicalEncOptions().EncMode()`.
+
+EncMode and DecMode use immutable options so their behavior won't accidentally change at runtime.  Modes are reusable, safe for concurrent use, and allow fast parallelism.
+
+__Creating and Using Encoding Modes__
+
+EncMode is an interface ([API](#api)) created from EncOptions struct.  EncMode uses immutable options after being created and is safe for concurrent use.  For best performance, EncMode should be reused.
+
+```
+// Create EncOptions using either struct literal or a function.
+opts := cbor.CanonicalEncOptions()
+
+// If needed, modify encoding options
+opts.Time = cbor.TimeUnix
+
+// Create reusable EncMode interface with immutable options, safe for concurrent use.
+em, err := opts.EncMode()   
+
+// Use EncMode like encoding/json, with same function signatures.
+b, err := em.Marshal(v)
+// or
+encoder := em.NewEncoder(w)
+err := encoder.Encode(v)
+```
+
+__Struct Tags (keyasint, toarray, omitempty)__
+
+The `keyasint`, `toarray`, and `omitempty` struct tags make it easy to use compact CBOR message formats.  Internet standards often use CBOR arrays and CBOR maps with int keys to save space.
+
+<hr>
+
+[![CBOR API](https://github.com/fxamacker/images/raw/master/cbor/v2.1.0/cbor_api_struct_tags.png)](#usage)
+
+<hr>
+
+__Decoding CWT (CBOR Web Token)__ using `keyasint` and `toarray` struct tags:
+```
+// Signed CWT is defined in RFC 8392
+type signedCWT struct {
+	_           struct{} `cbor:",toarray"`
+	Protected   []byte
+	Unprotected coseHeader
+	Payload     []byte
+	Signature   []byte
+}
+
+// Part of COSE header definition
+type coseHeader struct {
+	Alg int    `cbor:"1,keyasint,omitempty"`
+	Kid []byte `cbor:"4,keyasint,omitempty"`
+	IV  []byte `cbor:"5,keyasint,omitempty"`
+}
+
+// data is []byte containing signed CWT
+
+var v signedCWT
+if err := cbor.Unmarshal(data, &v); err != nil {
+	return err
+}
+```
+
+__Encoding CWT (CBOR Web Token)__ using `keyasint` and `toarray` struct tags:
+```
+// Use signedCWT struct defined in "Decoding CWT" example.
+
+var v signedCWT
+...
+if data, err := cbor.Marshal(v); err != nil {
+	return err
+}
+```
+
+__Encoding and Decoding CWT (CBOR Web Token) with CBOR Tags__
+```
+// Use signedCWT struct defined in "Decoding CWT" example.
+
+// Create TagSet (safe for concurrency).
+tags := cbor.NewTagSet()
+// Register tag COSE_Sign1 18 with signedCWT type.
+tags.Add(	
+	cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired}, 
+	reflect.TypeOf(signedCWT{}), 
+	18)
+
+// Create DecMode with immutable tags.
+dm, _ := cbor.DecOptions{}.DecModeWithTags(tags)
+
+// Unmarshal to signedCWT with tag support.
+var v signedCWT
+if err := dm.Unmarshal(data, &v); err != nil {
+	return err
+}
+
+// Create EncMode with immutable tags.
+em, _ := cbor.EncOptions{}.EncModeWithTags(tags)
+
+// Marshal signedCWT with tag number.
+if data, err := cbor.Marshal(v); err != nil {
+	return err
+}
+```
+
+For more examples, see [examples_test.go](example_test.go).
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Comparisons
+
+Comparisons are between this newer library and a well-known library that had 1,000+ stars before this library was created.  Default build settings for each library were used for all comparisons.
+
+__This library is safer__.  Small malicious CBOR messages are rejected quickly before they exhaust system resources.
+
+|     | fxamacker/cbor 2.1.0 | ugorji/go 1.1.7 |
+| --- | -------------------- | --------------- |
+| Malformed data #1  | 57.4 ns/op, 32 B/op, 1 allocs/op | ⚠️ fatal error: out of memory |
+| Malformed data #2  | 67.7 ns/op, 32 B/op, 1 allocs/op | ⚠️ runtime: out of memory: cannot allocate |
+
+&nbsp;
+
+__This library is smaller__. Programs like senmlCat can be 4 MB smaller by switching to this library.  Programs using more complex CBOR data types can be 9.2 MB smaller.
+
+![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.1.0/cbor_size_comparison.png "CBOR library and program size comparison chart")
+
+__This library is faster__ for encoding and decoding CBOR Web Token (CWT).  However, speed is only one factor and it can vary depending on data types and sizes.  Unlike the other library, this one doesn't use Go's ```unsafe``` package or code gen.
+
+![alt text](https://github.com/fxamacker/images/raw/master/cbor/v2.1.0/cbor_speed_comparison.png "CBOR library speed comparison chart")
+
+The resource intensive `codec.CborHandle` initialization (in the other library) was placed outside the benchmark loop to make sure their library wasn't penalized.
+
+__This library uses less memory__ for encoding and decoding CBOR Web Token (CWT) using test data from RFC 8392 A.1.
+
+|     | fxamacker/cbor 2.1.0 | ugorji/go 1.1.7 |
+| --- | -------------------- | --------------- |
+| Encode CWT claims | 176 B/op, 2 allocs/op | 1424 B/op, 4 allocs/op |
+| Decode CWT claims | 176 B/op, 6 allocs/op | 568 B/op, 6 allocs/op |
+
+Doing your own comparisons is highly recommended.  Use your most common message sizes and data types.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Benchmarks
+
+Go structs are faster than maps with string keys:
+
+* decoding into struct is >28% faster than decoding into map.
+* encoding struct is >35% faster than encoding map.
+
+Go structs with `keyasint` struct tag are faster than maps with integer keys:
+
+* decoding into struct is >28% faster than decoding into map.
+* encoding struct is >33% faster than encoding map.
+
+Go structs with `toarray` struct tag are faster than slice:
+
+* decoding into struct is >15% faster than decoding into slice.
+* encoding struct is >13% faster than encoding slice.
+
+Doing your own benchmarks is highly recommended.  Use your most common message sizes and data types.
+
+See [Benchmarks for fxamacker/cbor](CBOR_BENCHMARKS.md).
+
+## Fuzzing and Code Coverage
+
+__Over 375 tests__ must pass on 4 architectures before tagging a release.  They include all RFC 7049 examples, bugs found by fuzzing, maliciously crafted CBOR data, and over 87 tests with malformed data.
+
+__Code coverage__ must not fall below 95% when tagging a release.  Code coverage is 98.5% (`go test -cover`) for cbor v2.1 which is among the highest for libraries (in Go) of this type.
+
+__Coverage-guided fuzzing__ must pass 250+ million execs before tagging a release.  Fuzzing uses [fxamacker/cbor-fuzz](https://github.com/fxamacker/cbor-fuzz).  Default corpus has:
+
+* 2 files related to WebAuthn (FIDO U2F key).
+* 3 files with custom struct.
+* 9 files with [CWT examples (RFC 8392 Appendix A)](https://tools.ietf.org/html/rfc8392#appendix-A).
+* 17 files with [COSE examples (RFC 8152 Appendix B & C)](https://github.com/cose-wg/Examples/tree/master/RFC8152).
+* 81 files with [CBOR examples (RFC 7049 Appendix A) ](https://tools.ietf.org/html/rfc7049#appendix-A). It excludes 1 errata first reported in [issue #46](https://github.com/fxamacker/cbor/issues/46).
+
+Over 1,100 files (corpus) are used for fuzzing because it includes fuzz-generated corpus.
+
+To prevent excessive delays, fuzzing is not restarted for a release if changes are limited to docs and comments.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)
+
+## Versions and API Changes
+This project uses [Semantic Versioning](https://semver.org), so the API is always backwards compatible unless the major version number changes.  
+
+These functions have signatures identical to encoding/json and they will likely never change even after major new releases:  `Marshal`, `Unmarshal`, `NewEncoder`, `NewDecoder`, `encoder.Encode`, and `decoder.Decode`.
+
+Newly added API documented as "subject to change" are excluded from SemVer.
+
+Newly added API in the master branch that has never been release tagged are excluded from SemVer.
+
+## Code of Conduct 
+This project has adopted the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).  Contact [faye.github@gmail.com](mailto:faye.github@gmail.com) with any questions or comments.
+
+## Contributing
+Please refer to [How to Contribute](CONTRIBUTING.md).
+
+## Security Policy
+Security fixes are provided for the latest released version.
+
+To report security vulnerabilities, please email [faye.github@gmail.com](mailto:faye.github@gmail.com) and allow time for the problem to be resolved before reporting it to the public.
+
+## Disclaimers
+Phrases like "no crashes" or "doesn't crash" mean there are no known crash bugs in the latest version based on results of unit tests and coverage-guided fuzzing.  It doesn't imply the software is 100% bug-free or 100% invulnerable to all known and unknown attacks.
+
+Please read the license for additional disclaimers and terms.
+
+## Special Thanks
+
+__Making this library better__  
+
+* Montgomery Edwards⁴⁴⁸ for [x448/float16](https://github.com/x448/float16), updating the docs, creating charts & slideshow, filing issues, nudging me to ask for feedback from users, helping with design of v2.0-v2.1 API, and general idea for DupMapKeyEnforcedAPF.
+* Stefan Tatschner for using this library in [sep](https://git.sr.ht/~rumpelsepp/sep), being the 1st to discover my CBOR library, requesting time.Time in issue #1, and submitting this library in a [PR to cbor.io](https://github.com/cbor/cbor.github.io/pull/56) on Aug 12, 2019.
+* Yawning Angel for using this library to [oasis-core](https://github.com/oasislabs/oasis-core), and requesting BinaryMarshaler in issue #5.
+* Jernej Kos for requesting RawMessage in issue #11 and offering feedback on v2.1 API for CBOR tags.
+* ZenGround0 for using this library in [go-filecoin](https://github.com/filecoin-project/go-filecoin), filing "toarray" bug in issue #129, and requesting  
+CBOR BSTR <--> Go array in #133.
+* Keith Randall for [fixing Go bugs and providing workarounds](https://github.com/golang/go/issues/36400) so we don't have to wait for new versions of Go.
+
+__Help clarifying CBOR RFC 7049 or 7049bis__
+
+* Carsten Bormann for RFC 7049 (CBOR), his fast confirmation to my RFC 7049 errata, approving my pull request to 7049bis, and his patience when I misread a line in 7049bis.
+* Laurence Lundblade for his help on the IETF mailing list for 7049bis and for pointing out on a CBORbis issue that CBOR Undefined might be problematic translating to JSON.
+* Jeffrey Yasskin for his help on the IETF mailing list for 7049bis.
+
+__Words of encouragement and support__
+
+* Jakob Borg for his words of encouragement about this library at Go Forum.  This is especially appreciated in the early stages when there's a lot of rough edges.
+
+
+## License 
+Copyright © 2019-present [Faye Amacker](https://github.com/fxamacker).
+
+fxamacker/cbor is licensed under the MIT License.  See [LICENSE](LICENSE) for the full license text.
+
+<hr>
+
+⚓  [Install](#installation) • [Status](#current-status) • [Design Goals](#design-goals) • [Features](#features) • [Standards](#standards) • [API](#api) • [Usage](#usage) • [Fuzzing](#fuzzing-and-code-coverage) • [Security Policy](#security-policy) • [License](#license)

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/bench_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/bench_test.go
@@ -1,0 +1,674 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"bytes"
+	"io/ioutil"
+	"reflect"
+	"testing"
+)
+
+const rounds = 100
+
+type claims struct {
+	Iss string `cbor:"1,keyasint"`
+	Sub string `cbor:"2,keyasint"`
+	Aud string `cbor:"3,keyasint"`
+	Exp int    `cbor:"4,keyasint"`
+	Nbf int    `cbor:"5,keyasint"`
+	Iat int    `cbor:"6,keyasint"`
+	Cti []byte `cbor:"7,keyasint"`
+}
+
+type coseHeader struct {
+	Alg int    `cbor:"1,keyasint,omitempty"`
+	Kid []byte `cbor:"4,keyasint,omitempty"`
+	IV  []byte `cbor:"5,keyasint,omitempty"`
+}
+
+type macedCOSE struct {
+	_           struct{} `cbor:",toarray"`
+	Protected   []byte
+	Unprotected coseHeader
+	Payload     []byte
+	Tag         []byte
+}
+
+type coseKey struct {
+	Kty       int        `cbor:"1,keyasint,omitempty"`
+	Kid       []byte     `cbor:"2,keyasint,omitempty"`
+	Alg       int        `cbor:"3,keyasint,omitempty"`
+	KeyOpts   int        `cbor:"4,keyasint,omitempty"`
+	IV        []byte     `cbor:"5,keyasint,omitempty"`
+	CrvOrNOrK RawMessage `cbor:"-1,keyasint,omitempty"` // K for symmetric keys, Crv for elliptic curve keys, N for RSA modulus
+	XOrE      RawMessage `cbor:"-2,keyasint,omitempty"` // X for curve x-coordinate, E for RSA public exponent
+	Y         RawMessage `cbor:"-3,keyasint,omitempty"` // Y for curve y-cooridate
+	D         []byte     `cbor:"-4,keyasint,omitempty"`
+}
+
+type attestationObject struct {
+	AuthnData []byte     `cbor:"authData"`
+	Fmt       string     `cbor:"fmt"`
+	AttStmt   RawMessage `cbor:"attStmt"`
+}
+
+type SenMLRecord struct {
+	BaseName    string  `cbor:"-2,keyasint,omitempty"`
+	BaseTime    float64 `cbor:"-3,keyasint,omitempty"`
+	BaseUnit    string  `cbor:"-4,keyasint,omitempty"`
+	BaseValue   float64 `cbor:"-5,keyasint,omitempty"`
+	BaseSum     float64 `cbor:"-6,keyasint,omitempty"`
+	BaseVersion int     `cbor:"-1,keyasint,omitempty"`
+	Name        string  `cbor:"0,keyasint,omitempty"`
+	Unit        string  `cbor:"1,keyasint,omitempty"`
+	Time        float64 `cbor:"6,keyasint,omitempty"`
+	UpdateTime  float64 `cbor:"7,keyasint,omitempty"`
+	Value       float64 `cbor:"2,keyasint,omitempty"`
+	ValueS      string  `cbor:"3,keyasint,omitempty"`
+	ValueB      bool    `cbor:"4,keyasint,omitempty"`
+	ValueD      string  `cbor:"8,keyasint,omitempty"`
+	Sum         float64 `cbor:"5,keyasint,omitempty"`
+}
+
+type T1 struct {
+	T    bool
+	UI   uint
+	I    int
+	F    float64
+	B    []byte
+	S    string
+	Slci []int
+	Mss  map[string]string
+}
+
+type T2 struct {
+	T    bool              `cbor:"1,keyasint"`
+	UI   uint              `cbor:"2,keyasint"`
+	I    int               `cbor:"3,keyasint"`
+	F    float64           `cbor:"4,keyasint"`
+	B    []byte            `cbor:"5,keyasint"`
+	S    string            `cbor:"6,keyasint"`
+	Slci []int             `cbor:"7,keyasint"`
+	Mss  map[string]string `cbor:"8,keyasint"`
+}
+
+type T3 struct {
+	_    struct{} `cbor:",toarray"`
+	T    bool
+	UI   uint
+	I    int
+	F    float64
+	B    []byte
+	S    string
+	Slci []int
+	Mss  map[string]string
+}
+
+var decodeBenchmarks = []struct {
+	name          string
+	cborData      []byte
+	decodeToTypes []reflect.Type
+}{
+	{"bool", hexDecode("f5"), []reflect.Type{typeIntf, typeBool}},                                                                                                                                                                                           // true
+	{"positive int", hexDecode("1bffffffffffffffff"), []reflect.Type{typeIntf, typeUint64}},                                                                                                                                                                 // uint64(18446744073709551615)
+	{"negative int", hexDecode("3903e7"), []reflect.Type{typeIntf, typeInt64}},                                                                                                                                                                              // int64(-1000)
+	{"float", hexDecode("fbc010666666666666"), []reflect.Type{typeIntf, typeFloat64}},                                                                                                                                                                       // float64(-4.1)
+	{"bytes", hexDecode("581a0102030405060708090a0b0c0d0e0f101112131415161718191a"), []reflect.Type{typeIntf, typeByteSlice}},                                                                                                                               // []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
+	{"bytes indef len", hexDecode("5f410141024103410441054106410741084109410a410b410c410d410e410f4110411141124113411441154116411741184119411aff"), []reflect.Type{typeIntf, typeByteSlice}},                                                                 // []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
+	{"text", hexDecode("782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67"), []reflect.Type{typeIntf, typeString}},                                                                                                 // "The quick brown fox jumps over the lazy dog"
+	{"text indef len", hexDecode("7f61546168616561206171617561696163616b612061626172616f6177616e61206166616f61786120616a6175616d617061736120616f61766165617261206174616861656120616c6161617a617961206164616f6167ff"), []reflect.Type{typeIntf, typeString}}, // "The quick brown fox jumps over the lazy dog"
+	{"array", hexDecode("981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a"), []reflect.Type{typeIntf, typeIntSlice}},                                                                                                                          // []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
+	{"array indef len", hexDecode("9f0102030405060708090a0b0c0d0e0f101112131415161718181819181aff"), []reflect.Type{typeIntf, typeIntSlice}},                                                                                                                // []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
+	{"map", hexDecode("ad616161416162614261636143616461446165614561666146616761476168614861696149616a614a616c614c616d614d616e614e"), []reflect.Type{typeIntf, typeMapStringIntf, typeMapStringString}},                                                      // map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}}
+	{"map indef len", hexDecode("bf616161416162614261636143616461446165614561666146616761476168614861696149616a614a616b614b616c614c616d614d616e614eff"), []reflect.Type{typeIntf, typeMapStringIntf, typeMapStringString}},                                  // map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}}
+}
+
+var encodeBenchmarks = []struct {
+	name     string
+	cborData []byte
+	values   []interface{}
+}{
+	{"bool", hexDecode("f5"), []interface{}{true}},
+	{"positive int", hexDecode("1bffffffffffffffff"), []interface{}{uint64(18446744073709551615)}},
+	{"negative int", hexDecode("3903e7"), []interface{}{int64(-1000)}},
+	{"float", hexDecode("fbc010666666666666"), []interface{}{float64(-4.1)}},
+	{"bytes", hexDecode("581a0102030405060708090a0b0c0d0e0f101112131415161718191a"), []interface{}{[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}}},
+	{"text", hexDecode("782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67"), []interface{}{"The quick brown fox jumps over the lazy dog"}},
+	{"array", hexDecode("981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a"), []interface{}{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}}},
+	{"map", hexDecode("ad616161416162614261636143616461446165614561666146616761476168614861696149616a614a616c614c616d614d616e614e"), []interface{}{map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}}},
+}
+
+func BenchmarkUnmarshal(b *testing.B) {
+	for _, bm := range decodeBenchmarks {
+		for _, t := range bm.decodeToTypes {
+			name := "CBOR " + bm.name + " to Go " + t.String()
+			if t.Kind() == reflect.Struct {
+				name = "CBOR " + bm.name + " to Go " + t.Kind().String()
+			}
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					vPtr := reflect.New(t).Interface()
+					if err := Unmarshal(bm.cborData, vPtr); err != nil {
+						b.Fatal("Unmarshal:", err)
+					}
+				}
+			})
+		}
+	}
+	var moreBenchmarks = []struct {
+		name         string
+		cborData     []byte
+		decodeToType reflect.Type
+	}{
+		// Unmarshal CBOR map with string key to map[string]interface{}.
+		{
+			"CBOR map to Go map[string]interface{}",
+			hexDecode("a86154f56255691bffffffffffffffff61493903e76146fbc0106666666666666142581a0102030405060708090a0b0c0d0e0f101112131415161718191a6153782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6764536c6369981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a634d7373ad6163614361656145616661466167614761686148616e614e616d614d61616141616261426164614461696149616a614a616c614c"),
+			reflect.TypeOf(map[string]interface{}{}),
+		},
+		// Unmarshal CBOR map with string key to struct.
+		{
+			"CBOR map to Go struct",
+			hexDecode("a86154f56255491bffffffffffffffff61493903e76146fbc0106666666666666142581a0102030405060708090a0b0c0d0e0f101112131415161718191a6153782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6764536c6369981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a634d7373ad6163614361656145616661466167614761686148616e614e616d614d61616141616261426164614461696149616a614a616c614c"),
+			reflect.TypeOf(T1{}),
+		},
+		// Unmarshal CBOR map with integer key, such as COSE Key and SenML, to map[int]interface{}.
+		{
+			"CBOR map to Go map[int]interface{}",
+			hexDecode("a801f5021bffffffffffffffff033903e704fbc01066666666666605581a0102030405060708090a0b0c0d0e0f101112131415161718191a06782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6707981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a08ad61646144616661466167614761686148616d614d616e614e6161614161626142616361436165614561696149616a614a616c614c"),
+			reflect.TypeOf(map[int]interface{}{}),
+		},
+		// Unmarshal CBOR map with integer key, such as COSE Key and SenML, to struct.
+		{
+			"CBOR map to Go struct keyasint",
+			hexDecode("a801f5021bffffffffffffffff033903e704fbc01066666666666605581a0102030405060708090a0b0c0d0e0f101112131415161718191a06782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f6707981a0102030405060708090a0b0c0d0e0f101112131415161718181819181a08ad61646144616661466167614761686148616d614d616e614e6161614161626142616361436165614561696149616a614a616c614c"),
+			reflect.TypeOf(T2{}),
+		},
+		// Unmarshal CBOR array of known sequence of data types, such as signed/maced/encrypted CWT, to []interface{}.
+		{
+			"CBOR array to Go []interface{}",
+			hexDecode("88f51bffffffffffffffff3903e7fbc010666666666666581a0102030405060708090a0b0c0d0e0f101112131415161718191a782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67981a0102030405060708090a0b0c0d0e0f101112131415161718181819181aad616261426163614361646144616561456166614661696149616e614e616161416167614761686148616a614a616c614c616d614d"),
+			reflect.TypeOf([]interface{}{}),
+		},
+		// Unmarshal CBOR array of known sequence of data types, such as signed/maced/encrypted CWT, to struct.
+		{
+			"CBOR array to Go struct toarray",
+			hexDecode("88f51bffffffffffffffff3903e7fbc010666666666666581a0102030405060708090a0b0c0d0e0f101112131415161718191a782b54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67981a0102030405060708090a0b0c0d0e0f101112131415161718181819181aad616261426163614361646144616561456166614661696149616e614e616161416167614761686148616a614a616c614c616d614d"),
+			reflect.TypeOf(T3{}),
+		},
+	}
+	for _, bm := range moreBenchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				vPtr := reflect.New(bm.decodeToType).Interface()
+				if err := Unmarshal(bm.cborData, vPtr); err != nil {
+					b.Fatal("Unmarshal:", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	for _, bm := range decodeBenchmarks {
+		for _, t := range bm.decodeToTypes {
+			name := "CBOR " + bm.name + " to Go " + t.String()
+			if t.Kind() == reflect.Struct {
+				name = "CBOR " + bm.name + " to Go " + t.Kind().String()
+			}
+			buf := bytes.NewReader(bm.cborData)
+			decoder := NewDecoder(buf)
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					vPtr := reflect.New(t).Interface()
+					if err := decoder.Decode(vPtr); err != nil {
+						b.Fatal("Decode:", err)
+					}
+					buf.Seek(0, 0) //nolint:errcheck
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkDecodeStream(b *testing.B) {
+	var cborData []byte
+	for _, bm := range decodeBenchmarks {
+		for i := 0; i < len(bm.decodeToTypes); i++ {
+			cborData = append(cborData, bm.cborData...)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf := bytes.NewReader(cborData)
+		decoder := NewDecoder(buf)
+		for j := 0; j < rounds; j++ {
+			for _, bm := range decodeBenchmarks {
+				for _, t := range bm.decodeToTypes {
+					vPtr := reflect.New(t).Interface()
+					if err := decoder.Decode(vPtr); err != nil {
+						b.Fatal("Decode:", err)
+					}
+				}
+			}
+			buf.Seek(0, 0) //nolint:errcheck
+		}
+	}
+}
+
+func BenchmarkMarshal(b *testing.B) {
+	for _, bm := range encodeBenchmarks {
+		for _, v := range bm.values {
+			name := "Go " + reflect.TypeOf(v).String() + " to CBOR " + bm.name
+			if reflect.TypeOf(v).Kind() == reflect.Struct {
+				name = "Go " + reflect.TypeOf(v).Kind().String() + " to CBOR " + bm.name
+			}
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					if _, err := Marshal(v); err != nil {
+						b.Fatal("Marshal:", err)
+					}
+				}
+			})
+		}
+	}
+	// Marshal map[string]interface{} to CBOR map
+	m1 := map[string]interface{}{ //nolint:dupl
+		"T":    true,
+		"UI":   uint(18446744073709551615),
+		"I":    -1000,
+		"F":    -4.1,
+		"B":    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		"S":    "The quick brown fox jumps over the lazy dog",
+		"Slci": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		"Mss":  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
+	}
+	// Marshal struct to CBOR map
+	v1 := T1{ //nolint:dupl
+		T:    true,
+		UI:   18446744073709551615,
+		I:    -1000,
+		F:    -4.1,
+		B:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		S:    "The quick brown fox jumps over the lazy dog",
+		Slci: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		Mss:  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
+	}
+	// Marshal map[int]interface{} to CBOR map
+	m2 := map[int]interface{}{ //nolint:dupl
+		1: true,
+		2: uint(18446744073709551615),
+		3: -1000,
+		4: -4.1,
+		5: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		6: "The quick brown fox jumps over the lazy dog",
+		7: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		8: map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
+	}
+	// Marshal struct keyasint, such as COSE Key and SenML
+	v2 := T2{ //nolint:dupl
+		T:    true,
+		UI:   18446744073709551615,
+		I:    -1000,
+		F:    -4.1,
+		B:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		S:    "The quick brown fox jumps over the lazy dog",
+		Slci: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		Mss:  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
+	}
+	// Marshal []interface to CBOR array.
+	slc := []interface{}{
+		true,
+		uint(18446744073709551615),
+		-1000,
+		-4.1,
+		[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		"The quick brown fox jumps over the lazy dog",
+		[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
+	}
+	// Marshal struct toarray to CBOR array, such as signed/maced/encrypted CWT.
+	v3 := T3{ //nolint:dupl
+		T:    true,
+		UI:   18446744073709551615,
+		I:    -1000,
+		F:    -4.1,
+		B:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		S:    "The quick brown fox jumps over the lazy dog",
+		Slci: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
+		Mss:  map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"},
+	}
+	var moreBenchmarks = []struct {
+		name  string
+		value interface{}
+	}{
+		{"Go map[string]interface{} to CBOR map", m1},
+		{"Go struct to CBOR map", v1},
+		{"Go map[int]interface{} to CBOR map", m2},
+		{"Go struct keyasint to CBOR map", v2},
+		{"Go []interface{} to CBOR map", slc},
+		{"Go struct toarray to CBOR array", v3},
+	}
+	for _, bm := range moreBenchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := Marshal(bm.value); err != nil {
+					b.Fatal("Marshal:", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalCanonical(b *testing.B) {
+	type strc struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+		F string `cbor:"f"`
+		G string `cbor:"g"`
+		H string `cbor:"h"`
+		I string `cbor:"i"`
+		J string `cbor:"j"`
+		L string `cbor:"l"`
+		M string `cbor:"m"`
+		N string `cbor:"n"`
+	}
+	for _, bm := range []struct {
+		name     string
+		cborData []byte
+		values   []interface{}
+	}{
+		{"map", hexDecode("ad616161416162614261636143616461446165614561666146616761476168614861696149616a614a616c614c616d614d616e614e"), []interface{}{map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E", "f": "F", "g": "G", "h": "H", "i": "I", "j": "J", "l": "L", "m": "M", "n": "N"}, strc{A: "A", B: "B", C: "C", D: "D", E: "E", F: "F", G: "G", H: "H", I: "I", J: "J", L: "L", M: "M", N: "N"}}},
+	} {
+		for _, v := range bm.values {
+			name := "Go " + reflect.TypeOf(v).String() + " to CBOR " + bm.name
+			if reflect.TypeOf(v).Kind() == reflect.Struct {
+				name = "Go " + reflect.TypeOf(v).Kind().String() + " to CBOR " + bm.name
+			}
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					if _, err := Marshal(v); err != nil {
+						b.Fatal("Marshal:", err)
+					}
+				}
+			})
+			// Canonical encoding
+			name = "Go " + reflect.TypeOf(v).String() + " to CBOR " + bm.name + " canonical"
+			if reflect.TypeOf(v).Kind() == reflect.Struct {
+				name = "Go " + reflect.TypeOf(v).Kind().String() + " to CBOR " + bm.name + " canonical"
+			}
+			em, _ := EncOptions{Sort: SortCanonical}.EncMode()
+			b.Run(name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					if _, err := em.Marshal(v); err != nil {
+						b.Fatal("Marshal:", err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	for _, bm := range encodeBenchmarks {
+		for _, v := range bm.values {
+			name := "Go " + reflect.TypeOf(v).String() + " to CBOR " + bm.name
+			if reflect.TypeOf(v).Kind() == reflect.Struct {
+				name = "Go " + reflect.TypeOf(v).Kind().String() + " to CBOR " + bm.name
+			}
+			b.Run(name, func(b *testing.B) {
+				encoder := NewEncoder(ioutil.Discard)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if err := encoder.Encode(v); err != nil {
+						b.Fatal("Encode:", err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkEncodeStream(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		encoder := NewEncoder(ioutil.Discard)
+		for i := 0; i < rounds; i++ {
+			for _, bm := range encodeBenchmarks {
+				for _, v := range bm.values {
+					if err := encoder.Encode(v); err != nil {
+						b.Fatal("Encode:", err)
+					}
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkUnmarshalCOSE(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.2
+	testCases := []struct {
+		name     string
+		cborData []byte
+	}{
+		{"128-Bit Symmetric Key", hexDecode("a42050231f4c4d4d3051fdc2ec0a3851d5b3830104024c53796d6d6574726963313238030a")},
+		{"256-Bit Symmetric Key", hexDecode("a4205820403697de87af64611c1d32a05dab0fe1fcb715a86ab435f1ec99192d795693880104024c53796d6d6574726963323536030a")},
+		{"ECDSA P256 256-Bit Key", hexDecode("a72358206c1382765aec5358f117733d281c1c7bdc39884d04a45a1e6c67c858bc206c1922582060f7f1a780d8a783bfb7a2dd6b2796e8128dbbcef9d3d168db9529971a36e7b9215820143329cce7868e416927599cf65a34f3ce2ffda55a7eca69ed8919a394d42f0f2001010202524173796d6d657472696345434453413235360326")},
+	}
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				var v coseKey
+				if err := Unmarshal(tc.cborData, &v); err != nil {
+					b.Fatal("Unmarshal:", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalCOSE(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.2
+	testCases := []struct {
+		name     string
+		cborData []byte
+	}{
+		{"128-Bit Symmetric Key", hexDecode("a42050231f4c4d4d3051fdc2ec0a3851d5b3830104024c53796d6d6574726963313238030a")},
+		{"256-Bit Symmetric Key", hexDecode("a4205820403697de87af64611c1d32a05dab0fe1fcb715a86ab435f1ec99192d795693880104024c53796d6d6574726963323536030a")},
+		{"ECDSA P256 256-Bit Key", hexDecode("a72358206c1382765aec5358f117733d281c1c7bdc39884d04a45a1e6c67c858bc206c1922582060f7f1a780d8a783bfb7a2dd6b2796e8128dbbcef9d3d168db9529971a36e7b9215820143329cce7868e416927599cf65a34f3ce2ffda55a7eca69ed8919a394d42f0f2001010202524173796d6d657472696345434453413235360326")},
+	}
+	for _, tc := range testCases {
+		var v coseKey
+		if err := Unmarshal(tc.cborData, &v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := Marshal(v); err != nil {
+					b.Fatal("Marshal:", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalCWTClaims(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
+	cborData := hexDecode("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
+	for i := 0; i < b.N; i++ {
+		var v claims
+		if err := Unmarshal(cborData, &v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalCWTClaimsWithDupMapKeyOpt(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
+	cborData := hexDecode("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	for i := 0; i < b.N; i++ {
+		var v claims
+		if err := dm.Unmarshal(cborData, &v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+
+func BenchmarkMarshalCWTClaims(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
+	cborData := hexDecode("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
+	var v claims
+	if err := Unmarshal(cborData, &v); err != nil {
+		b.Fatal("Unmarshal:", err)
+	}
+	for i := 0; i < b.N; i++ {
+		if _, err := Marshal(v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalSenML(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8428#section-6
+	cborData := hexDecode("87a721781b75726e3a6465763a6f773a3130653230373361303130383030363a22fb41d303a15b00106223614120050067766f6c7461676501615602fb405e066666666666a3006763757272656e74062402fb3ff3333333333333a3006763757272656e74062302fb3ff4cccccccccccda3006763757272656e74062202fb3ff6666666666666a3006763757272656e74062102f93e00a3006763757272656e74062002fb3ff999999999999aa3006763757272656e74060002fb3ffb333333333333")
+	for i := 0; i < b.N; i++ {
+		var v []SenMLRecord
+		if err := Unmarshal(cborData, &v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+
+func BenchmarkMarshalSenML(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8428#section-6
+	cborData := hexDecode("87a721781b75726e3a6465763a6f773a3130653230373361303130383030363a22fb41d303a15b00106223614120050067766f6c7461676501615602fb405e066666666666a3006763757272656e74062402fb3ff3333333333333a3006763757272656e74062302fb3ff4cccccccccccda3006763757272656e74062202fb3ff6666666666666a3006763757272656e74062102f93e00a3006763757272656e74062002fb3ff999999999999aa3006763757272656e74060002fb3ffb333333333333")
+	var v []SenMLRecord
+	if err := Unmarshal(cborData, &v); err != nil {
+		b.Fatal("Unmarshal:", err)
+	}
+	for i := 0; i < b.N; i++ {
+		if _, err := Marshal(v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+
+func BenchmarkMarshalSenMLShortestFloat16(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8428#section-6
+	cborData := hexDecode("87a721781b75726e3a6465763a6f773a3130653230373361303130383030363a22fb41d303a15b00106223614120050067766f6c7461676501615602fb405e066666666666a3006763757272656e74062402fb3ff3333333333333a3006763757272656e74062302fb3ff4cccccccccccda3006763757272656e74062202fb3ff6666666666666a3006763757272656e74062102f93e00a3006763757272656e74062002fb3ff999999999999aa3006763757272656e74060002fb3ffb333333333333")
+	var v []SenMLRecord
+	if err := Unmarshal(cborData, &v); err != nil {
+		b.Fatal("Unmarshal:", err)
+	}
+	em, _ := EncOptions{ShortestFloat: ShortestFloat16}.EncMode()
+	for i := 0; i < b.N; i++ {
+		if _, err := em.Marshal(v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalWebAuthn(b *testing.B) {
+	// Data generated from Yubico security key
+	cborData := hexDecode("a363666d74686669646f2d7532666761747453746d74a26373696758483046022100e7ab373cfbd99fcd55fd59b0f6f17fef5b77a20ddec3db7f7e4d55174e366236022100828336b4822125fb56541fb14a8a273876acd339395ec2dad95cf41c1dd2a9ae637835638159024e3082024a30820132a0030201020204124a72fe300d06092a864886f70d01010b0500302e312c302a0603550403132359756269636f2055324620526f6f742043412053657269616c203435373230303633313020170d3134303830313030303030305a180f32303530303930343030303030305a302c312a302806035504030c2159756269636f205532462045452053657269616c203234393431343937323135383059301306072a8648ce3d020106082a8648ce3d030107034200043d8b1bbd2fcbf6086e107471601468484153c1c6d3b4b68a5e855e6e40757ee22bcd8988bf3befd7cdf21cb0bf5d7a150d844afe98103c6c6607d9faae287c02a33b3039302206092b0601040182c40a020415312e332e362e312e342e312e34313438322e312e313013060b2b0601040182e51c020101040403020520300d06092a864886f70d01010b05000382010100a14f1eea0076f6b8476a10a2be72e60d0271bb465b2dfbfc7c1bd12d351989917032631d795d097fa30a26a325634e85721bc2d01a86303f6bc075e5997319e122148b0496eec8d1f4f94cf4110de626c289443d1f0f5bbb239ca13e81d1d5aa9df5af8e36126475bfc23af06283157252762ff68879bcf0ef578d55d67f951b4f32b63c8aea5b0f99c67d7d814a7ff5a6f52df83e894a3a5d9c8b82e7f8bc8daf4c80175ff8972fda79333ec465d806eacc948f1bab22045a95558a48c20226dac003d41fbc9e05ea28a6bb5e10a49de060a0a4f6a2676a34d68c4abe8c61874355b9027e828ca9e064b002d62e8d8cf0744921753d35e3c87c5d5779453e7768617574684461746158c449960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d976341000000000000000000000000000000000000000000408903fd7dfd2c9770e98cae0123b13a2c27828a106349bc6277140e7290b7e9eb7976aa3c04ed347027caf7da3a2fa76304751c02208acfc4e7fc6c7ebbc375c8a5010203262001215820ad7f7992c335b90d882b2802061b97a4fabca7e2ee3e7a51e728b8055e4eb9c7225820e0966ba7005987fece6f0e0e13447aa98cec248e4000a594b01b74c1cb1d40b3")
+	for i := 0; i < b.N; i++ {
+		var v attestationObject
+		if err := Unmarshal(cborData, &v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+
+func BenchmarkMarshalWebAuthn(b *testing.B) {
+	// Data generated from Yubico security key
+	cborData := hexDecode("a363666d74686669646f2d7532666761747453746d74a26373696758483046022100e7ab373cfbd99fcd55fd59b0f6f17fef5b77a20ddec3db7f7e4d55174e366236022100828336b4822125fb56541fb14a8a273876acd339395ec2dad95cf41c1dd2a9ae637835638159024e3082024a30820132a0030201020204124a72fe300d06092a864886f70d01010b0500302e312c302a0603550403132359756269636f2055324620526f6f742043412053657269616c203435373230303633313020170d3134303830313030303030305a180f32303530303930343030303030305a302c312a302806035504030c2159756269636f205532462045452053657269616c203234393431343937323135383059301306072a8648ce3d020106082a8648ce3d030107034200043d8b1bbd2fcbf6086e107471601468484153c1c6d3b4b68a5e855e6e40757ee22bcd8988bf3befd7cdf21cb0bf5d7a150d844afe98103c6c6607d9faae287c02a33b3039302206092b0601040182c40a020415312e332e362e312e342e312e34313438322e312e313013060b2b0601040182e51c020101040403020520300d06092a864886f70d01010b05000382010100a14f1eea0076f6b8476a10a2be72e60d0271bb465b2dfbfc7c1bd12d351989917032631d795d097fa30a26a325634e85721bc2d01a86303f6bc075e5997319e122148b0496eec8d1f4f94cf4110de626c289443d1f0f5bbb239ca13e81d1d5aa9df5af8e36126475bfc23af06283157252762ff68879bcf0ef578d55d67f951b4f32b63c8aea5b0f99c67d7d814a7ff5a6f52df83e894a3a5d9c8b82e7f8bc8daf4c80175ff8972fda79333ec465d806eacc948f1bab22045a95558a48c20226dac003d41fbc9e05ea28a6bb5e10a49de060a0a4f6a2676a34d68c4abe8c61874355b9027e828ca9e064b002d62e8d8cf0744921753d35e3c87c5d5779453e7768617574684461746158c449960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d976341000000000000000000000000000000000000000000408903fd7dfd2c9770e98cae0123b13a2c27828a106349bc6277140e7290b7e9eb7976aa3c04ed347027caf7da3a2fa76304751c02208acfc4e7fc6c7ebbc375c8a5010203262001215820ad7f7992c335b90d882b2802061b97a4fabca7e2ee3e7a51e728b8055e4eb9c7225820e0966ba7005987fece6f0e0e13447aa98cec248e4000a594b01b74c1cb1d40b3")
+	var v attestationObject
+	if err := Unmarshal(cborData, &v); err != nil {
+		b.Fatal("Unmarshal:", err)
+	}
+	for i := 0; i < b.N; i++ {
+		if _, err := Marshal(v); err != nil {
+			b.Fatal("Marshal:", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalCOSEMAC(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.4
+	cborData := hexDecode("d83dd18443a10104a1044c53796d6d65747269633235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7148093101ef6d789200")
+
+	for i := 0; i < b.N; i++ {
+		var v macedCOSE
+		if err := Unmarshal(cborData, &v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalCOSEMACWithTag(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.4
+	cborData := hexDecode("d83dd18443a10104a1044c53796d6d65747269633235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7148093101ef6d789200")
+
+	// Register tag CBOR Web Token (CWT) 61 and COSE_Mac0 17 with macedCOSE type
+	tags := NewTagSet()
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(macedCOSE{}), 61, 17); err != nil {
+		b.Fatal("TagSet.Add:", err)
+	}
+
+	// Create DecMode with tags
+	dm, _ := DecOptions{}.DecModeWithTags(tags)
+
+	for i := 0; i < b.N; i++ {
+		var v macedCOSE
+		if err := dm.Unmarshal(cborData, &v); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
+}
+func BenchmarkMarshalCOSEMAC(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.4
+	cborData := hexDecode("d83dd18443a10104a1044c53796d6d65747269633235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7148093101ef6d789200")
+
+	var v macedCOSE
+	if err := Unmarshal(cborData, &v); err != nil {
+		b.Fatal("Unmarshal():", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		if _, err := Marshal(v); err != nil {
+			b.Fatal("Marshal():", v, err)
+		}
+	}
+}
+
+func BenchmarkMarshalCOSEMACWithTag(b *testing.B) {
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.4
+	cborData := hexDecode("d83dd18443a10104a1044c53796d6d65747269633235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7148093101ef6d789200")
+
+	// Register tag CBOR Web Token (CWT) 61 and COSE_Mac0 17 with macedCOSE type
+	tags := NewTagSet()
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, reflect.TypeOf(macedCOSE{}), 61, 17); err != nil {
+		b.Fatal("TagSet.Add:", err)
+	}
+
+	// Create EncMode with tags.
+	dm, _ := DecOptions{}.DecModeWithTags(tags)
+	em, _ := EncOptions{}.EncModeWithTags(tags)
+
+	var v macedCOSE
+	if err := dm.Unmarshal(cborData, &v); err != nil {
+		b.Fatal("Unmarshal():", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		if _, err := em.Marshal(v); err != nil {
+			b.Fatal("Marshal():", v, err)
+		}
+	}
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/cache.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/cache.go
@@ -1,0 +1,308 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var (
+	decodingStructTypeCache sync.Map // map[reflect.Type]*decodingStructType
+	encodingStructTypeCache sync.Map // map[reflect.Type]*encodingStructType
+	encodeFuncCache         sync.Map // map[reflect.Type]encodeFunc
+	typeInfoCache           sync.Map // map[reflect.Type]*typeInfo
+)
+
+type specialType int
+
+const (
+	specialTypeNone specialType = iota
+	specialTypeUnmarshalerIface
+	specialTypeEmptyIface
+	specialTypeTag
+	specialTypeTime
+)
+
+type typeInfo struct {
+	elemTypeInfo *typeInfo
+	keyTypeInfo  *typeInfo
+	typ          reflect.Type
+	kind         reflect.Kind
+	nonPtrType   reflect.Type
+	nonPtrKind   reflect.Kind
+	spclType     specialType
+}
+
+func newTypeInfo(t reflect.Type) *typeInfo {
+	tInfo := typeInfo{typ: t, kind: t.Kind()}
+
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	k := t.Kind()
+
+	tInfo.nonPtrType = t
+	tInfo.nonPtrKind = k
+
+	if k == reflect.Interface && t.NumMethod() == 0 {
+		tInfo.spclType = specialTypeEmptyIface
+	} else if t == typeTag {
+		tInfo.spclType = specialTypeTag
+	} else if t == typeTime {
+		tInfo.spclType = specialTypeTime
+	} else if reflect.PtrTo(t).Implements(typeUnmarshaler) {
+		tInfo.spclType = specialTypeUnmarshalerIface
+	}
+
+	switch k {
+	case reflect.Array, reflect.Slice:
+		tInfo.elemTypeInfo = getTypeInfo(t.Elem())
+	case reflect.Map:
+		tInfo.keyTypeInfo = getTypeInfo(t.Key())
+		tInfo.elemTypeInfo = getTypeInfo(t.Elem())
+	}
+
+	return &tInfo
+}
+
+type decodingStructType struct {
+	fields  fields
+	err     error
+	toArray bool
+}
+
+func getDecodingStructType(t reflect.Type) *decodingStructType {
+	if v, _ := decodingStructTypeCache.Load(t); v != nil {
+		return v.(*decodingStructType)
+	}
+
+	flds, structOptions := getFields(t)
+
+	toArray := hasToArrayOption(structOptions)
+
+	var err error
+	for i := 0; i < len(flds); i++ {
+		if flds[i].keyAsInt {
+			nameAsInt, numErr := strconv.Atoi(flds[i].name)
+			if numErr != nil {
+				err = errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")")
+				break
+			}
+			flds[i].nameAsInt = int64(nameAsInt)
+		}
+
+		flds[i].typInfo = getTypeInfo(flds[i].typ)
+	}
+
+	structType := &decodingStructType{fields: flds, err: err, toArray: toArray}
+	decodingStructTypeCache.Store(t, structType)
+	return structType
+}
+
+type encodingStructType struct {
+	fields            fields
+	bytewiseFields    fields
+	lengthFirstFields fields
+	err               error
+	toArray           bool
+	omitEmpty         bool
+	hasAnonymousField bool
+}
+
+func (st *encodingStructType) getFields(em *encMode) fields {
+	if em.sort == SortNone {
+		return st.fields
+	}
+	if em.sort == SortLengthFirst {
+		return st.lengthFirstFields
+	}
+	return st.bytewiseFields
+}
+
+type bytewiseFieldSorter struct {
+	fields fields
+}
+
+func (x *bytewiseFieldSorter) Len() int {
+	return len(x.fields)
+}
+
+func (x *bytewiseFieldSorter) Swap(i, j int) {
+	x.fields[i], x.fields[j] = x.fields[j], x.fields[i]
+}
+
+func (x *bytewiseFieldSorter) Less(i, j int) bool {
+	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) <= 0
+}
+
+type lengthFirstFieldSorter struct {
+	fields fields
+}
+
+func (x *lengthFirstFieldSorter) Len() int {
+	return len(x.fields)
+}
+
+func (x *lengthFirstFieldSorter) Swap(i, j int) {
+	x.fields[i], x.fields[j] = x.fields[j], x.fields[i]
+}
+
+func (x *lengthFirstFieldSorter) Less(i, j int) bool {
+	if len(x.fields[i].cborName) != len(x.fields[j].cborName) {
+		return len(x.fields[i].cborName) < len(x.fields[j].cborName)
+	}
+	return bytes.Compare(x.fields[i].cborName, x.fields[j].cborName) <= 0
+}
+
+func getEncodingStructType(t reflect.Type) *encodingStructType {
+	if v, _ := encodingStructTypeCache.Load(t); v != nil {
+		return v.(*encodingStructType)
+	}
+
+	flds, structOptions := getFields(t)
+
+	if hasToArrayOption(structOptions) {
+		return getEncodingStructToArrayType(t, flds)
+	}
+
+	var err error
+	var omitEmpty bool
+	var hasAnonymousField bool
+	var hasKeyAsInt bool
+	var hasKeyAsStr bool
+	e := getEncodeState()
+	for i := 0; i < len(flds); i++ {
+		// Get field's encodeFunc
+		flds[i].ef = getEncodeFunc(flds[i].typ)
+		if flds[i].ef == nil {
+			err = &UnsupportedTypeError{t}
+			break
+		}
+
+		// Encode field name
+		if flds[i].keyAsInt {
+			nameAsInt, numErr := strconv.Atoi(flds[i].name)
+			if numErr != nil {
+				err = errors.New("cbor: failed to parse field name \"" + flds[i].name + "\" to int (" + numErr.Error() + ")")
+				break
+			}
+			flds[i].nameAsInt = int64(nameAsInt)
+			if nameAsInt >= 0 {
+				encodeHead(e, byte(cborTypePositiveInt), uint64(nameAsInt))
+			} else {
+				n := nameAsInt*(-1) - 1
+				encodeHead(e, byte(cborTypeNegativeInt), uint64(n))
+			}
+			flds[i].cborName = make([]byte, e.Len())
+			copy(flds[i].cborName, e.Bytes())
+			e.Reset()
+
+			hasKeyAsInt = true
+		} else {
+			encodeHead(e, byte(cborTypeTextString), uint64(len(flds[i].name)))
+			flds[i].cborName = make([]byte, e.Len()+len(flds[i].name))
+			n := copy(flds[i].cborName, e.Bytes())
+			copy(flds[i].cborName[n:], flds[i].name)
+			e.Reset()
+
+			hasKeyAsStr = true
+		}
+
+		// Check if field is from embedded struct
+		if len(flds[i].idx) > 1 {
+			hasAnonymousField = true
+		}
+
+		// Check if field can be omitted when empty
+		if flds[i].omitEmpty {
+			omitEmpty = true
+		}
+	}
+	putEncodeState(e)
+
+	if err != nil {
+		structType := &encodingStructType{err: err}
+		encodingStructTypeCache.Store(t, structType)
+		return structType
+	}
+
+	// Sort fields by canonical order
+	bytewiseFields := make(fields, len(flds))
+	copy(bytewiseFields, flds)
+	sort.Sort(&bytewiseFieldSorter{bytewiseFields})
+
+	lengthFirstFields := bytewiseFields
+	if hasKeyAsInt && hasKeyAsStr {
+		lengthFirstFields = make(fields, len(flds))
+		copy(lengthFirstFields, flds)
+		sort.Sort(&lengthFirstFieldSorter{lengthFirstFields})
+	}
+
+	structType := &encodingStructType{
+		fields:            flds,
+		bytewiseFields:    bytewiseFields,
+		lengthFirstFields: lengthFirstFields,
+		omitEmpty:         omitEmpty,
+		hasAnonymousField: hasAnonymousField,
+	}
+	encodingStructTypeCache.Store(t, structType)
+	return structType
+}
+
+func getEncodingStructToArrayType(t reflect.Type, flds fields) *encodingStructType {
+	var hasAnonymousField bool
+	for i := 0; i < len(flds); i++ {
+		// Get field's encodeFunc
+		flds[i].ef = getEncodeFunc(flds[i].typ)
+		if flds[i].ef == nil {
+			structType := &encodingStructType{err: &UnsupportedTypeError{t}}
+			encodingStructTypeCache.Store(t, structType)
+			return structType
+		}
+
+		// Check if field is from embedded struct
+		if len(flds[i].idx) > 1 {
+			hasAnonymousField = true
+		}
+	}
+
+	structType := &encodingStructType{
+		fields:            flds,
+		toArray:           true,
+		hasAnonymousField: hasAnonymousField,
+	}
+	encodingStructTypeCache.Store(t, structType)
+	return structType
+}
+
+func getEncodeFunc(t reflect.Type) encodeFunc {
+	if v, _ := encodeFuncCache.Load(t); v != nil {
+		return v.(encodeFunc)
+	}
+	f := getEncodeFuncInternal(t)
+	encodeFuncCache.Store(t, f)
+	return f
+}
+
+func getTypeInfo(t reflect.Type) *typeInfo {
+	if v, _ := typeInfoCache.Load(t); v != nil {
+		return v.(*typeInfo)
+	}
+	tInfo := newTypeInfo(t)
+	typeInfoCache.Store(t, tInfo)
+	return tInfo
+}
+
+func hasToArrayOption(tag string) bool {
+	s := ",toarray"
+	idx := strings.Index(tag, s)
+	return idx >= 0 && (len(tag) == idx+len(s) || tag[idx+len(s)] == ',')
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/changeset.txt
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/changeset.txt
@@ -1,0 +1,2 @@
+master
+e84e0b642d33523306d5b2414eeffe1eb9c41563

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/decode.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/decode.go
@@ -1,0 +1,1516 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"encoding"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/x448/float16"
+)
+
+// Unmarshal parses the CBOR-encoded data and stores the result in the value
+// pointed to by v using the default decoding options.  If v is nil or not a
+// pointer, Unmarshal returns an error.
+//
+// Unmarshal uses the inverse of the encodings that Marshal uses, allocating
+// maps, slices, and pointers as necessary, with the following additional rules:
+//
+// To unmarshal CBOR into a pointer, Unmarshal first handles the case of the
+// CBOR being the CBOR literal null.  In that case, Unmarshal sets the pointer
+// to nil.  Otherwise, Unmarshal unmarshals the CBOR into the value pointed at
+// by the pointer.  If the pointer is nil, Unmarshal allocates a new value for
+// it to point to.
+//
+// To unmarshal CBOR into an interface value, Unmarshal stores one of these in
+// the interface value:
+//
+//     bool, for CBOR booleans
+//     uint64, for CBOR positive integers
+//     int64, for CBOR negative integers
+//     float64, for CBOR floating points
+//     []byte, for CBOR byte strings
+//     string, for CBOR text strings
+//     []interface{}, for CBOR arrays
+//     map[interface{}]interface{}, for CBOR maps
+//     nil, for CBOR null
+//
+// To unmarshal a CBOR array into a slice, Unmarshal allocates a new slice only
+// if the CBOR array is empty or slice capacity is less than CBOR array length.
+// Otherwise Unmarshal reuses the existing slice, overwriting existing elements.
+// Unmarshal sets the slice length to CBOR array length.
+//
+// To ummarshal a CBOR array into a Go array, Unmarshal decodes CBOR array
+// elements into corresponding Go array elements.  If the Go array is smaller
+// than the CBOR array, the additional CBOR array elements are discarded.  If
+// the CBOR array is smaller than the Go array, the additional Go array elements
+// are set to zero values.
+//
+// To unmarshal a CBOR map into a map, Unmarshal allocates a new map only if the
+// map is nil.  Otherwise Unmarshal reuses the existing map, keeping existing
+// entries.  Unmarshal stores key-value pairs from the CBOR map into Go map.
+//
+// To unmarshal a CBOR map into a struct, Unmarshal matches CBOR map keys to the
+// keys in the following priority:
+//
+//     1. "cbor" key in struct field tag,
+//     2. "json" key in struct field tag,
+//     3. struct field name.
+//
+// Unmarshal prefers an exact match but also accepts a case-insensitive match.
+// Map keys which don't have a corresponding struct field are ignored.
+//
+// To unmarshal a CBOR text string into a time.Time value, Unmarshal parses text
+// string formatted in RFC3339.  To unmarshal a CBOR integer/float into a
+// time.Time value, Unmarshal creates an unix time with integer/float as seconds
+// and fractional seconds since January 1, 1970 UTC.
+//
+// To unmarshal CBOR into a value implementing the Unmarshaler interface,
+// Unmarshal calls that value's UnmarshalCBOR method.
+//
+// Unmarshal decodes a CBOR byte string into a value implementing
+// encoding.BinaryUnmarshaler.
+//
+// If a CBOR value is not appropriate for a given Go type, or if a CBOR number
+// overflows the Go type, Unmarshal skips that field and completes the
+// unmarshalling as best as it can.  If no more serious errors are encountered,
+// unmarshal returns an UnmarshalTypeError describing the earliest such error.
+// In any case, it's not guaranteed that all the remaining fields following the
+// problematic one will be unmarshaled into the target object.
+//
+// The CBOR null value unmarshals into a slice/map/pointer/interface by setting
+// that Go value to nil.  Because null is often used to mean "not present",
+// unmarshalling a CBOR null into any other Go type has no effect on the value
+// produces no error.
+//
+// Unmarshal ignores CBOR tag data and parses tagged data following CBOR tag.
+func Unmarshal(data []byte, v interface{}) error {
+	return defaultDecMode.Unmarshal(data, v)
+}
+
+// Unmarshaler is the interface implemented by types that can unmarshal a CBOR
+// representation of themselves.  The input can be assumed to be a valid encoding
+// of a CBOR value. UnmarshalCBOR must copy the CBOR data if it wishes to retain
+// the data after returning.
+type Unmarshaler interface {
+	UnmarshalCBOR([]byte) error
+}
+
+// InvalidUnmarshalError describes an invalid argument passed to Unmarshal.
+type InvalidUnmarshalError struct {
+	Type reflect.Type
+}
+
+func (e *InvalidUnmarshalError) Error() string {
+	if e.Type == nil {
+		return "cbor: Unmarshal(nil)"
+	}
+	if e.Type.Kind() != reflect.Ptr {
+		return "cbor: Unmarshal(non-pointer " + e.Type.String() + ")"
+	}
+	return "cbor: Unmarshal(nil " + e.Type.String() + ")"
+}
+
+// UnmarshalTypeError describes a CBOR value that was not appropriate for a Go type.
+type UnmarshalTypeError struct {
+	Value  string       // description of CBOR value
+	Type   reflect.Type // type of Go value it could not be assigned to
+	Struct string       // struct type containing the field
+	Field  string       // name of the field holding the Go value
+	errMsg string       // additional error message (optional)
+}
+
+func (e *UnmarshalTypeError) Error() string {
+	var s string
+	if e.Struct != "" || e.Field != "" {
+		s = "cbor: cannot unmarshal " + e.Value + " into Go struct field " + e.Struct + "." + e.Field + " of type " + e.Type.String()
+	} else {
+		s = "cbor: cannot unmarshal " + e.Value + " into Go value of type " + e.Type.String()
+	}
+	if e.errMsg != "" {
+		s += " (" + e.errMsg + ")"
+	}
+	return s
+}
+
+// DupMapKeyError describes detected duplicate map key in CBOR map.
+type DupMapKeyError struct {
+	Key   interface{}
+	Index int
+}
+
+func (e *DupMapKeyError) Error() string {
+	return fmt.Sprintf("cbor: found duplicate map key \"%v\" at map element index %d", e.Key, e.Index)
+}
+
+// DupMapKeyMode specifies how to enforce duplicate map key.
+type DupMapKeyMode int
+
+const (
+	// DupMapKeyQuiet doesn't enforce duplicate map key. Decoder quietly (no error)
+	// uses faster of "keep first" or "keep last" depending on Go data type and other factors.
+	DupMapKeyQuiet DupMapKeyMode = iota
+
+	// DupMapKeyEnforcedAPF enforces detection and rejection of duplicate map keys.
+	// APF means "Allow Partial Fill" and the destination map or struct can be partially filled.
+	// If a duplicate map key is detected, DupMapKeyError is returned without further decoding
+	// of the map. It's the caller's responsibility to respond to DupMapKeyError by
+	// discarding the partially filled result if their protocol requires it.
+	// WARNING: using DupMapKeyEnforcedAPF will decrease performance and increase memory use.
+	DupMapKeyEnforcedAPF
+
+	maxDupMapKeyMode
+)
+
+func (dmkm DupMapKeyMode) valid() bool {
+	return dmkm < maxDupMapKeyMode
+}
+
+// DecOptions specifies decoding options.
+type DecOptions struct {
+	// DupMapKey specifies whether to enforce duplicate map key.
+	DupMapKey DupMapKeyMode
+
+	// TimeTag specifies whether to check validity of time.Time (e.g. valid tag number and tag content type).
+	// For now, valid tag number means 0 or 1 as specified in RFC 7049 if the Go type is time.Time.
+	TimeTag DecTagMode
+}
+
+// DecMode returns DecMode with immutable options and no tags (safe for concurrency).
+func (opts DecOptions) DecMode() (DecMode, error) {
+	return opts.decMode()
+}
+
+// DecModeWithTags returns DecMode with options and tags that are both immutable (safe for concurrency).
+func (opts DecOptions) DecModeWithTags(tags TagSet) (DecMode, error) {
+	if tags == nil {
+		return nil, errors.New("cbor: cannot create DecMode with nil value as TagSet")
+	}
+
+	dm, err := opts.decMode()
+	if err != nil {
+		return nil, err
+	}
+
+	// Copy tags
+	ts := tagSet(make(map[reflect.Type]*tagItem))
+	syncTags := tags.(*syncTagSet)
+	syncTags.RLock()
+	for contentType, tag := range syncTags.t {
+		if tag.opts.DecTag != DecTagIgnored {
+			ts[contentType] = tag
+		}
+	}
+	syncTags.RUnlock()
+
+	if len(ts) > 0 {
+		dm.tags = ts
+	}
+
+	return dm, nil
+}
+
+// DecModeWithSharedTags returns DecMode with immutable options and mutable shared tags (safe for concurrency).
+func (opts DecOptions) DecModeWithSharedTags(tags TagSet) (DecMode, error) {
+	if tags == nil {
+		return nil, errors.New("cbor: cannot create DecMode with nil value as TagSet")
+	}
+	dm, err := opts.decMode()
+	if err != nil {
+		return nil, err
+	}
+	dm.tags = tags
+	return dm, nil
+}
+
+func (opts DecOptions) decMode() (*decMode, error) {
+	if !opts.DupMapKey.valid() {
+		return nil, errors.New("cbor: invalid DupMapKey " + strconv.Itoa(int(opts.DupMapKey)))
+	}
+	if !opts.TimeTag.valid() {
+		return nil, errors.New("cbor: invalid TimeTag " + strconv.Itoa(int(opts.TimeTag)))
+	}
+	dm := decMode{dupMapKey: opts.DupMapKey, timeTag: opts.TimeTag}
+	return &dm, nil
+}
+
+// DecMode is the main interface for CBOR decoding.
+type DecMode interface {
+	Unmarshal(data []byte, v interface{}) error
+	NewDecoder(r io.Reader) *Decoder
+	DecOptions() DecOptions
+}
+
+type decMode struct {
+	tags      tagProvider
+	dupMapKey DupMapKeyMode
+	timeTag   DecTagMode
+}
+
+var defaultDecMode = &decMode{}
+
+// DecOptions returns user specified options used to create this DecMode.
+func (dm *decMode) DecOptions() DecOptions {
+	return DecOptions{DupMapKey: dm.dupMapKey, TimeTag: dm.timeTag}
+}
+
+// Unmarshal parses the CBOR-encoded data and stores the result in the value
+// pointed to by v using dm DecMode.  If v is nil or not a pointer, Unmarshal
+// returns an error.
+//
+// See the documentation for Unmarshal for details.
+func (dm *decMode) Unmarshal(data []byte, v interface{}) error {
+	d := decodeState{data: data, dm: dm}
+	return d.value(v)
+}
+
+// NewDecoder returns a new decoder that reads from r using dm DecMode.
+func (dm *decMode) NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{r: r, d: decodeState{dm: dm}}
+}
+
+type decodeState struct {
+	data []byte
+	off  int // next read offset in data
+	dm   *decMode
+}
+
+func (d *decodeState) value(v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return &InvalidUnmarshalError{reflect.TypeOf(v)}
+	}
+
+	if _, err := valid(d.data[d.off:]); err != nil {
+		return err
+	}
+
+	rv = rv.Elem()
+
+	if rv.Kind() == reflect.Interface && rv.NumMethod() == 0 {
+		// Fast path to decode to empty interface without retrieving typeInfo.
+		iv, err := d.parse()
+		if iv != nil {
+			rv.Set(reflect.ValueOf(iv))
+		}
+		return err
+	}
+
+	return d.parseToValue(rv, getTypeInfo(rv.Type()))
+}
+
+type cborType uint8
+
+const (
+	cborTypePositiveInt cborType = 0x00
+	cborTypeNegativeInt cborType = 0x20
+	cborTypeByteString  cborType = 0x40
+	cborTypeTextString  cborType = 0x60
+	cborTypeArray       cborType = 0x80
+	cborTypeMap         cborType = 0xa0
+	cborTypeTag         cborType = 0xc0
+	cborTypePrimitives  cborType = 0xe0
+)
+
+func (t cborType) String() string {
+	switch t {
+	case cborTypePositiveInt:
+		return "positive integer"
+	case cborTypeNegativeInt:
+		return "negative integer"
+	case cborTypeByteString:
+		return "byte string"
+	case cborTypeTextString:
+		return "UTF-8 text string"
+	case cborTypeArray:
+		return "array"
+	case cborTypeMap:
+		return "map"
+	case cborTypeTag:
+		return "tag"
+	case cborTypePrimitives:
+		return "primitives"
+	default:
+		return "Invalid type " + strconv.Itoa(int(t))
+	}
+}
+
+// parseToValue assumes data is well-formed, and does not perform bounds checking.
+// This function is complicated because it's the main function that decodes CBOR data to reflect.Value.
+func (d *decodeState) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
+	// Create new value for the pointer v to point to if CBOR value is not nil/undefined.
+	if !d.nextCBORNil() {
+		for v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				if !v.CanSet() {
+					d.skip()
+					return errors.New("cbor: cannot set new value for " + v.Type().String())
+				}
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+	}
+
+	if tInfo.spclType != specialTypeNone {
+		switch tInfo.spclType {
+		case specialTypeEmptyIface:
+			iv, err := d.parse()
+			if iv != nil {
+				v.Set(reflect.ValueOf(iv))
+			}
+			return err
+		case specialTypeTag:
+			return d.parseToTag(v)
+		case specialTypeTime:
+			return d.parseToTime(v)
+		case specialTypeUnmarshalerIface:
+			return d.parseToUnmarshaler(v)
+		}
+	}
+
+	// Check registered tag number
+	if tagItem := d.getRegisteredTagItem(tInfo.nonPtrType); tagItem != nil {
+		t := d.nextCBORType()
+		if t != cborTypeTag {
+			if tagItem.opts.DecTag == DecTagRequired {
+				d.skip() // Required tag number is absent, skip entire tag
+				return &UnmarshalTypeError{Value: t.String(), Type: tInfo.typ, errMsg: "expect CBOR tag value"}
+			}
+		} else if err := d.validRegisteredTagNums(tInfo.nonPtrType, tagItem.num); err != nil {
+			d.skip() // Skip tag content
+			return err
+		}
+	}
+
+	t := d.nextCBORType()
+
+	// Skip tag number(s) here to avoid recursion
+	if t == cborTypeTag {
+		d.getHead()
+		t = d.nextCBORType()
+		for t == cborTypeTag {
+			d.getHead()
+			t = d.nextCBORType()
+		}
+	}
+
+	switch t {
+	case cborTypePositiveInt:
+		_, _, val := d.getHead()
+		return fillPositiveInt(t, val, v)
+	case cborTypeNegativeInt:
+		_, _, val := d.getHead()
+		if val > math.MaxInt64 {
+			return &UnmarshalTypeError{
+				Value:  t.String(),
+				Type:   tInfo.nonPtrType,
+				errMsg: "-1-" + strconv.FormatUint(val, 10) + " overflows Go's int64",
+			}
+		}
+		nValue := int64(-1) ^ int64(val)
+		return fillNegativeInt(t, nValue, v)
+	case cborTypeByteString:
+		b := d.parseByteString()
+		return fillByteString(t, b, v)
+	case cborTypeTextString:
+		b, err := d.parseTextString()
+		if err != nil {
+			return err
+		}
+		return fillTextString(t, b, v)
+	case cborTypePrimitives:
+		_, ai, val := d.getHead()
+		if ai < 20 || ai == 24 {
+			return fillPositiveInt(t, val, v)
+		}
+		switch ai {
+		case 20, 21:
+			return fillBool(t, ai == 21, v)
+		case 22, 23:
+			return fillNil(t, v)
+		case 25:
+			f := float64(float16.Frombits(uint16(val)).Float32())
+			return fillFloat(t, f, v)
+		case 26:
+			f := float64(math.Float32frombits(uint32(val)))
+			return fillFloat(t, f, v)
+		case 27:
+			f := math.Float64frombits(val)
+			return fillFloat(t, f, v)
+		}
+	case cborTypeArray:
+		if tInfo.nonPtrKind == reflect.Slice {
+			return d.parseArrayToSlice(v, tInfo)
+		} else if tInfo.nonPtrKind == reflect.Array {
+			return d.parseArrayToArray(v, tInfo)
+		} else if tInfo.nonPtrKind == reflect.Struct {
+			return d.parseArrayToStruct(v, tInfo)
+		}
+		d.skip()
+		return &UnmarshalTypeError{Value: t.String(), Type: tInfo.nonPtrType}
+	case cborTypeMap:
+		if tInfo.nonPtrKind == reflect.Struct {
+			return d.parseMapToStruct(v, tInfo)
+		} else if tInfo.nonPtrKind == reflect.Map {
+			return d.parseMapToMap(v, tInfo)
+		}
+		d.skip()
+		return &UnmarshalTypeError{Value: t.String(), Type: tInfo.nonPtrType}
+	}
+	return nil
+}
+
+func (d *decodeState) parseToTag(v reflect.Value) error {
+	t := d.nextCBORType()
+	if t != cborTypeTag {
+		d.skip()
+		return &UnmarshalTypeError{Value: t.String(), Type: typeTag}
+	}
+
+	// Unmarshal tag number
+	_, _, num := d.getHead()
+
+	// Unmarshal tag content
+	content, err := d.parse()
+	if err != nil {
+		return err
+	}
+
+	v.Set(reflect.ValueOf(Tag{num, content}))
+	return nil
+}
+
+func (d *decodeState) parseToTime(v reflect.Value) error {
+	t := d.nextCBORType()
+
+	// Verify that tag number or absent of tag number is acceptable to specified timeTag.
+	if t == cborTypeTag {
+		if d.dm.timeTag == DecTagIgnored {
+			// Skip tag number
+			d.getHead()
+			t = d.nextCBORType()
+			for t == cborTypeTag {
+				d.getHead()
+				t = d.nextCBORType()
+			}
+		} else {
+			// Read tag number
+			_, _, tagNum := d.getHead()
+
+			// Verify tag number (0 or 1) is followed by appropriate tag content type.
+			t = d.nextCBORType()
+			switch tagNum {
+			case 0:
+				// Tag content (date/time text string in RFC 3339 format) must be string type.
+				if t != cborTypeTextString {
+					d.skip()
+					return errors.New("cbor: tag number 0 must be followed by text string, got " + t.String())
+				}
+			case 1:
+				// Tag content (epoch date/time) must be uint, int, or float type.
+				if t != cborTypePositiveInt && t != cborTypeNegativeInt && (d.data[d.off] < 0xf9 || d.data[d.off] > 0xfb) {
+					d.skip()
+					return errors.New("cbor: tag number 1 must be followed by integer or floating-point number, got " + t.String())
+				}
+			default:
+				d.skip()
+				return errors.New("cbor: wrong tag number for time.Time, got " + strconv.Itoa(int(tagNum)) + ", expect 0 or 1")
+			}
+		}
+	} else {
+		if d.dm.timeTag == DecTagRequired {
+			d.skip()
+			return &UnmarshalTypeError{Value: t.String(), Type: typeTime, errMsg: "expect CBOR tag value"}
+		}
+	}
+
+	switch t {
+	case cborTypePositiveInt:
+		_, _, val := d.getHead()
+		tm := time.Unix(int64(val), 0)
+		v.Set(reflect.ValueOf(tm))
+		return nil
+	case cborTypeNegativeInt:
+		_, _, val := d.getHead()
+		if val > math.MaxInt64 {
+			return &UnmarshalTypeError{
+				Value:  t.String(),
+				Type:   typeTime,
+				errMsg: "-1-" + strconv.FormatUint(val, 10) + " overflows Go's int64",
+			}
+		}
+		nValue := int64(-1) ^ int64(val)
+		tm := time.Unix(nValue, 0)
+		v.Set(reflect.ValueOf(tm))
+		return nil
+	case cborTypeTextString:
+		b, err := d.parseTextString()
+		if err != nil {
+			return err
+		}
+		tm, err := time.Parse(time.RFC3339, string(b))
+		if err != nil {
+			return errors.New("cbor: cannot set " + string(b) + " for time.Time: " + err.Error())
+		}
+		v.Set(reflect.ValueOf(tm))
+		return nil
+	case cborTypePrimitives:
+		_, ai, val := d.getHead()
+		var f float64
+		switch ai {
+		case 22, 23:
+			v.Set(reflect.ValueOf(time.Time{}))
+			return nil
+		case 25:
+			f = float64(float16.Frombits(uint16(val)).Float32())
+		case 26:
+			f = float64(math.Float32frombits(uint32(val)))
+		case 27:
+			f = math.Float64frombits(val)
+		default:
+			return &UnmarshalTypeError{Value: t.String(), Type: typeTime}
+		}
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			v.Set(reflect.ValueOf(time.Time{}))
+			return nil
+		}
+		f1, f2 := math.Modf(f)
+		tm := time.Unix(int64(f1), int64(f2*1e9))
+		v.Set(reflect.ValueOf(tm))
+		return nil
+	}
+	d.skip()
+	return &UnmarshalTypeError{Value: t.String(), Type: typeTime}
+}
+
+// parseToUnmarshaler assumes data is well-formed, and does not perform bounds checking.
+func (d *decodeState) parseToUnmarshaler(v reflect.Value) error {
+	if d.nextCBORNil() && v.Kind() == reflect.Ptr && v.IsNil() {
+		d.skip()
+		return nil
+	}
+
+	if v.Kind() != reflect.Ptr && v.CanAddr() {
+		v = v.Addr()
+	}
+	if u, ok := v.Interface().(Unmarshaler); ok {
+		start := d.off
+		d.skip()
+		return u.UnmarshalCBOR(d.data[start:d.off])
+	}
+	d.skip()
+	return errors.New("cbor: failed to assert " + v.Type().String() + " as cbor.Unmarshaler")
+}
+
+// parse assumes data is well-formed, and does not perform bounds checking.
+func (d *decodeState) parse() (interface{}, error) {
+	t := d.nextCBORType()
+	switch t {
+	case cborTypePositiveInt:
+		_, _, val := d.getHead()
+		return val, nil
+	case cborTypeNegativeInt:
+		_, _, val := d.getHead()
+		if val > math.MaxInt64 {
+			return nil, &UnmarshalTypeError{
+				Value:  t.String(),
+				Type:   reflect.TypeOf([]interface{}(nil)).Elem(),
+				errMsg: "-1-" + strconv.FormatUint(val, 10) + " overflows Go's int64",
+			}
+		}
+		nValue := int64(-1) ^ int64(val)
+		return nValue, nil
+	case cborTypeByteString:
+		return d.parseByteString(), nil
+	case cborTypeTextString:
+		b, err := d.parseTextString()
+		if err != nil {
+			return nil, err
+		}
+		return string(b), nil
+	case cborTypeTag:
+		_, _, tagNum := d.getHead()
+		nt := d.nextCBORType()
+		content, err := d.parse()
+		if err != nil {
+			return nil, err
+		}
+		switch tagNum {
+		case 0:
+			// Tag content should be date/time text string in RFC 3339 format.
+			s, ok := content.(string)
+			if !ok {
+				return nil, errors.New("cbor: tag number 0 must be followed by text string, got " + nt.String())
+			}
+			tm, err := time.Parse(time.RFC3339, s)
+			if err != nil {
+				return nil, errors.New("cbor: cannot set " + s + " for time.Time: " + err.Error())
+			}
+			return tm, nil
+		case 1:
+			// Tag content should be epoch date/time.
+			switch content := content.(type) {
+			case uint64:
+				return time.Unix(int64(content), 0), nil
+			case int64:
+				return time.Unix(content, 0), nil
+			case float64:
+				f1, f2 := math.Modf(content)
+				return time.Unix(int64(f1), int64(f2*1e9)), nil
+			default:
+				return nil, errors.New("cbor: tag number 1 must be followed by integer or floating-point number, got " + nt.String())
+			}
+		}
+		return Tag{tagNum, content}, nil
+	case cborTypePrimitives:
+		_, ai, val := d.getHead()
+		if ai < 20 || ai == 24 {
+			return val, nil
+		}
+		switch ai {
+		case 20, 21:
+			return (ai == 21), nil
+		case 22, 23:
+			return nil, nil
+		case 25:
+			f := float64(float16.Frombits(uint16(val)).Float32())
+			return f, nil
+		case 26:
+			f := float64(math.Float32frombits(uint32(val)))
+			return f, nil
+		case 27:
+			f := math.Float64frombits(val)
+			return f, nil
+		}
+	case cborTypeArray:
+		return d.parseArray()
+	case cborTypeMap:
+		return d.parseMap()
+	}
+	return nil, nil
+}
+
+// parseByteString parses CBOR encoded byte string.  It returns a byte slice
+// pointing to a copy of parsed data.
+func (d *decodeState) parseByteString() []byte {
+	_, ai, val := d.getHead()
+	if ai != 31 {
+		b := make([]byte, int(val))
+		copy(b, d.data[d.off:d.off+int(val)])
+		d.off += int(val)
+		return b
+	}
+	// Process indefinite length string chunks.
+	b := []byte{}
+	for !d.foundBreak() {
+		_, _, val = d.getHead()
+		b = append(b, d.data[d.off:d.off+int(val)]...)
+		d.off += int(val)
+	}
+	return b
+}
+
+// parseTextString parses CBOR encoded text string.  It does not return a string
+// to prevent creating an extra copy of string.  Caller should wrap returned
+// byte slice as string when needed.
+//
+// parseStruct() uses parseTextString() to improve memory and performance,
+// compared with using parse(reflect.Value).  parse(reflect.Value) sets
+// reflect.Value with parsed string, while parseTextString() returns zero-copy []byte.
+func (d *decodeState) parseTextString() ([]byte, error) {
+	_, ai, val := d.getHead()
+	if ai != 31 {
+		b := d.data[d.off : d.off+int(val)]
+		d.off += int(val)
+		if !utf8.Valid(b) {
+			return nil, &SemanticError{"cbor: invalid UTF-8 string"}
+		}
+		return b, nil
+	}
+	// Process indefinite length string chunks.
+	b := []byte{}
+	var err error
+	for !d.foundBreak() {
+		_, _, val = d.getHead()
+		x := d.data[d.off : d.off+int(val)]
+		d.off += int(val)
+		if !utf8.Valid(x) {
+			err = &SemanticError{"cbor: invalid UTF-8 string"}
+			break
+		}
+		b = append(b, x...)
+	}
+	if err != nil {
+		for !d.foundBreak() {
+			d.skip() // Skip remaining chunk on error
+		}
+		return nil, err
+	}
+	return b, nil
+}
+
+func (d *decodeState) parseArray() ([]interface{}, error) {
+	_, ai, val := d.getHead()
+	hasSize := (ai != 31)
+	count := int(val)
+	if !hasSize {
+		count = d.numOfItemsUntilBreak() // peek ahead to get array size to preallocate slice for better performance
+	}
+	v := make([]interface{}, count)
+	var e interface{}
+	var err, lastErr error
+	for i := 0; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+		if e, lastErr = d.parse(); lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+			continue
+		}
+		v[i] = e
+	}
+	return v, err
+}
+
+func (d *decodeState) parseArrayToSlice(v reflect.Value, tInfo *typeInfo) error {
+	_, ai, val := d.getHead()
+	hasSize := (ai != 31)
+	count := int(val)
+	if !hasSize {
+		count = d.numOfItemsUntilBreak() // peek ahead to get array size to preallocate slice for better performance
+	}
+	if count == 0 {
+		v.Set(reflect.MakeSlice(tInfo.nonPtrType, 0, 0))
+	}
+	if v.IsNil() || v.Cap() < count {
+		v.Set(reflect.MakeSlice(tInfo.nonPtrType, count, count))
+	}
+	v.SetLen(count)
+	var err error
+	for i := 0; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+		if lastErr := d.parseToValue(v.Index(i), tInfo.elemTypeInfo); lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+		}
+	}
+	return err
+}
+
+func (d *decodeState) parseArrayToArray(v reflect.Value, tInfo *typeInfo) error {
+	_, ai, val := d.getHead()
+	hasSize := (ai != 31)
+	count := int(val)
+	i := 0
+	var err error
+	for ; i < v.Len() && ((hasSize && i < count) || (!hasSize && !d.foundBreak())); i++ {
+		if lastErr := d.parseToValue(v.Index(i), tInfo.elemTypeInfo); lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+		}
+	}
+	// Set remaining Go array elements to zero values.
+	if i < v.Len() {
+		zeroV := reflect.Zero(tInfo.elemTypeInfo.typ)
+		for ; i < v.Len(); i++ {
+			v.Index(i).Set(zeroV)
+		}
+	}
+	// Skip remaining CBOR array elements
+	for ; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+		d.skip()
+	}
+	return err
+}
+
+func (d *decodeState) parseMap() (map[interface{}]interface{}, error) {
+	_, ai, val := d.getHead()
+	hasSize := (ai != 31)
+	count := int(val)
+	m := make(map[interface{}]interface{})
+	var k, e interface{}
+	var err, lastErr error
+	keyCount := 0
+	for i := 0; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+		// Parse CBOR map key.
+		if k, lastErr = d.parse(); lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+			d.skip()
+			continue
+		}
+
+		// Detect if CBOR map key can be used as Go map key.
+		kkind := reflect.ValueOf(k).Kind()
+		if tag, ok := k.(Tag); ok {
+			kkind = tag.contentKind()
+		}
+		if !isHashableKind(kkind) {
+			if err == nil {
+				err = errors.New("cbor: invalid map key type: " + kkind.String())
+			}
+			d.skip()
+			continue
+		}
+
+		// Parse CBOR map value.
+		if e, lastErr = d.parse(); lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+			continue
+		}
+
+		// Add key-value pair to Go map.
+		m[k] = e
+
+		// Detect duplicate map key.
+		if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+			newKeyCount := len(m)
+			if newKeyCount == keyCount {
+				m[k] = nil
+				err = &DupMapKeyError{k, i}
+				i++
+				// skip the rest of the map
+				for ; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+					d.skip() // Skip map key
+					d.skip() // Skip map value
+				}
+				return m, err
+			}
+			keyCount = newKeyCount
+		}
+	}
+	return m, err
+}
+
+func (d *decodeState) parseMapToMap(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
+	_, ai, val := d.getHead()
+	hasSize := (ai != 31)
+	count := int(val)
+	if v.IsNil() {
+		mapsize := count
+		if !hasSize {
+			mapsize = 0
+		}
+		v.Set(reflect.MakeMapWithSize(tInfo.nonPtrType, mapsize))
+	}
+	keyType, eleType := tInfo.keyTypeInfo.typ, tInfo.elemTypeInfo.typ
+	reuseKey, reuseEle := isImmutableKind(tInfo.keyTypeInfo.kind), isImmutableKind(tInfo.elemTypeInfo.kind)
+	var keyValue, eleValue, zeroKeyValue, zeroEleValue reflect.Value
+	keyIsInterfaceType := keyType == typeIntf // If key type is interface{}, need to check if key value is hashable.
+	var err, lastErr error
+	keyCount := v.Len()
+	var existingKeys map[interface{}]bool // Store existing map keys, used for detecting duplicate map key.
+	if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+		existingKeys = make(map[interface{}]bool, keyCount)
+		if keyCount > 0 {
+			vKeys := v.MapKeys()
+			for i := 0; i < len(vKeys); i++ {
+				existingKeys[vKeys[i].Interface()] = true
+			}
+		}
+	}
+	for i := 0; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+		// Parse CBOR map key.
+		if !keyValue.IsValid() {
+			keyValue = reflect.New(keyType).Elem()
+		} else if !reuseKey {
+			if !zeroKeyValue.IsValid() {
+				zeroKeyValue = reflect.Zero(keyType)
+			}
+			keyValue.Set(zeroKeyValue)
+		}
+		if lastErr = d.parseToValue(keyValue, tInfo.keyTypeInfo); lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+			d.skip()
+			continue
+		}
+
+		// Detect if CBOR map key can be used as Go map key.
+		if keyIsInterfaceType {
+			kkind := keyValue.Elem().Kind()
+			if keyValue.Elem().IsValid() {
+				if tag, ok := keyValue.Elem().Interface().(Tag); ok {
+					kkind = tag.contentKind()
+				}
+			}
+			if !isHashableKind(kkind) {
+				if err == nil {
+					err = errors.New("cbor: invalid map key type: " + kkind.String())
+				}
+				d.skip()
+				continue
+			}
+		}
+
+		// Parse CBOR map value.
+		if !eleValue.IsValid() {
+			eleValue = reflect.New(eleType).Elem()
+		} else if !reuseEle {
+			if !zeroEleValue.IsValid() {
+				zeroEleValue = reflect.Zero(eleType)
+			}
+			eleValue.Set(zeroEleValue)
+		}
+		if lastErr := d.parseToValue(eleValue, tInfo.elemTypeInfo); lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+			continue
+		}
+
+		// Add key-value pair to Go map.
+		v.SetMapIndex(keyValue, eleValue)
+
+		// Detect duplicate map key.
+		if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+			newKeyCount := v.Len()
+			if newKeyCount == keyCount {
+				kvi := keyValue.Interface()
+				if !existingKeys[kvi] {
+					v.SetMapIndex(keyValue, reflect.New(eleType).Elem())
+					err = &DupMapKeyError{kvi, i}
+					i++
+					// skip the rest of the map
+					for ; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+						d.skip() // skip map key
+						d.skip() // skip map value
+					}
+					return err
+				}
+				delete(existingKeys, kvi)
+			}
+			keyCount = newKeyCount
+		}
+	}
+	return err
+}
+
+func (d *decodeState) parseArrayToStruct(v reflect.Value, tInfo *typeInfo) error {
+	structType := getDecodingStructType(tInfo.nonPtrType)
+	if structType.err != nil {
+		return structType.err
+	}
+
+	if !structType.toArray {
+		t := d.nextCBORType()
+		d.skip()
+		return &UnmarshalTypeError{
+			Value:  t.String(),
+			Type:   tInfo.nonPtrType,
+			errMsg: "cannot decode CBOR array to struct without toarray option",
+		}
+	}
+
+	start := d.off
+	t, ai, val := d.getHead()
+	hasSize := (ai != 31)
+	count := int(val)
+	if !hasSize {
+		count = d.numOfItemsUntilBreak() // peek ahead to get array size
+	}
+	if count != len(structType.fields) {
+		d.off = start
+		d.skip()
+		return &UnmarshalTypeError{
+			Value:  t.String(),
+			Type:   tInfo.typ,
+			errMsg: "cannot decode CBOR array to struct with different number of elements",
+		}
+	}
+	var err error
+	for i := 0; (hasSize && i < count) || (!hasSize && !d.foundBreak()); i++ {
+		f := structType.fields[i]
+		fv, lastErr := fieldByIndex(v, f.idx)
+		if lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+			d.skip()
+			continue
+		}
+		if lastErr := d.parseToValue(fv, f.typInfo); lastErr != nil {
+			if err == nil {
+				if typeError, ok := lastErr.(*UnmarshalTypeError); ok {
+					typeError.Struct = tInfo.typ.String()
+					typeError.Field = f.name
+					err = typeError
+				} else {
+					err = lastErr
+				}
+			}
+		}
+	}
+	return err
+}
+
+// parseMapToStruct needs to be fast so gocyclo can be ignored for now.
+func (d *decodeState) parseMapToStruct(v reflect.Value, tInfo *typeInfo) error { //nolint:gocyclo
+	structType := getDecodingStructType(tInfo.nonPtrType)
+	if structType.err != nil {
+		return structType.err
+	}
+
+	if structType.toArray {
+		t := d.nextCBORType()
+		d.skip()
+		return &UnmarshalTypeError{
+			Value:  t.String(),
+			Type:   tInfo.nonPtrType,
+			errMsg: "cannot decode CBOR map to struct with toarray option",
+		}
+	}
+
+	foundFldIdx := make([]bool, len(structType.fields))
+	_, ai, val := d.getHead()
+	hasSize := (ai != 31)
+	count := int(val)
+	var err, lastErr error
+	keyCount := 0
+	var mapKeys map[interface{}]struct{} // Store map keys, used for detecting duplicate map key.
+	if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+		mapKeys = make(map[interface{}]struct{}, len(structType.fields))
+	}
+	for j := 0; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
+		var f *field
+		var k interface{} // Used by duplicate map key detection
+
+		t := d.nextCBORType()
+		if t == cborTypeTextString {
+			var keyBytes []byte
+			keyBytes, lastErr = d.parseTextString()
+			if lastErr != nil {
+				if err == nil {
+					err = lastErr
+				}
+				d.skip() // skip value
+				continue
+			}
+
+			keyLen := len(keyBytes)
+			// Find field with exact match
+			for i := 0; i < len(structType.fields); i++ {
+				fld := structType.fields[i]
+				if !foundFldIdx[i] && len(fld.name) == keyLen && fld.name == string(keyBytes) {
+					f = fld
+					foundFldIdx[i] = true
+					break
+				}
+			}
+			// Find field with case-insensitive match
+			if f == nil {
+				keyString := string(keyBytes)
+				for i := 0; i < len(structType.fields); i++ {
+					fld := structType.fields[i]
+					if !foundFldIdx[i] && len(fld.name) == keyLen && strings.EqualFold(fld.name, keyString) {
+						f = fld
+						foundFldIdx[i] = true
+						break
+					}
+				}
+			}
+
+			if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+				k = string(keyBytes)
+			}
+		} else if t <= cborTypeNegativeInt { // uint/int
+			var nameAsInt int64
+
+			if t == cborTypePositiveInt {
+				_, _, val := d.getHead()
+				nameAsInt = int64(val)
+			} else {
+				_, _, val := d.getHead()
+				if val > math.MaxInt64 {
+					if err == nil {
+						err = &UnmarshalTypeError{
+							Value:  t.String(),
+							Type:   reflect.TypeOf(int64(0)),
+							errMsg: "-1-" + strconv.FormatUint(val, 10) + " overflows Go's int64",
+						}
+					}
+					d.skip() // skip value
+					continue
+				}
+				nameAsInt = int64(-1) ^ int64(val)
+			}
+
+			// Find field
+			for i := 0; i < len(structType.fields); i++ {
+				fld := structType.fields[i]
+				if !foundFldIdx[i] && fld.keyAsInt && fld.nameAsInt == nameAsInt {
+					f = fld
+					foundFldIdx[i] = true
+					break
+				}
+			}
+
+			if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+				k = nameAsInt
+			}
+		} else {
+			if err == nil {
+				err = &UnmarshalTypeError{
+					Value:  t.String(),
+					Type:   reflect.TypeOf(""),
+					errMsg: "map key is of type " + t.String() + " and cannot be used to match struct field name",
+				}
+			}
+			if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+				// parse key
+				k, lastErr = d.parse()
+				if lastErr != nil {
+					d.skip() // skip value
+					continue
+				}
+				// Detect if CBOR map key can be used as Go map key.
+				kkind := reflect.ValueOf(k).Kind()
+				if tag, ok := k.(Tag); ok {
+					kkind = tag.contentKind()
+				}
+				if !isHashableKind(kkind) {
+					d.skip() // skip value
+					continue
+				}
+			} else {
+				d.skip() // skip key
+			}
+		}
+
+		if d.dm.dupMapKey == DupMapKeyEnforcedAPF {
+			mapKeys[k] = struct{}{}
+			newKeyCount := len(mapKeys)
+			if newKeyCount == keyCount {
+				err = &DupMapKeyError{k, j}
+				d.skip() // skip value
+				j++
+				// skip the rest of the map
+				for ; (hasSize && j < count) || (!hasSize && !d.foundBreak()); j++ {
+					d.skip()
+					d.skip()
+				}
+				return err
+			}
+			keyCount = newKeyCount
+		}
+
+		if f == nil {
+			d.skip() // Skip value
+			continue
+		}
+		// reflect.Value.FieldByIndex() panics at nil pointer to unexported
+		// anonymous field.  fieldByIndex() returns error.
+		fv, lastErr := fieldByIndex(v, f.idx)
+		if lastErr != nil {
+			if err == nil {
+				err = lastErr
+			}
+			d.skip()
+			continue
+		}
+		if lastErr = d.parseToValue(fv, f.typInfo); lastErr != nil {
+			if err == nil {
+				if typeError, ok := lastErr.(*UnmarshalTypeError); ok {
+					typeError.Struct = tInfo.nonPtrType.String()
+					typeError.Field = f.name
+					err = typeError
+				} else {
+					err = lastErr
+				}
+			}
+		}
+	}
+	return err
+}
+
+// validRegisteredTagNums verifies that tag numbers match registered tag numbers of type t.
+// validRegisteredTagNums assumes next CBOR data type is tag.  It scans all tag numbers, and stops at tag content.
+func (d *decodeState) validRegisteredTagNums(t reflect.Type, registeredTagNums []uint64) error {
+	// Scan until next cbor data is tag content.
+	tagNums := make([]uint64, 0, 2)
+	for d.nextCBORType() == cborTypeTag {
+		_, _, val := d.getHead()
+		tagNums = append(tagNums, val)
+	}
+
+	// Verify that tag numbers match registered tag numbers of type t
+	if len(tagNums) != len(registeredTagNums) {
+		return &WrongTagError{t, registeredTagNums, tagNums}
+	}
+	for i, n := range registeredTagNums {
+		if n != tagNums[i] {
+			return &WrongTagError{t, registeredTagNums, tagNums}
+		}
+	}
+	return nil
+}
+
+func (d *decodeState) getRegisteredTagItem(vt reflect.Type) *tagItem {
+	if d.dm.tags != nil {
+		return d.dm.tags.get(vt)
+	}
+	return nil
+}
+
+// skip moves data offset to the next item.  skip assumes data is well-formed,
+// and does not perform bounds checking.
+func (d *decodeState) skip() {
+	t, ai, val := d.getHead()
+
+	if ai == 31 {
+		switch t {
+		case cborTypeByteString, cborTypeTextString, cborTypeArray, cborTypeMap:
+			for {
+				if d.data[d.off] == 0xff {
+					d.off++
+					return
+				}
+				d.skip()
+			}
+		}
+	}
+
+	switch t {
+	case cborTypeByteString, cborTypeTextString:
+		d.off += int(val)
+	case cborTypeArray:
+		for i := 0; i < int(val); i++ {
+			d.skip()
+		}
+	case cborTypeMap:
+		for i := 0; i < int(val)*2; i++ {
+			d.skip()
+		}
+	case cborTypeTag:
+		d.skip()
+	}
+}
+
+// getHead assumes data is well-formed, and does not perform bounds checking.
+func (d *decodeState) getHead() (t cborType, ai byte, val uint64) {
+	t = cborType(d.data[d.off] & 0xe0)
+	ai = d.data[d.off] & 0x1f
+	val = uint64(ai)
+	d.off++
+
+	if ai < 24 {
+		return
+	}
+	if ai == 24 {
+		val = uint64(d.data[d.off])
+		d.off++
+		return
+	}
+	if ai == 25 {
+		val = uint64(binary.BigEndian.Uint16(d.data[d.off : d.off+2]))
+		d.off += 2
+		return
+	}
+	if ai == 26 {
+		val = uint64(binary.BigEndian.Uint32(d.data[d.off : d.off+4]))
+		d.off += 4
+		return
+	}
+	if ai == 27 {
+		val = binary.BigEndian.Uint64(d.data[d.off : d.off+8])
+		d.off += 8
+		return
+	}
+	return
+}
+
+func (d *decodeState) numOfItemsUntilBreak() int {
+	savedOff := d.off
+	i := 0
+	for !d.foundBreak() {
+		d.skip()
+		i++
+	}
+	d.off = savedOff
+	return i
+}
+
+// foundBreak assumes data is well-formed, and does not perform bounds checking.
+func (d *decodeState) foundBreak() bool {
+	if d.data[d.off] == 0xff {
+		d.off++
+		return true
+	}
+	return false
+}
+
+func (d *decodeState) reset(data []byte) {
+	d.data = data
+	d.off = 0
+}
+
+func (d *decodeState) nextCBORType() cborType {
+	return cborType(d.data[d.off] & 0xe0)
+}
+
+func (d *decodeState) nextCBORNil() bool {
+	return d.data[d.off] == 0xf6 || d.data[d.off] == 0xf7
+}
+
+var (
+	typeIntf              = reflect.TypeOf([]interface{}(nil)).Elem()
+	typeTime              = reflect.TypeOf(time.Time{})
+	typeUnmarshaler       = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
+	typeBinaryUnmarshaler = reflect.TypeOf((*encoding.BinaryUnmarshaler)(nil)).Elem()
+)
+
+func fillNil(t cborType, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Slice, reflect.Map, reflect.Interface, reflect.Ptr:
+		v.Set(reflect.Zero(v.Type()))
+		return nil
+	}
+	return nil
+}
+
+func fillPositiveInt(t cborType, val uint64, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if val > math.MaxInt64 {
+			return &UnmarshalTypeError{Value: t.String(), Type: v.Type(), errMsg: strconv.FormatUint(val, 10) + " overflows " + v.Type().String()}
+		}
+		if v.OverflowInt(int64(val)) {
+			return &UnmarshalTypeError{Value: t.String(), Type: v.Type(), errMsg: strconv.FormatUint(val, 10) + " overflows " + v.Type().String()}
+		}
+		v.SetInt(int64(val))
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if v.OverflowUint(val) {
+			return &UnmarshalTypeError{Value: t.String(), Type: v.Type(), errMsg: strconv.FormatUint(val, 10) + " overflows " + v.Type().String()}
+		}
+		v.SetUint(val)
+		return nil
+	case reflect.Float32, reflect.Float64:
+		f := float64(val)
+		v.SetFloat(f)
+		return nil
+	}
+	return &UnmarshalTypeError{Value: t.String(), Type: v.Type()}
+}
+
+func fillNegativeInt(t cborType, val int64, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.OverflowInt(val) {
+			return &UnmarshalTypeError{Value: t.String(), Type: v.Type(), errMsg: strconv.FormatInt(val, 10) + " overflows " + v.Type().String()}
+		}
+		v.SetInt(val)
+		return nil
+	case reflect.Float32, reflect.Float64:
+		f := float64(val)
+		v.SetFloat(f)
+		return nil
+	}
+	return &UnmarshalTypeError{Value: t.String(), Type: v.Type()}
+}
+
+func fillBool(t cborType, val bool, v reflect.Value) error {
+	if v.Kind() == reflect.Bool {
+		v.SetBool(val)
+		return nil
+	}
+	return &UnmarshalTypeError{Value: t.String(), Type: v.Type()}
+}
+
+func fillFloat(t cborType, val float64, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Float32, reflect.Float64:
+		if v.OverflowFloat(val) {
+			return &UnmarshalTypeError{
+				Value:  t.String(),
+				Type:   v.Type(),
+				errMsg: strconv.FormatFloat(val, 'E', -1, 64) + " overflows " + v.Type().String(),
+			}
+		}
+		v.SetFloat(val)
+		return nil
+	}
+	return &UnmarshalTypeError{Value: t.String(), Type: v.Type()}
+}
+
+func fillByteString(t cborType, val []byte, v reflect.Value) error {
+	if reflect.PtrTo(v.Type()).Implements(typeBinaryUnmarshaler) {
+		if v.CanAddr() {
+			v = v.Addr()
+			if u, ok := v.Interface().(encoding.BinaryUnmarshaler); ok {
+				return u.UnmarshalBinary(val)
+			}
+		}
+		return errors.New("cbor: cannot set new value for " + v.Type().String())
+	}
+	if v.Kind() == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 {
+		v.SetBytes(val)
+		return nil
+	}
+	return &UnmarshalTypeError{Value: t.String(), Type: v.Type()}
+}
+
+func fillTextString(t cborType, val []byte, v reflect.Value) error {
+	if v.Kind() == reflect.String {
+		v.SetString(string(val))
+		return nil
+	}
+	return &UnmarshalTypeError{Value: t.String(), Type: v.Type()}
+}
+
+func isImmutableKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64,
+		reflect.String:
+		return true
+	default:
+		return false
+	}
+}
+
+func isHashableKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.Slice, reflect.Map, reflect.Func:
+		return false
+	default:
+		return true
+	}
+}
+
+// fieldByIndex returns the nested field corresponding to the index.  It
+// allocates pointer to struct field if it is nil and settable.
+// reflect.Value.FieldByIndex() panics at nil pointer to unexported anonymous
+// field.  This function returns error.
+func fieldByIndex(v reflect.Value, index []int) (reflect.Value, error) {
+	for _, i := range index {
+		if v.Kind() == reflect.Ptr && v.Type().Elem().Kind() == reflect.Struct {
+			if v.IsNil() {
+				if !v.CanSet() {
+					return reflect.Value{}, errors.New("cbor: cannot set embedded pointer to unexported struct: " + v.Type().String())
+				}
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		v = v.Field(i)
+	}
+	return v, nil
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/decode_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/decode_test.go
@@ -1,0 +1,3875 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	typeBool            = reflect.TypeOf(true)
+	typeUint8           = reflect.TypeOf(uint8(0))
+	typeUint16          = reflect.TypeOf(uint16(0))
+	typeUint32          = reflect.TypeOf(uint32(0))
+	typeUint64          = reflect.TypeOf(uint64(0))
+	typeInt             = reflect.TypeOf(int(0))
+	typeInt8            = reflect.TypeOf(int8(0))
+	typeInt16           = reflect.TypeOf(int16(0))
+	typeInt32           = reflect.TypeOf(int32(0))
+	typeInt64           = reflect.TypeOf(int64(0))
+	typeFloat32         = reflect.TypeOf(float32(0))
+	typeFloat64         = reflect.TypeOf(float64(0))
+	typeString          = reflect.TypeOf("")
+	typeByteSlice       = reflect.TypeOf([]byte(nil))
+	typeIntSlice        = reflect.TypeOf([]int{})
+	typeStringSlice     = reflect.TypeOf([]string{})
+	typeMapStringInt    = reflect.TypeOf(map[string]int{})
+	typeMapStringString = reflect.TypeOf(map[string]string{})
+	typeMapStringIntf   = reflect.TypeOf(map[string]interface{}{})
+)
+
+type unmarshalTest struct {
+	cborData            []byte
+	emptyInterfaceValue interface{}
+	values              []interface{}
+	wrongTypes          []reflect.Type
+}
+
+var unmarshalTests = []unmarshalTest{
+	// CBOR test data are from https://tools.ietf.org/html/rfc7049#appendix-A.
+	// positive integer
+	{
+		hexDecode("00"),
+		uint64(0),
+		[]interface{}{uint8(0), uint16(0), uint32(0), uint64(0), uint(0), int8(0), int16(0), int32(0), int64(0), int(0), float32(0), float64(0)},
+		[]reflect.Type{typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("01"),
+		uint64(1),
+		[]interface{}{uint8(1), uint16(1), uint32(1), uint64(1), uint(1), int8(1), int16(1), int32(1), int64(1), int(1), float32(1), float64(1)},
+		[]reflect.Type{typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("0a"),
+		uint64(10),
+		[]interface{}{uint8(10), uint16(10), uint32(10), uint64(10), uint(10), int8(10), int16(10), int32(10), int64(10), int(10), float32(10), float64(10)},
+		[]reflect.Type{typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("17"),
+		uint64(23),
+		[]interface{}{uint8(23), uint16(23), uint32(23), uint64(23), uint(23), int8(23), int16(23), int32(23), int64(23), int(23), float32(23), float64(23)},
+		[]reflect.Type{typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("1818"),
+		uint64(24),
+		[]interface{}{uint8(24), uint16(24), uint32(24), uint64(24), uint(24), int8(24), int16(24), int32(24), int64(24), int(24), float32(24), float64(24)},
+		[]reflect.Type{typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("1819"),
+		uint64(25),
+		[]interface{}{uint8(25), uint16(25), uint32(25), uint64(25), uint(25), int8(25), int16(25), int32(25), int64(25), int(25), float32(25), float64(25)},
+		[]reflect.Type{typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("1864"),
+		uint64(100),
+		[]interface{}{uint8(100), uint16(100), uint32(100), uint64(100), uint(100), int8(100), int16(100), int32(100), int64(100), int(100), float32(100), float64(100)},
+		[]reflect.Type{typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("1903e8"),
+		uint64(1000),
+		[]interface{}{uint16(1000), uint32(1000), uint64(1000), uint(1000), int16(1000), int32(1000), int64(1000), int(1000), float32(1000), float64(1000)},
+		[]reflect.Type{typeUint8, typeInt8, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("1a000f4240"),
+		uint64(1000000),
+		[]interface{}{uint32(1000000), uint64(1000000), uint(1000000), int32(1000000), int64(1000000), int(1000000), float32(1000000), float64(1000000)},
+		[]reflect.Type{typeUint8, typeUint16, typeInt8, typeInt16, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("1b000000e8d4a51000"),
+		uint64(1000000000000),
+		[]interface{}{uint64(1000000000000), uint(1000000000000), int64(1000000000000), int(1000000000000), float32(1000000000000), float64(1000000000000)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeInt8, typeInt16, typeInt32, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("1bffffffffffffffff"),
+		uint64(18446744073709551615),
+		[]interface{}{uint64(18446744073709551615), uint(18446744073709551615), float32(18446744073709551615), float64(18446744073709551615)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeInt8, typeInt16, typeInt32, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	// negative integer
+	{
+		hexDecode("20"),
+		int64(-1),
+		[]interface{}{int8(-1), int16(-1), int32(-1), int64(-1), int(-1), float32(-1), float64(-1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("29"),
+		int64(-10),
+		[]interface{}{int8(-10), int16(-10), int32(-10), int64(-10), int(-10), float32(-10), float64(-10)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("3863"),
+		int64(-100),
+		[]interface{}{int8(-100), int16(-100), int32(-100), int64(-100), int(-100), float32(-100), float64(-100)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("3903e7"),
+		int64(-1000),
+		[]interface{}{int16(-1000), int32(-1000), int64(-1000), int(-1000), float32(-1000), float64(-1000)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	// {"3bffffffffffffffff", int64(-18446744073709551616)}, // CBOR value -18446744073709551616 overflows Go's int64, see TestNegIntOverflow
+	// byte string
+	{
+		hexDecode("40"),
+		[]byte{},
+		[]interface{}{[]byte{}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("4401020304"),
+		[]byte{1, 2, 3, 4},
+		[]interface{}{[]byte{1, 2, 3, 4}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("5f42010243030405ff"),
+		[]byte{1, 2, 3, 4, 5},
+		[]interface{}{[]byte{1, 2, 3, 4, 5}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	// text string
+	{
+		hexDecode("60"),
+		"",
+		[]interface{}{""},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("6161"),
+		"a",
+		[]interface{}{"a"},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("6449455446"),
+		"IETF",
+		[]interface{}{"IETF"},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("62225c"),
+		"\"\\",
+		[]interface{}{"\"\\"},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("62c3bc"),
+		"ü",
+		[]interface{}{"ü"},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("63e6b0b4"),
+		"水",
+		[]interface{}{"水"},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("64f0908591"),
+		"𐅑",
+		[]interface{}{"𐅑"},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("7f657374726561646d696e67ff"),
+		"streaming",
+		[]interface{}{"streaming"},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	// array
+	{
+		hexDecode("80"),
+		[]interface{}{},
+		[]interface{}{[]interface{}{}, []byte{}, []string{}, []int{}, [...]int{}, []float32{}, []float64{}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("83010203"),
+		[]interface{}{uint64(1), uint64(2), uint64(3)},
+		[]interface{}{[]interface{}{uint64(1), uint64(2), uint64(3)}, []byte{1, 2, 3}, []int{1, 2, 3}, []uint{1, 2, 3}, [...]int{1, 2, 3}, []float32{1, 2, 3}, []float64{1, 2, 3}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("8301820203820405"),
+		[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		[]interface{}{[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}, [...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("83018202039f0405ff"),
+		[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		[]interface{}{[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}, [...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("83019f0203ff820405"),
+		[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		[]interface{}{[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}, [...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("98190102030405060708090a0b0c0d0e0f101112131415161718181819"),
+		[]interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
+		[]interface{}{
+			[]interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
+			[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[...]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("9fff"),
+		[]interface{}{},
+		[]interface{}{[]interface{}{}, []byte{}, []string{}, []int{}, [...]int{}, []float32{}, []float64{}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("9f018202039f0405ffff"),
+		[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		[]interface{}{[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}, [...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("9f01820203820405ff"),
+		[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}},
+		[]interface{}{[]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}, [...]interface{}{uint64(1), []interface{}{uint64(2), uint64(3)}, []interface{}{uint64(4), uint64(5)}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff"),
+		[]interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
+		[]interface{}{
+			[]interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5), uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11), uint64(12), uint64(13), uint64(14), uint64(15), uint64(16), uint64(17), uint64(18), uint64(19), uint64(20), uint64(21), uint64(22), uint64(23), uint64(24), uint64(25)},
+			[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[...]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("826161a161626163"),
+		[]interface{}{"a", map[interface{}]interface{}{"b": "c"}},
+		[]interface{}{[]interface{}{"a", map[interface{}]interface{}{"b": "c"}}, [...]interface{}{"a", map[interface{}]interface{}{"b": "c"}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	{
+		hexDecode("826161bf61626163ff"),
+		[]interface{}{"a", map[interface{}]interface{}{"b": "c"}},
+		[]interface{}{[]interface{}{"a", map[interface{}]interface{}{"b": "c"}}, [...]interface{}{"a", map[interface{}]interface{}{"b": "c"}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{}), typeTag, typeRawTag},
+	},
+	// map
+	{
+		hexDecode("a0"),
+		map[interface{}]interface{}{},
+		[]interface{}{map[interface{}]interface{}{}, map[string]bool{}, map[string]int{}, map[int]string{}, map[int]bool{}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeBool, typeIntSlice, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("a201020304"),
+		map[interface{}]interface{}{uint64(1): uint64(2), uint64(3): uint64(4)},
+		[]interface{}{map[interface{}]interface{}{uint64(1): uint64(2), uint64(3): uint64(4)}, map[uint]int{1: 2, 3: 4}, map[int]uint{1: 2, 3: 4}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("a26161016162820203"),
+		map[interface{}]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
+		[]interface{}{map[interface{}]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
+			map[string]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("a56161614161626142616361436164614461656145"),
+		map[interface{}]interface{}{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
+		[]interface{}{map[interface{}]interface{}{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
+			map[string]interface{}{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
+			map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("bf61610161629f0203ffff"),
+		map[interface{}]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
+		[]interface{}{map[interface{}]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}},
+			map[string]interface{}{"a": uint64(1), "b": []interface{}{uint64(2), uint64(3)}}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("bf6346756ef563416d7421ff"),
+		map[interface{}]interface{}{"Fun": true, "Amt": int64(-2)},
+		[]interface{}{map[interface{}]interface{}{"Fun": true, "Amt": int64(-2)},
+			map[string]interface{}{"Fun": true, "Amt": int64(-2)}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	// tag
+	{
+		hexDecode("c074323031332d30332d32315432303a30343a30305a"),
+		time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC), // 2013-03-21 20:04:00 +0000 UTC
+		[]interface{}{"2013-03-21T20:04:00Z", time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC), Tag{0, "2013-03-21T20:04:00Z"}, RawTag{0, hexDecode("74323031332d30332d32315432303a30343a30305a")}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt},
+	}, // 0: standard date/time
+	{
+		hexDecode("c11a514b67b0"),
+		time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC), // 2013-03-21 20:04:00 +0000 UTC
+		[]interface{}{uint32(1363896240), uint64(1363896240), int32(1363896240), int64(1363896240), float32(1363896240), float64(1363896240), time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC), Tag{1, uint64(1363896240)}, RawTag{1, hexDecode("1a514b67b0")}},
+		[]reflect.Type{typeUint8, typeUint16, typeInt8, typeInt16, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt},
+	}, // 1: epoch-based date/time
+	{
+		hexDecode("c249010000000000000000"),
+		Tag{2, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		[]interface{}{[]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, Tag{2, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}, RawTag{2, hexDecode("49010000000000000000")}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt},
+	}, // 2: positive bignum: 18446744073709551616
+	{
+		hexDecode("c349010000000000000000"),
+		Tag{3, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		[]interface{}{[]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, Tag{3, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}, RawTag{3, hexDecode("49010000000000000000")}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt},
+	}, // 3: negative bignum: -18446744073709551617
+	{
+		hexDecode("c1fb41d452d9ec200000"),
+		time.Date(2013, 3, 21, 20, 4, 0, 500000000, time.UTC), // 2013-03-21 20:04:00.5 +0000 UTC
+		[]interface{}{float32(1363896240.5), float64(1363896240.5), time.Date(2013, 3, 21, 20, 4, 0, 500000000, time.UTC), Tag{1, float64(1363896240.5)}, RawTag{1, hexDecode("fb41d452d9ec200000")}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt},
+	}, // 1: epoch-based date/time
+	{
+		hexDecode("d74401020304"),
+		Tag{23, []byte{0x01, 0x02, 0x03, 0x04}},
+		[]interface{}{[]byte{0x01, 0x02, 0x03, 0x04}, Tag{23, []byte{0x01, 0x02, 0x03, 0x04}}, RawTag{23, hexDecode("4401020304")}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt},
+	}, // 23: expected conversion to base16 encoding
+	{
+		hexDecode("d818456449455446"),
+		Tag{24, []byte{0x64, 0x49, 0x45, 0x54, 0x46}},
+		[]interface{}{[]byte{0x64, 0x49, 0x45, 0x54, 0x46}, Tag{24, []byte{0x64, 0x49, 0x45, 0x54, 0x46}}, RawTag{24, hexDecode("456449455446")}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt},
+	}, // 24: encoded cborBytes data item
+	{
+		hexDecode("d82076687474703a2f2f7777772e6578616d706c652e636f6d"),
+		Tag{32, "http://www.example.com"},
+		[]interface{}{"http://www.example.com", Tag{32, "http://www.example.com"}, RawTag{32, hexDecode("76687474703a2f2f7777772e6578616d706c652e636f6d")}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt},
+	}, // 32: URI
+	// primitives
+	{
+		hexDecode("f4"),
+		false,
+		[]interface{}{false},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("f5"),
+		true,
+		[]interface{}{true},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("f6"),
+		nil,
+		[]interface{}{[]byte(nil), []int(nil), []string(nil), map[string]int(nil)},
+		[]reflect.Type{typeTag, typeRawTag},
+	},
+	{
+		hexDecode("f7"),
+		nil,
+		[]interface{}{[]byte(nil), []int(nil), []string(nil), map[string]int(nil)},
+		[]reflect.Type{typeTag, typeRawTag},
+	},
+	{
+		hexDecode("f0"),
+		uint64(16),
+		[]interface{}{uint8(16), uint16(16), uint32(16), uint64(16), uint(16), int8(16), int16(16), int32(16), int64(16), int(16), float32(16), float64(16)},
+		[]reflect.Type{typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	// This example is not well-formed because Simple value (with 5-bit value 24) must be >= 32.
+	// See RFC 7049 section 2.3 for details, instead of the incorrect example in RFC 7049 Appendex A.
+	// I reported an errata to RFC 7049 and Carsten Bormann confirmed at https://github.com/fxamacker/cbor/issues/46
+	/*
+		{
+			hexDecode("f818"),
+			uint64(24),
+			[]interface{}{uint8(24), uint16(24), uint32(24), uint64(24), uint(24), int8(24), int16(24), int32(24), int64(24), int(24), float32(24), float64(24)},
+			[]reflect.Type{typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt},
+		},
+	*/
+	{
+		hexDecode("f820"),
+		uint64(32),
+		[]interface{}{uint8(32), uint16(32), uint32(32), uint64(32), uint(32), int8(32), int16(32), int32(32), int64(32), int(32), float32(32), float64(32)},
+		[]reflect.Type{typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("f8ff"),
+		uint64(255),
+		[]interface{}{uint8(255), uint16(255), uint32(255), uint64(255), uint(255), int16(255), int32(255), int64(255), int(255), float32(255), float64(255)},
+		[]reflect.Type{typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	// More testcases not covered by https://tools.ietf.org/html/rfc7049#appendix-A.
+	{
+		hexDecode("5fff"), // empty indefinite length byte string
+		[]byte{},
+		[]interface{}{[]byte{}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("7fff"), // empty indefinite length text string
+		"",
+		[]interface{}{""},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+	},
+	{
+		hexDecode("bfff"), // empty indefinite length map
+		map[interface{}]interface{}{},
+		[]interface{}{map[interface{}]interface{}{}, map[string]bool{}, map[string]int{}, map[int]string{}, map[int]bool{}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeByteSlice, typeString, typeBool, typeIntSlice, typeTag, typeRawTag},
+	},
+	// More test data with tags
+	{
+		hexDecode("c13a0177f2cf"), // 1969-03-21T20:04:00Z, tag 1 with negative integer as epoch time
+		time.Date(1969, 3, 21, 20, 4, 0, 0, time.UTC),
+		[]interface{}{int32(-24638160), int64(-24638160), int32(-24638160), int64(-24638160), float32(-24638160), float64(-24638160), time.Date(1969, 3, 21, 20, 4, 0, 0, time.UTC), Tag{1, int64(-24638160)}, RawTag{1, hexDecode("3a0177f2cf")}},
+		[]reflect.Type{typeUint8, typeUint16, typeInt8, typeInt16, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt},
+	},
+	{
+		hexDecode("d83dd183010203"), // 61(17([1, 2, 3])), nested tags 61 and 17
+		Tag{61, Tag{17, []interface{}{uint64(1), uint64(2), uint64(3)}}},
+		[]interface{}{[]interface{}{uint64(1), uint64(2), uint64(3)}, []byte{1, 2, 3}, []int{1, 2, 3}, []uint{1, 2, 3}, [...]int{1, 2, 3}, []float32{1, 2, 3}, []float64{1, 2, 3}, Tag{61, Tag{17, []interface{}{uint64(1), uint64(2), uint64(3)}}}, RawTag{61, hexDecode("d183010203")}},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeFloat64, typeString, typeBool, typeStringSlice, typeMapStringInt, reflect.TypeOf([3]string{})},
+	},
+}
+
+type unmarshalFloatTest struct {
+	cborData            []byte
+	emptyInterfaceValue interface{}
+	values              []interface{}
+	wrongTypes          []reflect.Type
+	equalityThreshold   float64 // Not used for +inf, -inf, and NaN.
+}
+
+// unmarshalFloatTests includes test values for float16, float32, and float64.
+// Note: the function for float16 to float32 conversion was tested with all
+// 65536 values, which is too many to include here.
+var unmarshalFloatTests = []unmarshalFloatTest{
+	// CBOR test data are from https://tools.ietf.org/html/rfc7049#appendix-A.
+	// float16
+	{
+		hexDecode("f90000"),
+		float64(0.0),
+		[]interface{}{float32(0.0), float64(0.0)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f98000"),
+		float64(-0.0),
+		[]interface{}{float32(-0.0), float64(-0.0)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f93c00"),
+		float64(1.0),
+		[]interface{}{float32(1.0), float64(1.0)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f93e00"),
+		float64(1.5),
+		[]interface{}{float32(1.5), float64(1.5)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f97bff"),
+		float64(65504.0),
+		[]interface{}{float32(65504.0), float64(65504.0)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f90001"), // float16 subnormal value
+		float64(5.960464477539063e-08),
+		[]interface{}{float32(5.960464477539063e-08), float64(5.960464477539063e-08)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-16,
+	},
+	{
+		hexDecode("f90400"),
+		float64(6.103515625e-05),
+		[]interface{}{float32(6.103515625e-05), float64(6.103515625e-05)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-16,
+	},
+	{
+		hexDecode("f9c400"),
+		float64(-4.0),
+		[]interface{}{float32(-4.0), float64(-4.0)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f97c00"),
+		math.Inf(1),
+		[]interface{}{math.Float32frombits(0x7f800000), math.Inf(1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f97e00"),
+		math.NaN(),
+		[]interface{}{math.Float32frombits(0x7fc00000), math.NaN()},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f9fc00"),
+		math.Inf(-1),
+		[]interface{}{math.Float32frombits(0xff800000), math.Inf(-1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	// float32
+	{
+		hexDecode("fa47c35000"),
+		float64(100000.0),
+		[]interface{}{float32(100000.0), float64(100000.0)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fa7f7fffff"),
+		float64(3.4028234663852886e+38),
+		[]interface{}{float32(3.4028234663852886e+38), float64(3.4028234663852886e+38)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-9,
+	},
+	{
+		hexDecode("fa7f800000"),
+		math.Inf(1),
+		[]interface{}{math.Float32frombits(0x7f800000), math.Inf(1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fa7fc00000"),
+		math.NaN(),
+		[]interface{}{math.Float32frombits(0x7fc00000), math.NaN()},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("faff800000"),
+		math.Inf(-1),
+		[]interface{}{math.Float32frombits(0xff800000), math.Inf(-1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	// float64
+	{
+		hexDecode("fb3ff199999999999a"),
+		float64(1.1),
+		[]interface{}{float32(1.1), float64(1.1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-9,
+	},
+	{
+		hexDecode("fb7e37e43c8800759c"),
+		float64(1.0e+300),
+		[]interface{}{float64(1.0e+300)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeFloat32, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-9,
+	},
+	{
+		hexDecode("fbc010666666666666"),
+		float64(-4.1),
+		[]interface{}{float32(-4.1), float64(-4.1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-9,
+	},
+	{
+		hexDecode("fb7ff0000000000000"),
+		math.Inf(1),
+		[]interface{}{math.Float32frombits(0x7f800000), math.Inf(1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fb7ff8000000000000"),
+		math.NaN(),
+		[]interface{}{math.Float32frombits(0x7fc00000), math.NaN()},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fbfff0000000000000"),
+		math.Inf(-1),
+		[]interface{}{math.Float32frombits(0xff800000), math.Inf(-1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+
+	// float16 test data from https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+	{
+		hexDecode("f903ff"),
+		float64(0.000060976),
+		[]interface{}{float32(0.000060976), float64(0.000060976)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-9,
+	},
+	{
+		hexDecode("f93bff"),
+		float64(0.999511719),
+		[]interface{}{float32(0.999511719), float64(0.999511719)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-9,
+	},
+	{
+		hexDecode("f93c01"),
+		float64(1.000976563),
+		[]interface{}{float32(1.000976563), float64(1.000976563)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-9,
+	},
+	{
+		hexDecode("f93555"),
+		float64(0.333251953125),
+		[]interface{}{float32(0.333251953125), float64(0.333251953125)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		1e-9,
+	},
+	// CBOR test data "canonNums" are from https://github.com/cbor-wg/cbor-test-vectors
+	{
+		hexDecode("f9bd00"),
+		float64(-1.25),
+		[]interface{}{float32(-1.25), float64(-1.25)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f93e00"),
+		float64(1.5),
+		[]interface{}{float32(1.5), float64(1.5)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fb4024333333333333"),
+		float64(10.1),
+		[]interface{}{float32(10.1), float64(10.1)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f90001"),
+		float64(5.960464477539063e-8),
+		[]interface{}{float32(5.960464477539063e-8), float64(5.960464477539063e-8)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fa7f7fffff"),
+		float64(3.4028234663852886e+38),
+		[]interface{}{float32(3.4028234663852886e+38), float64(3.4028234663852886e+38)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f90400"),
+		float64(0.00006103515625),
+		[]interface{}{float32(0.00006103515625), float64(0.00006103515625)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("f933ff"),
+		float64(0.2498779296875),
+		[]interface{}{float32(0.2498779296875), float64(0.2498779296875)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fa33000000"),
+		float64(2.9802322387695312e-8),
+		[]interface{}{float32(2.9802322387695312e-8), float64(2.9802322387695312e-8)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fa33333866"),
+		float64(4.1727979294137185e-8),
+		[]interface{}{float32(4.1727979294137185e-8), float64(4.1727979294137185e-8)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+	{
+		hexDecode("fa37002000"),
+		float64(0.000007636845111846924),
+		[]interface{}{float32(0.000007636845111846924), float64(0.000007636845111846924)},
+		[]reflect.Type{typeUint8, typeUint16, typeUint32, typeUint64, typeInt8, typeInt16, typeInt32, typeInt64, typeByteSlice, typeString, typeBool, typeIntSlice, typeMapStringInt, typeTag, typeRawTag},
+		0.0,
+	},
+}
+
+const invalidUTF8ErrorMsg = "cbor: invalid UTF-8 string"
+
+func hexDecode(s string) []byte {
+	data, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func TestUnmarshal(t *testing.T) {
+	for _, tc := range unmarshalTests {
+		// Test unmarshalling CBOR into empty interface.
+		var v interface{}
+		if err := Unmarshal(tc.cborData, &v); err != nil {
+			t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+		} else {
+			if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
+				if vt, ok := v.(time.Time); !ok || !tm.Equal(vt) {
+					t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborData, v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+				}
+			} else if !reflect.DeepEqual(v, tc.emptyInterfaceValue) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborData, v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+			}
+		}
+		// Test unmarshalling CBOR into RawMessage.
+		var r RawMessage
+		if err := Unmarshal(tc.cborData, &r); err != nil {
+			t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+		} else if !bytes.Equal(r, tc.cborData) {
+			t.Errorf("Unmarshal(0x%x) returned RawMessage %v, want %v", tc.cborData, r, tc.cborData)
+		}
+		// Test unmarshalling CBOR into compatible data types.
+		for _, value := range tc.values {
+			v := reflect.New(reflect.TypeOf(value))
+			vPtr := v.Interface()
+			if err := Unmarshal(tc.cborData, vPtr); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+			} else {
+				if tm, ok := value.(time.Time); ok {
+					if vt, ok := v.Elem().Interface().(time.Time); !ok || !tm.Equal(vt) {
+						t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborData, v.Elem().Interface(), v.Elem().Interface(), value, value)
+					}
+				} else if !reflect.DeepEqual(v.Elem().Interface(), value) {
+					t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborData, v.Elem().Interface(), v.Elem().Interface(), value, value)
+				}
+			}
+		}
+		// Test unmarshalling CBOR into incompatible data types.
+		for _, typ := range tc.wrongTypes {
+			v := reflect.New(typ)
+			vPtr := v.Interface()
+			if err := Unmarshal(tc.cborData, vPtr); err == nil {
+				t.Errorf("Unmarshal(0x%x, %s) didn't return an error", tc.cborData, typ.String())
+			} else if _, ok := err.(*UnmarshalTypeError); !ok {
+				t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", tc.cborData, err)
+			} else if !strings.Contains(err.Error(), "cannot unmarshal") {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborData, err.Error(), "cannot unmarshal")
+			}
+		}
+	}
+}
+
+func TestUnmarshalFloat(t *testing.T) {
+	for _, tc := range unmarshalFloatTests {
+		// Test unmarshalling CBOR into empty interface.
+		var v interface{}
+		if err := Unmarshal(tc.cborData, &v); err != nil {
+			t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+		} else {
+			testFloat(t, tc.cborData, v, tc.emptyInterfaceValue, tc.equalityThreshold)
+		}
+		// Test unmarshalling CBOR into RawMessage.
+		var r RawMessage
+		if err := Unmarshal(tc.cborData, &r); err != nil {
+			t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+		} else if !bytes.Equal(r, tc.cborData) {
+			t.Errorf("Unmarshal(0x%x) returned RawMessage %v, want %v", tc.cborData, r, tc.cborData)
+		}
+		// Test unmarshalling CBOR into compatible data types.
+		for _, value := range tc.values {
+			v := reflect.New(reflect.TypeOf(value))
+			vPtr := v.Interface()
+			if err := Unmarshal(tc.cborData, vPtr); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+			} else {
+				testFloat(t, tc.cborData, v.Elem().Interface(), value, tc.equalityThreshold)
+			}
+		}
+		// Test unmarshalling CBOR into incompatible data types.
+		for _, typ := range tc.wrongTypes {
+			v := reflect.New(typ)
+			vPtr := v.Interface()
+			if err := Unmarshal(tc.cborData, vPtr); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborData)
+			} else if _, ok := err.(*UnmarshalTypeError); !ok {
+				t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", tc.cborData, err)
+			} else if !strings.Contains(err.Error(), "cannot unmarshal") {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborData, err.Error(), "cannot unmarshal")
+			}
+		}
+	}
+}
+
+func testFloat(t *testing.T, cborData []byte, f interface{}, wantf interface{}, equalityThreshold float64) {
+	switch wantf := wantf.(type) {
+	case float32:
+		f, ok := f.(float32)
+		if !ok {
+			t.Errorf("Unmarshal(0x%x) returned value of type %T, want float32", cborData, f)
+			return
+		}
+		if math.IsNaN(float64(wantf)) {
+			if !math.IsNaN(float64(f)) {
+				t.Errorf("Unmarshal(0x%x) = %f, want NaN", cborData, f)
+			}
+		} else if math.IsInf(float64(wantf), 0) {
+			if f != wantf {
+				t.Errorf("Unmarshal(0x%x) = %f, want %f", cborData, f, wantf)
+			}
+		} else if math.Abs(float64(f-wantf)) > equalityThreshold {
+			t.Errorf("Unmarshal(0x%x) = %.18f, want %.18f, diff %.18f > threshold %.18f", cborData, f, wantf, math.Abs(float64(f-wantf)), equalityThreshold)
+		}
+	case float64:
+		f, ok := f.(float64)
+		if !ok {
+			t.Errorf("Unmarshal(0x%x) returned value of type %T, want float64", cborData, f)
+			return
+		}
+		if math.IsNaN(wantf) {
+			if !math.IsNaN(f) {
+				t.Errorf("Unmarshal(0x%x) = %f, want NaN", cborData, f)
+			}
+		} else if math.IsInf(wantf, 0) {
+			if f != wantf {
+				t.Errorf("Unmarshal(0x%x) = %f, want %f", cborData, f, wantf)
+			}
+		} else if math.Abs(f-wantf) > equalityThreshold {
+			t.Errorf("Unmarshal(0x%x) = %.18f, want %.18f, diff %.18f > threshold %.18f", cborData, f, wantf, math.Abs(f-wantf), equalityThreshold)
+		}
+	}
+}
+
+func TestNegIntOverflow(t *testing.T) {
+	testCases := []struct {
+		cborData []byte
+		v        interface{}
+	}{
+		{hexDecode("3bffffffffffffffff"), new(interface{})},
+		{hexDecode("3bffffffffffffffff"), new(int64)},
+	}
+	for _, tc := range testCases {
+		if err := Unmarshal(tc.cborData, tc.v); err == nil {
+			t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborData)
+		} else if _, ok := err.(*UnmarshalTypeError); !ok {
+			t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", tc.cborData, err)
+		} else if !strings.Contains(err.Error(), "cannot unmarshal") {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborData, err.Error(), "cannot unmarshal")
+		}
+	}
+}
+
+func TestUnmarshalIntoPtrPrimitives(t *testing.T) {
+	cborDataInt := hexDecode("1818")                          // 24
+	cborDataString := hexDecode("7f657374726561646d696e67ff") // "streaming"
+
+	const wantInt = 24
+	const wantString = "streaming"
+
+	var p1 *int
+	var p2 *string
+	var p3 *RawMessage
+
+	var i int
+	pi := &i
+	ppi := &pi
+
+	var s string
+	ps := &s
+	pps := &ps
+
+	var r RawMessage
+	pr := &r
+	ppr := &pr
+
+	// Unmarshal CBOR integer into a non-nil pointer.
+	if err := Unmarshal(cborDataInt, &ppi); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborDataInt, err)
+	} else if i != wantInt {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %d", cborDataInt, i, i, wantInt)
+	}
+	// Unmarshal CBOR integer into a nil pointer.
+	if err := Unmarshal(cborDataInt, &p1); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborDataInt, err)
+	} else if *p1 != wantInt {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %d", cborDataInt, *pi, pi, wantInt)
+	}
+
+	// Unmarshal CBOR string into a non-nil pointer.
+	if err := Unmarshal(cborDataString, &pps); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborDataString, err)
+	} else if s != wantString {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborDataString, s, s, wantString)
+	}
+	// Unmarshal CBOR string into a nil pointer.
+	if err := Unmarshal(cborDataString, &p2); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborDataString, err)
+	} else if *p2 != wantString {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborDataString, *p2, p2, wantString)
+	}
+
+	// Unmarshal CBOR string into a non-nil RawMessage.
+	if err := Unmarshal(cborDataString, &ppr); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborDataString, err)
+	} else if !bytes.Equal(r, cborDataString) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborDataString, r, r, cborDataString)
+	}
+	// Unmarshal CBOR string into a nil pointer to RawMessage.
+	if err := Unmarshal(cborDataString, &p3); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborDataString, err)
+	} else if !bytes.Equal(*p3, cborDataString) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborDataString, *p3, p3, cborDataString)
+	}
+}
+
+func TestUnmarshalIntoPtrArrayPtrElem(t *testing.T) {
+	cborData := hexDecode("83010203") // []int{1, 2, 3}
+
+	n1, n2, n3 := 1, 2, 3
+
+	wantArray := []*int{&n1, &n2, &n3}
+
+	var p *[]*int
+
+	var slc []*int
+	pslc := &slc
+	ppslc := &pslc
+
+	// Unmarshal CBOR array into a non-nil pointer.
+	if err := Unmarshal(cborData, &ppslc); err != nil {
+		t.Errorf("Unmarshal(0x%x, %s) returned error %v", cborData, reflect.TypeOf(ppslc), err)
+	} else if !reflect.DeepEqual(slc, wantArray) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborData, slc, slc, wantArray)
+	}
+	// Unmarshal CBOR array into a nil pointer.
+	if err := Unmarshal(cborData, &p); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	} else if !reflect.DeepEqual(*p, wantArray) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborData, *p, p, wantArray)
+	}
+}
+
+func TestUnmarshalIntoPtrMapPtrElem(t *testing.T) {
+	cborData := hexDecode("a201020304") // {1: 2, 3: 4}
+
+	n1, n2, n3, n4 := 1, 2, 3, 4
+
+	wantMap := map[int]*int{n1: &n2, n3: &n4}
+
+	var p *map[int]*int
+
+	var m map[int]*int
+	pm := &m
+	ppm := &pm
+
+	// Unmarshal CBOR map into a non-nil pointer.
+	if err := Unmarshal(cborData, &ppm); err != nil {
+		t.Errorf("Unmarshal(0x%x, %s) returned error %v", cborData, reflect.TypeOf(ppm), err)
+	} else if !reflect.DeepEqual(m, wantMap) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborData, m, m, wantMap)
+	}
+	// Unmarshal CBOR map into a nil pointer.
+	if err := Unmarshal(cborData, &p); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	} else if !reflect.DeepEqual(*p, wantMap) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborData, *p, p, wantMap)
+	}
+}
+
+func TestUnmarshalIntoPtrStructPtrElem(t *testing.T) {
+	type s1 struct {
+		A *string `cbor:"a"`
+		B *string `cbor:"b"`
+		C *string `cbor:"c"`
+		D *string `cbor:"d"`
+		E *string `cbor:"e"`
+	}
+
+	cborData := hexDecode("a56161614161626142616361436164614461656145") // map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"}
+
+	a, b, c, d, e := "A", "B", "C", "D", "E"
+	wantObj := s1{A: &a, B: &b, C: &c, D: &d, E: &e}
+
+	var p *s1
+
+	var s s1
+	ps := &s
+	pps := &ps
+
+	// Unmarshal CBOR map into a non-nil pointer.
+	if err := Unmarshal(cborData, &pps); err != nil {
+		t.Errorf("Unmarshal(0x%x, %s) returned error %v", cborData, reflect.TypeOf(pps), err)
+	} else if !reflect.DeepEqual(s, wantObj) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborData, s, s, wantObj)
+	}
+	// Unmarshal CBOR map into a nil pointer.
+	if err := Unmarshal(cborData, &p); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	} else if !reflect.DeepEqual(*p, wantObj) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v", cborData, *p, p, wantObj)
+	}
+}
+
+func TestUnmarshalIntoArray(t *testing.T) {
+	cborData := hexDecode("83010203") // []int{1, 2, 3}
+
+	// Unmarshal CBOR array into Go array.
+	var arr1 [3]int
+	if err := Unmarshal(cborData, &arr1); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	} else if arr1 != [3]int{1, 2, 3} {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want [3]int{1, 2, 3}", cborData, arr1, arr1)
+	}
+
+	// Unmarshal CBOR array into Go array with more elements.
+	var arr2 [5]int
+	if err := Unmarshal(cborData, &arr2); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	} else if arr2 != [5]int{1, 2, 3, 0, 0} {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want [5]int{1, 2, 3, 0, 0}", cborData, arr2, arr2)
+	}
+
+	// Unmarshal CBOR array into Go array with less elements.
+	var arr3 [1]int
+	if err := Unmarshal(cborData, &arr3); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	} else if arr3 != [1]int{1} {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want [0]int{1}", cborData, arr3, arr3)
+	}
+}
+
+func TestUnmarshalNil(t *testing.T) {
+	cborData := [][]byte{hexDecode("f6"), hexDecode("f7")} // null, undefined
+
+	testCases := []struct {
+		name      string
+		value     interface{}
+		wantValue interface{}
+	}{
+		// Unmarshal CBOR nil into composite types.
+		{"[]byte", []byte{1, 2, 3}, []byte(nil)},
+		{"[]string", []string{"hello", "world"}, []string(nil)},
+		{"map[string]bool", map[string]bool{"hello": true, "goodbye": false}, map[string]bool(nil)},
+		// Unmarshal CBOR nil into basic types.
+		{"int", 10, 10},
+		{"float", 1.23, 1.23},
+		{"string", "hello", "hello"},
+		{"bool", true, true},
+		// Unmarshal CBOR nil into nil pointers.
+		{"*int", (*int)(nil), (*int)(nil)},
+		{"*string", (*string)(nil), (*string)(nil)},
+		{"*RawMessage", (*RawMessage)(nil), (*RawMessage)(nil)},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, data := range cborData {
+				v := reflect.New(reflect.TypeOf(tc.value))
+				v.Elem().Set(reflect.ValueOf(tc.value))
+				if err := Unmarshal(data, v.Interface()); err != nil {
+					t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
+				} else if !reflect.DeepEqual(v.Elem().Interface(), tc.wantValue) {
+					t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", data, v.Elem().Interface(), v.Elem().Interface(), tc.wantValue, tc.wantValue)
+				}
+			}
+		})
+	}
+}
+
+var invalidUnmarshalTests = []struct {
+	name         string
+	v            interface{}
+	wantErrorMsg string
+}{
+	{"unmarshal into nil interface{}", nil, "cbor: Unmarshal(nil)"},
+	{"unmarshal into non-pointer value", 5, "cbor: Unmarshal(non-pointer int)"},
+	{"unmarshal into nil pointer", (*int)(nil), "cbor: Unmarshal(nil *int)"},
+}
+
+func TestInvalidUnmarshal(t *testing.T) {
+	cborData := []byte{0x00}
+
+	for _, tc := range invalidUnmarshalTests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Unmarshal(cborData, tc.v)
+			if err == nil {
+				t.Errorf("Unmarshal(0x%x, %v) didn't return an error", cborData, tc.v)
+			} else if _, ok := err.(*InvalidUnmarshalError); !ok {
+				t.Errorf("Unmarshal(0x%x, %v) error type %T, want *InvalidUnmarshalError", cborData, tc.v, err)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Unmarshal(0x%x, %v) error %q, want %q", cborData, tc.v, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+var invalidCBORUnmarshalTests = []struct {
+	name                 string
+	cborData             []byte
+	wantErrorMsg         string
+	errorMsgPartialMatch bool
+}{
+	{"Nil data", []byte(nil), "EOF", false},
+	{"Empty data", []byte{}, "EOF", false},
+	{"Tag number not followed by tag content", []byte{0xc0}, "unexpected EOF", false},
+	{"Definite length strings with tagged chunk", hexDecode("5fc64401020304ff"), "cbor: wrong element type tag for indefinite-length byte string", false},
+	{"Definite length strings with tagged chunk", hexDecode("7fc06161ff"), "cbor: wrong element type tag for indefinite-length UTF-8 text string", false},
+	{"Invalid nested tag number", hexDecode("d864dc1a514b67b0"), "cbor: invalid additional information", true},
+	// Data from 7049bis G.1
+	// Premature end of the input
+	{"End of input in a head", hexDecode("18"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("19"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("1a"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("1b"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("1901"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("1a0102"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("1b01020304050607"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("38"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("58"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("78"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("98"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("9a01ff00"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("b8"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("d8"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("f8"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("f900"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("fa0000"), "unexpected EOF", false},
+	{"End of input in a head", hexDecode("fb000000"), "unexpected EOF", false},
+	{"Definite length strings with short data", hexDecode("41"), "unexpected EOF", false},
+	{"Definite length strings with short data", hexDecode("61"), "unexpected EOF", false},
+	{"Definite length strings with short data", hexDecode("5affffffff00"), "unexpected EOF", false},
+	{"Definite length strings with short data", hexDecode("5bffffffffffffffff010203"), "cbor: byte string length 18446744073709551615 is too large, causing integer overflow", false},
+	{"Definite length strings with short data", hexDecode("7affffffff00"), "unexpected EOF", false},
+	{"Definite length strings with short data", hexDecode("7b7fffffffffffffff010203"), "unexpected EOF", false},
+	{"Definite length maps and arrays not closed with enough items", hexDecode("81"), "unexpected EOF", false},
+	{"Definite length maps and arrays not closed with enough items", hexDecode("818181818181818181"), "unexpected EOF", false},
+	{"Definite length maps and arrays not closed with enough items", hexDecode("8200"), "unexpected EOF", false},
+	{"Definite length maps and arrays not closed with enough items", hexDecode("a1"), "unexpected EOF", false},
+	{"Definite length maps and arrays not closed with enough items", hexDecode("a20102"), "unexpected EOF", false},
+	{"Definite length maps and arrays not closed with enough items", hexDecode("a100"), "unexpected EOF", false},
+	{"Definite length maps and arrays not closed with enough items", hexDecode("a2000000"), "unexpected EOF", false},
+	{"Indefinite length strings not closed by a break stop code", hexDecode("5f4100"), "unexpected EOF", false},
+	{"Indefinite length strings not closed by a break stop code", hexDecode("7f6100"), "unexpected EOF", false},
+	{"Indefinite length maps and arrays not closed by a break stop code", hexDecode("9f"), "unexpected EOF", false},
+	{"Indefinite length maps and arrays not closed by a break stop code", hexDecode("9f0102"), "unexpected EOF", false},
+	{"Indefinite length maps and arrays not closed by a break stop code", hexDecode("bf"), "unexpected EOF", false},
+	{"Indefinite length maps and arrays not closed by a break stop code", hexDecode("bf01020102"), "unexpected EOF", false},
+	{"Indefinite length maps and arrays not closed by a break stop code", hexDecode("819f"), "unexpected EOF", false},
+	{"Indefinite length maps and arrays not closed by a break stop code", hexDecode("9f8000"), "unexpected EOF", false},
+	{"Indefinite length maps and arrays not closed by a break stop code", hexDecode("9f9f9f9f9fffffffff"), "unexpected EOF", false},
+	{"Indefinite length maps and arrays not closed by a break stop code", hexDecode("9f819f819f9fffffff"), "unexpected EOF", false},
+	// Five subkinds of well-formedness error kind 3 (syntax error)
+	{"Reserved additional information values", hexDecode("3e"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("5c"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("5d"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("5e"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("7c"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("7d"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("7e"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("9c"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("9d"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("9e"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("bc"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("bd"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("be"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("dc"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("dd"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("de"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("fc"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("fd"), "cbor: invalid additional information", true},
+	{"Reserved additional information values", hexDecode("fe"), "cbor: invalid additional information", true},
+	{"Reserved two-byte encodings of simple types", hexDecode("f800"), "cbor: invalid simple value 0 for type primitives", true},
+	{"Reserved two-byte encodings of simple types", hexDecode("f801"), "cbor: invalid simple value 1 for type primitives", true},
+	{"Reserved two-byte encodings of simple types", hexDecode("f818"), "cbor: invalid simple value 24 for type primitives", true},
+	{"Reserved two-byte encodings of simple types", hexDecode("f81f"), "cbor: invalid simple value 31 for type primitives", true},
+	{"Indefinite length string chunks not of the correct type", hexDecode("5f00ff"), "cbor: wrong element type positive integer for indefinite-length byte string", false},
+	{"Indefinite length string chunks not of the correct type", hexDecode("5f21ff"), "cbor: wrong element type negative integer for indefinite-length byte string", false},
+	{"Indefinite length string chunks not of the correct type", hexDecode("5f6100ff"), "cbor: wrong element type UTF-8 text string for indefinite-length byte string", false},
+	{"Indefinite length string chunks not of the correct type", hexDecode("5f80ff"), "cbor: wrong element type array for indefinite-length byte string", false},
+	{"Indefinite length string chunks not of the correct type", hexDecode("5fa0ff"), "cbor: wrong element type map for indefinite-length byte string", false},
+	{"Indefinite length string chunks not of the correct type", hexDecode("5fc000ff"), "cbor: wrong element type tag for indefinite-length byte string", false},
+	{"Indefinite length string chunks not of the correct type", hexDecode("5fe0ff"), "cbor: wrong element type primitives for indefinite-length byte string", false},
+	{"Indefinite length string chunks not of the correct type", hexDecode("7f4100ff"), "cbor: wrong element type byte string for indefinite-length UTF-8 text string", false},
+	{"Indefinite length string chunks not definite length", hexDecode("5f5f4100ffff"), "cbor: indefinite-length byte string chunk is not definite-length", false},
+	{"Indefinite length string chunks not definite length", hexDecode("7f7f6100ffff"), "cbor: indefinite-length UTF-8 text string chunk is not definite-length", false},
+	{"Break occurring on its own outside of an indefinite length item", hexDecode("ff"), "cbor: unexpected \"break\" code", true},
+	{"Break occurring in a definite length array or map or a tag", hexDecode("81ff"), "cbor: unexpected \"break\" code", true},
+	{"Break occurring in a definite length array or map or a tag", hexDecode("8200ff"), "cbor: unexpected \"break\" code", true},
+	{"Break occurring in a definite length array or map or a tag", hexDecode("a1ff"), "cbor: unexpected \"break\" code", true},
+	{"Break occurring in a definite length array or map or a tag", hexDecode("a1ff00"), "cbor: unexpected \"break\" code", true},
+	{"Break occurring in a definite length array or map or a tag", hexDecode("a100ff"), "cbor: unexpected \"break\" code", true},
+	{"Break occurring in a definite length array or map or a tag", hexDecode("a20000ff"), "cbor: unexpected \"break\" code", true},
+	{"Break occurring in a definite length array or map or a tag", hexDecode("9f81ff"), "cbor: unexpected \"break\" code", true},
+	{"Break occurring in a definite length array or map or a tag", hexDecode("9f829f819f9fffffffff"), "cbor: unexpected \"break\" code", true},
+	{"Break in indefinite length map would lead to odd number of items (break in a value position)", hexDecode("bf00ff"), "cbor: unexpected \"break\" code", true},
+	{"Break in indefinite length map would lead to odd number of items (break in a value position)", hexDecode("bf000000ff"), "cbor: unexpected \"break\" code", true},
+	{"Major type 0 with additional information 31", hexDecode("1f"), "cbor: invalid additional information 31 for type positive integer", true},
+	{"Major type 1 with additional information 31", hexDecode("3f"), "cbor: invalid additional information 31 for type negative integer", true},
+	{"Major type 6 with additional information 31", hexDecode("df"), "cbor: invalid additional information 31 for type tag", true},
+}
+
+func TestInvalidCBORUnmarshal(t *testing.T) {
+	for _, tc := range invalidCBORUnmarshalTests {
+		t.Run(tc.name, func(t *testing.T) {
+			var i interface{}
+			err := Unmarshal(tc.cborData, &i)
+			if err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborData)
+			} else if !tc.errorMsgPartialMatch && err.Error() != tc.wantErrorMsg {
+				t.Errorf("Unmarshal(0x%x) error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			} else if tc.errorMsgPartialMatch && !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestInvalidUTF8TextString(t *testing.T) {
+	invalidUTF8TextStringTests := []struct {
+		name         string
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		{"definite length text string", hexDecode("61fe"), invalidUTF8ErrorMsg},
+		{"indefinite length text string", hexDecode("7f62e6b061b4ff"), invalidUTF8ErrorMsg},
+	}
+	for _, tc := range invalidUTF8TextStringTests {
+		t.Run(tc.name, func(t *testing.T) {
+			var i interface{}
+			if err := Unmarshal(tc.cborData, &i); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborData)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Unmarshal(0x%x) error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+
+			var s string
+			if err := Unmarshal(tc.cborData, &s); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborData)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Unmarshal(0x%x) error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+	// Test decoding of mixed invalid text string and valid text string
+	cborData := hexDecode("7f62e6b061b4ff7f657374726561646d696e67ff")
+	dec := NewDecoder(bytes.NewReader(cborData))
+	var s string
+	if err := dec.Decode(&s); err == nil {
+		t.Errorf("Decode() didn't return an error")
+	} else if s != "" {
+		t.Errorf("Decode() returned %q, want %q", s, "")
+	}
+	if err := dec.Decode(&s); err != nil {
+		t.Errorf("Decode() returned error %v", err)
+	} else if s != "streaming" {
+		t.Errorf("Decode() returned %q, want %q", s, "streaming")
+	}
+}
+
+func TestUnmarshalStruct(t *testing.T) {
+	want := outer{
+		IntField:          123,
+		FloatField:        100000.0,
+		BoolField:         true,
+		StringField:       "test",
+		ByteStringField:   []byte{1, 3, 5},
+		ArrayField:        []string{"hello", "world"},
+		MapField:          map[string]bool{"morning": true, "afternoon": false},
+		NestedStructField: &inner{X: 1000, Y: 1000000},
+		unexportedField:   0,
+	}
+
+	tests := []struct {
+		name     string
+		cborData []byte
+		want     interface{}
+	}{
+		{"case-insensitive field name match", hexDecode("a868696e746669656c64187b6a666c6f61746669656c64fa47c3500069626f6f6c6669656c64f56b537472696e674669656c6464746573746f42797465537472696e674669656c64430103056a41727261794669656c64826568656c6c6f65776f726c64684d61704669656c64a2676d6f726e696e67f56961667465726e6f6f6ef4714e65737465645374727563744669656c64a261581903e861591a000f4240"), want},
+		{"exact field name match", hexDecode("a868496e744669656c64187b6a466c6f61744669656c64fa47c3500069426f6f6c4669656c64f56b537472696e674669656c6464746573746f42797465537472696e674669656c64430103056a41727261794669656c64826568656c6c6f65776f726c64684d61704669656c64a2676d6f726e696e67f56961667465726e6f6f6ef4714e65737465645374727563744669656c64a261581903e861591a000f4240"), want},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var v outer
+			if err := Unmarshal(tc.cborData, &v); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+			} else if !reflect.DeepEqual(v, want) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborData, v, v, want, want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalStructError1(t *testing.T) {
+	type outer2 struct {
+		IntField          int
+		FloatField        float32
+		BoolField         bool
+		StringField       string
+		ByteStringField   []byte
+		ArrayField        []int // wrong type
+		MapField          map[string]bool
+		NestedStructField map[int]string // wrong type
+		unexportedField   int64
+	}
+	want := outer2{
+		IntField:          123,
+		FloatField:        100000.0,
+		BoolField:         true,
+		StringField:       "test",
+		ByteStringField:   []byte{1, 3, 5},
+		ArrayField:        []int{0, 0},
+		MapField:          map[string]bool{"morning": true, "afternoon": false},
+		NestedStructField: map[int]string{},
+		unexportedField:   0,
+	}
+
+	cborData := hexDecode("a868496e744669656c64187b6a466c6f61744669656c64fa47c3500069426f6f6c4669656c64f56b537472696e674669656c6464746573746f42797465537472696e674669656c64430103056a41727261794669656c64826568656c6c6f65776f726c64684d61704669656c64a2676d6f726e696e67f56961667465726e6f6f6ef4714e65737465645374727563744669656c64a261581903e861591a000f4240")
+	const wantUnmarshalTypeErrorType = "UTF-8 text string"
+
+	var v outer2
+	if err := Unmarshal(cborData, &v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else {
+		if typeError, ok := err.(*UnmarshalTypeError); !ok {
+			t.Errorf("Unmarshal(0x%x) returned wrong type of error %T, want (*UnmarshalTypeError)", cborData, err)
+		} else {
+			if typeError.Value != wantUnmarshalTypeErrorType {
+				t.Errorf("Unmarshal(0x%x) (*UnmarshalTypeError).Value %s, want %s", cborData, typeError.Value, wantUnmarshalTypeErrorType)
+			}
+			if typeError.Type != typeInt {
+				t.Errorf("Unmarshal(0x%x) (*UnmarshalTypeError).Type %s, want %s", cborData, typeError.Type.String(), typeInt.String())
+			}
+			if typeError.Struct != "cbor.outer2" {
+				t.Errorf("Unmarshal(0x%x) (*UnmarshalTypeError).Struct %s, want %s", cborData, typeError.Struct, "cbor.outer2")
+			}
+			if typeError.Field != "ArrayField" {
+				t.Errorf("Unmarshal(0x%x) (*UnmarshalTypeError).Field %s, want %s", cborData, typeError.Field, "ArrayField")
+			}
+			if !strings.Contains(err.Error(), "cannot unmarshal UTF-8 text string into Go struct field") {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), "cannot unmarshal UTF-8 text string into Go struct field")
+			}
+		}
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, want, want)
+	}
+}
+
+func TestUnmarshalStructError2(t *testing.T) {
+	// Unmarshal integer and invalid UTF8 string as field name into struct
+	type strc struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+	}
+	want := strc{
+		A: "A",
+	}
+
+	// Unmarshal returns first error encountered, which is *UnmarshalTypeError (failed to unmarshal int into Go string)
+	cborData := hexDecode("a3fa47c35000026161614161fe6142") // {100000.0:2, "a":"A", 0xfe: B}
+	const wantUnmarshalTypeErrorMsg = "cannot unmarshal primitives into Go value of type string"
+	const wantUnmarshalTypeErrorType = "primitives"
+	v := strc{}
+	if err := Unmarshal(cborData, &v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else {
+		if typeError, ok := err.(*UnmarshalTypeError); !ok {
+			t.Errorf("Unmarshal(0x%x) returned wrong type of error %T, want (*UnmarshalTypeError)", cborData, err)
+		} else {
+			if typeError.Value != wantUnmarshalTypeErrorType {
+				t.Errorf("Unmarshal(0x%x) (*UnmarshalTypeError).Value %s, want %s", cborData, typeError.Value, wantUnmarshalTypeErrorType)
+			}
+			if typeError.Type != typeString {
+				t.Errorf("Unmarshal(0x%x) (*UnmarshalTypeError).Type %s, want %s", cborData, typeError.Type, typeString)
+			}
+			if !strings.Contains(err.Error(), wantUnmarshalTypeErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantUnmarshalTypeErrorMsg)
+			}
+		}
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, want, want)
+	}
+
+	// Unmarshal returns first error encountered, which is *cbor.SemanticError (invalid UTF8 string)
+	cborData = hexDecode("a361fe6142010261616141") // {0xfe: B, 1:2, "a":"A"}
+	v = strc{}
+	if err := Unmarshal(cborData, &v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else {
+		if _, ok := err.(*SemanticError); !ok {
+			t.Errorf("Unmarshal(0x%x) returned wrong type of error %T, want (*SemanticError)", cborData, err)
+		} else if err.Error() != invalidUTF8ErrorMsg {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want error %q", cborData, err.Error(), invalidUTF8ErrorMsg)
+		}
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, want, want)
+	}
+
+	// Unmarshal returns first error encountered, which is *cbor.SemanticError (invalid UTF8 string)
+	cborData = hexDecode("a3616261fe010261616141") // {"b": 0xfe, 1:2, "a":"A"}
+	v = strc{}
+	if err := Unmarshal(cborData, &v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else {
+		if _, ok := err.(*SemanticError); !ok {
+			t.Errorf("Unmarshal(0x%x) returned wrong type of error %T, want (*SemanticError)", cborData, err)
+		} else if err.Error() != invalidUTF8ErrorMsg {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want error %q", cborData, err.Error(), invalidUTF8ErrorMsg)
+		}
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, want, want)
+	}
+}
+
+func TestUnmarshalPrefilledArray(t *testing.T) {
+	prefilledArr := []int{1, 2, 3, 4, 5}
+	want := []int{10, 11, 3, 4, 5}
+	cborData := hexDecode("820a0b") // []int{10, 11}
+	if err := Unmarshal(cborData, &prefilledArr); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if len(prefilledArr) != 2 || cap(prefilledArr) != 5 {
+		t.Errorf("Unmarshal(0x%x) = %v (len %d, cap %d), want len == 2, cap == 5", cborData, prefilledArr, len(prefilledArr), cap(prefilledArr))
+	}
+	if !reflect.DeepEqual(prefilledArr[:cap(prefilledArr)], want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, prefilledArr, prefilledArr, want, want)
+	}
+
+	cborData = hexDecode("80") // empty array
+	if err := Unmarshal(cborData, &prefilledArr); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if len(prefilledArr) != 0 || cap(prefilledArr) != 0 {
+		t.Errorf("Unmarshal(0x%x) = %v (len %d, cap %d), want len == 0, cap == 0", cborData, prefilledArr, len(prefilledArr), cap(prefilledArr))
+	}
+}
+
+func TestUnmarshalPrefilledMap(t *testing.T) {
+	prefilledMap := map[string]string{"key": "value", "a": "1"}
+	want := map[string]string{"key": "value", "a": "A", "b": "B", "c": "C", "d": "D", "e": "E"}
+	cborData := hexDecode("a56161614161626142616361436164614461656145") // map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"}
+	if err := Unmarshal(cborData, &prefilledMap); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(prefilledMap, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, prefilledMap, prefilledMap, want, want)
+	}
+
+	prefilledMap = map[string]string{"key": "value"}
+	want = map[string]string{"key": "value"}
+	cborData = hexDecode("a0") // map[string]string{}
+	if err := Unmarshal(cborData, &prefilledMap); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(prefilledMap, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, prefilledMap, prefilledMap, want, want)
+	}
+}
+
+func TestUnmarshalPrefilledStruct(t *testing.T) {
+	type s struct {
+		a int
+		B []int
+		C bool
+	}
+	prefilledStruct := s{a: 100, B: []int{200, 300, 400, 500}, C: true}
+	want := s{a: 100, B: []int{2, 3}, C: true}
+	cborData := hexDecode("a26161016162820203") // map[string]interface{} {"a": 1, "b": []int{2, 3}}
+	if err := Unmarshal(cborData, &prefilledStruct); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(prefilledStruct, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, prefilledStruct, prefilledStruct, want, want)
+	}
+	if len(prefilledStruct.B) != 2 || cap(prefilledStruct.B) != 4 {
+		t.Errorf("Unmarshal(0x%x) = %v (len %d, cap %d), want len == 2, cap == 5", cborData, prefilledStruct.B, len(prefilledStruct.B), cap(prefilledStruct.B))
+	}
+	if !reflect.DeepEqual(prefilledStruct.B[:cap(prefilledStruct.B)], []int{2, 3, 400, 500}) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, prefilledStruct.B, prefilledStruct.B, []int{2, 3, 400, 500}, []int{2, 3, 400, 500})
+	}
+}
+
+func TestValid(t *testing.T) {
+	var buf bytes.Buffer
+	for _, t := range marshalTests {
+		buf.Write(t.cborData)
+	}
+	cborData := buf.Bytes()
+	var err error
+	for i := 0; i < len(marshalTests); i++ {
+		if cborData, err = valid(cborData); err != nil {
+			t.Errorf("Valid() returned error %v", err)
+		}
+	}
+	if len(cborData) != 0 {
+		t.Errorf("Valid() returned leftover data 0x%x, want none", cborData)
+	}
+}
+
+func TestStructFieldNil(t *testing.T) {
+	type TestStruct struct {
+		I   int
+		PI  *int
+		PPI **int
+	}
+	var struc TestStruct
+	cborData, err := Marshal(struc)
+	if err != nil {
+		t.Fatalf("Marshal(%+v) returned error %v", struc, err)
+	}
+	var struc2 TestStruct
+	err = Unmarshal(cborData, &struc2)
+	if err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	} else if !reflect.DeepEqual(struc, struc2) {
+		t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", cborData, struc2, struc)
+	}
+}
+
+func TestLengthOverflowsInt(t *testing.T) {
+	// Data is generating by go-fuzz.
+	// string/slice/map length in uint64 cast to int causes integer overflow.
+	cborData := [][]byte{
+		hexDecode("bbcf30303030303030cfd697829782"),
+		hexDecode("5bcf30303030303030cfd697829782"),
+	}
+	wantErrorMsg := "is too large"
+	for _, data := range cborData {
+		var intf interface{}
+		if err := Unmarshal(data, &intf); err == nil {
+			t.Errorf("Unmarshal(0x%x) didn't return an error, want error containing substring %q", data, wantErrorMsg)
+		} else if !strings.Contains(err.Error(), wantErrorMsg) {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want error containing substring %q", data, err.Error(), wantErrorMsg)
+		}
+	}
+}
+
+func TestMapKeyUnhashable(t *testing.T) {
+	// Data is generating by go-fuzz.
+	testCases := []struct {
+		name         string
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		{"slice as map key", hexDecode("bf8030ff"), "cbor: invalid map key type: slice"},                                                                 // {[]: -17}
+		{"map as map key", hexDecode("bf30a1a030ff"), "cbor: invalid map key type: map"},                                                                 // {-17: {{}: -17}}, empty map as map key
+		{"slice as map key", hexDecode("8f3030a730304430303030303030303030303030303030303030303030303030303030"), "cbor: invalid map key type: slice"},   // [-17, -17, {-17: -17, h'30303030': -17}, -17, -17, -17, -17, -17, -17, -17, -17, -17, -17, -17, -17], byte slice as may key
+		{"slice as map key", hexDecode("8f303030a730303030303030308530303030303030303030303030303030303030303030"), "cbor: invalid map key type: slice"}, // [-17, -17, -17, {-17: -17, [-17, -17, -17, -17, -17]: -17}, -17, -17, -17, -17, -17, -17, -17, -17, -17, -17, -17]
+		{"slice as map key", hexDecode("bfd1a388f730303030303030303030303030ff"), "cbor: invalid map key type: slice"},                                   // {17({[undefined, -17, -17, -17, -17, -17, -17, -17]: -17, -17: -17}): -17}}
+		{"map as map key", hexDecode("bfb0303030303030303030303030303030303030303030303030303030303030303030ff"), "cbor: invalid map key type: map"},     // {{-17: -17}: -17}, map as key
+		{"tagged slice as map key", hexDecode("a1c84c30303030303030303030303030"), "cbor: invalid map key type: slice"},                                  // {8(h'303030303030303030303030'): -17}
+		{"nested-tagged slice as map key", hexDecode("a33030306430303030d1cb4030"), "cbor: invalid map key type: slice"},                                 // {-17: "0000", 17(11(h'')): -17}
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v interface{}
+			if err := Unmarshal(tc.cborData, &v); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", tc.cborData, tc.wantErrorMsg)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+			if _, ok := v.(map[interface{}]interface{}); ok {
+				var v map[interface{}]interface{}
+				if err := Unmarshal(tc.cborData, &v); err == nil {
+					t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", tc.cborData, tc.wantErrorMsg)
+				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestMapKeyNaN(t *testing.T) {
+	// Data is generating by go-fuzz.
+	cborData := hexDecode("b0303030303030303030303030303030303038303030faffff30303030303030303030303030") // {-17: -17, NaN: -17}
+	var intf interface{}
+	if err := Unmarshal(cborData, &intf); err != nil {
+		t.Fatalf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	em, err := EncOptions{Sort: SortCanonical}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	if _, err := em.Marshal(intf); err != nil {
+		t.Errorf("Marshal(%v) returned error %v", intf, err)
+	}
+}
+
+func TestUnmarshalUndefinedElement(t *testing.T) {
+	// Data is generating by go-fuzz.
+	cborData := hexDecode("bfd1a388f730303030303030303030303030ff") // {17({[undefined, -17, -17, -17, -17, -17, -17, -17]: -17, -17: -17}): -17}
+	var intf interface{}
+	wantErrorMsg := "invalid map key type"
+	if err := Unmarshal(cborData, &intf); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want error containing substring %q", cborData, wantErrorMsg)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing substring %q", cborData, err.Error(), wantErrorMsg)
+	}
+}
+
+func TestMapKeyNil(t *testing.T) {
+	testData := [][]byte{
+		hexDecode("a1f630"), // {null: -17}
+	}
+	want := map[interface{}]interface{}{nil: int64(-17)}
+	for _, data := range testData {
+		var intf interface{}
+		if err := Unmarshal(data, &intf); err != nil {
+			t.Fatalf("Unmarshal(0x%x) returned error %v", data, err)
+		} else if !reflect.DeepEqual(intf, want) {
+			t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", data, intf, want)
+		}
+		if _, err := Marshal(intf); err != nil {
+			t.Errorf("Marshal(%v) returned error %v", intf, err)
+		}
+
+		var v map[interface{}]interface{}
+		if err := Unmarshal(data, &v); err != nil {
+			t.Errorf("Unmarshal(0x%x) returned error %v", data, err)
+		} else if !reflect.DeepEqual(v, want) {
+			t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", data, v, want)
+		}
+		if _, err := Marshal(v); err != nil {
+			t.Errorf("Marshal(%v) returned error %v", v, err)
+		}
+	}
+}
+
+func TestDecodeTime(t *testing.T) {
+	testCases := []struct {
+		name            string
+		cborRFC3339Time []byte
+		cborUnixTime    []byte
+		wantTime        time.Time
+	}{
+		{
+			name:            "zero time", // decode CBOR null to zero time
+			cborRFC3339Time: hexDecode("f6"),
+			cborUnixTime:    hexDecode("f6"),
+			wantTime:        time.Time{},
+		},
+		{
+			name:            "zero time", // decode CBOR undefined to zero time
+			cborRFC3339Time: hexDecode("f7"),
+			cborUnixTime:    hexDecode("f7"),
+			wantTime:        time.Time{},
+		},
+		{
+			name:            "NaN",
+			cborRFC3339Time: hexDecode("f97e00"),
+			cborUnixTime:    hexDecode("f97e00"),
+			wantTime:        time.Time{},
+		},
+		{
+			name:            "positive infinity",
+			cborRFC3339Time: hexDecode("f97c00"),
+			cborUnixTime:    hexDecode("f97c00"),
+			wantTime:        time.Time{},
+		},
+		{
+			name:            "negative infinity",
+			cborRFC3339Time: hexDecode("f9fc00"),
+			cborUnixTime:    hexDecode("f9fc00"),
+			wantTime:        time.Time{},
+		},
+		{
+			name:            "time without fractional seconds", // positive integer
+			cborRFC3339Time: hexDecode("74323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("1a514b67b0"),
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+		},
+		{
+			name:            "time with fractional seconds", // float
+			cborRFC3339Time: hexDecode("7819313937302d30312d30315432313a34363a34302d30363a3030"),
+			cborUnixTime:    hexDecode("fa47c35000"),
+			wantTime:        parseTime(time.RFC3339Nano, "1970-01-01T21:46:40-06:00"),
+		},
+		{
+			name:            "time with fractional seconds", // float
+			cborRFC3339Time: hexDecode("76323031332d30332d32315432303a30343a30302e355a"),
+			cborUnixTime:    hexDecode("fb41d452d9ec200000"),
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
+		},
+		{
+			name:            "time before January 1, 1970 UTC without fractional seconds", // negative integer
+			cborRFC3339Time: hexDecode("74313936392d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("3a0177f2cf"),
+			wantTime:        parseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tm := time.Now()
+			if err := Unmarshal(tc.cborRFC3339Time, &tm); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborRFC3339Time, err)
+			} else if !tc.wantTime.Equal(tm) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborRFC3339Time, tm, tm, tc.wantTime, tc.wantTime)
+			}
+			tm = time.Now()
+			if err := Unmarshal(tc.cborUnixTime, &tm); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborUnixTime, err)
+			} else if !tc.wantTime.Equal(tm) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborUnixTime, tm, tm, tc.wantTime, tc.wantTime)
+			}
+		})
+	}
+}
+
+func TestDecodeTimeWithTag(t *testing.T) {
+	testCases := []struct {
+		name            string
+		cborRFC3339Time []byte
+		cborUnixTime    []byte
+		wantTime        time.Time
+	}{
+		{
+			name:            "time without fractional seconds", // positive integer
+			cborRFC3339Time: hexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("c11a514b67b0"),
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+		},
+		{
+			name:            "time with fractional seconds", // float
+			cborRFC3339Time: hexDecode("c076323031332d30332d32315432303a30343a30302e355a"),
+			cborUnixTime:    hexDecode("c1fb41d452d9ec200000"),
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
+		},
+		{
+			name:            "time before January 1, 1970 UTC without fractional seconds", // negative integer
+			cborRFC3339Time: hexDecode("c074313936392d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("c13a0177f2cf"),
+			wantTime:        parseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tm := time.Now()
+			if err := Unmarshal(tc.cborRFC3339Time, &tm); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborRFC3339Time, err)
+			} else if !tc.wantTime.Equal(tm) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborRFC3339Time, tm, tm, tc.wantTime, tc.wantTime)
+			}
+			tm = time.Now()
+			if err := Unmarshal(tc.cborUnixTime, &tm); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborUnixTime, err)
+			} else if !tc.wantTime.Equal(tm) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborUnixTime, tm, tm, tc.wantTime, tc.wantTime)
+			}
+
+			var v interface{}
+			if err := Unmarshal(tc.cborRFC3339Time, &v); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborRFC3339Time, err)
+			} else if tm, ok := v.(time.Time); !ok || !tc.wantTime.Equal(tm) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborRFC3339Time, v, v, tc.wantTime, tc.wantTime)
+			}
+			v = nil
+			if err := Unmarshal(tc.cborUnixTime, &v); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborUnixTime, err)
+			} else if tm, ok := v.(time.Time); !ok || !tc.wantTime.Equal(tm) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborUnixTime, v, v, tc.wantTime, tc.wantTime)
+			}
+		})
+	}
+}
+
+func TestDecodeTimeError(t *testing.T) {
+	testCases := []struct {
+		name         string
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		{
+			name:         "invalid RFC3339 time string",
+			cborData:     hexDecode("7f657374726561646d696e67ff"),
+			wantErrorMsg: "cbor: cannot set streaming for time.Time",
+		},
+		{
+			name:         "byte string data cannot be decoded into time.Time",
+			cborData:     hexDecode("4f013030303030303030e03031ed3030"),
+			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type time.Time",
+		},
+		{
+			name:         "bool cannot be decoded into time.Time",
+			cborData:     hexDecode("f4"),
+			wantErrorMsg: "cbor: cannot unmarshal primitives into Go value of type time.Time",
+		},
+		{
+			name:         "invalid UTF-8 string",
+			cborData:     hexDecode("7f62e6b061b4ff"),
+			wantErrorMsg: "cbor: invalid UTF-8 string",
+		},
+		{
+			name:         "negative integer overflow",
+			cborData:     hexDecode("3bffffffffffffffff"),
+			wantErrorMsg: "cbor: cannot unmarshal negative integer into Go value of type time.Time",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tm := time.Now()
+			if err := Unmarshal(tc.cborData, &tm); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", tc.cborData, tc.wantErrorMsg)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestDecodeTimeWithTagError(t *testing.T) {
+	testCases := []struct {
+		name         string
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		{
+			name:         "Tag 0 with invalid RFC3339 time string",
+			cborData:     hexDecode("c07f657374726561646d696e67ff"),
+			wantErrorMsg: "cbor: cannot set streaming for time.Time",
+		},
+		{
+			name:         "Tag 0 with invalid UTF-8 string",
+			cborData:     hexDecode("c07f62e6b061b4ff"),
+			wantErrorMsg: "cbor: invalid UTF-8 string",
+		},
+		{
+			name:         "Tag 0 with integer content",
+			cborData:     hexDecode("c01a514b67b0"),
+			wantErrorMsg: "cbor: tag number 0 must be followed by text string, got positive integer",
+		},
+		{
+			name:         "Tag 0 with byte string content",
+			cborData:     hexDecode("c04f013030303030303030e03031ed3030"),
+			wantErrorMsg: "cbor: tag number 0 must be followed by text string, got byte string",
+		},
+		{
+			name:         "Tag 1 with negative integer overflow",
+			cborData:     hexDecode("c13bffffffffffffffff"),
+			wantErrorMsg: "cbor: cannot unmarshal negative integer into Go value",
+		},
+		{
+			name:         "Tag 1 with string content",
+			cborData:     hexDecode("c174323031332d30332d32315432303a30343a30305a"),
+			wantErrorMsg: "cbor: tag number 1 must be followed by integer or floating-point number, got UTF-8 text string",
+		},
+		{
+			name:         "Tag 1 with simple value",
+			cborData:     hexDecode("d801f6"), // 1(null)
+			wantErrorMsg: "cbor: tag number 1 must be followed by integer or floating-point number, got primitive",
+		},
+	}
+	dm, _ := DecOptions{TimeTag: DecTagOptional}.DecMode()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tm := time.Now()
+			if err := dm.Unmarshal(tc.cborData, &tm); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", tc.cborData, tc.wantErrorMsg)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.cborData, err, tc.wantErrorMsg)
+			}
+
+			var v interface{}
+			if err := dm.Unmarshal(tc.cborData, &v); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", tc.cborData, tc.wantErrorMsg)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.cborData, err, tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestDecodeTimeStreaming(t *testing.T) {
+	// Decoder decodes from mixed invalid and valid time.
+	testCases := []struct {
+		cborData     []byte
+		wantErrorMsg string
+		wantObj      time.Time
+	}{
+		{
+			cborData:     hexDecode("c07f62e6b061b4ff"),
+			wantErrorMsg: "cbor: invalid UTF-8 string",
+		},
+		{
+			cborData: hexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			wantObj:  time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
+		},
+		{
+			cborData:     hexDecode("c01a514b67b0"),
+			wantErrorMsg: "cbor: tag number 0 must be followed by text string, got positive integer",
+		},
+		{
+			cborData: hexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			wantObj:  time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
+		},
+		{
+			cborData:     hexDecode("c13bffffffffffffffff"),
+			wantErrorMsg: "-1-18446744073709551615 overflows Go's int64",
+		},
+		{
+			cborData: hexDecode("c11a514b67b0"),
+			wantObj:  time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
+		},
+		{
+			cborData:     hexDecode("c174323031332d30332d32315432303a30343a30305a"),
+			wantErrorMsg: "tag number 1 must be followed by integer or floating-point number, got UTF-8 text string",
+		},
+		{
+			cborData: hexDecode("c11a514b67b0"),
+			wantObj:  time.Date(2013, 3, 21, 20, 4, 0, 0, time.UTC),
+		},
+	}
+	// Data is a mixed stream of valid and invalid time data
+	var cborData []byte
+	for _, tc := range testCases {
+		cborData = append(cborData, tc.cborData...)
+	}
+	dm, _ := DecOptions{TimeTag: DecTagOptional}.DecMode()
+	dec := dm.NewDecoder(bytes.NewReader(cborData))
+	for _, tc := range testCases {
+		var v interface{}
+		err := dec.Decode(&v)
+		if tc.wantErrorMsg != "" {
+			if err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return error, want error msg %q", tc.cborData, tc.wantErrorMsg)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error msg %q, want %q", tc.cborData, err, tc.wantErrorMsg)
+			}
+		} else {
+			tm, ok := v.(time.Time)
+			if !ok {
+				t.Errorf("Unmarshal(0x%x) returned %s (%T), want time.Time", tc.cborData, v, v)
+			}
+			if !tc.wantObj.Equal(tm) {
+				t.Errorf("Unmarshal(0x%x) returned %s, want %s", tc.cborData, tm, tc.wantObj)
+			}
+		}
+	}
+	dec = dm.NewDecoder(bytes.NewReader(cborData))
+	for _, tc := range testCases {
+		var tm time.Time
+		err := dec.Decode(&tm)
+		if tc.wantErrorMsg != "" {
+			if err == nil {
+				t.Errorf("Unmarshal(0x%x) did't return error, want error msg %q", tc.cborData, tc.wantErrorMsg)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error msg %q, want %q", tc.cborData, err, tc.wantErrorMsg)
+			}
+		} else {
+			if !tc.wantObj.Equal(tm) {
+				t.Errorf("Unmarshal(0x%x) returned %s, want %s", tc.cborData, tm, tc.wantObj)
+			}
+		}
+	}
+}
+
+func TestDecTimeTagOption(t *testing.T) {
+	timeTagIgnoredDecMode, _ := DecOptions{TimeTag: DecTagIgnored}.DecMode()
+	timeTagOptionalDecMode, _ := DecOptions{TimeTag: DecTagOptional}.DecMode()
+	timeTagRequiredDecMode, _ := DecOptions{TimeTag: DecTagRequired}.DecMode()
+
+	testCases := []struct {
+		name            string
+		cborRFC3339Time []byte
+		cborUnixTime    []byte
+		decMode         DecMode
+		wantTime        time.Time
+		wantErrorMsg    string
+	}{
+		// not-tagged time CBOR data
+		{
+			name:            "not-tagged data with DecTagIgnored option",
+			cborRFC3339Time: hexDecode("74323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("1a514b67b0"),
+			decMode:         timeTagIgnoredDecMode,
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+		},
+		{
+			name:            "not-tagged data with timeTagOptionalDecMode option",
+			cborRFC3339Time: hexDecode("74323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("1a514b67b0"),
+			decMode:         timeTagOptionalDecMode,
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+		},
+		{
+			name:            "not-tagged data with timeTagRequiredDecMode option",
+			cborRFC3339Time: hexDecode("74323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("1a514b67b0"),
+			decMode:         timeTagRequiredDecMode,
+			wantErrorMsg:    "expect CBOR tag value",
+		},
+		// tagged time CBOR data
+		{
+			name:            "tagged data with timeTagIgnoredDecMode option",
+			cborRFC3339Time: hexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("c11a514b67b0"),
+			decMode:         timeTagIgnoredDecMode,
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+		},
+		{
+			name:            "tagged data with timeTagOptionalDecMode option",
+			cborRFC3339Time: hexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("c11a514b67b0"),
+			decMode:         timeTagOptionalDecMode,
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+		},
+		{
+			name:            "tagged data with timeTagRequiredDecMode option",
+			cborRFC3339Time: hexDecode("c074323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("c11a514b67b0"),
+			decMode:         timeTagRequiredDecMode,
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+		},
+		// mis-tagged time CBOR data
+		{
+			name:            "mis-tagged data with timeTagIgnoredDecMode option",
+			cborRFC3339Time: hexDecode("c8c974323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("c8c91a514b67b0"),
+			decMode:         timeTagIgnoredDecMode,
+			wantTime:        parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+		},
+		{
+			name:            "mis-tagged data with timeTagOptionalDecMode option",
+			cborRFC3339Time: hexDecode("c8c974323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("c8c91a514b67b0"),
+			decMode:         timeTagOptionalDecMode,
+			wantErrorMsg:    "cbor: wrong tag number for time.Time, got 8, expect 0 or 1",
+		},
+		{
+			name:            "mis-tagged data with timeTagRequiredDecMode option",
+			cborRFC3339Time: hexDecode("c8c974323031332d30332d32315432303a30343a30305a"),
+			cborUnixTime:    hexDecode("c8c91a514b67b0"),
+			decMode:         timeTagRequiredDecMode,
+			wantErrorMsg:    "cbor: wrong tag number for time.Time, got 8, expect 0 or 1",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tm := time.Now()
+			err := tc.decMode.Unmarshal(tc.cborRFC3339Time, &tm)
+			if tc.wantErrorMsg != "" {
+				if err == nil {
+					t.Errorf("Unmarshal(0x%x) didn't return error", tc.cborRFC3339Time)
+				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborRFC3339Time, err.Error(), tc.wantErrorMsg)
+				}
+			} else {
+				if !tc.wantTime.Equal(tm) {
+					t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborRFC3339Time, tm, tm, tc.wantTime, tc.wantTime)
+				}
+			}
+
+			tm = time.Now()
+			err = tc.decMode.Unmarshal(tc.cborUnixTime, &tm)
+			if tc.wantErrorMsg != "" {
+				if err == nil {
+					t.Errorf("Unmarshal(0x%x) didn't return error", tc.cborRFC3339Time)
+				} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+					t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborRFC3339Time, err.Error(), tc.wantErrorMsg)
+				}
+			} else {
+				if !tc.wantTime.Equal(tm) {
+					t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborRFC3339Time, tm, tm, tc.wantTime, tc.wantTime)
+				}
+			}
+		})
+	}
+}
+
+func TestUnmarshalStructTag1(t *testing.T) {
+	type strc struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+	}
+	want := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	cborData := hexDecode("a3616161416162614261636143") // {"a":"A", "b":"B", "c":"C"}
+
+	var v strc
+	if err := Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, want, want)
+	}
+}
+
+func TestUnmarshalStructTag2(t *testing.T) {
+	type strc struct {
+		A string `json:"a"`
+		B string `json:"b"`
+		C string `json:"c"`
+	}
+	want := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	cborData := hexDecode("a3616161416162614261636143") // {"a":"A", "b":"B", "c":"C"}
+
+	var v strc
+	if err := Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, want, want)
+	}
+}
+
+func TestUnmarshalStructTag3(t *testing.T) {
+	type strc struct {
+		A string `json:"x" cbor:"a"`
+		B string `json:"y" cbor:"b"`
+		C string `json:"z"`
+	}
+	want := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	cborData := hexDecode("a36161614161626142617a6143") // {"a":"A", "b":"B", "z":"C"}
+
+	var v strc
+	if err := Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, v, v, want, want)
+	}
+}
+
+func TestUnmarshalStructTag4(t *testing.T) {
+	type strc struct {
+		A string `json:"x" cbor:"a"`
+		B string `json:"y" cbor:"b"`
+		C string `json:"-"`
+	}
+	want := strc{
+		A: "A",
+		B: "B",
+	}
+	cborData := hexDecode("a3616161416162614261636143") // {"a":"A", "b":"B", "c":"C"}
+
+	var v strc
+	if err := Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, v, v, want, want)
+	}
+}
+
+type number uint64
+
+func (n number) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 8)
+	binary.BigEndian.PutUint64(data, uint64(n))
+	return
+}
+
+func (n *number) UnmarshalBinary(data []byte) (err error) {
+	if len(data) != 8 {
+		return errors.New("number:UnmarshalBinary: invalid length")
+	}
+	*n = number(binary.BigEndian.Uint64(data))
+	return
+}
+
+type stru struct {
+	a, b, c string
+}
+
+func (s *stru) MarshalBinary() ([]byte, error) {
+	return []byte(fmt.Sprintf("%s,%s,%s", s.a, s.b, s.c)), nil
+}
+
+func (s *stru) UnmarshalBinary(data []byte) (err error) {
+	ss := strings.Split(string(data), ",")
+	if len(ss) != 3 {
+		return errors.New("stru:UnmarshalBinary: invalid element count")
+	}
+	s.a, s.b, s.c = ss[0], ss[1], ss[2]
+	return
+}
+
+type marshalBinaryError string
+
+func (n marshalBinaryError) MarshalBinary() (data []byte, err error) {
+	return nil, errors.New(string(n))
+}
+
+func TestBinaryMarshalerUnmarshaler(t *testing.T) {
+	testCases := []roundTripTest{
+		{
+			name:         "primitive obj",
+			obj:          number(1234567890),
+			wantCborData: hexDecode("4800000000499602d2"),
+		},
+		{
+			name:         "struct obj",
+			obj:          stru{a: "a", b: "b", c: "c"},
+			wantCborData: hexDecode("45612C622C63"),
+		},
+	}
+	em, _ := EncOptions{}.EncMode()
+	dm, _ := DecOptions{}.DecMode()
+	testRoundTrip(t, testCases, em, dm)
+}
+
+func TestBinaryUnmarshalerError(t *testing.T) { //nolint:dupl
+	testCases := []struct {
+		name         string
+		typ          reflect.Type
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		{
+			name:         "primitive type",
+			typ:          reflect.TypeOf(number(0)),
+			cborData:     hexDecode("44499602d2"),
+			wantErrorMsg: "number:UnmarshalBinary: invalid length",
+		},
+		{
+			name:         "struct type",
+			typ:          reflect.TypeOf(stru{}),
+			cborData:     hexDecode("47612C622C632C64"),
+			wantErrorMsg: "stru:UnmarshalBinary: invalid element count",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := reflect.New(tc.typ)
+			if err := Unmarshal(tc.cborData, v.Interface()); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", tc.cborData, tc.wantErrorMsg)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestBinaryMarshalerError(t *testing.T) {
+	wantErrorMsg := "MarshalBinary: error"
+	v := marshalBinaryError(wantErrorMsg)
+	if _, err := Marshal(v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", v, wantErrorMsg)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want %q", v, err.Error(), wantErrorMsg)
+	}
+}
+
+type number2 uint64
+
+func (n number2) MarshalCBOR() (data []byte, err error) {
+	m := map[string]uint64{"num": uint64(n)}
+	return Marshal(m)
+}
+
+func (n *number2) UnmarshalCBOR(data []byte) (err error) {
+	var v map[string]uint64
+	if err := Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*n = number2(v["num"])
+	return nil
+}
+
+type stru2 struct {
+	a, b, c string
+}
+
+func (s *stru2) MarshalCBOR() ([]byte, error) {
+	v := []string{s.a, s.b, s.c}
+	return Marshal(v)
+}
+
+func (s *stru2) UnmarshalCBOR(data []byte) (err error) {
+	var v []string
+	if err := Unmarshal(data, &v); err != nil {
+		return err
+	}
+	if len(v) > 0 {
+		s.a = v[0]
+	}
+	if len(v) > 1 {
+		s.b = v[1]
+	}
+	if len(v) > 2 {
+		s.c = v[2]
+	}
+	return nil
+}
+
+type marshalCBORError string
+
+func (n marshalCBORError) MarshalCBOR() (data []byte, err error) {
+	return nil, errors.New(string(n))
+}
+
+func TestMarshalerUnmarshaler(t *testing.T) {
+	testCases := []roundTripTest{
+		{
+			name:         "primitive obj",
+			obj:          number2(1),
+			wantCborData: hexDecode("a1636e756d01"),
+		},
+		{
+			name:         "struct obj",
+			obj:          stru2{a: "a", b: "b", c: "c"},
+			wantCborData: hexDecode("83616161626163"),
+		},
+	}
+	em, _ := EncOptions{}.EncMode()
+	dm, _ := DecOptions{}.DecMode()
+	testRoundTrip(t, testCases, em, dm)
+}
+
+func TestUnmarshalerError(t *testing.T) { //nolint:dupl
+	testCases := []struct {
+		name         string
+		typ          reflect.Type
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		{
+			name:         "primitive type",
+			typ:          reflect.TypeOf(number2(0)),
+			cborData:     hexDecode("44499602d2"),
+			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type map[string]uint64",
+		},
+		{
+			name:         "struct type",
+			typ:          reflect.TypeOf(stru2{}),
+			cborData:     hexDecode("47612C622C632C64"),
+			wantErrorMsg: "cbor: cannot unmarshal byte string into Go value of type []string",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := reflect.New(tc.typ)
+			if err := Unmarshal(tc.cborData, v.Interface()); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error msg %q", tc.cborData, tc.wantErrorMsg)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestMarshalerError(t *testing.T) {
+	wantErrorMsg := "MarshalCBOR: error"
+	v := marshalCBORError(wantErrorMsg)
+	if _, err := Marshal(v); err == nil {
+		t.Errorf("Marshal(%+v) didn't return an error, want error msg %q", v, wantErrorMsg)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Marshal(%+v) returned error %q, want %q", v, err.Error(), wantErrorMsg)
+	}
+}
+
+// Found at https://github.com/oasislabs/oasis-core/blob/master/go/common/cbor/cbor_test.go
+func TestOutOfMem1(t *testing.T) {
+	cborData := []byte("\x9b\x00\x00000000")
+	var f []byte
+	if err := Unmarshal(cborData, &f); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	}
+}
+
+// Found at https://github.com/oasislabs/oasis-core/blob/master/go/common/cbor/cbor_test.go
+func TestOutOfMem2(t *testing.T) {
+	cborData := []byte("\x9b\x00\x00\x81112233")
+	var f []byte
+	if err := Unmarshal(cborData, &f); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	}
+}
+
+// Found at https://github.com/cose-wg/Examples/tree/master/RFC8152
+func TestCOSEExamples(t *testing.T) {
+	cborData := [][]byte{
+		hexDecode("D8608443A10101A1054C02D1F7E6F26C43D4868D87CE582464F84D913BA60A76070A9A48F26E97E863E2852948658F0811139868826E89218A75715B818440A101225818DBD43C4E9D719C27C6275C67D628D493F090593DB8218F11818344A1013818A220A401022001215820B2ADD44368EA6D641F9CA9AF308B4079AEB519F11E9B8A55A600B21233E86E6822F40458246D65726961646F632E6272616E64796275636B406275636B6C616E642E6578616D706C6540"),
+		hexDecode("D8628440A054546869732069732074686520636F6E74656E742E818343A10126A1044231315840E2AEAFD40D69D19DFE6E52077C5D7FF4E408282CBEFB5D06CBF414AF2E19D982AC45AC98B8544C908B4507DE1E90B717C3D34816FE926A2B98F53AFD2FA0F30A"),
+		hexDecode("D8628440A054546869732069732074686520636F6E74656E742E828343A10126A1044231315840E2AEAFD40D69D19DFE6E52077C5D7FF4E408282CBEFB5D06CBF414AF2E19D982AC45AC98B8544C908B4507DE1E90B717C3D34816FE926A2B98F53AFD2FA0F30A8344A1013823A104581E62696C626F2E62616767696E7340686F626269746F6E2E6578616D706C65588400A2D28A7C2BDB1587877420F65ADF7D0B9A06635DD1DE64BB62974C863F0B160DD2163734034E6AC003B01E8705524C5C4CA479A952F0247EE8CB0B4FB7397BA08D009E0C8BF482270CC5771AA143966E5A469A09F613488030C5B07EC6D722E3835ADB5B2D8C44E95FFB13877DD2582866883535DE3BB03D01753F83AB87BB4F7A0297"),
+		hexDecode("D8628440A1078343A10126A10442313158405AC05E289D5D0E1B0A7F048A5D2B643813DED50BC9E49220F4F7278F85F19D4A77D655C9D3B51E805A74B099E1E085AACD97FC29D72F887E8802BB6650CCEB2C54546869732069732074686520636F6E74656E742E818343A10126A1044231315840E2AEAFD40D69D19DFE6E52077C5D7FF4E408282CBEFB5D06CBF414AF2E19D982AC45AC98B8544C908B4507DE1E90B717C3D34816FE926A2B98F53AFD2FA0F30A"),
+		hexDecode("D8628456A2687265736572766564F40281687265736572766564A054546869732069732074686520636F6E74656E742E818343A10126A10442313158403FC54702AA56E1B2CB20284294C9106A63F91BAC658D69351210A031D8FC7C5FF3E4BE39445B1A3E83E1510D1ACA2F2E8A7C081C7645042B18ABA9D1FAD1BD9C"),
+		hexDecode("D28443A10126A10442313154546869732069732074686520636F6E74656E742E58408EB33E4CA31D1C465AB05AAC34CC6B23D58FEF5C083106C4D25A91AEF0B0117E2AF9A291AA32E14AB834DC56ED2A223444547E01F11D3B0916E5A4C345CACB36"),
+		hexDecode("D8608443A10101A1054CC9CF4DF2FE6C632BF788641358247ADBE2709CA818FB415F1E5DF66F4E1A51053BA6D65A1A0C52A357DA7A644B8070A151B0818344A1013818A220A40102200121582098F50A4FF6C05861C8860D13A638EA56C3F5AD7590BBFBF054E1C7B4D91D628022F50458246D65726961646F632E6272616E64796275636B406275636B6C616E642E6578616D706C6540"),
+		hexDecode("D8608443A1010AA1054D89F52F65A1C580933B5261A76C581C753548A19B1307084CA7B2056924ED95F2E3B17006DFE931B687B847818343A10129A2335061616262636364646565666667676868044A6F75722D73656372657440"),
+		hexDecode("D8608443A10101A2054CC9CF4DF2FE6C632BF7886413078344A1013823A104581E62696C626F2E62616767696E7340686F626269746F6E2E6578616D706C65588400929663C8789BB28177AE28467E66377DA12302D7F9594D2999AFA5DFA531294F8896F2B6CDF1740014F4C7F1A358E3A6CF57F4ED6FB02FCF8F7AA989F5DFD07F0700A3A7D8F3C604BA70FA9411BD10C2591B483E1D2C31DE003183E434D8FBA18F17A4C7E3DFA003AC1CF3D30D44D2533C4989D3AC38C38B71481CC3430C9D65E7DDFF58247ADBE2709CA818FB415F1E5DF66F4E1A51053BA6D65A1A0C52A357DA7A644B8070A151B0818344A1013818A220A40102200121582098F50A4FF6C05861C8860D13A638EA56C3F5AD7590BBFBF054E1C7B4D91D628022F50458246D65726961646F632E6272616E64796275636B406275636B6C616E642E6578616D706C6540"),
+		hexDecode("D8608443A10101A1054C02D1F7E6F26C43D4868D87CE582464F84D913BA60A76070A9A48F26E97E863E28529D8F5335E5F0165EEE976B4A5F6C6F09D818344A101381FA3225821706572656772696E2E746F6F6B407475636B626F726F7567682E6578616D706C650458246D65726961646F632E6272616E64796275636B406275636B6C616E642E6578616D706C6535420101581841E0D76F579DBD0D936A662D54D8582037DE2E366FDE1C62"),
+		hexDecode("D08343A1010AA1054D89F52F65A1C580933B5261A78C581C5974E1B99A3A4CC09A659AA2E9E7FFF161D38CE71CB45CE460FFB569"),
+		hexDecode("D08343A1010AA1064261A7581C252A8911D465C125B6764739700F0141ED09192DE139E053BD09ABCA"),
+		hexDecode("D8618543A1010FA054546869732069732074686520636F6E74656E742E489E1226BA1F81B848818340A20125044A6F75722D73656372657440"),
+		hexDecode("D8618543A10105A054546869732069732074686520636F6E74656E742E582081A03448ACD3D305376EAA11FB3FE416A955BE2CBE7EC96F012C994BC3F16A41818344A101381AA3225821706572656772696E2E746F6F6B407475636B626F726F7567682E6578616D706C650458246D65726961646F632E6272616E64796275636B406275636B6C616E642E6578616D706C653558404D8553E7E74F3C6A3A9DD3EF286A8195CBF8A23D19558CCFEC7D34B824F42D92BD06BD2C7F0271F0214E141FB779AE2856ABF585A58368B017E7F2A9E5CE4DB540"),
+		hexDecode("D8618543A1010EA054546869732069732074686520636F6E74656E742E4836F5AFAF0BAB5D43818340A2012404582430313863306165352D346439622D343731622D626664362D6565663331346263373033375818711AB0DC2FC4585DCE27EFFA6781C8093EBA906F227B6EB0"),
+		hexDecode("D8618543A10105A054546869732069732074686520636F6E74656E742E5820BF48235E809B5C42E995F2B7D5FA13620E7ED834E337F6AA43DF161E49E9323E828344A101381CA220A4010220032158420043B12669ACAC3FD27898FFBA0BCD2E6C366D53BC4DB71F909A759304ACFB5E18CDC7BA0B13FF8C7636271A6924B1AC63C02688075B55EF2D613574E7DC242F79C322F504581E62696C626F2E62616767696E7340686F626269746F6E2E6578616D706C655828339BC4F79984CDC6B3E6CE5F315A4C7D2B0AC466FCEA69E8C07DFBCA5BB1F661BC5F8E0DF9E3EFF58340A2012404582430313863306165352D346439622D343731622D626664362D65656633313462633730333758280B2C7CFCE04E98276342D6476A7723C090DFDD15F9A518E7736549E998370695E6D6A83B4AE507BB"),
+		hexDecode("D18443A1010FA054546869732069732074686520636F6E74656E742E48726043745027214F"),
+	}
+	for _, d := range cborData {
+		var v interface{}
+		if err := Unmarshal(d, &v); err != nil {
+			t.Errorf("Unmarshal(0x%x) returned error %v", d, err)
+		}
+	}
+}
+
+func TestUnmarshalStructKeyAsIntError(t *testing.T) {
+	type T1 struct {
+		F1 int `cbor:"1,keyasint"`
+	}
+	cborData := hexDecode("a13bffffffffffffffff01") // {1: -18446744073709551616}
+	var v T1
+	if err := Unmarshal(cborData, &v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), "cannot unmarshal")
+	}
+}
+
+func TestUnmarshalArrayToStruct(t *testing.T) {
+	type T struct {
+		_ struct{} `cbor:",toarray"`
+		A int
+		B int
+		C int
+	}
+	testCases := []struct {
+		name     string
+		cborData []byte
+	}{
+		{"definite length array", hexDecode("83010203")},
+		{"indefinite length array", hexDecode("9f010203ff")},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v T
+			if err := Unmarshal(tc.cborData, &v); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+			}
+		})
+	}
+}
+
+func TestUnmarshalArrayToStructNoToArrayOptionError(t *testing.T) {
+	type T struct {
+		A int
+		B int
+		C int
+	}
+	cborData := hexDecode("8301020383010203")
+	var v1 T
+	wantT := T{}
+	dec := NewDecoder(bytes.NewReader(cborData))
+	if err := dec.Decode(&v1); err == nil {
+		t.Errorf("Decode(%+v) didn't return an error", v1)
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Decode(%+v) returned wrong error type %T, want (*UnmarshalTypeError)", v1, err)
+	} else if !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Errorf("Decode(%+v) returned error %q, want error containing %q", err.Error(), v1, "cannot unmarshal")
+	}
+	if !reflect.DeepEqual(v1, wantT) {
+		t.Errorf("Decode() = %+v (%T), want %+v (%T)", v1, v1, wantT, wantT)
+	}
+	var v2 []int
+	want := []int{1, 2, 3}
+	if err := dec.Decode(&v2); err != nil {
+		t.Errorf("Decode() returned error %v", err)
+	}
+	if !reflect.DeepEqual(v2, want) {
+		t.Errorf("Decode() = %+v (%T), want %+v (%T)", v2, v2, want, want)
+	}
+}
+
+func TestUnmarshalNonArrayDataToStructToArray(t *testing.T) {
+	type T struct {
+		_ struct{} `cbor:",toarray"`
+		A int
+		B int
+		C int
+	}
+	testCases := []struct {
+		name     string
+		cborData []byte
+	}{
+		{"CBOR positive int", hexDecode("00")},                        // 0
+		{"CBOR negative int", hexDecode("20")},                        // -1
+		{"CBOR byte string", hexDecode("4401020304")},                 // h`01020304`
+		{"CBOR text string", hexDecode("7f657374726561646d696e67ff")}, // streaming
+		{"CBOR map", hexDecode("a3614101614202614303")},               // {"A": 1, "B": 2, "C": 3}
+		{"CBOR bool", hexDecode("f5")},                                // true
+		{"CBOR float", hexDecode("fa7f7fffff")},                       // 3.4028234663852886e+38
+	}
+	wantT := T{}
+	wantErrorMsg := "cannot unmarshal"
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v T
+			if err := Unmarshal(tc.cborData, &v); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborData)
+			} else if _, ok := err.(*UnmarshalTypeError); !ok {
+				t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", tc.cborData, err)
+			} else if !strings.Contains(err.Error(), wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborData, err.Error(), wantErrorMsg)
+			}
+			if !reflect.DeepEqual(v, wantT) {
+				t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", tc.cborData, v, v, wantT, wantT)
+			}
+		})
+	}
+}
+
+func TestUnmarshalArrayToStructWrongSizeError(t *testing.T) {
+	type T struct {
+		_ struct{} `cbor:",toarray"`
+		A int
+		B int
+	}
+	cborData := hexDecode("8301020383010203")
+	var v1 T
+	wantT := T{}
+	dec := NewDecoder(bytes.NewReader(cborData))
+	if err := dec.Decode(&v1); err == nil {
+		t.Errorf("Decode(%+v) didn't return an error", v1)
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Decode(%+v) returned wrong error type %T, want (*UnmarshalTypeError)", v1, err)
+	} else if !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Errorf("Decode(%+v) returned error %q, want error containing %q", v1, err.Error(), "cannot unmarshal")
+	}
+	if !reflect.DeepEqual(v1, wantT) {
+		t.Errorf("Decode() = %+v (%T), want %+v (%T)", v1, v1, wantT, wantT)
+	}
+	var v2 []int
+	want := []int{1, 2, 3}
+	if err := dec.Decode(&v2); err != nil {
+		t.Errorf("Decode() returned error %v", err)
+	}
+	if !reflect.DeepEqual(v2, want) {
+		t.Errorf("Decode() = %+v (%T), want %+v (%T)", v2, v2, want, want)
+	}
+}
+
+func TestUnmarshalArrayToStructWrongFieldTypeError(t *testing.T) {
+	type T struct {
+		_ struct{} `cbor:",toarray"`
+		A int
+		B string
+		C int
+	}
+	testCases := []struct {
+		name         string
+		cborData     []byte
+		wantErrorMsg string
+		wantV        interface{}
+	}{
+		// [1, 2, 3]
+		{"wrong field type", hexDecode("83010203"), "cannot unmarshal", T{A: 1, C: 3}},
+		// [1, 0xfe, 3]
+		{"invalid UTF-8 string", hexDecode("830161fe03"), invalidUTF8ErrorMsg, T{A: 1, C: 3}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v T
+			if err := Unmarshal(tc.cborData, &v); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborData)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+			if !reflect.DeepEqual(v, tc.wantV) {
+				t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", tc.cborData, v, v, tc.wantV, tc.wantV)
+			}
+		})
+	}
+}
+
+func TestUnmarshalArrayToStructCannotSetEmbeddedPointerError(t *testing.T) {
+	type (
+		s1 struct {
+			x int //nolint:unused,structcheck
+			X int
+		}
+		S2 struct {
+			y int //nolint:unused,structcheck
+			Y int
+		}
+		S struct {
+			_ struct{} `cbor:",toarray"`
+			*s1
+			*S2
+		}
+	)
+	cborData := []byte{0x82, 0x02, 0x04} // [2, 4]
+	const wantErrorMsg = "cannot set embedded pointer to unexported struct"
+	wantV := S{S2: &S2{Y: 4}}
+	var v S
+	err := Unmarshal(cborData, &v)
+	if err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want error %q", cborData, wantErrorMsg)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(v, wantV) {
+		t.Errorf("Decode() = %+v (%T), want %+v (%T)", v, v, wantV, wantV)
+	}
+}
+
+func TestUnmarshalIntoSliceError(t *testing.T) {
+	cborData := []byte{0x83, 0x61, 0x61, 0x61, 0xfe, 0x61, 0x62} // ["a", 0xfe, "b"]
+	wantErrorMsg := invalidUTF8ErrorMsg
+	var want interface{}
+
+	// Unmarshal CBOR array into Go empty interface.
+	var v1 interface{}
+	want = []interface{}{"a", interface{}(nil), "b"}
+	if err := Unmarshal(cborData, &v1); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", cborData, wantErrorMsg)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(v1, want) {
+		t.Errorf("Unmarshal(0x%x) = %v, want %v", cborData, v1, want)
+	}
+
+	// Unmarshal CBOR array into Go slice.
+	var v2 []string
+	want = []string{"a", "", "b"}
+	if err := Unmarshal(cborData, &v2); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", cborData, wantErrorMsg)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(v2, want) {
+		t.Errorf("Unmarshal(0x%x) = %v, want %v", cborData, v2, want)
+	}
+
+	// Unmarshal CBOR array into Go array.
+	var v3 [3]string
+	want = [3]string{"a", "", "b"}
+	if err := Unmarshal(cborData, &v3); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", cborData, wantErrorMsg)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(v3, want) {
+		t.Errorf("Unmarshal(0x%x) = %v, want %v", cborData, v3, want)
+	}
+
+	// Unmarshal CBOR array into populated Go slice.
+	v4 := []string{"hello", "to", "you"}
+	want = []string{"a", "to", "b"}
+	if err := Unmarshal(cborData, &v4); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", cborData, wantErrorMsg)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(v4, want) {
+		t.Errorf("Unmarshal(0x%x) = %v, want %v", cborData, v4, want)
+	}
+}
+
+func TestUnmarshalIntoMapError(t *testing.T) {
+	cborData := [][]byte{
+		{0xa3, 0x61, 0x61, 0x61, 0x41, 0x61, 0xfe, 0x61, 0x43, 0x61, 0x62, 0x61, 0x42}, // {"a":"A", 0xfe: "C", "b":"B"}
+		{0xa3, 0x61, 0x61, 0x61, 0x41, 0x61, 0x63, 0x61, 0xfe, 0x61, 0x62, 0x61, 0x42}, // {"a":"A", "c": 0xfe, "b":"B"}
+	}
+	wantErrorMsg := invalidUTF8ErrorMsg
+	var want interface{}
+
+	for _, data := range cborData {
+		// Unmarshal CBOR map into Go empty interface.
+		var v1 interface{}
+		want = map[interface{}]interface{}{"a": "A", "b": "B"}
+		if err := Unmarshal(data, &v1); err == nil {
+			t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", data, wantErrorMsg)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(v1, want) {
+			t.Errorf("Unmarshal(0x%x) = %v, want %v", data, v1, want)
+		}
+
+		// Unmarshal CBOR map into Go map[interface{}]interface{}.
+		var v2 map[interface{}]interface{}
+		want = map[interface{}]interface{}{"a": "A", "b": "B"}
+		if err := Unmarshal(data, &v2); err == nil {
+			t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", data, wantErrorMsg)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(v2, want) {
+			t.Errorf("Unmarshal(0x%x) = %v, want %v", data, v2, want)
+		}
+
+		// Unmarshal CBOR array into Go map[string]string.
+		var v3 map[string]string
+		want = map[string]string{"a": "A", "b": "B"}
+		if err := Unmarshal(data, &v3); err == nil {
+			t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", data, wantErrorMsg)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(v3, want) {
+			t.Errorf("Unmarshal(0x%x) = %v, want %v", data, v3, want)
+		}
+
+		// Unmarshal CBOR array into populated Go map[string]string.
+		v4 := map[string]string{"c": "D"}
+		want = map[string]string{"a": "A", "b": "B", "c": "D"}
+		if err := Unmarshal(data, &v4); err == nil {
+			t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", data, wantErrorMsg)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want %q", data, err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(v4, want) {
+			t.Errorf("Unmarshal(0x%x) = %v, want %v", data, v4, want)
+		}
+	}
+}
+
+func TestStructToArrayError(t *testing.T) {
+	type coseHeader struct {
+		Alg int    `cbor:"1,keyasint,omitempty"`
+		Kid []byte `cbor:"4,keyasint,omitempty"`
+		IV  []byte `cbor:"5,keyasint,omitempty"`
+	}
+	type nestedCWT struct {
+		_           struct{} `cbor:",toarray"`
+		Protected   []byte
+		Unprotected coseHeader
+		Ciphertext  []byte
+	}
+	for _, tc := range []struct {
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		// [-17, [-17, -17], -17]
+		{hexDecode("9f3082303030ff"), "cbor: cannot unmarshal negative integer into Go struct field cbor.nestedCWT.Protected of type []uint8"},
+		// [[], [], ["\x930000", -17]]
+		{hexDecode("9f9fff9fff9f65933030303030ffff"), "cbor: cannot unmarshal array into Go struct field cbor.nestedCWT.Unprotected of type cbor.coseHeader (cannot decode CBOR array to struct without toarray option)"},
+	} {
+		var v nestedCWT
+		if err := Unmarshal(tc.cborData, &v); err == nil {
+			t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", tc.cborData, tc.wantErrorMsg)
+		} else if err.Error() != tc.wantErrorMsg {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+		}
+	}
+}
+
+func TestStructKeyAsIntError(t *testing.T) {
+	type claims struct {
+		Iss string  `cbor:"1,keyasint"`
+		Sub string  `cbor:"2,keyasint"`
+		Aud string  `cbor:"3,keyasint"`
+		Exp float64 `cbor:"4,keyasint"`
+		Nbf float64 `cbor:"5,keyasint"`
+		Iat float64 `cbor:"6,keyasint"`
+		Cti []byte  `cbor:"7,keyasint"`
+	}
+	cborData := hexDecode("bf0783e662f03030ff") // {7: [simple(6), "\xF00", -17]}
+	wantErrorMsg := invalidUTF8ErrorMsg
+	wantV := claims{Cti: []byte{6, 0, 0}}
+	var v claims
+	if err := Unmarshal(cborData, &v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want %q", cborData, wantErrorMsg)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(v, wantV) {
+		t.Errorf("Unmarshal(0x%x) = %v, want %v", cborData, v, wantV)
+	}
+}
+
+func TestUnmarshalToNotNilInterface(t *testing.T) {
+	cborData := hexDecode("83010203") // []uint64{1, 2, 3}
+	s := "hello"                      //nolint:goconst
+	var v interface{} = s             // Unmarshal() sees v as type inteface{} and sets CBOR data as default Go type.  s is unmodified.  Same behavior as encoding/json.
+	wantV := []interface{}{uint64(1), uint64(2), uint64(3)}
+	if err := Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	} else if !reflect.DeepEqual(v, wantV) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, wantV, wantV)
+	} else if s != "hello" {
+		t.Errorf("Unmarshal(0x%x) modified s %q", cborData, s)
+	}
+}
+
+func TestDecOptions(t *testing.T) {
+	opts1 := DecOptions{TimeTag: DecTagRequired, DupMapKey: DupMapKeyEnforcedAPF}
+	dm, err := opts1.DecMode()
+	if err != nil {
+		t.Errorf("DecMode() returned an error %v", err)
+	} else {
+		opts2 := dm.DecOptions()
+		if !reflect.DeepEqual(opts1, opts2) {
+			t.Errorf("DecOptions->DecMode->DecOptions returned different values: %v, %v", opts1, opts2)
+		}
+	}
+}
+
+type roundTripTest struct {
+	name         string
+	obj          interface{}
+	wantCborData []byte
+}
+
+func testRoundTrip(t *testing.T, testCases []roundTripTest, em EncMode, dm DecMode) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := em.Marshal(tc.obj)
+			if err != nil {
+				t.Errorf("Marshal(%+v) returned error %v", tc.obj, err)
+			}
+			if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.obj, b, tc.wantCborData)
+			}
+			v := reflect.New(reflect.TypeOf(tc.obj))
+			if err := dm.Unmarshal(b, v.Interface()); err != nil {
+				t.Errorf("Unmarshal() returned error %v", err)
+			}
+			if !reflect.DeepEqual(tc.obj, v.Elem().Interface()) {
+				t.Errorf("Marshal-Unmarshal returned different values: %v, %v", tc.obj, v.Elem().Interface())
+			}
+		})
+	}
+}
+
+func TestDecModeInvalidTimeTag(t *testing.T) {
+	wantErrorMsg := "cbor: invalid TimeTag 101"
+	_, err := DecOptions{TimeTag: 101}.DecMode()
+	if err == nil {
+		t.Errorf("DecMode() didn't return an error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("DecMode() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestDecModeInvalidDuplicateMapKey(t *testing.T) {
+	wantErrorMsg := "cbor: invalid DupMapKey 101"
+	_, err := DecOptions{DupMapKey: 101}.DecMode()
+	if err == nil {
+		t.Errorf("DecMode() didn't return an error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("DecMode() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestUnmarshalStructKeyAsIntNumError(t *testing.T) {
+	type T1 struct {
+		F1 int `cbor:"a,keyasint"`
+	}
+	type T2 struct {
+		F1 int `cbor:"-18446744073709551616,keyasint"`
+	}
+	testCases := []struct {
+		name         string
+		cborData     []byte
+		obj          interface{}
+		wantErrorMsg string
+	}{
+		{
+			name:         "string as key",
+			cborData:     hexDecode("a1616101"),
+			obj:          T1{},
+			wantErrorMsg: "cbor: failed to parse field name \"a\" to int",
+		},
+		{
+			name:         "out of range int as key",
+			cborData:     hexDecode("a13bffffffffffffffff01"),
+			obj:          T2{},
+			wantErrorMsg: "cbor: failed to parse field name \"-18446744073709551616\" to int",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := reflect.New(reflect.TypeOf(tc.obj))
+			err := Unmarshal(tc.cborData, v.Interface())
+			if err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error, want error %q", tc.cborData, tc.wantErrorMsg)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Unmarshal(0x%x) error %v, want %v", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestUnmarshalEmptyMapWithDupMapKeyOpt(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cborData []byte
+		wantV    interface{}
+	}{
+		{
+			name:     "empty map",
+			cborData: hexDecode("a0"),
+			wantV:    map[interface{}]interface{}{},
+		},
+		{
+			name:     "indefinite empty map",
+			cborData: hexDecode("bfff"),
+			wantV:    map[interface{}]interface{}{},
+		},
+	}
+
+	dm, err := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	if err != nil {
+		t.Errorf("DecMode() returned error %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v interface{}
+			if err := dm.Unmarshal(tc.cborData, &v); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", tc.cborData, err)
+			}
+			if !reflect.DeepEqual(v, tc.wantV) {
+				t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", tc.cborData, v, v, tc.wantV, tc.wantV)
+			}
+		})
+	}
+}
+
+func TestUnmarshalDupMapKeyToEmptyInterface(t *testing.T) {
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	// Duplicate key overwrites previous value (default).
+	wantV := map[interface{}]interface{}{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
+	var v interface{}
+	if err := Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, wantV) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, wantV, wantV)
+	}
+
+	// Duplicate key triggers error.
+	wantV = map[interface{}]interface{}{"a": nil, "b": "B", "c": "C"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var v2 interface{}
+	if err := dm.Unmarshal(cborData, &v2); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*DupMapKeyError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", cborData, err)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(v2, wantV) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v2, v2, wantV, wantV)
+	}
+}
+
+func TestStreamDupMapKeyToEmptyInterface(t *testing.T) {
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // map with duplicate key "c": {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	var b []byte
+	for i := 0; i < 3; i++ {
+		b = append(b, cborData...)
+	}
+
+	// Duplicate key overwrites previous value (default).
+	wantV := map[interface{}]interface{}{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
+	dec := NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var v1 interface{}
+		if err := dec.Decode(&v1); err != nil {
+			t.Errorf("Decode() returned error %v", err)
+		}
+		if !reflect.DeepEqual(v1, wantV) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", v1, v1, wantV, wantV)
+		}
+	}
+	var v interface{}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+
+	// Duplicate key triggers error.
+	wantV = map[interface{}]interface{}{"a": nil, "b": "B", "c": "C"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	dec = dm.NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var v2 interface{}
+		if err := dec.Decode(&v2); err == nil {
+			t.Errorf("Decode() didn't return an error")
+		} else if _, ok := err.(*DupMapKeyError); !ok {
+			t.Errorf("Decode() returned wrong error type %T, want (*DupMapKeyError)", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Decode() returned error %q, want error containing %q", err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(v2, wantV) {
+			t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v2, v2, wantV, wantV)
+		}
+	}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+}
+
+func TestUnmarshalDupMapKeyToEmptyMap(t *testing.T) {
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	// Duplicate key overwrites previous value (default).
+	wantM := map[string]string{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
+	var m map[string]string
+	if err := Unmarshal(cborData, &m); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(m, wantM) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, m, m, wantM, wantM)
+	}
+
+	// Duplicate key triggers error.
+	wantM = map[string]string{"a": "", "b": "B", "c": "C"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var m2 map[string]string
+	if err := dm.Unmarshal(cborData, &m2); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*DupMapKeyError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", cborData, err)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(m2, wantM) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, m2, m2, wantM, wantM)
+	}
+}
+
+func TestStreamDupMapKeyToEmptyMap(t *testing.T) {
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	var b []byte
+	for i := 0; i < 3; i++ {
+		b = append(b, cborData...)
+	}
+
+	// Duplicate key overwrites previous value (default).
+	wantM := map[string]string{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E"}
+	dec := NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var m1 map[string]string
+		if err := dec.Decode(&m1); err != nil {
+			t.Errorf("Decode() returned error %v", err)
+		}
+		if !reflect.DeepEqual(m1, wantM) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", m1, m1, wantM, wantM)
+		}
+	}
+	var v interface{}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+
+	// Duplicate key triggers error.
+	wantM = map[string]string{"a": "", "b": "B", "c": "C"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	dec = dm.NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var m2 map[string]string
+		if err := dec.Decode(&m2); err == nil {
+			t.Errorf("Decode() didn't return an error")
+		} else if _, ok := err.(*DupMapKeyError); !ok {
+			t.Errorf("Decode() returned wrong error type %T, want (*DupMapKeyError)", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Decode() returned error %q, want error containing %q", err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(m2, wantM) {
+			t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, m2, m2, wantM, wantM)
+		}
+	}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+}
+
+func TestUnmarshalDupMapKeyToNotEmptyMap(t *testing.T) {
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	// Duplicate key overwrites previous value (default).
+	m := map[string]string{"a": "Z", "b": "Z", "c": "Z", "d": "Z", "e": "Z", "f": "Z"}
+	wantM := map[string]string{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E", "f": "Z"}
+	if err := Unmarshal(cborData, &m); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(m, wantM) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, m, m, wantM, wantM)
+	}
+
+	// Duplicate key triggers error.
+	m2 := map[string]string{"a": "Z", "b": "Z", "c": "Z", "d": "Z", "e": "Z", "f": "Z"}
+	wantM = map[string]string{"a": "", "b": "B", "c": "C", "d": "Z", "e": "Z", "f": "Z"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	if err := dm.Unmarshal(cborData, &m2); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*DupMapKeyError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(m2, wantM) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, m2, m2, wantM, wantM)
+	}
+}
+
+func TestStreamDupMapKeyToNotEmptyMap(t *testing.T) {
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	var b []byte
+	for i := 0; i < 3; i++ {
+		b = append(b, cborData...)
+	}
+
+	// Duplicate key overwrites previous value (default).
+	wantM := map[string]string{"a": "F", "b": "B", "c": "C", "d": "D", "e": "E", "f": "Z"}
+	dec := NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		m1 := map[string]string{"a": "Z", "b": "Z", "c": "Z", "d": "Z", "e": "Z", "f": "Z"}
+		if err := dec.Decode(&m1); err != nil {
+			t.Errorf("Decode() returned error %v", err)
+		}
+		if !reflect.DeepEqual(m1, wantM) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", m1, m1, wantM, wantM)
+		}
+	}
+	var v interface{}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+
+	// Duplicate key triggers error.
+	wantM = map[string]string{"a": "", "b": "B", "c": "C", "d": "Z", "e": "Z", "f": "Z"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	dec = dm.NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		m2 := map[string]string{"a": "Z", "b": "Z", "c": "Z", "d": "Z", "e": "Z", "f": "Z"}
+		if err := dec.Decode(&m2); err == nil {
+			t.Errorf("Decode() didn't return an error")
+		} else if _, ok := err.(*DupMapKeyError); !ok {
+			t.Errorf("Decode() returned wrong error type %T, want (*DupMapKeyError)", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Decode() returned error %q, want error containing %q", err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(m2, wantM) {
+			t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, m2, m2, wantM, wantM)
+		}
+	}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStruct(t *testing.T) {
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	// Duplicate key doesn't overwrite previous value (default).
+	wantS := s{A: "A", B: "B", C: "C", D: "D", E: "E"}
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error.
+	wantS = s{A: "A", B: "B", C: "C"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*DupMapKeyError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestStreamDupMapKeyToStruct(t *testing.T) {
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	var b []byte
+	for i := 0; i < 3; i++ {
+		b = append(b, cborData...)
+	}
+
+	// Duplicate key overwrites previous value (default).
+	wantS := s{A: "A", B: "B", C: "C", D: "D", E: "E"}
+	dec := NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s1 s
+		if err := dec.Decode(&s1); err != nil {
+			t.Errorf("Decode() returned error %v", err)
+		}
+		if !reflect.DeepEqual(s1, wantS) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", s1, s1, wantS, wantS)
+		}
+	}
+	var v interface{}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+
+	// Duplicate key triggers error.
+	wantS = s{A: "A", B: "B", C: "C"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	dec = dm.NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s2 s
+		if err := dec.Decode(&s2); err == nil {
+			t.Errorf("Decode() didn't return an error")
+		} else if _, ok := err.(*DupMapKeyError); !ok {
+			t.Errorf("Decode() returned wrong error type %T, want (*DupMapKeyError)", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Decode() returned error %q, want error containing %q", err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(s2, wantS) {
+			t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+		}
+	}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+}
+
+// dupl map key is a struct field
+func TestUnmarshalDupMapKeyToStructKeyAsInt(t *testing.T) {
+	type s struct {
+		A int `cbor:"1,keyasint"`
+		B int `cbor:"3,keyasint"`
+		C int `cbor:"5,keyasint"`
+	}
+	cborData := hexDecode("a40102030401030506") // {1:2, 3:4, 1:3, 5:6}
+
+	// Duplicate key doesn't overwrite previous value (default).
+	wantS := s{A: 2, B: 4, C: 6}
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error.
+	wantS = s{A: 2, B: 4}
+	wantErrorMsg := "cbor: found duplicate map key \"1\" at map element index 2"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*DupMapKeyError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestStreamDupMapKeyToStructKeyAsInt(t *testing.T) {
+	type s struct {
+		A int `cbor:"1,keyasint"`
+		B int `cbor:"3,keyasint"`
+		C int `cbor:"5,keyasint"`
+	}
+	cborData := hexDecode("a40102030401030506") // {1:2, 3:4, 1:3, 5:6}
+
+	var b []byte
+	for i := 0; i < 3; i++ {
+		b = append(b, cborData...)
+	}
+
+	// Duplicate key overwrites previous value (default).
+	wantS := s{A: 2, B: 4, C: 6}
+	dec := NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s1 s
+		if err := dec.Decode(&s1); err != nil {
+			t.Errorf("Decode() returned error %v", err)
+		}
+		if !reflect.DeepEqual(s1, wantS) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", s1, s1, wantS, wantS)
+		}
+	}
+	var v interface{}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+
+	// Duplicate key triggers error.
+	wantS = s{A: 2, B: 4}
+	wantErrorMsg := "cbor: found duplicate map key \"1\" at map element index 2"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	dec = dm.NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s2 s
+		if err := dec.Decode(&s2); err == nil {
+			t.Errorf("Decode() didn't return an error")
+		} else if _, ok := err.(*DupMapKeyError); !ok {
+			t.Errorf("Decode() returned wrong error type %T, want (*DupMapKeyError)", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Decode() returned error %q, want error containing %q", err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(s2, wantS) {
+			t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+		}
+	}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStructNoMatchingField(t *testing.T) {
+	type s struct {
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	wantS := s{B: "B", C: "C", D: "D", E: "E"}
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error even though map key "a" doesn't have a corresponding struct field.
+	wantS = s{B: "B", C: "C"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*DupMapKeyError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestStreamDupMapKeyToStructNoMatchingField(t *testing.T) {
+	type s struct {
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a6616161416162614261636143616161466164614461656145") // {"a": "A", "b": "B", "c": "C", "a": "F", "d": "D", "e": "E"}
+
+	var b []byte
+	for i := 0; i < 3; i++ {
+		b = append(b, cborData...)
+	}
+
+	// Duplicate key overwrites previous value (default).
+	wantS := s{B: "B", C: "C", D: "D", E: "E"}
+	dec := NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s1 s
+		if err := dec.Decode(&s1); err != nil {
+			t.Errorf("Decode() returned error %v", err)
+		}
+		if !reflect.DeepEqual(s1, wantS) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", s1, s1, wantS, wantS)
+		}
+	}
+	var v interface{}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+
+	// Duplicate key triggers error.
+	wantS = s{B: "B", C: "C"}
+	wantErrorMsg := "cbor: found duplicate map key \"a\" at map element index 3"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	dec = dm.NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s2 s
+		if err := dec.Decode(&s2); err == nil {
+			t.Errorf("Decode() didn't return an error")
+		} else if _, ok := err.(*DupMapKeyError); !ok {
+			t.Errorf("Decode() returned wrong error type %T, want (*DupMapKeyError)", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Decode() returned error %q, want error containing %q", err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(s2, wantS) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", s2, s2, wantS, wantS)
+		}
+	}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStructKeyAsIntNoMatchingField(t *testing.T) {
+	type s struct {
+		B int `cbor:"3,keyasint"`
+		C int `cbor:"5,keyasint"`
+	}
+	cborData := hexDecode("a40102030401030506") // {1:2, 3:4, 1:3, 5:6}
+
+	wantS := s{B: 4, C: 6}
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error even though map key "a" doesn't have a corresponding struct field.
+	wantS = s{B: 4}
+	wantErrorMsg := "cbor: found duplicate map key \"1\" at map element index 2"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*DupMapKeyError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestStreamDupMapKeyToStructKeyAsIntNoMatchingField(t *testing.T) {
+	type s struct {
+		B int `cbor:"3,keyasint"`
+		C int `cbor:"5,keyasint"`
+	}
+	cborData := hexDecode("a40102030401030506") // {1:2, 3:4, 1:3, 5:6}
+
+	var b []byte
+	for i := 0; i < 3; i++ {
+		b = append(b, cborData...)
+	}
+
+	// Duplicate key overwrites previous value (default).
+	wantS := s{B: 4, C: 6}
+	dec := NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s1 s
+		if err := dec.Decode(&s1); err != nil {
+			t.Errorf("Decode() returned error %v", err)
+		}
+		if !reflect.DeepEqual(s1, wantS) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", s1, s1, wantS, wantS)
+		}
+	}
+	var v interface{}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+
+	// Duplicate key triggers error.
+	wantS = s{B: 4}
+	wantErrorMsg := "cbor: found duplicate map key \"1\" at map element index 2"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	dec = dm.NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s2 s
+		if err := dec.Decode(&s2); err == nil {
+			t.Errorf("Decode() didn't return an error")
+		} else if _, ok := err.(*DupMapKeyError); !ok {
+			t.Errorf("Decode() returned wrong error type %T, want (*DupMapKeyError)", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Decode() returned error %q, want error containing %q", err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(s2, wantS) {
+			t.Errorf("Decode() = %v (%T), want %v (%T)", s2, s2, wantS, wantS)
+		}
+	}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStructWrongType(t *testing.T) {
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a861616141fa47c35000026162614261636143fa47c3500003616161466164614461656145") // {"a": "A", 100000.0:2, "b": "B", "c": "C", 100000.0:3, "a": "F", "d": "D", "e": "E"}
+
+	var s1 s
+	wantS := s{A: "A", B: "B", C: "C", D: "D", E: "E"}
+	wantErrorMsg := "cbor: cannot unmarshal"
+	if err := Unmarshal(cborData, &s1); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	wantS = s{A: "A", B: "B", C: "C"}
+	wantErrorMsg = "cbor: found duplicate map key \"100000\" at map element index 4"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*DupMapKeyError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*DupMapKeyError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestStreamDupMapKeyToStructWrongType(t *testing.T) {
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a861616141fa47c35000026162614261636143fa47c3500003616161466164614461656145") // {"a": "A", 100000.0:2, "b": "B", "c": "C", 100000.0:3, "a": "F", "d": "D", "e": "E"}
+
+	var b []byte
+	for i := 0; i < 3; i++ {
+		b = append(b, cborData...)
+	}
+
+	wantS := s{A: "A", B: "B", C: "C", D: "D", E: "E"}
+	wantErrorMsg := "cbor: cannot unmarshal"
+	dec := NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s1 s
+		if err := dec.Decode(&s1); err == nil {
+			t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+		} else if _, ok := err.(*UnmarshalTypeError); !ok {
+			t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+		} else if !strings.Contains(err.Error(), wantErrorMsg) {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(s1, wantS) {
+			t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+		}
+	}
+	var v interface{}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+
+	// Duplicate key triggers error.
+	wantS = s{A: "A", B: "B", C: "C"}
+	wantErrorMsg = "cbor: found duplicate map key \"100000\" at map element index 4"
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	dec = dm.NewDecoder(bytes.NewReader(b))
+	for i := 0; i < 3; i++ {
+		var s2 s
+		if err := dec.Decode(&s2); err == nil {
+			t.Errorf("Decode() didn't return an error")
+		} else if _, ok := err.(*DupMapKeyError); !ok {
+			t.Errorf("Decode() returned wrong error type %T, want (*DupMapKeyError)", err)
+		} else if err.Error() != wantErrorMsg {
+			t.Errorf("Decode() returned error %q, want error containing %q", err.Error(), wantErrorMsg)
+		}
+		if !reflect.DeepEqual(s2, wantS) {
+			t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+		}
+	}
+	if err := dec.Decode(&v); err != io.EOF {
+		t.Errorf("Decode() returned error %v, want %v", err, io.EOF)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStructStringParseError(t *testing.T) {
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a661fe6141616261426163614361fe61466164614461656145") // {"\xFE": "A", "b": "B", "c": "C", "\xFE": "F", "d": "D", "e": "E"}
+	wantS := s{A: "", B: "B", C: "C", D: "D", E: "E"}
+	wantErrorMsg := "cbor: invalid UTF-8 string"
+
+	// Duplicate key doesn't overwrite previous value (default).
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*SemanticError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*SemanticError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error.
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*SemanticError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*SemanticError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStructIntParseError(t *testing.T) {
+	type s struct {
+		A int `cbor:"1,keyasint"`
+		B int `cbor:"3,keyasint"`
+		C int `cbor:"5,keyasint"`
+	}
+	cborData := hexDecode("a43bffffffffffffffff0203043bffffffffffffffff030506") // {-18446744073709551616:2, 3:4, -18446744073709551616:3, 5:6}
+
+	// Duplicate key doesn't overwrite previous value (default).
+	wantS := s{B: 4, C: 6}
+	wantErrorMsg := "cbor: cannot unmarshal"
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error.
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStructWrongTypeParseError(t *testing.T) {
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a68161fe614161626142616361438161fe61466164614461656145") // {["\xFE"]: "A", "b": "B", "c": "C", ["\xFE"]: "F", "d": "D", "e": "E"}
+
+	// Duplicate key doesn't overwrite previous value (default).
+	wantS := s{A: "", B: "B", C: "C", D: "D", E: "E"}
+	wantErrorMsg := "cbor: cannot unmarshal"
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error.
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStructWrongTypeUnhashableError(t *testing.T) {
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a6810061416162614261636143810061466164614461656145") // {[0]: "A", "b": "B", "c": "C", [0]: "F", "d": "D", "e": "E"}
+	wantS := s{A: "", B: "B", C: "C", D: "D", E: "E"}
+
+	// Duplicate key doesn't overwrite previous value (default).
+	wantErrorMsg := "cbor: cannot unmarshal"
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error.
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}
+
+func TestUnmarshalDupMapKeyToStructTagTypeError(t *testing.T) {
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+		D string `cbor:"d"`
+		E string `cbor:"e"`
+	}
+	cborData := hexDecode("a6c24901000000000000000061416162614261636143c24901000000000000000061466164614461656145") // {bignum(18446744073709551616): "A", "b": "B", "c": "C", bignum(18446744073709551616): "F", "d": "D", "e": "E"}
+	wantS := s{A: "", B: "B", C: "C", D: "D", E: "E"}
+
+	// Duplicate key doesn't overwrite previous value (default).
+	wantErrorMsg := "cbor: cannot unmarshal"
+	var s1 s
+	if err := Unmarshal(cborData, &s1); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error", cborData)
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s1, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s1, s1, wantS, wantS)
+	}
+
+	// Duplicate key triggers error.
+	dm, _ := DecOptions{DupMapKey: DupMapKeyEnforcedAPF}.DecMode()
+	var s2 s
+	if err := dm.Unmarshal(cborData, &s2); err == nil {
+		t.Errorf("Unmarshal(0x%x, %s) didn't return an error", cborData, reflect.TypeOf(s2))
+	} else if _, ok := err.(*UnmarshalTypeError); !ok {
+		t.Errorf("Unmarshal(0x%x) returned wrong error type %T, want (*UnmarshalTypeError)", cborData, err)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", cborData, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(s2, wantS) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", cborData, s2, s2, wantS, wantS)
+	}
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/doc.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/doc.go
@@ -1,0 +1,109 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+/*
+Package cbor is a fast & safe CBOR encoder & decoder (RFC 7049) with a
+standard API + toarray & keyasint struct tags, CBOR tags, float64->32->16,
+CTAP2 & Canonical CBOR, duplicate map key options, and is customizable via
+simple API.
+
+CBOR encoding options allow "preferred serialization" by encoding integers and floats
+to their smallest forms (like float16) when values fit.
+
+Struct tags like "keyasint", "toarray" and "omitempty" makes CBOR data smaller.
+
+For example, "toarray" makes struct fields encode to array elements.  And "keyasint"
+makes struct fields encode to elements of CBOR map with int keys.
+
+Basics
+
+Function signatures identical to encoding/json include:
+
+    Marshal, Unmarshal, NewEncoder, NewDecoder, encoder.Encode, decoder.Decode.
+
+Codec functions are available at package-level (using defaults) or by creating modes
+from options at runtime.
+
+"Mode" in this API means definite way of encoding or decoding. Specifically, EncMode or DecMode.
+
+EncMode and DecMode interfaces are created from EncOptions or DecOptions structs.  For example,
+
+    em := cbor.EncOptions{...}.EncMode()
+    em := cbor.CanonicalEncOptions().EncMode()
+    em := cbor.CTAP2EncOptions().EncMode()
+
+Modes use immutable options to avoid side-effects and simplify concurrency. Behavior of modes
+won't accidentally change at runtime after they're created.
+
+Modes are intended to be reused and are safe for concurrent use.
+
+EncMode and DecMode Interfaces
+
+    // EncMode interface uses immutable options and is safe for concurrent use.
+    type EncMode interface {
+	Marshal(v interface{}) ([]byte, error)
+	NewEncoder(w io.Writer) *Encoder
+	EncOptions() EncOptions  // returns copy of options
+    }
+
+    // DecMode interface uses immutable options and is safe for concurrent use.
+    type DecMode interface {
+	Unmarshal(data []byte, v interface{}) error
+	NewDecoder(r io.Reader) *Decoder
+	DecOptions() DecOptions  // returns copy of options
+    }
+
+Using Default Encoding Mode
+
+    b, err := cbor.Marshal(v)
+
+    encoder := cbor.NewEncoder(w)
+    err = encoder.Encode(v)
+
+Using Default Decoding Mode
+
+    err := cbor.Unmarshal(b, &v)
+
+    decoder := cbor.NewDecoder(r)
+    err = decoder.Decode(&v)
+
+Creating and Using Encoding Modes
+
+    // Create EncOptions using either struct literal or a function.
+    opts := cbor.CanonicalEncOptions()
+
+    // If needed, modify encoding options
+    opts.Time = cbor.TimeUnix
+
+    // Create reusable EncMode interface with immutable options, safe for concurrent use.
+    em, err := opts.EncMode()
+
+    // Use EncMode like encoding/json, with same function signatures.
+    b, err := em.Marshal(v)
+    // or
+    encoder := em.NewEncoder(w)
+    err := encoder.Encode(v)
+
+Default Options
+
+Default encoding options are listed at https://github.com/fxamacker/cbor#api
+
+Struct Tags
+
+Struct tags like `cbor:"name,omitempty"` and `json:"name,omitempty"` work as expected.
+If both struct tags are specified then `cbor` is used.
+
+Struct tags like "keyasint", "toarray", and "omitempty" make it easy to use
+very compact formats like COSE and CWT (CBOR Web Tokens) with structs.
+
+For example, "toarray" makes struct fields encode to array elements.  And "keyasint"
+makes struct fields encode to elements of CBOR map with int keys.
+
+https://raw.githubusercontent.com/fxamacker/images/master/cbor/v2.0.0/cbor_easy_api.png
+
+Tests and Fuzzing
+
+Over 375 tests are included in this package. Cover-guided fuzzing is handled by a separate package:
+fxamacker/cbor-fuzz.
+*/
+package cbor

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/encode.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/encode.go
@@ -1,0 +1,1262 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"reflect"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/x448/float16"
+)
+
+// Marshal returns the CBOR encoding of v using the default encoding options.
+//
+// Marshal uses the following type-dependent default encodings:
+//
+// Boolean values encode as CBOR booleans (type 7).
+//
+// Positive integer values encode as CBOR positive integers (type 0).
+//
+// Negative integer values encode as CBOR negative integers (type 1).
+//
+// Floating point values encode as CBOR floating points (type 7).
+//
+// String values encode as CBOR text strings (type 3).
+//
+// []byte values encode as CBOR byte strings (type 2).
+//
+// Array and slice values encode as CBOR arrays (type 4).
+//
+// Map values encode as CBOR maps (type 5).
+//
+// Struct values encode as CBOR maps (type 5).  Each exported struct field
+// becomes a pair with field name encoded as CBOR text string (type 3) and
+// field value encoded based on its type.
+//
+// Pointer values encode as the value pointed to.
+//
+// Nil slice/map/pointer/interface values encode as CBOR nulls (type 7).
+//
+// time.Time values encode as text strings specified in RFC3339 when
+// EncOptions.TimeRFC3339 is true; otherwise, time.Time values encode as
+// numerical representation of seconds since January 1, 1970 UTC.
+//
+// If value implements the Marshaler interface, Marshal calls its MarshalCBOR
+// method.  If value implements encoding.BinaryMarshaler instead, Marhsal
+// calls its MarshalBinary method and encode it as CBOR byte string.
+//
+// Marshal supports format string stored under the "cbor" key in the struct
+// field's tag.  CBOR format string can specify the name of the field, "omitempty"
+// and "keyasint" options, and special case "-" for field omission.  If "cbor"
+// key is absent, Marshal uses "json" key.
+//
+// Struct field name is treated as integer if it has "keyasint" option in
+// its format string.  The format string must specify an integer as its
+// field name.
+//
+// Special struct field "_" is used to specify struct level options, such as
+// "toarray". "toarray" option enables Go struct to be encoded as CBOR array.
+// "omitempty" is disabled by "toarray" to ensure that the same number
+// of elements are encoded every time.
+//
+// Anonymous struct fields are usually marshaled as if their exported fields
+// were fields in the outer struct.  Marshal follows the same struct fields
+// visibility rules used by JSON encoding package.  An anonymous struct field
+// with a name given in its CBOR tag is treated as having that name, rather
+// than being anonymous.  An anonymous struct field of interface type is
+// treated the same as having that type as its name, rather than being anonymous.
+//
+// Interface values encode as the value contained in the interface.  A nil
+// interface value encodes as the null CBOR value.
+//
+// Channel, complex, and functon values cannot be encoded in CBOR.  Attempting
+// to encode such a value causes Marshal to return an UnsupportedTypeError.
+func Marshal(v interface{}) ([]byte, error) {
+	return defaultEncMode.Marshal(v)
+}
+
+// Marshaler is the interface implemented by types that can marshal themselves
+// into valid CBOR.
+type Marshaler interface {
+	MarshalCBOR() ([]byte, error)
+}
+
+// UnsupportedTypeError is returned by Marshal when attempting to encode an
+// unsupported value type.
+type UnsupportedTypeError struct {
+	Type reflect.Type
+}
+
+func (e *UnsupportedTypeError) Error() string {
+	return "cbor: unsupported type: " + e.Type.String()
+}
+
+// SortMode identifies supported sorting order.
+type SortMode int
+
+const (
+	// SortNone means no sorting.
+	SortNone SortMode = 0
+
+	// SortLengthFirst causes map keys or struct fields to be sorted such that:
+	//     - If two keys have different lengths, the shorter one sorts earlier;
+	//     - If two keys have the same length, the one with the lower value in
+	//       (byte-wise) lexical order sorts earlier.
+	// It is used in "Canonical CBOR" encoding in RFC 7049 3.9.
+	SortLengthFirst SortMode = 1
+
+	// SortBytewiseLexical causes map keys or struct fields to be sorted in the
+	// bytewise lexicographic order of their deterministic CBOR encodings.
+	// It is used in "CTAP2 Canonical CBOR" and "Core Deterministic Encoding"
+	// in RFC 7049bis.
+	SortBytewiseLexical SortMode = 2
+
+	// SortCanonical is used in "Canonical CBOR" encoding in RFC 7049 3.9.
+	SortCanonical SortMode = SortLengthFirst
+
+	// SortCTAP2 is used in "CTAP2 Canonical CBOR".
+	SortCTAP2 SortMode = SortBytewiseLexical
+
+	// SortCoreDeterministic is used in "Core Deterministic Encoding" in RFC 7049bis.
+	SortCoreDeterministic SortMode = SortBytewiseLexical
+
+	maxSortMode SortMode = 3
+)
+
+func (sm SortMode) valid() bool {
+	return sm < maxSortMode
+}
+
+// ShortestFloatMode specifies which floating-point format should
+// be used as the shortest possible format for CBOR encoding.
+// It is not used for encoding Infinity and NaN values.
+type ShortestFloatMode int
+
+const (
+	// ShortestFloatNone makes float values encode without any conversion.
+	// This is the default for ShortestFloatMode in v1.
+	// E.g. a float32 in Go will encode to CBOR float32.  And
+	// a float64 in Go will encode to CBOR float64.
+	ShortestFloatNone ShortestFloatMode = iota
+
+	// ShortestFloat16 specifies float16 as the shortest form that preserves value.
+	// E.g. if float64 can convert to float32 while preserving value, then
+	// encoding will also try to convert float32 to float16.  So a float64 might
+	// encode as CBOR float64, float32 or float16 depending on the value.
+	ShortestFloat16
+
+	maxShortestFloat
+)
+
+func (sfm ShortestFloatMode) valid() bool {
+	return sfm < maxShortestFloat
+}
+
+// NaNConvertMode specifies how to encode NaN and overrides ShortestFloatMode.
+// ShortestFloatMode is not used for encoding Infinity and NaN values.
+type NaNConvertMode int
+
+const (
+	// NaNConvert7e00 always encodes NaN to 0xf97e00 (CBOR float16 = 0x7e00).
+	NaNConvert7e00 NaNConvertMode = iota
+
+	// NaNConvertNone never modifies or converts NaN to other representations
+	// (float64 NaN stays float64, etc. even if it can use float16 without losing
+	// any bits).
+	NaNConvertNone
+
+	// NaNConvertPreserveSignal converts NaN to the smallest form that preserves
+	// value (quiet bit + payload) as described in RFC 7049bis Draft 12.
+	NaNConvertPreserveSignal
+
+	// NaNConvertQuiet always forces quiet bit = 1 and shortest form that preserves
+	// NaN payload.
+	NaNConvertQuiet
+
+	maxNaNConvert
+)
+
+func (ncm NaNConvertMode) valid() bool {
+	return ncm < maxNaNConvert
+}
+
+// InfConvertMode specifies how to encode Infinity and overrides ShortestFloatMode.
+// ShortestFloatMode is not used for encoding Infinity and NaN values.
+type InfConvertMode int
+
+const (
+	// InfConvertFloat16 always converts Inf to lossless IEEE binary16 (float16).
+	InfConvertFloat16 InfConvertMode = iota
+
+	// InfConvertNone never converts (used by CTAP2 Canonical CBOR).
+	InfConvertNone
+
+	maxInfConvert
+)
+
+func (icm InfConvertMode) valid() bool {
+	return icm < maxInfConvert
+}
+
+// TimeMode specifies how to encode time.Time values.
+type TimeMode int
+
+const (
+	// TimeUnix causes time.Time to be encoded as epoch time in integer with second precision.
+	TimeUnix TimeMode = iota
+
+	// TimeUnixMicro causes time.Time to be encoded as epoch time in float-point rounded to microsecond precision.
+	TimeUnixMicro
+
+	// TimeUnixDynamic causes time.Time to be encoded as integer if time.Time doesn't have fractional seconds,
+	// otherwise float-point rounded to microsecond precision.
+	TimeUnixDynamic
+
+	// TimeRFC3339 causes time.Time to be encoded as RFC3339 formatted string with second precision.
+	TimeRFC3339
+
+	// TimeRFC3339Nano causes time.Time to be encoded as RFC3339 formatted string with nanosecond precision.
+	TimeRFC3339Nano
+
+	maxTimeMode
+)
+
+func (tm TimeMode) valid() bool {
+	return tm < maxTimeMode
+}
+
+// EncOptions specifies encoding options.
+type EncOptions struct {
+	// Sort specifies sorting order.
+	Sort SortMode
+
+	// ShortestFloat specifies the shortest floating-point encoding that preserves
+	// the value being encoded.
+	ShortestFloat ShortestFloatMode
+
+	// NaNConvert specifies how to encode NaN and it overrides ShortestFloatMode.
+	NaNConvert NaNConvertMode
+
+	// InfConvert specifies how to encode Inf and it overrides ShortestFloatMode.
+	InfConvert InfConvertMode
+
+	// Time specifies how to encode time.Time.
+	Time TimeMode
+
+	// TimeTag allows time.Time to be encoded with a tag number.
+	// RFC3339 format gets tag number 0, and numeric epoch time tag number 1.
+	TimeTag EncTagMode
+
+	disableIndefiniteLength bool
+}
+
+// CanonicalEncOptions returns EncOptions for "Canonical CBOR" encoding,
+// defined in RFC 7049 Section 3.9 with the following rules:
+//
+//     1. "Integers must be as small as possible."
+//     2. "The expression of lengths in major types 2 through 5 must be as short as possible."
+//     3. The keys in every map must be sorted in length-first sorting order.
+//        See SortLengthFirst for details.
+//     4. "Indefinite-length items must be made into definite-length items."
+//     5. "If a protocol allows for IEEE floats, then additional canonicalization rules might
+//        need to be added.  One example rule might be to have all floats start as a 64-bit
+//        float, then do a test conversion to a 32-bit float; if the result is the same numeric
+//        value, use the shorter value and repeat the process with a test conversion to a
+//        16-bit float.  (This rule selects 16-bit float for positive and negative Infinity
+//        as well.)  Also, there are many representations for NaN.  If NaN is an allowed value,
+//        it must always be represented as 0xf97e00."
+//
+func CanonicalEncOptions() EncOptions {
+	return EncOptions{
+		Sort:                    SortCanonical,
+		ShortestFloat:           ShortestFloat16,
+		NaNConvert:              NaNConvert7e00,
+		InfConvert:              InfConvertFloat16,
+		disableIndefiniteLength: true,
+	}
+}
+
+// CTAP2EncOptions returns EncOptions for "CTAP2 Canonical CBOR" encoding,
+// defined in CTAP specification, with the following rules:
+//
+//     1. "Integers must be encoded as small as possible."
+//     2. "The representations of any floating-point values are not changed."
+//     3. "The expression of lengths in major types 2 through 5 must be as short as possible."
+//     4. "Indefinite-length items must be made into definite-length items.""
+//     5. The keys in every map must be sorted in bytewise lexicographic order.
+//        See SortBytewiseLexical for details.
+//     6. "Tags as defined in Section 2.4 in [RFC7049] MUST NOT be present."
+//
+func CTAP2EncOptions() EncOptions {
+	return EncOptions{
+		Sort:                    SortCTAP2,
+		ShortestFloat:           ShortestFloatNone,
+		NaNConvert:              NaNConvertNone,
+		InfConvert:              InfConvertNone,
+		disableIndefiniteLength: true,
+	}
+}
+
+// CoreDetEncOptions returns EncOptions for "Core Deterministic" encoding,
+// defined in RFC 7049bis with the following rules:
+//
+//     1. "Preferred serialization MUST be used. In particular, this means that arguments
+//        (see Section 3) for integers, lengths in major types 2 through 5, and tags MUST
+//        be as short as possible"
+//        "Floating point values also MUST use the shortest form that preserves the value"
+//     2. "Indefinite-length items MUST NOT appear."
+//     3. "The keys in every map MUST be sorted in the bytewise lexicographic order of
+//        their deterministic encodings."
+//
+func CoreDetEncOptions() EncOptions {
+	return EncOptions{
+		Sort:                    SortCoreDeterministic,
+		ShortestFloat:           ShortestFloat16,
+		NaNConvert:              NaNConvert7e00,
+		InfConvert:              InfConvertFloat16,
+		disableIndefiniteLength: true,
+	}
+}
+
+// PreferredUnsortedEncOptions returns EncOptions for "Preferred Serialization" encoding,
+// defined in RFC 7049bis with the following rules:
+//
+//     1. "The preferred serialization always uses the shortest form of representing the argument
+//        (Section 3);"
+//     2. "it also uses the shortest floating-point encoding that preserves the value being
+//        encoded (see Section 5.5)."
+//        "The preferred encoding for a floating-point value is the shortest floating-point encoding
+//        that preserves its value, e.g., 0xf94580 for the number 5.5, and 0xfa45ad9c00 for the
+//        number 5555.5, unless the CBOR-based protocol specifically excludes the use of the shorter
+//        floating-point encodings. For NaN values, a shorter encoding is preferred if zero-padding
+//        the shorter significand towards the right reconstitutes the original NaN value (for many
+//        applications, the single NaN encoding 0xf97e00 will suffice)."
+//     3. "Definite length encoding is preferred whenever the length is known at the time the
+//        serialization of the item starts."
+//
+func PreferredUnsortedEncOptions() EncOptions {
+	return EncOptions{
+		Sort:          SortNone,
+		ShortestFloat: ShortestFloat16,
+		NaNConvert:    NaNConvert7e00,
+		InfConvert:    InfConvertFloat16,
+	}
+}
+
+// EncMode returns EncMode with immutable options and no tags (safe for concurrency).
+func (opts EncOptions) EncMode() (EncMode, error) {
+	return opts.encMode()
+}
+
+// EncModeWithTags returns EncMode with options and tags that are both immutable (safe for concurrency).
+func (opts EncOptions) EncModeWithTags(tags TagSet) (EncMode, error) {
+	if tags == nil {
+		return nil, errors.New("cbor: cannot create EncMode with nil value as TagSet")
+	}
+	em, err := opts.encMode()
+	if err != nil {
+		return nil, err
+	}
+	// Copy tags
+	ts := tagSet(make(map[reflect.Type]*tagItem))
+	syncTags := tags.(*syncTagSet)
+	syncTags.RLock()
+	for contentType, tag := range syncTags.t {
+		if tag.opts.EncTag != EncTagNone {
+			ts[contentType] = tag
+		}
+	}
+	syncTags.RUnlock()
+	if len(ts) > 0 {
+		em.tags = ts
+	}
+	return em, nil
+}
+
+// EncModeWithSharedTags returns EncMode with immutable options and mutable shared tags (safe for concurrency).
+func (opts EncOptions) EncModeWithSharedTags(tags TagSet) (EncMode, error) {
+	if tags == nil {
+		return nil, errors.New("cbor: cannot create EncMode with nil value as TagSet")
+	}
+	em, err := opts.encMode()
+	if err != nil {
+		return nil, err
+	}
+	em.tags = tags
+	return em, nil
+}
+
+func (opts EncOptions) encMode() (*encMode, error) {
+	if !opts.Sort.valid() {
+		return nil, errors.New("cbor: invalid SortMode " + strconv.Itoa(int(opts.Sort)))
+	}
+	if !opts.ShortestFloat.valid() {
+		return nil, errors.New("cbor: invalid ShortestFloatMode " + strconv.Itoa(int(opts.ShortestFloat)))
+	}
+	if !opts.NaNConvert.valid() {
+		return nil, errors.New("cbor: invalid NaNConvertMode " + strconv.Itoa(int(opts.NaNConvert)))
+	}
+	if !opts.InfConvert.valid() {
+		return nil, errors.New("cbor: invalid InfConvertMode " + strconv.Itoa(int(opts.InfConvert)))
+	}
+	if !opts.Time.valid() {
+		return nil, errors.New("cbor: invalid TimeMode " + strconv.Itoa(int(opts.Time)))
+	}
+	if !opts.TimeTag.valid() {
+		return nil, errors.New("cbor: invalid TimeTag " + strconv.Itoa(int(opts.TimeTag)))
+	}
+	em := encMode{
+		sort:                    opts.Sort,
+		shortestFloat:           opts.ShortestFloat,
+		nanConvert:              opts.NaNConvert,
+		infConvert:              opts.InfConvert,
+		time:                    opts.Time,
+		timeTag:                 opts.TimeTag,
+		disableIndefiniteLength: opts.disableIndefiniteLength,
+	}
+	return &em, nil
+}
+
+// EncMode is the main interface for CBOR encoding.
+type EncMode interface {
+	Marshal(v interface{}) ([]byte, error)
+	NewEncoder(w io.Writer) *Encoder
+	EncOptions() EncOptions
+}
+
+type encMode struct {
+	tags                    tagProvider
+	sort                    SortMode
+	shortestFloat           ShortestFloatMode
+	nanConvert              NaNConvertMode
+	infConvert              InfConvertMode
+	time                    TimeMode
+	timeTag                 EncTagMode
+	disableIndefiniteLength bool
+}
+
+var defaultEncMode = &encMode{}
+
+// EncOptions returns user specified options used to create this EncMode.
+func (em *encMode) EncOptions() EncOptions {
+	return EncOptions{
+		Sort:                    em.sort,
+		ShortestFloat:           em.shortestFloat,
+		NaNConvert:              em.nanConvert,
+		InfConvert:              em.infConvert,
+		Time:                    em.time,
+		TimeTag:                 em.timeTag,
+		disableIndefiniteLength: em.disableIndefiniteLength,
+	}
+}
+
+func (em *encMode) encTagBytes(t reflect.Type) []byte {
+	if em.tags != nil {
+		if tagItem := em.tags.get(t); tagItem != nil {
+			return tagItem.cborTagNum
+		}
+	}
+	return nil
+}
+
+// Marshal returns the CBOR encoding of v using em encMode.
+//
+// See the documentation for Marshal for details.
+func (em *encMode) Marshal(v interface{}) ([]byte, error) {
+	e := getEncodeState()
+
+	if err := encode(e, em, reflect.ValueOf(v)); err != nil {
+		putEncodeState(e)
+		return nil, err
+	}
+
+	buf := make([]byte, e.Len())
+	copy(buf, e.Bytes())
+
+	putEncodeState(e)
+	return buf, nil
+}
+
+// NewEncoder returns a new encoder that writes to w using em EncMode.
+func (em *encMode) NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: w, em: em, e: getEncodeState()}
+}
+
+// An encodeState encodes CBOR into a bytes.Buffer.
+type encodeState struct {
+	bytes.Buffer
+	scratch [16]byte
+}
+
+// encodeStatePool caches unused encodeState objects for later reuse.
+var encodeStatePool = sync.Pool{
+	New: func() interface{} {
+		e := new(encodeState)
+		e.Grow(32) // TODO: make this configurable
+		return e
+	},
+}
+
+func getEncodeState() *encodeState {
+	return encodeStatePool.Get().(*encodeState)
+}
+
+// putEncodeState returns e to encodeStatePool.
+func putEncodeState(e *encodeState) {
+	e.Reset()
+	encodeStatePool.Put(e)
+}
+
+type encodeFunc func(e *encodeState, em *encMode, v reflect.Value) error
+
+var (
+	cborFalse            = []byte{0xf4}
+	cborTrue             = []byte{0xf5}
+	cborNil              = []byte{0xf6}
+	cborNaN              = []byte{0xf9, 0x7e, 0x00}
+	cborPositiveInfinity = []byte{0xf9, 0x7c, 0x00}
+	cborNegativeInfinity = []byte{0xf9, 0xfc, 0x00}
+)
+
+func encode(e *encodeState, em *encMode, v reflect.Value) error {
+	if !v.IsValid() {
+		// v is zero value
+		e.Write(cborNil)
+		return nil
+	}
+	vt := v.Type()
+	f := getEncodeFunc(vt)
+	if f == nil {
+		return &UnsupportedTypeError{vt}
+	}
+
+	return f(e, em, v)
+}
+
+func encodeBool(e *encodeState, em *encMode, v reflect.Value) error {
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	b := cborFalse
+	if v.Bool() {
+		b = cborTrue
+	}
+	e.Write(b)
+	return nil
+}
+
+func encodeInt(e *encodeState, em *encMode, v reflect.Value) error {
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	i := v.Int()
+	if i >= 0 {
+		encodeHead(e, byte(cborTypePositiveInt), uint64(i))
+		return nil
+	}
+	i = i*(-1) - 1
+	encodeHead(e, byte(cborTypeNegativeInt), uint64(i))
+	return nil
+}
+
+func encodeUint(e *encodeState, em *encMode, v reflect.Value) error {
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	encodeHead(e, byte(cborTypePositiveInt), v.Uint())
+	return nil
+}
+
+func encodeFloat(e *encodeState, em *encMode, v reflect.Value) error {
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	f64 := v.Float()
+	if math.IsNaN(f64) {
+		return encodeNaN(e, em, v)
+	}
+	if math.IsInf(f64, 0) {
+		return encodeInf(e, em, v)
+	}
+	fopt := em.shortestFloat
+	if v.Kind() == reflect.Float64 && (fopt == ShortestFloatNone || cannotFitFloat32(f64)) {
+		// Encode float64
+		// Don't use encodeFloat64() because it cannot be inlined.
+		e.scratch[0] = byte(cborTypePrimitives) | byte(27)
+		binary.BigEndian.PutUint64(e.scratch[1:], math.Float64bits(f64))
+		e.Write(e.scratch[:9])
+		return nil
+	}
+
+	f32 := float32(f64)
+	if fopt == ShortestFloat16 {
+		var f16 float16.Float16
+		p := float16.PrecisionFromfloat32(f32)
+		if p == float16.PrecisionExact {
+			// Roundtrip float32->float16->float32 test isn't needed.
+			f16 = float16.Fromfloat32(f32)
+		} else if p == float16.PrecisionUnknown {
+			// Try roundtrip float32->float16->float32 to determine if float32 can fit into float16.
+			f16 = float16.Fromfloat32(f32)
+			if f16.Float32() == f32 {
+				p = float16.PrecisionExact
+			}
+		}
+		if p == float16.PrecisionExact {
+			// Encode float16
+			// Don't use encodeFloat16() because it cannot be inlined.
+			e.scratch[0] = byte(cborTypePrimitives) | byte(25)
+			binary.BigEndian.PutUint16(e.scratch[1:], uint16(f16))
+			e.Write(e.scratch[:3])
+			return nil
+		}
+	}
+
+	// Encode float32
+	// Don't use encodeFloat32() because it cannot be inlined.
+	e.scratch[0] = byte(cborTypePrimitives) | byte(26)
+	binary.BigEndian.PutUint32(e.scratch[1:], math.Float32bits(f32))
+	e.Write(e.scratch[:5])
+	return nil
+}
+
+func encodeInf(e *encodeState, em *encMode, v reflect.Value) error {
+	f64 := v.Float()
+	if em.infConvert == InfConvertFloat16 {
+		if f64 > 0 {
+			e.Write(cborPositiveInfinity)
+		} else {
+			e.Write(cborNegativeInfinity)
+		}
+		return nil
+	}
+	if v.Kind() == reflect.Float64 {
+		return encodeFloat64(e, f64)
+	}
+	return encodeFloat32(e, float32(f64))
+}
+
+func encodeNaN(e *encodeState, em *encMode, v reflect.Value) error {
+	switch em.nanConvert {
+	case NaNConvert7e00:
+		e.Write(cborNaN)
+		return nil
+
+	case NaNConvertNone:
+		if v.Kind() == reflect.Float64 {
+			return encodeFloat64(e, v.Float())
+		}
+		f32 := float32NaNFromReflectValue(v)
+		return encodeFloat32(e, f32)
+
+	default: // NaNConvertPreserveSignal, NaNConvertQuiet
+		if v.Kind() == reflect.Float64 {
+			f64 := v.Float()
+			f64bits := math.Float64bits(f64)
+			if em.nanConvert == NaNConvertQuiet && f64bits&(1<<51) == 0 {
+				f64bits |= 1 << 51 // Set quiet bit = 1
+				f64 = math.Float64frombits(f64bits)
+			}
+			// The lower 29 bits are dropped when converting from float64 to float32.
+			if f64bits&0x1fffffff != 0 {
+				// Encode NaN as float64 because dropped coef bits from float64 to float32 are not all 0s.
+				return encodeFloat64(e, f64)
+			}
+			// Create float32 from float64 manually because float32(f64) always turns on NaN's quiet bits.
+			sign := uint32(f64bits>>32) & (1 << 31)
+			exp := uint32(0x7f800000)
+			coef := uint32((f64bits & 0xfffffffffffff) >> 29)
+			f32bits := sign | exp | coef
+			f32 := math.Float32frombits(f32bits)
+			// The lower 13 bits are dropped when converting from float32 to float16.
+			if f32bits&0x1fff != 0 {
+				// Encode NaN as float32 because dropped coef bits from float32 to float16 are not all 0s.
+				return encodeFloat32(e, f32)
+			}
+			// Encode NaN as float16
+			f16, _ := float16.FromNaN32ps(f32) // Ignore err because it only returns error when f32 is not a NaN.
+			return encodeFloat16(e, f16)
+		}
+
+		f32 := float32NaNFromReflectValue(v)
+		f32bits := math.Float32bits(f32)
+		if em.nanConvert == NaNConvertQuiet && f32bits&(1<<22) == 0 {
+			f32bits |= 1 << 22 // Set quiet bit = 1
+			f32 = math.Float32frombits(f32bits)
+		}
+		// The lower 13 bits are dropped coef bits when converting from float32 to float16.
+		if f32bits&0x1fff != 0 {
+			// Encode NaN as float32 because dropped coef bits from float32 to float16 are not all 0s.
+			return encodeFloat32(e, f32)
+		}
+		f16, _ := float16.FromNaN32ps(f32) // Ignore err because it only returns error when f32 is not a NaN.
+		return encodeFloat16(e, f16)
+	}
+}
+
+func encodeFloat16(e *encodeState, f16 float16.Float16) error {
+	e.scratch[0] = byte(cborTypePrimitives) | byte(25)
+	binary.BigEndian.PutUint16(e.scratch[1:], uint16(f16))
+	e.Write(e.scratch[:3])
+	return nil
+}
+
+func encodeFloat32(e *encodeState, f32 float32) error {
+	e.scratch[0] = byte(cborTypePrimitives) | byte(26)
+	binary.BigEndian.PutUint32(e.scratch[1:], math.Float32bits(f32))
+	e.Write(e.scratch[:5])
+	return nil
+}
+
+func encodeFloat64(e *encodeState, f64 float64) error {
+	e.scratch[0] = byte(cborTypePrimitives) | byte(27)
+	binary.BigEndian.PutUint64(e.scratch[1:], math.Float64bits(f64))
+	e.Write(e.scratch[:9])
+	return nil
+}
+
+func encodeByteString(e *encodeState, em *encMode, v reflect.Value) error {
+	vk := v.Kind()
+	if vk == reflect.Slice && v.IsNil() {
+		e.Write(cborNil)
+		return nil
+	}
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	slen := v.Len()
+	if slen == 0 {
+		return e.WriteByte(byte(cborTypeByteString))
+	}
+	encodeHead(e, byte(cborTypeByteString), uint64(slen))
+	if vk == reflect.Array {
+		for i := 0; i < slen; i++ {
+			e.WriteByte(byte(v.Index(i).Uint()))
+		}
+		return nil
+	}
+	e.Write(v.Bytes())
+	return nil
+}
+
+func encodeString(e *encodeState, em *encMode, v reflect.Value) error {
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	s := v.String()
+	encodeHead(e, byte(cborTypeTextString), uint64(len(s)))
+	e.WriteString(s)
+	return nil
+}
+
+// Assuming that arrayEncoder.f != nil
+type arrayEncoder struct {
+	f encodeFunc
+}
+
+func (ae arrayEncoder) encodeArray(e *encodeState, em *encMode, v reflect.Value) error {
+	if v.Kind() == reflect.Slice && v.IsNil() {
+		e.Write(cborNil)
+		return nil
+	}
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	alen := v.Len()
+	if alen == 0 {
+		return e.WriteByte(byte(cborTypeArray))
+	}
+	encodeHead(e, byte(cborTypeArray), uint64(alen))
+	for i := 0; i < alen; i++ {
+		if err := ae.f(e, em, v.Index(i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Assuming that arrayEncoder.kf and arrayEncoder.ef are not nil
+type mapEncoder struct {
+	kf, ef encodeFunc
+}
+
+func (me mapEncoder) encodeMap(e *encodeState, em *encMode, v reflect.Value) error {
+	if v.IsNil() {
+		e.Write(cborNil)
+		return nil
+	}
+	if b := em.encTagBytes(v.Type()); b != nil {
+		e.Write(b)
+	}
+	mlen := v.Len()
+	if mlen == 0 {
+		return e.WriteByte(byte(cborTypeMap))
+	}
+	if em.sort != SortNone {
+		return me.encodeMapCanonical(e, em, v)
+	}
+	encodeHead(e, byte(cborTypeMap), uint64(mlen))
+	iter := v.MapRange()
+	for iter.Next() {
+		if err := me.kf(e, em, iter.Key()); err != nil {
+			return err
+		}
+		if err := me.ef(e, em, iter.Value()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type keyValue struct {
+	keyCBORData, keyValueCBORData []byte
+	keyLen, keyValueLen           int
+}
+
+type bytewiseKeyValueSorter struct {
+	kvs []keyValue
+}
+
+func (x *bytewiseKeyValueSorter) Len() int {
+	return len(x.kvs)
+}
+
+func (x *bytewiseKeyValueSorter) Swap(i, j int) {
+	x.kvs[i], x.kvs[j] = x.kvs[j], x.kvs[i]
+}
+
+func (x *bytewiseKeyValueSorter) Less(i, j int) bool {
+	return bytes.Compare(x.kvs[i].keyCBORData, x.kvs[j].keyCBORData) <= 0
+}
+
+type lengthFirstKeyValueSorter struct {
+	kvs []keyValue
+}
+
+func (x *lengthFirstKeyValueSorter) Len() int {
+	return len(x.kvs)
+}
+
+func (x *lengthFirstKeyValueSorter) Swap(i, j int) {
+	x.kvs[i], x.kvs[j] = x.kvs[j], x.kvs[i]
+}
+
+func (x *lengthFirstKeyValueSorter) Less(i, j int) bool {
+	if len(x.kvs[i].keyCBORData) != len(x.kvs[j].keyCBORData) {
+		return len(x.kvs[i].keyCBORData) < len(x.kvs[j].keyCBORData)
+	}
+	return bytes.Compare(x.kvs[i].keyCBORData, x.kvs[j].keyCBORData) <= 0
+}
+
+var keyValuePool = sync.Pool{}
+
+func getKeyValues(length int) *[]keyValue {
+	v := keyValuePool.Get()
+	if v == nil {
+		y := make([]keyValue, length)
+		return &y
+	}
+	x := v.(*[]keyValue)
+	if cap(*x) >= length {
+		*x = (*x)[:length]
+		return x
+	}
+	// []keyValue from the pool does not have enough capacity.
+	// Return it back to the pool and create a new one.
+	keyValuePool.Put(x)
+	y := make([]keyValue, length)
+	return &y
+}
+
+func putKeyValues(x *[]keyValue) {
+	*x = (*x)[:0]
+	keyValuePool.Put(x)
+}
+
+func (me mapEncoder) encodeMapCanonical(e *encodeState, em *encMode, v reflect.Value) error {
+	kve := getEncodeState()       // accumulated cbor encoded key-values
+	kvsp := getKeyValues(v.Len()) // for sorting keys
+	kvs := *kvsp
+	iter := v.MapRange()
+	for i := 0; iter.Next(); i++ {
+		off := kve.Len()
+		if err := me.kf(kve, em, iter.Key()); err != nil {
+			putEncodeState(kve)
+			putKeyValues(kvsp)
+			return err
+		}
+		n1 := kve.Len() - off
+		if err := me.ef(kve, em, iter.Value()); err != nil {
+			putEncodeState(kve)
+			putKeyValues(kvsp)
+			return err
+		}
+		n2 := kve.Len() - off
+		// Save key and keyvalue length to create slice later.
+		kvs[i] = keyValue{keyLen: n1, keyValueLen: n2}
+	}
+
+	b := kve.Bytes()
+	for i, off := 0, 0; i < len(kvs); i++ {
+		kvs[i].keyCBORData = b[off : off+kvs[i].keyLen]
+		kvs[i].keyValueCBORData = b[off : off+kvs[i].keyValueLen]
+		off += kvs[i].keyValueLen
+	}
+
+	if em.sort == SortBytewiseLexical {
+		sort.Sort(&bytewiseKeyValueSorter{kvs})
+	} else {
+		sort.Sort(&lengthFirstKeyValueSorter{kvs})
+	}
+
+	encodeHead(e, byte(cborTypeMap), uint64(len(kvs)))
+	for i := 0; i < len(kvs); i++ {
+		e.Write(kvs[i].keyValueCBORData)
+	}
+
+	putEncodeState(kve)
+	putKeyValues(kvsp)
+	return nil
+}
+
+func encodeStructToArray(e *encodeState, em *encMode, v reflect.Value, flds fields) error {
+	encodeHead(e, byte(cborTypeArray), uint64(len(flds)))
+FieldLoop:
+	for i := 0; i < len(flds); i++ {
+		f := flds[i]
+		fv := v
+		for k, n := range f.idx {
+			if k > 0 {
+				if fv.Kind() == reflect.Ptr && fv.Type().Elem().Kind() == reflect.Struct {
+					if fv.IsNil() {
+						// Write nil for null pointer to embedded struct
+						e.Write(cborNil)
+						continue FieldLoop
+					}
+					fv = fv.Elem()
+				}
+			}
+			fv = fv.Field(n)
+		}
+		if err := f.ef(e, em, fv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodeFixedLengthStruct(e *encodeState, em *encMode, v reflect.Value, flds fields) error {
+	encodeHead(e, byte(cborTypeMap), uint64(len(flds)))
+
+	for i := 0; i < len(flds); i++ {
+		f := flds[i]
+		e.Write(f.cborName)
+
+		fv := v.Field(f.idx[0])
+		if err := f.ef(e, em, fv); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func encodeStruct(e *encodeState, em *encMode, v reflect.Value) error {
+	vt := v.Type()
+	structType := getEncodingStructType(vt)
+	if structType.err != nil {
+		return structType.err
+	}
+
+	if b := em.encTagBytes(vt); b != nil {
+		e.Write(b)
+	}
+
+	if structType.toArray {
+		return encodeStructToArray(e, em, v, structType.fields)
+	}
+
+	flds := structType.getFields(em)
+
+	if !structType.hasAnonymousField && !structType.omitEmpty {
+		return encodeFixedLengthStruct(e, em, v, flds)
+	}
+
+	kve := getEncodeState() // encode key-value pairs based on struct field tag options
+	kvcount := 0
+FieldLoop:
+	for i := 0; i < len(flds); i++ {
+		f := flds[i]
+		fv := v
+		for k, n := range f.idx {
+			if k > 0 {
+				if fv.Kind() == reflect.Ptr && fv.Type().Elem().Kind() == reflect.Struct {
+					if fv.IsNil() {
+						// Null pointer to embedded struct
+						continue FieldLoop
+					}
+					fv = fv.Elem()
+				}
+			}
+			fv = fv.Field(n)
+		}
+		if f.omitEmpty && isEmptyValue(fv) {
+			continue
+		}
+
+		kve.Write(f.cborName)
+
+		if err := f.ef(kve, em, fv); err != nil {
+			putEncodeState(kve)
+			return err
+		}
+		kvcount++
+	}
+
+	encodeHead(e, byte(cborTypeMap), uint64(kvcount))
+	e.Write(kve.Bytes())
+
+	putEncodeState(kve)
+	return nil
+}
+
+func encodeIntf(e *encodeState, em *encMode, v reflect.Value) error {
+	if v.IsNil() {
+		e.Write(cborNil)
+		return nil
+	}
+	return encode(e, em, v.Elem())
+}
+
+func encodeTime(e *encodeState, em *encMode, v reflect.Value) error {
+	t := v.Interface().(time.Time)
+	if t.IsZero() {
+		e.Write(cborNil) // Even if tag is required, encode as CBOR null.
+		return nil
+	}
+	if em.timeTag == EncTagRequired {
+		tagNumber := 1
+		if em.time == TimeRFC3339 || em.time == TimeRFC3339Nano {
+			tagNumber = 0
+		}
+		encodeHead(e, byte(cborTypeTag), uint64(tagNumber))
+	}
+	switch em.time {
+	case TimeUnix:
+		secs := t.Unix()
+		return encodeInt(e, em, reflect.ValueOf(secs))
+	case TimeUnixMicro:
+		t = t.UTC().Round(time.Microsecond)
+		f := float64(t.UnixNano()) / 1e9
+		return encodeFloat(e, em, reflect.ValueOf(f))
+	case TimeUnixDynamic:
+		t = t.UTC().Round(time.Microsecond)
+		secs, nsecs := t.Unix(), uint64(t.Nanosecond())
+		if nsecs == 0 {
+			return encodeInt(e, em, reflect.ValueOf(secs))
+		}
+		f := float64(secs) + float64(nsecs)/1e9
+		return encodeFloat(e, em, reflect.ValueOf(f))
+	case TimeRFC3339:
+		s := t.Format(time.RFC3339)
+		return encodeString(e, em, reflect.ValueOf(s))
+	default: // TimeRFC3339Nano
+		s := t.Format(time.RFC3339Nano)
+		return encodeString(e, em, reflect.ValueOf(s))
+	}
+}
+
+func encodeBinaryMarshalerType(e *encodeState, em *encMode, v reflect.Value) error {
+	vt := v.Type()
+	m, ok := v.Interface().(encoding.BinaryMarshaler)
+	if !ok {
+		pv := reflect.New(vt)
+		pv.Elem().Set(v)
+		m = pv.Interface().(encoding.BinaryMarshaler)
+	}
+	data, err := m.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	if b := em.encTagBytes(vt); b != nil {
+		e.Write(b)
+	}
+	encodeHead(e, byte(cborTypeByteString), uint64(len(data)))
+	e.Write(data)
+	return nil
+}
+
+func encodeMarshalerType(e *encodeState, em *encMode, v reflect.Value) error {
+	m, ok := v.Interface().(Marshaler)
+	if !ok {
+		pv := reflect.New(v.Type())
+		pv.Elem().Set(v)
+		m = pv.Interface().(Marshaler)
+	}
+	data, err := m.MarshalCBOR()
+	if err != nil {
+		return err
+	}
+	e.Write(data)
+	return nil
+}
+
+func encodeTag(e *encodeState, em *encMode, v reflect.Value) error {
+	t := v.Interface().(Tag)
+
+	// Marshal tag number
+	encodeHead(e, byte(cborTypeTag), t.Number)
+
+	// Marshal tag content
+	if err := encode(e, em, reflect.ValueOf(t.Content)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func encodeHead(e *encodeState, t byte, n uint64) {
+	if n <= 23 {
+		e.WriteByte(t | byte(n))
+		return
+	}
+	if n <= math.MaxUint8 {
+		e.scratch[0] = t | byte(24)
+		e.scratch[1] = byte(n)
+		e.Write(e.scratch[:2])
+		return
+	}
+	if n <= math.MaxUint16 {
+		e.scratch[0] = t | byte(25)
+		binary.BigEndian.PutUint16(e.scratch[1:], uint16(n))
+		e.Write(e.scratch[:3])
+		return
+	}
+	if n <= math.MaxUint32 {
+		e.scratch[0] = t | byte(26)
+		binary.BigEndian.PutUint32(e.scratch[1:], uint32(n))
+		e.Write(e.scratch[:5])
+		return
+	}
+	e.scratch[0] = t | byte(27)
+	binary.BigEndian.PutUint64(e.scratch[1:], n)
+	e.Write(e.scratch[:9])
+}
+
+var (
+	typeMarshaler       = reflect.TypeOf((*Marshaler)(nil)).Elem()
+	typeBinaryMarshaler = reflect.TypeOf((*encoding.BinaryMarshaler)(nil)).Elem()
+)
+
+func getEncodeFuncInternal(t reflect.Type) encodeFunc {
+	k := t.Kind()
+	if k == reflect.Ptr {
+		return getEncodeIndirectValueFunc(t)
+	}
+	if t == typeTag {
+		return encodeTag
+	}
+	if t == typeTime {
+		return encodeTime
+	}
+	if reflect.PtrTo(t).Implements(typeMarshaler) {
+		return encodeMarshalerType
+	}
+	if reflect.PtrTo(t).Implements(typeBinaryMarshaler) {
+		return encodeBinaryMarshalerType
+	}
+	switch k {
+	case reflect.Bool:
+		return encodeBool
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return encodeInt
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return encodeUint
+	case reflect.Float32, reflect.Float64:
+		return encodeFloat
+	case reflect.String:
+		return encodeString
+	case reflect.Slice, reflect.Array:
+		if t.Elem().Kind() == reflect.Uint8 {
+			return encodeByteString
+		}
+		f := getEncodeFunc(t.Elem())
+		if f == nil {
+			return nil
+		}
+		return arrayEncoder{f: f}.encodeArray
+	case reflect.Map:
+		kf, ef := getEncodeFunc(t.Key()), getEncodeFunc(t.Elem())
+		if kf == nil || ef == nil {
+			return nil
+		}
+		return mapEncoder{kf: kf, ef: ef}.encodeMap
+	case reflect.Struct:
+		return encodeStruct
+	case reflect.Interface:
+		return encodeIntf
+	}
+	return nil
+}
+
+func getEncodeIndirectValueFunc(t reflect.Type) encodeFunc {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	f := getEncodeFunc(t)
+	if f == nil {
+		return nil
+	}
+	return func(e *encodeState, em *encMode, v reflect.Value) error {
+		for v.Kind() == reflect.Ptr && !v.IsNil() {
+			v = v.Elem()
+		}
+		if v.Kind() == reflect.Ptr && v.IsNil() {
+			e.Write(cborNil)
+			return nil
+		}
+		return f(e, em, v)
+	}
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func cannotFitFloat32(f64 float64) bool {
+	f32 := float32(f64)
+	return float64(f32) != f64
+}
+
+// float32NaNFromReflectValue extracts float32 NaN from reflect.Value while preserving NaN's quiet bit.
+func float32NaNFromReflectValue(v reflect.Value) float32 {
+	// Keith Randall's workaround for issue https://github.com/golang/go/issues/36400
+	p := reflect.New(v.Type())
+	p.Elem().Set(v)
+	f32 := p.Convert(reflect.TypeOf((*float32)(nil))).Elem().Interface().(float32)
+	return f32
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/encode_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/encode_test.go
@@ -1,0 +1,2914 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type marshalTest struct {
+	cborData []byte
+	values   []interface{}
+}
+
+type marshalErrorTest struct {
+	name         string
+	value        interface{}
+	wantErrorMsg string
+}
+
+type inner struct {
+	X, Y, z int64
+}
+
+type outer struct {
+	IntField          int
+	FloatField        float32
+	BoolField         bool
+	StringField       string
+	ByteStringField   []byte
+	ArrayField        []string
+	MapField          map[string]bool
+	NestedStructField *inner
+	unexportedField   int64
+}
+
+const (
+	wantIndefiniteLengthErrorMsg = "cbor: indefinite-length items are not allowed"
+)
+
+// CBOR test data are from https://tools.ietf.org/html/rfc7049#appendix-A.
+var marshalTests = []marshalTest{
+	// positive integer
+	{hexDecode("00"), []interface{}{uint(0), uint8(0), uint16(0), uint32(0), uint64(0), int(0), int8(0), int16(0), int32(0), int64(0)}},
+	{hexDecode("01"), []interface{}{uint(1), uint8(1), uint16(1), uint32(1), uint64(1), int(1), int8(1), int16(1), int32(1), int64(1)}},
+	{hexDecode("0a"), []interface{}{uint(10), uint8(10), uint16(10), uint32(10), uint64(10), int(10), int8(10), int16(10), int32(10), int64(10)}},
+	{hexDecode("17"), []interface{}{uint(23), uint8(23), uint16(23), uint32(23), uint64(23), int(23), int8(23), int16(23), int32(23), int64(23)}},
+	{hexDecode("1818"), []interface{}{uint(24), uint8(24), uint16(24), uint32(24), uint64(24), int(24), int8(24), int16(24), int32(24), int64(24)}},
+	{hexDecode("1819"), []interface{}{uint(25), uint8(25), uint16(25), uint32(25), uint64(25), int(25), int8(25), int16(25), int32(25), int64(25)}},
+	{hexDecode("1864"), []interface{}{uint(100), uint8(100), uint16(100), uint32(100), uint64(100), int(100), int8(100), int16(100), int32(100), int64(100)}},
+	{hexDecode("18ff"), []interface{}{uint(255), uint8(255), uint16(255), uint32(255), uint64(255), int(255), int16(255), int32(255), int64(255)}},
+	{hexDecode("190100"), []interface{}{uint(256), uint16(256), uint32(256), uint64(256), int(256), int16(256), int32(256), int64(256)}},
+	{hexDecode("1903e8"), []interface{}{uint(1000), uint16(1000), uint32(1000), uint64(1000), int(1000), int16(1000), int32(1000), int64(1000)}},
+	{hexDecode("19ffff"), []interface{}{uint(65535), uint16(65535), uint32(65535), uint64(65535), int(65535), int32(65535), int64(65535)}},
+	{hexDecode("1a00010000"), []interface{}{uint(65536), uint32(65536), uint64(65536), int(65536), int32(65536), int64(65536)}},
+	{hexDecode("1a000f4240"), []interface{}{uint(1000000), uint32(1000000), uint64(1000000), int(1000000), int32(1000000), int64(1000000)}},
+	{hexDecode("1affffffff"), []interface{}{uint(4294967295), uint32(4294967295), uint64(4294967295), int64(4294967295)}},
+	{hexDecode("1b000000e8d4a51000"), []interface{}{uint64(1000000000000), int64(1000000000000)}},
+	{hexDecode("1bffffffffffffffff"), []interface{}{uint64(18446744073709551615)}},
+	// negative integer
+	{hexDecode("20"), []interface{}{int(-1), int8(-1), int16(-1), int32(-1), int64(-1)}},
+	{hexDecode("29"), []interface{}{int(-10), int8(-10), int16(-10), int32(-10), int64(-10)}},
+	{hexDecode("37"), []interface{}{int(-24), int8(-24), int16(-24), int32(-24), int64(-24)}},
+	{hexDecode("3818"), []interface{}{int(-25), int8(-25), int16(-25), int32(-25), int64(-25)}},
+	{hexDecode("3863"), []interface{}{int(-100), int8(-100), int16(-100), int32(-100), int64(-100)}},
+	{hexDecode("38ff"), []interface{}{int(-256), int16(-256), int32(-256), int64(-256)}},
+	{hexDecode("390100"), []interface{}{int(-257), int16(-257), int32(-257), int64(-257)}},
+	{hexDecode("3903e7"), []interface{}{int(-1000), int16(-1000), int32(-1000), int64(-1000)}},
+	{hexDecode("39ffff"), []interface{}{int(-65536), int32(-65536), int64(-65536)}},
+	{hexDecode("3a00010000"), []interface{}{int(-65537), int32(-65537), int64(-65537)}},
+	{hexDecode("3affffffff"), []interface{}{int64(-4294967296)}},
+	// byte string
+	{hexDecode("40"), []interface{}{[]byte{}}},
+	{hexDecode("4401020304"), []interface{}{[]byte{1, 2, 3, 4}, [...]byte{1, 2, 3, 4}}},
+	// text string
+	{hexDecode("60"), []interface{}{""}},
+	{hexDecode("6161"), []interface{}{"a"}},
+	{hexDecode("6449455446"), []interface{}{"IETF"}},
+	{hexDecode("62225c"), []interface{}{"\"\\"}},
+	{hexDecode("62c3bc"), []interface{}{"ü"}},
+	{hexDecode("63e6b0b4"), []interface{}{"水"}},
+	{hexDecode("64f0908591"), []interface{}{"𐅑"}},
+	// array
+	{
+		hexDecode("80"),
+		[]interface{}{
+			[0]int{},
+			[]uint{},
+			// []uint8{},
+			[]uint16{},
+			[]uint32{},
+			[]uint64{},
+			[]int{},
+			[]int8{},
+			[]int16{},
+			[]int32{},
+			[]int64{},
+			[]string{},
+			[]bool{}, []float32{}, []float64{}, []interface{}{},
+		},
+	},
+	{
+		hexDecode("83010203"),
+		[]interface{}{
+			[...]int{1, 2, 3},
+			[]uint{1, 2, 3},
+			// []uint8{1, 2, 3},
+			[]uint16{1, 2, 3},
+			[]uint32{1, 2, 3},
+			[]uint64{1, 2, 3},
+			[]int{1, 2, 3},
+			[]int8{1, 2, 3},
+			[]int16{1, 2, 3},
+			[]int32{1, 2, 3},
+			[]int64{1, 2, 3},
+			[]interface{}{1, 2, 3},
+		},
+	},
+	{
+		hexDecode("8301820203820405"),
+		[]interface{}{
+			[...]interface{}{1, [...]int{2, 3}, [...]int{4, 5}},
+			[]interface{}{1, []uint{2, 3}, []uint{4, 5}},
+			// []interface{}{1, []uint8{2, 3}, []uint8{4, 5}},
+			[]interface{}{1, []uint16{2, 3}, []uint16{4, 5}},
+			[]interface{}{1, []uint32{2, 3}, []uint32{4, 5}},
+			[]interface{}{1, []uint64{2, 3}, []uint64{4, 5}},
+			[]interface{}{1, []int{2, 3}, []int{4, 5}},
+			[]interface{}{1, []int8{2, 3}, []int8{4, 5}},
+			[]interface{}{1, []int16{2, 3}, []int16{4, 5}},
+			[]interface{}{1, []int32{2, 3}, []int32{4, 5}},
+			[]interface{}{1, []int64{2, 3}, []int64{4, 5}},
+			[]interface{}{1, []interface{}{2, 3}, []interface{}{4, 5}},
+		},
+	},
+	{
+		hexDecode("98190102030405060708090a0b0c0d0e0f101112131415161718181819"),
+		[]interface{}{
+			[...]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			// []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+			[]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
+		},
+	},
+	{
+		hexDecode("826161a161626163"),
+		[]interface{}{
+			[...]interface{}{"a", map[string]string{"b": "c"}},
+			[]interface{}{"a", map[string]string{"b": "c"}},
+			[]interface{}{"a", map[interface{}]interface{}{"b": "c"}},
+		},
+	},
+	// map
+	{
+		hexDecode("a0"),
+		[]interface{}{
+			map[uint]bool{},
+			map[uint8]bool{},
+			map[uint16]bool{},
+			map[uint32]bool{},
+			map[uint64]bool{},
+			map[int]bool{},
+			map[int8]bool{},
+			map[int16]bool{},
+			map[int32]bool{},
+			map[int64]bool{},
+			map[float32]bool{},
+			map[float64]bool{},
+			map[bool]bool{},
+			map[string]bool{},
+			map[interface{}]interface{}{},
+		},
+	},
+	{
+		hexDecode("a201020304"),
+		[]interface{}{
+			map[uint]uint{3: 4, 1: 2},
+			map[uint8]uint8{3: 4, 1: 2},
+			map[uint16]uint16{3: 4, 1: 2},
+			map[uint32]uint32{3: 4, 1: 2},
+			map[uint64]uint64{3: 4, 1: 2},
+			map[int]int{3: 4, 1: 2},
+			map[int8]int8{3: 4, 1: 2},
+			map[int16]int16{3: 4, 1: 2},
+			map[int32]int32{3: 4, 1: 2},
+			map[int64]int64{3: 4, 1: 2},
+			map[interface{}]interface{}{3: 4, 1: 2},
+		},
+	},
+	{
+		hexDecode("a26161016162820203"),
+		[]interface{}{
+			map[string]interface{}{"a": 1, "b": []interface{}{2, 3}},
+			map[interface{}]interface{}{"b": []interface{}{2, 3}, "a": 1},
+		},
+	},
+	{
+		hexDecode("a56161614161626142616361436164614461656145"),
+		[]interface{}{
+			map[string]string{"a": "A", "b": "B", "c": "C", "d": "D", "e": "E"},
+			map[interface{}]interface{}{"b": "B", "a": "A", "c": "C", "e": "E", "d": "D"},
+		},
+	},
+	// tag
+	{
+		hexDecode("c074323031332d30332d32315432303a30343a30305a"),
+		[]interface{}{Tag{0, "2013-03-21T20:04:00Z"}, RawTag{0, hexDecode("74323031332d30332d32315432303a30343a30305a")}},
+	}, // 0: standard date/time
+	{
+		hexDecode("c11a514b67b0"),
+		[]interface{}{Tag{1, uint64(1363896240)}, RawTag{1, hexDecode("1a514b67b0")}},
+	}, // 1: epoch-based date/time
+	{
+		hexDecode("c249010000000000000000"),
+		[]interface{}{Tag{2, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}, RawTag{2, hexDecode("49010000000000000000")}},
+	}, // 2: positive bignum: 18446744073709551616
+	{
+		hexDecode("c349010000000000000000"),
+		[]interface{}{Tag{3, []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}, RawTag{3, hexDecode("49010000000000000000")}},
+	}, // 3: negative bignum: -18446744073709551617
+	{
+		hexDecode("c1fb41d452d9ec200000"),
+		[]interface{}{Tag{1, float64(1363896240.5)}, RawTag{1, hexDecode("fb41d452d9ec200000")}},
+	}, // 1: epoch-based date/time
+	{
+		hexDecode("d74401020304"),
+		[]interface{}{Tag{23, []byte{0x01, 0x02, 0x03, 0x04}}, RawTag{23, hexDecode("4401020304")}},
+	}, // 23: expected conversion to base16 encoding
+	{
+		hexDecode("d818456449455446"),
+		[]interface{}{Tag{24, []byte{0x64, 0x49, 0x45, 0x54, 0x46}}, RawTag{24, hexDecode("456449455446")}},
+	}, // 24: encoded cborBytes data item
+	{
+		hexDecode("d82076687474703a2f2f7777772e6578616d706c652e636f6d"),
+		[]interface{}{Tag{32, "http://www.example.com"}, RawTag{32, hexDecode("76687474703a2f2f7777772e6578616d706c652e636f6d")}},
+	}, // 32: URI
+	// primitives
+	{hexDecode("f4"), []interface{}{false}},
+	{hexDecode("f5"), []interface{}{true}},
+	{hexDecode("f6"), []interface{}{nil, []byte(nil), []int(nil), map[uint]bool(nil), (*int)(nil), io.Reader(nil)}},
+	// nan, positive and negative inf
+	{hexDecode("f97c00"), []interface{}{math.Inf(1)}},
+	{hexDecode("f97e00"), []interface{}{math.NaN()}},
+	{hexDecode("f9fc00"), []interface{}{math.Inf(-1)}},
+	// float32
+	{hexDecode("fa47c35000"), []interface{}{float32(100000.0)}},
+	{hexDecode("fa7f7fffff"), []interface{}{float32(3.4028234663852886e+38)}},
+	// float64
+	{hexDecode("fb3ff199999999999a"), []interface{}{float64(1.1)}},
+	{hexDecode("fb7e37e43c8800759c"), []interface{}{float64(1.0e+300)}},
+	{hexDecode("fbc010666666666666"), []interface{}{float64(-4.1)}},
+	// More testcases not covered by https://tools.ietf.org/html/rfc7049#appendix-A.
+	{
+		hexDecode("d83dd183010203"), // 61(17([1, 2, 3])), nested tags 61 and 17
+		[]interface{}{Tag{61, Tag{17, []interface{}{uint64(1), uint64(2), uint64(3)}}}, RawTag{61, hexDecode("d183010203")}},
+	},
+}
+
+var exMarshalTests = []marshalTest{
+	{
+		// array of nils
+		hexDecode("83f6f6f6"),
+		[]interface{}{
+			[]interface{}{nil, nil, nil},
+		},
+	},
+}
+
+func TestMarshal(t *testing.T) {
+	testMarshal(t, marshalTests)
+	testMarshal(t, exMarshalTests)
+}
+
+func TestInvalidTypeMarshal(t *testing.T) {
+	type s1 struct {
+		Chan chan bool
+	}
+	type s2 struct {
+		_    struct{} `cbor:",toarray"`
+		Chan chan bool
+	}
+	var marshalErrorTests = []marshalErrorTest{
+		{"channel cannot be marshaled", make(chan bool), "cbor: unsupported type: chan bool"},
+		{"slice of channel cannot be marshaled", make([]chan bool, 10), "cbor: unsupported type: []chan bool"},
+		{"slice of pointer to channel cannot be marshaled", make([]*chan bool, 10), "cbor: unsupported type: []*chan bool"},
+		{"map of channel cannot be marshaled", make(map[string]chan bool), "cbor: unsupported type: map[string]chan bool"},
+		{"struct of channel cannot be marshaled", s1{}, "cbor: unsupported type: cbor.s1"},
+		{"struct of channel cannot be marshaled", s2{}, "cbor: unsupported type: cbor.s2"},
+		{"function cannot be marshaled", func(i int) int { return i * i }, "cbor: unsupported type: func(int) int"},
+		{"complex cannot be marshaled", complex(100, 8), "cbor: unsupported type: complex128"},
+	}
+	em, err := EncOptions{Sort: SortCanonical}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	for _, tc := range marshalErrorTests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := Marshal(&tc.value)
+			if err == nil {
+				t.Errorf("Marshal(%v) didn't return an error, want error %q", tc.value, tc.wantErrorMsg)
+			} else if _, ok := err.(*UnsupportedTypeError); !ok {
+				t.Errorf("Marshal(%v) error type %T, want *UnsupportedTypeError", tc.value, err)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Marshal(%v) error %q, want %q", tc.value, err.Error(), tc.wantErrorMsg)
+			} else if b != nil {
+				t.Errorf("Marshal(%v) = 0x%x, want nil", tc.value, b)
+			}
+
+			b, err = em.Marshal(&tc.value)
+			if err == nil {
+				t.Errorf("Marshal(%v) didn't return an error, want error %q", tc.value, tc.wantErrorMsg)
+			} else if _, ok := err.(*UnsupportedTypeError); !ok {
+				t.Errorf("Marshal(%v) error type %T, want *UnsupportedTypeError", tc.value, err)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Marshal(%v) error %q, want %q", tc.value, err.Error(), tc.wantErrorMsg)
+			} else if b != nil {
+				t.Errorf("Marshal(%v) = 0x%x, want nil", tc.value, b)
+			}
+		})
+	}
+}
+
+func TestMarshalLargeByteString(t *testing.T) {
+	// []byte{100, 100, 100, ...}
+	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 10000000}
+	tests := make([]marshalTest, len(lengths))
+	for i, length := range lengths {
+		cborData := bytes.NewBuffer(encodeCborHeader(cborTypeByteString, uint64(length)))
+		value := make([]byte, length)
+		for j := 0; j < length; j++ {
+			cborData.WriteByte(100)
+			value[j] = 100
+		}
+		tests[i] = marshalTest{cborData.Bytes(), []interface{}{value}}
+	}
+
+	testMarshal(t, tests)
+}
+
+func TestMarshalLargeTextString(t *testing.T) {
+	// "ddd..."
+	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 10000000}
+	tests := make([]marshalTest, len(lengths))
+	for i, length := range lengths {
+		cborData := bytes.NewBuffer(encodeCborHeader(cborTypeTextString, uint64(length)))
+		value := make([]byte, length)
+		for j := 0; j < length; j++ {
+			cborData.WriteByte(100)
+			value[j] = 100
+		}
+		tests[i] = marshalTest{cborData.Bytes(), []interface{}{string(value)}}
+	}
+
+	testMarshal(t, tests)
+}
+
+func TestMarshalLargeArray(t *testing.T) {
+	// []string{"水", "水", "水", ...}
+	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 10000000}
+	tests := make([]marshalTest, len(lengths))
+	for i, length := range lengths {
+		cborData := bytes.NewBuffer(encodeCborHeader(cborTypeArray, uint64(length)))
+		value := make([]string, length)
+		for j := 0; j < length; j++ {
+			cborData.Write([]byte{0x63, 0xe6, 0xb0, 0xb4})
+			value[j] = "水"
+		}
+		tests[i] = marshalTest{cborData.Bytes(), []interface{}{value}}
+	}
+
+	testMarshal(t, tests)
+}
+
+func TestMarshalLargeMapCanonical(t *testing.T) {
+	// map[int]int {0:0, 1:1, 2:2, ...}
+	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 1000000}
+	tests := make([]marshalTest, len(lengths))
+	for i, length := range lengths {
+		cborData := bytes.NewBuffer(encodeCborHeader(cborTypeMap, uint64(length)))
+		value := make(map[int]int, length)
+		for j := 0; j < length; j++ {
+			d := encodeCborHeader(cborTypePositiveInt, uint64(j))
+			cborData.Write(d)
+			cborData.Write(d)
+			value[j] = j
+		}
+		tests[i] = marshalTest{cborData.Bytes(), []interface{}{value}}
+	}
+
+	testMarshal(t, tests)
+}
+
+func TestMarshalLargeMap(t *testing.T) {
+	// map[int]int {0:0, 1:1, 2:2, ...}
+	lengths := []int{0, 1, 2, 22, 23, 24, 254, 255, 256, 65534, 65535, 65536, 1000000}
+	for _, length := range lengths {
+		m1 := make(map[int]int, length)
+		for i := 0; i < length; i++ {
+			m1[i] = i
+		}
+
+		cborData, err := Marshal(m1)
+		if err != nil {
+			t.Fatalf("Marshal(%v) returned error %v", m1, err)
+		}
+
+		m2 := make(map[int]int)
+		if err = Unmarshal(cborData, &m2); err != nil {
+			t.Fatalf("Unmarshal(0x%x) returned error %v", cborData, err)
+		}
+
+		if !reflect.DeepEqual(m1, m2) {
+			t.Errorf("Unmarshal() = %v, want %v", m2, m1)
+		}
+	}
+}
+
+func encodeCborHeader(t cborType, n uint64) []byte {
+	b := make([]byte, 9)
+	if n <= 23 {
+		b[0] = byte(t) | byte(n)
+		return b[:1]
+	} else if n <= math.MaxUint8 {
+		b[0] = byte(t) | byte(24)
+		b[1] = byte(n)
+		return b[:2]
+	} else if n <= math.MaxUint16 {
+		b[0] = byte(t) | byte(25)
+		binary.BigEndian.PutUint16(b[1:], uint16(n))
+		return b[:3]
+	} else if n <= math.MaxUint32 {
+		b[0] = byte(t) | byte(26)
+		binary.BigEndian.PutUint32(b[1:], uint32(n))
+		return b[:5]
+	} else {
+		b[0] = byte(t) | byte(27)
+		binary.BigEndian.PutUint64(b[1:], n)
+		return b[:9]
+	}
+}
+
+func testMarshal(t *testing.T, testCases []marshalTest) {
+	em, err := EncOptions{Sort: SortCanonical}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	for _, tc := range testCases {
+		for _, value := range tc.values {
+			if _, err := Marshal(value); err != nil {
+				t.Errorf("Marshal(%v) returned error %v", value, err)
+			}
+			if b, err := em.Marshal(value); err != nil {
+				t.Errorf("Marshal(%v) returned error %v", value, err)
+			} else if !bytes.Equal(b, tc.cborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", value, b, tc.cborData)
+			}
+		}
+		r := RawMessage(tc.cborData)
+		if b, err := Marshal(r); err != nil {
+			t.Errorf("Marshal(%v) returned error %v", r, err)
+		} else if !bytes.Equal(b, r) {
+			t.Errorf("Marshal(%v) returned %v, want %v", r, b, r)
+		}
+	}
+}
+
+func TestMarshalStruct(t *testing.T) {
+	v1 := outer{
+		IntField:          123,
+		FloatField:        100000.0,
+		BoolField:         true,
+		StringField:       "test",
+		ByteStringField:   []byte{1, 3, 5},
+		ArrayField:        []string{"hello", "world"},
+		MapField:          map[string]bool{"afternoon": false, "morning": true},
+		NestedStructField: &inner{X: 1000, Y: 1000000, z: 10000000},
+		unexportedField:   6,
+	}
+	unmarshalWant := outer{
+		IntField:          123,
+		FloatField:        100000.0,
+		BoolField:         true,
+		StringField:       "test",
+		ByteStringField:   []byte{1, 3, 5},
+		ArrayField:        []string{"hello", "world"},
+		MapField:          map[string]bool{"afternoon": false, "morning": true},
+		NestedStructField: &inner{X: 1000, Y: 1000000},
+	}
+
+	cborData, err := Marshal(v1)
+	if err != nil {
+		t.Fatalf("Marshal(%v) returned error %v", v1, err)
+	}
+
+	var v2 outer
+	if err = Unmarshal(cborData, &v2); err != nil {
+		t.Fatalf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+
+	if !reflect.DeepEqual(unmarshalWant, v2) {
+		t.Errorf("Unmarshal() = %v, want %v", v2, unmarshalWant)
+	}
+}
+func TestMarshalStructCanonical(t *testing.T) {
+	v := outer{
+		IntField:          123,
+		FloatField:        100000.0,
+		BoolField:         true,
+		StringField:       "test",
+		ByteStringField:   []byte{1, 3, 5},
+		ArrayField:        []string{"hello", "world"},
+		MapField:          map[string]bool{"afternoon": false, "morning": true},
+		NestedStructField: &inner{X: 1000, Y: 1000000, z: 10000000},
+		unexportedField:   6,
+	}
+	var cborData bytes.Buffer
+	cborData.WriteByte(byte(cborTypeMap) | 8) // CBOR header: map type with 8 items (exported fields)
+
+	cborData.WriteByte(byte(cborTypeTextString) | 8) // "IntField"
+	cborData.WriteString("IntField")
+	cborData.WriteByte(byte(cborTypePositiveInt) | 24)
+	cborData.WriteByte(123)
+
+	cborData.WriteByte(byte(cborTypeTextString) | 8) // "MapField"
+	cborData.WriteString("MapField")
+	cborData.WriteByte(byte(cborTypeMap) | 2)
+	cborData.WriteByte(byte(cborTypeTextString) | 7)
+	cborData.WriteString("morning")
+	cborData.WriteByte(byte(cborTypePrimitives) | 21)
+	cborData.WriteByte(byte(cborTypeTextString) | 9)
+	cborData.WriteString("afternoon")
+	cborData.WriteByte(byte(cborTypePrimitives) | 20)
+
+	cborData.WriteByte(byte(cborTypeTextString) | 9) // "BoolField"
+	cborData.WriteString("BoolField")
+	cborData.WriteByte(byte(cborTypePrimitives) | 21)
+
+	cborData.WriteByte(byte(cborTypeTextString) | 10) // "ArrayField"
+	cborData.WriteString("ArrayField")
+	cborData.WriteByte(byte(cborTypeArray) | 2)
+	cborData.WriteByte(byte(cborTypeTextString) | 5)
+	cborData.WriteString("hello")
+	cborData.WriteByte(byte(cborTypeTextString) | 5)
+	cborData.WriteString("world")
+
+	cborData.WriteByte(byte(cborTypeTextString) | 10) // "FloatField"
+	cborData.WriteString("FloatField")
+	cborData.Write([]byte{0xfa, 0x47, 0xc3, 0x50, 0x00})
+
+	cborData.WriteByte(byte(cborTypeTextString) | 11) // "StringField"
+	cborData.WriteString("StringField")
+	cborData.WriteByte(byte(cborTypeTextString) | 4)
+	cborData.WriteString("test")
+
+	cborData.WriteByte(byte(cborTypeTextString) | 15) // "ByteStringField"
+	cborData.WriteString("ByteStringField")
+	cborData.WriteByte(byte(cborTypeByteString) | 3)
+	cborData.Write([]byte{1, 3, 5})
+
+	cborData.WriteByte(byte(cborTypeTextString) | 17) // "NestedStructField"
+	cborData.WriteString("NestedStructField")
+	cborData.WriteByte(byte(cborTypeMap) | 2)
+	cborData.WriteByte(byte(cborTypeTextString) | 1)
+	cborData.WriteString("X")
+	cborData.WriteByte(byte(cborTypePositiveInt) | 25)
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(1000))
+	cborData.Write(b)
+	cborData.WriteByte(byte(cborTypeTextString) | 1)
+	cborData.WriteString("Y")
+	cborData.WriteByte(byte(cborTypePositiveInt) | 26)
+	b = make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(1000000))
+	cborData.Write(b)
+
+	em, err := EncOptions{Sort: SortCanonical}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %q", err)
+	}
+	if b, err := em.Marshal(v); err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	} else if !bytes.Equal(b, cborData.Bytes()) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, cborData.Bytes())
+	}
+}
+
+func TestMarshalNullPointerToEmbeddedStruct(t *testing.T) {
+	type (
+		T1 struct {
+			N int
+		}
+		T2 struct {
+			*T1
+		}
+	)
+	v := T2{}
+	wantCborData := []byte{0xa0} // {}
+	cborData, err := Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(wantCborData, cborData) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, cborData, wantCborData)
+	}
+}
+
+func TestMarshalNullPointerToStruct(t *testing.T) {
+	type (
+		T1 struct {
+			N int
+		}
+		T2 struct {
+			T *T1
+		}
+	)
+	v := T2{}
+	wantCborData := []byte{0xa1, 0x61, 0x54, 0xf6} // {T: nil}
+	cborData, err := Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(wantCborData, cborData) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, cborData, wantCborData)
+	}
+}
+
+func TestAnonymousFields1(t *testing.T) {
+	// Fields with the same name at the same level are ignored
+	type (
+		S1 struct{ x, X int }
+		S2 struct{ x, X int }
+		S  struct {
+			S1
+			S2
+		}
+	)
+	s := S{S1{1, 2}, S2{3, 4}}
+	want := []byte{0xa0} // {}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+}
+
+func TestAnonymousFields2(t *testing.T) {
+	// Field with the same name at a less nested level is serialized
+	type (
+		S1 struct{ x, X int }
+		S2 struct{ x, X int }
+		S  struct {
+			S1
+			S2
+			x, X int
+		}
+	)
+	s := S{S1{1, 2}, S2{3, 4}, 5, 6}
+	want := []byte{0xa1, 0x61, 0x58, 0x06} // {X:6}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S
+	unmarshalWant := S{X: 6}
+	if err := Unmarshal(b, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v, unmarshalWant) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v, v, unmarshalWant, unmarshalWant)
+	}
+}
+
+func TestAnonymousFields3(t *testing.T) {
+	// Unexported embedded field of non-struct type should not be serialized
+	type (
+		myInt int
+		S     struct {
+			myInt
+		}
+	)
+	s := S{5}
+	want := []byte{0xa0} // {}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+}
+
+func TestAnonymousFields4(t *testing.T) {
+	// Exported embedded field of non-struct type should be serialized
+	type (
+		MyInt int
+		S     struct {
+			MyInt
+		}
+	)
+	s := S{5}
+	want := []byte{0xa1, 0x65, 0x4d, 0x79, 0x49, 0x6e, 0x74, 0x05} // {MyInt: 5}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S
+	if err = Unmarshal(b, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v, s) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v, v, s, s)
+	}
+}
+
+func TestAnonymousFields5(t *testing.T) {
+	// Unexported embedded field of pointer to non-struct type should not be serialized
+	type (
+		myInt int
+		S     struct {
+			*myInt
+		}
+	)
+	s := S{new(myInt)}
+	*s.myInt = 5
+	want := []byte{0xa0} // {}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+}
+
+func TestAnonymousFields6(t *testing.T) {
+	// Exported embedded field of pointer to non-struct type should be serialized
+	type (
+		MyInt int
+		S     struct {
+			*MyInt
+		}
+	)
+	s := S{new(MyInt)}
+	*s.MyInt = 5
+	want := []byte{0xa1, 0x65, 0x4d, 0x79, 0x49, 0x6e, 0x74, 0x05} // {MyInt: 5}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S
+	if err = Unmarshal(b, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v, s) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v, v, s, s)
+	}
+}
+
+func TestAnonymousFields7(t *testing.T) {
+	// Exported fields of embedded structs should have their exported fields be serialized
+	type (
+		s1 struct{ x, X int }
+		S2 struct{ y, Y int }
+		S  struct {
+			s1
+			S2
+		}
+	)
+	s := S{s1{1, 2}, S2{3, 4}}
+	want := []byte{0xa2, 0x61, 0x58, 0x02, 0x61, 0x59, 0x04} // {X:2, Y:4}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S
+	unmarshalWant := S{s1{X: 2}, S2{Y: 4}}
+	if err = Unmarshal(b, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v, unmarshalWant) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v, v, unmarshalWant, unmarshalWant)
+	}
+}
+
+func TestAnonymousFields8(t *testing.T) {
+	// Exported fields of pointers
+	type (
+		s1 struct{ x, X int }
+		S2 struct{ y, Y int }
+		S  struct {
+			*s1
+			*S2
+		}
+	)
+	s := S{&s1{1, 2}, &S2{3, 4}}
+	want := []byte{0xa2, 0x61, 0x58, 0x02, 0x61, 0x59, 0x04} // {X:2, Y:4}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	// v cannot be unmarshaled to because reflect cannot allocate unexported field s1.
+	var v1 S
+	wantErrorMsg := "cannot set embedded pointer to unexported struct"
+	wantV := S{S2: &S2{Y: 4}}
+	err = Unmarshal(b, &v1)
+	if err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want error %q", b, wantErrorMsg)
+	} else if !strings.Contains(err.Error(), wantErrorMsg) {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want error %q", b, err.Error(), wantErrorMsg)
+	}
+	if !reflect.DeepEqual(v1, wantV) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", b, v1, v1, wantV, wantV)
+	}
+
+	// v can be unmarshaled to because unexported field s1 is already allocated.
+	var v2 S
+	v2.s1 = &s1{}
+	unmarshalWant := S{&s1{X: 2}, &S2{Y: 4}}
+	if err = Unmarshal(b, &v2); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v2, unmarshalWant) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v2, v2, unmarshalWant, unmarshalWant)
+	}
+}
+
+func TestAnonymousFields9(t *testing.T) {
+	// Multiple levels of nested anonymous fields
+	type (
+		MyInt1 int
+		MyInt2 int
+		myInt  int
+		s2     struct {
+			MyInt2
+			myInt
+		}
+		s1 struct {
+			MyInt1
+			myInt
+			s2
+		}
+		S struct {
+			s1
+			myInt
+		}
+	)
+	s := S{s1{1, 2, s2{3, 4}}, 6}
+	want := []byte{0xa2, 0x66, 0x4d, 0x79, 0x49, 0x6e, 0x74, 0x31, 0x01, 0x66, 0x4d, 0x79, 0x49, 0x6e, 0x74, 0x32, 0x03} // {MyInt1: 1, MyInt2: 3}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S
+	unmarshalWant := S{s1: s1{MyInt1: 1, s2: s2{MyInt2: 3}}}
+	if err = Unmarshal(b, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v, unmarshalWant) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v, v, unmarshalWant, unmarshalWant)
+	}
+}
+
+func TestAnonymousFields10(t *testing.T) {
+	// Fields of the same struct type at the same level
+	type (
+		s3 struct {
+			Z int
+		}
+		s1 struct {
+			X int
+			s3
+		}
+		s2 struct {
+			Y int
+			s3
+		}
+		S struct {
+			s1
+			s2
+		}
+	)
+	s := S{s1{1, s3{2}}, s2{3, s3{4}}}
+	want := []byte{0xa2, 0x61, 0x58, 0x01, 0x61, 0x59, 0x03} // {X: 1, Y: 3}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S
+	unmarshalWant := S{s1: s1{X: 1}, s2: s2{Y: 3}}
+	if err = Unmarshal(b, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v, unmarshalWant) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v, v, unmarshalWant, unmarshalWant)
+	}
+}
+
+func TestAnonymousFields11(t *testing.T) {
+	// Fields of the same struct type at different levels
+	type (
+		s2 struct {
+			X int
+		}
+		s1 struct {
+			Y int
+			s2
+		}
+		S struct {
+			s1
+			s2
+		}
+	)
+	s := S{s1{1, s2{2}}, s2{3}}
+	want := []byte{0xa2, 0x61, 0x59, 0x01, 0x61, 0x58, 0x03} // {Y: 1, X: 3}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S
+	unmarshalWant := S{s1: s1{Y: 1}, s2: s2{X: 3}}
+	if err = Unmarshal(b, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v, unmarshalWant) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v, v, unmarshalWant, unmarshalWant)
+	}
+}
+
+func TestOmitEmpty(t *testing.T) {
+	type s struct {
+		Sr  string                 `cbor:"sr"`
+		So  string                 `cbor:"so,omitempty"`
+		Sw  string                 `cbor:"-"`
+		Ir  int                    `cbor:"omitempty"` // actually named omitempty, not an option
+		Io  int                    `cbor:"io,omitempty"`
+		Slr []string               `cbor:"slr"`
+		Slo []string               `cbor:"slo,omitempty"`
+		Mr  map[string]interface{} `cbor:"mr"`
+		Mo  map[string]interface{} `cbor:"mo,omitempty"`
+		Ms  map[string]interface{} `cbor:",omitempty"`
+		Fr  float64                `cbor:"fr"`
+		Fo  float64                `cbor:"fo,omitempty"`
+		Br  bool                   `cbor:"br"`
+		Bo  bool                   `cbor:"bo,omitempty"`
+		Ur  uint                   `cbor:"ur"`
+		Uo  uint                   `cbor:"uo,omitempty"`
+		Str struct{}               `cbor:"str"`
+		Sto struct{}               `cbor:"sto,omitempty"`
+		Pr  *int                   `cbor:"pr"`
+		Po  *int                   `cbor:"po,omitempty"`
+	}
+
+	// {"sr": "", "omitempty": 0, "slr": null, "mr": {}, "Ms": {"a": true}, "fr": 0, "br": false, "ur": 0, "str": {}, "sto": {}, "pr": nil }
+	want := []byte{0xab,
+		0x62, 0x73, 0x72, 0x60,
+		0x69, 0x6f, 0x6d, 0x69, 0x74, 0x65, 0x6d, 0x70, 0x74, 0x79, 0x00,
+		0x63, 0x73, 0x6c, 0x72, 0xf6,
+		0x62, 0x6d, 0x72, 0xa0,
+		0x62, 0x4d, 0x73, 0xa1, 0x61, 0x61, 0xf5,
+		0x62, 0x66, 0x72, 0xfb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x62, 0x62, 0x72, 0xf4,
+		0x62, 0x75, 0x72, 0x00,
+		0x63, 0x73, 0x74, 0x72, 0xa0,
+		0x63, 0x73, 0x74, 0x6f, 0xa0,
+		0x62, 0x70, 0x72, 0xf6}
+
+	var v s
+	v.Sw = "something"
+	v.Mr = map[string]interface{}{}
+	v.Mo = map[string]interface{}{}
+	v.Ms = map[string]interface{}{"a": true}
+
+	b, err := Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, want)
+	}
+}
+
+type StructA struct {
+	S string
+}
+
+type StructC struct {
+	S string
+}
+
+type StructD struct { // Same as StructA after tagging.
+	XXX string `cbor:"S"`
+}
+
+// StructD's tagged S field should dominate StructA's.
+type StructY struct {
+	StructA
+	StructD
+}
+
+// There are no tags here, so S should not appear.
+type StructZ struct {
+	StructA
+	StructC
+	StructY // Contains a tagged S field through StructD; should not dominate.
+}
+
+func TestTaggedFieldDominates(t *testing.T) {
+	// Test that a field with a tag dominates untagged fields.
+	v := StructY{
+		StructA{"StructA"},
+		StructD{"StructD"},
+	}
+	want := []byte{0xa1, 0x61, 0x53, 0x67, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74, 0x44} // {"S":"StructD"}
+	b, err := Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, want)
+	}
+
+	var v2 StructY
+	unmarshalWant := StructY{StructD: StructD{"StructD"}}
+	if err = Unmarshal(b, &v2); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v2, unmarshalWant) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", b, v2, v2, unmarshalWant, unmarshalWant)
+	}
+}
+
+func TestDuplicatedFieldDisappears(t *testing.T) {
+	v := StructZ{
+		StructA{"StructA"},
+		StructC{"StructC"},
+		StructY{
+			StructA{"nested StructA"},
+			StructD{"nested StructD"},
+		},
+	}
+	want := []byte{0xa0} // {}
+	b, err := Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, want)
+	}
+}
+
+type (
+	S1 struct {
+		X int
+	}
+	S2 struct {
+		X int
+	}
+	S3 struct {
+		X  int
+		S1 `cbor:"S1"`
+	}
+	S4 struct {
+		X int
+		io.Reader
+	}
+)
+
+func (s S2) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func TestTaggedAnonymousField(t *testing.T) {
+	// Test that an anonymous field with a name given in its CBOR tag is treated as having that name, rather than being anonymous.
+	s := S3{X: 1, S1: S1{X: 2}}
+	want := []byte{0xa2, 0x61, 0x58, 0x01, 0x62, 0x53, 0x31, 0xa1, 0x61, 0x58, 0x02} // {X: 1, S1: {X:2}}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S3
+	unmarshalWant := S3{X: 1, S1: S1{X: 2}}
+	if err = Unmarshal(b, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+	} else if !reflect.DeepEqual(v, unmarshalWant) {
+		t.Errorf("Unmarshal(0x%x) = %+v (%T), want %+v (%T)", b, v, v, unmarshalWant, unmarshalWant)
+	}
+}
+
+func TestAnonymousInterfaceField(t *testing.T) {
+	// Test that an anonymous struct field of interface type is treated the same as having that type as its name, rather than being anonymous.
+	s := S4{X: 1, Reader: S2{X: 2}}
+	want := []byte{0xa2, 0x61, 0x58, 0x01, 0x66, 0x52, 0x65, 0x61, 0x64, 0x65, 0x72, 0xa1, 0x61, 0x58, 0x02} // {X: 1, Reader: {X:2}}
+	b, err := Marshal(s)
+	if err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", s, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", s, b, want)
+	}
+
+	var v S4
+	const wantErrorMsg = "cannot unmarshal map into Go struct field cbor.S4.Reader of type io.Reader"
+	if err = Unmarshal(b, &v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want error (*UnmarshalTypeError)", b)
+	} else {
+		if typeError, ok := err.(*UnmarshalTypeError); !ok {
+			t.Errorf("Unmarshal(0x%x) returned wrong type of error %T, want (*UnmarshalTypeError)", b, err)
+		} else if !strings.Contains(typeError.Error(), wantErrorMsg) {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", b, err.Error(), wantErrorMsg)
+		}
+	}
+}
+
+func TestEncodeInterface(t *testing.T) {
+	var r io.Reader = S2{X: 2}
+	want := []byte{0xa1, 0x61, 0x58, 0x02} // {X:2}
+	b, err := Marshal(r)
+	if err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", r, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", r, b, want)
+	}
+
+	var v io.Reader
+	const wantErrorMsg = "cannot unmarshal map into Go value of type io.Reader"
+	if err = Unmarshal(b, &v); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return an error, want error (*UnmarshalTypeError)", b)
+	} else {
+		if typeError, ok := err.(*UnmarshalTypeError); !ok {
+			t.Errorf("Unmarshal(0x%x) returned wrong type of error %T, want (*UnmarshalTypeError)", b, err)
+		} else if !strings.Contains(typeError.Error(), wantErrorMsg) {
+			t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", b, err.Error(), wantErrorMsg)
+		}
+	}
+}
+
+func TestEncodeTime(t *testing.T) {
+	timeUnixOpt := EncOptions{Time: TimeUnix}
+	timeUnixMicroOpt := EncOptions{Time: TimeUnixMicro}
+	timeUnixDynamicOpt := EncOptions{Time: TimeUnixDynamic}
+	timeRFC3339Opt := EncOptions{Time: TimeRFC3339}
+	timeRFC3339NanoOpt := EncOptions{Time: TimeRFC3339Nano}
+
+	type timeConvert struct {
+		opt          EncOptions
+		wantCborData []byte
+	}
+	testCases := []struct {
+		name    string
+		tm      time.Time
+		convert []timeConvert
+	}{
+		{
+			name: "zero time",
+			tm:   time.Time{},
+			convert: []timeConvert{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+			},
+		},
+		{
+			name: "time without fractional seconds",
+			tm:   parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			convert: []timeConvert{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: hexDecode("1a514b67b0"), // 1363896240
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: hexDecode("fb41d452d9ec000000"), // 1363896240.0
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: hexDecode("1a514b67b0"), // 1363896240
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: hexDecode("74323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: hexDecode("74323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+				},
+			},
+		},
+		{
+			name: "time with fractional seconds",
+			tm:   parseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
+			convert: []timeConvert{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: hexDecode("1a514b67b0"), // 1363896240
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: hexDecode("fb41d452d9ec200000"), // 1363896240.5
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: hexDecode("fb41d452d9ec200000"), // 1363896240.5
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: hexDecode("74323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: hexDecode("76323031332d30332d32315432303a30343a30302e355a"), // "2013-03-21T20:04:00.5Z"
+				},
+			},
+		},
+		{
+			name: "time before January 1, 1970 UTC without fractional seconds",
+			tm:   parseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
+			convert: []timeConvert{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: hexDecode("3a0177f2cf"), // -24638160
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: hexDecode("fbc1777f2d00000000"), // -24638160.0
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: hexDecode("3a0177f2cf"), // -24638160
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: hexDecode("74313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: hexDecode("74313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		for _, convert := range tc.convert {
+			var convertName string
+			switch convert.opt.Time {
+			case TimeUnix:
+				convertName = "TimeUnix"
+			case TimeUnixMicro:
+				convertName = "TimeUnixMicro"
+			case TimeUnixDynamic:
+				convertName = "TimeUnixDynamic"
+			case TimeRFC3339:
+				convertName = "TimeRFC3339"
+			case TimeRFC3339Nano:
+				convertName = "TimeRFC3339Nano"
+			}
+			name := tc.name + " with " + convertName + " option"
+			t.Run(name, func(t *testing.T) {
+				em, err := convert.opt.EncMode()
+				if err != nil {
+					t.Errorf("EncMode() returned error %v", err)
+				}
+				b, err := em.Marshal(tc.tm)
+				if err != nil {
+					t.Errorf("Marshal(%+v) returned error %v", tc.tm, err)
+				} else if !bytes.Equal(b, convert.wantCborData) {
+					t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.tm, b, convert.wantCborData)
+				}
+			})
+		}
+	}
+}
+
+func TestEncodeTimeWithTag(t *testing.T) {
+	timeUnixOpt := EncOptions{Time: TimeUnix, TimeTag: EncTagRequired}
+	timeUnixMicroOpt := EncOptions{Time: TimeUnixMicro, TimeTag: EncTagRequired}
+	timeUnixDynamicOpt := EncOptions{Time: TimeUnixDynamic, TimeTag: EncTagRequired}
+	timeRFC3339Opt := EncOptions{Time: TimeRFC3339, TimeTag: EncTagRequired}
+	timeRFC3339NanoOpt := EncOptions{Time: TimeRFC3339Nano, TimeTag: EncTagRequired}
+
+	type timeConvert struct {
+		opt          EncOptions
+		wantCborData []byte
+	}
+	testCases := []struct {
+		name    string
+		tm      time.Time
+		convert []timeConvert
+	}{
+		{
+			name: "zero time",
+			tm:   time.Time{},
+			convert: []timeConvert{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: hexDecode("f6"), // encode as CBOR null
+				},
+			},
+		},
+		{
+			name: "time without fractional seconds",
+			tm:   parseTime(time.RFC3339Nano, "2013-03-21T20:04:00Z"),
+			convert: []timeConvert{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: hexDecode("c11a514b67b0"), // 1363896240
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: hexDecode("c1fb41d452d9ec000000"), // 1363896240.0
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: hexDecode("c11a514b67b0"), // 1363896240
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: hexDecode("c074323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: hexDecode("c074323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+				},
+			},
+		},
+		{
+			name: "time with fractional seconds",
+			tm:   parseTime(time.RFC3339Nano, "2013-03-21T20:04:00.5Z"),
+			convert: []timeConvert{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: hexDecode("c11a514b67b0"), // 1363896240
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: hexDecode("c1fb41d452d9ec200000"), // 1363896240.5
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: hexDecode("c1fb41d452d9ec200000"), // 1363896240.5
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: hexDecode("c074323031332d30332d32315432303a30343a30305a"), // "2013-03-21T20:04:00Z"
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: hexDecode("c076323031332d30332d32315432303a30343a30302e355a"), // "2013-03-21T20:04:00.5Z"
+				},
+			},
+		},
+		{
+			name: "time before January 1, 1970 UTC without fractional seconds",
+			tm:   parseTime(time.RFC3339Nano, "1969-03-21T20:04:00Z"),
+			convert: []timeConvert{
+				{
+					opt:          timeUnixOpt,
+					wantCborData: hexDecode("c13a0177f2cf"), // -24638160
+				},
+				{
+					opt:          timeUnixMicroOpt,
+					wantCborData: hexDecode("c1fbc1777f2d00000000"), // -24638160.0
+				},
+				{
+					opt:          timeUnixDynamicOpt,
+					wantCborData: hexDecode("c13a0177f2cf"), // -24638160
+				},
+				{
+					opt:          timeRFC3339Opt,
+					wantCborData: hexDecode("c074313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
+				},
+				{
+					opt:          timeRFC3339NanoOpt,
+					wantCborData: hexDecode("c074313936392d30332d32315432303a30343a30305a"), // "1969-03-21T20:04:00Z"
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		for _, convert := range tc.convert {
+			var convertName string
+			switch convert.opt.Time {
+			case TimeUnix:
+				convertName = "TimeUnix"
+			case TimeUnixMicro:
+				convertName = "TimeUnixMicro"
+			case TimeUnixDynamic:
+				convertName = "TimeUnixDynamic"
+			case TimeRFC3339:
+				convertName = "TimeRFC3339"
+			case TimeRFC3339Nano:
+				convertName = "TimeRFC3339Nano"
+			}
+			name := tc.name + " with " + convertName + " option"
+			t.Run(name, func(t *testing.T) {
+				em, err := convert.opt.EncMode()
+				if err != nil {
+					t.Errorf("EncMode() returned error %v", err)
+				}
+				b, err := em.Marshal(tc.tm)
+				if err != nil {
+					t.Errorf("Marshal(%+v) returned error %v", tc.tm, err)
+				} else if !bytes.Equal(b, convert.wantCborData) {
+					t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.tm, b, convert.wantCborData)
+				}
+			})
+		}
+	}
+}
+
+func parseTime(layout string, value string) time.Time {
+	tm, err := time.Parse(layout, value)
+	if err != nil {
+		panic(err)
+	}
+	return tm
+}
+
+func TestInvalidTimeMode(t *testing.T) {
+	wantErrorMsg := "cbor: invalid TimeMode 100"
+	_, err := EncOptions{Time: TimeMode(100)}.EncMode()
+	if err == nil {
+		t.Errorf("EncMode() didn't return an error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("EncMode() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestMarshalStructTag1(t *testing.T) {
+	type strc struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+	}
+	v := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	want := hexDecode("a3616161416162614261636143") // {"a":"A", "b":"B", "c":"C"}
+	if b, err := Marshal(v); err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", v, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%+v) = %v, want %v", v, b, want)
+	}
+}
+
+func TestMarshalStructTag2(t *testing.T) {
+	type strc struct {
+		A string `json:"a"`
+		B string `json:"b"`
+		C string `json:"c"`
+	}
+	v := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	want := hexDecode("a3616161416162614261636143") // {"a":"A", "b":"B", "c":"C"}
+	if b, err := Marshal(v); err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", v, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%+v) = %v, want %v", v, b, want)
+	}
+}
+
+func TestMarshalStructTag3(t *testing.T) {
+	type strc struct {
+		A string `json:"x" cbor:"a"`
+		B string `json:"y" cbor:"b"`
+		C string `json:"z"`
+	}
+	v := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	want := hexDecode("a36161614161626142617a6143") // {"a":"A", "b":"B", "z":"C"}
+	if b, err := Marshal(v); err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", v, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%+v) = %v, want %v", v, b, want)
+	}
+}
+
+func TestMarshalStructTag4(t *testing.T) {
+	type strc struct {
+		A string `json:"x" cbor:"a"`
+		B string `json:"y" cbor:"b"`
+		C string `json:"-"`
+	}
+	v := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	want := hexDecode("a26161614161626142") // {"a":"A", "b":"B"}
+	if b, err := Marshal(v); err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", v, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%+v) = %v, want %v", v, b, want)
+	}
+}
+
+func TestMarshalStructLongFieldName(t *testing.T) {
+	type strc struct {
+		A string `cbor:"a"`
+		B string `cbor:"abcdefghijklmnopqrstuvwxyz"`
+		C string `cbor:"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn"`
+	}
+	v := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	want := hexDecode("a361616141781a6162636465666768696a6b6c6d6e6f707172737475767778797a614278426162636465666768696a6b6c6d6e6f707172737475767778797a6162636465666768696a6b6c6d6e6f707172737475767778797a6162636465666768696a6b6c6d6e6143") // {"a":"A", "abcdefghijklmnopqrstuvwxyz":"B", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn":"C"}
+	if b, err := Marshal(v); err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", v, err)
+	} else if !bytes.Equal(b, want) {
+		t.Errorf("Marshal(%+v) = %v, want %v", v, b, want)
+	}
+}
+
+func TestMarshalRawMessageValue(t *testing.T) {
+	type (
+		T1 struct {
+			M RawMessage `cbor:",omitempty"`
+		}
+		T2 struct {
+			M *RawMessage `cbor:",omitempty"`
+		}
+	)
+
+	var (
+		rawNil   = RawMessage(nil)
+		rawEmpty = RawMessage([]byte{})
+		raw      = RawMessage([]byte{0x01})
+	)
+
+	tests := []struct {
+		obj  interface{}
+		want []byte
+	}{
+		// Test with nil RawMessage.
+		{rawNil, []byte{0xf6}},
+		{&rawNil, []byte{0xf6}},
+		{[]interface{}{rawNil}, []byte{0x81, 0xf6}},
+		{&[]interface{}{rawNil}, []byte{0x81, 0xf6}},
+		{[]interface{}{&rawNil}, []byte{0x81, 0xf6}},
+		{&[]interface{}{&rawNil}, []byte{0x81, 0xf6}},
+		{struct{ M RawMessage }{rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&struct{ M RawMessage }{rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{struct{ M *RawMessage }{&rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&struct{ M *RawMessage }{&rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{map[string]interface{}{"M": rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&map[string]interface{}{"M": rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{map[string]interface{}{"M": &rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&map[string]interface{}{"M": &rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{T1{rawNil}, []byte{0xa0}},
+		{T2{&rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&T1{rawNil}, []byte{0xa0}},
+		{&T2{&rawNil}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+
+		// Test with empty, but non-nil, RawMessage.
+		{rawEmpty, []byte{0xf6}},
+		{&rawEmpty, []byte{0xf6}},
+		{[]interface{}{rawEmpty}, []byte{0x81, 0xf6}},
+		{&[]interface{}{rawEmpty}, []byte{0x81, 0xf6}},
+		{[]interface{}{&rawEmpty}, []byte{0x81, 0xf6}},
+		{&[]interface{}{&rawEmpty}, []byte{0x81, 0xf6}},
+		{struct{ M RawMessage }{rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&struct{ M RawMessage }{rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{struct{ M *RawMessage }{&rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&struct{ M *RawMessage }{&rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{map[string]interface{}{"M": rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&map[string]interface{}{"M": rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{map[string]interface{}{"M": &rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&map[string]interface{}{"M": &rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{T1{rawEmpty}, []byte{0xa0}},
+		{T2{&rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+		{&T1{rawEmpty}, []byte{0xa0}},
+		{&T2{&rawEmpty}, []byte{0xa1, 0x61, 0x4d, 0xf6}},
+
+		// Test with RawMessage with some data.
+		{raw, []byte{0x01}},
+		{&raw, []byte{0x01}},
+		{[]interface{}{raw}, []byte{0x81, 0x01}},
+		{&[]interface{}{raw}, []byte{0x81, 0x01}},
+		{[]interface{}{&raw}, []byte{0x81, 0x01}},
+		{&[]interface{}{&raw}, []byte{0x81, 0x01}},
+		{struct{ M RawMessage }{raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{&struct{ M RawMessage }{raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{struct{ M *RawMessage }{&raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{&struct{ M *RawMessage }{&raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{map[string]interface{}{"M": raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{&map[string]interface{}{"M": raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{map[string]interface{}{"M": &raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{&map[string]interface{}{"M": &raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{T1{raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{T2{&raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{&T1{raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+		{&T2{&raw}, []byte{0xa1, 0x61, 0x4d, 0x01}},
+	}
+
+	for _, tc := range tests {
+		b, err := Marshal(tc.obj)
+		if err != nil {
+			t.Errorf("Marshal(%+v) returned error %v", tc.obj, err)
+		}
+		if !bytes.Equal(b, tc.want) {
+			t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.obj, b, tc.want)
+		}
+	}
+}
+
+func TestCyclicDataStructure(t *testing.T) {
+	type Node struct {
+		V int   `cbor:"v"`
+		N *Node `cbor:"n,omitempty"`
+	}
+	v := Node{1, &Node{2, &Node{3, nil}}}                                                                                  // linked list: 1, 2, 3
+	wantCborData := []byte{0xa2, 0x61, 0x76, 0x01, 0x61, 0x6e, 0xa2, 0x61, 0x76, 0x02, 0x61, 0x6e, 0xa1, 0x61, 0x76, 0x03} // {v: 1, n: {v: 2, n: {v: 3}}}
+	cborData, err := Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(wantCborData, cborData) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, cborData, wantCborData)
+	}
+	var v1 Node
+	if err = Unmarshal(cborData, &v1); err != nil {
+		t.Fatalf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, v1) {
+		t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", cborData, v1, v)
+	}
+}
+
+func TestMarshalUnmarshalStructKeyAsInt(t *testing.T) {
+	type T struct {
+		F1 int `cbor:"1,omitempty,keyasint"`
+		F2 int `cbor:"2,omitempty"`
+		F3 int `cbor:"-3,omitempty,keyasint"`
+	}
+	testCases := []struct {
+		name         string
+		obj          interface{}
+		wantCborData []byte
+	}{
+		{
+			"Zero value struct",
+			T{},
+			hexDecode("a0"), // {}
+		},
+		{
+			"Initialized value struct",
+			T{F1: 1, F2: 2, F3: 3},
+			hexDecode("a301012203613202"), // {1: 1, -3: 3, "2": 2}
+		},
+	}
+	em, err := EncOptions{Sort: SortCanonical}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned error %v", err)
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := em.Marshal(tc.obj)
+			if err != nil {
+				t.Errorf("Marshal(%+v) returned error %v", tc.obj, err)
+			}
+			if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.obj, b, tc.wantCborData)
+			}
+
+			var v2 T
+			if err := Unmarshal(b, &v2); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+			}
+			if !reflect.DeepEqual(tc.obj, v2) {
+				t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", b, v2, tc.obj)
+			}
+		})
+	}
+}
+
+func TestMarshalStructKeyAsIntNumError(t *testing.T) {
+	type T1 struct {
+		F1 int `cbor:"2.0,keyasint"`
+	}
+	type T2 struct {
+		F1 int `cbor:"-18446744073709551616,keyasint"`
+	}
+	testCases := []struct {
+		name         string
+		obj          interface{}
+		wantErrorMsg string
+	}{
+		{
+			name:         "float as key",
+			obj:          T1{},
+			wantErrorMsg: "cbor: failed to parse field name \"2.0\" to int",
+		},
+		{
+			name:         "out of range int as key",
+			obj:          T2{},
+			wantErrorMsg: "cbor: failed to parse field name \"-18446744073709551616\" to int",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := Marshal(tc.obj)
+			if err == nil {
+				t.Errorf("Marshal(%+v) didn't return an error, want error %q", tc.obj, tc.wantErrorMsg)
+			} else if !strings.Contains(err.Error(), tc.wantErrorMsg) {
+				t.Errorf("Marshal(%v) error %v, want %v", tc.obj, err.Error(), tc.wantErrorMsg)
+			} else if b != nil {
+				t.Errorf("Marshal(%v) = 0x%x, want nil", tc.obj, b)
+			}
+		})
+	}
+}
+
+func TestMarshalUnmarshalStructToArray(t *testing.T) {
+	type T1 struct {
+		M int `cbor:",omitempty"`
+	}
+	type T2 struct {
+		N int `cbor:",omitempty"`
+		O int `cbor:",omitempty"`
+	}
+	type T struct {
+		_   struct{} `cbor:",toarray"`
+		A   int      `cbor:",omitempty"`
+		B   T1       // nested struct
+		T1           // embedded struct
+		*T2          // embedded struct
+	}
+	testCases := []struct {
+		name         string
+		obj          T
+		wantCborData []byte
+	}{
+		{
+			"Zero value struct (test omitempty)",
+			T{},
+			hexDecode("8500a000f6f6"), // [0, {}, 0, nil, nil]
+		},
+		{
+			"Initialized struct",
+			T{A: 24, B: T1{M: 1}, T1: T1{M: 2}, T2: &T2{N: 3, O: 4}},
+			hexDecode("851818a1614d01020304"), // [24, {M: 1}, 2, 3, 4]
+		},
+		{
+			"Null pointer to embedded struct",
+			T{A: 24, B: T1{M: 1}, T1: T1{M: 2}},
+			hexDecode("851818a1614d0102f6f6"), // [24, {M: 1}, 2, nil, nil]
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := Marshal(tc.obj)
+			if err != nil {
+				t.Errorf("Marshal(%+v) returned error %v", tc.obj, err)
+			}
+			if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.obj, b, tc.wantCborData)
+			}
+
+			// SortMode should be ignored for struct to array encoding
+			em, err := EncOptions{Sort: SortCanonical}.EncMode()
+			if err != nil {
+				t.Errorf("EncMode() returned error %v", err)
+			}
+			b, err = em.Marshal(tc.obj)
+			if err != nil {
+				t.Errorf("Marshal(%+v) returned error %v", tc.obj, err)
+			}
+			if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", tc.obj, b, tc.wantCborData)
+			}
+
+			var v2 T
+			if err := Unmarshal(b, &v2); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+			}
+			if tc.obj.T2 == nil {
+				if !reflect.DeepEqual(*(v2.T2), T2{}) {
+					t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", b, v2, tc.obj)
+				}
+				v2.T2 = nil
+			}
+			if !reflect.DeepEqual(tc.obj, v2) {
+				t.Errorf("Unmarshal(0x%x) returned %+v, want %+v", b, v2, tc.obj)
+			}
+		})
+	}
+}
+
+func TestMapSort(t *testing.T) {
+	m := make(map[interface{}]bool)
+	m[10] = true
+	m[100] = true
+	m[-1] = true
+	m["z"] = true
+	m["aa"] = true
+	m[[1]int{100}] = true
+	m[[1]int{-1}] = true
+	m[false] = true
+
+	lenFirstSortedCborData := hexDecode("a80af520f5f4f51864f5617af58120f5626161f5811864f5") // sorted keys: 10, -1, false, 100, "z", [-1], "aa", [100]
+	bytewiseSortedCborData := hexDecode("a80af51864f520f5617af5626161f5811864f58120f5f4f5") // sorted keys: 10, 100, -1, "z", "aa", [100], [-1], false
+
+	testCases := []struct {
+		name         string
+		opts         EncOptions
+		wantCborData []byte
+	}{
+		{"Length first sort", EncOptions{Sort: SortLengthFirst}, lenFirstSortedCborData},
+		{"Bytewise sort", EncOptions{Sort: SortBytewiseLexical}, bytewiseSortedCborData},
+		{"CBOR canonical sort", EncOptions{Sort: SortCanonical}, lenFirstSortedCborData},
+		{"CTAP2 canonical sort", EncOptions{Sort: SortCTAP2}, bytewiseSortedCborData},
+		{"Core deterministic sort", EncOptions{Sort: SortCoreDeterministic}, bytewiseSortedCborData},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			em, err := tc.opts.EncMode()
+			if err != nil {
+				t.Errorf("EncMode() returned error %v", err)
+			}
+			b, err := em.Marshal(m)
+			if err != nil {
+				t.Errorf("Marshal(%v) returned error %v", m, err)
+			}
+			if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", m, b, tc.wantCborData)
+			}
+		})
+	}
+}
+
+func TestStructSort(t *testing.T) {
+	type T struct {
+		A bool `cbor:"aa"`
+		B bool `cbor:"z"`
+		C bool `cbor:"-1,keyasint"`
+		D bool `cbor:"100,keyasint"`
+		E bool `cbor:"10,keyasint"`
+	}
+	var v T
+
+	unsortedCborData := hexDecode("a5626161f4617af420f41864f40af4")       // unsorted fields: "aa", "z", -1, 100, 10
+	lenFirstSortedCborData := hexDecode("a50af420f41864f4617af4626161f4") // sorted fields: 10, -1, 100, "z", "aa",
+	bytewiseSortedCborData := hexDecode("a50af41864f420f4617af4626161f4") // sorted fields: 10, 100, -1, "z", "aa"
+
+	testCases := []struct {
+		name         string
+		opts         EncOptions
+		wantCborData []byte
+	}{
+		{"No sort", EncOptions{}, unsortedCborData},
+		{"No sort", EncOptions{Sort: SortNone}, unsortedCborData},
+		{"Length first sort", EncOptions{Sort: SortLengthFirst}, lenFirstSortedCborData},
+		{"Bytewise sort", EncOptions{Sort: SortBytewiseLexical}, bytewiseSortedCborData},
+		{"CBOR canonical sort", EncOptions{Sort: SortCanonical}, lenFirstSortedCborData},
+		{"CTAP2 canonical sort", EncOptions{Sort: SortCTAP2}, bytewiseSortedCborData},
+		{"Core deterministic sort", EncOptions{Sort: SortCoreDeterministic}, bytewiseSortedCborData},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			em, err := tc.opts.EncMode()
+			if err != nil {
+				t.Errorf("EncMode() returned error %v", err)
+			}
+			b, err := em.Marshal(v)
+			if err != nil {
+				t.Errorf("Marshal(%v) returned error %v", v, err)
+			}
+			if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, tc.wantCborData)
+			}
+		})
+	}
+}
+
+func TestInvalidSort(t *testing.T) {
+	wantErrorMsg := "cbor: invalid SortMode 100"
+	_, err := EncOptions{Sort: SortMode(100)}.EncMode()
+	if err == nil {
+		t.Errorf("EncMode() didn't return an error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("EncMode() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestTypeAlias(t *testing.T) { //nolint:dupl,unconvert
+	type myBool = bool
+	type myUint = uint
+	type myUint8 = uint8
+	type myUint16 = uint16
+	type myUint32 = uint32
+	type myUint64 = uint64
+	type myInt = int
+	type myInt8 = int8
+	type myInt16 = int16
+	type myInt32 = int32
+	type myInt64 = int64
+	type myFloat32 = float32
+	type myFloat64 = float64
+	type myString = string
+	type myByteSlice = []byte
+	type myIntSlice = []int
+	type myIntArray = [4]int
+	type myMapIntInt = map[int]int
+
+	testCases := []roundTripTest{
+		{
+			name:         "bool alias",
+			obj:          myBool(true),
+			wantCborData: hexDecode("f5"),
+		},
+		{
+			name:         "uint alias",
+			obj:          myUint(0),
+			wantCborData: hexDecode("00"),
+		},
+		{
+			name:         "uint8 alias",
+			obj:          myUint8(0),
+			wantCborData: hexDecode("00"),
+		},
+		{
+			name:         "uint16 alias",
+			obj:          myUint16(1000),
+			wantCborData: hexDecode("1903e8"),
+		},
+		{
+			name:         "uint32 alias",
+			obj:          myUint32(1000000),
+			wantCborData: hexDecode("1a000f4240"),
+		},
+		{
+			name:         "uint64 alias",
+			obj:          myUint64(1000000000000),
+			wantCborData: hexDecode("1b000000e8d4a51000"),
+		},
+		{
+			name:         "int alias",
+			obj:          myInt(-1),
+			wantCborData: hexDecode("20"),
+		},
+		{
+			name:         "int8 alias",
+			obj:          myInt8(-1),
+			wantCborData: hexDecode("20"),
+		},
+		{
+			name:         "int16 alias",
+			obj:          myInt16(-1000),
+			wantCborData: hexDecode("3903e7"),
+		},
+		{
+			name:         "int32 alias",
+			obj:          myInt32(-1000),
+			wantCborData: hexDecode("3903e7"),
+		},
+		{
+			name:         "int64 alias",
+			obj:          myInt64(-1000),
+			wantCborData: hexDecode("3903e7"),
+		},
+		{
+			name:         "float32 alias",
+			obj:          myFloat32(100000.0),
+			wantCborData: hexDecode("fa47c35000"),
+		},
+		{
+			name:         "float64 alias",
+			obj:          myFloat64(1.1),
+			wantCborData: hexDecode("fb3ff199999999999a"),
+		},
+		{
+			name:         "string alias",
+			obj:          myString("a"),
+			wantCborData: hexDecode("6161"),
+		},
+		{
+			name:         "[]byte alias",
+			obj:          myByteSlice([]byte{1, 2, 3, 4}), //nolint:unconvert
+			wantCborData: hexDecode("4401020304"),
+		},
+		{
+			name:         "[]int alias",
+			obj:          myIntSlice([]int{1, 2, 3, 4}), //nolint:unconvert
+			wantCborData: hexDecode("8401020304"),
+		},
+		{
+			name:         "[4]int alias",
+			obj:          myIntArray([...]int{1, 2, 3, 4}), //nolint:unconvert
+			wantCborData: hexDecode("8401020304"),
+		},
+		{
+			name:         "map[int]int alias",
+			obj:          myMapIntInt(map[int]int{1: 2, 3: 4}), //nolint:unconvert
+			wantCborData: hexDecode("a201020304"),
+		},
+	}
+	em, err := EncOptions{Sort: SortCanonical}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	dm, err := DecOptions{}.DecMode()
+	if err != nil {
+		t.Errorf("DecMode() returned an error %v", err)
+	}
+	testRoundTrip(t, testCases, em, dm)
+}
+
+func TestNewTypeWithBuiltinUnderlyingType(t *testing.T) { //nolint:dupl
+	type myBool bool
+	type myUint uint
+	type myUint8 uint8
+	type myUint16 uint16
+	type myUint32 uint32
+	type myUint64 uint64
+	type myInt int
+	type myInt8 int8
+	type myInt16 int16
+	type myInt32 int32
+	type myInt64 int64
+	type myFloat32 float32
+	type myFloat64 float64
+	type myString string
+	type myByteSlice []byte
+	type myIntSlice []int
+	type myIntArray [4]int
+	type myMapIntInt map[int]int
+
+	testCases := []roundTripTest{
+		{
+			name:         "bool alias",
+			obj:          myBool(true),
+			wantCborData: hexDecode("f5"),
+		},
+		{
+			name:         "uint alias",
+			obj:          myUint(0),
+			wantCborData: hexDecode("00"),
+		},
+		{
+			name:         "uint8 alias",
+			obj:          myUint8(0),
+			wantCborData: hexDecode("00"),
+		},
+		{
+			name:         "uint16 alias",
+			obj:          myUint16(1000),
+			wantCborData: hexDecode("1903e8"),
+		},
+		{
+			name:         "uint32 alias",
+			obj:          myUint32(1000000),
+			wantCborData: hexDecode("1a000f4240"),
+		},
+		{
+			name:         "uint64 alias",
+			obj:          myUint64(1000000000000),
+			wantCborData: hexDecode("1b000000e8d4a51000"),
+		},
+		{
+			name:         "int alias",
+			obj:          myInt(-1),
+			wantCborData: hexDecode("20"),
+		},
+		{
+			name:         "int8 alias",
+			obj:          myInt8(-1),
+			wantCborData: hexDecode("20"),
+		},
+		{
+			name:         "int16 alias",
+			obj:          myInt16(-1000),
+			wantCborData: hexDecode("3903e7"),
+		},
+		{
+			name:         "int32 alias",
+			obj:          myInt32(-1000),
+			wantCborData: hexDecode("3903e7"),
+		},
+		{
+			name:         "int64 alias",
+			obj:          myInt64(-1000),
+			wantCborData: hexDecode("3903e7"),
+		},
+		{
+			name:         "float32 alias",
+			obj:          myFloat32(100000.0),
+			wantCborData: hexDecode("fa47c35000"),
+		},
+		{
+			name:         "float64 alias",
+			obj:          myFloat64(1.1),
+			wantCborData: hexDecode("fb3ff199999999999a"),
+		},
+		{
+			name:         "string alias",
+			obj:          myString("a"),
+			wantCborData: hexDecode("6161"),
+		},
+		{
+			name:         "[]byte alias",
+			obj:          myByteSlice([]byte{1, 2, 3, 4}),
+			wantCborData: hexDecode("4401020304"),
+		},
+		{
+			name:         "[]int alias",
+			obj:          myIntSlice([]int{1, 2, 3, 4}),
+			wantCborData: hexDecode("8401020304"),
+		},
+		{
+			name:         "[4]int alias",
+			obj:          myIntArray([...]int{1, 2, 3, 4}),
+			wantCborData: hexDecode("8401020304"),
+		},
+		{
+			name:         "map[int]int alias",
+			obj:          myMapIntInt(map[int]int{1: 2, 3: 4}),
+			wantCborData: hexDecode("a201020304"),
+		},
+	}
+	em, err := EncOptions{Sort: SortCanonical}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	dm, err := DecOptions{}.DecMode()
+	if err != nil {
+		t.Errorf("DecMode() returned an error %v", err)
+	}
+	testRoundTrip(t, testCases, em, dm)
+}
+
+func TestShortestFloat16(t *testing.T) {
+	testCases := []struct {
+		name         string
+		f64          float64
+		wantCborData []byte
+	}{
+		// Data from RFC 7049 appendix A
+		{"Shrink to float16", 0.0, hexDecode("f90000")},
+		{"Shrink to float16", 1.0, hexDecode("f93c00")},
+		{"Shrink to float16", 1.5, hexDecode("f93e00")},
+		{"Shrink to float16", 65504.0, hexDecode("f97bff")},
+		{"Shrink to float16", 5.960464477539063e-08, hexDecode("f90001")},
+		{"Shrink to float16", 6.103515625e-05, hexDecode("f90400")},
+		{"Shrink to float16", -4.0, hexDecode("f9c400")},
+		// Data from https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+		{"Shrink to float16", 0.333251953125, hexDecode("f93555")},
+		// Data from 7049bis 4.2.1 and 5.5
+		{"Shrink to float16", 5.5, hexDecode("f94580")},
+		// Data from RFC 7049 appendix A
+		{"Shrink to float32", 100000.0, hexDecode("fa47c35000")},
+		{"Shrink to float32", 3.4028234663852886e+38, hexDecode("fa7f7fffff")},
+		// Data from 7049bis 4.2.1 and 5.5
+		{"Shrink to float32", 5555.5, hexDecode("fa45ad9c00")},
+		{"Shrink to float32", 1000000.5, hexDecode("fa49742408")},
+		// Data from RFC 7049 appendix A
+		{"Shrink to float64", 1.0e+300, hexDecode("fb7e37e43c8800759c")},
+	}
+	em, err := EncOptions{ShortestFloat: ShortestFloat16}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := em.Marshal(tc.f64)
+			if err != nil {
+				t.Errorf("Marshal(%v) returned error %v", tc.f64, err)
+			} else if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", tc.f64, b, tc.wantCborData)
+			}
+			var f64 float64
+			if err = Unmarshal(b, &f64); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+			} else if f64 != tc.f64 {
+				t.Errorf("Unmarshal(0x%x) = %f, want %f", b, f64, tc.f64)
+			}
+		})
+	}
+}
+
+/*
+func TestShortestFloat32(t *testing.T) {
+	testCases := []struct {
+		name         string
+		f64          float64
+		wantCborData []byte
+	}{
+		// Data from RFC 7049 appendix A
+		{"Shrink to float32", 0.0, hexDecode("fa00000000")},
+		{"Shrink to float32", 1.0, hexDecode("fa3f800000")},
+		{"Shrink to float32", 1.5, hexDecode("fa3fc00000")},
+		{"Shrink to float32", 65504.0, hexDecode("fa477fe000")},
+		{"Shrink to float32", 5.960464477539063e-08, hexDecode("fa33800000")},
+		{"Shrink to float32", 6.103515625e-05, hexDecode("fa38800000")},
+		{"Shrink to float32", -4.0, hexDecode("fac0800000")},
+		// Data from https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+		{"Shrink to float32", 0.333251953125, hexDecode("fa3eaaa000")},
+		// Data from 7049bis 4.2.1 and 5.5
+		{"Shrink to float32", 5.5, hexDecode("fa40b00000")},
+		// Data from RFC 7049 appendix A
+		{"Shrink to float32", 100000.0, hexDecode("fa47c35000")},
+		{"Shrink to float32", 3.4028234663852886e+38, hexDecode("fa7f7fffff")},
+		// Data from 7049bis 4.2.1 and 5.5
+		{"Shrink to float32", 5555.5, hexDecode("fa45ad9c00")},
+		{"Shrink to float32", 1000000.5, hexDecode("fa49742408")},
+		// Data from RFC 7049 appendix A
+		{"Shrink to float64", 1.0e+300, hexDecode("fb7e37e43c8800759c")},
+	}
+	em, err := EncOptions{ShortestFloat: ShortestFloat32}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := em.Marshal(tc.f64)
+			if err != nil {
+				t.Errorf("Marshal(%v) returned error %v", tc.f64, err)
+			} else if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", tc.f64, b, tc.wantCborData)
+			}
+			var f64 float64
+			if err = Unmarshal(b, &f64); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+			} else if f64 != tc.f64 {
+				t.Errorf("Unmarshal(0x%x) = %f, want %f", b, f64, tc.f64)
+			}
+		})
+	}
+}
+
+func TestShortestFloat64(t *testing.T) {
+	testCases := []struct {
+		name         string
+		f64          float64
+		wantCborData []byte
+	}{
+		// Data from RFC 7049 appendix A
+		{"Shrink to float64", 0.0, hexDecode("fb0000000000000000")},
+		{"Shrink to float64", 1.0, hexDecode("fb3ff0000000000000")},
+		{"Shrink to float64", 1.5, hexDecode("fb3ff8000000000000")},
+		{"Shrink to float64", 65504.0, hexDecode("fb40effc0000000000")},
+		{"Shrink to float64", 5.960464477539063e-08, hexDecode("fb3e70000000000000")},
+		{"Shrink to float64", 6.103515625e-05, hexDecode("fb3f10000000000000")},
+		{"Shrink to float64", -4.0, hexDecode("fbc010000000000000")},
+		// Data from https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+		{"Shrink to float64", 0.333251953125, hexDecode("fb3fd5540000000000")},
+		// Data from 7049bis 4.2.1 and 5.5
+		{"Shrink to float64", 5.5, hexDecode("fb4016000000000000")},
+		// Data from RFC 7049 appendix A
+		{"Shrink to float64", 100000.0, hexDecode("fb40f86a0000000000")},
+		{"Shrink to float64", 3.4028234663852886e+38, hexDecode("fb47efffffe0000000")},
+		// Data from 7049bis 4.2.1 and 5.5
+		{"Shrink to float64", 5555.5, hexDecode("fb40b5b38000000000")},
+		{"Shrink to float64", 1000000.5, hexDecode("fb412e848100000000")},
+		// Data from RFC 7049 appendix A
+		{"Shrink to float64", 1.0e+300, hexDecode("fb7e37e43c8800759c")},
+	}
+	em, err := EncOptions{ShortestFloat: ShortestFloat64}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := em.Marshal(tc.f64)
+			if err != nil {
+				t.Errorf("Marshal(%v) returned error %v", tc.f64, err)
+			} else if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", tc.f64, b, tc.wantCborData)
+			}
+			var f64 float64
+			if err = Unmarshal(b, &f64); err != nil {
+				t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+			} else if f64 != tc.f64 {
+				t.Errorf("Unmarshal(0x%x) = %f, want %f", b, f64, tc.f64)
+			}
+		})
+	}
+}
+*/
+func TestShortestFloatNone(t *testing.T) {
+	testCases := []struct {
+		name         string
+		f            interface{}
+		wantCborData []byte
+	}{
+		// Data from RFC 7049 appendix A
+		{"float32", float32(0.0), hexDecode("fa00000000")},
+		{"float64", float64(0.0), hexDecode("fb0000000000000000")},
+		{"float32", float32(1.0), hexDecode("fa3f800000")},
+		{"float64", float64(1.0), hexDecode("fb3ff0000000000000")},
+		{"float32", float32(1.5), hexDecode("fa3fc00000")},
+		{"float64", float64(1.5), hexDecode("fb3ff8000000000000")},
+		{"float32", float32(65504.0), hexDecode("fa477fe000")},
+		{"float64", float64(65504.0), hexDecode("fb40effc0000000000")},
+		{"float32", float32(5.960464477539063e-08), hexDecode("fa33800000")},
+		{"float64", float64(5.960464477539063e-08), hexDecode("fb3e70000000000000")},
+		{"float32", float32(6.103515625e-05), hexDecode("fa38800000")},
+		{"float64", float64(6.103515625e-05), hexDecode("fb3f10000000000000")},
+		{"float32", float32(-4.0), hexDecode("fac0800000")},
+		{"float64", float64(-4.0), hexDecode("fbc010000000000000")},
+		// Data from https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+		{"float32", float32(0.333251953125), hexDecode("fa3eaaa000")},
+		{"float64", float64(0.333251953125), hexDecode("fb3fd5540000000000")},
+		// Data from 7049bis 4.2.1 and 5.5
+		{"float32", float32(5.5), hexDecode("fa40b00000")},
+		{"float64", float64(5.5), hexDecode("fb4016000000000000")},
+		// Data from RFC 7049 appendix A
+		{"float32", float32(100000.0), hexDecode("fa47c35000")},
+		{"float64", float64(100000.0), hexDecode("fb40f86a0000000000")},
+		{"float32", float32(3.4028234663852886e+38), hexDecode("fa7f7fffff")},
+		{"float64", float64(3.4028234663852886e+38), hexDecode("fb47efffffe0000000")},
+		// Data from 7049bis 4.2.1 and 5.5
+		{"float32", float32(5555.5), hexDecode("fa45ad9c00")},
+		{"float64", float64(5555.5), hexDecode("fb40b5b38000000000")},
+		{"float32", float32(1000000.5), hexDecode("fa49742408")},
+		{"float64", float64(1000000.5), hexDecode("fb412e848100000000")},
+		{"float64", float64(1.0e+300), hexDecode("fb7e37e43c8800759c")},
+	}
+	em, err := EncOptions{ShortestFloat: ShortestFloatNone}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := em.Marshal(tc.f)
+			if err != nil {
+				t.Errorf("Marshal(%v) returned error %v", tc.f, err)
+			} else if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", tc.f, b, tc.wantCborData)
+			}
+			if reflect.ValueOf(tc.f).Kind() == reflect.Float32 {
+				var f32 float32
+				if err = Unmarshal(b, &f32); err != nil {
+					t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+				} else if f32 != tc.f {
+					t.Errorf("Unmarshal(0x%x) = %f, want %f", b, f32, tc.f)
+				}
+			} else {
+				var f64 float64
+				if err = Unmarshal(b, &f64); err != nil {
+					t.Errorf("Unmarshal(0x%x) returned error %v", b, err)
+				} else if f64 != tc.f {
+					t.Errorf("Unmarshal(0x%x) = %f, want %f", b, f64, tc.f)
+				}
+			}
+		})
+	}
+}
+
+func TestInvalidShortestFloat(t *testing.T) {
+	wantErrorMsg := "cbor: invalid ShortestFloatMode 100"
+	_, err := EncOptions{ShortestFloat: ShortestFloatMode(100)}.EncMode()
+	if err == nil {
+		t.Errorf("EncMode() didn't return an error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("EncMode() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestInfConvert(t *testing.T) {
+	infConvertNoneOpt := EncOptions{InfConvert: InfConvertNone}
+	infConvertFloat16Opt := EncOptions{InfConvert: InfConvertFloat16}
+	testCases := []struct {
+		name         string
+		v            interface{}
+		opts         EncOptions
+		wantCborData []byte
+	}{
+		{"float32 -inf no conversion", float32(math.Inf(-1)), infConvertNoneOpt, hexDecode("faff800000")},
+		{"float32 +inf no conversion", float32(math.Inf(1)), infConvertNoneOpt, hexDecode("fa7f800000")},
+		{"float64 -inf no conversion", math.Inf(-1), infConvertNoneOpt, hexDecode("fbfff0000000000000")},
+		{"float64 +inf no conversion", math.Inf(1), infConvertNoneOpt, hexDecode("fb7ff0000000000000")},
+		{"float32 -inf to float16", float32(math.Inf(-1)), infConvertFloat16Opt, hexDecode("f9fc00")},
+		{"float32 +inf to float16", float32(math.Inf(1)), infConvertFloat16Opt, hexDecode("f97c00")},
+		{"float64 -inf to float16", math.Inf(-1), infConvertFloat16Opt, hexDecode("f9fc00")},
+		{"float64 +inf to float16", math.Inf(1), infConvertFloat16Opt, hexDecode("f97c00")},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			em, err := tc.opts.EncMode()
+			if err != nil {
+				t.Errorf("EncMode() returned an error %v", err)
+			}
+			b, err := em.Marshal(tc.v)
+			if err != nil {
+				t.Errorf("Marshal(%v) returned error %v", tc.v, err)
+			} else if !bytes.Equal(b, tc.wantCborData) {
+				t.Errorf("Marshal(%v) = 0x%x, want 0x%x", tc.v, b, tc.wantCborData)
+			}
+		})
+	}
+}
+
+func TestInvalidInfConvert(t *testing.T) {
+	wantErrorMsg := "cbor: invalid InfConvertMode 100"
+	_, err := EncOptions{InfConvert: InfConvertMode(100)}.EncMode()
+	if err == nil {
+		t.Errorf("EncMode() didn't return an error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("EncMode() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+// Keith Randall's workaround for constant propagation issue https://github.com/golang/go/issues/36400
+const (
+	// qnan 32 bits constants
+	qnanConst0xffc00001 uint32 = 0xffc00001
+	qnanConst0x7fc00001 uint32 = 0x7fc00001
+	qnanConst0xffc02000 uint32 = 0xffc02000
+	qnanConst0x7fc02000 uint32 = 0x7fc02000
+	// snan 32 bits constants
+	snanConst0xff800001 uint32 = 0xff800001
+	snanConst0x7f800001 uint32 = 0x7f800001
+	snanConst0xff802000 uint32 = 0xff802000
+	snanConst0x7f802000 uint32 = 0x7f802000
+	// qnan 64 bits constants
+	qnanConst0xfff8000000000001 uint64 = 0xfff8000000000001
+	qnanConst0x7ff8000000000001 uint64 = 0x7ff8000000000001
+	qnanConst0xfff8000020000000 uint64 = 0xfff8000020000000
+	qnanConst0x7ff8000020000000 uint64 = 0x7ff8000020000000
+	qnanConst0xfffc000000000000 uint64 = 0xfffc000000000000
+	qnanConst0x7ffc000000000000 uint64 = 0x7ffc000000000000
+	// snan 64 bits constants
+	snanConst0xfff0000000000001 uint64 = 0xfff0000000000001
+	snanConst0x7ff0000000000001 uint64 = 0x7ff0000000000001
+	snanConst0xfff0000020000000 uint64 = 0xfff0000020000000
+	snanConst0x7ff0000020000000 uint64 = 0x7ff0000020000000
+	snanConst0xfff4000000000000 uint64 = 0xfff4000000000000
+	snanConst0x7ff4000000000000 uint64 = 0x7ff4000000000000
+)
+
+var (
+	// qnan 32 bits variables
+	qnanVar0xffc00001 uint32 = qnanConst0xffc00001
+	qnanVar0x7fc00001 uint32 = qnanConst0x7fc00001
+	qnanVar0xffc02000 uint32 = qnanConst0xffc02000
+	qnanVar0x7fc02000 uint32 = qnanConst0x7fc02000
+	// snan 32 bits variables
+	snanVar0xff800001 uint32 = snanConst0xff800001
+	snanVar0x7f800001 uint32 = snanConst0x7f800001
+	snanVar0xff802000 uint32 = snanConst0xff802000
+	snanVar0x7f802000 uint32 = snanConst0x7f802000
+	// qnan 64 bits variables
+	qnanVar0xfff8000000000001 uint64 = qnanConst0xfff8000000000001
+	qnanVar0x7ff8000000000001 uint64 = qnanConst0x7ff8000000000001
+	qnanVar0xfff8000020000000 uint64 = qnanConst0xfff8000020000000
+	qnanVar0x7ff8000020000000 uint64 = qnanConst0x7ff8000020000000
+	qnanVar0xfffc000000000000 uint64 = qnanConst0xfffc000000000000
+	qnanVar0x7ffc000000000000 uint64 = qnanConst0x7ffc000000000000
+	// snan 64 bits variables
+	snanVar0xfff0000000000001 uint64 = snanConst0xfff0000000000001
+	snanVar0x7ff0000000000001 uint64 = snanConst0x7ff0000000000001
+	snanVar0xfff0000020000000 uint64 = snanConst0xfff0000020000000
+	snanVar0x7ff0000020000000 uint64 = snanConst0x7ff0000020000000
+	snanVar0xfff4000000000000 uint64 = snanConst0xfff4000000000000
+	snanVar0x7ff4000000000000 uint64 = snanConst0x7ff4000000000000
+)
+
+func TestNaNConvert(t *testing.T) {
+	nanConvert7e00Opt := EncOptions{NaNConvert: NaNConvert7e00}
+	nanConvertNoneOpt := EncOptions{NaNConvert: NaNConvertNone}
+	nanConvertPreserveSignalOpt := EncOptions{NaNConvert: NaNConvertPreserveSignal}
+	nanConvertQuietOpt := EncOptions{NaNConvert: NaNConvertQuiet}
+
+	type nanConvert struct {
+		opt          EncOptions
+		wantCborData []byte
+	}
+	testCases := []struct {
+		v       interface{}
+		convert []nanConvert
+	}{
+		// float32 qNaN dropped payload not zero
+		{math.Float32frombits(qnanVar0xffc00001), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("faffc00001")},
+			{nanConvertPreserveSignalOpt, hexDecode("faffc00001")},
+			{nanConvertQuietOpt, hexDecode("faffc00001")},
+		}},
+		// float32 qNaN dropped payload not zero
+		{math.Float32frombits(qnanVar0x7fc00001), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fa7fc00001")},
+			{nanConvertPreserveSignalOpt, hexDecode("fa7fc00001")},
+			{nanConvertQuietOpt, hexDecode("fa7fc00001")},
+		}},
+		// float32 -qNaN dropped payload zero
+		{math.Float32frombits(qnanVar0xffc02000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("faffc02000")},
+			{nanConvertPreserveSignalOpt, hexDecode("f9fe01")},
+			{nanConvertQuietOpt, hexDecode("f9fe01")},
+		}},
+		// float32 qNaN dropped payload zero
+		{math.Float32frombits(qnanVar0x7fc02000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fa7fc02000")},
+			{nanConvertPreserveSignalOpt, hexDecode("f97e01")},
+			{nanConvertQuietOpt, hexDecode("f97e01")},
+		}},
+		// float32 -sNaN dropped payload not zero
+		{math.Float32frombits(snanVar0xff800001), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("faff800001")},
+			{nanConvertPreserveSignalOpt, hexDecode("faff800001")},
+			{nanConvertQuietOpt, hexDecode("faffc00001")},
+		}},
+		// float32 sNaN dropped payload not zero
+		{math.Float32frombits(snanVar0x7f800001), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fa7f800001")},
+			{nanConvertPreserveSignalOpt, hexDecode("fa7f800001")},
+			{nanConvertQuietOpt, hexDecode("fa7fc00001")},
+		}},
+		// float32 -sNaN dropped payload zero
+		{math.Float32frombits(snanVar0xff802000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("faff802000")},
+			{nanConvertPreserveSignalOpt, hexDecode("f9fc01")},
+			{nanConvertQuietOpt, hexDecode("f9fe01")},
+		}},
+		// float32 sNaN dropped payload zero
+		{math.Float32frombits(snanVar0x7f802000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fa7f802000")},
+			{nanConvertPreserveSignalOpt, hexDecode("f97c01")},
+			{nanConvertQuietOpt, hexDecode("f97e01")},
+		}},
+		// float64 -qNaN dropped payload not zero
+		{math.Float64frombits(qnanVar0xfff8000000000001), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fbfff8000000000001")},
+			{nanConvertPreserveSignalOpt, hexDecode("fbfff8000000000001")},
+			{nanConvertQuietOpt, hexDecode("fbfff8000000000001")},
+		}},
+		// float64 qNaN dropped payload not zero
+		{math.Float64frombits(qnanVar0x7ff8000000000001), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fb7ff8000000000001")},
+			{nanConvertPreserveSignalOpt, hexDecode("fb7ff8000000000001")},
+			{nanConvertQuietOpt, hexDecode("fb7ff8000000000001")},
+		}},
+		// float64 -qNaN dropped payload zero
+		{math.Float64frombits(qnanVar0xfff8000020000000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fbfff8000020000000")},
+			{nanConvertPreserveSignalOpt, hexDecode("faffc00001")},
+			{nanConvertQuietOpt, hexDecode("faffc00001")},
+		}},
+		// float64 qNaN dropped payload zero
+		{math.Float64frombits(qnanVar0x7ff8000020000000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fb7ff8000020000000")},
+			{nanConvertPreserveSignalOpt, hexDecode("fa7fc00001")},
+			{nanConvertQuietOpt, hexDecode("fa7fc00001")},
+		}},
+		// float64 -qNaN dropped payload zero
+		{math.Float64frombits(qnanVar0xfffc000000000000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fbfffc000000000000")},
+			{nanConvertPreserveSignalOpt, hexDecode("f9ff00")},
+			{nanConvertQuietOpt, hexDecode("f9ff00")},
+		}},
+		// float64 qNaN dropped payload zero
+		{math.Float64frombits(qnanVar0x7ffc000000000000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fb7ffc000000000000")},
+			{nanConvertPreserveSignalOpt, hexDecode("f97f00")},
+			{nanConvertQuietOpt, hexDecode("f97f00")},
+		}},
+		// float64 -sNaN dropped payload not zero
+		{math.Float64frombits(snanVar0xfff0000000000001), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fbfff0000000000001")},
+			{nanConvertPreserveSignalOpt, hexDecode("fbfff0000000000001")},
+			{nanConvertQuietOpt, hexDecode("fbfff8000000000001")},
+		}},
+		// float64 sNaN dropped payload not zero
+		{math.Float64frombits(snanVar0x7ff0000000000001), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fb7ff0000000000001")},
+			{nanConvertPreserveSignalOpt, hexDecode("fb7ff0000000000001")},
+			{nanConvertQuietOpt, hexDecode("fb7ff8000000000001")},
+		}},
+		// float64 -sNaN dropped payload zero
+		{math.Float64frombits(snanVar0xfff0000020000000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fbfff0000020000000")},
+			{nanConvertPreserveSignalOpt, hexDecode("faff800001")},
+			{nanConvertQuietOpt, hexDecode("faffc00001")},
+		}},
+		// float64 sNaN dropped payload zero
+		{math.Float64frombits(snanVar0x7ff0000020000000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fb7ff0000020000000")},
+			{nanConvertPreserveSignalOpt, hexDecode("fa7f800001")},
+			{nanConvertQuietOpt, hexDecode("fa7fc00001")},
+		}},
+		// float64 -sNaN dropped payload zero
+		{math.Float64frombits(snanVar0xfff4000000000000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fbfff4000000000000")},
+			{nanConvertPreserveSignalOpt, hexDecode("f9fd00")},
+			{nanConvertQuietOpt, hexDecode("f9ff00")},
+		}},
+		// float64 sNaN dropped payload zero
+		{math.Float64frombits(snanVar0x7ff4000000000000), []nanConvert{
+			{nanConvert7e00Opt, hexDecode("f97e00")},
+			{nanConvertNoneOpt, hexDecode("fb7ff4000000000000")},
+			{nanConvertPreserveSignalOpt, hexDecode("f97d00")},
+			{nanConvertQuietOpt, hexDecode("f97f00")},
+		}},
+	}
+	for _, tc := range testCases {
+		for _, convert := range tc.convert {
+			var convertName string
+			switch convert.opt.NaNConvert {
+			case NaNConvert7e00:
+				convertName = "Convert7e00"
+			case NaNConvertNone:
+				convertName = "ConvertNone"
+			case NaNConvertPreserveSignal:
+				convertName = "ConvertPreserveSignal"
+			case NaNConvertQuiet:
+				convertName = "ConvertQuiet"
+			}
+			var vName string
+			switch v := tc.v.(type) {
+			case float32:
+				vName = fmt.Sprintf("0x%x", math.Float32bits(v))
+			case float64:
+				vName = fmt.Sprintf("0x%x", math.Float64bits(v))
+			}
+			name := convertName + "_" + vName
+			t.Run(name, func(t *testing.T) {
+				em, err := convert.opt.EncMode()
+				if err != nil {
+					t.Errorf("EncMode() returned an error %v", err)
+				}
+				b, err := em.Marshal(tc.v)
+				if err != nil {
+					t.Errorf("Marshal(%v) returned error %v", tc.v, err)
+				} else if !bytes.Equal(b, convert.wantCborData) {
+					t.Errorf("Marshal(%v) = 0x%x, want 0x%x", tc.v, b, convert.wantCborData)
+				}
+			})
+		}
+	}
+}
+
+func TestInvalidNaNConvert(t *testing.T) {
+	wantErrorMsg := "cbor: invalid NaNConvertMode 100"
+	_, err := EncOptions{NaNConvert: NaNConvertMode(100)}.EncMode()
+	if err == nil {
+		t.Errorf("EncMode() didn't return an error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("EncMode() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestMarshalSenML(t *testing.T) {
+	// Data from https://tools.ietf.org/html/rfc8428#section-6
+	// Data contains 13 floating-point numbers.
+	cborData := hexDecode("87a721781b75726e3a6465763a6f773a3130653230373361303130383030363a22fb41d303a15b00106223614120050067766f6c7461676501615602fb405e066666666666a3006763757272656e74062402fb3ff3333333333333a3006763757272656e74062302fb3ff4cccccccccccda3006763757272656e74062202fb3ff6666666666666a3006763757272656e74062102f93e00a3006763757272656e74062002fb3ff999999999999aa3006763757272656e74060002fb3ffb333333333333")
+	testCases := []struct {
+		name string
+		opts EncOptions
+	}{
+		{"EncOptions ShortestFloatNone", EncOptions{}},
+		{"EncOptions ShortestFloat16", EncOptions{ShortestFloat: ShortestFloat16}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v []SenMLRecord
+			if err := Unmarshal(cborData, &v); err != nil {
+				t.Errorf("Marshal() returned error %v", err)
+			}
+			em, err := tc.opts.EncMode()
+			if err != nil {
+				t.Errorf("EncMode() returned an error %v", err)
+			}
+			b, err := em.Marshal(v)
+			if err != nil {
+				t.Errorf("Unmarshal() returned error %v ", err)
+			}
+			var v2 []SenMLRecord
+			if err := Unmarshal(b, &v2); err != nil {
+				t.Errorf("Marshal() returned error %v", err)
+			}
+			if !reflect.DeepEqual(v, v2) {
+				t.Errorf("SenML round-trip failed: v1 %+v, v2 %+v", v, v2)
+			}
+		})
+	}
+}
+
+func TestCanonicalEncOptions(t *testing.T) { //nolint:dupl
+	wantSortMode := SortCanonical
+	wantShortestFloat := ShortestFloat16
+	wantNaNConvert := NaNConvert7e00
+	wantInfConvert := InfConvertFloat16
+	em, err := CanonicalEncOptions().EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	opts := em.EncOptions()
+	if opts.Sort != wantSortMode {
+		t.Errorf("CanonicalEncOptions() returned EncOptions with Sort %d, want %d", opts.Sort, wantSortMode)
+	}
+	if opts.ShortestFloat != wantShortestFloat {
+		t.Errorf("CanonicalEncOptions() returned EncOptions with ShortestFloat %d, want %d", opts.ShortestFloat, wantShortestFloat)
+	}
+	if opts.NaNConvert != wantNaNConvert {
+		t.Errorf("CanonicalEncOptions() returned EncOptions with NaNConvert %d, want %d", opts.NaNConvert, wantNaNConvert)
+	}
+	if opts.InfConvert != wantInfConvert {
+		t.Errorf("CanonicalEncOptions() returned EncOptions with InfConvert %d, want %d", opts.InfConvert, wantInfConvert)
+	}
+	enc := em.NewEncoder(ioutil.Discard)
+	if err := enc.StartIndefiniteArray(); err == nil {
+		t.Errorf("StartIndefiniteArray() didn't return an error")
+	} else if err.Error() != wantIndefiniteLengthErrorMsg {
+		t.Errorf("StartIndefiniteArray() returned error %q, want %q", err.Error(), wantIndefiniteLengthErrorMsg)
+	}
+}
+
+func TestCTAP2EncOptions(t *testing.T) { //nolint:dupl
+	wantSortMode := SortCTAP2
+	wantShortestFloat := ShortestFloatNone
+	wantNaNConvert := NaNConvertNone
+	wantInfConvert := InfConvertNone
+	em, err := CTAP2EncOptions().EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	opts := em.EncOptions()
+	if opts.Sort != wantSortMode {
+		t.Errorf("CTAP2EncOptions() returned EncOptions with Sort %d, want %d", opts.Sort, wantSortMode)
+	}
+	if opts.ShortestFloat != wantShortestFloat {
+		t.Errorf("CTAP2EncOptions() returned EncOptions with ShortestFloat %d, want %d", opts.ShortestFloat, wantShortestFloat)
+	}
+	if opts.NaNConvert != wantNaNConvert {
+		t.Errorf("CTAP2EncOptions() returned EncOptions with NaNConvert %d, want %d", opts.NaNConvert, wantNaNConvert)
+	}
+	if opts.InfConvert != wantInfConvert {
+		t.Errorf("CTAP2EncOptions() returned EncOptions with InfConvert %d, want %d", opts.InfConvert, wantInfConvert)
+	}
+	enc := em.NewEncoder(ioutil.Discard)
+	if err := enc.StartIndefiniteArray(); err == nil {
+		t.Errorf("StartIndefiniteArray() didn't return an error")
+	} else if err.Error() != wantIndefiniteLengthErrorMsg {
+		t.Errorf("StartIndefiniteArray() returned error %q, want %q", err.Error(), wantIndefiniteLengthErrorMsg)
+	}
+}
+
+func TestCoreDetEncOptions(t *testing.T) { //nolint:dupl
+	wantSortMode := SortCoreDeterministic
+	wantShortestFloat := ShortestFloat16
+	wantNaNConvert := NaNConvert7e00
+	wantInfConvert := InfConvertFloat16
+	em, err := CoreDetEncOptions().EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	opts := em.EncOptions()
+	if opts.Sort != wantSortMode {
+		t.Errorf("CoreDetEncOptions() returned EncOptions with Sort %d, want %d", opts.Sort, wantSortMode)
+	}
+	if opts.ShortestFloat != wantShortestFloat {
+		t.Errorf("CoreDetEncOptions() returned EncOptions with ShortestFloat %d, want %d", opts.ShortestFloat, wantShortestFloat)
+	}
+	if opts.NaNConvert != wantNaNConvert {
+		t.Errorf("CoreDetEncOptions() returned EncOptions with NaNConvert %d, want %d", opts.NaNConvert, wantNaNConvert)
+	}
+	if opts.InfConvert != wantInfConvert {
+		t.Errorf("CoreDetEncOptions() returned EncOptions with InfConvert %d, want %d", opts.InfConvert, wantInfConvert)
+	}
+	enc := em.NewEncoder(ioutil.Discard)
+	if err := enc.StartIndefiniteArray(); err == nil {
+		t.Errorf("StartIndefiniteArray() didn't return an error")
+	} else if err.Error() != wantIndefiniteLengthErrorMsg {
+		t.Errorf("StartIndefiniteArray() returned error %q, want %q", err.Error(), wantIndefiniteLengthErrorMsg)
+	}
+}
+
+func TestPreferredUnsortedEncOptions(t *testing.T) {
+	wantSortMode := SortNone
+	wantShortestFloat := ShortestFloat16
+	wantNaNConvert := NaNConvert7e00
+	wantInfConvert := InfConvertFloat16
+	em, err := PreferredUnsortedEncOptions().EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	opts := em.EncOptions()
+	if opts.Sort != wantSortMode {
+		t.Errorf("PreferredUnsortedEncOptions() returned EncOptions with Sort %d, want %d", opts.Sort, wantSortMode)
+	}
+	if opts.ShortestFloat != wantShortestFloat {
+		t.Errorf("PreferredUnsortedEncOptions() returned EncOptions with ShortestFloat %d, want %d", opts.ShortestFloat, wantShortestFloat)
+	}
+	if opts.NaNConvert != wantNaNConvert {
+		t.Errorf("PreferredUnsortedEncOptions() returned EncOptions with NaNConvert %d, want %d", opts.NaNConvert, wantNaNConvert)
+	}
+	if opts.InfConvert != wantInfConvert {
+		t.Errorf("PreferredUnsortedEncOptions() returned EncOptions with InfConvert %d, want %d", opts.InfConvert, wantInfConvert)
+	}
+	enc := em.NewEncoder(ioutil.Discard)
+	if err := enc.StartIndefiniteArray(); err != nil {
+		t.Errorf("StartIndefiniteArray() returned error %v", err)
+	}
+}
+
+func TestEncOptions(t *testing.T) {
+	opts1 := EncOptions{
+		Sort:          SortBytewiseLexical,
+		ShortestFloat: ShortestFloat16,
+		NaNConvert:    NaNConvertPreserveSignal,
+		InfConvert:    InfConvertNone,
+		Time:          TimeRFC3339Nano,
+		TimeTag:       EncTagRequired,
+	}
+	em, err := opts1.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	} else {
+		opts2 := em.EncOptions()
+		if !reflect.DeepEqual(opts1, opts2) {
+			t.Errorf("EncOptions->EncMode->EncOptions returned different values: %v, %v", opts1, opts2)
+		}
+	}
+}
+
+func TestEncModeInvalidTimeTag(t *testing.T) {
+	wantErrorMsg := "cbor: invalid TimeTag 100"
+	_, err := EncOptions{TimeTag: 100}.EncMode()
+	if err == nil {
+		t.Errorf("EncMode() didn't return an error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("EncMode() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/example_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/example_test.go
@@ -1,0 +1,571 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+func ExampleMarshal() {
+	type Animal struct {
+		Age    int
+		Name   string
+		Owners []string
+		Male   bool
+	}
+	animal := Animal{Age: 4, Name: "Candy", Owners: []string{"Mary", "Joe"}}
+	b, err := cbor.Marshal(animal)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", b)
+	// Output:
+	// a46341676504644e616d656543616e6479664f776e65727382644d617279634a6f65644d616c65f4
+}
+
+func ExampleMarshal_time() {
+	tm, _ := time.Parse(time.RFC3339, "2013-03-21T20:04:00Z")
+
+	// Encode time as string in RFC3339 format with second precision.
+	em, err := cbor.EncOptions{Time: cbor.TimeRFC3339}.EncMode()
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	b, err := em.Marshal(tm)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", b)
+
+	// Encode time as numerical representation of seconds since January 1, 1970 UTC.
+	em, err = cbor.EncOptions{Time: cbor.TimeUnix}.EncMode()
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	b, err = em.Marshal(tm)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", b)
+	// Output:
+	// 74323031332d30332d32315432303a30343a30305a
+	// 1a514b67b0
+}
+
+// This example uses Marshal to encode struct and map in canonical form.
+func ExampleMarshal_canonical() {
+	type Animal struct {
+		Age      int
+		Name     string
+		Contacts map[string]string
+		Male     bool
+	}
+	animal := Animal{Age: 4, Name: "Candy", Contacts: map[string]string{"Mary": "111-111-1111", "Joe": "222-222-2222"}}
+	em, err := cbor.CanonicalEncOptions().EncMode()
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	b, err := em.Marshal(animal)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", b)
+	// Output:
+	// a46341676504644d616c65f4644e616d656543616e647968436f6e7461637473a2634a6f656c3232322d3232322d32323232644d6172796c3131312d3131312d31313131
+}
+
+// This example uses "toarray" struct tag to encode struct as CBOR array.
+func ExampleMarshal_toarray() {
+	type Record struct {
+		_           struct{} `cbor:",toarray"`
+		Name        string
+		Unit        string
+		Measurement int
+	}
+	rec := Record{Name: "current", Unit: "V", Measurement: 1}
+	b, err := cbor.Marshal(rec)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", b)
+	// Output:
+	// 836763757272656e74615601
+}
+
+// This example uses "keyasint" struct tag to encode struct's fiele names as integer.
+// This feautre is very useful in handling COSE, CWT, SenML data.
+func ExampleMarshal_keyasint() {
+	type Record struct {
+		Name        string `cbor:"1,keyasint"`
+		Unit        string `cbor:"2,keyasint"`
+		Measurement int    `cbor:"3,keyasint"`
+	}
+	rec := Record{Name: "current", Unit: "V", Measurement: 1}
+	b, err := cbor.Marshal(rec)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", b)
+	// Output:
+	// a3016763757272656e740261560301
+}
+
+func ExampleUnmarshal() {
+	type Animal struct {
+		Age    int
+		Name   string
+		Owners []string
+		Male   bool
+	}
+	cborData, _ := hex.DecodeString("a46341676504644e616d656543616e6479664f776e65727382644d617279634a6f65644d616c65f4")
+	var animal Animal
+	err := cbor.Unmarshal(cborData, &animal)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v", animal)
+	// Output:
+	// {Age:4 Name:Candy Owners:[Mary Joe] Male:false}
+}
+
+func ExampleUnmarshal_time() {
+	cborRFC3339Time, _ := hex.DecodeString("74323031332d30332d32315432303a30343a30305a")
+	tm := time.Time{}
+	if err := cbor.Unmarshal(cborRFC3339Time, &tm); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v\n", tm.UTC().Format(time.RFC3339Nano))
+	cborUnixTime, _ := hex.DecodeString("1a514b67b0")
+	tm = time.Time{}
+	if err := cbor.Unmarshal(cborUnixTime, &tm); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v\n", tm.UTC().Format(time.RFC3339Nano))
+	// Output:
+	// 2013-03-21T20:04:00Z
+	// 2013-03-21T20:04:00Z
+}
+
+func ExampleEncoder() {
+	type Animal struct {
+		Age    int
+		Name   string
+		Owners []string
+		Male   bool
+	}
+	animals := []Animal{
+		{Age: 4, Name: "Candy", Owners: []string{"Mary", "Joe"}, Male: false},
+		{Age: 6, Name: "Rudy", Owners: []string{"Cindy"}, Male: true},
+		{Age: 2, Name: "Duke", Owners: []string{"Norton"}, Male: true},
+	}
+	var buf bytes.Buffer
+	em, err := cbor.CanonicalEncOptions().EncMode()
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	enc := em.NewEncoder(&buf)
+	for _, animal := range animals {
+		err := enc.Encode(animal)
+		if err != nil {
+			fmt.Println("error:", err)
+		}
+	}
+	fmt.Printf("%x\n", buf.Bytes())
+	// Output:
+	// a46341676504644d616c65f4644e616d656543616e6479664f776e65727382644d617279634a6f65a46341676506644d616c65f5644e616d656452756479664f776e657273816543696e6479a46341676502644d616c65f5644e616d656444756b65664f776e65727381664e6f72746f6e
+}
+
+// ExampleEncoder_indefiniteLengthByteString encodes a stream of definite
+// length byte string ("chunks") as an indefinite length byte string.
+func ExampleEncoder_indefiniteLengthByteString() {
+	var buf bytes.Buffer
+	encoder := cbor.NewEncoder(&buf)
+	// Start indefinite length byte string encoding.
+	if err := encoder.StartIndefiniteByteString(); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode definite length byte string.
+	if err := encoder.Encode([]byte{1, 2}); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode definite length byte string.
+	if err := encoder.Encode([3]byte{3, 4, 5}); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Close indefinite length byte string.
+	if err := encoder.EndIndefinite(); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", buf.Bytes())
+	// Output:
+	// 5f42010243030405ff
+}
+
+// ExampleEncoder_indefiniteLengthTextString encodes a stream of definite
+// length text string ("chunks") as an indefinite length text string.
+func ExampleEncoder_indefiniteLengthTextString() {
+	var buf bytes.Buffer
+	encoder := cbor.NewEncoder(&buf)
+	// Start indefinite length text string encoding.
+	if err := encoder.StartIndefiniteTextString(); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode definite length text string.
+	if err := encoder.Encode("strea"); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode definite length text string.
+	if err := encoder.Encode("ming"); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Close indefinite length text string.
+	if err := encoder.EndIndefinite(); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", buf.Bytes())
+	// Output:
+	// 7f657374726561646d696e67ff
+}
+
+// ExampleEncoder_indefiniteLengthArray encodes a stream of elements as an
+// indefinite length array.  Encoder supports nested indefinite length values.
+func ExampleEncoder_indefiniteLengthArray() {
+	var buf bytes.Buffer
+	enc := cbor.NewEncoder(&buf)
+	// Start indefinite length array encoding.
+	if err := enc.StartIndefiniteArray(); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode array element.
+	if err := enc.Encode(1); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode array element.
+	if err := enc.Encode([]int{2, 3}); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Start a nested indefinite length array as array element.
+	if err := enc.StartIndefiniteArray(); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode nested array element.
+	if err := enc.Encode(4); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode nested array element.
+	if err := enc.Encode(5); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Close nested indefinite length array.
+	if err := enc.EndIndefinite(); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Close outer indefinite length array.
+	if err := enc.EndIndefinite(); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", buf.Bytes())
+	// Output:
+	// 9f018202039f0405ffff
+}
+
+// ExampleEncoder_indefiniteLengthMap encodes a stream of elements as an
+// indefinite length map.  Encoder supports nested indefinite length values.
+func ExampleEncoder_indefiniteLengthMap() {
+	var buf bytes.Buffer
+	em, err := cbor.EncOptions{Sort: cbor.SortCanonical}.EncMode()
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	enc := em.NewEncoder(&buf)
+	// Start indefinite length map encoding.
+	if err := enc.StartIndefiniteMap(); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode map key.
+	if err := enc.Encode("a"); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode map value.
+	if err := enc.Encode(1); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encode map key.
+	if err := enc.Encode("b"); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Start an indefinite length array as map value.
+	if err := enc.StartIndefiniteArray(); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encoded array element.
+	if err := enc.Encode(2); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encoded array element.
+	if err := enc.Encode(3); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Close indefinite length array.
+	if err := enc.EndIndefinite(); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Close indefinite length map.
+	if err := enc.EndIndefinite(); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%x\n", buf.Bytes())
+	// Output:
+	// bf61610161629f0203ffff
+}
+
+func ExampleDecoder() {
+	type Animal struct {
+		Age    int
+		Name   string
+		Owners []string
+		Male   bool
+	}
+	cborData, _ := hex.DecodeString("a46341676504644d616c65f4644e616d656543616e6479664f776e65727382644d617279634a6f65a46341676506644d616c65f5644e616d656452756479664f776e657273816543696e6479a46341676502644d616c65f5644e616d656444756b65664f776e65727381664e6f72746f6e")
+	dec := cbor.NewDecoder(bytes.NewReader(cborData))
+	for {
+		var animal Animal
+		if err := dec.Decode(&animal); err != nil {
+			if err != io.EOF {
+				fmt.Println("error:", err)
+			}
+			break
+		}
+		fmt.Printf("%+v\n", animal)
+	}
+	// Output:
+	// {Age:4 Name:Candy Owners:[Mary Joe] Male:false}
+	// {Age:6 Name:Rudy Owners:[Cindy] Male:true}
+	// {Age:2 Name:Duke Owners:[Norton] Male:true}
+}
+
+func Example_cWT() {
+	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	type claims struct {
+		Iss string `cbor:"1,keyasint"`
+		Sub string `cbor:"2,keyasint"`
+		Aud string `cbor:"3,keyasint"`
+		Exp int    `cbor:"4,keyasint"`
+		Nbf int    `cbor:"5,keyasint"`
+		Iat int    `cbor:"6,keyasint"`
+		Cti []byte `cbor:"7,keyasint"`
+	}
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
+	cborData, _ := hex.DecodeString("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
+	var v claims
+	if err := cbor.Unmarshal(cborData, &v); err != nil {
+		fmt.Println("error:", err)
+	}
+	if _, err := cbor.Marshal(v); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v", v)
+	// Output:
+	// {Iss:coap://as.example.com Sub:erikw Aud:coap://light.example.com Exp:1444064944 Nbf:1443944944 Iat:1443944944 Cti:[11 113]}
+}
+
+func Example_cWTWithDupMapKeyOption() {
+	type claims struct {
+		Iss string `cbor:"1,keyasint"`
+		Sub string `cbor:"2,keyasint"`
+		Aud string `cbor:"3,keyasint"`
+		Exp int    `cbor:"4,keyasint"`
+		Nbf int    `cbor:"5,keyasint"`
+		Iat int    `cbor:"6,keyasint"`
+		Cti []byte `cbor:"7,keyasint"`
+	}
+
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.1
+	cborData, _ := hex.DecodeString("a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b71")
+
+	dm, _ := cbor.DecOptions{DupMapKey: cbor.DupMapKeyEnforcedAPF}.DecMode()
+
+	var v claims
+	if err := dm.Unmarshal(cborData, &v); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v", v)
+	// Output:
+	// {Iss:coap://as.example.com Sub:erikw Aud:coap://light.example.com Exp:1444064944 Nbf:1443944944 Iat:1443944944 Cti:[11 113]}
+}
+
+func Example_signedCWT() {
+	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	// Partial COSE header definition
+	type coseHeader struct {
+		Alg int    `cbor:"1,keyasint,omitempty"`
+		Kid []byte `cbor:"4,keyasint,omitempty"`
+		IV  []byte `cbor:"5,keyasint,omitempty"`
+	}
+	// Use "toarray" struct tag to encode/decode struct to/from CBOR array.
+	type signedCWT struct {
+		_           struct{} `cbor:",toarray"`
+		Protected   []byte
+		Unprotected coseHeader
+		Payload     []byte
+		Signature   []byte
+	}
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.3
+	cborData, _ := hex.DecodeString("d28443a10126a104524173796d6d657472696345434453413235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7158405427c1ff28d23fbad1f29c4c7c6a555e601d6fa29f9179bc3d7438bacaca5acd08c8d4d4f96131680c429a01f85951ecee743a52b9b63632c57209120e1c9e30")
+	var v signedCWT
+	if err := cbor.Unmarshal(cborData, &v); err != nil {
+		fmt.Println("error:", err)
+	}
+	if _, err := cbor.Marshal(v); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v", v)
+	// Output:
+	// {_:{} Protected:[161 1 38] Unprotected:{Alg:0 Kid:[65 115 121 109 109 101 116 114 105 99 69 67 68 83 65 50 53 54] IV:[]} Payload:[167 1 117 99 111 97 112 58 47 47 97 115 46 101 120 97 109 112 108 101 46 99 111 109 2 101 101 114 105 107 119 3 120 24 99 111 97 112 58 47 47 108 105 103 104 116 46 101 120 97 109 112 108 101 46 99 111 109 4 26 86 18 174 176 5 26 86 16 217 240 6 26 86 16 217 240 7 66 11 113] Signature:[84 39 193 255 40 210 63 186 209 242 156 76 124 106 85 94 96 29 111 162 159 145 121 188 61 116 56 186 202 202 90 205 8 200 212 212 249 97 49 104 12 66 154 1 248 89 81 236 238 116 58 82 185 182 54 50 197 114 9 18 14 28 158 48]}
+}
+
+func Example_signedCWTWithTag() {
+	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	// Partial COSE header definition
+	type coseHeader struct {
+		Alg int    `cbor:"1,keyasint,omitempty"`
+		Kid []byte `cbor:"4,keyasint,omitempty"`
+		IV  []byte `cbor:"5,keyasint,omitempty"`
+	}
+	// Use "toarray" struct tag to encode/decode struct to/from CBOR array.
+	type signedCWT struct {
+		_           struct{} `cbor:",toarray"`
+		Protected   []byte
+		Unprotected coseHeader
+		Payload     []byte
+		Signature   []byte
+	}
+
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.3
+	cborData, _ := hex.DecodeString("d28443a10126a104524173796d6d657472696345434453413235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7158405427c1ff28d23fbad1f29c4c7c6a555e601d6fa29f9179bc3d7438bacaca5acd08c8d4d4f96131680c429a01f85951ecee743a52b9b63632c57209120e1c9e30")
+
+	// Register tag COSE_Sign1 18 with signedCWT type.
+	tags := cbor.NewTagSet()
+	if err := tags.Add(
+		cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired},
+		reflect.TypeOf(signedCWT{}),
+		18); err != nil {
+		fmt.Println("error:", err)
+	}
+
+	dm, _ := cbor.DecOptions{}.DecModeWithTags(tags)
+	em, _ := cbor.EncOptions{}.EncModeWithTags(tags)
+
+	var v signedCWT
+	if err := dm.Unmarshal(cborData, &v); err != nil {
+		fmt.Println("error:", err)
+	}
+
+	if _, err := em.Marshal(v); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v", v)
+	// Output:
+	// {_:{} Protected:[161 1 38] Unprotected:{Alg:0 Kid:[65 115 121 109 109 101 116 114 105 99 69 67 68 83 65 50 53 54] IV:[]} Payload:[167 1 117 99 111 97 112 58 47 47 97 115 46 101 120 97 109 112 108 101 46 99 111 109 2 101 101 114 105 107 119 3 120 24 99 111 97 112 58 47 47 108 105 103 104 116 46 101 120 97 109 112 108 101 46 99 111 109 4 26 86 18 174 176 5 26 86 16 217 240 6 26 86 16 217 240 7 66 11 113] Signature:[84 39 193 255 40 210 63 186 209 242 156 76 124 106 85 94 96 29 111 162 159 145 121 188 61 116 56 186 202 202 90 205 8 200 212 212 249 97 49 104 12 66 154 1 248 89 81 236 238 116 58 82 185 182 54 50 197 114 9 18 14 28 158 48]}
+}
+
+func Example_cOSE() {
+	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	// Use cbor.RawMessage to delay unmarshaling (CrvOrNOrK's data type depends on Kty's value).
+	type coseKey struct {
+		Kty       int             `cbor:"1,keyasint,omitempty"`
+		Kid       []byte          `cbor:"2,keyasint,omitempty"`
+		Alg       int             `cbor:"3,keyasint,omitempty"`
+		KeyOpts   int             `cbor:"4,keyasint,omitempty"`
+		IV        []byte          `cbor:"5,keyasint,omitempty"`
+		CrvOrNOrK cbor.RawMessage `cbor:"-1,keyasint,omitempty"` // K for symmetric keys, Crv for elliptic curve keys, N for RSA modulus
+		XOrE      cbor.RawMessage `cbor:"-2,keyasint,omitempty"` // X for curve x-coordinate, E for RSA public exponent
+		Y         cbor.RawMessage `cbor:"-3,keyasint,omitempty"` // Y for curve y-cooridate
+		D         []byte          `cbor:"-4,keyasint,omitempty"`
+	}
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.2
+	// 128-Bit Symmetric Key
+	cborData, _ := hex.DecodeString("a42050231f4c4d4d3051fdc2ec0a3851d5b3830104024c53796d6d6574726963313238030a")
+	var v coseKey
+	if err := cbor.Unmarshal(cborData, &v); err != nil {
+		fmt.Println("error:", err)
+	}
+	if _, err := cbor.Marshal(v); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v", v)
+	// Output:
+	// {Kty:4 Kid:[83 121 109 109 101 116 114 105 99 49 50 56] Alg:10 KeyOpts:0 IV:[] CrvOrNOrK:[80 35 31 76 77 77 48 81 253 194 236 10 56 81 213 179 131] XOrE:[] Y:[] D:[]}
+}
+
+func Example_senML() {
+	// Use "keyasint" struct tag to encode/decode struct to/from CBOR map.
+	type SenMLRecord struct {
+		BaseName    string  `cbor:"-2,keyasint,omitempty"`
+		BaseTime    float64 `cbor:"-3,keyasint,omitempty"`
+		BaseUnit    string  `cbor:"-4,keyasint,omitempty"`
+		BaseValue   float64 `cbor:"-5,keyasint,omitempty"`
+		BaseSum     float64 `cbor:"-6,keyasint,omitempty"`
+		BaseVersion int     `cbor:"-1,keyasint,omitempty"`
+		Name        string  `cbor:"0,keyasint,omitempty"`
+		Unit        string  `cbor:"1,keyasint,omitempty"`
+		Time        float64 `cbor:"6,keyasint,omitempty"`
+		UpdateTime  float64 `cbor:"7,keyasint,omitempty"`
+		Value       float64 `cbor:"2,keyasint,omitempty"`
+		ValueS      string  `cbor:"3,keyasint,omitempty"`
+		ValueB      bool    `cbor:"4,keyasint,omitempty"`
+		ValueD      string  `cbor:"8,keyasint,omitempty"`
+		Sum         float64 `cbor:"5,keyasint,omitempty"`
+	}
+	// Data from https://tools.ietf.org/html/rfc8428#section-6
+	cborData, _ := hex.DecodeString("87a721781b75726e3a6465763a6f773a3130653230373361303130383030363a22fb41d303a15b00106223614120050067766f6c7461676501615602fb405e066666666666a3006763757272656e74062402fb3ff3333333333333a3006763757272656e74062302fb3ff4cccccccccccda3006763757272656e74062202fb3ff6666666666666a3006763757272656e74062102f93e00a3006763757272656e74062002fb3ff999999999999aa3006763757272656e74060002fb3ffb333333333333")
+	var v []*SenMLRecord
+	if err := cbor.Unmarshal(cborData, &v); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Encoder uses ShortestFloat16 option to use float16 as the shortest form that preserves floating-point value.
+	em, err := cbor.EncOptions{ShortestFloat: cbor.ShortestFloat16}.EncMode()
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	if _, err := em.Marshal(v); err != nil {
+		fmt.Println("error:", err)
+	}
+	for _, rec := range v {
+		fmt.Printf("%+v\n", *rec)
+	}
+	// Output:
+	// {BaseName:urn:dev:ow:10e2073a0108006: BaseTime:1.276020076001e+09 BaseUnit:A BaseValue:0 BaseSum:0 BaseVersion:5 Name:voltage Unit:V Time:0 UpdateTime:0 Value:120.1 ValueS: ValueB:false ValueD: Sum:0}
+	// {BaseName: BaseTime:0 BaseUnit: BaseValue:0 BaseSum:0 BaseVersion:0 Name:current Unit: Time:-5 UpdateTime:0 Value:1.2 ValueS: ValueB:false ValueD: Sum:0}
+	// {BaseName: BaseTime:0 BaseUnit: BaseValue:0 BaseSum:0 BaseVersion:0 Name:current Unit: Time:-4 UpdateTime:0 Value:1.3 ValueS: ValueB:false ValueD: Sum:0}
+	// {BaseName: BaseTime:0 BaseUnit: BaseValue:0 BaseSum:0 BaseVersion:0 Name:current Unit: Time:-3 UpdateTime:0 Value:1.4 ValueS: ValueB:false ValueD: Sum:0}
+	// {BaseName: BaseTime:0 BaseUnit: BaseValue:0 BaseSum:0 BaseVersion:0 Name:current Unit: Time:-2 UpdateTime:0 Value:1.5 ValueS: ValueB:false ValueD: Sum:0}
+	// {BaseName: BaseTime:0 BaseUnit: BaseValue:0 BaseSum:0 BaseVersion:0 Name:current Unit: Time:-1 UpdateTime:0 Value:1.6 ValueS: ValueB:false ValueD: Sum:0}
+	// {BaseName: BaseTime:0 BaseUnit: BaseValue:0 BaseSum:0 BaseVersion:0 Name:current Unit: Time:0 UpdateTime:0 Value:1.7 ValueS: ValueB:false ValueD: Sum:0}
+}
+
+func Example_webAuthn() {
+	// Use cbor.RawMessage to delay unmarshaling (AttStmt's data type depends on Fmt's value).
+	type attestationObject struct {
+		AuthnData []byte          `cbor:"authData"`
+		Fmt       string          `cbor:"fmt"`
+		AttStmt   cbor.RawMessage `cbor:"attStmt"`
+	}
+	cborData, _ := hex.DecodeString("a363666d74686669646f2d7532666761747453746d74a26373696758483046022100e7ab373cfbd99fcd55fd59b0f6f17fef5b77a20ddec3db7f7e4d55174e366236022100828336b4822125fb56541fb14a8a273876acd339395ec2dad95cf41c1dd2a9ae637835638159024e3082024a30820132a0030201020204124a72fe300d06092a864886f70d01010b0500302e312c302a0603550403132359756269636f2055324620526f6f742043412053657269616c203435373230303633313020170d3134303830313030303030305a180f32303530303930343030303030305a302c312a302806035504030c2159756269636f205532462045452053657269616c203234393431343937323135383059301306072a8648ce3d020106082a8648ce3d030107034200043d8b1bbd2fcbf6086e107471601468484153c1c6d3b4b68a5e855e6e40757ee22bcd8988bf3befd7cdf21cb0bf5d7a150d844afe98103c6c6607d9faae287c02a33b3039302206092b0601040182c40a020415312e332e362e312e342e312e34313438322e312e313013060b2b0601040182e51c020101040403020520300d06092a864886f70d01010b05000382010100a14f1eea0076f6b8476a10a2be72e60d0271bb465b2dfbfc7c1bd12d351989917032631d795d097fa30a26a325634e85721bc2d01a86303f6bc075e5997319e122148b0496eec8d1f4f94cf4110de626c289443d1f0f5bbb239ca13e81d1d5aa9df5af8e36126475bfc23af06283157252762ff68879bcf0ef578d55d67f951b4f32b63c8aea5b0f99c67d7d814a7ff5a6f52df83e894a3a5d9c8b82e7f8bc8daf4c80175ff8972fda79333ec465d806eacc948f1bab22045a95558a48c20226dac003d41fbc9e05ea28a6bb5e10a49de060a0a4f6a2676a34d68c4abe8c61874355b9027e828ca9e064b002d62e8d8cf0744921753d35e3c87c5d5779453e7768617574684461746158c449960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d976341000000000000000000000000000000000000000000408903fd7dfd2c9770e98cae0123b13a2c27828a106349bc6277140e7290b7e9eb7976aa3c04ed347027caf7da3a2fa76304751c02208acfc4e7fc6c7ebbc375c8a5010203262001215820ad7f7992c335b90d882b2802061b97a4fabca7e2ee3e7a51e728b8055e4eb9c7225820e0966ba7005987fece6f0e0e13447aa98cec248e4000a594b01b74c1cb1d40b3")
+	var v attestationObject
+	if err := cbor.Unmarshal(cborData, &v); err != nil {
+		fmt.Println("error:", err)
+	}
+	if _, err := cbor.Marshal(v); err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%+v", v)
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/go.mod
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/go.mod
@@ -1,0 +1,5 @@
+module github.com/fxamacker/cbor/v2
+
+go 1.12
+
+require github.com/x448/float16 v0.8.4

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/go.sum
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/go.sum
@@ -1,0 +1,2 @@
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/maxdepth_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/maxdepth_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"testing"
+)
+
+func TestDepth(t *testing.T) {
+	testCases := []struct {
+		name      string
+		cborData  []byte
+		wantDepth int
+	}{
+		{"uint", hexDecode("00"), 1},                                                          // 0
+		{"int", hexDecode("20"), 1},                                                           // -1
+		{"bool", hexDecode("f4"), 1},                                                          // false
+		{"nil", hexDecode("f6"), 1},                                                           // nil
+		{"float", hexDecode("fa47c35000"), 1},                                                 // 100000.0
+		{"byte string", hexDecode("40"), 1},                                                   // []byte{}
+		{"indefinite length byte string", hexDecode("5f42010243030405ff"), 1},                 // []byte{1, 2, 3, 4, 5}
+		{"text string", hexDecode("60"), 1},                                                   // ""
+		{"indefinite length text string", hexDecode("7f657374726561646d696e67ff"), 1},         // "streaming"
+		{"empty array", hexDecode("80"), 1},                                                   // []
+		{"indefinite length empty array", hexDecode("9fff"), 1},                               // []
+		{"array", hexDecode("98190102030405060708090a0b0c0d0e0f101112131415161718181819"), 2}, // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
+		{"indefinite length array", hexDecode("9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff"), 2}, // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
+		{"nested array", hexDecode("8301820203820405"), 3},                                                      // [1,[2,3],[4,5]]
+		{"indefinite length nested array", hexDecode("83018202039f0405ff"), 3},                                  // [1,[2,3],[4,5]]
+		{"array and map", hexDecode("826161a161626163"), 3},                                                     // [a", {"b": "c"}]
+		{"indefinite length array and map", hexDecode("826161bf61626163ff"), 3},                                 // [a", {"b": "c"}]
+		{"empty map", hexDecode("a0"), 1},                                                                       // {}
+		{"indefinite length empty map", hexDecode("bfff"), 1},                                                   // {}
+		{"map", hexDecode("a201020304"), 2},                                                                     // {1:2, 3:4}
+		{"nested map", hexDecode("a26161016162820203"), 3},                                                      // {"a": 1, "b": [2, 3]}
+		{"indefinite length nested map", hexDecode("bf61610161629f0203ffff"), 3},                                // {"a": 1, "b": [2, 3]}
+		{"tag", hexDecode("c074323031332d30332d32315432303a30343a30305a"), 1},                                   // 0("2013-03-21T20:04:00Z")
+		{"tagged map", hexDecode("d864a26161016162820203"), 3},                                                  // 100({"a": 1, "b": [2, 3]})
+		{"tagged map and array", hexDecode("d864a26161016162d865d866820203"), 4},                                // 100({"a": 1, "b": 101(102([2, 3]))})
+		{"nested tag", hexDecode("d864d865d86674323031332d30332d32315432303a30343a30305a"), 3},                  // 100(101(102("2013-03-21T20:04:00Z")))
+		{"32-level array", hexDecode("820181818181818181818181818181818181818181818181818181818181818101"), 32},
+		{"32-level indefinite length array", hexDecode("9f0181818181818181818181818181818181818181818181818181818181818101ff"), 32},
+		{"32-level map", hexDecode("a10181818181818181818181818181818181818181818181818181818181818101"), 32},
+		{"32-level indefinite length map", hexDecode("bf0181818181818181818181818181818181818181818181818181818181818101ff"), 32},
+		{"32-level tag", hexDecode("d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d86474323031332d30332d32315432303a30343a30305a"), 32}, // 100(100(...("2013-03-21T20:04:00Z")))
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, depth, err := validInternal(tc.cborData, 0, 1)
+			if err != nil {
+				t.Errorf("valid(0x%x) returned error %v", tc.cborData, err)
+			}
+			if depth != tc.wantDepth {
+				t.Errorf("valid(0x%x) returned depth %d, want %d", tc.cborData, depth, tc.wantDepth)
+			}
+		})
+	}
+}
+
+func TestDepthError(t *testing.T) {
+	testCases := []struct {
+		name         string
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		{"33-level array", hexDecode("82018181818181818181818181818181818181818181818181818181818181818101"), "cbor: reached max depth 32"},
+		{"33-level indefinite length array", hexDecode("9f018181818181818181818181818181818181818181818181818181818181818101ff"), "cbor: reached max depth 32"},
+		{"33-level map", hexDecode("a1018181818181818181818181818181818181818181818181818181818181818101"), "cbor: reached max depth 32"},
+		{"33-level indefinite length map", hexDecode("bf018181818181818181818181818181818181818181818181818181818181818101ff"), "cbor: reached max depth 32"},
+		{"33-level tag", hexDecode("d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d864d86474323031332d30332d32315432303a30343a30305a"), "cbor: reached max depth 32"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := validInternal(tc.cborData, 0, 1)
+			if err == nil {
+				t.Errorf("valid(0x%x) didn't return an error, want %q", tc.cborData, tc.wantErrorMsg)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("valid(0x%x) returned error %q, want %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/stream.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/stream.go
@@ -1,0 +1,196 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"errors"
+	"io"
+	"reflect"
+)
+
+// Decoder reads and decodes CBOR values from an input stream.
+type Decoder struct {
+	r         io.Reader
+	buf       []byte
+	d         decodeState
+	off       int // start of unread data in buf
+	bytesRead int
+}
+
+// NewDecoder returns a new decoder that reads from r using the default decoding options.
+func NewDecoder(r io.Reader) *Decoder {
+	return defaultDecMode.NewDecoder(r)
+}
+
+// Decode reads the next CBOR-encoded value from its input and stores it in
+// the value pointed to by v.
+func (dec *Decoder) Decode(v interface{}) error {
+	if len(dec.buf) == dec.off {
+		if n, err := dec.read(); n == 0 {
+			return err
+		}
+	}
+
+	dec.d.reset(dec.buf[dec.off:])
+	err := dec.d.value(v)
+	dec.off += dec.d.off
+	dec.bytesRead += dec.d.off
+	if err != nil {
+		if err != io.ErrUnexpectedEOF {
+			return err
+		}
+		// Need to read more data.
+		if n, e := dec.read(); n == 0 {
+			return e
+		}
+		return dec.Decode(v)
+	}
+	return nil
+}
+
+// NumBytesRead returns the number of bytes read.
+func (dec *Decoder) NumBytesRead() int {
+	return dec.bytesRead
+}
+
+func (dec *Decoder) read() (int, error) {
+	// Copy unread data over read data and reset off to 0.
+	if dec.off > 0 {
+		n := copy(dec.buf, dec.buf[dec.off:])
+		dec.buf = dec.buf[:n]
+		dec.off = 0
+	}
+
+	// Grow buf if needed.
+	const minRead = 512
+	if cap(dec.buf)-len(dec.buf) < minRead {
+		newBuf := make([]byte, len(dec.buf), 2*cap(dec.buf)+minRead)
+		copy(newBuf, dec.buf)
+		dec.buf = newBuf
+	}
+
+	// Read from reader and reslice buf.
+	n, err := dec.r.Read(dec.buf[len(dec.buf):cap(dec.buf)])
+	dec.buf = dec.buf[0 : len(dec.buf)+n]
+	return n, err
+}
+
+// Encoder writes CBOR values to an output stream.
+type Encoder struct {
+	w          io.Writer
+	em         *encMode
+	e          *encodeState
+	indefTypes []cborType
+}
+
+// NewEncoder returns a new encoder that writes to w using the default encoding options.
+func NewEncoder(w io.Writer) *Encoder {
+	return defaultEncMode.NewEncoder(w)
+}
+
+// Encode writes the CBOR encoding of v to the stream.
+func (enc *Encoder) Encode(v interface{}) error {
+	if len(enc.indefTypes) > 0 && v != nil {
+		indefType := enc.indefTypes[len(enc.indefTypes)-1]
+		if indefType == cborTypeTextString {
+			k := reflect.TypeOf(v).Kind()
+			if k != reflect.String {
+				return errors.New("cbor: cannot encode item type " + k.String() + " for indefinite-length text string")
+			}
+		} else if indefType == cborTypeByteString {
+			t := reflect.TypeOf(v)
+			k := t.Kind()
+			if (k != reflect.Array && k != reflect.Slice) || t.Elem().Kind() != reflect.Uint8 {
+				return errors.New("cbor: cannot encode item type " + k.String() + " for indefinite-length byte string")
+			}
+		}
+	}
+
+	err := encode(enc.e, enc.em, reflect.ValueOf(v))
+	if err == nil {
+		_, err = enc.e.WriteTo(enc.w)
+	}
+	enc.e.Reset()
+	return err
+}
+
+// StartIndefiniteByteString starts byte string encoding of indefinite length.
+// Subsequent calls of (*Encoder).Encode() encodes definite length byte strings
+// ("chunks") as one continguous string until EndIndefinite is called.
+func (enc *Encoder) StartIndefiniteByteString() error {
+	return enc.startIndefinite(cborTypeByteString)
+}
+
+// StartIndefiniteTextString starts text string encoding of indefinite length.
+// Subsequent calls of (*Encoder).Encode() encodes definite length text strings
+// ("chunks") as one continguous string until EndIndefinite is called.
+func (enc *Encoder) StartIndefiniteTextString() error {
+	return enc.startIndefinite(cborTypeTextString)
+}
+
+// StartIndefiniteArray starts array encoding of indefinite length.
+// Subsequent calls of (*Encoder).Encode() encodes elements of the array
+// until EndIndefinite is called.
+func (enc *Encoder) StartIndefiniteArray() error {
+	return enc.startIndefinite(cborTypeArray)
+}
+
+// StartIndefiniteMap starts array encoding of indefinite length.
+// Subsequent calls of (*Encoder).Encode() encodes elements of the map
+// until EndIndefinite is called.
+func (enc *Encoder) StartIndefiniteMap() error {
+	return enc.startIndefinite(cborTypeMap)
+}
+
+// EndIndefinite closes last opened indefinite length value.
+func (enc *Encoder) EndIndefinite() error {
+	if len(enc.indefTypes) == 0 {
+		return errors.New("cbor: cannot encode \"break\" code outside indefinite length values")
+	}
+	_, err := enc.w.Write([]byte{0xff})
+	if err == nil {
+		enc.indefTypes = enc.indefTypes[:len(enc.indefTypes)-1]
+	}
+	return err
+}
+
+var cborIndefHeader = map[cborType][]byte{
+	cborTypeByteString: {0x5f},
+	cborTypeTextString: {0x7f},
+	cborTypeArray:      {0x9f},
+	cborTypeMap:        {0xbf},
+}
+
+func (enc *Encoder) startIndefinite(typ cborType) error {
+	if enc.em.disableIndefiniteLength {
+		return errors.New("cbor: indefinite-length items are not allowed")
+	}
+	_, err := enc.w.Write(cborIndefHeader[typ])
+	if err == nil {
+		enc.indefTypes = append(enc.indefTypes, typ)
+	}
+	return err
+}
+
+// RawMessage is a raw encoded CBOR value. It implements Marshaler and
+// Unmarshaler interfaces and can be used to delay CBOR decoding or
+// precompute a CBOR encoding.
+type RawMessage []byte
+
+// MarshalCBOR returns m as the CBOR encoding of m.
+func (m RawMessage) MarshalCBOR() ([]byte, error) {
+	if len(m) == 0 {
+		return cborNil, nil
+	}
+	return m, nil
+}
+
+// UnmarshalCBOR sets *m to a copy of data.
+func (m *RawMessage) UnmarshalCBOR(data []byte) error {
+	if m == nil {
+		return errors.New("cbor.RawMessage: UnmarshalCBOR on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/stream_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/stream_test.go
@@ -1,0 +1,425 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestDecoder(t *testing.T) {
+	var buf bytes.Buffer
+	for i := 0; i < 5; i++ {
+		for _, tc := range unmarshalTests {
+			buf.Write(tc.cborData)
+		}
+	}
+	decoder := NewDecoder(&buf)
+	bytesRead := 0
+	for i := 0; i < 5; i++ {
+		for _, tc := range unmarshalTests {
+			var v interface{}
+			if err := decoder.Decode(&v); err != nil {
+				t.Fatalf("Decode() returned error %v", err)
+			}
+			if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
+				if vt, ok := v.(time.Time); !ok || !tm.Equal(vt) {
+					t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+				}
+			} else if !reflect.DeepEqual(v, tc.emptyInterfaceValue) {
+				t.Errorf("Decode() = %v (%T), want %v (%T)", v, v, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+			}
+			bytesRead += len(tc.cborData)
+			if decoder.NumBytesRead() != bytesRead {
+				t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+			}
+		}
+	}
+	// no more data
+	var v interface{}
+	err := decoder.Decode(&v)
+	if v != nil {
+		t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
+	}
+	if err != io.EOF {
+		t.Errorf("Decode() returned error %v, want io.EOF (no more data)", err)
+	}
+}
+
+func TestDecoderUnmarshalTypeError(t *testing.T) {
+	var buf bytes.Buffer
+	for i := 0; i < 5; i++ {
+		for _, tc := range unmarshalTests {
+			for j := 0; j < len(tc.wrongTypes)*2; j++ {
+				buf.Write(tc.cborData)
+			}
+		}
+	}
+	decoder := NewDecoder(&buf)
+	bytesRead := 0
+	for i := 0; i < 5; i++ {
+		for _, tc := range unmarshalTests {
+			for _, typ := range tc.wrongTypes {
+				v := reflect.New(typ)
+				if err := decoder.Decode(v.Interface()); err == nil {
+					t.Errorf("Decode(0x%x) didn't return an error, want UnmarshalTypeError", tc.cborData)
+				} else if _, ok := err.(*UnmarshalTypeError); !ok {
+					t.Errorf("Decode(0x%x) returned wrong error type %T, want UnmarshalTypeError", tc.cborData, err)
+				}
+				bytesRead += len(tc.cborData)
+				if decoder.NumBytesRead() != bytesRead {
+					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+				}
+
+				var vi interface{}
+				if err := decoder.Decode(&vi); err != nil {
+					t.Errorf("Decode() returned error %v", err)
+				}
+				if tm, ok := tc.emptyInterfaceValue.(time.Time); ok {
+					if vt, ok := vi.(time.Time); !ok || !tm.Equal(vt) {
+						t.Errorf("Decode() = %v (%T), want %v (%T)", vi, vi, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+					}
+				} else if !reflect.DeepEqual(vi, tc.emptyInterfaceValue) {
+					t.Errorf("Decode() = %v (%T), want %v (%T)", vi, vi, tc.emptyInterfaceValue, tc.emptyInterfaceValue)
+				}
+				bytesRead += len(tc.cborData)
+				if decoder.NumBytesRead() != bytesRead {
+					t.Errorf("NumBytesRead() = %v, want %v", decoder.NumBytesRead(), bytesRead)
+				}
+			}
+		}
+	}
+	// no more data
+	var v interface{}
+	err := decoder.Decode(&v)
+	if v != nil {
+		t.Errorf("Decode() = %v (%T), want nil (no more data)", v, v)
+	}
+	if err != io.EOF {
+		t.Errorf("Decode() returned error %v, want io.EOF (no more data)", err)
+	}
+}
+
+func TestDecoderStructTag(t *testing.T) {
+	type strc struct {
+		A string `json:"x" cbor:"a"`
+		B string `json:"y" cbor:"b"`
+		C string `json:"z"`
+	}
+	want := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	cborData := hexDecode("a36161614161626142617a6143") // {"a":"A", "b":"B", "z":"C"}
+
+	var v strc
+	dec := NewDecoder(bytes.NewReader(cborData))
+	if err := dec.Decode(&v); err != nil {
+		t.Errorf("Decode() returned error %v", err)
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Decode() = %+v (%T), want %+v (%T)", v, v, want, want)
+	}
+}
+
+func TestEncoder(t *testing.T) {
+	var want bytes.Buffer
+	var w bytes.Buffer
+	em, err := CanonicalEncOptions().EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	encoder := em.NewEncoder(&w)
+	for _, tc := range marshalTests {
+		for _, value := range tc.values {
+			want.Write(tc.cborData)
+
+			if err := encoder.Encode(value); err != nil {
+				t.Fatalf("Encode() returned error %v", err)
+			}
+		}
+	}
+	if !bytes.Equal(w.Bytes(), want.Bytes()) {
+		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want.Bytes())
+	}
+}
+
+func TestEncoderError(t *testing.T) {
+	testcases := []struct {
+		name         string
+		value        interface{}
+		wantErrorMsg string
+	}{
+		{"channel cannot be marshaled", make(chan bool), "cbor: unsupported type: chan bool"},
+		{"function cannot be marshaled", func(i int) int { return i * i }, "cbor: unsupported type: func(int) int"},
+		{"complex cannot be marshaled", complex(100, 8), "cbor: unsupported type: complex128"},
+	}
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := encoder.Encode(&tc.value)
+			if err == nil {
+				t.Errorf("Encode(%v) didn't return an error, want error %q", tc.value, tc.wantErrorMsg)
+			} else if _, ok := err.(*UnsupportedTypeError); !ok {
+				t.Errorf("Encode(%v) error type %T, want *UnsupportedTypeError", tc.value, err)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("Encode(%v) error %q, want %q", tc.value, err.Error(), tc.wantErrorMsg)
+			}
+		})
+	}
+	if w.Len() != 0 {
+		t.Errorf("Encoder's writer has %d bytes of data, want empty data", w.Len())
+	}
+}
+
+func TestIndefiniteByteString(t *testing.T) {
+	want := hexDecode("5f42010243030405ff")
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteByteString(); err != nil {
+		t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+	}
+	if err := encoder.Encode([]byte{1, 2}); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode([3]byte{3, 4, 5}); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if !bytes.Equal(w.Bytes(), want) {
+		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+}
+
+func TestIndefiniteByteStringError(t *testing.T) {
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteByteString(); err != nil {
+		t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+	}
+	if err := encoder.Encode([]int{1, 2}); err == nil {
+		t.Errorf("Encode() didn't return an error")
+	} else if err.Error() != "cbor: cannot encode item type slice for indefinite-length byte string" {
+		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type slice for indefinite-length byte string")
+	}
+	if err := encoder.Encode("hello"); err == nil {
+		t.Errorf("Encode() didn't return an error")
+	} else if err.Error() != "cbor: cannot encode item type string for indefinite-length byte string" {
+		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type string for indefinite-length byte string")
+	}
+}
+
+func TestIndefiniteTextString(t *testing.T) {
+	want := hexDecode("7f657374726561646d696e67ff")
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteTextString(); err != nil {
+		t.Fatalf("StartIndefiniteTextString() returned error %v", err)
+	}
+	if err := encoder.Encode("strea"); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode("ming"); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if !bytes.Equal(w.Bytes(), want) {
+		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+}
+
+func TestIndefiniteTextStringError(t *testing.T) {
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteTextString(); err != nil {
+		t.Fatalf("StartIndefiniteTextString() returned error %v", err)
+	}
+	if err := encoder.Encode([]byte{1, 2}); err == nil {
+		t.Errorf("Encode() didn't return an error")
+	} else if err.Error() != "cbor: cannot encode item type slice for indefinite-length text string" {
+		t.Errorf("Encode() returned error %q, want %q", err.Error(), "cbor: cannot encode item type slice for indefinite-length text string")
+	}
+}
+
+func TestIndefiniteArray(t *testing.T) {
+	want := hexDecode("9f018202039f0405ffff")
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteArray(); err != nil {
+		t.Fatalf("StartIndefiniteArray() returned error %v", err)
+	}
+	if err := encoder.Encode(1); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode([]int{2, 3}); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.StartIndefiniteArray(); err != nil {
+		t.Fatalf("StartIndefiniteArray() returned error %v", err)
+	}
+	if err := encoder.Encode(4); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode(5); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if !bytes.Equal(w.Bytes(), want) {
+		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+}
+
+func TestIndefiniteMap(t *testing.T) {
+	want := hexDecode("bf61610161629f0203ffff")
+	var w bytes.Buffer
+	em, err := EncOptions{Sort: SortCanonical}.EncMode()
+	if err != nil {
+		t.Errorf("EncMode() returned an error %v", err)
+	}
+	encoder := em.NewEncoder(&w)
+	if err := encoder.StartIndefiniteMap(); err != nil {
+		t.Fatalf("StartIndefiniteMap() returned error %v", err)
+	}
+	if err := encoder.Encode("a"); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode(1); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode("b"); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.StartIndefiniteArray(); err != nil {
+		t.Fatalf("StartIndefiniteArray() returned error %v", err)
+	}
+	if err := encoder.Encode(2); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.Encode(3); err != nil {
+		t.Fatalf("Encode() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if !bytes.Equal(w.Bytes(), want) {
+		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+}
+
+func TestIndefiniteLengthError(t *testing.T) {
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.StartIndefiniteByteString(); err != nil {
+		t.Fatalf("StartIndefiniteByteString() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err != nil {
+		t.Fatalf("EndIndefinite() returned error %v", err)
+	}
+	if err := encoder.EndIndefinite(); err == nil {
+		t.Fatalf("EndIndefinite() didn't return an error")
+	}
+}
+
+func TestEncoderStructTag(t *testing.T) {
+	type strc struct {
+		A string `json:"x" cbor:"a"`
+		B string `json:"y" cbor:"b"`
+		C string `json:"z"`
+	}
+	v := strc{
+		A: "A",
+		B: "B",
+		C: "C",
+	}
+	want := hexDecode("a36161614161626142617a6143") // {"a":"A", "b":"B", "z":"C"}
+
+	var w bytes.Buffer
+	encoder := NewEncoder(&w)
+	if err := encoder.Encode(v); err != nil {
+		t.Errorf("Encode(%+v) returned error %v", v, err)
+	}
+	if !bytes.Equal(w.Bytes(), want) {
+		t.Errorf("Encoding mismatch: got %v, want %v", w.Bytes(), want)
+	}
+}
+
+func TestRawMessage(t *testing.T) {
+	type strc struct {
+		A RawMessage  `cbor:"a"`
+		B *RawMessage `cbor:"b"`
+		C *RawMessage `cbor:"c"`
+	}
+	cborData := hexDecode("a361610161628202036163f6") // {"a": 1, "b": [2, 3], "c": nil},
+	r := RawMessage(hexDecode("820203"))
+	want := strc{
+		A: RawMessage([]byte{0x01}),
+		B: &r,
+	}
+	var v strc
+	if err := Unmarshal(cborData, &v); err != nil {
+		t.Fatalf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, want) {
+		t.Errorf("Unmarshal(0x%x) returned v %v, want %v", cborData, v, want)
+	}
+	b, err := Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal(%+v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, cborData) {
+		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", v, b, cborData)
+	}
+}
+
+func TestNullRawMessage(t *testing.T) {
+	r := RawMessage(nil)
+	wantCborData := []byte{0xf6}
+	b, err := Marshal(r)
+	if err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", r, err)
+	}
+	if !bytes.Equal(b, wantCborData) {
+		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", r, b, wantCborData)
+	}
+}
+
+func TestEmptyRawMessage(t *testing.T) {
+	var r RawMessage
+	wantCborData := []byte{0xf6}
+	b, err := Marshal(r)
+	if err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", r, err)
+	}
+	if !bytes.Equal(b, wantCborData) {
+		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", r, b, wantCborData)
+	}
+}
+
+func TestNilRawMessageUnmarshalCBORError(t *testing.T) {
+	wantErrorMsg := "cbor.RawMessage: UnmarshalCBOR on nil pointer"
+	var r *RawMessage
+	cborData := hexDecode("01")
+	if err := r.UnmarshalCBOR(cborData); err == nil {
+		t.Errorf("UnmarshalCBOR() didn't return error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("UnmarshalCBOR() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/structfields.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/structfields.go
@@ -1,0 +1,210 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+)
+
+type field struct {
+	name      string
+	nameAsInt int64 // used to decoder to match field name with CBOR int
+	cborName  []byte
+	idx       []int
+	typ       reflect.Type
+	ef        encodeFunc
+	typInfo   *typeInfo // used to decoder to reuse type info
+	tagged    bool      // used to choose dominant field (at the same level tagged fields dominate untagged fields)
+	omitEmpty bool      // used to skip empty field
+	keyAsInt  bool      // used to encode/decode field name as int
+}
+
+type fields []*field
+
+// indexFieldSorter sorts fields by field idx at each level, breaking ties with idx depth.
+type indexFieldSorter struct {
+	fields fields
+}
+
+func (x *indexFieldSorter) Len() int {
+	return len(x.fields)
+}
+
+func (x *indexFieldSorter) Swap(i, j int) {
+	x.fields[i], x.fields[j] = x.fields[j], x.fields[i]
+}
+
+func (x *indexFieldSorter) Less(i, j int) bool {
+	iIdx := x.fields[i].idx
+	jIdx := x.fields[j].idx
+	for k, d := range iIdx {
+		if k >= len(jIdx) {
+			// fields[j].idx is a subset of fields[i].idx.
+			return false
+		}
+		if d != jIdx[k] {
+			// fields[i].idx and fields[j].idx are different.
+			return d < jIdx[k]
+		}
+	}
+	// fields[i].idx is either the same as, or a subset of fields[j].idx.
+	return true
+}
+
+// nameLevelAndTagFieldSorter sorts fields by field name, idx depth, and presence of tag.
+type nameLevelAndTagFieldSorter struct {
+	fields fields
+}
+
+func (x *nameLevelAndTagFieldSorter) Len() int {
+	return len(x.fields)
+}
+
+func (x *nameLevelAndTagFieldSorter) Swap(i, j int) {
+	x.fields[i], x.fields[j] = x.fields[j], x.fields[i]
+}
+
+func (x *nameLevelAndTagFieldSorter) Less(i, j int) bool {
+	if x.fields[i].name != x.fields[j].name {
+		return x.fields[i].name < x.fields[j].name
+	}
+	if len(x.fields[i].idx) != len(x.fields[j].idx) {
+		return len(x.fields[i].idx) < len(x.fields[j].idx)
+	}
+	if x.fields[i].tagged != x.fields[j].tagged {
+		return x.fields[i].tagged
+	}
+	return i < j // Field i and j have the same name, depth, and tagged status. Nothing else matters.
+}
+
+// getFields returns a list of visible fields of struct type typ following Go
+// visibility rules for struct fields.
+func getFields(typ reflect.Type) (flds fields, structOptions string) {
+	// Inspired by typeFields() in stdlib's encoding/json/encode.go.
+
+	var current map[reflect.Type][][]int // key: struct type, value: field index of this struct type at the same level
+	next := map[reflect.Type][][]int{typ: nil}
+	visited := map[reflect.Type]bool{} // Inspected struct type at less nested levels.
+
+	for len(next) > 0 {
+		current, next = next, map[reflect.Type][][]int{}
+
+		for structType, structIdx := range current {
+			if len(structIdx) > 1 {
+				continue // Fields of the same embedded struct type at the same level are ignored.
+			}
+
+			if visited[structType] {
+				continue
+			}
+			visited[structType] = true
+
+			var fieldIdx []int
+			if len(structIdx) > 0 {
+				fieldIdx = structIdx[0]
+			}
+
+			for i := 0; i < structType.NumField(); i++ {
+				f := structType.Field(i)
+				ft := f.Type
+
+				if ft.Kind() == reflect.Ptr {
+					ft = ft.Elem()
+				}
+
+				exportable := f.PkgPath == ""
+				if f.Anonymous {
+					if !exportable && ft.Kind() != reflect.Struct {
+						// Nonexportable anonymous fields of non-struct type are ignored.
+						continue
+					}
+					// Nonexportable anonymous field of struct type can contain exportable fields for serialization.
+				} else if !exportable {
+					// Get special field "_" struct options
+					if f.Name == "_" {
+						tag := f.Tag.Get("cbor")
+						if tag != "-" {
+							structOptions = tag
+						}
+					}
+					// Nonexportable fields are ignored.
+					continue
+				}
+
+				tag := f.Tag.Get("cbor")
+				if tag == "" {
+					tag = f.Tag.Get("json")
+				}
+				if tag == "-" {
+					continue
+				}
+
+				idx := make([]int, len(fieldIdx)+1)
+				copy(idx, fieldIdx)
+				idx[len(fieldIdx)] = i
+
+				tagged := len(tag) > 0
+				tagFieldName, omitempty, keyasint := getFieldNameAndOptionsFromTag(tag)
+
+				fieldName := tagFieldName
+				if tagFieldName == "" {
+					fieldName = f.Name
+				}
+
+				if !f.Anonymous || ft.Kind() != reflect.Struct || len(tagFieldName) > 0 {
+					flds = append(flds, &field{name: fieldName, idx: idx, typ: f.Type, tagged: tagged, omitEmpty: omitempty, keyAsInt: keyasint})
+					continue
+				}
+
+				// f is anonymous struct of type ft.
+				next[ft] = append(next[ft], idx)
+			}
+		}
+	}
+
+	sort.Sort(&nameLevelAndTagFieldSorter{flds})
+
+	// Keep visible fields.
+	visibleFields := flds[:0]
+	for i, j := 0, 0; i < len(flds); i = j {
+		name := flds[i].name
+		for j = i + 1; j < len(flds) && flds[j].name == name; j++ {
+		}
+		if j-i == 1 || len(flds[i].idx) < len(flds[i+1].idx) || (flds[i].tagged && !flds[i+1].tagged) {
+			// Keep the field if the field name is unique, or if the first field
+			// is at a less nested level, or if the first field is tagged and
+			// the second field is not.
+			visibleFields = append(visibleFields, flds[i])
+		}
+	}
+
+	sort.Sort(&indexFieldSorter{visibleFields})
+
+	return visibleFields, structOptions
+}
+
+func getFieldNameAndOptionsFromTag(tag string) (name string, omitEmpty bool, keyAsInt bool) {
+	if tag == "" {
+		return
+	}
+	idx := strings.Index(tag, ",")
+	if idx == -1 {
+		return tag, false, false
+	}
+	if idx > 0 {
+		name = tag[:idx]
+		tag = tag[idx:]
+	}
+	s := ",omitempty"
+	if idx = strings.Index(tag, s); idx >= 0 && (len(tag) == idx+len(s) || tag[idx+len(s)] == ',') {
+		omitEmpty = true
+	}
+	s = ",keyasint"
+	if idx = strings.Index(tag, s); idx >= 0 && (len(tag) == idx+len(s) || tag[idx+len(s)] == ',') {
+		keyAsInt = true
+	}
+	return
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/tag.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/tag.go
@@ -1,0 +1,247 @@
+package cbor
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// Tag represents CBOR tag data, including tag number and unmarshaled tag content.
+type Tag struct {
+	Number  uint64
+	Content interface{}
+}
+
+func (t Tag) contentKind() reflect.Kind {
+	c := t.Content
+	for {
+		t, ok := c.(Tag)
+		if !ok {
+			break
+		}
+		c = t.Content
+	}
+	return reflect.ValueOf(c).Kind()
+}
+
+// RawTag represents CBOR tag data, including tag number and raw tag content.
+// RawTag implements Unmarshaler and Marshaler interfaces.
+type RawTag struct {
+	Number  uint64
+	Content RawMessage
+}
+
+// UnmarshalCBOR sets *t with tag number and raw tag content copied from data.
+func (t *RawTag) UnmarshalCBOR(data []byte) error {
+	if t == nil {
+		return errors.New("cbor.RawTag: UnmarshalCBOR on nil pointer")
+	}
+
+	d := decodeState{data: data, dm: defaultDecMode}
+
+	// Unmarshal tag number.
+	typ, _, num := d.getHead()
+	if typ != cborTypeTag {
+		return &UnmarshalTypeError{Value: typ.String(), Type: typeRawTag}
+	}
+	t.Number = num
+
+	// Unmarshal tag content.
+	c := d.data[d.off:]
+	t.Content = make([]byte, len(c))
+	copy(t.Content, c)
+	return nil
+}
+
+// MarshalCBOR returns CBOR encoding of t.
+func (t RawTag) MarshalCBOR() ([]byte, error) {
+	e := getEncodeState()
+	encodeHead(e, byte(cborTypeTag), t.Number)
+
+	buf := make([]byte, len(e.Bytes())+len(t.Content))
+	n := copy(buf, e.Bytes())
+	copy(buf[n:], t.Content)
+
+	putEncodeState(e)
+	return buf, nil
+}
+
+// DecTagMode specifies how decoder handles tag number.
+type DecTagMode int
+
+const (
+	// DecTagIgnored makes decoder ignore tag number (skips if present).
+	DecTagIgnored DecTagMode = iota
+
+	// DecTagOptional makes decoder verify tag number if it's present.
+	DecTagOptional
+
+	// DecTagRequired makes decoder verify tag number and tag number must be present.
+	DecTagRequired
+
+	maxDecTagMode
+)
+
+func (dtm DecTagMode) valid() bool {
+	return dtm < maxDecTagMode
+}
+
+// EncTagMode specifies how encoder handles tag number.
+type EncTagMode int
+
+const (
+	// EncTagNone makes encoder not encode tag number.
+	EncTagNone EncTagMode = iota
+
+	// EncTagRequired makes encoder encode tag number.
+	EncTagRequired
+
+	maxEncTagMode
+)
+
+func (etm EncTagMode) valid() bool {
+	return etm < maxEncTagMode
+}
+
+// TagOptions specifies how encoder and decoder handle tag number.
+type TagOptions struct {
+	DecTag DecTagMode
+	EncTag EncTagMode
+}
+
+// TagSet is an interface to add and remove tag info.  It is used by EncMode and DecMode
+// to provide CBOR tag support.
+type TagSet interface {
+	// Add adds given tag number(s), content type, and tag options to TagSet.
+	Add(opts TagOptions, contentType reflect.Type, num uint64, nestedNum ...uint64) error
+
+	// Remove removes given tag content type from TagSet.
+	Remove(contentType reflect.Type)
+
+	tagProvider
+}
+
+type tagProvider interface {
+	get(t reflect.Type) *tagItem
+}
+
+type tagItem struct {
+	num         []uint64
+	cborTagNum  []byte
+	contentType reflect.Type
+	opts        TagOptions
+}
+
+type (
+	tagSet map[reflect.Type]*tagItem
+
+	syncTagSet struct {
+		sync.RWMutex
+		t tagSet
+	}
+)
+
+func (t tagSet) get(typ reflect.Type) *tagItem {
+	return t[typ]
+}
+
+// NewTagSet returns TagSet (safe for concurrency).
+func NewTagSet() TagSet {
+	return &syncTagSet{t: make(map[reflect.Type]*tagItem)}
+}
+
+// Add adds given tag number(s), content type, and tag options to TagSet.
+func (t *syncTagSet) Add(opts TagOptions, contentType reflect.Type, num uint64, nestedNum ...uint64) error {
+	if contentType == nil {
+		return errors.New("cbor: cannot add nil content type to TagSet")
+	}
+	for contentType.Kind() == reflect.Ptr {
+		contentType = contentType.Elem()
+	}
+	tag, err := newTagItem(opts, contentType, num, nestedNum...)
+	if err != nil {
+		return err
+	}
+	t.Lock()
+	defer t.Unlock()
+	if _, ok := t.t[contentType]; ok {
+		return errors.New("cbor: content type " + contentType.String() + " already exists in TagSet")
+	}
+	t.t[contentType] = tag
+	return nil
+}
+
+// Remove removes given tag content type from TagSet.
+func (t *syncTagSet) Remove(contentType reflect.Type) {
+	for contentType.Kind() == reflect.Ptr {
+		contentType = contentType.Elem()
+	}
+	t.Lock()
+	delete(t.t, contentType)
+	t.Unlock()
+}
+
+func (t *syncTagSet) get(typ reflect.Type) *tagItem {
+	t.RLock()
+	ti := t.t[typ]
+	t.RUnlock()
+	return ti
+}
+
+func newTagItem(opts TagOptions, contentType reflect.Type, num uint64, nestedNum ...uint64) (*tagItem, error) {
+	if opts.DecTag == DecTagIgnored && opts.EncTag == EncTagNone {
+		return nil, errors.New("cbor: cannot add tag with DecTagIgnored and EncTagNone options to TagSet")
+	}
+	if contentType.PkgPath() == "" || contentType.Kind() == reflect.Interface {
+		return nil, errors.New("cbor: can only add named types to TagSet, got " + contentType.String())
+	}
+	if contentType == typeTime {
+		return nil, errors.New("cbor: cannot add time.Time to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead")
+	}
+	if contentType == typeTag {
+		return nil, errors.New("cbor: cannot add cbor.Tag to TagSet")
+	}
+	if contentType == typeRawTag {
+		return nil, errors.New("cbor: cannot add cbor.RawTag to TagSet")
+	}
+	if num == 0 || num == 1 {
+		return nil, errors.New("cbor: cannot add tag number 0 or 1 to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead")
+	}
+	if reflect.PtrTo(contentType).Implements(typeMarshaler) && opts.EncTag != EncTagNone {
+		return nil, errors.New("cbor: cannot add cbor.Marshaler to TagSet with EncTag != EncTagNone")
+	}
+	if reflect.PtrTo(contentType).Implements(typeUnmarshaler) && opts.DecTag != DecTagIgnored {
+		return nil, errors.New("cbor: cannot add cbor.Unmarshaler to TagSet with DecTag != DecTagIgnored")
+	}
+
+	te := tagItem{num: []uint64{num}, opts: opts, contentType: contentType}
+	te.num = append(te.num, nestedNum...)
+
+	// Cache encoded tag numbers
+	e := getEncodeState()
+	for _, n := range te.num {
+		encodeHead(e, byte(cborTypeTag), n)
+	}
+	te.cborTagNum = make([]byte, e.Len())
+	copy(te.cborTagNum, e.Bytes())
+	putEncodeState(e)
+
+	return &te, nil
+}
+
+var (
+	typeTag    = reflect.TypeOf(Tag{})
+	typeRawTag = reflect.TypeOf(RawTag{})
+)
+
+// WrongTagError describes mismatch between CBOR tag and registered tag.
+type WrongTagError struct {
+	RegisteredType   reflect.Type
+	RegisteredTagNum []uint64
+	TagNum           []uint64
+}
+
+func (e *WrongTagError) Error() string {
+	return fmt.Sprintf("cbor: wrong tag number for %s, got %v, expected %v", e.RegisteredType.String(), e.TagNum, e.RegisteredTagNum)
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/tag_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/tag_test.go
@@ -1,0 +1,1097 @@
+package cbor
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTagNewTypeWithBuiltinUnderlyingType(t *testing.T) {
+	type myBool bool
+	type myUint uint
+	type myUint8 uint8
+	type myUint16 uint16
+	type myUint32 uint32
+	type myUint64 uint64
+	type myInt int
+	type myInt8 int8
+	type myInt16 int16
+	type myInt32 int32
+	type myInt64 int64
+	type myFloat32 float32
+	type myFloat64 float64
+	type myString string
+	type myByteSlice []byte
+	type myIntSlice []int
+	type myIntArray [4]int
+	type myMapIntInt map[int]int
+
+	types := []reflect.Type{
+		reflect.TypeOf(myBool(false)),
+		reflect.TypeOf(myUint(0)),
+		reflect.TypeOf(myUint8(0)),
+		reflect.TypeOf(myUint16(0)),
+		reflect.TypeOf(myUint32(0)),
+		reflect.TypeOf(myUint64(0)),
+		reflect.TypeOf(myInt(0)),
+		reflect.TypeOf(myInt8(0)),
+		reflect.TypeOf(myInt16(0)),
+		reflect.TypeOf(myInt32(0)),
+		reflect.TypeOf(myInt64(0)),
+		reflect.TypeOf(myFloat32(0)),
+		reflect.TypeOf(myFloat64(0)),
+		reflect.TypeOf(myString("")),
+		reflect.TypeOf(myByteSlice([]byte{})),
+		reflect.TypeOf(myIntSlice([]int{})),
+		reflect.TypeOf(myIntArray([4]int{})),
+		reflect.TypeOf(myMapIntInt(map[int]int{})),
+	}
+
+	tags := NewTagSet()
+	for i, typ := range types {
+		tagNum := uint64(100 + i)
+		if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, typ, tagNum); err != nil {
+			t.Fatalf("TagSet.Add(%s, %d) returned error %v", typ, tagNum, err)
+		}
+	}
+
+	em, _ := EncOptions{Sort: SortCanonical}.EncModeWithTags(tags)
+	dm, _ := DecOptions{}.DecModeWithTags(tags)
+
+	testCases := []roundTripTest{
+		{
+			name:         "bool",
+			obj:          myBool(true),
+			wantCborData: hexDecode("d864f5"),
+		},
+		{
+			name:         "uint",
+			obj:          myUint(0),
+			wantCborData: hexDecode("d86500"),
+		},
+		{
+			name:         "uint8",
+			obj:          myUint8(0),
+			wantCborData: hexDecode("d86600"),
+		},
+		{
+			name:         "uint16",
+			obj:          myUint16(1000),
+			wantCborData: hexDecode("d8671903e8"),
+		},
+		{
+			name:         "uint32",
+			obj:          myUint32(1000000),
+			wantCborData: hexDecode("d8681a000f4240"),
+		},
+		{
+			name:         "uint64",
+			obj:          myUint64(1000000000000),
+			wantCborData: hexDecode("d8691b000000e8d4a51000"),
+		},
+		{
+			name:         "int",
+			obj:          myInt(-1),
+			wantCborData: hexDecode("d86a20"),
+		},
+		{
+			name:         "int8",
+			obj:          myInt8(-1),
+			wantCborData: hexDecode("d86b20"),
+		},
+		{
+			name:         "int16",
+			obj:          myInt16(-1000),
+			wantCborData: hexDecode("d86c3903e7"),
+		},
+		{
+			name:         "int32",
+			obj:          myInt32(-1000),
+			wantCborData: hexDecode("d86d3903e7"),
+		},
+		{
+			name:         "int64",
+			obj:          myInt64(-1000),
+			wantCborData: hexDecode("d86e3903e7"),
+		},
+		{
+			name:         "float32",
+			obj:          myFloat32(100000.0),
+			wantCborData: hexDecode("d86ffa47c35000"),
+		},
+		{
+			name:         "float64",
+			obj:          myFloat64(1.1),
+			wantCborData: hexDecode("d870fb3ff199999999999a"),
+		},
+		{
+			name:         "string",
+			obj:          myString("a"),
+			wantCborData: hexDecode("d8716161"),
+		},
+		{
+			name:         "[]byte",
+			obj:          myByteSlice([]byte{1, 2, 3, 4}),
+			wantCborData: hexDecode("d8724401020304"),
+		},
+		{
+			name:         "[]int",
+			obj:          myIntSlice([]int{1, 2, 3, 4}),
+			wantCborData: hexDecode("d8738401020304"),
+		},
+		{
+			name:         "[4]int",
+			obj:          myIntArray([...]int{1, 2, 3, 4}),
+			wantCborData: hexDecode("d8748401020304"),
+		},
+		{
+			name:         "map[int]int",
+			obj:          myMapIntInt(map[int]int{1: 2, 3: 4}),
+			wantCborData: hexDecode("d875a201020304"),
+		},
+	}
+
+	testRoundTrip(t, testCases, em, dm)
+}
+
+func TestTagBinaryMarshalerUnmarshaler(t *testing.T) {
+	t1 := reflect.TypeOf((*number)(nil)) // Use *number for testing purpose
+	t2 := reflect.TypeOf(stru{})
+
+	tags := NewTagSet()
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, t1, 123); err != nil {
+		t.Fatalf("TagSet.Add(%s, %d) returned error %v", t1, 123, err)
+	}
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, t2, 124); err != nil {
+		t.Fatalf("TagSet.Add(%s, %d) returned error %v", t2, 124, err)
+	}
+
+	em, _ := EncOptions{}.EncModeWithTags(tags)
+	dm, _ := DecOptions{}.DecModeWithTags(tags)
+
+	testCases := []roundTripTest{
+		{
+			name:         "primitive obj",
+			obj:          number(1234567890),
+			wantCborData: hexDecode("d87b4800000000499602d2"),
+		},
+		{
+			name:         "struct obj",
+			obj:          stru{a: "a", b: "b", c: "c"},
+			wantCborData: hexDecode("d87c45612C622C63"),
+		},
+	}
+
+	testRoundTrip(t, testCases, em, dm)
+}
+
+func TestTagStruct(t *testing.T) {
+	type coseHeader struct {
+		Alg int    `cbor:"1,keyasint,omitempty"`
+		Kid []byte `cbor:"4,keyasint,omitempty"`
+		IV  []byte `cbor:"5,keyasint,omitempty"`
+	}
+	type signedCWT struct {
+		_           struct{} `cbor:",toarray"`
+		Protected   []byte
+		Unprotected coseHeader
+		Payload     []byte
+		Signature   []byte
+	}
+
+	t1 := reflect.TypeOf(signedCWT{})
+
+	tags := NewTagSet()
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, t1, 18); err != nil {
+		t.Fatalf("TagSet.Add(%s, %d) returned error %v", t1, 18, err)
+	}
+
+	em, _ := EncOptions{}.EncModeWithTags(tags)
+	dm, _ := DecOptions{}.DecModeWithTags(tags)
+
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.3
+	cborData := hexDecode("d28443a10126a104524173796d6d657472696345434453413235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7158405427c1ff28d23fbad1f29c4c7c6a555e601d6fa29f9179bc3d7438bacaca5acd08c8d4d4f96131680c429a01f85951ecee743a52b9b63632c57209120e1c9e30")
+	var v signedCWT
+	if err := dm.Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal() returned error %v", err)
+	}
+	b, err := em.Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, cborData) {
+		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", v, b, cborData)
+	}
+}
+
+func TestNestedTagStruct(t *testing.T) {
+	type coseHeader struct {
+		Alg int    `cbor:"1,keyasint,omitempty"`
+		Kid []byte `cbor:"4,keyasint,omitempty"`
+		IV  []byte `cbor:"5,keyasint,omitempty"`
+	}
+	type macedCOSE struct {
+		_           struct{} `cbor:",toarray"`
+		Protected   []byte
+		Unprotected coseHeader
+		Payload     []byte
+		Tag         []byte
+	}
+
+	t1 := reflect.TypeOf(macedCOSE{})
+
+	// Register tag CBOR Web Token (CWT) 61 and COSE_Mac0 17 with macedCOSE type
+	tags := NewTagSet()
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, t1, 61, 17); err != nil {
+		t.Fatalf("TagSet.Add(%s, %d, %v) returned error %v", t1, 61, 17, err)
+	}
+
+	em, _ := EncOptions{}.EncModeWithTags(tags)
+	dm, _ := DecOptions{}.DecModeWithTags(tags)
+
+	// Data from https://tools.ietf.org/html/rfc8392#appendix-A section A.4
+	cborData := hexDecode("d83dd18443a10104a1044c53796d6d65747269633235365850a70175636f61703a2f2f61732e6578616d706c652e636f6d02656572696b77037818636f61703a2f2f6c696768742e6578616d706c652e636f6d041a5612aeb0051a5610d9f0061a5610d9f007420b7148093101ef6d789200")
+	var v macedCOSE
+	if err := dm.Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal() returned error %v", err)
+	}
+	b, err := em.Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%+v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, cborData) {
+		t.Errorf("Marshal(%+v) = 0x%x, want 0x%x", v, b, cborData)
+	}
+}
+
+func TestAddTagError(t *testing.T) {
+	type myInt int
+	testCases := []struct {
+		name         string
+		typ          reflect.Type
+		num          uint64
+		opts         TagOptions
+		wantErrorMsg string
+	}{
+		{
+			name:         "nil type",
+			typ:          nil,
+			num:          100,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: cannot add nil content type to TagSet",
+		},
+		{
+			name:         "DecTag is DecTagIgnored && EncTag is EncTagNone",
+			typ:          reflect.TypeOf(myInt(0)),
+			num:          100,
+			opts:         TagOptions{DecTag: DecTagIgnored, EncTag: EncTagNone},
+			wantErrorMsg: "cbor: cannot add tag with DecTagIgnored and EncTagNone options to TagSet",
+		},
+		{
+			name:         "time.Time",
+			typ:          reflect.TypeOf(time.Time{}),
+			num:          101,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: cannot add time.Time to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead",
+		},
+		{
+			name:         "builtin type string",
+			typ:          reflect.TypeOf(""),
+			num:          102,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: can only add named types to TagSet, got string",
+		},
+		{
+			name:         "unnamed type struct{}",
+			typ:          reflect.TypeOf(struct{}{}),
+			num:          103,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: can only add named types to TagSet, got struct {}",
+		},
+		{
+			name:         "interface",
+			typ:          reflect.TypeOf((*io.Reader)(nil)).Elem(),
+			num:          104,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: can only add named types to TagSet, got io.Reader",
+		},
+		{
+			name:         "cbor.Tag",
+			typ:          reflect.TypeOf(Tag{}),
+			num:          105,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: cannot add cbor.Tag to TagSet",
+		},
+		{
+			name:         "cbor.RawTag",
+			typ:          reflect.TypeOf(RawTag{}),
+			num:          106,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: cannot add cbor.RawTag to TagSet",
+		},
+		{
+			name:         "cbor.Unmarshaler",
+			typ:          reflect.TypeOf(number2(0)),
+			num:          107,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagNone},
+			wantErrorMsg: "cbor: cannot add cbor.Unmarshaler to TagSet with DecTag != DecTagIgnored",
+		},
+		{
+			name:         "cbor.Marshaler",
+			typ:          reflect.TypeOf(number2(0)),
+			num:          108,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: cannot add cbor.Marshaler to TagSet with EncTag != EncTagNone",
+		},
+		{
+			name:         "tag number 0",
+			typ:          reflect.TypeOf(myInt(0)),
+			num:          0,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: cannot add tag number 0 or 1 to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead",
+		},
+		{
+			name:         "tag number 1",
+			typ:          reflect.TypeOf(myInt(0)),
+			num:          1,
+			opts:         TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired},
+			wantErrorMsg: "cbor: cannot add tag number 0 or 1 to TagSet, use EncOptions.TimeTag and DecOptions.TimeTag instead",
+		},
+	}
+	tags := NewTagSet()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tags.Add(tc.opts, tc.typ, tc.num); err == nil {
+				t.Errorf("TagSet.Add(%s, %d) didn't return an error", tc.typ.String(), tc.num)
+			} else if err.Error() != tc.wantErrorMsg {
+				var typeString string
+				if tc.typ == nil {
+					typeString = "nil"
+				} else {
+					typeString = tc.typ.String()
+				}
+				t.Errorf("TagSet.Add(%s, %d) returned error msg %q, want %q", typeString, tc.num, err, tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestAddDuplicateTagError(t *testing.T) {
+	type myInt int
+	myIntType := reflect.TypeOf(myInt(0))
+	wantErrorMsg := "cbor: content type cbor.myInt already exists in TagSet"
+
+	tags := NewTagSet()
+	// Add myIntType and 100 to tags
+	if err := tags.Add(TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired}, myIntType, 100); err != nil {
+		t.Errorf("TagSet.Add(%s, %d) returned error %v", myIntType.String(), 100, err)
+	}
+	// Add myIntType and 101 to tags
+	if err := tags.Add(TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired}, myIntType, 101); err == nil {
+		t.Errorf("TagSet.Add(%s, %d) didn't return an error", myIntType.String(), 101)
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("TagSet.Add(%s, %d) returned error msg %q, want %q", myIntType, 100, err, wantErrorMsg)
+	}
+}
+
+func TestAddRemoveTag(t *testing.T) {
+	type myInt int
+	type myFloat float64
+	myIntType := reflect.TypeOf(myInt(0))
+	myFloatType := reflect.TypeOf(myFloat(0.0))
+	pMyIntType := reflect.TypeOf((*myInt)(nil))
+	pMyFloatType := reflect.TypeOf((*myFloat)(nil))
+
+	tags := NewTagSet()
+	stags := tags.(*syncTagSet)
+	if err := tags.Add(TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired}, myIntType, 100); err != nil {
+		t.Errorf("TagSet.Add(%s, %d) returned error %v", myIntType.String(), 100, err)
+	}
+	if err := tags.Add(TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired}, myFloatType, 101); err != nil {
+		t.Errorf("TagSet.Add(%s, %d) returned error %v", myFloatType.String(), 101, err)
+	}
+	if err := tags.Add(TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired}, pMyIntType, 102); err == nil {
+		t.Errorf("TagSet.Add(%s, %d) didn't return an error", pMyIntType.String(), 102)
+	}
+	if err := tags.Add(TagOptions{DecTag: DecTagRequired, EncTag: EncTagRequired}, pMyFloatType, 103); err == nil {
+		t.Errorf("TagSet.Add(%s, %d) didn't return an error", pMyFloatType.String(), 103)
+	}
+	if len(stags.t) != 2 {
+		t.Errorf("TagSet len is %d, want %d", len(stags.t), 2)
+	}
+	tags.Remove(pMyIntType)
+	if len(stags.t) != 1 {
+		t.Errorf("TagSet len is %d, want %d", len(stags.t), 1)
+	}
+	tags.Remove(pMyFloatType)
+	if len(stags.t) != 0 {
+		t.Errorf("TagSet len is %d, want %d", len(stags.t), 0)
+	}
+	tags.Remove(myIntType)
+	tags.Remove(myFloatType)
+}
+
+func TestAddTagTypeAliasError(t *testing.T) {
+	type myBool = bool
+	type myUint = uint
+	type myUint8 = uint8
+	type myUint16 = uint16
+	type myUint32 = uint32
+	type myUint64 = uint64
+	type myInt = int
+	type myInt8 = int8
+	type myInt16 = int16
+	type myInt32 = int32
+	type myInt64 = int64
+	type myFloat32 = float32
+	type myFloat64 = float64
+	type myString = string
+	type myByteSlice = []byte
+	type myIntSlice = []int
+	type myIntArray = [4]int
+	type myMapIntInt = map[int]int
+
+	testCases := []struct {
+		name         string
+		typ          reflect.Type
+		wantErrorMsg string
+	}{
+		{
+			name:         "bool",
+			typ:          reflect.TypeOf(myBool(false)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got bool",
+		},
+		{
+			name:         "uint",
+			typ:          reflect.TypeOf(myUint(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got uint",
+		},
+		{
+			name:         "uint8",
+			typ:          reflect.TypeOf(myUint8(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got uint8",
+		},
+		{
+			name:         "uint16",
+			typ:          reflect.TypeOf(myUint16(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got uint16",
+		},
+		{
+			name:         "uint32",
+			typ:          reflect.TypeOf(myUint32(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got uint32",
+		},
+		{
+			name:         "uint64",
+			typ:          reflect.TypeOf(myUint64(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got uint64",
+		},
+		{
+			name:         "int",
+			typ:          reflect.TypeOf(myInt(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got int",
+		},
+		{
+			name:         "int8",
+			typ:          reflect.TypeOf(myInt8(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got int8",
+		},
+		{
+			name:         "int16",
+			typ:          reflect.TypeOf(myInt16(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got int16",
+		},
+		{
+			name:         "int32",
+			typ:          reflect.TypeOf(myInt32(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got int32",
+		},
+		{
+			name:         "int64",
+			typ:          reflect.TypeOf(myInt64(0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got int64",
+		},
+		{
+			name:         "float32",
+			typ:          reflect.TypeOf(myFloat32(0.0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got float32",
+		},
+		{
+			name:         "float64",
+			typ:          reflect.TypeOf(myFloat64(0.0)),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got float64",
+		},
+		{
+			name:         "string",
+			typ:          reflect.TypeOf(myString("")),
+			wantErrorMsg: "cbor: can only add named types to TagSet, got string",
+		},
+		{
+			name:         "[]byte",
+			typ:          reflect.TypeOf(myByteSlice([]byte{})), //nolint:unconvert
+			wantErrorMsg: "cbor: can only add named types to TagSet, got []uint8",
+		},
+		{
+			name:         "[]int",
+			typ:          reflect.TypeOf(myIntSlice([]int{})), //nolint:unconvert
+			wantErrorMsg: "cbor: can only add named types to TagSet, got []int",
+		},
+		{
+			name:         "[4]int",
+			typ:          reflect.TypeOf(myIntArray([4]int{})), //nolint:unconvert
+			wantErrorMsg: "cbor: can only add named types to TagSet, got [4]int",
+		},
+		{
+			name:         "map[int]int",
+			typ:          reflect.TypeOf(myMapIntInt(map[int]int{})), //nolint:unconvert
+			wantErrorMsg: "cbor: can only add named types to TagSet, got map[int]int",
+		},
+	}
+
+	tags := NewTagSet()
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, tc.typ, uint64(100+i)); err == nil {
+				t.Errorf("TagSet.Add(%s, %d) didn't return an error", tc.typ.String(), 0)
+			} else if err.Error() != tc.wantErrorMsg {
+				t.Errorf("TagSet.Add(%s, %d) returned error msg %q, want %q", tc.typ.String(), 0, err, tc.wantErrorMsg)
+			}
+		})
+	}
+}
+
+// TestDecodeTag decodes tag data with DecTagRequired/EncTagOptional/EncTagNone options.
+func TestDecodeTagData(t *testing.T) {
+	type myInt int
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+	}
+
+	type tagInfo struct {
+		t reflect.Type
+		n []uint64
+	}
+	tagInfos := []tagInfo{
+		{reflect.TypeOf((*number)(nil)), []uint64{123}}, // BinaryMarshaler *number
+		{reflect.TypeOf(stru{}), []uint64{124}},         // BinaryMarshaler stru
+		{reflect.TypeOf(myInt(0)), []uint64{125}},       // non-struct type
+		{reflect.TypeOf(s{}), []uint64{126}},            // struct type
+	}
+
+	tagsDecRequired := NewTagSet()
+	tagsDecOptional := NewTagSet()
+	tagsDecIgnored := NewTagSet()
+	for _, tag := range tagInfos {
+		if err := tagsDecRequired.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, tag.t, tag.n[0], tag.n[1:]...); err != nil {
+			t.Fatalf("TagSet.Add(%s, %v) returned error %v", tag.t, tag.n, err)
+		}
+		if err := tagsDecOptional.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagOptional}, tag.t, tag.n[0], tag.n[1:]...); err != nil {
+			t.Fatalf("TagSet.Add(%s, %v) returned error %v", tag.t, tag.n, err)
+		}
+		if err := tagsDecIgnored.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagIgnored}, tag.t, tag.n[0], tag.n[1:]...); err != nil {
+			t.Fatalf("TagSet.Add(%s, %v) returned error %v", tag.t, tag.n, err)
+		}
+	}
+
+	type tag struct {
+		name   string
+		tagSet TagSet
+	}
+	tags := []tag{
+		{"EncTagRequired_DecTagRequired", tagsDecRequired},
+		{"EncTagRequired_DecTagOptional", tagsDecOptional},
+		{"EncTagRequired_DecTagIgnored", tagsDecIgnored},
+	}
+
+	testCases := []roundTripTest{
+		{
+			name:         "BinaryMarshaler non-struct",
+			obj:          number(1234567890),
+			wantCborData: hexDecode("d87b4800000000499602d2"),
+		},
+		{
+			name:         "BinaryMarshaler struct",
+			obj:          stru{a: "a", b: "b", c: "c"},
+			wantCborData: hexDecode("d87c45612C622C63"),
+		},
+		{
+			name:         "non-struct",
+			obj:          myInt(1),
+			wantCborData: hexDecode("d87d01"),
+		},
+		{
+			name:         "struct",
+			obj:          s{A: "A", B: "B", C: "C"},
+			wantCborData: hexDecode("d87ea3616161416162614261636143"), // {"a":"A", "b":"B", "c":"C"}
+		},
+	}
+	for _, tag := range tags {
+		t.Run(tag.name, func(t *testing.T) {
+			em, _ := EncOptions{}.EncModeWithTags(tag.tagSet)
+			dm, _ := DecOptions{}.DecModeWithTags(tag.tagSet)
+			testRoundTrip(t, testCases, em, dm)
+		})
+	}
+}
+
+// TestDecodeNoTag decodes no-tag data with DecTagRequired/EncTagOptional/EncTagNone options
+func TestDecodeNoTagData(t *testing.T) {
+	type myInt int
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+	}
+
+	type tagInfo struct {
+		t reflect.Type
+		n []uint64
+	}
+	tagInfos := []tagInfo{
+		{reflect.TypeOf((*number)(nil)), []uint64{123}}, // BinaryMarshaler *number
+		{reflect.TypeOf(stru{}), []uint64{124}},         // BinaryMarshaler stru
+		{reflect.TypeOf(myInt(0)), []uint64{125}},       // non-struct type
+		{reflect.TypeOf(s{}), []uint64{126}},            // struct type
+	}
+
+	tagsDecRequired := NewTagSet()
+	tagsDecOptional := NewTagSet()
+	for _, tag := range tagInfos {
+		if err := tagsDecRequired.Add(TagOptions{EncTag: EncTagNone, DecTag: DecTagRequired}, tag.t, tag.n[0], tag.n[1:]...); err != nil {
+			t.Fatalf("TagSet.Add(%s, %v) returned error %v", tag.t, tag.n, err)
+		}
+		if err := tagsDecOptional.Add(TagOptions{EncTag: EncTagNone, DecTag: DecTagOptional}, tag.t, tag.n[0], tag.n[1:]...); err != nil {
+			t.Fatalf("TagSet.Add(%s, %v) returned error %v", tag.t, tag.n, err)
+		}
+	}
+
+	type tag struct {
+		name   string
+		tagSet TagSet
+	}
+	tags := []tag{
+		{"EncTagIgnored_DecTagOptional", tagsDecOptional},
+	}
+
+	testCases := []roundTripTest{
+		{
+			name:         "BinaryMarshaler non-struct",
+			obj:          number(1234567890),
+			wantCborData: hexDecode("4800000000499602d2"),
+		},
+		{
+			name:         "BinaryMarshaler struct",
+			obj:          stru{a: "a", b: "b", c: "c"},
+			wantCborData: hexDecode("45612C622C63"),
+		},
+		{
+			name:         "non-struct",
+			obj:          myInt(1),
+			wantCborData: hexDecode("01"),
+		},
+		{
+			name:         "struct",
+			obj:          s{A: "A", B: "B", C: "C"},
+			wantCborData: hexDecode("a3616161416162614261636143"), // {"a":"A", "b":"B", "c":"C"}
+		},
+	}
+
+	for _, tag := range tags {
+		t.Run(tag.name, func(t *testing.T) {
+			em, _ := EncOptions{}.EncModeWithTags(tag.tagSet)
+			dm, _ := DecOptions{}.DecModeWithTags(tag.tagSet)
+			testRoundTrip(t, testCases, em, dm)
+		})
+	}
+
+	// Decode non-tag data with DecTagRequired option returns UnmarshalTypeError
+	for _, tc := range testCases {
+		name := "EncTagIgnored_DecTagRequired " + tc.name
+		t.Run(name, func(t *testing.T) {
+			dm, _ := DecOptions{}.DecModeWithTags(tagsDecRequired)
+			v := reflect.New(reflect.TypeOf(tc.obj))
+			if err := dm.Unmarshal(tc.wantCborData, v.Interface()); err == nil {
+				t.Errorf("Unmarshal(0x%x) didn't return an error", tc.wantCborData)
+			} else {
+				if _, ok := err.(*UnmarshalTypeError); !ok {
+					t.Errorf("Unmarshal(0x%x) returned wrong type of error %T, want (*UnmarshalTypeError)", tc.wantCborData, err)
+				} else if !strings.Contains(err.Error(), "expect CBOR tag value") {
+					t.Errorf("Unmarshal(0x%x) returned error %q, want error containing %q", tc.wantCborData, err.Error(), "expect CBOR tag value")
+				}
+			}
+		})
+	}
+}
+
+// TestDecodeWrongTag decodes wrong tag data with DecTagRequired/EncTagOptional/EncTagNone options
+func TestDecodeWrongTag(t *testing.T) {
+	type myInt int
+	type s struct {
+		A string `cbor:"a"`
+		B string `cbor:"b"`
+		C string `cbor:"c"`
+	}
+
+	type tagInfo struct {
+		t reflect.Type
+		n []uint64
+	}
+	tagInfos := []tagInfo{
+		{reflect.TypeOf((*number)(nil)), []uint64{123}}, // BinaryMarshaler *number
+		{reflect.TypeOf(stru{}), []uint64{124}},         // BinaryMarshaler stru
+		{reflect.TypeOf(myInt(0)), []uint64{100}},       // non-struct type
+		{reflect.TypeOf(s{}), []uint64{101, 102}},       // struct type
+	}
+
+	tagsDecRequired := NewTagSet()
+	tagsDecOptional := NewTagSet()
+	tagsDecIgnored := NewTagSet()
+	for _, tag := range tagInfos {
+		if err := tagsDecRequired.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, tag.t, tag.n[0], tag.n[1:]...); err != nil {
+			t.Fatalf("TagSet.Add(%s, %v) returned error %v", tag.t, tag.n, err)
+		}
+		if err := tagsDecOptional.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagOptional}, tag.t, tag.n[0], tag.n[1:]...); err != nil {
+			t.Fatalf("TagSet.Add(%s, %v) returned error %v", tag.t, tag.n, err)
+		}
+		if err := tagsDecIgnored.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagIgnored}, tag.t, tag.n[0], tag.n[1:]...); err != nil {
+			t.Fatalf("TagSet.Add(%s, %v) returned error %v", tag.t, tag.n, err)
+		}
+	}
+	type tag struct {
+		name   string
+		tagSet TagSet
+	}
+	tags := []tag{
+		{"EncTagRequired_DecTagRequired", tagsDecRequired},
+		{"EncTagRequired_DecTagOptional", tagsDecOptional},
+	}
+
+	testCases := []struct {
+		name         string
+		obj          interface{}
+		cborData     []byte
+		wantErrorMsg string
+	}{
+		{
+			name:         "BinaryMarshaler non-struct",
+			obj:          number(1234567890),
+			cborData:     hexDecode("d87d4800000000499602d2"),
+			wantErrorMsg: "cbor: wrong tag number for cbor.number, got [125], expected [123]",
+		},
+		{
+			name:         "BinaryMarshaler struct",
+			obj:          stru{a: "a", b: "b", c: "c"},
+			cborData:     hexDecode("d87d45612C622C63"),
+			wantErrorMsg: "cbor: wrong tag number for cbor.stru, got [125], expected [124]",
+		},
+		{
+			name:         "non-struct",
+			obj:          myInt(1),
+			cborData:     hexDecode("d87d01"),
+			wantErrorMsg: "cbor: wrong tag number for cbor.myInt, got [125], expected [100]",
+		},
+		{
+			name:         "struct",
+			obj:          s{A: "A", B: "B", C: "C"},
+			cborData:     hexDecode("d87ea3616161416162614261636143"), // {"a":"A", "b":"B", "c":"C"}
+			wantErrorMsg: "cbor: wrong tag number for cbor.s, got [126], expected [101 102]",
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, tag := range tags {
+			name := tag.name + " " + tc.name
+			t.Run(name, func(t *testing.T) {
+				dm, _ := DecOptions{}.DecModeWithTags(tag.tagSet)
+				v := reflect.New(reflect.TypeOf(tc.obj))
+				if err := dm.Unmarshal(tc.cborData, v.Interface()); err == nil {
+					t.Errorf("Unmarshal(0x%x) didn't return an error", tc.cborData)
+				} else {
+					if _, ok := err.(*WrongTagError); !ok {
+						t.Errorf("Unmarshal(0x%x) returned wrong type of error %T, want (*WrongTagError)", tc.cborData, err)
+					} else if err.Error() != tc.wantErrorMsg {
+						t.Errorf("Unmarshal(0x%x) returned error %q, want error %q", tc.cborData, err.Error(), tc.wantErrorMsg)
+					}
+				}
+			})
+		}
+	}
+
+	// Decode wrong tag data with DecTagIgnored option returns no error.
+	for _, tc := range testCases {
+		name := "EncTagRequired_DecTagIgnored " + tc.name
+		t.Run(name, func(t *testing.T) {
+			dm, _ := DecOptions{}.DecModeWithTags(tagsDecIgnored)
+			v := reflect.New(reflect.TypeOf(tc.obj))
+			if err := dm.Unmarshal(tc.cborData, v.Interface()); err != nil {
+				t.Errorf("Unmarshal() returned error %v", err)
+			}
+			if !reflect.DeepEqual(tc.obj, v.Elem().Interface()) {
+				t.Errorf("Marshal-Unmarshal returned different values: %v, %v", tc.obj, v.Elem().Interface())
+			}
+		})
+	}
+}
+
+func TestEncodeSharedTag(t *testing.T) {
+	type myInt int
+
+	myIntType := reflect.TypeOf(myInt(0))
+
+	sharedTagSet := NewTagSet()
+
+	em, err := EncOptions{}.EncModeWithSharedTags(sharedTagSet)
+	if err != nil {
+		t.Errorf("EncModeWithSharedTags() returned error %v", err)
+	}
+
+	// Register myInt type with tag number 123
+	if err = sharedTagSet.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, myIntType, 123); err != nil {
+		t.Fatalf("TagSet.Add(%s, %v) returned error %v", myIntType, 100, err)
+	}
+
+	// Encode myInt with tag number 123
+	v := myInt(1)
+	wantCborData := hexDecode("d87b01")
+	b, err := em.Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, wantCborData) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, wantCborData)
+	}
+
+	// Unregister myInt type
+	sharedTagSet.Remove(myIntType)
+
+	// Encode myInt without tag number 123
+	v = myInt(2)
+	wantCborData = hexDecode("02")
+	b, err = em.Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, wantCborData) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, wantCborData)
+	}
+
+	// Register myInt type with tag number 234
+	if err = sharedTagSet.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, myIntType, 234); err != nil {
+		t.Fatalf("TagSet.Add(%s, %v) returned error %v", myIntType, 100, err)
+	}
+
+	// Encode myInt with tag number 234
+	v = myInt(3)
+	wantCborData = hexDecode("d8ea03")
+	b, err = em.Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, wantCborData) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, wantCborData)
+	}
+
+}
+
+func TestDecodeSharedTag(t *testing.T) {
+	type myInt int
+
+	myIntType := reflect.TypeOf(myInt(0))
+
+	sharedTagSet := NewTagSet()
+
+	dm, err := DecOptions{}.DecModeWithSharedTags(sharedTagSet)
+	if err != nil {
+		t.Errorf("DecModeWithSharedTags() returned error %v", err)
+	}
+
+	// Register myInt type with tag number 123
+	if err = sharedTagSet.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, myIntType, 123); err != nil {
+		t.Fatalf("TagSet.Add(%s, %v) returned error %v", myIntType, 100, err)
+	}
+
+	// Decode myInt with tag number 123
+	var v myInt
+	wantV := myInt(1)
+	cborData := hexDecode("d87b01")
+	if err = dm.Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, wantV) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, wantV, wantV)
+	}
+
+	// Unregister myInt type
+	sharedTagSet.Remove(myIntType)
+
+	// Decode myInt without tag number
+	wantV = myInt(2)
+	cborData = hexDecode("02")
+	if err := dm.Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, wantV) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, wantV, wantV)
+	}
+
+	// Register myInt type with tag number 234
+	if err := sharedTagSet.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired}, myIntType, 234); err != nil {
+		t.Fatalf("TagSet.Add(%s, %v) returned error %v", myIntType, 100, err)
+	}
+
+	// Decode myInt with tag number 234
+	wantV = myInt(3)
+	cborData = hexDecode("d8ea03")
+	if err := dm.Unmarshal(cborData, &v); err != nil {
+		t.Errorf("Unmarshal(0x%x) returned error %v", cborData, err)
+	}
+	if !reflect.DeepEqual(v, wantV) {
+		t.Errorf("Unmarshal(0x%x) = %v (%T), want %v (%T)", cborData, v, v, wantV, wantV)
+	}
+}
+
+func TestDecModeWithTagsError(t *testing.T) {
+	// Create DecMode with nil as TagSet
+	wantErrorMsg := "cbor: cannot create DecMode with nil value as TagSet"
+	dm, err := DecOptions{}.DecModeWithTags(nil)
+	if dm != nil {
+		t.Errorf("DecModeWithTags(nil) returned %v", dm)
+	}
+	if err.Error() != wantErrorMsg {
+		t.Errorf("DecModeWithTags(nil) returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+	dm, err = DecOptions{}.DecModeWithSharedTags(nil)
+	if dm != nil {
+		t.Errorf("DecModeWithSharedTags(nil) returned %v", dm)
+	}
+	if err.Error() != wantErrorMsg {
+		t.Errorf("DecModeWithSharedTags(nil) returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+
+	// Create DecMode with invalid EncOptions
+	wantErrorMsg = "cbor: invalid TimeTag 100"
+	dm, err = DecOptions{TimeTag: 100}.DecModeWithTags(NewTagSet())
+	if dm != nil {
+		t.Errorf("DecModeWithTags() returned %v", dm)
+	}
+	if err.Error() != wantErrorMsg {
+		t.Errorf("DecModeWithTags() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+	dm, err = DecOptions{TimeTag: 100}.DecModeWithSharedTags(NewTagSet())
+	if dm != nil {
+		t.Errorf("DecModeWithSharedTags() returned %v", dm)
+	}
+	if err.Error() != wantErrorMsg {
+		t.Errorf("DecModeWithSharedTags() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestEncModeWithTagsError(t *testing.T) {
+	// Create EncMode with nil as TagSet
+	wantErrorMsg := "cbor: cannot create EncMode with nil value as TagSet"
+	em, err := EncOptions{}.EncModeWithTags(nil)
+	if em != nil {
+		t.Errorf("EncModeWithTags(nil) returned %v", em)
+	}
+	if err.Error() != wantErrorMsg {
+		t.Errorf("EncModeWithTags(nil) returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+	em, err = EncOptions{}.EncModeWithSharedTags(nil)
+	if em != nil {
+		t.Errorf("EncModeWithSharedTags(nil) returned %v", em)
+	}
+	if err.Error() != wantErrorMsg {
+		t.Errorf("EncModeWithSharedTags(nil) returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+
+	// Create EncMode with invalid EncOptions
+	wantErrorMsg = "cbor: invalid TimeTag 100"
+	em, err = EncOptions{TimeTag: 100}.EncModeWithTags(NewTagSet())
+	if em != nil {
+		t.Errorf("EncModeWithTags() returned %v", em)
+	}
+	if err.Error() != wantErrorMsg {
+		t.Errorf("EncModeWithTags() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+	em, err = EncOptions{TimeTag: 100}.EncModeWithSharedTags(NewTagSet())
+	if em != nil {
+		t.Errorf("EncModeWithSharedTags() returned %v", em)
+	}
+	if err.Error() != wantErrorMsg {
+		t.Errorf("EncModeWithSharedTags() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestNilRawTagUnmarshalCBORError(t *testing.T) {
+	wantErrorMsg := "cbor.RawTag: UnmarshalCBOR on nil pointer"
+	var tag *RawTag
+	cborData := hexDecode("c249010000000000000000")
+	if err := tag.UnmarshalCBOR(cborData); err == nil {
+		t.Errorf("UnmarshalCBOR() didn't return error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("UnmarshalCBOR() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestTagUnmarshalError(t *testing.T) {
+	cborData := hexDecode("d87b61fe") // invalid UTF-8 string
+	var tag Tag
+	if err := Unmarshal(cborData, &tag); err == nil {
+		t.Errorf("Unmarshal(0x%x) didn't return error", cborData)
+	} else if err.Error() != invalidUTF8ErrorMsg {
+		t.Errorf("Unmarshal(0x%x) returned error %q, want %q", cborData, err.Error(), invalidUTF8ErrorMsg)
+	}
+}
+
+func TestTagMarshalError(t *testing.T) {
+	wantErrorMsg := "cbor: unsupported type: chan bool"
+	tag := Tag{
+		Number:  123,
+		Content: make(chan bool),
+	}
+	if _, err := Marshal(tag); err == nil {
+		t.Errorf("Marshal() didn't return error")
+	} else if err.Error() != wantErrorMsg {
+		t.Errorf("Marshal() returned error %q, want %q", err.Error(), wantErrorMsg)
+	}
+}
+
+func TestTagMarshal(t *testing.T) {
+	m := make(map[interface{}]bool)
+	m[10] = true
+	m[100] = true
+	m[-1] = true
+	m["z"] = true
+	m["aa"] = true
+	m[[1]int{100}] = true
+	m[[1]int{-1}] = true
+	m[false] = true
+
+	v := Tag{100, m}
+
+	lenFirstSortedCborData := hexDecode("d864a80af520f5f4f51864f5617af58120f5626161f5811864f5") // tag number: 100, value: map with sorted keys: 10, -1, false, 100, "z", [-1], "aa", [100]
+	bytewiseSortedCborData := hexDecode("d864a80af51864f520f5617af5626161f5811864f58120f5f4f5") // tag number: 100, value: map with sorted keys: 10, 100, -1, "z", "aa", [100], [-1], false
+
+	em, _ := EncOptions{Sort: SortLengthFirst}.EncMode()
+	b, err := em.Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, lenFirstSortedCborData) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, lenFirstSortedCborData)
+	}
+
+	em, _ = EncOptions{Sort: SortBytewiseLexical}.EncMode()
+	b, err = em.Marshal(v)
+	if err != nil {
+		t.Errorf("Marshal(%v) returned error %v", v, err)
+	}
+	if !bytes.Equal(b, bytewiseSortedCborData) {
+		t.Errorf("Marshal(%v) = 0x%x, want 0x%x", v, b, bytewiseSortedCborData)
+	}
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/valid.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/fxamacker/cbor/valid.go
@@ -1,0 +1,233 @@
+// Copyright (c) Faye Amacker. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+package cbor
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"strconv"
+)
+
+// SyntaxError is a description of a CBOR syntax error.
+type SyntaxError struct {
+	msg string
+}
+
+func (e *SyntaxError) Error() string { return e.msg }
+
+// SemanticError is a description of a CBOR semantic error.
+type SemanticError struct {
+	msg string
+}
+
+func (e *SemanticError) Error() string { return e.msg }
+
+// valid checks whether CBOR data is complete and well-formed.
+func valid(data []byte) (rest []byte, err error) {
+	if len(data) == 0 {
+		return nil, io.EOF
+	}
+	offset, _, err := validInternal(data, 0, 1)
+	if err != nil {
+		return nil, err
+	}
+	return data[offset:], nil
+}
+
+const (
+	maxNestingLevel = 32
+)
+
+// validInternal checks data's well-formedness and returns data's next offset, max depth, and error.
+func validInternal(data []byte, off int, depth int) (int, int, error) {
+	if depth > maxNestingLevel {
+		return 0, 0, errors.New("cbor: reached max depth " + strconv.Itoa(maxNestingLevel))
+	}
+
+	off, t, ai, val, err := validHead(data, off)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if ai == 31 {
+		if t == cborTypeByteString || t == cborTypeTextString {
+			return validIndefiniteString(data, off, t, depth)
+		}
+		return validIndefiniteArrOrMap(data, off, t, depth)
+	}
+
+	dataLen := len(data)
+
+	switch t {
+	case cborTypeByteString, cborTypeTextString:
+		valInt := int(val)
+		if valInt < 0 {
+			// Detect integer overflow
+			return 0, 0, errors.New("cbor: " + t.String() + " length " + strconv.FormatUint(val, 10) + " is too large, causing integer overflow")
+		}
+		if dataLen-off < valInt { // valInt+off may overflow integer
+			return 0, 0, io.ErrUnexpectedEOF
+		}
+		off += valInt
+	case cborTypeArray, cborTypeMap:
+		valInt := int(val)
+		if valInt < 0 {
+			// Detect integer overflow
+			return 0, 0, errors.New("cbor: " + t.String() + " length " + strconv.FormatUint(val, 10) + " is too large, causing integer overflow")
+		}
+		count := 1
+		if t == cborTypeMap {
+			count = 2
+		}
+		maxDepth := depth
+		for j := 0; j < count; j++ {
+			for i := 0; i < valInt; i++ {
+				var d int
+				if off, d, err = validInternal(data, off, depth+1); err != nil {
+					return 0, 0, err
+				}
+				if d > maxDepth {
+					maxDepth = d // Save max depth
+				}
+			}
+		}
+		depth = maxDepth
+	case cborTypeTag:
+		// Scan nested tag numbers to avoid recursion.
+		for {
+			if dataLen == off { // Tag number must be followed by tag content.
+				return 0, 0, io.ErrUnexpectedEOF
+			}
+			if cborType(data[off]&0xe0) != cborTypeTag {
+				break
+			}
+			if off, _, _, _, err = validHead(data, off); err != nil {
+				return 0, 0, err
+			}
+			depth++
+		}
+		// Check tag content.
+		return validInternal(data, off, depth)
+	}
+	return off, depth, nil
+}
+
+// validIndefiniteString checks indefinite length byte/text string's well-formedness and returns data's next offset, max depth, and error.
+func validIndefiniteString(data []byte, off int, t cborType, depth int) (int, int, error) {
+	var err error
+	dataLen := len(data)
+	for {
+		if dataLen == off {
+			return 0, 0, io.ErrUnexpectedEOF
+		}
+		if data[off] == 0xff {
+			off++
+			break
+		}
+		// Peek ahead to get next type and indefinite length status.
+		nt := cborType(data[off] & 0xe0)
+		if t != nt {
+			return 0, 0, &SyntaxError{"cbor: wrong element type " + nt.String() + " for indefinite-length " + t.String()}
+		}
+		if (data[off] & 0x1f) == 31 {
+			return 0, 0, &SyntaxError{"cbor: indefinite-length " + t.String() + " chunk is not definite-length"}
+		}
+		if off, depth, err = validInternal(data, off, depth); err != nil {
+			return 0, 0, err
+		}
+	}
+	return off, depth, nil
+}
+
+// validIndefiniteArrOrMap checks indefinite length array/map's well-formedness and returns data's next offset, max depth, and error.
+func validIndefiniteArrOrMap(data []byte, off int, t cborType, depth int) (int, int, error) {
+	var err error
+	maxDepth := depth
+	dataLen := len(data)
+	i := 0
+	for {
+		if dataLen == off {
+			return 0, 0, io.ErrUnexpectedEOF
+		}
+		if data[off] == 0xff {
+			off++
+			break
+		}
+		var d int
+		if off, d, err = validInternal(data, off, depth+1); err != nil {
+			return 0, 0, err
+		}
+		if d > maxDepth {
+			maxDepth = d
+		}
+		i++
+	}
+	if t == cborTypeMap && i%2 == 1 {
+		return 0, 0, &SyntaxError{"cbor: unexpected \"break\" code"}
+	}
+	return off, maxDepth, nil
+}
+
+func validHead(data []byte, off int) (_ int, t cborType, ai byte, val uint64, err error) {
+	dataLen := len(data) - off
+	if dataLen == 0 {
+		return 0, 0, 0, 0, io.ErrUnexpectedEOF
+	}
+
+	t = cborType(data[off] & 0xe0)
+	ai = data[off] & 0x1f
+	val = uint64(ai)
+	off++
+
+	if ai < 24 {
+		return off, t, ai, val, nil
+	}
+	if ai == 24 {
+		if dataLen < 2 {
+			return 0, 0, 0, 0, io.ErrUnexpectedEOF
+		}
+		val = uint64(data[off])
+		off++
+		if t == cborTypePrimitives && val < 32 {
+			return 0, 0, 0, 0, &SyntaxError{"cbor: invalid simple value " + strconv.Itoa(int(val)) + " for type " + t.String()}
+		}
+		return off, t, ai, val, nil
+	}
+	if ai == 25 {
+		if dataLen < 3 {
+			return 0, 0, 0, 0, io.ErrUnexpectedEOF
+		}
+		val = uint64(binary.BigEndian.Uint16(data[off : off+2]))
+		off += 2
+		return off, t, ai, val, nil
+	}
+	if ai == 26 {
+		if dataLen < 5 {
+			return 0, 0, 0, 0, io.ErrUnexpectedEOF
+		}
+		val = uint64(binary.BigEndian.Uint32(data[off : off+4]))
+		off += 4
+		return off, t, ai, val, nil
+	}
+	if ai == 27 {
+		if dataLen < 9 {
+			return 0, 0, 0, 0, io.ErrUnexpectedEOF
+		}
+		val = binary.BigEndian.Uint64(data[off : off+8])
+		off += 8
+		return off, t, ai, val, nil
+	}
+	if ai == 31 {
+		switch t {
+		case cborTypePositiveInt, cborTypeNegativeInt, cborTypeTag:
+			return 0, 0, 0, 0, &SyntaxError{"cbor: invalid additional information " + strconv.Itoa(int(ai)) + " for type " + t.String()}
+		case cborTypePrimitives: // 0xff (break code) should not be outside validIndefinite().
+			return 0, 0, 0, 0, &SyntaxError{"cbor: unexpected \"break\" code"}
+		}
+		return off, t, ai, val, nil
+	}
+	// ai == 28, 29, 30
+	return 0, 0, 0, 0, &SyntaxError{"cbor: invalid additional information " + strconv.Itoa(int(ai)) + " for type " + t.String()}
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/.golangci.yml
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/.golangci.yml
@@ -1,0 +1,73 @@
+# github.com/x448/float16/.golangci.yml
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - dupl    
+    - errcheck
+    - goconst
+    - gocyclo
+    - gofmt
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - maligned
+    - misspell
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+   
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gomnd
+        - lll
+
+# Do not remove linters-settings, some extra linters like gocritic are enabled from Github Actions or cli.
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - paramTypeCombine
+      - whyNoLint
+      - wrapperFunc    
+  gocyclo:
+    min-complexity: 15
+  gofmt:
+    simplify: false    
+  goimports:
+    local-prefixes: github.com/x448/float16
+  golint:
+    min-confidence: 0
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US

--- a/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/LICENSE
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-present Montgomery Edwards⁴⁴⁸ and Faye Amacker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/README.md
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/README.md
@@ -1,0 +1,135 @@
+# Float16 (Binary16) in Go/Golang
+[![](https://github.com/x448/float16/workflows/ci/badge.svg)](https://github.com/x448/float16/actions?query=workflow%3Aci)
+[![](https://github.com/x448/float16/workflows/cover%20100%25/badge.svg)](https://github.com/x448/float16/actions?query=workflow%3A%22cover+100%25%22)
+[![](https://github.com/x448/float16/workflows/linters/badge.svg)](https://github.com/x448/float16/actions?query=workflow%3Alinters)
+[![Go Report Card](https://goreportcard.com/badge/github.com/x448/float16)](https://goreportcard.com/report/github.com/x448/float16)
+[![Release](https://img.shields.io/github/release/x448/float16.svg?style=flat-square)](https://github.com/x448/float16/releases)
+[![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/x448/float16/master/LICENSE)
+
+[__`x448/float16`__](https://github.com/x448/float16) package provides [IEEE 754 half-precision floating-point format (binary16)](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) with IEEE 754 default rounding for conversions. IEEE 754-2008 refers to this 16-bit floating-point format as binary16.
+
+IEEE 754 default rounding ("Round-to-Nearest RoundTiesToEven") is considered the most accurate and statistically unbiased estimate of the true result.
+
+All possible 4+ billion floating-point conversions with this library are verified to be correct.
+
+Lowercase "float16" refers to IEEE 754 binary16. And capitalized "Float16" refers to exported Go data type.
+
+## Features
+Current features include:
+
+* float16 to float32 conversions use lossless conversion.
+* float32 to float16 conversions use IEEE 754-2008 "Round-to-Nearest RoundTiesToEven".
+* conversions using pure Go take about 2.65 ns/op on a desktop amd64.
+* unit tests provide 100% code coverage and check all possible 4+ billion conversions.
+* other functions include: IsInf(), IsNaN(), IsNormal(), PrecisionFromfloat32(), String(), etc.
+* all functions in this library use zero allocs except String().
+
+## Status
+This library is used by [fxamacker/cbor](https://github.com/fxamacker/cbor) and is ready for production use on supported platforms. The version number < 1.0 indicates more functions and options are planned but not yet published.
+
+Current status:
+
+* Core API is done and breaking API changes are unlikely.
+* 100% of unit tests pass:
+  * short mode (`go test -short`) tests around 65765 conversions in 0.005s.  
+  * normal mode (`go test`) tests all possible 4+ billion conversions in about 95s.  
+* 100% code coverage with both short mode and normal mode.  
+* Tested on amd64, arm64, ppc64le, and s390x.
+ 
+Roadmap:
+
+* Add functions for fast batch conversions leveraging SIMD when supported by hardware.
+* Speed up unit test when verifying all possible 4+ billion conversions.
+ 
+## Float16 to Float32 Conversion
+Conversions from float16 to float32 are lossless conversions.  All 65536 possible float16 to float32 conversions (in pure Go) are confirmed to be correct.  
+
+Unit tests take a fraction of a second to check all 65536 expected values for float16 to float32 conversions.
+
+## Float32 to Float16 Conversion
+Conversions from float32 to float16 use IEEE 754 default rounding ("Round-to-Nearest RoundTiesToEven").  All 4294967296 possible float32 to float16 conversions (in pure Go) are confirmed to be correct.  
+
+Unit tests in normal mode take about 1-2 minutes to check all 4+ billion float32 input values and results for Fromfloat32(), FromNaN32ps(), and PrecisionFromfloat32(). 
+
+Unit tests in short mode use a small subset (around 229 float32 inputs) and finish in under 0.01 second while still reaching 100% code coverage.
+
+## Usage
+Install with `go get github.com/x448/float16`.
+```
+// Convert float32 to float16
+pi := float32(math.Pi)
+pi16 := float16.Fromfloat32(pi)
+
+// Convert float16 to float32
+pi32 := pi16.Float32()
+
+// PrecisionFromfloat32() is faster than the overhead of calling a function.
+// This example only converts if there's no data loss and input is not a subnormal.
+if float16.PrecisionFromfloat32(pi) == float16.PrecisionExact {
+    pi16 := float16.Fromfloat32(pi)
+}
+```
+
+## Float16 Type and API
+Float16 (capitalized) is a Go type with uint16 as the underlying state.  There are 6 exported functions and 9 exported methods.
+```
+package float16 // import "github.com/x448/float16"
+
+// Exported types and consts
+type Float16 uint16
+const ErrInvalidNaNValue = float16Error("float16: invalid NaN value, expected IEEE 754 NaN")
+
+// Exported functions
+Fromfloat32(f32 float32) Float16   // Float16 number converted from f32 using IEEE 754 default rounding
+                                      with identical results to AMD and Intel F16C hardware. NaN inputs 
+                                      are converted with quiet bit always set on, to be like F16C.
+
+FromNaN32ps(nan float32) (Float16, error)   // Float16 NaN without modifying quiet bit.
+                                            // The "ps" suffix means "preserve signaling".
+                                            // Returns sNaN and ErrInvalidNaNValue if nan isn't a NaN.
+                                 
+Frombits(b16 uint16) Float16       // Float16 number corresponding to b16 (IEEE 754 binary16 rep.)
+NaN() Float16                      // Float16 of IEEE 754 binary16 not-a-number
+Inf(sign int) Float16              // Float16 of IEEE 754 binary16 infinity according to sign
+
+PrecisionFromfloat32(f32 float32) Precision  // quickly indicates exact, ..., overflow, underflow
+                                             // (inline and < 1 ns/op)
+// Exported methods
+(f Float16) Float32() float32      // float32 number converted from f16 using lossless conversion
+(f Float16) Bits() uint16          // the IEEE 754 binary16 representation of f
+(f Float16) IsNaN() bool           // true if f is not-a-number (NaN)
+(f Float16) IsQuietNaN() bool      // true if f is a quiet not-a-number (NaN)
+(f Float16) IsInf(sign int) bool   // true if f is infinite based on sign (-1=NegInf, 0=any, 1=PosInf)
+(f Float16) IsFinite() bool        // true if f is not infinite or NaN
+(f Float16) IsNormal() bool        // true if f is not zero, infinite, subnormal, or NaN.
+(f Float16) Signbit() bool         // true if f is negative or negative zero
+(f Float16) String() string        // string representation of f to satisfy fmt.Stringer interface
+```
+See [API](https://godoc.org/github.com/x448/float16) at godoc.org for more info.
+
+## Benchmarks
+Conversions (in pure Go) are around 2.65 ns/op for float16 -> float32 and float32 -> float16 on amd64. Speeds can vary depending on input value.
+
+```
+All functions have zero allocations except float16.String().
+
+FromFloat32pi-2  2.59ns ± 0%    // speed using Fromfloat32() to convert a float32 of math.Pi to Float16
+ToFloat32pi-2    2.69ns ± 0%    // speed using Float32() to convert a float16 of math.Pi to float32
+Frombits-2       0.29ns ± 5%    // speed using Frombits() to cast a uint16 to Float16
+
+PrecisionFromFloat32-2  0.29ns ± 1%  // speed using PrecisionFromfloat32() to check for overflows, etc.
+```
+
+## System Requirements
+* Go 1.12 (or newer).
+* amd64, arm64, ppc64le, or s390x.
+
+Other architectures and Go versions may work, but are not tested regularly.
+
+## Special Thanks
+Special thanks to Kathryn Long (starkat99) for creating [half-rs](https://github.com/starkat99/half-rs), a very nice rust implementation of float16.
+
+## License
+Copyright © 2019-present Montgomery Edwards⁴⁴⁸ and Faye Amacker.
+
+x448/float16 is licensed under the MIT License.  See [LICENSE](LICENSE) for the full license text.

--- a/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/changeset.txt
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/changeset.txt
@@ -1,0 +1,2 @@
+master
+e05feda6110a1a856d5e652ddadf51b54b7c9e0a

--- a/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/float16.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/float16.go
@@ -1,0 +1,302 @@
+// Copyright 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
+//
+// Special thanks to Kathryn Long for her Rust implementation
+// of float16 at github.com/starkat99/half-rs (MIT license)
+
+package float16
+
+import (
+	"math"
+	"strconv"
+)
+
+// Float16 represents IEEE 754 half-precision floating-point numbers (binary16).
+type Float16 uint16
+
+// Precision indicates whether the conversion to Float16 is
+// exact, subnormal without dropped bits, inexact, underflow, or overflow.
+type Precision int
+
+const (
+
+	// PrecisionExact is for non-subnormals that don't drop bits during conversion.
+	// All of these can round-trip.  Should always convert to float16.
+	PrecisionExact Precision = iota
+
+	// PrecisionUnknown is for subnormals that don't drop bits during conversion but
+	// not all of these can round-trip so precision is unknown without more effort.
+	// Only 2046 of these can round-trip and the rest cannot round-trip.
+	PrecisionUnknown
+
+	// PrecisionInexact is for dropped significand bits and cannot round-trip.
+	// Some of these are subnormals. Cannot round-trip float32->float16->float32.
+	PrecisionInexact
+
+	// PrecisionUnderflow is for Underflows. Cannot round-trip float32->float16->float32.
+	PrecisionUnderflow
+
+	// PrecisionOverflow is for Overflows. Cannot round-trip float32->float16->float32.
+	PrecisionOverflow
+)
+
+// PrecisionFromfloat32 returns Precision without performing
+// the conversion.  Conversions from both Infinity and NaN
+// values will always report PrecisionExact even if NaN payload
+// or NaN-Quiet-Bit is lost. This function is kept simple to
+// allow inlining and run < 0.5 ns/op, to serve as a fast filter.
+func PrecisionFromfloat32(f32 float32) Precision {
+	u32 := math.Float32bits(f32)
+
+	if u32 == 0 || u32 == 0x80000000 {
+		// +- zero will always be exact conversion
+		return PrecisionExact
+	}
+
+	const COEFMASK uint32 = 0x7fffff // 23 least significant bits
+	const EXPSHIFT uint32 = 23
+	const EXPBIAS uint32 = 127
+	const EXPMASK uint32 = uint32(0xff) << EXPSHIFT
+	const DROPMASK uint32 = COEFMASK >> 10
+
+	exp := int32(((u32 & EXPMASK) >> EXPSHIFT) - EXPBIAS)
+	coef := u32 & COEFMASK
+
+	if exp == 128 {
+		// +- infinity or NaN
+		// apps may want to do extra checks for NaN separately
+		return PrecisionExact
+	}
+
+	// https://en.wikipedia.org/wiki/Half-precision_floating-point_format says,
+	// "Decimals between 2^−24 (minimum positive subnormal) and 2^−14 (maximum subnormal): fixed interval 2^−24"
+	if exp < -24 {
+		return PrecisionUnderflow
+	}
+	if exp > 15 {
+		return PrecisionOverflow
+	}
+	if (coef & DROPMASK) != uint32(0) {
+		// these include subnormals and non-subnormals that dropped bits
+		return PrecisionInexact
+	}
+
+	if exp < -14 {
+		// Subnormals. Caller may want to test these further.
+		// There are 2046 subnormals that can successfully round-trip f32->f16->f32
+		// and 20 of those 2046 have 32-bit input coef == 0.
+		// RFC 7049 and 7049bis Draft 12 don't precisely define "preserves value"
+		// so some protocols and libraries will choose to handle subnormals differently
+		// when deciding to encode them to CBOR float32 vs float16.
+		return PrecisionUnknown
+	}
+
+	return PrecisionExact
+}
+
+// Frombits returns the float16 number corresponding to the IEEE 754 binary16
+// representation u16, with the sign bit of u16 and the result in the same bit
+// position. Frombits(Bits(x)) == x.
+func Frombits(u16 uint16) Float16 {
+	return Float16(u16)
+}
+
+// Fromfloat32 returns a Float16 value converted from f32. Conversion uses
+// IEEE default rounding (nearest int, with ties to even).
+func Fromfloat32(f32 float32) Float16 {
+	return Float16(f32bitsToF16bits(math.Float32bits(f32)))
+}
+
+// ErrInvalidNaNValue indicates a NaN was not received.
+const ErrInvalidNaNValue = float16Error("float16: invalid NaN value, expected IEEE 754 NaN")
+
+type float16Error string
+
+func (e float16Error) Error() string { return string(e) }
+
+// FromNaN32ps converts nan to IEEE binary16 NaN while preserving both
+// signaling and payload. Unlike Fromfloat32(), which can only return
+// qNaN because it sets quiet bit = 1, this can return both sNaN and qNaN.
+// If the result is infinity (sNaN with empty payload), then the
+// lowest bit of payload is set to make the result a NaN.
+// Returns ErrInvalidNaNValue and 0x7c01 (sNaN) if nan isn't IEEE 754 NaN.
+// This function was kept simple to be able to inline.
+func FromNaN32ps(nan float32) (Float16, error) {
+	const SNAN = Float16(uint16(0x7c01)) // signaling NaN
+
+	u32 := math.Float32bits(nan)
+	sign := u32 & 0x80000000
+	exp := u32 & 0x7f800000
+	coef := u32 & 0x007fffff
+
+	if (exp != 0x7f800000) || (coef == 0) {
+		return SNAN, ErrInvalidNaNValue
+	}
+
+	u16 := uint16((sign >> 16) | uint32(0x7c00) | (coef >> 13))
+
+	if (u16 & 0x03ff) == 0 {
+		// result became infinity, make it NaN by setting lowest bit in payload
+		u16 |= 0x0001
+	}
+
+	return Float16(u16), nil
+}
+
+// NaN returns a Float16 of IEEE 754 binary16 not-a-number (NaN).
+// Returned NaN value 0x7e01 has all exponent bits = 1 with the
+// first and last bits = 1 in the significand. This is consistent
+// with Go's 64-bit math.NaN(). Canonical CBOR in RFC 7049 uses 0x7e00.
+func NaN() Float16 {
+	return Float16(0x7e01)
+}
+
+// Inf returns a Float16 with an infinity value with the specified sign.
+// A sign >= returns positive infinity.
+// A sign < 0 returns negative infinity.
+func Inf(sign int) Float16 {
+	if sign >= 0 {
+		return Float16(0x7c00)
+	}
+	return Float16(0x8000 | 0x7c00)
+}
+
+// Float32 returns a float32 converted from f (Float16).
+// This is a lossless conversion.
+func (f Float16) Float32() float32 {
+	u32 := f16bitsToF32bits(uint16(f))
+	return math.Float32frombits(u32)
+}
+
+// Bits returns the IEEE 754 binary16 representation of f, with the sign bit
+// of f and the result in the same bit position. Bits(Frombits(x)) == x.
+func (f Float16) Bits() uint16 {
+	return uint16(f)
+}
+
+// IsNaN reports whether f is an IEEE 754 binary16 “not-a-number” value.
+func (f Float16) IsNaN() bool {
+	return (f&0x7c00 == 0x7c00) && (f&0x03ff != 0)
+}
+
+// IsQuietNaN reports whether f is a quiet (non-signaling) IEEE 754 binary16
+// “not-a-number” value.
+func (f Float16) IsQuietNaN() bool {
+	return (f&0x7c00 == 0x7c00) && (f&0x03ff != 0) && (f&0x0200 != 0)
+}
+
+// IsInf reports whether f is an infinity (inf).
+// A sign > 0 reports whether f is positive inf.
+// A sign < 0 reports whether f is negative inf.
+// A sign == 0 reports whether f is either inf.
+func (f Float16) IsInf(sign int) bool {
+	return ((f == 0x7c00) && sign >= 0) ||
+		(f == 0xfc00 && sign <= 0)
+}
+
+// IsFinite returns true if f is neither infinite nor NaN.
+func (f Float16) IsFinite() bool {
+	return (uint16(f) & uint16(0x7c00)) != uint16(0x7c00)
+}
+
+// IsNormal returns true if f is neither zero, infinite, subnormal, or NaN.
+func (f Float16) IsNormal() bool {
+	exp := uint16(f) & uint16(0x7c00)
+	return (exp != uint16(0x7c00)) && (exp != 0)
+}
+
+// Signbit reports whether f is negative or negative zero.
+func (f Float16) Signbit() bool {
+	return (uint16(f) & uint16(0x8000)) != 0
+}
+
+// String satisfies the fmt.Stringer interface.
+func (f Float16) String() string {
+	return strconv.FormatFloat(float64(f.Float32()), 'f', -1, 32)
+}
+
+// f16bitsToF32bits returns uint32 (float32 bits) converted from specified uint16.
+func f16bitsToF32bits(in uint16) uint32 {
+	// All 65536 conversions with this were confirmed to be correct
+	// by Montgomery Edwards⁴⁴⁸ (github.com/x448).
+
+	sign := uint32(in&0x8000) << 16 // sign for 32-bit
+	exp := uint32(in&0x7c00) >> 10  // exponenent for 16-bit
+	coef := uint32(in&0x03ff) << 13 // significand for 32-bit
+
+	if exp == 0x1f {
+		if coef == 0 {
+			// infinity
+			return sign | 0x7f800000 | coef
+		}
+		// NaN
+		return sign | 0x7fc00000 | coef
+	}
+
+	if exp == 0 {
+		if coef == 0 {
+			// zero
+			return sign
+		}
+
+		// normalize subnormal numbers
+		exp++
+		for coef&0x7f800000 == 0 {
+			coef <<= 1
+			exp--
+		}
+		coef &= 0x007fffff
+	}
+
+	return sign | ((exp + (0x7f - 0xf)) << 23) | coef
+}
+
+// f32bitsToF16bits returns uint16 (Float16 bits) converted from the specified float32.
+// Conversion rounds to nearest integer with ties to even.
+func f32bitsToF16bits(u32 uint32) uint16 {
+	// Translated from Rust to Go by Montgomery Edwards⁴⁴⁸ (github.com/x448).
+	// All 4294967296 conversions with this were confirmed to be correct by x448.
+	// Original Rust implementation is by Kathryn Long (github.com/starkat99) with MIT license.
+
+	sign := u32 & 0x80000000
+	exp := u32 & 0x7f800000
+	coef := u32 & 0x007fffff
+
+	if exp == 0x7f800000 {
+		// NaN or Infinity
+		nanBit := uint32(0)
+		if coef != 0 {
+			nanBit = uint32(0x0200)
+		}
+		return uint16((sign >> 16) | uint32(0x7c00) | nanBit | (coef >> 13))
+	}
+
+	halfSign := sign >> 16
+
+	unbiasedExp := int32(exp>>23) - 127
+	halfExp := unbiasedExp + 15
+
+	if halfExp >= 0x1f {
+		return uint16(halfSign | uint32(0x7c00))
+	}
+
+	if halfExp <= 0 {
+		if 14-halfExp > 24 {
+			return uint16(halfSign)
+		}
+		c := coef | uint32(0x00800000)
+		halfCoef := c >> uint32(14-halfExp)
+		roundBit := uint32(1) << uint32(13-halfExp)
+		if (c&roundBit) != 0 && (c&(3*roundBit-1)) != 0 {
+			halfCoef++
+		}
+		return uint16(halfSign | halfCoef)
+	}
+
+	uHalfExp := uint32(halfExp) << 10
+	halfCoef := coef >> 13
+	roundBit := uint32(0x00001000)
+	if (coef&roundBit) != 0 && (coef&(3*roundBit-1)) != 0 {
+		return uint16((halfSign | uHalfExp | halfCoef) + 1)
+	}
+	return uint16(halfSign | uHalfExp | halfCoef)
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/float16_bench_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/float16_bench_test.go
@@ -1,0 +1,88 @@
+// Copyright 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
+
+package float16_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/x448/float16"
+)
+
+// prevent compiler optimizing out code by assigning to these
+var resultF16 float16.Float16
+var resultF32 float32
+var resultStr string
+var pcn float16.Precision
+
+func BenchmarkFloat32pi(b *testing.B) {
+	result := float32(0)
+	pi32 := float32(math.Pi)
+	pi16 := float16.Fromfloat32(pi32)
+	for i := 0; i < b.N; i++ {
+		f16 := float16.Frombits(uint16(pi16))
+		result = f16.Float32()
+	}
+	resultF32 = result
+}
+
+func BenchmarkFrombits(b *testing.B) {
+	result := float16.Float16(0)
+	pi32 := float32(math.Pi)
+	pi16 := float16.Fromfloat32(pi32)
+	for i := 0; i < b.N; i++ {
+		result = float16.Frombits(uint16(pi16))
+	}
+	resultF16 = result
+}
+
+func BenchmarkFromFloat32pi(b *testing.B) {
+	result := float16.Float16(0)
+
+	pi := float32(math.Pi)
+	for i := 0; i < b.N; i++ {
+		result = float16.Fromfloat32(pi)
+	}
+	resultF16 = result
+}
+
+func BenchmarkFromFloat32nan(b *testing.B) {
+	result := float16.Float16(0)
+
+	nan := float32(math.NaN())
+	for i := 0; i < b.N; i++ {
+		result = float16.Fromfloat32(nan)
+	}
+	resultF16 = result
+}
+
+func BenchmarkFromFloat32subnorm(b *testing.B) {
+	result := float16.Float16(0)
+
+	subnorm := math.Float32frombits(0x007fffff)
+	for i := 0; i < b.N; i++ {
+		result = float16.Fromfloat32(subnorm)
+	}
+	resultF16 = result
+}
+
+func BenchmarkPrecisionFromFloat32(b *testing.B) {
+	var result float16.Precision
+
+	for i := 0; i < b.N; i++ {
+		f32 := float32(0.00001) + float32(0.00001)
+		result = float16.PrecisionFromfloat32(f32)
+	}
+	pcn = result
+}
+
+func BenchmarkString(b *testing.B) {
+	var result string
+
+	pi32 := float32(math.Pi)
+	pi16 := float16.Fromfloat32(pi32)
+	for i := 0; i < b.N; i++ {
+		result = pi16.String()
+	}
+	resultStr = result
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/float16_test.go
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/float16_test.go
@@ -1,0 +1,798 @@
+// Copyright 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
+
+package float16_test
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/x448/float16"
+)
+
+// wantF32toF16bits is a tiny subset of expected values
+var wantF32toF16bits = []struct {
+	in  float32
+	out uint16
+}{
+	// generated to provide 100% code coverage plus additional tests for rounding, etc.
+	{in: math.Float32frombits(0x00000000), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x00000001), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x00001fff), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x00002000), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x00003fff), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x00004000), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x007fffff), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x00800000), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x33000000), out: 0x0000}, // in f32=0.000000, out f16=0
+	{in: math.Float32frombits(0x33000001), out: 0x0001}, // in f32=0.000000, out f16=0.000000059604645
+	{in: math.Float32frombits(0x33000002), out: 0x0001}, // in f32=0.000000, out f16=0.000000059604645
+	{in: math.Float32frombits(0x387fc000), out: 0x03ff}, // in f32=0.000061, out f16=0.00006097555 // exp32=-15 (underflows binary16 exp) but round-trips
+	{in: math.Float32frombits(0x387fffff), out: 0x0400}, // in f32=0.000061, out f16=0.000061035156
+	{in: math.Float32frombits(0x38800000), out: 0x0400}, // in f32=0.000061, out f16=0.000061035156
+	{in: math.Float32frombits(0x38801fff), out: 0x0401}, // in f32=0.000061, out f16=0.00006109476
+	{in: math.Float32frombits(0x38802000), out: 0x0401}, // in f32=0.000061, out f16=0.00006109476
+	{in: math.Float32frombits(0x38803fff), out: 0x0402}, // in f32=0.000061, out f16=0.000061154366
+	{in: math.Float32frombits(0x38804000), out: 0x0402}, // in f32=0.000061, out f16=0.000061154366
+	{in: math.Float32frombits(0x33bfffff), out: 0x0001}, // in f32=0.000000, out f16=0.000000059604645
+	{in: math.Float32frombits(0x33c00000), out: 0x0002}, // in f32=0.000000, out f16=0.00000011920929
+	{in: math.Float32frombits(0x33c00001), out: 0x0002}, // in f32=0.000000, out f16=0.00000011920929
+	{in: math.Float32frombits(0x477fffff), out: 0x7c00}, // in f32=65535.996094, out f16=+Inf
+	{in: math.Float32frombits(0x47800000), out: 0x7c00}, // in f32=65536.000000, out f16=+Inf
+	{in: math.Float32frombits(0x7f7fffff), out: 0x7c00}, // in f32=340282346638528859811704183484516925440.000000, out f16=+Inf
+	{in: math.Float32frombits(0x7f800000), out: 0x7c00}, // in f32=+Inf, out f16=+Inf
+	{in: math.Float32frombits(0x7f801fff), out: 0x7e00}, // in f32=NaN, out f16=NaN
+	{in: math.Float32frombits(0x7f802000), out: 0x7e01}, // in f32=NaN, out f16=NaN
+	{in: math.Float32frombits(0x7f803fff), out: 0x7e01}, // in f32=NaN, out f16=NaN
+	{in: math.Float32frombits(0x7f804000), out: 0x7e02}, // in f32=NaN, out f16=NaN
+	{in: math.Float32frombits(0x7fffffff), out: 0x7fff}, // in f32=NaN, out f16=NaN
+	{in: math.Float32frombits(0x80000000), out: 0x8000}, // in f32=-0.000000, out f16=-0
+	{in: math.Float32frombits(0x80001fff), out: 0x8000}, // in f32=-0.000000, out f16=-0
+	{in: math.Float32frombits(0x80002000), out: 0x8000}, // in f32=-0.000000, out f16=-0
+	{in: math.Float32frombits(0x80003fff), out: 0x8000}, // in f32=-0.000000, out f16=-0
+	{in: math.Float32frombits(0x80004000), out: 0x8000}, // in f32=-0.000000, out f16=-0
+	{in: math.Float32frombits(0x807fffff), out: 0x8000}, // in f32=-0.000000, out f16=-0
+	{in: math.Float32frombits(0x80800000), out: 0x8000}, // in f32=-0.000000, out f16=-0
+	{in: math.Float32frombits(0xb87fc000), out: 0x83ff}, // in f32=-0.000061, out f16=-0.00006097555 // exp32=-15 (underflows binary16 exp) but round-trips
+	{in: math.Float32frombits(0xb87fffff), out: 0x8400}, // in f32=-0.000061, out f16=-0.000061035156
+	{in: math.Float32frombits(0xb8800000), out: 0x8400}, // in f32=-0.000061, out f16=-0.000061035156
+	{in: math.Float32frombits(0xb8801fff), out: 0x8401}, // in f32=-0.000061, out f16=-0.00006109476
+	{in: math.Float32frombits(0xb8802000), out: 0x8401}, // in f32=-0.000061, out f16=-0.00006109476
+	{in: math.Float32frombits(0xb8803fff), out: 0x8402}, // in f32=-0.000061, out f16=-0.000061154366
+	{in: math.Float32frombits(0xb8804000), out: 0x8402}, // in f32=-0.000061, out f16=-0.000061154366
+	{in: math.Float32frombits(0xc77fffff), out: 0xfc00}, // in f32=-65535.996094, out f16=-Inf
+	{in: math.Float32frombits(0xc7800000), out: 0xfc00}, // in f32=-65536.000000, out f16=-Inf
+	{in: math.Float32frombits(0xff7fffff), out: 0xfc00}, // in f32=-340282346638528859811704183484516925440.000000, out f16=-Inf
+	{in: math.Float32frombits(0xff800000), out: 0xfc00}, // in f32=-Inf, out f16=-Inf
+	{in: math.Float32frombits(0xff801fff), out: 0xfe00}, // in f32=NaN, out f16=NaN
+	{in: math.Float32frombits(0xff802000), out: 0xfe01}, // in f32=NaN, out f16=NaN
+	{in: math.Float32frombits(0xff803fff), out: 0xfe01}, // in f32=NaN, out f16=NaN
+	{in: math.Float32frombits(0xff804000), out: 0xfe02}, // in f32=NaN, out f16=NaN
+	// additional tests
+	{in: math.Float32frombits(0xc77ff000), out: 0xfc00}, // in f32=-65520.000000, out f16=-Inf
+	{in: math.Float32frombits(0xc77fef00), out: 0xfbff}, // in f32=-65519.000000, out f16=-65504
+	{in: math.Float32frombits(0xc77fee00), out: 0xfbff}, // in f32=-65518.000000, out f16=-65504
+	{in: math.Float32frombits(0xc5802000), out: 0xec01}, // in f32=-4100.000000, out f16=-4100
+	{in: math.Float32frombits(0xc5801800), out: 0xec01}, // in f32=-4099.000000, out f16=-4100
+	{in: math.Float32frombits(0xc5801000), out: 0xec00}, // in f32=-4098.000000, out f16=-4096
+	{in: math.Float32frombits(0xc5800800), out: 0xec00}, // in f32=-4097.000000, out f16=-4096
+	{in: math.Float32frombits(0xc5800000), out: 0xec00}, // in f32=-4096.000000, out f16=-4096
+	{in: math.Float32frombits(0xc57ff000), out: 0xec00}, // in f32=-4095.000000, out f16=-4096
+	{in: math.Float32frombits(0xc57fe000), out: 0xebff}, // in f32=-4094.000000, out f16=-4094
+	{in: math.Float32frombits(0xc57fd000), out: 0xebfe}, // in f32=-4093.000000, out f16=-4092
+	{in: math.Float32frombits(0xc5002000), out: 0xe801}, // in f32=-2050.000000, out f16=-2050
+	{in: math.Float32frombits(0xc5001000), out: 0xe800}, // in f32=-2049.000000, out f16=-2048
+	{in: math.Float32frombits(0xc5000829), out: 0xe800}, // in f32=-2048.510010, out f16=-2048
+	{in: math.Float32frombits(0xc5000800), out: 0xe800}, // in f32=-2048.500000, out f16=-2048
+	{in: math.Float32frombits(0xc50007d7), out: 0xe800}, // in f32=-2048.489990, out f16=-2048
+	{in: math.Float32frombits(0xc5000000), out: 0xe800}, // in f32=-2048.000000, out f16=-2048
+	{in: math.Float32frombits(0xc4fff052), out: 0xe800}, // in f32=-2047.510010, out f16=-2048
+	{in: math.Float32frombits(0xc4fff000), out: 0xe800}, // in f32=-2047.500000, out f16=-2048
+	{in: math.Float32frombits(0xc4ffefae), out: 0xe7ff}, // in f32=-2047.489990, out f16=-2047
+	{in: math.Float32frombits(0xc4ffe000), out: 0xe7ff}, // in f32=-2047.000000, out f16=-2047
+	{in: math.Float32frombits(0xc4ffc000), out: 0xe7fe}, // in f32=-2046.000000, out f16=-2046
+	{in: math.Float32frombits(0xc4ffa000), out: 0xe7fd}, // in f32=-2045.000000, out f16=-2045
+	{in: math.Float32frombits(0xbf800000), out: 0xbc00}, // in f32=-1.000000, out f16=-1
+	{in: math.Float32frombits(0xbf028f5c), out: 0xb814}, // in f32=-0.510000, out f16=-0.5097656
+	{in: math.Float32frombits(0xbf000000), out: 0xb800}, // in f32=-0.500000, out f16=-0.5
+	{in: math.Float32frombits(0xbefae148), out: 0xb7d7}, // in f32=-0.490000, out f16=-0.48999023
+	{in: math.Float32frombits(0x3efae148), out: 0x37d7}, // in f32=0.490000, out f16=0.48999023
+	{in: math.Float32frombits(0x3f000000), out: 0x3800}, // in f32=0.500000, out f16=0.5
+	{in: math.Float32frombits(0x3f028f5c), out: 0x3814}, // in f32=0.510000, out f16=0.5097656
+	{in: math.Float32frombits(0x3f800000), out: 0x3c00}, // in f32=1.000000, out f16=1
+	{in: math.Float32frombits(0x3fbeb852), out: 0x3df6}, // in f32=1.490000, out f16=1.4902344
+	{in: math.Float32frombits(0x3fc00000), out: 0x3e00}, // in f32=1.500000, out f16=1.5
+	{in: math.Float32frombits(0x3fc147ae), out: 0x3e0a}, // in f32=1.510000, out f16=1.5097656
+	{in: math.Float32frombits(0x3fcf1bbd), out: 0x3e79}, // in f32=1.618034, out f16=1.6181641
+	{in: math.Float32frombits(0x401f5c29), out: 0x40fb}, // in f32=2.490000, out f16=2.4902344
+	{in: math.Float32frombits(0x40200000), out: 0x4100}, // in f32=2.500000, out f16=2.5
+	{in: math.Float32frombits(0x4020a3d7), out: 0x4105}, // in f32=2.510000, out f16=2.5097656
+	{in: math.Float32frombits(0x402df854), out: 0x4170}, // in f32=2.718282, out f16=2.71875
+	{in: math.Float32frombits(0x40490fdb), out: 0x4248}, // in f32=3.141593, out f16=3.140625
+	{in: math.Float32frombits(0x40b00000), out: 0x4580}, // in f32=5.500000, out f16=5.5
+	{in: math.Float32frombits(0x44ffa000), out: 0x67fd}, // in f32=2045.000000, out f16=2045
+	{in: math.Float32frombits(0x44ffc000), out: 0x67fe}, // in f32=2046.000000, out f16=2046
+	{in: math.Float32frombits(0x44ffe000), out: 0x67ff}, // in f32=2047.000000, out f16=2047
+	{in: math.Float32frombits(0x44ffefae), out: 0x67ff}, // in f32=2047.489990, out f16=2047
+	{in: math.Float32frombits(0x44fff000), out: 0x6800}, // in f32=2047.500000, out f16=2048
+	{in: math.Float32frombits(0x44fff052), out: 0x6800}, // in f32=2047.510010, out f16=2048
+	{in: math.Float32frombits(0x45000000), out: 0x6800}, // in f32=2048.000000, out f16=2048
+	{in: math.Float32frombits(0x450007d7), out: 0x6800}, // in f32=2048.489990, out f16=2048
+	{in: math.Float32frombits(0x45000800), out: 0x6800}, // in f32=2048.500000, out f16=2048
+	{in: math.Float32frombits(0x45000829), out: 0x6800}, // in f32=2048.510010, out f16=2048
+	{in: math.Float32frombits(0x45001000), out: 0x6800}, // in f32=2049.000000, out f16=2048
+	{in: math.Float32frombits(0x450017d7), out: 0x6801}, // in f32=2049.489990, out f16=2050
+	{in: math.Float32frombits(0x45001800), out: 0x6801}, // in f32=2049.500000, out f16=2050
+	{in: math.Float32frombits(0x45001829), out: 0x6801}, // in f32=2049.510010, out f16=2050
+	{in: math.Float32frombits(0x45002000), out: 0x6801}, // in f32=2050.000000, out f16=2050
+	{in: math.Float32frombits(0x45003000), out: 0x6802}, // in f32=2051.000000, out f16=2052
+	{in: math.Float32frombits(0x457fd000), out: 0x6bfe}, // in f32=4093.000000, out f16=4092
+	{in: math.Float32frombits(0x457fe000), out: 0x6bff}, // in f32=4094.000000, out f16=4094
+	{in: math.Float32frombits(0x457ff000), out: 0x6c00}, // in f32=4095.000000, out f16=4096
+	{in: math.Float32frombits(0x45800000), out: 0x6c00}, // in f32=4096.000000, out f16=4096
+	{in: math.Float32frombits(0x45800800), out: 0x6c00}, // in f32=4097.000000, out f16=4096
+	{in: math.Float32frombits(0x45801000), out: 0x6c00}, // in f32=4098.000000, out f16=4096
+	{in: math.Float32frombits(0x45801800), out: 0x6c01}, // in f32=4099.000000, out f16=4100
+	{in: math.Float32frombits(0x45802000), out: 0x6c01}, // in f32=4100.000000, out f16=4100
+	{in: math.Float32frombits(0x45ad9c00), out: 0x6d6d}, // in f32=5555.500000, out f16=5556
+	{in: math.Float32frombits(0x45ffe800), out: 0x6fff}, // in f32=8189.000000, out f16=8188
+	{in: math.Float32frombits(0x45fff000), out: 0x7000}, // in f32=8190.000000, out f16=8192
+	{in: math.Float32frombits(0x45fff800), out: 0x7000}, // in f32=8191.000000, out f16=8192
+	{in: math.Float32frombits(0x46000000), out: 0x7000}, // in f32=8192.000000, out f16=8192
+	{in: math.Float32frombits(0x46000400), out: 0x7000}, // in f32=8193.000000, out f16=8192
+	{in: math.Float32frombits(0x46000800), out: 0x7000}, // in f32=8194.000000, out f16=8192
+	{in: math.Float32frombits(0x46000c00), out: 0x7000}, // in f32=8195.000000, out f16=8192
+	{in: math.Float32frombits(0x46001000), out: 0x7000}, // in f32=8196.000000, out f16=8192
+	{in: math.Float32frombits(0x46001400), out: 0x7001}, // in f32=8197.000000, out f16=8200
+	{in: math.Float32frombits(0x46001800), out: 0x7001}, // in f32=8198.000000, out f16=8200
+	{in: math.Float32frombits(0x46001c00), out: 0x7001}, // in f32=8199.000000, out f16=8200
+	{in: math.Float32frombits(0x46002000), out: 0x7001}, // in f32=8200.000000, out f16=8200
+	{in: math.Float32frombits(0x46002400), out: 0x7001}, // in f32=8201.000000, out f16=8200
+	{in: math.Float32frombits(0x46002800), out: 0x7001}, // in f32=8202.000000, out f16=8200
+	{in: math.Float32frombits(0x46002c00), out: 0x7001}, // in f32=8203.000000, out f16=8200
+	{in: math.Float32frombits(0x46003000), out: 0x7002}, // in f32=8204.000000, out f16=8208
+	{in: math.Float32frombits(0x467fec00), out: 0x73ff}, // in f32=16379.000000, out f16=16376
+	{in: math.Float32frombits(0x467ff000), out: 0x7400}, // in f32=16380.000000, out f16=16384
+	{in: math.Float32frombits(0x467ff400), out: 0x7400}, // in f32=16381.000000, out f16=16384
+	{in: math.Float32frombits(0x467ff800), out: 0x7400}, // in f32=16382.000000, out f16=16384
+	{in: math.Float32frombits(0x467ffc00), out: 0x7400}, // in f32=16383.000000, out f16=16384
+	{in: math.Float32frombits(0x46800000), out: 0x7400}, // in f32=16384.000000, out f16=16384
+	{in: math.Float32frombits(0x46800200), out: 0x7400}, // in f32=16385.000000, out f16=16384
+	{in: math.Float32frombits(0x46800400), out: 0x7400}, // in f32=16386.000000, out f16=16384
+	{in: math.Float32frombits(0x46800600), out: 0x7400}, // in f32=16387.000000, out f16=16384
+	{in: math.Float32frombits(0x46800800), out: 0x7400}, // in f32=16388.000000, out f16=16384
+	{in: math.Float32frombits(0x46800a00), out: 0x7400}, // in f32=16389.000000, out f16=16384
+	{in: math.Float32frombits(0x46800c00), out: 0x7400}, // in f32=16390.000000, out f16=16384
+	{in: math.Float32frombits(0x46800e00), out: 0x7400}, // in f32=16391.000000, out f16=16384
+	{in: math.Float32frombits(0x46801000), out: 0x7400}, // in f32=16392.000000, out f16=16384
+	{in: math.Float32frombits(0x46801200), out: 0x7401}, // in f32=16393.000000, out f16=16400
+	{in: math.Float32frombits(0x46801400), out: 0x7401}, // in f32=16394.000000, out f16=16400
+	{in: math.Float32frombits(0x46801600), out: 0x7401}, // in f32=16395.000000, out f16=16400
+	{in: math.Float32frombits(0x46801800), out: 0x7401}, // in f32=16396.000000, out f16=16400
+	{in: math.Float32frombits(0x46801a00), out: 0x7401}, // in f32=16397.000000, out f16=16400
+	{in: math.Float32frombits(0x46801c00), out: 0x7401}, // in f32=16398.000000, out f16=16400
+	{in: math.Float32frombits(0x46801e00), out: 0x7401}, // in f32=16399.000000, out f16=16400
+	{in: math.Float32frombits(0x46802000), out: 0x7401}, // in f32=16400.000000, out f16=16400
+	{in: math.Float32frombits(0x46802200), out: 0x7401}, // in f32=16401.000000, out f16=16400
+	{in: math.Float32frombits(0x46802400), out: 0x7401}, // in f32=16402.000000, out f16=16400
+	{in: math.Float32frombits(0x46802600), out: 0x7401}, // in f32=16403.000000, out f16=16400
+	{in: math.Float32frombits(0x46802800), out: 0x7401}, // in f32=16404.000000, out f16=16400
+	{in: math.Float32frombits(0x46802a00), out: 0x7401}, // in f32=16405.000000, out f16=16400
+	{in: math.Float32frombits(0x46802c00), out: 0x7401}, // in f32=16406.000000, out f16=16400
+	{in: math.Float32frombits(0x46802e00), out: 0x7401}, // in f32=16407.000000, out f16=16400
+	{in: math.Float32frombits(0x46803000), out: 0x7402}, // in f32=16408.000000, out f16=16416
+	{in: math.Float32frombits(0x46ffee00), out: 0x77ff}, // in f32=32759.000000, out f16=32752
+	{in: math.Float32frombits(0x46fff000), out: 0x7800}, // in f32=32760.000000, out f16=32768
+	{in: math.Float32frombits(0x46fff200), out: 0x7800}, // in f32=32761.000000, out f16=32768
+	{in: math.Float32frombits(0x46fff400), out: 0x7800}, // in f32=32762.000000, out f16=32768
+	{in: math.Float32frombits(0x46fff600), out: 0x7800}, // in f32=32763.000000, out f16=32768
+	{in: math.Float32frombits(0x46fff800), out: 0x7800}, // in f32=32764.000000, out f16=32768
+	{in: math.Float32frombits(0x46fffa00), out: 0x7800}, // in f32=32765.000000, out f16=32768
+	{in: math.Float32frombits(0x46fffc00), out: 0x7800}, // in f32=32766.000000, out f16=32768
+	{in: math.Float32frombits(0x46fffe00), out: 0x7800}, // in f32=32767.000000, out f16=32768
+	{in: math.Float32frombits(0x47000000), out: 0x7800}, // in f32=32768.000000, out f16=32768
+	{in: math.Float32frombits(0x47000100), out: 0x7800}, // in f32=32769.000000, out f16=32768
+	{in: math.Float32frombits(0x47000200), out: 0x7800}, // in f32=32770.000000, out f16=32768
+	{in: math.Float32frombits(0x47000300), out: 0x7800}, // in f32=32771.000000, out f16=32768
+	{in: math.Float32frombits(0x47000400), out: 0x7800}, // in f32=32772.000000, out f16=32768
+	{in: math.Float32frombits(0x47000500), out: 0x7800}, // in f32=32773.000000, out f16=32768
+	{in: math.Float32frombits(0x47000600), out: 0x7800}, // in f32=32774.000000, out f16=32768
+	{in: math.Float32frombits(0x47000700), out: 0x7800}, // in f32=32775.000000, out f16=32768
+	{in: math.Float32frombits(0x47000800), out: 0x7800}, // in f32=32776.000000, out f16=32768
+	{in: math.Float32frombits(0x47000900), out: 0x7800}, // in f32=32777.000000, out f16=32768
+	{in: math.Float32frombits(0x47000a00), out: 0x7800}, // in f32=32778.000000, out f16=32768
+	{in: math.Float32frombits(0x47000b00), out: 0x7800}, // in f32=32779.000000, out f16=32768
+	{in: math.Float32frombits(0x47000c00), out: 0x7800}, // in f32=32780.000000, out f16=32768
+	{in: math.Float32frombits(0x47000d00), out: 0x7800}, // in f32=32781.000000, out f16=32768
+	{in: math.Float32frombits(0x47000e00), out: 0x7800}, // in f32=32782.000000, out f16=32768
+	{in: math.Float32frombits(0x47000f00), out: 0x7800}, // in f32=32783.000000, out f16=32768
+	{in: math.Float32frombits(0x47001000), out: 0x7800}, // in f32=32784.000000, out f16=32768
+	{in: math.Float32frombits(0x47001100), out: 0x7801}, // in f32=32785.000000, out f16=32800
+	{in: math.Float32frombits(0x47001200), out: 0x7801}, // in f32=32786.000000, out f16=32800
+	{in: math.Float32frombits(0x47001300), out: 0x7801}, // in f32=32787.000000, out f16=32800
+	{in: math.Float32frombits(0x47001400), out: 0x7801}, // in f32=32788.000000, out f16=32800
+	{in: math.Float32frombits(0x47001500), out: 0x7801}, // in f32=32789.000000, out f16=32800
+	{in: math.Float32frombits(0x47001600), out: 0x7801}, // in f32=32790.000000, out f16=32800
+	{in: math.Float32frombits(0x47001700), out: 0x7801}, // in f32=32791.000000, out f16=32800
+	{in: math.Float32frombits(0x47001800), out: 0x7801}, // in f32=32792.000000, out f16=32800
+	{in: math.Float32frombits(0x47001900), out: 0x7801}, // in f32=32793.000000, out f16=32800
+	{in: math.Float32frombits(0x47001a00), out: 0x7801}, // in f32=32794.000000, out f16=32800
+	{in: math.Float32frombits(0x47001b00), out: 0x7801}, // in f32=32795.000000, out f16=32800
+	{in: math.Float32frombits(0x47001c00), out: 0x7801}, // in f32=32796.000000, out f16=32800
+	{in: math.Float32frombits(0x47001d00), out: 0x7801}, // in f32=32797.000000, out f16=32800
+	{in: math.Float32frombits(0x47001e00), out: 0x7801}, // in f32=32798.000000, out f16=32800
+	{in: math.Float32frombits(0x47001f00), out: 0x7801}, // in f32=32799.000000, out f16=32800
+	{in: math.Float32frombits(0x47002000), out: 0x7801}, // in f32=32800.000000, out f16=32800
+	{in: math.Float32frombits(0x47002100), out: 0x7801}, // in f32=32801.000000, out f16=32800
+	{in: math.Float32frombits(0x47002200), out: 0x7801}, // in f32=32802.000000, out f16=32800
+	{in: math.Float32frombits(0x47002300), out: 0x7801}, // in f32=32803.000000, out f16=32800
+	{in: math.Float32frombits(0x47002400), out: 0x7801}, // in f32=32804.000000, out f16=32800
+	{in: math.Float32frombits(0x47002500), out: 0x7801}, // in f32=32805.000000, out f16=32800
+	{in: math.Float32frombits(0x47002600), out: 0x7801}, // in f32=32806.000000, out f16=32800
+	{in: math.Float32frombits(0x47002700), out: 0x7801}, // in f32=32807.000000, out f16=32800
+	{in: math.Float32frombits(0x47002800), out: 0x7801}, // in f32=32808.000000, out f16=32800
+	{in: math.Float32frombits(0x47002900), out: 0x7801}, // in f32=32809.000000, out f16=32800
+	{in: math.Float32frombits(0x47002a00), out: 0x7801}, // in f32=32810.000000, out f16=32800
+	{in: math.Float32frombits(0x47002b00), out: 0x7801}, // in f32=32811.000000, out f16=32800
+	{in: math.Float32frombits(0x47002c00), out: 0x7801}, // in f32=32812.000000, out f16=32800
+	{in: math.Float32frombits(0x47002d00), out: 0x7801}, // in f32=32813.000000, out f16=32800
+	{in: math.Float32frombits(0x47002e00), out: 0x7801}, // in f32=32814.000000, out f16=32800
+	{in: math.Float32frombits(0x47002f00), out: 0x7801}, // in f32=32815.000000, out f16=32800
+	{in: math.Float32frombits(0x47003000), out: 0x7802}, // in f32=32816.000000, out f16=32832
+	{in: math.Float32frombits(0x477fe500), out: 0x7bff}, // in f32=65509.000000, out f16=65504
+	{in: math.Float32frombits(0x477fe100), out: 0x7bff}, // in f32=65505.000000, out f16=65504
+	{in: math.Float32frombits(0x477fee00), out: 0x7bff}, // in f32=65518.000000, out f16=65504
+	{in: math.Float32frombits(0x477fef00), out: 0x7bff}, // in f32=65519.000000, out f16=65504
+	{in: math.Float32frombits(0x477feffd), out: 0x7bff}, // in f32=65519.988281, out f16=65504
+	{in: math.Float32frombits(0x477ff000), out: 0x7c00}, // in f32=65520.000000, out f16=+Inf
+}
+
+func TestPrecisionFromfloat32(t *testing.T) {
+	for i, v := range wantF32toF16bits {
+		f16 := float16.Fromfloat32(v.in)
+		u16 := uint16(f16)
+
+		if u16 != v.out {
+			t.Errorf("i=%d, in f32bits=0x%08x, wanted=0x%04x, got=0x%04x.", i, math.Float32bits(v.in), v.out, u16)
+		}
+
+		checkPrecision(t, v.in, f16, uint64(i))
+	}
+
+	f32 := float32(5.5) // value that doesn't drop any bits in the significand, is within normal exponent range
+	pre := float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionExact {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionExact (%d), got=%d.", math.Float32bits(f32), float16.PrecisionExact, pre)
+	}
+
+	f32 = math.Float32frombits(0x38000000) // subnormal value with coef = 0 that can round-trip float32->float16->float32
+	pre = float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionUnknown {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionUnknown (%d), got=%d.", math.Float32bits(f32), float16.PrecisionUnknown, pre)
+	}
+
+	f32 = math.Float32frombits(0x387fc000) // subnormal value with coef !=0 that can round-trip float32->float16->float32
+	pre = float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionUnknown {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionUnknown (%d), got=%d.", math.Float32bits(f32), float16.PrecisionUnknown, pre)
+	}
+
+	f32 = math.Float32frombits(0x33c00000) // subnormal value with no dropped bits that cannot round-trip float32->float16->float32
+	pre = float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionUnknown {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionUnknown (%d), got=%d.", math.Float32bits(f32), float16.PrecisionUnknown, pre)
+	}
+
+	f32 = math.Float32frombits(0x38000001) // subnormal value with dropped non-zero bits > 0
+	pre = float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionInexact {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionInexact (%d), got=%d.", math.Float32bits(f32), float16.PrecisionInexact, pre)
+	}
+
+	f32 = float32(math.Pi) // value that cannot "preserve value" because it drops bits in the significand
+	pre = float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionInexact {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionInexact (%d), got=%d.", math.Float32bits(f32), float16.PrecisionInexact, pre)
+	}
+
+	f32 = math.Float32frombits(0x1) // value that will underflow
+	pre = float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionUnderflow {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionUnderflow (%d), got=%d.", math.Float32bits(f32), float16.PrecisionUnderflow, pre)
+	}
+
+	f32 = math.Float32frombits(0x33000000) // value that will underflow
+	pre = float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionUnderflow {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionUnderflow (%d), got=%d.", math.Float32bits(f32), float16.PrecisionUnderflow, pre)
+	}
+
+	f32 = math.Float32frombits(0x47800000) // value that will overflow
+	pre = float16.PrecisionFromfloat32(f32)
+	if pre != float16.PrecisionOverflow {
+		t.Errorf("f32bits=0x%08x, wanted=PrecisionOverflow (%d), got=%d.", math.Float32bits(f32), float16.PrecisionOverflow, pre)
+	}
+
+}
+
+func TestFromNaN32ps(t *testing.T) {
+	for i, v := range wantF32toF16bits {
+		f16 := float16.Fromfloat32(v.in)
+		u16 := uint16(f16)
+
+		if u16 != v.out {
+			t.Errorf("i=%d, in f32bits=0x%08x, wanted=0x%04x, got=0x%04x.", i, math.Float32bits(v.in), v.out, u16)
+		}
+
+		checkFromNaN32ps(t, v.in, f16)
+	}
+
+	// since checkFromNaN32ps rejects non-NaN input, try one here
+	nan, err := float16.FromNaN32ps(float32(math.Pi))
+	if err != float16.ErrInvalidNaNValue {
+		t.Errorf("FromNaN32ps: in float32(math.Pi) wanted err float16.ErrInvalidNaNValue, got err = %q", err)
+	}
+	if err.Error() != "float16: invalid NaN value, expected IEEE 754 NaN" {
+		t.Errorf("unexpected string value returned by err.Error() for ErrInvalidNaNValue: %s", err.Error())
+	}
+	if uint16(nan) != 0x7c01 { // signaling NaN
+		t.Errorf("FromNaN32ps: in float32(math.Pi) wanted nan = 0x7c01, got nan = 0x%04x", uint16(nan))
+	}
+
+}
+
+// Test a small subset of possible conversions from float32 to Float16.
+// TestSomeFromFloat32 runs in under 1 second while TestAllFromFloat32 takes about 45 seconds.
+func TestSomeFromFloat32(t *testing.T) {
+
+	for i, v := range wantF32toF16bits {
+		f16 := float16.Fromfloat32(v.in)
+		u16 := uint16(f16)
+
+		if u16 != v.out {
+			t.Errorf("i=%d, in f32bits=0x%08x, wanted=0x%04x, got=0x%04x.", i, math.Float32bits(v.in), v.out, u16)
+		}
+	}
+}
+
+// Test all possible 4294967296 float32 input values and results for
+// Fromfloat32(), FromNaN32ps(), and PrecisionFromfloat32().
+func TestAllFromFloat32(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping TestAllFromFloat32 in short mode.")
+	}
+
+	fmt.Printf("WARNING: TestAllFromFloat32 should take about 1-2 minutes to run on amd64, other platforms may take longer...\n")
+
+	// Blake2b is "3f310bc5608a087462d361644fe66feeb4c68145f6f18eb6f1439cd7914888b6df9e30ae5350dce0635162cc6a2f23b31b3e4353ca132a3c552bdbd58baa54e6"
+	const wantSHA512 = "08670429a475164d6c4a080969e35231c77ef7069b430b5f38af22e013796b7818bbe8f5942a6ddf26de0e1dfc67d02243f483d85729ebc3762fc2948a5ca1f8"
+
+	const batchSize uint32 = 16384
+	results := make([]uint16, batchSize)
+	buf := new(bytes.Buffer)
+	h := sha512.New()
+
+	for i := uint64(0); i < uint64(0xFFFFFFFF); i += uint64(batchSize) {
+		// fill results
+		for j := uint32(0); j < batchSize; j++ {
+			inF32 := math.Float32frombits(uint32(i) + j)
+			f16 := float16.Fromfloat32(inF32)
+			results[j] = uint16(f16)
+			checkPrecision(t, inF32, f16, i)
+			checkFromNaN32ps(t, inF32, f16)
+		}
+
+		// convert results to []byte
+		err := binary.Write(buf, binary.LittleEndian, results)
+		if err != nil {
+			panic(err)
+		}
+
+		// update hash with []byte of results
+		_, err = h.Write(buf.Bytes())
+		if err != nil {
+			panic(err)
+		}
+
+		buf.Reset()
+	}
+
+	// display hash digest in hex
+	digest := h.Sum(nil)
+	gotSHA512hex := hex.EncodeToString(digest)
+	if gotSHA512hex != wantSHA512 {
+		t.Errorf("gotSHA512hex = %s", gotSHA512hex)
+	}
+}
+
+// Test all 65536 conversions from float16 to float32.
+// TestAllToFloat32 runs in under 1 second.
+func TestAllToFloat32(t *testing.T) {
+	// Blake2b is "078d8e3fac9480de1493f22c8f9bfc1eb2051537c536f00f621557d70eed1af057a487c3e252f6d593769f5288d5ab66d8e9cd1adba359838802944bdb731f4d"
+	const wantSHA512 = "1a4ccec9fd7b6e83310c6b4958a25778cd95f8d4f88b19950e4b8d6932a955f7fbd96b1c9bd9b2a79c3a9d34d653f55e671f8f86e6a5a876660cd38479001aa6"
+	const batchSize uint32 = 16384
+	results := make([]float32, batchSize)
+	buf := new(bytes.Buffer)
+	h := sha512.New()
+
+	for i := uint64(0); i < uint64(0xFFFF); i += uint64(batchSize) {
+		// fill results
+		for j := uint32(0); j < batchSize; j++ {
+			inU16 := uint16(i) + uint16(j)
+			f16 := float16.Float16(inU16)
+			results[j] = f16.Float32()
+		}
+
+		// convert results to []byte
+		err := binary.Write(buf, binary.LittleEndian, results)
+		if err != nil {
+			panic(err)
+		}
+
+		// update hash with []byte of results
+		_, err = h.Write(buf.Bytes())
+		if err != nil {
+			panic(err)
+		}
+
+		buf.Reset()
+	}
+
+	// display hash digest in hex
+	digest := h.Sum(nil)
+	gotSHA512hex := hex.EncodeToString(digest)
+	if gotSHA512hex != wantSHA512 {
+		t.Errorf("Float16toFloat32: gotSHA512hex = %s", gotSHA512hex)
+	}
+
+}
+
+func TestFrombits(t *testing.T) {
+	x := uint16(0x1234)
+	f16 := float16.Frombits(x)
+	if uint16(f16) != f16.Bits() || uint16(f16) != x {
+		t.Errorf("float16.Frombits(0x7fff) returned %04x, wanted %04x", uint16(f16), x)
+	}
+}
+
+func TestNaN(t *testing.T) {
+	nan := float16.NaN()
+	if !nan.IsNaN() {
+		t.Errorf("nan.IsNaN() returned false, wanted true")
+	}
+}
+
+func TestInf(t *testing.T) {
+	posInf := float16.Inf(0)
+	if uint16(posInf) != 0x7c00 {
+		t.Errorf("float16.Inf(0) returned %04x, wanted %04x", uint16(posInf), 0x7c00)
+	}
+
+	posInf = float16.Inf(1)
+	if uint16(posInf) != 0x7c00 {
+		t.Errorf("float16.Inf(1) returned %04x, wanted %04x", uint16(posInf), 0x7c00)
+	}
+
+	negInf := float16.Inf(-1)
+	if uint16(negInf) != 0xfc00 {
+		t.Errorf("float16.Inf(-1) returned %04x, wanted %04x", uint16(negInf), 0xfc00)
+	}
+}
+
+func TestBits(t *testing.T) {
+	x := uint16(0x1234)
+	f16 := float16.Frombits(x)
+	if uint16(f16) != f16.Bits() || f16.Bits() != x {
+		t.Errorf("Bits() returned %04x, wanted %04x", uint16(f16), x)
+	}
+}
+
+func TestIsFinite(t *testing.T) {
+	// IsFinite returns true if f is neither infinite nor NaN.
+
+	finite := float16.Fromfloat32(float32(1.5))
+	if !finite.IsFinite() {
+		t.Errorf("finite.Infinite() returned false, wanted true")
+	}
+
+	posInf := float16.Inf(0)
+	if posInf.IsFinite() {
+		t.Errorf("posInf.Infinite() returned true, wanted false")
+	}
+
+	negInf := float16.Inf(-1)
+	if negInf.IsFinite() {
+		t.Errorf("negInf.Infinite() returned true, wanted false")
+	}
+
+	nan := float16.NaN()
+	if nan.IsFinite() {
+		t.Errorf("nan.Infinite() returned true, wanted false")
+	}
+}
+
+func TestIsNaN(t *testing.T) {
+
+	f16 := float16.Float16(0)
+	if f16.IsNaN() {
+		t.Errorf("Float16(0).IsNaN() returned true, wanted false")
+	}
+
+	f16 = float16.Float16(0x7e00)
+	if !f16.IsNaN() {
+		t.Errorf("Float16(0x7e00).IsNaN() returned false, wanted true")
+	}
+}
+
+func TestIsQuietNaN(t *testing.T) {
+
+	f16 := float16.Float16(0)
+	if f16.IsQuietNaN() {
+		t.Errorf("Float16(0).IsQuietNaN() returned true, wanted false")
+	}
+
+	f16 = float16.Float16(0x7e00)
+	if !f16.IsQuietNaN() {
+		t.Errorf("Float16(0x7e00).IsQuietNaN() returned false, wanted true")
+	}
+
+	f16 = float16.Float16(0x7e00 ^ 0x0200)
+	if f16.IsQuietNaN() {
+		t.Errorf("Float16(0x7e00 ^ 0x0200).IsQuietNaN() returned true, wanted false")
+	}
+}
+
+func TestIsNormal(t *testing.T) {
+	// IsNormal returns true if f is neither zero, infinite, subnormal, or NaN.
+
+	zero := float16.Frombits(0)
+	if zero.IsNormal() {
+		t.Errorf("zero.IsNormal() returned true, wanted false")
+	}
+
+	posInf := float16.Inf(0)
+	if posInf.IsNormal() {
+		t.Errorf("posInf.IsNormal() returned true, wanted false")
+	}
+
+	negInf := float16.Inf(-1)
+	if negInf.IsNormal() {
+		t.Errorf("negInf.IsNormal() returned true, wanted false")
+	}
+
+	nan := float16.NaN()
+	if nan.IsNormal() {
+		t.Errorf("nan.IsNormal() returned true, wanted false")
+	}
+
+	subnormal := float16.Frombits(0x0001)
+	if subnormal.IsNormal() {
+		t.Errorf("subnormal.IsNormal() returned true, wanted false")
+	}
+
+	normal := float16.Fromfloat32(float32(1.5))
+	if !normal.IsNormal() {
+		t.Errorf("normal.IsNormal() returned false, wanted true")
+	}
+
+}
+
+func TestSignbit(t *testing.T) {
+
+	f16 := float16.Fromfloat32(float32(0.0))
+	if f16.Signbit() {
+		t.Errorf("float16.Fromfloat32(float32(0)).Signbit() returned true, wanted false")
+	}
+
+	f16 = float16.Fromfloat32(float32(2.0))
+	if f16.Signbit() {
+		t.Errorf("float16.Fromfloat32(float32(2)).Signbit() returned true, wanted false")
+	}
+
+	f16 = float16.Fromfloat32(float32(-2.0))
+	if !f16.Signbit() {
+		t.Errorf("float16.Fromfloat32(float32(-2)).Signbit() returned false, wanted true")
+	}
+
+}
+
+func TestString(t *testing.T) {
+	f16 := float16.Fromfloat32(1.5)
+	s := f16.String()
+	if s != "1.5" {
+		t.Errorf("Float16(1.5).String() returned %s, wanted 1.5", s)
+	}
+
+	f16 = float16.Fromfloat32(3.141593)
+	s = f16.String()
+	if s != "3.140625" {
+		t.Errorf("Float16(3.141593).String() returned %s, wanted 3.140625", s)
+	}
+
+}
+
+func TestIsInf(t *testing.T) {
+
+	f16 := float16.Float16(0)
+	if f16.IsInf(0) {
+		t.Errorf("Float16(0).IsInf(0) returned true, wanted false")
+	}
+
+	f16 = float16.Float16(0x7c00)
+	if !f16.IsInf(0) {
+		t.Errorf("Float16(0x7c00).IsInf(0) returned false, wanted true")
+	}
+
+	f16 = float16.Float16(0x7c00)
+	if !f16.IsInf(1) {
+		t.Errorf("Float16(0x7c00).IsInf(1) returned false, wanted true")
+	}
+
+	f16 = float16.Float16(0x7c00)
+	if f16.IsInf(-1) {
+		t.Errorf("Float16(0x7c00).IsInf(-1) returned true, wanted false")
+	}
+
+	f16 = float16.Float16(0xfc00)
+	if !f16.IsInf(0) {
+		t.Errorf("Float16(0xfc00).IsInf(0) returned false, wanted true")
+	}
+
+	f16 = float16.Float16(0xfc00)
+	if f16.IsInf(1) {
+		t.Errorf("Float16(0xfc00).IsInf(1) returned true, wanted false")
+	}
+
+	f16 = float16.Float16(0xfc00)
+	if !f16.IsInf(-1) {
+		t.Errorf("Float16(0xfc00).IsInf(-1) returned false, wanted true")
+	}
+}
+
+func float32parts(f32 float32) (exp int32, coef uint32, dropped uint32) {
+	const COEFMASK uint32 = 0x7fffff // 23 least significant bits
+	const EXPSHIFT uint32 = 23
+	const EXPBIAS uint32 = 127
+	const EXPMASK uint32 = uint32(0xff) << EXPSHIFT
+	const DROPMASK uint32 = COEFMASK >> 10
+	u32 := math.Float32bits(f32)
+	exp = int32(((u32 & EXPMASK) >> EXPSHIFT) - EXPBIAS)
+	coef = u32 & COEFMASK
+	dropped = coef & DROPMASK
+	return exp, coef, dropped
+}
+
+func isNaN32(f32 float32) bool {
+	exp, coef, _ := float32parts(f32)
+	return (exp == 128) && (coef != 0)
+}
+
+func isQuietNaN32(f32 float32) bool {
+	exp, coef, _ := float32parts(f32)
+	return (exp == 128) && (coef != 0) && ((coef & 0x00400000) != 0)
+}
+
+func checkFromNaN32ps(t *testing.T, f32 float32, f16 float16.Float16) {
+
+	if !isNaN32(f32) {
+		return
+	}
+
+	u32 := math.Float32bits(f32)
+	nan16, err := float16.FromNaN32ps(f32)
+
+	if isQuietNaN32(f32) {
+		// result should be the same
+		if err != nil {
+			t.Errorf("FromNaN32ps: qnan = 0x%08x (%f) wanted err = nil, got err = %q", u32, f32, err)
+		}
+		if uint16(nan16) != uint16(f16) {
+			t.Errorf("FromNaN32ps: qnan = 0x%08x (%f) wanted nan16 = %v, got nan16 = %v", u32, f32, f16, nan16)
+		}
+	} else {
+		// result should differ only by the signaling/quiet bit unless payload is empty
+		if err != nil {
+			t.Errorf("FromNaN32ps: snan = 0x%08x (%f) wanted err = nil, got err = %q", u32, f32, err)
+		}
+
+		coef := uint16(f16) & uint16(0x03ff)
+		payload := uint16(f16) & uint16(0x01ff)
+		diff := uint16(nan16 ^ f16)
+
+		if payload == 0 {
+			// the lowest bit needed to be set to prevent turning sNaN into infinity, so 2 bits differ
+			if diff != 0x0201 {
+				t.Errorf("FromNaN32ps: snan = 0x%08x (%f) wanted diff == 0x0201, got 0x%04x", u32, f32, diff)
+			}
+		} else {
+			// only the quiet bit was restored, so 1 bit differs
+			if diff != 0x0200 {
+				t.Errorf("FromNaN32ps: snan = 0x%08x (%f) wanted diff == 0x0200, got 0x%04x. f16=0x%04x n16=0x%04x coef=0x%04x", u32, f32, diff, uint16(f16), uint16(nan16), coef)
+			}
+		}
+	}
+}
+
+func checkPrecision(t *testing.T, f32 float32, f16 float16.Float16, i uint64) {
+	// TODO: rewrite this test when time allows
+
+	u32 := math.Float32bits(f32)
+	u16 := f16.Bits()
+	f32bis := f16.Float32()
+	u32bis := math.Float32bits(f32bis)
+	pre := float16.PrecisionFromfloat32(f32)
+	roundtripped := u32 == u32bis
+	exp32, coef32, dropped32 := float32parts(f32)
+
+	if roundtripped {
+		checkRoundTrippedPrecision(t, u32, u16, u32bis, exp32, coef32, dropped32)
+		return
+	}
+
+	if pre == float16.PrecisionExact {
+		// this should only happen if both input and output are NaN
+		if !(f16.IsNaN() && isNaN32(f32)) {
+			t.Errorf("i=%d, PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionExact when roundtrip failed with non-special value", i, u32, f32, u16, u32bis, f32bis)
+		}
+
+	} else if pre == float16.PrecisionUnknown {
+		if exp32 < -24 {
+			t.Errorf("i=%d, PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionUnknown, wanted PrecisionUnderflow", i, u32, f32, u16, u32bis, f32bis)
+		}
+		if dropped32 != 0 {
+			t.Errorf("i=%d, PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionUnknown, wanted PrecisionInexact", i, u32, f32, u16, u32bis, f32bis)
+		}
+	} else if pre == float16.PrecisionInexact {
+		checkPrecisionInexact(t, u32, u16, u32bis, exp32, coef32, dropped32)
+	} else if pre == float16.PrecisionUnderflow {
+		if exp32 >= -14 {
+			t.Errorf("i=%d, PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionUnderflow when exp32 is >= -14", i, u32, f32, u16, u32bis, f32bis)
+		}
+	} else if pre == float16.PrecisionOverflow {
+		if exp32 <= 15 {
+			t.Errorf("i=%d, PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionOverflow when exp32 is <= 15", i, u32, f32, u16, u32bis, f32bis)
+		}
+	}
+}
+
+func checkPrecisionInexact(t *testing.T, u32 uint32, u16 uint16, u32bis uint32, exp32 int32, coef32 uint32, dropped32 uint32) {
+	f32 := math.Float32frombits(u32)
+	f32bis := math.Float32frombits(u32bis)
+
+	if exp32 < -24 {
+		t.Errorf("PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionInexact, wanted PrecisionUnderflow", u32, f32, u16, u32bis, f32bis)
+	}
+	if exp32 > 15 {
+		t.Errorf("PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionInexact, wanted PrecisionOverflow", u32, f32, u16, u32bis, f32bis)
+	}
+	if coef32 == 0 {
+		t.Errorf("PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionInexact when coef32 is 0", u32, f32, u16, u32bis, f32bis)
+	}
+	if dropped32 == 0 {
+		t.Errorf("PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), got PrecisionInexact when dropped32 is 0", u32, f32, u16, u32bis, f32bis)
+	}
+}
+
+func checkRoundTrippedPrecision(t *testing.T, u32 uint32, u16 uint16, u32bis uint32, exp32 int32, coef32 uint32, dropped32 uint32) {
+	f32 := math.Float32frombits(u32)
+	f32bis := math.Float32frombits(u32bis)
+	pre := float16.PrecisionFromfloat32(f32)
+	f16 := float16.Frombits(u16)
+
+	if dropped32 != 0 {
+		t.Errorf("PrecisionFromfloat32 in f32bits=0x%08x (%f), out f16bits=0x%04x, back=0x%08x (%f), dropped32 != 0 with successful roundtrip", u32, f32, u16, u32bis, f32bis)
+	}
+
+	if pre != float16.PrecisionExact {
+		// there are 2046 values that are subnormal and can round-trip float32->float16->float32
+		if pre != float16.PrecisionUnknown {
+			t.Errorf("PrecisionFromfloat32 in f32bits=0x%08x (%032b) (%f), out f16bits=0x%04x (%v), back=0x%08x (%f), got %v, wanted PrecisionExact, exp=%d, coef=%d, drpd=%d", u32, u32, f32, u16, f16, u32bis, f32bis, pre, exp32, coef32, dropped32)
+		}
+	}
+
+}

--- a/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/go.mod
+++ b/traffic_ops/ort/atstccfg/vendor/github.com/x448/float16/go.mod
@@ -1,0 +1,3 @@
+module github.com/x448/float16
+
+go 1.11


### PR DESCRIPTION
Fixes ORT caching to CBOR. The current Gob encoding is fundamentally broken. See https://github.com/golang/go/issues/4609 . It's not isomorphic: it does not decode what in encodes. In practical terms, default values like 0 become null pointers, resulting in missing remap lines in the config.

This changes the default to CBOR, which is an IETF RFC standard. See https://tools.ietf.org/html/rfc7049 .

It also adds a unit test, to verify the default cache format is isomorphic. Gob fails the test, CBOR and JSON pass it.

Includes tests. No docs, no changelog, no interface change.

- [x] This PR fixes is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests.

Generate remap.config with assigned delivery services of type "HTTP" (which is represented by `0`, the default int value). Without this fix, remap lines will be missing. With fix, config file should have appropriate remap lines for HTTP DSes.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information