### PR TITLE
deprecate /servers/checks and move functionality to /servercheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.5/letsencrypt/dnsrecords `GET`
   - /api/2.0/vault/ping `GET`
   - /api/2.0/vault/bucket/:bucket/key/:key/values `GET`
+  - /api/2.0/servercheck `GET`
 
 ### Changed
 - Fix to traffic_ops_ort.pl to strip specific comment lines before checking if a file has changed.  Also promoted a changed file message from DEBUG to ERROR for report mode.
@@ -79,6 +80,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /traffic_monitor/stats
   - /types/trimmed
   - /user/current/jobs
+  - /servers/checks
 
 ## [4.0.0] - 2019-12-16
 ### Added

--- a/docs/source/api/v1/servers_checks.rst
+++ b/docs/source/api/v1/servers_checks.rst
@@ -62,7 +62,7 @@ Response Structure
 	Set-Cookie: mojolicious=...; Path=/; Expires=Thu, 23 Jan 2020 20:00:19 GMT; Max-Age=3600; HttpOnly
 	X-Server-Name: traffic_ops_golang/
 	Date: Thu, 23 Jan 2020 19:00:19 GMT
-	Content-Length: 202
+	Content-Length: 449
 
 	{ "alerts": [
 		{

--- a/docs/source/api/v1/servers_checks.rst
+++ b/docs/source/api/v1/servers_checks.rst
@@ -18,6 +18,9 @@
 ******************
 ``servers/checks``
 ******************
+.. deprecated:: ATCv4
+	Use the ``GET`` method of :ref:`to-api-servercheck` instead.
+
 Deals with the various checks associated with certain types of servers.
 
 .. seealso:: :ref:`to-check-ext`
@@ -61,7 +64,13 @@ Response Structure
 	Date: Thu, 23 Jan 2020 19:00:19 GMT
 	Content-Length: 202
 
-	{ "response": [
+	{ "alerts": [
+		{
+			"text": "This endpoint is deprecated, please use GET /servercheck instead",
+			"level": "warning"
+		}
+	],
+	"response": [
 		{
 			"adminState": "REPORTED",
 			"cacheGroup": "CDN_in_a_Box_Edge",

--- a/docs/source/api/v2/servercheck.rst
+++ b/docs/source/api/v2/servercheck.rst
@@ -19,11 +19,73 @@
 ``servercheck``
 ***************
 
-Updates the resulting value from running a given check extension on a server.
+.. seealso:: :ref:`to-check-ext`
+
+``GET``
+=======
+Fetches identifying and meta information as well as "check" values regarding all servers that have a :term:`Type` with a name beginning with "EDGE" or "MID" (ostensibly this is equivalent to all :term:`cache servers`).
+
+:Auth. Required: Yes
+:Roles Required: None
+:Response Type:  Array
+
+Request Structure
+-----------------
+No parameters available.
+
+Response Structure
+------------------
+:adminState:   The name of the server's :term:`Status` - called "adminState" for legacy reasons
+:cacheGroup:   The name of the :term:`Cache Group` to which the server belongs
+:checks:       An optionally present map of the names of "checks" to their values. Only numeric and boolean checks are represented, and boolean checks are represented as integers with ``0`` meaning "false" and ``1`` meaning "true". Will not appear if the server in question has no valued "checks".
+:hostName:     The (short) hostname of the server
+:id:           The server's integral, unique identifier
+:profile:      The name of the :term:`Profile` used by the server
+:revalPending: A boolean that indicates whether or not the server has pending revalidations
+:type:         The name of the server's :term:`Type`
+:updPending:   A boolean that indicates whether or not the server has pending updates
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Thu, 23 Jan 2020 20:00:19 GMT; Max-Age=3600; HttpOnly
+	X-Server-Name: traffic_ops_golang/
+	Date: Thu, 23 Jan 2020 19:00:19 GMT
+	Content-Length: 202
+
+	{ "response": [
+		{
+			"adminState": "REPORTED",
+			"cacheGroup": "CDN_in_a_Box_Edge",
+			"id": 12,
+			"hostName": "edge",
+			"revalPending": false,
+			"profile": "ATS_EDGE_TIER_CACHE",
+			"type": "EDGE",
+			"updPending": false
+		},
+		{
+			"adminState": "REPORTED",
+			"cacheGroup": "CDN_in_a_Box_Mid",
+			"id": 11,
+			"hostName": "mid",
+			"revalPending": false,
+			"profile": "ATS_MID_TIER_CACHE",
+			"type": "MID",
+			"updPending": false
+		}
+	]}
 
 ``POST``
 ========
-Post a server check result to the "serverchecks" table.
+Post a server check result to the "serverchecks" table. Updates the resulting value from running a given check extension on a server.
 
 :Auth. Required: Yes
 :Roles Required: None\ [1]_

--- a/docs/source/api/v2/servercheck.rst
+++ b/docs/source/api/v2/servercheck.rst
@@ -58,7 +58,7 @@ Response Structure
 	Set-Cookie: mojolicious=...; Path=/; Expires=Thu, 23 Jan 2020 20:00:19 GMT; Max-Age=3600; HttpOnly
 	X-Server-Name: traffic_ops_golang/
 	Date: Thu, 23 Jan 2020 19:00:19 GMT
-	Content-Length: 202
+	Content-Length: 352
 
 	{ "response": [
 		{

--- a/traffic_ops/client/servercheck.go
+++ b/traffic_ops/client/servercheck.go
@@ -23,7 +23,6 @@ import (
 )
 
 const API_SERVERCHECK = apiBase + "/servercheck"
-const API_SERVERS_CHECKS = apiBase + "/servers/checks"
 
 // InsertServerCheckStatus Will insert/update the servercheck value based on if it already exists or not.
 func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable) (*tc.ServercheckPostResponse, ReqInf, error) {
@@ -42,13 +41,13 @@ func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable)
 	return &resp, reqInf, nil
 }
 
-// GetServersChecks fetches check and meta information about servers from /servers/checks.
+// GetServersChecks fetches check and meta information about servers from /servercheck.
 func (to *Session) GetServersChecks() ([]tc.GenericServerCheck, tc.Alerts, ReqInf, error) {
 	var response struct {
 		tc.Alerts
 		Response []tc.GenericServerCheck `json:"response"`
 	}
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
-	reqInf, err := get(to, API_SERVERS_CHECKS, &response)
+	reqInf, err := get(to, API_SERVERCHECK, &response)
 	return response.Response, response.Alerts, reqInf, err
 }

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -138,6 +138,45 @@ func HandleErr(w http.ResponseWriter, r *http.Request, tx *sql.Tx, statusCode in
 	handleSimpleErr(w, r, statusCode, userErr, sysErr)
 }
 
+// GetDeprecationAlerts returns a standard deprecation alert depending on if an alternative is provided.
+func GetDeprecationAlerts(alternative *string) tc.Alerts {
+	var alerts tc.Alerts
+	if alternative != nil {
+		alerts = tc.CreateAlerts(tc.WarnLevel, fmt.Sprintf("This endpoint is deprecated, please use %s instead", *alternative))
+	} else {
+		alerts = tc.CreateAlerts(tc.WarnLevel, "This endpoint is deprecated, and will be removed in the future")
+	}
+
+	return alerts
+}
+
+// HandleDeprecatedErr handles an API error, adding a deprecation alert, rolling back the transaction, writing the given statusCode and userErr to the user, and logging the sysErr. If userErr is nil, the text of the HTTP statusCode is written.
+//
+// The alternative may be nil if there is no alternative and the deprecation message will be selected appropriately.
+//
+// The tx may be nil, if there is no transaction. Passing a nil tx is strongly discouraged if a transaction exists, because it will result in copy-paste errors for the common APIInfo use case.
+//
+// This is a helper for the common case; not using this in unusual cases is perfectly acceptable.
+func HandleDeprecatedErr(w http.ResponseWriter, r *http.Request, tx *sql.Tx, statusCode int, userErr error, sysErr error, alternative *string) {
+	if respWritten(r) {
+		log.Errorf("HandleDeprecatedErr called after a write already occurred! Attempting to write the error anyway! Path %s", r.URL.Path)
+		// Don't return, attempt to rollback and write the error anyway
+	}
+	setRespWritten(r)
+
+	if tx != nil {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Errorln("rolling back transaction: " + err.Error())
+		}
+	}
+
+	alerts := GetDeprecationAlerts(alternative)
+
+	userErr = LogErr(r, statusCode, userErr, sysErr)
+	alerts.AddAlerts(tc.CreateErrorAlerts(userErr))
+	WriteAlerts(w, r, statusCode, alerts)
+}
+
 // LogErr handles the logging of errors and setting up possibly nil errors without actually writing anything to a
 // http.ResponseWriter, unlike handleSimpleErr. It returns the userErr which will be initialized to the
 // http.StatusText of errCode if it was passed as nil - otherwise left alone.

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -138,18 +138,6 @@ func HandleErr(w http.ResponseWriter, r *http.Request, tx *sql.Tx, statusCode in
 	handleSimpleErr(w, r, statusCode, userErr, sysErr)
 }
 
-// GetDeprecationAlerts returns a standard deprecation alert depending on if an alternative is provided.
-func GetDeprecationAlerts(alternative *string) tc.Alerts {
-	var alerts tc.Alerts
-	if alternative != nil {
-		alerts = tc.CreateAlerts(tc.WarnLevel, fmt.Sprintf("This endpoint is deprecated, please use %s instead", *alternative))
-	} else {
-		alerts = tc.CreateAlerts(tc.WarnLevel, "This endpoint is deprecated, and will be removed in the future")
-	}
-
-	return alerts
-}
-
 // HandleDeprecatedErr handles an API error, adding a deprecation alert, rolling back the transaction, writing the given statusCode and userErr to the user, and logging the sysErr. If userErr is nil, the text of the HTTP statusCode is written.
 //
 // The alternative may be nil if there is no alternative and the deprecation message will be selected appropriately.
@@ -170,7 +158,7 @@ func HandleDeprecatedErr(w http.ResponseWriter, r *http.Request, tx *sql.Tx, sta
 		}
 	}
 
-	alerts := GetDeprecationAlerts(alternative)
+	alerts := CreateDeprecationAlerts(alternative)
 
 	userErr = LogErr(r, statusCode, userErr, sysErr)
 	alerts.AddAlerts(tc.CreateErrorAlerts(userErr))
@@ -963,4 +951,3 @@ func CreateDeprecationAlerts(alternative *string) tc.Alerts {
 		return tc.CreateAlerts(tc.WarnLevel, "This endpoint is deprecated, and will be removed in the future")
 	}
 }
-

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -310,7 +310,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{2, 0}, http.MethodGet, `servers/status$`, server.GetServersStatusCountsHandler, auth.PrivLevelReadOnly, Authenticated, nil, 2252786293, noPerlBypass},
 
 		//Serverchecks
-		{api.Version{2, 0}, http.MethodGet, `servers/checks/?$`, servercheck.ReadServersChecks, auth.PrivLevelReadOnly, Authenticated, nil, 2796112922, noPerlBypass},
+		{api.Version{2, 0}, http.MethodGet, `servercheck/?$`, servercheck.ReadServerCheck, auth.PrivLevelReadOnly, Authenticated, nil, 2796112922, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPost, `servercheck/?$`, servercheck.CreateUpdateServercheck, auth.PrivLevelInvalid, Authenticated, nil, 2764281568, noPerlBypass},
 
 		//Server Details
@@ -720,7 +720,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{1, 1}, http.MethodGet, `servers/totals$`, handlerToFunc(proxyHandler), 0, NoAuth, []middleware.Middleware{}, 2037840835, noPerlBypass},
 
 		//Serverchecks
-		{api.Version{1, 1}, http.MethodGet, `servers/checks(/|\.json)?$`, servercheck.ReadServersChecks, auth.PrivLevelReadOnly, Authenticated, nil, 1796112922, perlBypass},
+		{api.Version{1, 1}, http.MethodGet, `servers/checks(/|\.json)?$`, servercheck.DeprecatedReadServersChecks, auth.PrivLevelReadOnly, Authenticated, nil, 1796112922, perlBypass},
 		{api.Version{1, 1}, http.MethodPost, `servercheck/?(\.json)?$`, servercheck.CreateUpdateServercheck, auth.PrivLevelInvalid, Authenticated, nil, 1764281568, perlBypass},
 
 		//Server Details

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -231,7 +231,7 @@ func DeprecatedReadServersChecks(w http.ResponseWriter, r *http.Request) {
 		api.HandleDeprecatedErr(w, r, tx, errCode, userErr, sysErr, util.StrPtr(ServerCheck_Get_Endpoint))
 	}
 
-	alerts := api.GetDeprecationAlerts(util.StrPtr(ServerCheck_Get_Endpoint))
+	alerts := api.CreateDeprecationAlerts(util.StrPtr(ServerCheck_Get_Endpoint))
 	api.WriteAlertsObj(w, r, http.StatusOK, alerts, data)
 }
 

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -211,6 +211,7 @@ func ReadServerCheck(w http.ResponseWriter, r *http.Request) {
 	data, userErr, sysErr, errCode := handleReadServerCheck(inf, tx)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		return
 	}
 
 	api.WriteResp(w, r, data)
@@ -229,6 +230,7 @@ func DeprecatedReadServersChecks(w http.ResponseWriter, r *http.Request) {
 	data, userErr, sysErr, errCode := handleReadServerCheck(inf, tx)
 	if userErr != nil || sysErr != nil {
 		api.HandleDeprecatedErr(w, r, tx, errCode, userErr, sysErr, util.StrPtr(ServerCheck_Get_Endpoint))
+		return
 	}
 
 	alerts := api.CreateDeprecationAlerts(util.StrPtr(ServerCheck_Get_Endpoint))

--- a/traffic_portal/app/src/common/api/ServerService.js
+++ b/traffic_portal/app/src/common/api/ServerService.js
@@ -209,7 +209,7 @@ var ServerService = function($http, locationUtils, messageModel, ENV) {
     };
 
     this.getCacheChecks = function() {
-        return $http.get(ENV.api['root'] + "servers/checks").then(
+        return $http.get(ENV.api['root'] + "servercheck").then(
             function(result) {
                 return result.data.response;
             },


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR deprecates /servers/checks and moves functionality to /servercheck


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Documentation
- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Verify that GET /api/1.5/servers/checks now has an appropriate deprecation alert
Verify that GET /api/2.0/servers/checks does not exist
Verify that GET /api/2.0/servercheck returns the same information that /api/1.5/servers/checks does but without the alert
Verify that Traffic Portal Cache Checks link still works (requires TP to use api 2.0)

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR does not need testing updates
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
