### PR TITLE
Deprecate GET deliveryservices/{dsid}/regexes/{regexid}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /cdns/usage/overview
   - /deliveryservice_user
   - /deliveryservice_user/:dsId/:userId
+  - /deliveryservices/{dsid}/regexes/{regexid} (GET)
   - /deliveryservices/:id/state
   - /divisions/:division_name/regions
   - /divisions/name/:name

--- a/docs/source/api/v1/deliveryservices_id_regexes.rst
+++ b/docs/source/api/v1/deliveryservices_id_regexes.rst
@@ -37,6 +37,21 @@ Request Structure
 	|  ID  | The integral, unique identifier of the :term:`Delivery Service` being inspected |
 	+------+---------------------------------------------------------------------------------+
 
+.. table:: Request Query Parameters
+
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| Name        | Required | Description                                                                                                                          |
+	+=============+==========+======================================================================================================================================+
+	| id          | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| limit       | no       | Choose the maximum number of results to return                                                                                       |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| offset      | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
+	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
 .. code-block:: http
 	:caption: Request Example
 

--- a/docs/source/api/v1/deliveryservices_id_regexes_rid.rst
+++ b/docs/source/api/v1/deliveryservices_id_regexes_rid.rst
@@ -21,6 +21,9 @@
 
 ``GET``
 =======
+.. deprecated:: ATCv4
+	Use the ``GET`` method of :ref:`to-api-v1-deliveryservices-id-regexes` with the query parameter ``id`` instead.
+
 Retrieves a specific routing regular expression for a specific :term:`Delivery Service`.
 
 :Auth. Required: Yes
@@ -78,6 +81,12 @@ Response Structure
 			"typeName": "HOST_REGEXP",
 			"setNumber": 0,
 			"pattern": ".*\\.demo1\\..*"
+		}
+	],
+	"alerts": [
+		{
+			"text": "This endpoint is deprecated, please use GET '/deliveryservices/{dsid}/regexes' with query parameter id instead",
+			"level": "warning"
 		}
 	]}
 

--- a/docs/source/api/v2/deliveryservices_id_regexes.rst
+++ b/docs/source/api/v2/deliveryservices_id_regexes.rst
@@ -37,6 +37,21 @@ Request Structure
 	|  ID  | The integral, unique identifier of the :term:`Delivery Service` being inspected |
 	+------+---------------------------------------------------------------------------------+
 
+.. table:: Request Query Parameters
+
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| Name        | Required | Description                                                                                                                          |
+	+=============+==========+======================================================================================================================================+
+	| id          | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| limit       | no       | Choose the maximum number of results to return                                                                                       |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| offset      | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
+	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
 .. code-block:: http
 	:caption: Request Example
 

--- a/docs/source/api/v2/deliveryservices_id_regexes_rid.rst
+++ b/docs/source/api/v2/deliveryservices_id_regexes_rid.rst
@@ -19,69 +19,6 @@
 ``deliveryservices/{{ID}}/regexes/{{rID}}``
 *******************************************
 
