### PR TITLE
Removed references to '/internal/' API endpoints

### DIFF
--- a/docs/source/api/v1/cdns_name_configs_routing.rst
+++ b/docs/source/api/v1/cdns_name_configs_routing.rst
@@ -261,7 +261,7 @@ Response Structure
 				"tld.ttls.DNSKEY": 30,
 				"geolocation.polling.interval": 86400000,
 				"tld.soa.expire": 604800,
-				"federationmapping.polling.url": "https://${toHostname}/internal/api/1.3/federations.json",
+				"federationmapping.polling.url": "https://${toHostname}/api/1.5/federations/all",
 				"coveragezone.polling.url": "https://trafficops.infra.ciab.test:443/coverage-zone.json",
 				"tld.soa.minimum": 30,
 				"geolocation.polling.url": "https://trafficops.infra.ciab.test:443/GeoLite2-City.mmdb.gz",

--- a/docs/source/api/v1/cdns_name_snapshot.rst
+++ b/docs/source/api/v1/cdns_name_snapshot.rst
@@ -365,7 +365,7 @@ Response Structure
 			"dnssec.enabled": "false",
 			"domain_name": "mycdn.ciab.test",
 			"federationmapping.polling.interval": "60000",
-			"federationmapping.polling.url": "https://${toHostname}/internal/api/1.3/federations.json",
+			"federationmapping.polling.url": "https://${toHostname}/api/1.5/federations/all",
 			"geolocation.polling.interval": "86400000",
 			"geolocation.polling.url": "https://trafficops.infra.ciab.test:443/GeoLite2-City.mmdb.gz",
 			"keystore.maintenance.interval": "300",

--- a/docs/source/api/v1/cdns_name_snapshot_new.rst
+++ b/docs/source/api/v1/cdns_name_snapshot_new.rst
@@ -365,7 +365,7 @@ Response Structure
 			"dnssec.enabled": "false",
 			"domain_name": "mycdn.ciab.test",
 			"federationmapping.polling.interval": "60000",
-			"federationmapping.polling.url": "https://${toHostname}/internal/api/1.3/federations.json",
+			"federationmapping.polling.url": "https://${toHostname}/api/1.5/federations/all",
 			"geolocation.polling.interval": "86400000",
 			"geolocation.polling.url": "https://trafficops.infra.ciab.test:443/GeoLite2-City.mmdb.gz",
 			"keystore.maintenance.interval": "300",


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

Removes references to old, `/internal/api/{{version}}`-based TO API endpoints from the documentation.

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Build the documentation, verify no errors and that output is factually correct.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**