### PR TITLE
Add experimental cache self-monitoring

### DIFF
--- a/experimental/monitorless/CRConfig.json
+++ b/experimental/monitorless/CRConfig.json
@@ -1,0 +1,259 @@
+{
+  "config": {
+    "domain_name": "cdn.test"
+  },
+  "contentServers": {
+    "mm-sanjose-ec0": {
+      "cacheGroup": "sanjose",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-sanjose-ec1": {
+      "cacheGroup": "sanjose",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-sanjose-ec2": {
+      "cacheGroup": "sanjose",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-denver-ec0": {
+      "cacheGroup": "denver",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-denver-ec1": {
+      "cacheGroup": "denver",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-denver-ec2": {
+      "cacheGroup": "denver",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-jacksonville-ec0": {
+      "cacheGroup": "jacksonville",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-jacksonville-ec1": {
+      "cacheGroup": "jacksonville",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-jacksonville-ec2": {
+      "cacheGroup": "jacksonville",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-chicago-ec0": {
+      "cacheGroup": "chicago",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-chicago-ec1": {
+      "cacheGroup": "chicago",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-chicago-ec2": {
+      "cacheGroup": "chicago",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-pittsburgh-ec0": {
+      "cacheGroup": "pittsburgh",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-pittsburgh-ec1": {
+      "cacheGroup": "pittsburgh",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-pittsburgh-ec2": {
+      "cacheGroup": "pittsburgh",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-nashville-ec0": {
+      "cacheGroup": "nashville",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-nashville-ec1": {
+      "cacheGroup": "nashville",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-nashville-ec2": {
+      "cacheGroup": "nashville",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-houston-ec0": {
+      "cacheGroup": "houston",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-houston-ec1": {
+      "cacheGroup": "houston",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-houston-ec2": {
+      "cacheGroup": "houston",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-saltlake-ec0": {
+      "cacheGroup": "saltlake",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-saltlake-ec1": {
+      "cacheGroup": "saltlake",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-saltlake-ec2": {
+      "cacheGroup": "saltlake",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-richmond-ec0": {
+      "cacheGroup": "richmond",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-richmond-ec1": {
+      "cacheGroup": "richmond",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-richmond-ec2": {
+      "cacheGroup": "richmond",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-seattle-ec0": {
+      "cacheGroup": "seattle",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-seattle-ec1": {
+      "cacheGroup": "seattle",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "mm-seattle-ec2": {
+      "cacheGroup": "seattle",
+      "ip": "192.0.2.1",
+      "port": 8081,
+      "status": "REPORTED",
+      "type": "EDGE"
+    }
+  },
+  "edgeLocations": {
+      "sanjose": {
+        "latitude": 37.2970523,
+        "longitude": -121.9574963
+      },
+      "denver": {
+        "latitude": 39.7645187,
+        "longitude": -104.9951946
+      },
+      "jacksonville": {
+        "latitude": 30.345284,
+        "longitude": -81.9632913
+      },
+      "chicago": {
+        "latitude": 41.8339037,
+        "longitude": -87.8720469
+      },
+      "pittsburgh": {
+        "latitude": 40.431478,
+        "longitude": -80.0505402
+      },
+      "nashville": {
+        "latitude": 36.186836,
+        "longitude": -86.9253289
+      },
+      "houston": {
+        "latitude": 29.8174782,
+        "longitude": -95.681476
+      },
+      "saltlake": {
+        "latitude": 40.7767833,
+        "longitude": -112.0605681
+      },
+      "richmond": {
+        "latitude": 37.5247764,
+        "longitude": -77.5633012
+      },
+      "seattle": {
+        "latitude": 47.6131746,
+        "longitude": -122.4821468
+      }
+  }
+}

--- a/experimental/monitorless/Dockerfile
+++ b/experimental/monitorless/Dockerfile
@@ -1,0 +1,45 @@
+# docker run must:
+#
+# - pass in the CRConfig as a volume to /external/CRConfig.json
+#   e.g. '--volume $(pwd)/CRConfig.json:/CRConfig.json'
+#   - Note the container copies the file, and promises not to change the host file.
+#     Unfortunately, it's not possible in Docker to copy in a file or unmount a volume.
+#
+# - pass the environment variable HEALTH_PORT
+#   e.g. '--env HEALTH_PORT=8089'
+#
+# - pass the environment variable CRSTATES_PORT
+#   e.g. '--env CRSTATES_PORT=8088'
+#
+FROM centos/systemd
+
+COPY remapgen/remapgen /
+COPY astatstwo/astatstwo /
+COPY healthcombiner/healthcombiner /
+# TODO add build arg for rpm file
+COPY trafficserver.rpm /
+COPY logging.yaml /
+COPY Dockerfile_run.sh /
+
+RUN yum update -y
+RUN yum install -y epel-release
+RUN yum install -y jq
+RUN yum install -y initscripts net-tools # debug
+RUN yum install -y trafficserver.rpm
+RUN mkdir -p /opt/trafficserver/etc/trafficserver/
+RUN mkdir -p /etc/trafficserver/
+RUN cp logging.yaml /opt/trafficserver/etc/trafficserver/ # handle both /opt/ and / installs
+RUN cp logging.yaml /etc/trafficserver/
+
+RUN printf $'CONFIG proxy.config.http.parent_proxy_routing_enable INT 1\n\
+CONFIG proxy.config.http.insert_response_via_str INT 3\n\
+CONFIG proxy.config.http.insert_request_via_str INT 1\n\
+' > /opt/trafficserver/etc/trafficserver/records.config
+
+RUN cp  /opt/trafficserver/etc/trafficserver/records.config /etc/trafficserver/records.config
+
+
+RUN mkdir -p /external
+RUN touch /external/CRConfig.json # file needs to exist, so when it's mounted as a volume, it's mounted as a file not a dir
+
+CMD /Dockerfile_run.sh

--- a/experimental/monitorless/Dockerfile_run.sh
+++ b/experimental/monitorless/Dockerfile_run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+envvars=( HEALTH_PORT CRSTATES_PORT )
+for v in $envvars; do
+	if [[ -z $$v ]]; then echo "$v is unset"; exit 1; fi
+done
+
+ats_install_prefix=""
+if [ -f "/opt/trafficserver/bin/trafficserver" ]; then
+	ats_install_prefix="/opt/trafficserver"
+fi
+
+start() {
+	nohup /astatstwo -debug -port="${HEALTH_PORT}" &
+	nohup /healthcombiner -crconfig-path=/CRConfig.json -debug -port="${CRSTATES_PORT}" &
+	# TODO run healthcombiner
+	"${ats_install_prefix}/bin/trafficserver" start
+	exec tail -f "${ats_install_prefix}/var/log/trafficserver/traffic.out"
+}
+
+init() {
+	if [ ! -f /external/CRConfig.json ]; then
+		echo "must run with a volume at /external/CRConfig.json"
+		exit
+	fi
+
+	# copy the file, so we can change it without modify the host if we want
+	cp /external/CRConfig.json /CRConfig.json
+	ATS_PORT=`cat /CRConfig.json | jq ".contentServers.\"${HOSTNAME}\".port"`
+
+	echo "CONFIG proxy.config.http.server_ports STRING ${ATS_PORT} ${ATS_PORT}:ipv6" >> "${ats_install_prefix}/etc/trafficserver/records.config"
+	echo "CONFIG proxy.config.proxy_name STRING ${HOSTNAME}"  >> "${ats_install_prefix}/etc/trafficserver/records.config"
+
+	# TODO run remapgen, place remaps and parents
+
+	echo "INITIALIZED=1" >> /etc/environment
+}
+
+source /etc/environment
+if [ -z "$INITIALIZED" ]; then init; fi
+start

--- a/experimental/monitorless/README.md
+++ b/experimental/monitorless/README.md
@@ -1,0 +1,86 @@
+# Monitorless Monitoring
+
+This proof-of-concept aims to replace the Traffic Monitor in Traffic Control with ATS remap rules.
+
+## Benefits
+
+By using ATS to do the expensive, difficult to write, high-performance things the Monitor currently does, developers on Traffic Control don't have to solve the difficult high-performance problems that ATS already solves.
+
+In addition, this also eliminates a highly CPU- and network-intensive application from production deployments.
+
+# Apps
+
+Monitorless Monitoring consists of 3 applications:
+
+1. `astatstwo` replaces the astats plugin, returning health data.
+2. `remapgen` generates the remap.config rules needed for routing health requests through ATS
+3. `healthcombiner` aggregates health from all caches into the legacy /CrStates.json consumed by Traffic Router.
+    - this is not strictly required, TR could make requests for each cache directly to ATS. But this allows Monitorless Monitoring to work without modifying Traffic Router.
+
+# Instructions
+
+The Proof-of-Concept creates Dockerfiles performing the ATS remapping and "monitorless monitoring."
+
+
+## Prerequisites
+
+You'll need Docker, Go, and `jq` installed locally.
+You'll also need a Apache Traffic Server 8.0 RPM in this directory named `trafficserver.rpm`.
+    - Should work with an RPM that installs at /opt/trafficserver
+    - I tried to make it  work with https://ci.trafficserver.apache.org/RPMS/CentOS7/trafficserver-8.0.3-1.el7.x86_64.rpm which installs to / and uses dynamic linking, but I haven't gotten the dynamic linking working in Docker yet.
+        - Note that is an unstable development build! The ATS project does not provide Release RPMs. If you need Traffic Server for any kind of real or production use, it is highly recommended to build it from a release source.
+
+## Installation
+
+```sh
+(cd remapgen && env GOOS=linux GOARCH=amd64 go build)
+(cd astatstwo && env GOOS=linux GOARCH=amd64 go build)
+(cd healthcombiner && env GOOS=linux GOARCH=amd64 go build)
+
+docker build --no-cache --rm --tag mm:0.1 .
+docker network create mm
+./create-containers.sh
+```
+
+## Cleanup
+
+```sh
+./create-containers.sh clean
+docker rmi mm:0.1
+docker network remove mm
+rm remapgen/remapgen
+rm astatstwo/astatstwo
+rm healthcombiner/healthcombiner
+```
+
+## Example Commands
+
+Example commands to play with the health protocol.
+
+Entering a container:
+`docker exec -it houston-ec0 /bin/bash`
+
+Inside one container, requesting the health of another:
+`curl -Lvsk -H 'Host: near.health.mm-seattle-ec2.cdn.test:8081' http://localhost:8081`
+  - observe the Via header, to see which caches were requested.
+
+Requesting the `astatstwo` service:
+`curl -Lvsk -H http://localhost:8089`
+
+Requesting the `healthcombiner` service:
+`curl -Lvsk -H http://localhost:8088/CRStates.json`
+
+Set a container's `astatstwo` service to serve Unavailable (503):n
+`curl -Lvsk -X POST http://localhost:8083/debug?available=false`
+
+See what the remap rules look like (they include detailed comments as to what was chosen and why):
+`cat /opt/trafficserver/etc/trafficserver/remap.config`
+
+See what the parent rules look like (also include detailed comments):
+`cat /opt/trafficserver/etc/trafficserver/parent.config`
+
+Containers are built from the CRConfig.json in this directory. You should be able to add and rename servers and cachegroups, to change how containers are created.
+    - Note remap rules don't work for servers with different ports yet. All servers need the same port, for now.
+    - Note create-containers.sh doesn't use the IPs, but rather copies the file and overwrites them with the dynamically-created IPs of the Docker containers.
+
+You can also change `health_port` and `crstates_port` in create-containers.sh, and it should work.

--- a/experimental/monitorless/astatstwo/astatstwo.go
+++ b/experimental/monitorless/astatstwo/astatstwo.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+func main() {
+	port := flag.Int("port", 80, "Port to serve on")
+	timeoutMS := flag.Int("timeout-ms", 10000, "HTTP read and write timeout")
+	debug := flag.Bool("debug", false, "Whether to enable debug HTTP directives. Unsecured, should never be enabled in a production environment.")
+	flag.Parse()
+
+	timeout := time.Duration(*timeoutMS) * time.Millisecond
+
+	server := &http.Server{
+		Addr:         ":" + strconv.Itoa(*port),
+		Handler:      MakeHandler(&HandlerCfg{Debug: *debug}),
+		ReadTimeout:  timeout,
+		WriteTimeout: timeout,
+	}
+
+	fmt.Println("Listening on " + server.Addr)
+	if err := server.ListenAndServe(); err != nil {
+		fmt.Println("ERROR: " + err.Error())
+		os.Exit(1)
+	}
+	os.Exit(0) // should never happen; unless we add a "shutdown" directive
+}
+
+type HandlerCfg struct {
+	Debug bool
+	// Atomic, MUST NOT be accessed outside atomic.
+	// DO NOT change to a bool or make non-atomic. Booleans still must be atomic.
+	Unavailable uint32
+}
+
+// MakeHandler currently takes just the debug bool, but it can be changed to take lots of things if necessary.
+func MakeHandler(cfg *HandlerCfg) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		handler(w, r, cfg)
+	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request, cfg *HandlerCfg) {
+	if cfg.Debug && strings.HasPrefix(r.URL.Path, PathPrefixDebug) {
+		handlerDebug(w, r, cfg)
+		return
+	}
+
+	handlerHealth(w, r, cfg)
+}
+
+const PathPrefixDebug = `/debug`
+
+func handlerDebug(w http.ResponseWriter, r *http.Request, cfg *HandlerCfg) {
+	switch r.Method {
+	case http.MethodPost:
+		query := r.URL.Query()
+		if availStrs, ok := query["available"]; ok {
+			if len(availStrs) > 0 && strings.HasPrefix(availStrs[0], "f") {
+				atomic.StoreUint32(&cfg.Unavailable, 1)
+			} else {
+				atomic.StoreUint32(&cfg.Unavailable, 0)
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, "unknown debug directive POST\n")
+		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+func handlerHealth(w http.ResponseWriter, r *http.Request, cfg *HandlerCfg) {
+	switch r.Method {
+	case http.MethodHead:
+		fallthrough
+	case http.MethodGet:
+		if atomic.LoadUint32(&cfg.Unavailable) != 0 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+}

--- a/experimental/monitorless/create-containers.sh
+++ b/experimental/monitorless/create-containers.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# set -e          # exit if any command has a nonzero exit code
+# set -u          # exit if any undefined variable is referenced
+# set -o pipefail # exit if any command in a pipeline is nonzero # commented, because sometimes you want to || true
+
+#
+# Creates and configures docker containers for monitorless monitoring.
+# Requires:
+# - jq
+# - the working directory be experimental/monitorless
+# - A docker image named 'mm' exist. Run 'docker build --no-cache --rm --tag mm:0.1 .'
+# - A CRConfig.json at ./CRConfig.json
+#    - Everything in the CRConfig.json needs to be correct, except the IPs
+#      This script will create containers for all servers in .contentServers
+#      It will copy the CRConfig to crconfig-mm.json, and then modify it to have the docker container IPs
+# - A docker network named 'mm'.
+#
+
+if [[ "$1" == "clean" ]]; then
+	echo "removing containers: "
+	container_names=$(cat CRConfig.json | jq -r '.contentServers | keys | .[]')
+	container_names_spaced=$(echo $container_names)
+	docker rm -f $container_names_spaced
+	rm ./mm-crconfig.json
+	exit 0
+fi
+
+# Note this script copies ./CRConfig.json into ./mm-crconfig.json and modifies it for the created containers
+
+if [ -z "${BASH_VERSINFO}" ] || [ -z "${BASH_VERSINFO[0]}" ] || [ ${BASH_VERSINFO[0]} -lt 4 ]; then
+	printf "This script requires Bash version >= 4\n";
+	exit 1;
+fi
+
+# TODO create docker image if it doesn't exist
+# TODO create docker network if it doesn't exist
+
+printf "running bash 4+\n"
+
+# configurable variables:
+health_port=8089
+crstates_port=8088
+
+container_names=$(cat CRConfig.json | jq -r '.contentServers | keys | .[]')
+
+cp ./CRConfig.json ./mm-crconfig.json
+
+# this is slightly insane, but because docker exec reads from stdin, the better read line loop doesn't work
+for container_name in ${container_names//\\n/ }; do
+	printf "creating container '${container_name}'\n"
+	# TODO exclude non-reported/online? non-edges?
+
+	docker run --detach --name "${container_name}" --hostname "${container_name}" --net mm --env HEALTH_PORT="${health_port}" --env CRSTATES_PORT="${crstates_port}" --volume $(pwd)/mm-crconfig.json:/external/CRConfig.json -- mm:0.1
+
+	# Set this server's IP in the CRConfig to the docker container's IP
+	ip=$(docker exec -i "${container_name}" sh -c 'ip addr' | grep -A 2 ': eth0' | tail -1 | awk '{print $2}' | cut -f1 -d'/')
+	cat mm-crconfig.json | jq "(.contentServers.\"${container_name}\".ip ) = \"${ip}\"" > mm-crconfig.json.tmp
+	mv mm-crconfig.json{.tmp,}
+	printf "ip: ${ip}\n"
+
+done
+
+# after all containers are created, and their IPs put in the CRConfig, run remapgen in the containers
+
+for container_name in ${container_names//\\n/ }; do
+	ats_install_prefix=""
+	docker exec -i "${container_name}" sh -c "test -f /opt/trafficserver/bin/trafficserver"
+	ats_in_opt=$?
+	printf "container ${container_name} in opt: ${ats_in_opt}\n"
+	if [ "$ats_in_opt" = "0" ]; then
+		ats_install_prefix="/opt/trafficserver"
+	fi
+	printf "container ${container_name} prefix: '${ats_install_prefix}'\n"
+
+	# re-copy the external CRConfig that we just added IPs to, to prevent accidental modification
+	docker exec -i "${container_name}" sh -c "cat /external/CRConfig.json > /CRConfig.json"
+
+	docker exec -i "${container_name}" sh -c "/remapgen -host ${container_name} -crconfig-path /CRConfig.json -health-port \${HEALTH_PORT} -comments=true -config remap > ${ats_install_prefix}/etc/trafficserver/remap.config"
+
+	docker exec -i "${container_name}" sh -c "/remapgen -host ${container_name} -crconfig-path /CRConfig.json -health-port \${HEALTH_PORT} -comments=true -config parent > ${ats_install_prefix}/etc/trafficserver/parent.config"
+
+	docker exec -i "${container_name}" sh -c "pkill traffic_manager && pkill '[TS_MAIN]' && sleep 1 && ${ats_install_prefix}/bin/trafficserver start"
+#	docker exec -i "${container_name}" sh -c '${ats_install_prefix}/trafficserver/bin/trafficserver restart'
+done

--- a/experimental/monitorless/healthcombiner/healthcombiner.go
+++ b/experimental/monitorless/healthcombiner/healthcombiner.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const HealthPort = 33417
+const HealthSubdomain = `health`
+const NearSubdomain = `near`
+const FarSubdomain = `far`
+
+func main() {
+	port := flag.Int("port", 80, "Port to serve on")
+	// TODO separate server and client timeouts
+	serverTimeoutMS := flag.Int("server-timeout-ms", 5000, "HTTP read and write timeout for this server")
+	clientTimeoutMS := flag.Int("client-timeout-ms", 5000, "HTTPread and write timeout for client requests to ATS")
+	insecure := flag.Bool("insecure", false, "Whether to ignore HTTPS certificate errors when making client requests")
+	debug := flag.Bool("debug", false, "Whether to enable debug HTTP directives. Unsecured, should never be enabled in a production environment.")
+	crConfigPath := flag.String("crconfig-path", "", "CRConfig path")
+	crConfigIntervalMS := flag.Int("crconfig-interval-ms", 30000, "CRConfig refresh interavl")
+	flag.Parse()
+
+	// TODO add flag hostname override
+	// The hostname isn't actually used to request locally, but rather to look up the ATS port in the CRConfig.
+	// The request is always to localhost.
+	// TODO add flag override to actually request the override host, to allow the healthcombiner to run remotely.
+	hostName := os.Getenv("HOSTNAME")
+
+	if *crConfigPath == "" {
+		fmt.Fprintf(os.Stderr, "-crconfig-path is required\n")
+		os.Exit(1)
+	}
+
+	serverTimeout := time.Duration(*serverTimeoutMS) * time.Millisecond
+	clientTimeout := time.Duration(*clientTimeoutMS) * time.Millisecond
+	crConfigInterval := time.Duration(*crConfigIntervalMS) * time.Millisecond
+
+	handlerCfg := &HandlerCfg{Debug: *debug, ClientTimeout: clientTimeout, Insecure: *insecure, HostName: hostName}
+
+	crc, err := GetCRConfig(*crConfigPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR getting CRConfig '"+*crConfigPath+"': "+err.Error()+"\n")
+		os.Exit(1)
+	}
+	crcPtr := (unsafe.Pointer)(crc)
+	handlerCfg.crConfig = &crcPtr
+
+	server := &http.Server{
+		Addr:         ":" + strconv.Itoa(*port),
+		Handler:      MakeHandler(handlerCfg),
+		ReadTimeout:  serverTimeout,
+		WriteTimeout: serverTimeout,
+	}
+
+	go RefreshCRConfig(handlerCfg, crConfigInterval, *crConfigPath)
+
+	{
+		// start workers
+
+		const numWorkers = 100
+		const workerChanBufSize = 10
+
+		reqCh := make(chan Req, workerChanBufSize)
+
+		httpClient := &http.Client{
+			Timeout: handlerCfg.ClientTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: handlerCfg.Insecure},
+			},
+		}
+
+		sv, ok := crc.ContentServers[hostName]
+		if !ok {
+			// TODO continue and use default 80?
+			fmt.Fprintf(os.Stderr, "CRConfig missing this server '"+hostName+"'")
+			os.Exit(1)
+		}
+		localPort := 80
+		if sv.Port != nil && *sv.Port != 80 {
+			localPort = *sv.Port
+		}
+
+		reqFQDN := "localhost"
+		reqURI := "http://" + reqFQDN
+		if localPort != 80 {
+			reqURI += ":" + strconv.Itoa(localPort)
+		}
+
+		reqURL, err := url.Parse(reqURI)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "creating URL: "+err.Error())
+			os.Exit(1)
+		}
+
+		for i := 0; i < numWorkers; i++ {
+			go StartReqWorker(httpClient, reqURL, reqCh)
+		}
+		handlerCfg.ReqCh = reqCh
+	}
+
+	fmt.Println("Listening on " + server.Addr)
+	if err := server.ListenAndServe(); err != nil {
+		fmt.Println("ERROR: " + err.Error())
+		os.Exit(1)
+	}
+	os.Exit(0) // should never happen; unless we add a "shutdown" directive
+}
+
+type HandlerCfg struct {
+	Debug         bool
+	ClientTimeout time.Duration
+	Insecure      bool
+	HostName      string
+	ReqCh         chan Req
+
+	// crConfig is set atomically. DO NOT access outside atomic operations, i.e. GetCRConfig,SetCRConfig
+	crConfig *unsafe.Pointer
+}
+
+func (h *HandlerCfg) GetCRConfig() *tc.CRConfig {
+	return (*tc.CRConfig)(atomic.LoadPointer(h.crConfig))
+}
+
+func (h *HandlerCfg) SetCRConfig(crc *tc.CRConfig) {
+	atomic.StorePointer(h.crConfig, (unsafe.Pointer)(crc))
+}
+
+// MakeHandler currently takes just the debug bool, but it can be changed to take lots of things if necessary.
+func MakeHandler(cfg *HandlerCfg) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		handler(w, r, cfg)
+	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request, cfg *HandlerCfg) {
+	handlerCRStates(w, r, cfg)
+}
+
+func handlerCRStates(w http.ResponseWriter, r *http.Request, cfg *HandlerCfg) {
+	switch r.Method {
+	case http.MethodGet:
+		if !strings.HasPrefix(strings.ToLower(r.URL.Path), `/crstates`) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		crStates, err := buildCRStates(cfg)
+		if err != nil {
+			fmt.Println("ERROR building CRStates: " + err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(crStates); err != nil {
+			// TODO don't log? We don't generally log client errors.
+			//      Should we encode to bytes first, to be sure it's a client err not a json err?
+			fmt.Println("ERROR writing CRStates: " + err.Error())
+		}
+		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+type CRStates struct {
+	Caches          map[tc.CacheName]IsAvailable                       `json:"caches"`
+	DeliveryService map[tc.DeliveryServiceName]CRStatesDeliveryService `json:"deliveryServices"`
+}
+type CRStatesDeliveryService struct {
+	DisabledLocations []tc.CacheGroupName `json:"disabledLocations"`
+	IsAvailable       bool                `json:"isAvailable"`
+}
+type IsAvailable struct {
+	IsAvailable bool `json:"isAvailable"`
+}
+
+func buildCRStates(cfg *HandlerCfg) (*CRStates, error) {
+	crs := &CRStates{
+		Caches:          map[tc.CacheName]IsAvailable{},
+		DeliveryService: map[tc.DeliveryServiceName]CRStatesDeliveryService{},
+	}
+
+	crc := cfg.GetCRConfig()
+
+	cdnDomainI, ok := crc.Config[`domain_name`]
+	if !ok {
+		return nil, errors.New("CRConfig Config missing 'domain_name'")
+	}
+	cdnDomain, ok := cdnDomainI.(string)
+	if !ok {
+		return nil, fmt.Errorf("CRConfig Config 'domain_name' unexpected type %T", cdnDomainI)
+	}
+
+	sv, ok := crc.ContentServers[cfg.HostName]
+	if !ok {
+		// TODO continue and use default 80?
+		return nil, fmt.Errorf("CRConfig missing this server '" + cfg.HostName + "'")
+	}
+	localPort := 80
+	if sv.Port != nil && *sv.Port != 80 {
+		localPort = *sv.Port
+	}
+
+	type RespStruct struct {
+		Server string
+		Near   bool
+		Ch     chan bool
+	}
+	responses := []RespStruct{}
+
+	// TODO also get mids
+	for svName, sv := range crc.ContentServers {
+		if sv.ServerStatus == nil {
+			return nil, errors.New("CRConfig server '" + svName + "' missing status")
+		}
+		if tc.CacheStatus(*sv.ServerStatus) == tc.CacheStatusOffline {
+			continue // TODO warn? Shouldn't even be in the CRConfig
+		}
+		if tc.CacheStatus(*sv.ServerStatus) == tc.CacheStatusAdminDown {
+			fmt.Println("DEBUG server '" + svName + "' AdminDown - unavailable")
+			crs.Caches[tc.CacheName(svName)] = IsAvailable{IsAvailable: false}
+			continue
+		}
+		if tc.CacheStatus(*sv.ServerStatus) == tc.CacheStatusOnline {
+			fmt.Println("DEBUG server '" + svName + "' Online - available")
+			crs.Caches[tc.CacheName(svName)] = IsAvailable{IsAvailable: true}
+			continue
+		}
+		if tc.CacheStatus(*sv.ServerStatus) != tc.CacheStatusReported {
+			// TODO error: unknown status
+			fmt.Println("DEBUG server '" + svName + "' unknown - unavailable")
+			crs.Caches[tc.CacheName(svName)] = IsAvailable{IsAvailable: false}
+			continue
+		}
+
+		// TODO remove duplicate with near and far requests/availability
+
+		healthFQDN := HealthSubdomain + `.` + svName + `.` + cdnDomain
+		hostHdr := healthFQDN
+		if localPort != 80 {
+			hostHdr += ":" + strconv.Itoa(localPort)
+		}
+
+		respCh := make(chan bool, 1)
+		cfg.ReqCh <- Req{Host: NearSubdomain + `.` + hostHdr, Resp: respCh}
+		responses = append(responses, RespStruct{Server: svName, Near: true, Ch: respCh})
+
+		respChFar := make(chan bool, 1)
+		cfg.ReqCh <- Req{Host: FarSubdomain + `.` + hostHdr, Resp: respChFar}
+		responses = append(responses, RespStruct{Server: svName, Near: false, Ch: respChFar})
+	}
+
+	nearAvail := map[tc.CacheName]bool{}
+	farAvail := map[tc.CacheName]bool{}
+
+	// TODO get responses as they come in, instead of having to wait in order
+	//      (requires refactoring channel design)
+	for _, resp := range responses {
+		avail := <-resp.Ch
+		if resp.Near {
+			nearAvail[tc.CacheName(resp.Server)] = avail
+		} else {
+			farAvail[tc.CacheName(resp.Server)] = avail
+		}
+	}
+
+	for host, avail := range nearAvail {
+		if avail && farAvail[host] {
+			crs.Caches[host] = IsAvailable{IsAvailable: true}
+		} else {
+			crs.Caches[host] = IsAvailable{IsAvailable: false}
+		}
+	}
+
+	return crs, nil
+}
+
+// RefreshCRConfig refreshes the CRConfig every interval. Does not return.
+func RefreshCRConfig(cfg *HandlerCfg, interval time.Duration, path string) {
+	// TODO change refresh from a file path to the TO URL.
+	timer := time.NewTimer(0)
+	for {
+		<-timer.C
+		crc, err := GetCRConfig(path)
+		if err != nil {
+			fmt.Println("ERROR refreshing CRConfig path '" + path + "': " + err.Error())
+		} else {
+			fmt.Println("DEBUG refreshed CRConfig path '" + path + "'")
+			cfg.SetCRConfig(crc)
+		}
+		timer.Reset(interval)
+	}
+}
+
+func GetCRConfig(path string) (*tc.CRConfig, error) {
+	crcFi, err := os.Open(path)
+	if err != nil {
+		return nil, errors.New("opening CRConfig path '" + path + "': " + err.Error())
+	}
+	defer crcFi.Close()
+
+	crc := &tc.CRConfig{}
+	if err := json.NewDecoder(crcFi).Decode(crc); err != nil {
+		return nil, errors.New("decoding CRConfig path '" + path + "': " + err.Error())
+	}
+	return crc, nil
+}
+
+type Req struct {
+	Host string
+	Resp chan bool
+}
+
+func StartReqWorker(httpClient *http.Client, reqURL *url.URL, reqCh chan Req) {
+	for workerReq := range reqCh {
+		req := &http.Request{
+			Method: http.MethodGet,
+			URL:    reqURL,
+			Host:   workerReq.Host,
+		}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			// TODO log
+			workerReq.Resp <- false
+			continue
+		}
+		resp.Body.Close() // immediately close, there should be no body, and we don't care if there is
+		// TODO log unavailable codes?
+		workerReq.Resp <- resp.StatusCode >= 200 && resp.StatusCode <= 299
+	}
+}

--- a/experimental/monitorless/logging.yaml
+++ b/experimental/monitorless/logging.yaml
@@ -1,0 +1,11 @@
+formats:
+- name: textlog
+  format: '%<cqtq> chi=%<chi> phn=%<phn> php=%<php> shn=%<shn> url=%<cquuc> cqhm=%<cqhm> cqhv=%<cqpv> pssc=%<pssc> ttms=%<ttms> b=%<pscl> sssc=%<sssc> sscl=%<sscl> cfsc=%<cfsc> pfsc=%<pfsc> crc=%<crc> phr=%<phr> pqsn=%<shn> uas="%<{User-Agent}cqh>">'
+logs:
+- mode: ascii
+  filename: request
+  format: textlog
+  rolling_enabled: 'both'
+  rolling_interval_sec: 172800
+  rolling_offset_hr: 24
+  rolling_size_mb: 512

--- a/experimental/monitorless/remapgen/remapgen.go
+++ b/experimental/monitorless/remapgen/remapgen.go
@@ -1,0 +1,659 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"flag"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const HealthSubdomain = `health`
+const NearSubdomain = `near`
+const FarSubdomain = `far`
+
+func main() {
+	host := flag.String("host", "", "hostname to generate remap and parent lines for")
+	crcPath := flag.String("crconfig-path", "", "CRConfig file path")
+	comments := flag.Bool("comments", true, "Whether to add comments to the generated text")
+	configToGen := flag.String("config", "", "The ATS config file to generate. Options: remap, parent")
+	healthPort := flag.Int("health-port", 0, "The health port of the health service (astatstwo)")
+	flag.Parse()
+
+	usageStr := `Usage: ./remapgen -host my-host-name -crconfig-path ./path/to/crconfig.json -config remap -health-port 8083` + "\n"
+	if *healthPort == 0 {
+		fmt.Fprintf(os.Stderr, usageStr)
+		os.Exit(1)
+	}
+	if *host == "" || *crcPath == "" {
+		fmt.Fprintf(os.Stderr, usageStr)
+		os.Exit(1)
+	}
+	if *configToGen != "remap" && *configToGen != "parent" {
+		fmt.Fprintf(os.Stderr, usageStr)
+		os.Exit(1)
+	}
+
+	crcFi, err := os.Open(*crcPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "opening CRConfig path '"+*crcPath+"': "+err.Error()+"\n")
+		os.Exit(1)
+	}
+	defer crcFi.Close()
+
+	crc := &tc.CRConfig{}
+	if err := json.NewDecoder(crcFi).Decode(crc); err != nil {
+		fmt.Fprintf(os.Stderr, "decoding CRConfig path '"+*crcPath+"': "+err.Error()+"\n")
+		os.Exit(1)
+	}
+
+	remapLines, parentLines, err := GenerateRemapParentLines(crc, tc.CacheName(*host), *healthPort, *comments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error generating lines: "+err.Error()+"\n")
+		os.Exit(1)
+	}
+
+	switch *configToGen {
+	case "remap":
+		fmt.Println(remapLines)
+	case "parent":
+		fmt.Println(parentLines)
+	}
+}
+
+/*
+1. remaps to every other cache which is NOT in this cache's CG
+    - two remaps: to the same CG, and to the designated "far CG" which will poll that cache "from a distance."
+    - remaps in order to "cache monitors," where every cache shares the same order, so one cache is always the "cache monitor" (unless it's down, in which case the next one on the list "becomes" the "cache monitor."
+2. remaps to caches in this cache's CG
+    - two remaps: directly to that cache (near), and to the designated "far CG" which will poll that cache "from a distance."
+    - remaps directly to that cache
+3. remap to self, to astatstwo
+    - remaps to localhost:astatstwoport
+*/
+
+// GenerateRemapLines generates the health remap.config and parent.config lines.
+// The crc.ContentServers[name].DeliveryServices is not used and may be nil (huge size/performance gain).
+// Returns the remap lines, the parent lines, and any error
+func GenerateRemapParentLines(crc *tc.CRConfig, hostName tc.CacheName, healthPort int, comments bool) (string, string, error) {
+	cdnDomainI, ok := crc.Config[`domain_name`]
+	if !ok {
+		return "", "", errors.New("CRConfig Config missing 'domain_name'")
+	}
+	cdnDomain, ok := cdnDomainI.(string)
+	if !ok {
+		return "", "", fmt.Errorf("CRConfig Config 'domain_name' unexpected type %T", cdnDomainI)
+	}
+
+	remapSvName := hostName
+	remapSv, ok := crc.ContentServers[string(hostName)]
+	if !ok {
+		return "", "", errors.New("host '" + string(hostName) + "' not in CRConfig")
+	}
+	if remapSv.CacheGroup == nil {
+		return "", "", errors.New("host '" + string(hostName) + "' has no CacheGroup")
+	}
+	// remapSvCG, ok := crc.EdgeLocations[*remapSv.CacheGroup]
+	// if !ok {
+	// 	return "", "", errors.New("host '" + string(hostName) + "' CacheGroup '" + *remapSv.CacheGroup + "' not in CRConfig.EdgeLocations!")
+	// }
+
+	// cgServers is a cache.
+	// The data exists in crc.ContentServers, this just saves iterating over every server every time.
+	cgServers := map[tc.CacheGroupName][]string{}
+	for svName, sv := range crc.ContentServers {
+		// TODO handle mids
+		if sv.ServerType == nil || tc.CacheType(*sv.ServerType) != tc.CacheTypeEdge {
+			continue
+		}
+		if sv.CacheGroup == nil {
+			return "", "", errors.New("server '" + svName + "' has no CacheGroup")
+		}
+		cgServers[tc.CacheGroupName(*sv.CacheGroup)] = append(cgServers[tc.CacheGroupName(*sv.CacheGroup)], svName)
+	}
+
+	// sort deterministically.
+	for _, servers := range cgServers {
+		// This sorts alphabetically. We could sort by something else, e.g. consistent hash
+		sort.Strings(servers)
+	}
+
+	// get the "far cachegroup" for every unique cachegroup on any server
+	farCGs := map[tc.CacheGroupName]tc.CacheGroupName{}
+	for svName, sv := range crc.ContentServers {
+		// TODO handle mids
+		if sv.ServerType == nil || tc.CacheType(*sv.ServerType) != tc.CacheTypeEdge {
+			continue
+		}
+		if sv.CacheGroup == nil {
+			return "", "", errors.New("server '" + svName + "' has no CacheGroup")
+		}
+		cg := *sv.CacheGroup
+		if _, ok := farCGs[tc.CacheGroupName(cg)]; ok {
+			continue
+		}
+		farCG, err := GetFarCacheGroup(crc, tc.CacheGroupName(cg))
+		if err != nil {
+			return "", "", errors.New("getting far cachegroup: " + err.Error())
+		}
+		farCGs[tc.CacheGroupName(cg)] = farCG
+	}
+
+	farCGComments := ``
+	for from, to := range farCGs {
+		farCGComments += `# Far cachegroup for '` + string(from) + `' is '` + string(to) + `'
+`
+	}
+
+	// TODO when making the remap rule for each server:
+	// Determine if we _are_ the far cachegroup for that server.
+	// If so, make the remap rule to that server direct
+
+	remapLines := ""
+	parentLines := ""
+	if comments {
+		parentLines += farCGComments
+	}
+
+	// Sort the server names to iterate, so the generated config is deterministic.
+	serverNames := []string{}
+	for name, _ := range crc.ContentServers {
+		serverNames = append(serverNames, name)
+	}
+	sort.Strings(serverNames)
+
+	for _, svName := range serverNames {
+		sv := crc.ContentServers[svName]
+
+		// TODO handle mids
+		if sv.ServerType == nil || tc.CacheType(*sv.ServerType) != tc.CacheTypeEdge {
+			continue
+		}
+		if sv.CacheGroup == nil {
+			return "", "", errors.New("generating remap for '" + svName + "': null CacheGroup")
+		}
+		farCG, ok := farCGs[tc.CacheGroupName(*sv.CacheGroup)]
+		if !ok {
+			return "", "", errors.New("generating remap for '" + svName + "': CacheGroup '" + *sv.CacheGroup + "' not in far cachegroup list")
+		}
+
+		svRemaps, svParents, err := MakeRemapLinesServer(crc, cdnDomain, cgServers, tc.CacheName(svName), &sv, remapSvName, &remapSv, farCG, healthPort, comments)
+		if err != nil {
+			return "", "", errors.New("generating remap for '" + svName + "': " + err.Error())
+		}
+		remapLines += svRemaps
+		parentLines += svParents
+	}
+
+	return remapLines, parentLines, nil
+}
+
+// MakeRemapLinesServer creates the health remap lines for the given sv server. The remapSv is the server the remap lines are being generated for.
+// Each line is terminated by a newline
+func MakeRemapLinesServer(
+	crc *tc.CRConfig,
+	cdnDomain string,
+	cgServers map[tc.CacheGroupName][]string,
+	svName tc.CacheName,
+	sv *tc.CRConfigTrafficOpsServer,
+	remapSvName tc.CacheName,
+	remapSv *tc.CRConfigTrafficOpsServer,
+	farCG tc.CacheGroupName,
+	healthPort int,
+	comments bool,
+) (string, string, error) {
+	if svName == remapSvName {
+		return MakeRemapLinesSelf(crc, cdnDomain, svName, sv, healthPort, comments)
+	}
+	if *sv.CacheGroup == *remapSv.CacheGroup {
+		return MakeRemapLinesSameCacheGroup(crc, cdnDomain, cgServers, svName, sv, remapSvName, remapSv, farCG, healthPort, comments)
+	}
+	return MakeRemapLinesOtherCacheGroup(crc, cdnDomain, cgServers, svName, sv, remapSvName, remapSv, healthPort, comments)
+}
+
+// MakeRemapLineSelf makes a remap line to the health service on this server.
+// The domainPrefix is a prefix on the FQDN, typically "near" or "far". May not be empty.
+func MakeRemapLineSelf(
+	crc *tc.CRConfig,
+	cdnDomain string,
+	domainPrefix string,
+	svName tc.CacheName,
+	sv *tc.CRConfigTrafficOpsServer,
+	healthPort int,
+	comments bool,
+) (string, string, error) {
+	// TODO HTTPS option?
+	// TODO determine if we need to add the port here, for custom ports
+	remapFQDN := domainPrefix + `.` + HealthSubdomain + `.` + string(svName) + `.` + cdnDomain
+	remapURI := `http://` + remapFQDN
+	if sv.Port != nil && *sv.Port != 80 {
+		remapURI += `:` + strconv.Itoa(*sv.Port)
+	}
+	remapURI += `/`
+
+	healthPortStr := strconv.Itoa(healthPort)
+
+	remapLine := `map ` + remapURI + ` http://localhost:` + healthPortStr + "\n"
+	remapComment := `# self remap to local astats service
+`
+
+	portStr := "80"
+	if sv.Port != nil {
+		portStr = strconv.Itoa(*sv.Port)
+	}
+
+	if sv.Ip == nil {
+		return "", "", errors.New("null IP")
+	}
+	// TODO verify IP is a valid IP
+	// TODO add IPv4 and IPv6 rules
+	// TODO add HTTPS port health
+
+	parentComment := `
+# health: self
+# health: parent IP ` + *sv.Ip + ` is self
+`
+	//	TODO determine if self needs a parent line (for retry?)
+	parentLine := `dest_domain=` + remapFQDN + ` port=` + portStr + ` parent="` + *sv.Ip + `:` + healthPortStr + `|0.999" round_robin=false qstring=ignore go_direct=false parent_is_proxy=false parent_retry=unavailable_server_retry unavailable_server_retry_responses="500" max_unavailable_server_retries=1
+
+	`
+	parentLine = "" // DEBUG
+	if comments {
+		parentLine = parentComment + parentLine
+		remapLine = remapComment + remapLine
+	}
+
+	return remapLine, parentLine, nil
+}
+
+// MakeRemapLineDirect makes a remap on this server directly to the given server.
+// This is used for servers in the same cachegroup, as well as "far" remaps where this server is in the chosen far cachegroup of the given server's cachegroup.
+// The domainPrefix is a prefix on the FQDN, typically "near" or "far". May not be empty.
+func MakeRemapLineDirect(
+	crc *tc.CRConfig,
+	cdnDomain string,
+	domainPrefix string,
+	svName tc.CacheName,
+	sv *tc.CRConfigTrafficOpsServer,
+	remapSvName tc.CacheName,
+	remapSv *tc.CRConfigTrafficOpsServer,
+	healthPort int,
+	comments bool,
+) (string, string, error) {
+	remapFromFQDN := domainPrefix + `.` + HealthSubdomain + `.` + string(svName) + `.` + cdnDomain
+	remapFromURI := `http://` + remapFromFQDN
+	if remapSv.Port != nil && *remapSv.Port != 80 {
+		remapFromURI += `:` + strconv.Itoa(*remapSv.Port)
+	}
+	remapFromURI += `/`
+
+	remapToFQDN := domainPrefix + `.` + HealthSubdomain + `.` + string(svName) + `.` + cdnDomain
+
+	remapToURI := `http://` + remapToFQDN
+	if sv.Port != nil && *sv.Port != 80 {
+		remapToURI += `:` + strconv.Itoa(*sv.Port)
+	}
+	remapToURI += `/`
+
+	remapComment := `# map from ` + remapFromFQDN + ` on this server's port, to the same domain on the target's port, with via servers in parent.config
+`
+	remapLine := `map ` + remapFromURI + ` ` + remapToURI + "\n"
+
+	toPortStr := "80"
+	if sv.Port != nil {
+		toPortStr = strconv.Itoa(*sv.Port)
+	}
+
+	if sv.Ip == nil {
+		return "", "", errors.New("null IP")
+	}
+
+	// healthPortStr := strconv.Itoa(healthPort)
+
+	if remapSv.CacheGroup == nil {
+		return "", "", errors.New("this server " + string(remapSvName) + " had null cachegroup in CRConfig")
+	}
+	if sv.CacheGroup == nil {
+		return "", "", errors.New("server " + string(svName) + " had null cachegroup in CRConfig")
+	}
+
+	reasonCGStr := "the same cachegroup as this server"
+	if tc.CacheGroupName(*sv.CacheGroup) != tc.CacheGroupName(*remapSv.CacheGroup) {
+		reasonCGStr = "cachegroup " + *sv.CacheGroup
+	}
+	reasonDistStr := "'near'"
+	if domainPrefix == FarSubdomain {
+		reasonDistStr = "'far'"
+	}
+	reasonStr := "in " + reasonCGStr + " for " + reasonDistStr + " health"
+
+	parentComment := `
+# health: direct to ` + string(svName) + ` ` + reasonStr + `
+# health: parent IP ` + *sv.Ip + ` is ` + string(svName) + `, the server we're mapping to
+`
+	parentLine := `dest_domain=` + remapToFQDN + ` port=` + toPortStr + ` parent="` + *sv.Ip + `:` + strconv.Itoa(*sv.Port) + `|0.999" round_robin=false qstring=ignore go_direct=false parent_is_proxy=false parent_retry=unavailable_server_retry unavailable_server_retry_responses="500" max_unavailable_server_retries=1` + "\n"
+	if comments {
+		parentLine = parentComment + parentLine
+		remapLine = remapComment + remapLine
+	}
+
+	return remapLine, parentLine, nil
+}
+
+// MakeRemapLineVia creates a remap line to the given server through the servers on the given cachegroup.
+// This is used for "near" rules for servers not in this server's cachegroup, as well as for "far" rules for servers which are in this server's cachegroup (because if the server is in this server's CG, we need to go far away first).
+// The domainPrefix is a prefix on the FQDN, typically "near" or "far". May not be empty.
+func MakeRemapLineVia(
+	crc *tc.CRConfig,
+	cdnDomain string,
+	domainPrefix string,
+	cgServers map[tc.CacheGroupName][]string,
+	svName tc.CacheName,
+	sv *tc.CRConfigTrafficOpsServer,
+	remapSvName tc.CacheName,
+	remapSv *tc.CRConfigTrafficOpsServer,
+	cg tc.CacheGroupName,
+	healthPort int,
+	comments bool,
+) (string, string, error) {
+	remapFromFQDN := domainPrefix + `.` + HealthSubdomain + `.` + string(svName) + `.` + cdnDomain
+	remapFromURI := `http://` + remapFromFQDN
+	if remapSv.Port != nil && *remapSv.Port != 80 {
+		remapFromURI += `:` + strconv.Itoa(*remapSv.Port)
+	}
+	remapFromURI += `/`
+
+	remapToFQDN := domainPrefix + `.` + HealthSubdomain + `.` + string(svName) + `.` + cdnDomain
+	remapToURI := `http://` + remapToFQDN
+	if sv.Port != nil && *sv.Port != 80 {
+		remapToURI += `:` + strconv.Itoa(*sv.Port)
+	}
+	remapToURI += `/`
+
+	remapComment := `# map from ` + remapFromFQDN + ` on this server's port, to the same domain on the target's port
+`
+	remapLine := `map ` + remapFromURI + ` ` + remapToURI + "\n"
+
+	toPortStr := "80"
+	if sv.Port != nil {
+		toPortStr = strconv.Itoa(*sv.Port)
+	}
+
+	if sv.Ip == nil {
+		return "", "", errors.New("null IP")
+	}
+
+	// healthPortStr := strconv.Itoa(healthPort)
+
+	parentServers := cgServers[cg]
+	if len(parentServers) == 0 {
+		return "", "", errors.New("no servers for the cachegroup '" + string(cg) + "'")
+	}
+	parentsStrs := []string{}
+	parentComments := []string{}
+	for _, parentSvName := range parentServers {
+		parentSv, ok := crc.ContentServers[parentSvName]
+		if !ok {
+			return "", "", errors.New("parent '" + parentSvName + "' not in CRConfig")
+		}
+		if parentSv.Ip == nil {
+			return "", "", errors.New("parent '" + parentSvName + "' has null IP")
+		}
+		parentsStrs = append(parentsStrs, *parentSv.Ip+`:`+strconv.Itoa(*parentSv.Port)+`|0.999`)
+		parentComments = append(parentComments, `# health: parent IP `+*parentSv.Ip+` is `+string(parentSvName)+` in `+string(cg))
+	}
+
+	parentStr := strings.Join(parentsStrs, `;`)
+
+	if remapSv.CacheGroup == nil {
+		return "", "", errors.New("this server '" + string(remapSvName) + "' had null CacheGroup!")
+	}
+	if sv.CacheGroup == nil {
+		return "", "", errors.New("server '" + string(remapSvName) + "' had null CacheGroup!")
+	}
+
+	reasonCGStr := "the same cachegroup as"
+	if tc.CacheGroupName(*sv.CacheGroup) != tc.CacheGroupName(*remapSv.CacheGroup) {
+		reasonCGStr = "a different cachegroup than"
+	}
+	reasonDistStr := "'near'"
+	if domainPrefix == FarSubdomain {
+		reasonDistStr = "'far'"
+	}
+	reasonStr := "in " + reasonCGStr + " this server, for " + reasonDistStr + " health"
+	parentComment := `
+# health: ` + string(svName) + ` via ` + string(cg) + ` ` + reasonStr + `
+` + strings.Join(parentComments, "\n") + `
+`
+
+	parentLine := `dest_domain=` + remapToFQDN + ` port=` + toPortStr + ` parent="` + parentStr + `" round_robin=false qstring=ignore go_direct=false parent_is_proxy=false parent_retry=unavailable_server_retry unavailable_server_retry_responses="500" max_unavailable_server_retries=1` + "\n"
+	if comments {
+		parentLine = parentComment + parentLine
+		remapLine = remapComment + remapLine
+	}
+
+	return remapLine, parentLine, nil
+}
+
+// MakeRemapLinesSelf is used to generate this server's own remap to localhost:astats2
+func MakeRemapLinesSelf(crc *tc.CRConfig, cdnDomain string, svName tc.CacheName, sv *tc.CRConfigTrafficOpsServer, healthPort int, comments bool) (string, string, error) {
+	remapLines := ``
+	parentLines := ``
+	{
+		remapLine, parentLine, err := MakeRemapLineSelf(crc, cdnDomain, NearSubdomain, svName, sv, healthPort, comments)
+		if err != nil {
+			return "", "", errors.New("making self near remap line: " + err.Error())
+		}
+		remapLines += remapLine
+		parentLines += parentLine
+	}
+	{
+		remapLine, parentLine, err := MakeRemapLineSelf(crc, cdnDomain, FarSubdomain, svName, sv, healthPort, comments)
+		if err != nil {
+			return "", "", errors.New("making self far remap line: " + err.Error())
+		}
+		remapLines += remapLine
+		parentLines += parentLine
+	}
+	return remapLines, parentLines, nil
+}
+
+func MakeRemapLinesSameCacheGroup(
+	crc *tc.CRConfig,
+	cdnDomain string,
+	cgServers map[tc.CacheGroupName][]string,
+	svName tc.CacheName,
+	sv *tc.CRConfigTrafficOpsServer,
+	remapSvName tc.CacheName,
+	remapSv *tc.CRConfigTrafficOpsServer,
+	farCG tc.CacheGroupName,
+	healthPort int,
+	comments bool,
+) (string, string, error) {
+	remapLines := ``
+	parentLines := ``
+	{
+		remapLine, parentLine, err := MakeRemapLineDirect(crc, cdnDomain, NearSubdomain, svName, sv, remapSvName, remapSv, healthPort, comments)
+		if err != nil {
+			return "", "", errors.New("making same cg near remap line: " + err.Error())
+		}
+		remapLines += remapLine
+		parentLines += parentLine
+	}
+	{
+		remapLine, parentLine, err := MakeRemapLineVia(crc, cdnDomain, FarSubdomain, cgServers, svName, sv, remapSvName, remapSv, farCG, healthPort, comments)
+		if err != nil {
+			return "", "", errors.New("making same cg far remap line: " + err.Error())
+		}
+		remapLines += remapLine
+		parentLines += parentLine
+	}
+	return remapLines, parentLines, nil
+}
+
+// MakeRemapLinesDifferentCacheGroup is used to generate remaps to a server in this server's own CacheGroup (i.e. directly to that server, not to a deterministic "cache monitor" server in that server's CG).
+func MakeRemapLinesOtherCacheGroup(
+	crc *tc.CRConfig,
+	cdnDomain string,
+	cgServers map[tc.CacheGroupName][]string,
+	svName tc.CacheName,
+	sv *tc.CRConfigTrafficOpsServer,
+	remapSvName tc.CacheName,
+	remapSv *tc.CRConfigTrafficOpsServer,
+	healthPort int,
+	comments bool,
+) (string, string, error) {
+	remapLines := ``
+	parentLines := ``
+	{
+		if remapSv.CacheGroup == nil {
+			return "", "", errors.New("server '" + string(svName) + "has null cachegroup in CRConfig")
+		}
+		remapLine, parentLine, err := MakeRemapLineVia(crc, cdnDomain, NearSubdomain, cgServers, svName, sv, remapSvName, remapSv, tc.CacheGroupName(*sv.CacheGroup), healthPort, comments)
+		if err != nil {
+			return "", "", errors.New("making other cg near remap line: " + err.Error())
+		}
+		remapLines += remapLine
+		parentLines += parentLine
+	}
+	{
+		remapLine, parentLine, err := MakeRemapLineDirect(crc, cdnDomain, FarSubdomain, svName, sv, remapSvName, remapSv, healthPort, comments)
+		if err != nil {
+			return "", "", errors.New("making other cg far remap line: " + err.Error())
+		}
+		remapLines += remapLine
+		parentLines += parentLine
+	}
+	return remapLines, parentLines, nil
+}
+
+// GetCacheGroupDistances returns the distance of every CacehGroup in crc from the given cg.
+// Returns the distance in meters (though callers shouldn't care the unit, as distances should only ever be used relatively).
+func GetCacheGroupDistances(crc *tc.CRConfig, cg tc.CRConfigLatitudeLongitude) map[tc.CacheGroupName]float64 {
+	dist := map[tc.CacheGroupName]float64{}
+	for name, ll := range crc.EdgeLocations {
+		dist[tc.CacheGroupName(name)] = DistanceMeters(ll.Lat, ll.Lon, cg.Lat, cg.Lon)
+	}
+	return dist
+}
+
+// GetFarCacheGroup gets a "far" cachegroup, which will be used to generate "far" remap lines.
+// The "far" cachegroup is calculated deterministically (and must be), so it will always be the same for any given cachegroup, for the same CRConfig.
+// The "far" cachegroup is determined as follows:
+// 1. All cachegroups with a distance greater than the median are removed.
+// 2. All cachegroups with fewer caches than the average number of caches in the remaining cachegroups are removed.
+// 3. The remaining cachegroups are sorted alphabetically.
+//    - The order doesn't matter, and  could be changed, as long as it's deterministic.
+// 4. The first cachegroup in the remaining sorted list is chosen.
+//
+// An error is returned if cg is not in crc, or if no other cachegroups are in crc.
+func GetFarCacheGroup(crc *tc.CRConfig, cg tc.CacheGroupName) (tc.CacheGroupName, error) {
+	// TODO: add "midLocations" to CRConfig. Needed by GetServerFarCacheGroup to poll mids
+	cgLatLon, ok := crc.EdgeLocations[string(cg)]
+	if !ok {
+		return "", errors.New("cg '" + string(cg) + " not in CRConfig!")
+	}
+
+	cgSizes := map[tc.CacheGroupName]int{}
+	for svName, sv := range crc.ContentServers {
+		// TODO exclude OFFLINE/ADMIN_DOWN?
+		if sv.CacheGroup == nil {
+			return "", errors.New(svName + "had null CacheGroup!")
+		}
+		cgSizes[tc.CacheGroupName(*sv.CacheGroup)] = cgSizes[tc.CacheGroupName(*sv.CacheGroup)] + 1
+	}
+
+	names := []string{}
+	for name, _ := range crc.EdgeLocations {
+		if name == string(cg) {
+			continue
+		}
+		if cgSizes[tc.CacheGroupName(name)] == 0 {
+			continue // skip cachegroups with no caches
+		}
+		names = append(names, name)
+	}
+
+	cgDists := map[string]float64{}
+	// TODO change to a rolling average. Adding everything then dividing loses a lot of precision.
+	avgDist := 0.0
+	for _, name := range names {
+		dist := DistanceMeters(crc.EdgeLocations[name].Lat, crc.EdgeLocations[name].Lon, cgLatLon.Lat, cgLatLon.Lon)
+		avgDist += dist
+		cgDists[name] = dist
+	}
+	avgDist /= float64(len(names))
+
+	farNames := []string{}
+	for _, name := range names {
+		if dist := cgDists[name]; dist < avgDist {
+			continue
+		}
+		farNames = append(farNames, name)
+	}
+
+	// Of the remaining cachegroups which are greater than the average distance:
+	// Get the average size.
+
+	avgFarSize := 0.0
+	for _, name := range farNames {
+		if cgSizes[tc.CacheGroupName(name)] == 0 {
+			continue // skip CGs with no caches
+		}
+		avgFarSize += float64(cgSizes[tc.CacheGroupName(name)])
+	}
+	avgFarSize /= float64(len(farNames)) // TODO change to rolling average; Summing and dividing loses precision
+
+	// Remove cachegroups with less than the average number of servers.
+	// This helps eliminate CGs which are testing, beta, canary, etc,
+	// As well as generally sending "far" requests to bigger CGs that can handle the requests better
+	// (though the request cost is tiny)
+
+	farBigNames := []string{}
+	for _, name := range farNames {
+		if cgSizes[tc.CacheGroupName(name)] < int(avgFarSize) {
+			continue
+		}
+		farBigNames = append(farBigNames, name)
+	}
+
+	// TODO determine if the alphabetical first is usually/always the same for many cachegroups.
+	// That is, are we using one CG as the "far" CG for a bunch of others?
+	// If so, should we make the deterministic selection more distributed, e.g. a consistent hash?
+	sort.Strings(farBigNames)
+
+	if len(farBigNames) == 0 {
+		return "", errors.New("no cachegroups besides this one in the CRConfig!")
+	}
+
+	return tc.CacheGroupName(farBigNames[0]), nil
+}
+
+// DistanceMeters calculates the distance in meters between lat1,lon1 and lat2,lon2.
+// From https://gist.github.com/cdipaolo/d3f8db3848278b49db68
+func DistanceMeters(lat1, lon1, lat2, lon2 float64) float64 {
+	// convert to radians
+	// must cast radius as float to multiply later
+	var la1, lo1, la2, lo2, r float64
+	la1 = lat1 * math.Pi / 180
+	lo1 = lon1 * math.Pi / 180
+	la2 = lat2 * math.Pi / 180
+	lo2 = lon2 * math.Pi / 180
+
+	r = 6378100 // Earth radius in METERS
+
+	// calculate
+	h := hsin(la2-la1) + math.Cos(la1)*math.Cos(la2)*hsin(lo2-lo1)
+
+	return 2 * r * math.Asin(math.Sqrt(h))
+}
+
+func hsin(theta float64) float64 {
+	return math.Pow(math.Sin(theta/2), 2)
+}


### PR DESCRIPTION
Adds an experimental Proof-of-Concept project to replace the Cache Health Monitoring part of Traffic Monitor with cache remap rules, so the caches monitor themselves.

This has a number of benefits.
- saves TC operators having to deploy a CPU- and network-intensive application.
- saves the TC project the difficult and expensive development of a high-performance application.
- Automatically horizontally scalable, solves the current monitor scalability problem out of the box.

In a nutshell, there are 3 components:
- `astatstwo` replaces astats, monitors health on the cache, and returns a 204 or 503.
- `remapgen` generates remap rules for any cache to forward health requests to any other cache.
    - will include remaps for near, far, IPv4, and IPv6 health.
- `healthcombiner` requests the health of all caches from localhost and builds `/CRStates.json` consumed by Traffic Router.
    - Not strictly necessary, the Router could request health for each cache, but this allows us to avoid modifying the Router.

See the README.md for more details.

No tests, no docs, no changelog, experimental PoC.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?

None, experimental.

## What is the best way to verify this PR?
Follow the instructions in the README.md to create the experimental setup.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
