### PR TITLE
TP: Format DNSSEC keys effectiveDate in RCF3339 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Fix to traffic_ops_ort.pl to strip specific comment lines before checking if a file has changed.  Also promoted a changed file message from DEBUG to ERROR for report mode.
+- Fixed Traffic Portal regenerating CDN DNSSEC keys with the wrong effective date
 - Updated The Traffic Ops Python, Go and Java clients to use API version 2.0 (when possible)
 - Updated CDN-in-a-Box scripts and enroller to use TO API version 2.0
 - Updated numerous, miscellaneous tools to use TO API version 2.0

--- a/traffic_portal/app/src/common/modules/form/cdnDnssecKeys/generate/FormGenerateCdnDnssecKeysController.js
+++ b/traffic_portal/app/src/common/modules/form/cdnDnssecKeys/generate/FormGenerateCdnDnssecKeysController.js
@@ -20,7 +20,7 @@
 var FormGenerateCdnDnssecKeysController = function(cdn, dnssecKeysRequest, $scope, $location, $uibModal, formUtils, locationUtils, cdnService, messageModel) {
 
 	var generate = function() {
-		$scope.dnssecKeysRequest.effectiveDate = moment($scope.effectiveDate).format('x');
+		$scope.dnssecKeysRequest.effectiveDate = moment($scope.effectiveDate).utc().format();
 		cdnService.generateDNSSECKeys($scope.dnssecKeysRequest)
 			.then(function(result) {
 				messageModel.setMessages(result.data.alerts, true);


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Currently, TP is formatting the effectiveDate field in the request as
unix epoch in MILLISECONDS. TO API expects epoch time format to be in
SECONDS. This means that TO creates DNSSEC keys with an effective date
ridiculously far into the future, when it was meant for the effective
date to be "now".

Alternatively, just format it as RFC3339, which the TO API can
also parse.

- [x] This PR is not related to any Issue 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
Without this PR installed, in Traffic Portal open the developer console and generate CDN DNSSEC keys. Verify that the `effectiveDate` field sent in the request to TO is formatted as a unix epoch time -- e.g. `"1583439180411"`.

With the PR installed, do the same thing but verify the time is formatted in RFC3339 format -- e.g. `"2020-03-05T20:57:00Z"`.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.x


## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [x] Bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
