### PR TITLE
fixed nil exception in cert autorenewal

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
@@ -190,12 +190,8 @@ func RunAutorenewal(existingCerts []ExistingCerts, cfg *config.Config, ctx conte
 
 	if cfg.SMTP.Enabled && cfg.ConfigLetsEncrypt.SendExpEmail {
 		errCode, userErr, sysErr := AlertExpiringCerts(keysFound, *cfg)
-		if userErr != nil {
-			log.Errorf("cert autorenewal: sending email: errCode: %d userErr: %s", errCode, userErr.Error())
-			return
-		}
-		if sysErr != nil {
-			log.Errorf("cert autorenewal: sending email: errCode: %d sysErr: %s", errCode, sysErr.Error())
+		if userErr != nil || sysErr != nil {
+			log.Errorf("cert autorenewal: sending email: errCode: %d userErr: %v sysErr: %v", errCode, userErr, sysErr)
 			return
 		}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
@@ -190,8 +190,12 @@ func RunAutorenewal(existingCerts []ExistingCerts, cfg *config.Config, ctx conte
 
 	if cfg.SMTP.Enabled && cfg.ConfigLetsEncrypt.SendExpEmail {
 		errCode, userErr, sysErr := AlertExpiringCerts(keysFound, *cfg)
-		if userErr != nil || sysErr != nil {
-			log.Errorf("cert autorenewal: sending email: errCode: %d userErr: %s sysErr: %s", errCode, userErr.Error(), sysErr.Error())
+		if userErr != nil {
+			log.Errorf("cert autorenewal: sending email: errCode: %d userErr: %s", errCode, userErr.Error())
+			return
+		}
+		if sysErr != nil {
+			log.Errorf("cert autorenewal: sending email: errCode: %d sysErr: %s", errCode, sysErr.Error())
 			return
 		}
 


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4480 

This PR fixes a bug that results in a nil exception in the certificate autorenewal script.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

ensure that SMTP is enabled and lets_encrypt send_expiration_email is enabled
update the html template to be invalid or non-existent (/opt/traffic_ops/app/templates/send_mail/autorenewcerts_mail.html)
POST to the /letsencrypt/autorenew endpoint
verify that an error starting with "cert autorenewal: sending email: errCode:" is logged successfully and a nil exception is not thrown

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->
No tests, docs, CHANGELONG, or database migration are necessary since this is a small bug fix.

- [x] This PR does not require tests
- [x] This PR does not require documentation
- [x] This PR does not require an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