-``GET``
-=======
-Retrieves a specific routing regular expression for a specific :term:`Delivery Service`.
-
-:Auth. Required: Yes
-:Roles Required: None\ [#tenancy]_
-:Response Type:  Array
-
-Request Structure
------------------
-.. table:: Request Path Parameters
-
-	+------+-----------------------------------------------------------------------------------+
-	| Name |                Description                                                        |
-	+======+===================================================================================+
-	| ID   | The integral, unique identifier of the :term:`Delivery Service` being inspected   |
-	+------+-----------------------------------------------------------------------------------+
-	| rID  | The integral, unique identifier of the routing regular expression being inspected |
-	+------+-----------------------------------------------------------------------------------+
-
-.. code-block:: http
-	:caption: Request Example
-
-	GET /api/2.0/deliveryservices/1/regexes/1 HTTP/1.1
-	Host: trafficops.infra.ciab.test
-	User-Agent: curl/7.47.0
-	Accept: */*
-	Cookie: mojolicious=...
-
-Response Structure
-------------------
-:id:        The integral, unique identifier of this regular expression
-:pattern:   The actual regular expression - ``\``\ s are escaped
-:setNumber: The order in which the regular expression is evaluated against requests
-:type:      The integral, unique identifier of the type of this regular expression
-:typeName:  The type of regular expression - determines that against which it will be evaluated
-
-.. code-block:: http
-	:caption: Response Example
-
-	HTTP/1.1 200 OK
-	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-	Access-Control-Allow-Origin: *
-	Content-Type: application/json
-	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-	Whole-Content-Sha512: fW9Fde4WRpp2ShRAC41P9s/PhU71LI/SEzHgYjGqfzhk45wq0kpaWy76JvPfLpowY8eDTp8Y8TL5rNGEc+bM+A==
-	X-Server-Name: traffic_ops_golang/
-	Date: Tue, 27 Nov 2018 21:08:34 GMT
-	Content-Length: 100
-
-	{ "response": [
-		{
-			"id": 1,
-			"type": 31,
-			"typeName": "HOST_REGEXP",
-			"setNumber": 0,
-			"pattern": ".*\\.demo1\\..*"
-		}
-	]}
-
-
 ``PUT``
 =======
 Updates a routing regular expression.

--- a/traffic_control/clients/python/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/tosession.py
@@ -992,25 +992,14 @@ class TOSession(RestApiSession):
 		"""
 
 	@api_request('get', 'deliveryservices/{delivery_service_id:d}/regexes', ('2.0',))
-	def get_deliveryservice_regexes_by_id(self, delivery_service_id=None):
+	def get_deliveryservice_regexes_by_id(self, delivery_service_id=None, query_params=None):
 		"""
 		Get RegExes for a Delivery Service by Id.
 		:ref:`to-api-deliveryservices-id-regexes`
 		:param delivery_service_id: The delivery service Id
 		:type delivery_service_id: int
-		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
-		:raises: Union[LoginError, OperationError]
-		"""
-
-	@api_request('get', 'deliveryservices/{delivery_service_id:d}/regexes/{regex_id:d}', ('2.0',))
-	def get_deliveryservice_regexes_by_regex_id(self, delivery_service_id=None, regex_id=None):
-		"""
-		Retrieves a regex for a specific delivery service.
-		:ref:`to-api-deliveryservices-id-regexes-rid`
-		:param delivery_service_id: The delivery service Id
-		:type delivery_service_id: int
-		:param regex_id: The delivery service regex id
-		:type regex_id: int
+		:param query_params: The url query parameters for the call
+		:type query_params: Dict[str, Any]
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -428,7 +428,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		//Delivery Services Regexes
 		{api.Version{2, 0}, http.MethodGet, `deliveryservices_regexes/?$`, deliveryservicesregexes.Get, auth.PrivLevelReadOnly, Authenticated, nil, 205501453, noPerlBypass},
 		{api.Version{2, 0}, http.MethodGet, `deliveryservices/{dsid}/regexes/?$`, deliveryservicesregexes.DSGet, auth.PrivLevelReadOnly, Authenticated, nil, 277432763, noPerlBypass},
-		{api.Version{2, 0}, http.MethodGet, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.DSGetID, auth.PrivLevelReadOnly, Authenticated, nil, 2044974567, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPost, `deliveryservices/{dsid}/regexes/?$`, deliveryservicesregexes.Post, auth.PrivLevelOperations, Authenticated, nil, 212737800, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPut, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Put, auth.PrivLevelOperations, Authenticated, nil, 2248339691, noPerlBypass},
 		{api.Version{2, 0}, http.MethodDelete, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Delete, auth.PrivLevelOperations, Authenticated, nil, 2246731663, noPerlBypass},

--- a/traffic_portal/app/src/common/api/DeliveryServiceRegexService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRegexService.js
@@ -31,7 +31,7 @@ var DeliveryServiceRegexService = function($http, locationUtils, messageModel, E
 	};
 
 	this.getDeliveryServiceRegex = function(dsId, regexId) {
-		return $http.get(ENV.api['root'] + 'deliveryservices/' + dsId + '/regexes/' + regexId).then(
+		return $http.get(ENV.api['root'] + 'deliveryservices/' + dsId + '/regexes', {params: {id: regexId}}).then(
 			function(result) {
 				return result.data.response[0];
 			},


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Documentation
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run traffic ops and make sure you can not hit the endpoint in API 2.0 and when performing a GET on it in 1.x you receive a deprecation message back in the returned alerts. 

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
