### PR TITLE
Add ORT atstccfg plugin hook to modify files

### DIFF
--- a/traffic_ops/ort/atstccfg/cfgfile/all.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/all.go
@@ -36,19 +36,14 @@ import (
 )
 
 // GetAllConfigs gets all config files for cfg.CacheHostName.
-func GetAllConfigs(cfg config.TCCfg) ([]ATSConfigFile, error) {
-	toData, err := GetTOData(cfg)
-	if err != nil {
-		return nil, errors.New("getting data from traffic ops: " + err.Error())
-	}
-
+func GetAllConfigs(cfg config.TCCfg, toData *config.TOData) ([]config.ATSConfigFile, error) {
 	meta, err := GetMeta(toData)
 	if err != nil {
 		return nil, errors.New("creating meta: " + err.Error())
 	}
 
 	hasSSLMultiCertConfig := false
-	configs := []ATSConfigFile{}
+	configs := []config.ATSConfigFile{}
 	for _, fi := range meta.ConfigFiles {
 		if cfg.RevalOnly && fi.FileNameOnDisk != atscfg.RegexRevalidateFileName {
 			continue
@@ -61,7 +56,7 @@ func GetAllConfigs(cfg config.TCCfg) ([]ATSConfigFile, error) {
 			hasSSLMultiCertConfig = true
 		}
 		txt = PreprocessConfigFile(toData.Server, txt)
-		configs = append(configs, ATSConfigFile{ATSConfigMetaDataConfigFile: fi, Text: txt, ContentType: contentType})
+		configs = append(configs, config.ATSConfigFile{ATSConfigMetaDataConfigFile: fi, Text: txt, ContentType: contentType})
 	}
 
 	if hasSSLMultiCertConfig {
@@ -78,7 +73,7 @@ func GetAllConfigs(cfg config.TCCfg) ([]ATSConfigFile, error) {
 const HdrConfigFilePath = "Path"
 
 // WriteConfigs writes the given configs as a RFC2046§5.1 MIME multipart/mixed message.
-func WriteConfigs(configs []ATSConfigFile, output io.Writer) error {
+func WriteConfigs(configs []config.ATSConfigFile, output io.Writer) error {
 	w := multipart.NewWriter(output)
 
 	// Create a unique boundary. Because we're using a text encoding, we need to make sure the boundary text doesn't occur in any body.

--- a/traffic_ops/ort/atstccfg/cfgfile/astatsdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/astatsdotconfig.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileAstatsDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfileAstatsDotConfig(toData *config.TOData) (string, string, error) {
 	paramData := map[string]string{}
 	// TODO add configFile query param to profile/parameters endpoint, to only get needed data
 	for _, param := range toData.ServerParams {

--- a/traffic_ops/ort/atstccfg/cfgfile/atsdotrules.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/atsdotrules.go
@@ -21,11 +21,12 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
 const ATSDotRulesFileName = StorageFileName
 
-func GetConfigFileProfileATSDotRules(toData *TOData) (string, string, error) {
+func GetConfigFileProfileATSDotRules(toData *config.TOData) (string, string, error) {
 	paramData := map[string]string{}
 	// TODO add configFile query param to profile/parameters endpoint, to only get needed data
 	for _, param := range toData.ServerParams {

--- a/traffic_ops/ort/atstccfg/cfgfile/bgfetchdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/bgfetchdotconfig.go
@@ -22,8 +22,9 @@ package cfgfile
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNBGFetchDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileCDNBGFetchDotConfig(toData *config.TOData) (string, string, error) {
 	return atscfg.MakeBGFetchDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL), atscfg.ContentTypeBGFetchDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/cachedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cachedotconfig.go
@@ -22,9 +22,10 @@ package cfgfile
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileCacheDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfileCacheDotConfig(toData *config.TOData) (string, string, error) {
 	profileServerIDsMap := map[int]struct{}{}
 	for _, sv := range toData.Servers {
 		if sv.Profile != toData.Server.Profile {

--- a/traffic_ops/ort/atstccfg/cfgfile/cacheurldotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cacheurldotconfig.go
@@ -22,9 +22,10 @@ package cfgfile
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNCacheURL(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNCacheURL(toData *config.TOData, fileName string) (string, string, error) {
 	dsIDs := map[int]struct{}{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.ID != nil {
@@ -62,6 +63,6 @@ func GetConfigFileCDNCacheURL(toData *TOData, fileName string) (string, string, 
 	return atscfg.MakeCacheURLDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, fileName, cfgDSes), atscfg.ContentTypeCacheURLDotConfig, nil
 }
 
-func GetConfigFileCDNCacheURLPlain(toData *TOData) (string, string, error) {
+func GetConfigFileCDNCacheURLPlain(toData *config.TOData) (string, string, error) {
 	return GetConfigFileCDNCacheURL(toData, "cacheurl.config")
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/cfgfile.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cfgfile.go
@@ -34,85 +34,15 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/toreq"
 )
 
-// TOData is the Traffic Ops data needed to generate configs.
-// See each field for details on the data required.
-// - If a field says 'must', the creation of TOData is guaranteed to do so, and users of the struct may rely on that.
-// - If it says 'may', the creation may or may not do so, and therefore users of the struct must filter if they
-//   require the potential fields to be omitted to generate correctly.
-type TOData struct {
-	// Servers must be all the servers from Traffic Ops. May include servers not on the current cdn.
-	Servers []tc.Server
-
-	// CacheGroups must be all cachegroups in Traffic Ops with Servers on the current server's cdn. May also include CacheGroups without servers on the current cdn.
-	CacheGroups []tc.CacheGroupNullable
-
-	// GlobalParams must be all Parameters in Traffic Ops on the tc.GlobalProfileName Profile. Must not include other parameters.
-	GlobalParams []tc.Parameter
-
-	// ScopeParams must be all Parameters in Traffic Ops with the name "scope". Must not include other Parameters.
-	ScopeParams []tc.Parameter
-
-	// ServerParams must be all Parameters on the Profile of the current server. Must not include other Parameters.
-	ServerParams []tc.Parameter
-
-	// CacheKeyParams must be all Parameters with the ConfigFile atscfg.CacheKeyParameterConfigFile.
-	CacheKeyParams []tc.Parameter
-
-	// ParentConfigParams must be all Parameters with the ConfigFile "parent.config.
-	ParentConfigParams []tc.Parameter
-
-	// DeliveryServices must include all Delivery Services on the current server's cdn, including those not assigned to the server. Must not include delivery services on other cdns.
-	DeliveryServices []tc.DeliveryServiceNullable
-
-	// DeliveryServiceServers must include all delivery service servers in Traffic Ops for all delivery services on the current cdn, including those not assigned to the current server.
-	DeliveryServiceServers []tc.DeliveryServiceServer
-
-	// Server must be the server we're fetching configs from
-	Server tc.Server
-
-	// TOToolName must be the Parameter named 'tm.toolname' on the tc.GlobalConfigFileName Profile.
-	TOToolName string
-
-	// TOToolName must be the Parameter named 'tm.url' on the tc.GlobalConfigFileName Profile.
-	TOURL string
-
-	// Jobs must be all Jobs on the server's CDN. May include jobs on other CDNs.
-	Jobs []tc.Job
-
-	// CDN must be the CDN of the server.
-	CDN tc.CDN
-
-	// DeliveryServiceRegexes must be all regexes on all delivery services on this server's cdn.
-	DeliveryServiceRegexes []tc.DeliveryServiceRegexes
-
-	// Profile must be the Profile of the server being requested.
-	Profile tc.Profile
-
-	// URISigningKeys must be a map of every delivery service which is URI Signed, to its keys.
-	URISigningKeys map[tc.DeliveryServiceName][]byte
-
-	// URLSigKeys must be a map of every delivery service which uses URL Sig, to its keys.
-	URLSigKeys map[tc.DeliveryServiceName]tc.URLSigKeys
-
-	// ServerCapabilities must be a map of all server IDs on this server's CDN, to a set of their capabilities. May also include servers from other cdns.
-	ServerCapabilities map[int]map[atscfg.ServerCapability]struct{}
-
-	// DSRequiredCapabilities must be a map of all delivery service IDs on this server's CDN, to a set of their required capabilities. Delivery Services with no required capabilities may not have an entry in the map.
-	DSRequiredCapabilities map[int]map[atscfg.ServerCapability]struct{}
-
-	// SSLKeys must be all the ssl keys for the server's cdn.
-	SSLKeys []tc.CDNSSLKeys
-}
-
 // TODO: validate all "profile scope" files are the server's profile.
 //       If they ever weren't, we'll send bad data, because we're only getting the server's profile data.
 //       Getting all data for all profiles in TOData isn't reasonable.
 // TODO info log profile name, cdn name (ORT was logging, and doesn't get that data anymore, so we need to log here)
-func GetTOData(cfg config.TCCfg) (*TOData, error) {
+func GetTOData(cfg config.TCCfg) (*config.TOData, error) {
 	start := time.Now()
 	defer func() { log.Infof("GetTOData took %v\n", time.Since(start)) }()
 
-	toData := &TOData{}
+	toData := &config.TOData{}
 
 	serversF := func() error {
 		defer func(start time.Time) { log.Infof("serversF took %v\n", time.Since(start)) }(time.Now())
@@ -476,10 +406,4 @@ func ParamsToMultiMap(params []tc.Parameter) map[string][]string {
 		mp[param.Name] = append(mp[param.Name], param.Value)
 	}
 	return mp
-}
-
-type ATSConfigFile struct {
-	tc.ATSConfigMetaDataConfigFile
-	Text        string
-	ContentType string
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/cfgfile_test.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cfgfile_test.go
@@ -25,11 +25,12 @@ import (
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
 func TestWriteConfigs(t *testing.T) {
 	buf := &bytes.Buffer{}
-	configs := []ATSConfigFile{
+	configs := []config.ATSConfigFile{
 		{
 			ATSConfigMetaDataConfigFile: tc.ATSConfigMetaDataConfigFile{
 				FileNameOnDisk: "config0.txt",

--- a/traffic_ops/ort/atstccfg/cfgfile/chkconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/chkconfig.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerChkconfig(toData *TOData) (string, string, error) {
+func GetConfigFileServerChkconfig(toData *config.TOData) (string, string, error) {
 	fileParams := map[string][]string{}
 	for _, param := range toData.ServerParams {
 		if param.ConfigFile != atscfg.ChkconfigParamConfigFile {

--- a/traffic_ops/ort/atstccfg/cfgfile/dropqstringdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/dropqstringdotconfig.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileDropQStringDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfileDropQStringDotConfig(toData *config.TOData) (string, string, error) {
 	dropQStringVal := (*string)(nil)
 	for _, param := range toData.ServerParams {
 		if param.ConfigFile != atscfg.DropQStringDotConfigFileName {

--- a/traffic_ops/ort/atstccfg/cfgfile/facts.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/facts.go
@@ -21,8 +21,9 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfile12MFacts(toData *TOData) (string, string, error) {
+func GetConfigFileProfile12MFacts(toData *config.TOData) (string, string, error) {
 	return atscfg.Make12MFacts(toData.Server.Profile, toData.TOToolName, toData.TOURL), atscfg.ContentType12MFacts, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/headerrewritedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/headerrewritedotconfig.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNHeaderRewrite(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNHeaderRewrite(toData *config.TOData, fileName string) (string, string, error) {
 	dsName := strings.TrimSuffix(strings.TrimPrefix(fileName, atscfg.HeaderRewritePrefix), atscfg.ConfigSuffix) // TODO verify prefix and suffix? Perl doesn't
 
 	tcDS := tc.DeliveryServiceNullable{}

--- a/traffic_ops/ort/atstccfg/cfgfile/headerrewritemiddotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/headerrewritemiddotconfig.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNHeaderRewriteMid(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNHeaderRewriteMid(toData *config.TOData, fileName string) (string, string, error) {
 	dsName := strings.TrimSuffix(strings.TrimPrefix(fileName, atscfg.HeaderRewriteMidPrefix), atscfg.ConfigSuffix) // TODO verify prefix and suffix? Perl doesn't
 
 	tcDS := tc.DeliveryServiceNullable{}

--- a/traffic_ops/ort/atstccfg/cfgfile/hostingdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/hostingdotconfig.go
@@ -25,12 +25,13 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
 const ServerHostingDotConfigMidIncludeInactive = false
 const ServerHostingDotConfigEdgeIncludeInactive = true
 
-func GetConfigFileServerHostingDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileServerHostingDotConfig(toData *config.TOData) (string, string, error) {
 	fileParams := ParamsToMap(FilterParams(toData.ServerParams, atscfg.HostingConfigParamConfigFile, "", "", ""))
 
 	cdnServers := map[tc.CacheName]tc.Server{}

--- a/traffic_ops/ort/atstccfg/cfgfile/ipallowdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/ipallowdotconfig.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerIPAllowDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileServerIPAllowDotConfig(toData *config.TOData) (string, string, error) {
 	fileParams := ParamsToMultiMap(FilterParams(toData.ServerParams, atscfg.IPAllowConfigFileName, "", "", ""))
 
 	cgMap := map[string]tc.CacheGroupNullable{}

--- a/traffic_ops/ort/atstccfg/cfgfile/loggingdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/loggingdotconfig.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileLoggingDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfileLoggingDotConfig(toData *config.TOData) (string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.LoggingFileName, "", "", "location"))
 	return atscfg.MakeLoggingDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLoggingDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/loggingdotyaml.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/loggingdotyaml.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileLoggingDotYAML(toData *TOData) (string, string, error) {
+func GetConfigFileProfileLoggingDotYAML(toData *config.TOData) (string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.LoggingYAMLFileName, "", "", "location"))
 	return atscfg.MakeLoggingDotYAML(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLoggingDotYAML, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/logsxmldotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/logsxmldotconfig.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileLogsXMLDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfileLogsXMLDotConfig(toData *config.TOData) (string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.LogsXMLFileName, "", "", "location"))
 	return atscfg.MakeLogsXMLDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLogsDotXML, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/meta.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/meta.go
@@ -24,9 +24,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetMeta(toData *TOData) (*tc.ATSConfigMetaData, error) {
+func GetMeta(toData *config.TOData) (*tc.ATSConfigMetaData, error) {
 	cgMap := map[string]tc.CacheGroupNullable{}
 	for _, cg := range toData.CacheGroups {
 		if cg.Name == nil {

--- a/traffic_ops/ort/atstccfg/cfgfile/packages.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/packages.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerPackages(toData *TOData) (string, string, error) {
+func GetConfigFileServerPackages(toData *config.TOData) (string, string, error) {
 	params := ParamsToMultiMap(FilterParams(toData.ServerParams, atscfg.PackagesParamConfigFile, "", "", ""))
 	return atscfg.MakePackages(params), atscfg.ContentTypePackages, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/parentdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/parentdotconfig.go
@@ -30,9 +30,10 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerParentDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, error) {
 	cgMap := map[string]tc.CacheGroupNullable{}
 	for _, cg := range toData.CacheGroups {
 		if cg.Name == nil {

--- a/traffic_ops/ort/atstccfg/cfgfile/plugindotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/plugindotconfig.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfilePluginDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfilePluginDotConfig(toData *config.TOData) (string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.PluginFileName, "", "", "location"))
 	return atscfg.MakePluginDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypePluginDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/recordsdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/recordsdotconfig.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileRecordsDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfileRecordsDotConfig(toData *config.TOData) (string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.RecordsFileName, "", "", "location"))
 	return atscfg.MakeRecordsDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeRecordsDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/regexremapdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/regexremapdotconfig.go
@@ -27,7 +27,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNRegexRemap(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNRegexRemap(toData *config.TOData, fileName string) (string, string, error) {
 	configSuffix := `.config`
 	if !strings.HasPrefix(fileName, atscfg.RegexRemapPrefix) || !strings.HasSuffix(fileName, configSuffix) {
 		return `{"alerts":[{"level":"error","text":"Error - regex remap file '` + fileName + `' not of the form 'regex_remap_*.config! Please file a bug with Traffic Control, this should never happen."}]}`, "", config.ErrBadRequest

--- a/traffic_ops/ort/atstccfg/cfgfile/regexrevalidatedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/regexrevalidatedotconfig.go
@@ -23,9 +23,10 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNRegexRevalidateDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileCDNRegexRevalidateDotConfig(toData *config.TOData) (string, string, error) {
 	params := map[string][]string{}
 	for _, param := range toData.GlobalParams {
 		if param.ConfigFile != atscfg.RegexRevalidateFileName {

--- a/traffic_ops/ort/atstccfg/cfgfile/remapdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/remapdotconfig.go
@@ -29,9 +29,10 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerRemapDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, error) {
 	// TODO TOAPI add /servers?cdn=1 query param
 
 	atsVersionParam := ""

--- a/traffic_ops/ort/atstccfg/cfgfile/routing.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/routing.go
@@ -29,14 +29,14 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-var scopeConfigFileFuncs = map[string]func(toData *TOData, fileName string) (string, string, error){
+var scopeConfigFileFuncs = map[string]func(toData *config.TOData, fileName string) (string, string, error){
 	"cdns":     GetConfigFileCDN,
 	"servers":  GetConfigFileServer,
 	"profiles": GetConfigFileProfile,
 }
 
 // GetConfigFile returns the text of the generated config file, the MIME Content Type of the config file, and any error.
-func GetConfigFile(toData *TOData, fileInfo tc.ATSConfigMetaDataConfigFile) (string, string, error) {
+func GetConfigFile(toData *config.TOData, fileInfo tc.ATSConfigMetaDataConfigFile) (string, string, error) {
 	path := fileInfo.APIURI
 	// TODO remove the URL path parsing. It's a legacy from when config files were endpoints in the meta config.
 	// We should replace it with actually calling the right file and name directly.
@@ -65,10 +65,10 @@ func GetConfigFile(toData *TOData, fileInfo tc.ATSConfigMetaDataConfigFile) (str
 type ConfigFilePrefixSuffixFunc struct {
 	Prefix string
 	Suffix string
-	Func   func(toData *TOData, fileName string) (string, string, error)
+	Func   func(toData *config.TOData, fileName string) (string, string, error)
 }
 
-func GetConfigFileCDN(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileCDN(toData *config.TOData, fileName string) (string, string, error) {
 	log.Infoln("GetConfigFileCDN cdn '" + toData.Server.CDNName + "' fileName '" + fileName + "'")
 
 	txt := ""
@@ -95,7 +95,7 @@ func GetConfigFileCDN(toData *TOData, fileName string) (string, string, error) {
 	return txt, contentType, nil
 }
 
-func GetConfigFileProfile(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileProfile(toData *config.TOData, fileName string) (string, string, error) {
 	log.Infoln("GetConfigFileProfile profile '" + toData.Server.Profile + "' fileName '" + fileName + "'")
 
 	txt := ""
@@ -118,16 +118,16 @@ func GetConfigFileProfile(toData *TOData, fileName string) (string, string, erro
 }
 
 // ConfigFileFuncs returns a map[scope][configFile]configFileFunc.
-func ConfigFileFuncs() map[string]map[string]func(toData *TOData) (string, string, error) {
-	return map[string]map[string]func(toData *TOData) (string, string, error){
+func ConfigFileFuncs() map[string]map[string]func(toData *config.TOData) (string, string, error) {
+	return map[string]map[string]func(toData *config.TOData) (string, string, error){
 		"cdns":     CDNConfigFileFuncs(),
 		"servers":  ServerConfigFileFuncs(),
 		"profiles": ProfileConfigFileFuncs(),
 	}
 }
 
-func CDNConfigFileFuncs() map[string]func(toData *TOData) (string, string, error) {
-	return map[string]func(toData *TOData) (string, string, error){
+func CDNConfigFileFuncs() map[string]func(toData *config.TOData) (string, string, error) {
+	return map[string]func(toData *config.TOData) (string, string, error){
 		"regex_revalidate.config": GetConfigFileCDNRegexRevalidateDotConfig,
 		"bg_fetch.config":         GetConfigFileCDNBGFetchDotConfig,
 		"ssl_multicert.config":    GetConfigFileCDNSSLMultiCertDotConfig,
@@ -143,8 +143,8 @@ var ConfigFileCDNPrefixSuffixFuncs = []ConfigFilePrefixSuffixFunc{
 	{"set_dscp_", ".config", GetConfigFileCDNSetDSCP},
 }
 
-func ProfileConfigFileFuncs() map[string]func(toData *TOData) (string, string, error) {
-	return map[string]func(toData *TOData) (string, string, error){
+func ProfileConfigFileFuncs() map[string]func(toData *config.TOData) (string, string, error) {
+	return map[string]func(toData *config.TOData) (string, string, error){
 		"12M_facts":           GetConfigFileProfile12MFacts,
 		"50-ats.rules":        GetConfigFileProfileATSDotRules,
 		"astats.config":       GetConfigFileProfileAstatsDotConfig,
@@ -161,8 +161,8 @@ func ProfileConfigFileFuncs() map[string]func(toData *TOData) (string, string, e
 	}
 }
 
-func ServerConfigFileFuncs() map[string]func(toData *TOData) (string, string, error) {
-	return map[string]func(toData *TOData) (string, string, error){
+func ServerConfigFileFuncs() map[string]func(toData *config.TOData) (string, string, error) {
+	return map[string]func(toData *config.TOData) (string, string, error){
 		"parent.config":   GetConfigFileServerParentDotConfig,
 		"remap.config":    GetConfigFileServerRemapDotConfig,
 		"cache.config":    GetConfigFileServerCacheDotConfig,
@@ -173,7 +173,7 @@ func ServerConfigFileFuncs() map[string]func(toData *TOData) (string, string, er
 	}
 }
 
-func GetConfigFileServer(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileServer(toData *config.TOData, fileName string) (string, string, error) {
 	log.Infoln("GetConfigFileServer server '" + toData.Server.HostName + "' fileName '" + fileName + "'")
 	txt := ""
 	contentType := ""

--- a/traffic_ops/ort/atstccfg/cfgfile/servercachedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/servercachedotconfig.go
@@ -25,11 +25,12 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
 const ServerCacheDotConfigIncludeInactiveDSes = false // TODO move to lib/go-atscfg
 
-func GetConfigFileServerCacheDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileServerCacheDotConfig(toData *config.TOData) (string, string, error) {
 	// TODO TOAPI add /servers?cdn=1 query param
 
 	// TODO remove this, we generated the scope, we know it's right? Or should we have an extra safety check?

--- a/traffic_ops/ort/atstccfg/cfgfile/serverunknownconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/serverunknownconfig.go
@@ -22,9 +22,10 @@ package cfgfile
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerUnknownConfig(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileServerUnknownConfig(toData *config.TOData, fileName string) (string, string, error) {
 	params := ParamsToMultiMap(FilterParams(toData.ServerParams, fileName, "", "", ""))
 	return atscfg.MakeServerUnknown(tc.CacheName(toData.Server.HostName), toData.Server.DomainName, toData.TOToolName, toData.TOURL, params), atscfg.ContentTypeServerUnknownConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/setdscpdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/setdscpdotconfig.go
@@ -24,9 +24,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNSetDSCP(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNSetDSCP(toData *config.TOData, fileName string) (string, string, error) {
 	// TODO verify prefix, suffix, and that it's a number? Perl doesn't.
 	dscpNumStr := fileName
 	dscpNumStr = strings.TrimPrefix(dscpNumStr, "set_dscp_")

--- a/traffic_ops/ort/atstccfg/cfgfile/sslkeys.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/sslkeys.go
@@ -25,13 +25,14 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetSSLCertsAndKeyFiles(toData *TOData) ([]ATSConfigFile, error) {
+func GetSSLCertsAndKeyFiles(toData *config.TOData) ([]config.ATSConfigFile, error) {
 	dses := atscfg.DeliveryServicesToSSLMultiCertDSes(toData.DeliveryServices)
 	dses = atscfg.GetSSLMultiCertDotConfigDeliveryServices(dses)
 
-	configs := []ATSConfigFile{}
+	configs := []config.ATSConfigFile{}
 	for _, keys := range toData.SSLKeys {
 		dsName := tc.DeliveryServiceName(keys.DeliveryService)
 		ds, ok := dses[dsName]
@@ -59,13 +60,13 @@ func GetSSLCertsAndKeyFiles(toData *TOData) ([]ATSConfigFile, error) {
 
 		certName, keyName := atscfg.GetSSLMultiCertDotConfigCertAndKeyName(dsName, ds)
 
-		keyFile := ATSConfigFile{}
+		keyFile := config.ATSConfigFile{}
 		keyFile.FileNameOnDisk = keyName
 		keyFile.Location = "/opt/trafficserver/etc/trafficserver/ssl/" // TODO read config, don't hard code
 		keyFile.Text = string(key)
 		configs = append(configs, keyFile)
 
-		certFile := ATSConfigFile{}
+		certFile := config.ATSConfigFile{}
 		certFile.FileNameOnDisk = certName
 		certFile.Location = "/opt/trafficserver/etc/trafficserver/ssl/" // TODO read config, don't hard code
 		certFile.Text = string(cert)

--- a/traffic_ops/ort/atstccfg/cfgfile/sslmulticertdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/sslmulticertdotconfig.go
@@ -22,9 +22,10 @@ package cfgfile
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNSSLMultiCertDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileCDNSSLMultiCertDotConfig(toData *config.TOData) (string, string, error) {
 	cfgDSes := atscfg.DeliveryServicesToSSLMultiCertDSes(toData.DeliveryServices)
 
 	return atscfg.MakeSSLMultiCertDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, cfgDSes), atscfg.ContentTypeSSLMultiCertDotConfig, nil

--- a/traffic_ops/ort/atstccfg/cfgfile/storagedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/storagedotconfig.go
@@ -21,11 +21,12 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
 const StorageFileName = "storage.config"
 
-func GetConfigFileProfileStorageDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfileStorageDotConfig(toData *config.TOData) (string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, StorageFileName, "", "", "location"))
 	return atscfg.MakeStorageDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeStorageDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/sysctldotconf.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/sysctldotconf.go
@@ -21,9 +21,10 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileSysCtlDotConf(toData *TOData) (string, string, error) {
+func GetConfigFileProfileSysCtlDotConf(toData *config.TOData) (string, string, error) {
 	paramData := map[string]string{}
 	// TODO add configFile query param to profile/parameters endpoint, to only get needed data
 	for _, param := range toData.ServerParams {

--- a/traffic_ops/ort/atstccfg/cfgfile/unknownconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/unknownconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileUnknownConfig(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileProfileUnknownConfig(toData *config.TOData, fileName string) (string, string, error) {
 	inScope := false
 	for _, scopeParam := range toData.ScopeParams {
 		if scopeParam.ConfigFile != fileName {

--- a/traffic_ops/ort/atstccfg/cfgfile/urisigningconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/urisigningconfig.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileURISigningConfig(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileProfileURISigningConfig(toData *config.TOData, fileName string) (string, string, error) {
 	dsName := GetDSFromURISigningConfigFileName(fileName)
 	if dsName == "" {
 		// extra safety, this should never happen, the routing shouldn't get here

--- a/traffic_ops/ort/atstccfg/cfgfile/urlsigconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/urlsigconfig.go
@@ -25,9 +25,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileURLSigConfig(toData *TOData, fileName string) (string, string, error) {
+func GetConfigFileProfileURLSigConfig(toData *config.TOData, fileName string) (string, string, error) {
 	paramData := map[string]string{}
 	// TODO add configFile query param to profile/parameters endpoint, to only get needed data
 	for _, param := range toData.ServerParams {

--- a/traffic_ops/ort/atstccfg/cfgfile/volumedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/volumedotconfig.go
@@ -21,11 +21,12 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
 const VolumeFileName = StorageFileName
 
-func GetConfigFileProfileVolumeDotConfig(toData *TOData) (string, string, error) {
+func GetConfigFileProfileVolumeDotConfig(toData *config.TOData) (string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, VolumeFileName, "", "", ""))
 	return atscfg.MakeVolumeDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeVolumeDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/config/config.go
+++ b/traffic_ops/ort/atstccfg/config/config.go
@@ -28,7 +28,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
 	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
 
 	flag "github.com/ogier/pflag"
@@ -195,4 +197,80 @@ func ValidateURL(u *url.URL) error {
 func RetryBackoffSeconds(currentRetry int) int {
 	// TODO make configurable?
 	return int(math.Pow(2.0, float64(currentRetry)))
+}
+
+type ATSConfigFile struct {
+	tc.ATSConfigMetaDataConfigFile
+	Text        string
+	ContentType string
+}
+
+// TOData is the Traffic Ops data needed to generate configs.
+// See each field for details on the data required.
+// - If a field says 'must', the creation of TOData is guaranteed to do so, and users of the struct may rely on that.
+// - If it says 'may', the creation may or may not do so, and therefore users of the struct must filter if they
+//   require the potential fields to be omitted to generate correctly.
+type TOData struct {
+	// Servers must be all the servers from Traffic Ops. May include servers not on the current cdn.
+	Servers []tc.Server
+
+	// CacheGroups must be all cachegroups in Traffic Ops with Servers on the current server's cdn. May also include CacheGroups without servers on the current cdn.
+	CacheGroups []tc.CacheGroupNullable
+
+	// GlobalParams must be all Parameters in Traffic Ops on the tc.GlobalProfileName Profile. Must not include other parameters.
+	GlobalParams []tc.Parameter
+
+	// ScopeParams must be all Parameters in Traffic Ops with the name "scope". Must not include other Parameters.
+	ScopeParams []tc.Parameter
+
+	// ServerParams must be all Parameters on the Profile of the current server. Must not include other Parameters.
+	ServerParams []tc.Parameter
+
+	// CacheKeyParams must be all Parameters with the ConfigFile atscfg.CacheKeyParameterConfigFile.
+	CacheKeyParams []tc.Parameter
+
+	// ParentConfigParams must be all Parameters with the ConfigFile "parent.config.
+	ParentConfigParams []tc.Parameter
+
+	// DeliveryServices must include all Delivery Services on the current server's cdn, including those not assigned to the server. Must not include delivery services on other cdns.
+	DeliveryServices []tc.DeliveryServiceNullable
+
+	// DeliveryServiceServers must include all delivery service servers in Traffic Ops for all delivery services on the current cdn, including those not assigned to the current server.
+	DeliveryServiceServers []tc.DeliveryServiceServer
+
+	// Server must be the server we're fetching configs from
+	Server tc.Server
+
+	// TOToolName must be the Parameter named 'tm.toolname' on the tc.GlobalConfigFileName Profile.
+	TOToolName string
+
+	// TOToolName must be the Parameter named 'tm.url' on the tc.GlobalConfigFileName Profile.
+	TOURL string
+
+	// Jobs must be all Jobs on the server's CDN. May include jobs on other CDNs.
+	Jobs []tc.Job
+
+	// CDN must be the CDN of the server.
+	CDN tc.CDN
+
+	// DeliveryServiceRegexes must be all regexes on all delivery services on this server's cdn.
+	DeliveryServiceRegexes []tc.DeliveryServiceRegexes
+
+	// Profile must be the Profile of the server being requested.
+	Profile tc.Profile
+
+	// URISigningKeys must be a map of every delivery service which is URI Signed, to its keys.
+	URISigningKeys map[tc.DeliveryServiceName][]byte
+
+	// URLSigKeys must be a map of every delivery service which uses URL Sig, to its keys.
+	URLSigKeys map[tc.DeliveryServiceName]tc.URLSigKeys
+
+	// ServerCapabilities must be a map of all server IDs on this server's CDN, to a set of their capabilities. May also include servers from other cdns.
+	ServerCapabilities map[int]map[atscfg.ServerCapability]struct{}
+
+	// DSRequiredCapabilities must be a map of all delivery service IDs on this server's CDN, to a set of their required capabilities. Delivery Services with no required capabilities may not have an entry in the map.
+	DSRequiredCapabilities map[int]map[atscfg.ServerCapability]struct{}
+
+	// SSLKeys must be all the ssl keys for the server's cdn.
+	SSLKeys []tc.CDNSSLKeys
 }

--- a/traffic_ops/ort/atstccfg/plugin/hello_world.go
+++ b/traffic_ops/ort/atstccfg/plugin/hello_world.go
@@ -15,24 +15,35 @@ package plugin
 */
 
 import (
-	"fmt"
-	"os"
+	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
 func init() {
-	// AddPlugin(10000, Funcs{onRequest: hello})
+	// AddPlugin(10000, Funcs{modifyFiles: hello})
 }
 
 const HelloPath = "/_hello_world"
 
-func hello(d OnRequestData) IsRequestHandled {
-	if d.Cfg.TOURL.Path != HelloPath {
-		return RequestUnhandled
+// hello is an example "hello world" plugin. To test, create a Parameter assigned to the server you're running ORT/atstccfg on, named "enable_hello_world", with the Config File "hello_world" and the value "true"
+func hello(d ModifyFilesData) []config.ATSConfigFile {
+	hasHelloParam := false
+	for _, param := range d.TOData.ServerParams {
+		if param.Name == "enable_hello_world" && param.ConfigFile == "hello_world" && param.Value == "true" {
+			hasHelloParam = true
+			break
+		}
+	}
+	if !hasHelloParam {
+		return d.Files
 	}
 
-	cfgFile := "Hello World!\n"
+	fi := config.ATSConfigFile{}
 
-	fmt.Println(cfgFile)
-	os.Exit(42)
-	return RequestHandled
+	fi.Text = "Hello, World!\n"
+	fi.ContentType = "text/plain"
+	fi.FileNameOnDisk = "hello.txt"
+	fi.Location = "/opt/trafficserver/etc/trafficserver/"
+
+	d.Files = append(d.Files, fi)
+	return d.Files
 }

--- a/traffic_ops/ort/atstccfg/plugin/plugin.go
+++ b/traffic_ops/ort/atstccfg/plugin/plugin.go
@@ -52,7 +52,7 @@ func getAll() pluginsSlice {
 
 type Plugins interface {
 	OnStartup(d StartupData)
-	OnRequest(d OnRequestData) bool
+	ModifyFiles(d ModifyFilesData) []config.ATSConfigFile
 }
 
 func AddPlugin(priority uint64, funcs Funcs) {
@@ -68,16 +68,18 @@ func AddPlugin(priority uint64, funcs Funcs) {
 }
 
 type Funcs struct {
-	onStartup StartupFunc
-	onRequest OnRequestFunc
+	onStartup   StartupFunc
+	modifyFiles ModifyFilesFunc
 }
 
 type StartupData struct {
 	Cfg config.Cfg
 }
 
-type OnRequestData struct {
-	Cfg config.TCCfg
+type ModifyFilesData struct {
+	Cfg    config.TCCfg
+	TOData *config.TOData
+	Files  []config.ATSConfigFile
 }
 
 type IsRequestHandled bool
@@ -88,7 +90,7 @@ const (
 )
 
 type StartupFunc func(d StartupData)
-type OnRequestFunc func(d OnRequestData) IsRequestHandled
+type ModifyFilesFunc func(d ModifyFilesData) []config.ATSConfigFile
 
 type pluginObj struct {
 	funcs    Funcs
@@ -120,18 +122,16 @@ func (ps plugins) OnStartup(d StartupData) {
 	}
 }
 
-// OnRequest returns a boolean whether to immediately stop processing the request. If a plugin returns true, this is immediately returned with no further plugins processed.
-func (ps plugins) OnRequest(d OnRequestData) bool {
-	log.Infof("plugins.OnRequest calling %+v plugins\n", len(ps.slice))
+// ModifyFiles returns a slice of config files to use. May return d.Files unmodified, or may add, remove, or modify files in d.Files.
+func (ps plugins) ModifyFiles(d ModifyFilesData) []config.ATSConfigFile {
+	log.Infof("plugins.ModifyFiles calling %+v plugins\n", len(ps.slice))
 	for _, p := range ps.slice {
-		if p.funcs.onRequest == nil {
-			log.Infoln("plugins.OnRequest plugging " + p.name + " - no onRequest func")
+		if p.funcs.modifyFiles == nil {
+			log.Infoln("plugins.ModifyFiles plugging " + p.name + " - no modifyFiles func")
 			continue
 		}
-		log.Infoln("plugins.OnRequest plugging " + p.name)
-		if stop := p.funcs.onRequest(d); stop {
-			return true
-		}
+		log.Infoln("plugins.ModifyFiles plugging " + p.name)
+		d.Files = p.funcs.modifyFiles(d)
 	}
-	return false
+	return d.Files
 }

--- a/traffic_ops/ort/traffic_ops_ort.pl
+++ b/traffic_ops/ort/traffic_ops_ort.pl
@@ -1599,6 +1599,9 @@ sub parse_multipart_config_files {
 		exit 1;
 	}
 
+	my $last_boundary = "--" . $boundary . "--"; # multipart ends in --boundary--
+	$multipart_txt =~ s/$last_boundary//;       # remove it
+
 	my @files = split("--" . $boundary . "\r\n", $multipart_txt);
 
 	my %all_files;


### PR DESCRIPTION
Since atstccfg now generates all files at once, just having the
OnRequest hook was mostly useless.

This changes it to a 'ModifyFiles' hook, which is called after
generation and can add, remove, or modify generated files.
It also receives the TOData object, so it doesn't have to fetch
data already fetched.

Includes tests.
No docs, no public interface change. `atstccfg` is not stable and is not documented for TC user usage yet.
No changelog, no public interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Verify hello world plugin works as expected. Write a plugin.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information