### PR TITLE
 Fix broken ORT caching resulting in malformed config files, using JSON

### DIFF
--- a/traffic_ops/ort/atstccfg/toreq/caching.go
+++ b/traffic_ops/ort/atstccfg/toreq/caching.go
@@ -21,7 +21,6 @@ package toreq
 
 import (
 	"bufio"
-	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,8 +40,8 @@ import (
 
 // DefaultCacheFormat is the encoder, decoder, and file extension to use for caching.
 // This may be changed at compile-time. See CacheFormatJSON.
-// Note this is not used for all cache files. Notably, Delivery Service Servers use a custom CSV format, which is faster than gob.
-var DefaultCacheFormat = CacheFormatGob
+// Note this is not used for all cache files. Notably, Delivery Service Servers use a custom CSV format, which is faster.
+var DefaultCacheFormat = CacheFormatJSON
 
 // GetCached attempts to get the given object from tempDir/cacheFileName.
 // If the cache file doesn't exist, is too old, or is malformed, it uses getter to get the object, and stores it in cacheFileName.
@@ -149,7 +148,6 @@ type CacheFormat struct {
 	Extension string
 }
 
-var CacheFormatGob = CacheFormat{GobEncode, GobDecode, GobExtension}
 var CacheFormatJSON = CacheFormat{JSONEncode, JSONDecode, JSONExtension}
 
 // CacheFormatDSS is a special format encoder/decoder optimized for Delivery Service Servers.
@@ -163,11 +161,6 @@ const JSONExtension = ".json"
 
 func JSONDecode(r io.Reader, obj interface{}) error { return json.NewDecoder(r).Decode(obj) }
 func JSONEncode(w io.Writer, obj interface{}) error { return json.NewEncoder(w).Encode(obj) }
-
-const GobExtension = ".gob"
-
-func GobDecode(r io.Reader, obj interface{}) error { return gob.NewDecoder(r).Decode(obj) }
-func GobEncode(w io.Writer, obj interface{}) error { return gob.NewEncoder(w).Encode(obj) }
 
 func StringToCookies(cookiesStr string) []*http.Cookie {
 	hdr := http.Header{}

--- a/traffic_ops/ort/atstccfg/toreq/caching_test.go
+++ b/traffic_ops/ort/atstccfg/toreq/caching_test.go
@@ -20,10 +20,15 @@ package toreq
  */
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 )
 
 func TestWriteCacheJSON(t *testing.T) {
@@ -67,43 +72,92 @@ func TestWriteCacheJSON(t *testing.T) {
 	}
 }
 
-func TestWriteCacheGob(t *testing.T) {
-	type Obj struct {
-		S string `json:"s"`
-	}
+func TestDefaultCacheFormatIsomorphic(t *testing.T) {
+	// Test whether DefaultCacheFormat is isomorphic.
+	// That is, whether serializing and deserializing produces the original object.
+	// This might seem silly, but encoding/gob is not isomorphic and fails this test.
+	// We requires an isomorphic cache format, or config files will be wrong.
 
-	fileName := "TestWriteCacheGob.gob"
+	// Delivery Service is one of TC's most complex objects, so use an array of it to test.
+	// It's important to test null pointers, as well as pointers to default values (a common failure).
+
+	dsMatchPtr := []tc.DeliveryServiceMatch{
+		tc.DeliveryServiceMatch{
+			Type:      tc.DSMatchTypeHostRegex,
+			SetNumber: 0,
+			Pattern:   "foo",
+		},
+		tc.DeliveryServiceMatch{
+			Type:      tc.DSMatchTypeInvalid,
+			SetNumber: 42,
+			Pattern:   "",
+		},
+	}
+	dsTypeInvalidPtr := tc.DSTypeInvalid
+
+	ds1 := tc.DeliveryServiceNullable{}
+	ds1.Active = util.BoolPtr(false)
+	ds1.AnonymousBlockingEnabled = nil
+	ds1.CacheURL = util.StrPtr("")
+	ds1.CCRDNSTTL = util.IntPtr(0)
+	ds1.CDNID = nil
+	ds1.CDNName = nil
+	ds1.CheckPath = util.StrPtr("foo")
+	ds1.DisplayName = util.StrPtr("")
+	ds1.DSCP = nil
+	ds1.LogsEnabled = util.BoolPtr(true)
+	// ds1.MatchList = &dsMatchPtr
+	ds1.MissLat = nil
+	ds1.MissLong = util.FloatPtr(0)
+	ds1.Signed = false
+	ds1.Type = &dsTypeInvalidPtr
+	// ds1.ExampleURLs = []string{"foo", ""}
+
+	ds2 := tc.DeliveryServiceNullable{}
+	ds2.Active = nil
+	ds2.AnonymousBlockingEnabled = util.BoolPtr(false)
+	ds2.CacheURL = util.StrPtr("")
+	ds2.CCRDNSTTL = util.IntPtr(0)
+	ds2.CDNID = nil
+	ds2.CDNName = nil
+	ds2.CheckPath = util.StrPtr("foo")
+	ds2.DisplayName = util.StrPtr("")
+	ds2.DSCP = nil
+	ds2.LogsEnabled = util.BoolPtr(true)
+	ds2.MatchList = &dsMatchPtr
+	ds2.MissLat = util.FloatPtr(0)
+	ds2.MissLong = util.FloatPtr(42)
+	ds2.Signed = true
+	ds2.Type = nil
+	ds2.ExampleURLs = nil
+
+	dses := []tc.DeliveryServiceNullable{ds1, ds2}
+
+	fileName := "TestDefaultCacheFormatIsomorphic"
+
 	tmpDir := os.TempDir()
 	filePath := filepath.Join(tmpDir, fileName)
 	defer os.Remove(filePath)
 
-	{
-		largeObj := Obj{
-			S: `
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+	WriteCache(DefaultCacheFormat.Encoder, tmpDir, fileName, dses)
 
-    Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam varius, turpis et commodo pharetra, est eros bibendum elit, nec luctus magna felis sollicitudin mauris. Integer in mauris eu nibh euismod gravida. Duis ac tellus et risus vulputate vehicula. Donec lobortis risus a elit. Etiam tempor. Ut ullamcorper, ligula eu tempor congue, eros est euismod turpis, id tincidunt sapien risus a quam. Maecenas fermentum consequat mi. Donec fermentum. Pellentesque malesuada nulla a mi. Duis sapien sem, aliquet nec, commodo eget, consequat quis, neque. Aliquam faucibus, elit ut dictum aliquet, felis nisl adipiscing sapien, sed malesuada diam lacus eget erat. Cras mollis scelerisque nunc. Nullam arcu. Aliquam consequat. Curabitur augue lorem, dapibus quis, laoreet et, pretium ac, nisi. Aenean magna nisl, mollis quis, molestie eu, feugiat in, orci. In hac habitasse platea dictumst.
-`,
-		}
-
-		WriteCache(CacheFormatGob.Encoder, tmpDir, fileName, largeObj)
-		loadedLargeObj := Obj{}
-		if err := ReadCache(CacheFormatGob.Decoder, tmpDir, fileName, time.Hour, &loadedLargeObj); err != nil {
-			t.Fatalf("ReadCache large error expected nil, actual: " + err.Error())
-		} else if largeObj.S != loadedLargeObj.S {
-			t.Fatalf("ReadCache expected %+v actual %+v\n", largeObj.S, loadedLargeObj.S)
-		}
+	readDSes := []tc.DeliveryServiceNullable{}
+	if err := ReadCache(DefaultCacheFormat.Decoder, tmpDir, fileName, time.Hour, &readDSes); err != nil {
+		t.Fatalf("ReadCache error expected nil, actual: " + err.Error())
+	}
+	if len(readDSes) != 2 {
+		t.Fatalf("ReadCache error expected 2 dses, actual: %v", len(readDSes))
 	}
 
-	{
-		// Write a smaller object to the same file, to make sure it properly truncates, and doesn't leave old text lying around (resulting in malformed gob)
-		smallObj := Obj{S: `foo`}
-		WriteCache(CacheFormatGob.Encoder, tmpDir, fileName, smallObj)
-		loadedSmallObj := Obj{}
-		if err := ReadCache(CacheFormatGob.Decoder, tmpDir, fileName, time.Hour, &loadedSmallObj); err != nil {
-			t.Fatalf("ReadCache small error expected nil, actual: " + err.Error())
-		} else if smallObj.S != loadedSmallObj.S {
-			t.Fatalf("ReadCache expected %+v actual %+v\n", smallObj.S, loadedSmallObj.S)
-		}
+	if !reflect.DeepEqual(dses[0], readDSes[0]) {
+		dsj, _ := json.MarshalIndent(dses[0], "", " ")
+		dsrj, _ := json.MarshalIndent(readDSes[0], "", " ")
+		t.Errorf("ReadCache expected %+v actual %+v\n", string(dsj), string(dsrj))
+	}
+
+	if !reflect.DeepEqual(dses[1], readDSes[1]) {
+		dsj, _ := json.MarshalIndent(dses[1], "", " ")
+		dsrj, _ := json.MarshalIndent(readDSes[1], "", " ")
+		t.Errorf("ReadCache expected %+v actual %+v\n", string(dsj), string(dsrj))
 	}
 }


### PR DESCRIPTION
See #4432 - this is an alternative to that PR, using JSON, which make an ORT run ~50% slower than CBOR, but doesn't require upgrading Go to 1.12. I'll let the community decide which to merge.

Fixes ORT caching to JSON. The current Gob encoding is fundamentally broken. See https://github.com/golang/go/issues/4609 . It's not isomorphic: it does not decode what in encodes. In practical terms, default values like 0 become null pointers, resulting in missing remap lines in the config.

This changes the default to JSON.

It also adds a unit test, to verify the default cache format is isomorphic. Gob fails the test, CBOR and JSON pass it.

Includes tests. No docs, no changelog, no interface change.

- [x] This PR fixes is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests.

Generate remap.config with assigned delivery services of type "HTTP" (which is represented by `0`, the default int value). Without this fix, remap lines will be missing. With fix, config file should have appropriate remap lines for HTTP DSes.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information