### PR TITLE
fixed so parameters can be associated with cachegroups and profiles

### DIFF
--- a/docs/source/api/v1/cachegroupparameters.rst
+++ b/docs/source/api/v1/cachegroupparameters.rst
@@ -87,7 +87,7 @@ Response Structure
 
 ``POST``
 ========
-Assign :term:`Parameter`\ (s) to :term:`Cache Group`\ (s). :term:`Parameters` already assigned to one or more :term:`Profiles` cannot be assigned to :term:`Cache Groups`.
+Assign :term:`Parameter`\ (s) to :term:`Cache Group`\ (s).
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"

--- a/docs/source/api/v2/cachegroupparameters.rst
+++ b/docs/source/api/v2/cachegroupparameters.rst
@@ -87,7 +87,7 @@ Response Structure
 
 ``POST``
 ========
-Assign :term:`Parameter`\ (s) to :term:`Cache Group`\ (s). :term:`Parameters` already assigned to one or more :term:`Profiles` cannot be assigned to :term:`Cache Groups`.
+Assign :term:`Parameter`\ (s) to :term:`Cache Group`\ (s).
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"

--- a/traffic_ops/app/lib/API/CachegroupParameter.pm
+++ b/traffic_ops/app/lib/API/CachegroupParameter.pm
@@ -69,10 +69,10 @@ sub create {
 			$self->db->txn_rollback();
 			return $self->alert("Parameter with id: " . $param->{parameterId} . " doesn't exist");
 		}
-		my $cg_param = $self->db->resultset('ProfileParameter')->find( { parameter => $parameter->id, profile => $cg->id } );
+		my $cg_param = $self->db->resultset('CachegroupParameter')->find( { parameter => $parameter->id, cachegroup => $cg->id } );
 		if ( defined($cg_param) ) {
 			$self->db->txn_rollback();
-			return $self->alert("parameter: " . $param->{parameterId} . " already associated with profile: " . $param->{profileId});
+			return $self->alert("parameter: " . $param->{parameterId} . " already associated with cachegroup: " . $param->{cacheGroupId});
 		}
 		$self->db->resultset('CachegroupParameter')->create( { parameter => $parameter->id, cachegroup => $cg->id } )->insert();
 	}
@@ -81,7 +81,7 @@ sub create {
 	&log( $self, "New cache group parameter associations were created.", "APICHANGE" );
 
 	my $response = $params;
-	return $self->success($response, "Profile parameter associations were created.");
+	return $self->success($response, "Cachegroup parameter associations were created.");
 }
 
 sub delete {
@@ -112,7 +112,7 @@ sub delete {
 
 	&log( $self, "Deleted cache group parameter " . $cg->name . " <-> " . $parameter->name, "APICHANGE" );
 
-	return $self->success_message("Profile parameter association was deleted.");
+	return $self->success_message("Cachegroup parameter association was deleted.");
 }
 
 

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -288,7 +288,7 @@ func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, p := range params {
-		ppExists, err := dbhelpers.CachegroupParameterExistsByParameterID(*p.Parameter, *p.CacheGroup, inf.Tx.Tx)
+		ppExists, err := dbhelpers.CachegroupParameterAssociationExists(*p.Parameter, *p.CacheGroup, inf.Tx.Tx)
 		if err != nil {
 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 			return

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -288,13 +288,13 @@ func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, p := range params {
-		ppExists, err := dbhelpers.ProfileParameterExistsByParameterID(*p.Parameter, inf.Tx.Tx)
+		ppExists, err := dbhelpers.CachegroupParameterExistsByParameterID(*p.Parameter, *p.CacheGroup, inf.Tx.Tx)
 		if err != nil {
 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 			return
 		}
 		if ppExists {
-			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("parameter: "+strconv.Itoa(*p.Parameter)+" already associated with one or more profiles."), nil)
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("parameter: "+strconv.Itoa(*p.Parameter)+" already associated with cachegroup: "+strconv.Itoa(*p.CacheGroup)+"."), nil)
 			return
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -747,11 +747,11 @@ func GetUserByID(id int, tx *sql.Tx) (tc.User, bool, error) {
 	return u, true, err
 }
 
-// CachegroupParameterExistsByParameterID returns whether a cachegroup parameter association with the given parameter id exists, and any error.
-func CachegroupParameterExistsByParameterID(id int, cachegroup int, tx *sql.Tx) (bool, error) {
+// CachegroupParameterAssociationExists returns whether a cachegroup parameter association with the given parameter id exists, and any error.
+func CachegroupParameterAssociationExists(id int, cachegroup int, tx *sql.Tx) (bool, error) {
 	count := 0
 	if err := tx.QueryRow(`SELECT count(*) from cachegroup_parameter where parameter = $1 and cachegroup = $2`, id, cachegroup).Scan(&count); err != nil {
-		return false, errors.New("querying profile parameter existence from parameter id: " + err.Error())
+		return false, errors.New("querying cachegroup parameter existence: " + err.Error())
 	}
 	return count > 0, nil
 }

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -747,10 +747,10 @@ func GetUserByID(id int, tx *sql.Tx) (tc.User, bool, error) {
 	return u, true, err
 }
 
-// ProfileParameterExistsByParameterID returns whether a profile parameter association with the given parameter id exists, and any error.
-func ProfileParameterExistsByParameterID(id int, tx *sql.Tx) (bool, error) {
+// CachegroupParameterExistsByParameterID returns whether a cachegroup parameter association with the given parameter id exists, and any error.
+func CachegroupParameterExistsByParameterID(id int, cachegroup int, tx *sql.Tx) (bool, error) {
 	count := 0
-	if err := tx.QueryRow(`SELECT count(*) from profile_parameter where parameter = $1`, id).Scan(&count); err != nil {
+	if err := tx.QueryRow(`SELECT count(*) from cachegroup_parameter where parameter = $1 and cachegroup = $2`, id, cachegroup).Scan(&count); err != nil {
 		return false, errors.New("querying profile parameter existence from parameter id: " + err.Error())
 	}
 	return count > 0, nil


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR fixes a bug with the /cachegroupparameters endpoint.  it updates the Perl and Go code to check if a cachegroup/parameter association has already been made (previously checked for profile associations)

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Documentation
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Verify that the POST to /cachegroupparameters endpoint works as expected for a new association.
Verify that a POST to /cachegroupparameters with a duplicate returns an appropriate error.
Verify that a POST to /cachegroupparameters with a parameter already associated to one or more Profiles successfully adds the association.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR is a bug fix so tests are unnecessary
- [x] This PR includes documentation
- [x] This PR does not require an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
