### PR TITLE
'fixed' grafana scripted dashboard to use exact hostname instead of regular expression match

### DIFF
--- a/traffic_stats/grafana/traffic_ops_server.js
+++ b/traffic_stats/grafana/traffic_ops_server.js
@@ -13,1368 +13,1359 @@
      limitations under the License.
 */
 
-/* global _ */
-
 /*
  * Scripted dashboard for traffic ops.
  *
  * Based on the grafana scripted.js script (which is ASF 2.0 licensed).
  */
 
-
-
-// accessible variables in this scope
-var window, document, ARGS, $, jQuery, moment, kbn;
+'use strict';
 
 // Setup some variables
 var dashboard;
 
-// All url parameters are available via the ARGS object
+// All URL parameters are available via the ARGS object
 var ARGS;
 
-// Intialize a skeleton with nothing but a rows array and service object
+// Intialize a skeleton with nothing but a rows array and service object,
+// and setting default time and refresh interval.
 dashboard = {
-  rows : [],
+  refresh: "30s",
+  rows: [],
+  // time can be overridden in the URL using from/to parameters, but this is
+  // handled automatically in grafana core during dashboard initialization
+  time: {
+    from: "now-24h",
+    to: "now"
+  }
 };
 
+let which = 'argName';
 
-// Set default time
-// time can be overriden in the url using from/to parameters, but this is
-// handled automatically in grafana core during dashboard initialization
-dashboard.time = {
-  from: "now-24h",
-  to: "now"
-};
-
-var which = 'argName';
-
-if(!_.isUndefined(ARGS.which)) {
+if(ARGS.which !== undefined) {
   which = ARGS.which;
 }
 
 // Set a title
 dashboard.title = which;
-//set refresh interval
-dashboard.refresh = "30s";
 
-
-{
-  dashboard.rows.push(    {
-      "height": "250px",
-      "panels": [
-        {
-          "title": "bandwidth",
-          "error": false,
-          "span": 12,
-          "editable": true,
-          "type": "graph",
-          "id": 1,
-          "datasource": "cache_stats",
-          "renderer": "flot",
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 2,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": true,
-            "min": false,
-            "max": true,
-            "current": true,
-            "total": false,
-            "avg": false
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true,
-            "sort": 0,
-            "msResolution": false
-          },
-          "timeFrom": null,
-          "timeShift": null,
-          "targets": [
-            {
-              "measurement": "bandwidth.1min",
-              "tags": {},
-              "query": "SELECT mean(value) FROM \"monthly\".\"bandwidth.1min\" WHERE hostname= '" + which + "' and $timeFilter GROUP BY time(60s)",
-              "rawQuery": true,
-              "refId": "A",
-              "policy": "default",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "groupBy": [
-                {
-                  "type": "time",
-                  "params": [
-                    "$interval"
-                  ]
-                },
-                {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
-                }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "value"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  }
-                ]
-              ],
-              "alias": "bandwidth"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "yaxes": [
-            {
-              "show": true,
-              "min": null,
-              "max": null,
-              "logBase": 1,
-              "format": "Kbits"
-            },
-            {
-              "show": true,
-              "min": null,
-              "max": null,
-              "logBase": 1,
-              "format": "short"
-            }
-          ],
-          "xaxis": {
-            "show": true
-          }
-        }
-      ],
-      "title": "Row",
-      "collapse": false,
-      "editable": true
-    },
-    {
-      "height": "250px",
-      "panels": [
-        {
-          "title": "conns",
-          "error": false,
-          "span": 12,
-          "editable": true,
-          "type": "graph",
-          "id": 2,
-          "datasource": "cache_stats",
-          "renderer": "flot",
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 2,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": true,
-            "min": false,
-            "max": true,
-            "current": true,
-            "total": false,
-            "avg": false
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true,
-            "sort": 0,
-            "msResolution": false
-          },
-          "timeFrom": null,
-          "timeShift": null,
-          "targets": [
-            {
-              "measurement": "connections.1min",
-              "tags": {},
-              "query": "SELECT mean(value) FROM \"monthly\".\"connections.1min\" WHERE hostname= '" + which + "' and $timeFilter GROUP BY time(60s)",
-              "rawQuery": true,
-              "refId": "A",
-              "policy": "default",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "groupBy": [
-                {
-                  "type": "time",
-                  "params": [
-                    "$interval"
-                  ]
-                },
-                {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
-                }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "value"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  }
-                ]
-              ],
-              "alias": "connections"
-            }
-          ],
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": [],
-          "yaxes": [
-            {
-              "show": true,
-              "min": null,
-              "max": null,
-              "logBase": 1,
-              "format": "short"
-            },
-            {
-              "show": true,
-              "min": null,
-              "max": null,
-              "logBase": 1
-            }
-          ],
-          "xaxis": {
-            "show": true
-          }
-        }
-      ],
-      "title": "Row",
-      "collapse": false,
-      "editable": true
-    },
-    {
-      "title": "cpu and mem",
-      "height": "250px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "CPU Usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "isNew": true,
-          "id": 3,
-          "targets": [
-            {
-              "refId": "A",
-              "policy": "default",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/" + which + "/"
-                }
-              ],
-              "groupBy": [
-                {
-                  "type": "time",
-                  "params": [
-                    "$interval"
-                  ]
-                },
-                {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
-                }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "usage_system"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "cpu_system"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "usage_iowait"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "cpu_iowait"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "usage_user"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "cpu_user"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "usage_guest"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "cpu_guest"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "usage_steal"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "cpu_steal"
-                    ]
-                  }
-                ]
-              ],
-              "measurement": "cpu",
-              "alias": "$col"
-            }
-          ],
-          "datasource": "telegraf",
-          "renderer": "flot",
-          "yaxes": [
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "percent"
-            },
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            }
-          ],
-          "xaxis": {
-            "show": true
-          },
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 2,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "shared": true,
-            "msResolution": true,
-            "sort": 2
-          },
-          "timeFrom": null,
-          "timeShift": null,
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+dashboard.rows.push(
+  {
+    "height": "250px",
+    "panels": [
+      {
+        "title": "bandwidth",
+        "error": false,
+        "span": 12,
+        "editable": true,
+        "type": "graph",
+        "id": 1,
+        "datasource": "cache_stats",
+        "renderer": "flot",
+        "grid": {
+          "threshold1": null,
+          "threshold2": null,
+          "threshold1Color": "rgba(216, 200, 27, 0.27)",
+          "threshold2Color": "rgba(234, 112, 112, 0.22)"
         },
-        {
-          "title": "Memory Usage",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "isNew": true,
-          "id": 4,
-          "targets": [
-            {
-              "refId": "A",
-              "policy": "default",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/" + which + "/"
-                }
-              ],
-              "groupBy": [
-                {
-                  "type": "time",
-                  "params": [
-                    "$interval"
-                  ]
-                },
-                {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
-                }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "used_percent"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "mem_used"
-                    ]
-                  }
-                ]
-              ],
-              "measurement": "mem",
-              "alias": "$col"
-            }
-          ],
-          "datasource": "telegraf",
-          "renderer": "flot",
-          "yaxes": [
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "percent"
-            },
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            }
-          ],
-          "xaxis": {
-            "show": true
-          },
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 2,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": true,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "individual",
-            "shared": true,
-            "msResolution": true,
-            "sort": 0
-          },
-          "timeFrom": null,
-          "timeShift": null,
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ]
-    },
-    {
-      "title": "load avg and diskio",
-      "height": "250px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "Load Average",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "isNew": true,
-          "id": 5,
-          "targets": [
-            {
-              "refId": "A",
-              "policy": "default",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/" + which + "/"
-                }
-              ],
-              "groupBy": [
-                {
-                  "type": "time",
-                  "params": [
-                    "$interval"
-                  ]
-                },
-                {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
-                }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "load1"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "load1"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "load5"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "load5"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "load15"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "load15"
-                    ]
-                  }
-                ]
-              ],
-              "measurement": "system",
-              "alias": "$col"
-            }
-          ],
-          "datasource": "telegraf",
-          "renderer": "flot",
-          "yaxes": [
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            },
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            }
-          ],
-          "xaxis": {
-            "show": true
-          },
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 2,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true,
-            "msResolution": true,
-            "sort": 0
-          },
-          "timeFrom": null,
-          "timeShift": null,
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "points": false,
+        "pointradius": 5,
+        "bars": false,
+        "stack": false,
+        "percentage": false,
+        "legend": {
+          "show": true,
+          "values": true,
+          "min": false,
+          "max": true,
+          "current": true,
+          "total": false,
+          "avg": false
         },
-        {
-          "title": "Read/Write Time",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "isNew": true,
-          "id": 6,
-          "targets": [
-            {
-              "refId": "A",
-              "policy": "default",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/" + which + "/"
-                }
-              ],
-              "groupBy": [
-                {
-                  "type": "time",
-                  "params": [
-                    "$interval"
-                  ]
-                },
-                {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
-                }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "read_time"
-                    ]
-                  },
-                  {
-                    "type": "sum",
-                    "params": []
-                  },
-                  {
-                    "type": "non_negative_derivative",
-                    "params": [
-                      "10s"
-                    ]
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "read_time"
-                    ]
-                  }
-                ]
-              ],
-              "measurement": "diskio",
-              "alias": "$col"
-            },
-            {
-              "refId": "B",
-              "policy": "default",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/" + which + "/"
-                }
-              ],
-              "groupBy": [
-                {
-                  "type": "time",
-                  "params": [
-                    "$interval"
-                  ]
-                },
-                {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
-                }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "write_time"
-                    ]
-                  },
-                  {
-                    "type": "sum",
-                    "params": []
-                  },
-                  {
-                    "type": "non_negative_derivative",
-                    "params": [
-                      "10s"
-                    ]
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "write_time"
-                    ]
-                  }
-                ]
-              ],
-              "measurement": "diskio",
-              "alias": "$col"
-            }
-          ],
-          "datasource": "telegraf",
-          "renderer": "flot",
-          "yaxes": [
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "ns"
-            },
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            }
-          ],
-          "xaxis": {
-            "show": true
-          },
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 2,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
-            "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true,
-            "msResolution": true,
-            "sort": 0
-          },
-          "timeFrom": null,
-          "timeShift": null,
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        }
-      ]
-    },
-    {
-      "title": "Wrap Count and netstat",
-      "height": "250px",
-      "editable": true,
-      "collapse": false,
-      "panels": [
-        {
-          "title": "wrap count",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "isNew": true,
-          "id": 7,
-          "targets": [
-            {
-              "refId": "A",
-              "policy": "monthly",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "tags": [
+        "nullPointMode": "connected",
+        "steppedLine": false,
+        "tooltip": {
+          "value_type": "cumulative",
+          "shared": true,
+          "sort": 0,
+          "msResolution": false
+        },
+        "timeFrom": null,
+        "timeShift": null,
+        "targets": [
+          {
+            "measurement": "bandwidth.1min",
+            "tags": {},
+            "query": `SELECT mean(value) FROM "monthly"."bandwidth.1min" WHERE hostname= '${which}' and $timeFilter GROUP BY time(60s)`,
+            "rawQuery": true,
+            "refId": "A",
+            "policy": "default",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "groupBy": [
               {
-                  "key": "hostname",
-                  "operator": "=~",
-                  "value": "/" + which + "/"
-                }
-              ],
-              "groupBy": [
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
                 {
-                  "type": "time",
+                  "type": "field",
                   "params": [
-                    "$interval"
+                    "value"
                   ]
                 },
                 {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
+                  "type": "mean",
+                  "params": []
                 }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "vol1_wrap_count"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "vol1"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "vol2_wrap_count"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "vol2"
-                    ]
-                  }
-                ]
-              ],
-              "measurement": "wrap_count.1min",
-              "alias": "$col"
-            }
-          ],
-          "datasource": "cache_stats",
-          "renderer": "flot",
-          "yaxes": [
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            },
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            }
-          ],
-          "xaxis": {
-            "show": true
-          },
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 2,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
+              ]
+            ],
+            "alias": "bandwidth"
+          }
+        ],
+        "aliasColors": {},
+        "seriesOverrides": [],
+        "links": [],
+        "yaxes": [
+          {
             "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false
+            "min": null,
+            "max": null,
+            "logBase": 1,
+            "format": "Kbits"
           },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true,
-            "sort": 0,
-            "msResolution": true
-          },
-          "timeFrom": null,
-          "timeShift": null,
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
-        },
-        {
-          "title": "netstat",
-          "error": false,
-          "span": 6,
-          "editable": true,
-          "type": "graph",
-          "isNew": true,
-          "id": 8,
-          "targets": [
-            {
-              "refId": "A",
-              "policy": "default",
-              "dsType": "influxdb",
-              "resultFormat": "time_series",
-              "tags": [
-                {
-                  "key": "host",
-                  "operator": "=~",
-                  "value": "/" + which + "/"
-                }
-              ],
-              "groupBy": [
-                {
-                  "type": "time",
-                  "params": [
-                    "$interval"
-                  ]
-                },
-                {
-                  "type": "fill",
-                  "params": [
-                    "null"
-                  ]
-                }
-              ],
-              "select": [
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_close"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_close"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_close_wait"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_close_wait"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_established"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_established"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_time_wait"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_time_wait"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_closing"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_closing"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_fin_wait1"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_fin_wait1"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_fin_wait2"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_fin_wait2"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_last_ack"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_last_ack"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_syn_recv"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_syn_recv"
-                    ]
-                  }
-                ],
-                [
-                  {
-                    "type": "field",
-                    "params": [
-                      "tcp_syn_sent"
-                    ]
-                  },
-                  {
-                    "type": "mean",
-                    "params": []
-                  },
-                  {
-                    "type": "alias",
-                    "params": [
-                      "tcp_syn_sent"
-                    ]
-                  }
-                ]
-              ],
-              "measurement": "netstat",
-              "alias": "$col"
-            }
-          ],
-          "datasource": "telegraf",
-          "renderer": "flot",
-          "yaxes": [
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            },
-            {
-              "label": null,
-              "show": true,
-              "logBase": 1,
-              "min": null,
-              "max": null,
-              "format": "short"
-            }
-          ],
-          "xaxis": {
-            "show": true
-          },
-          "grid": {
-            "threshold1": null,
-            "threshold2": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "lines": true,
-          "fill": 1,
-          "linewidth": 2,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "percentage": false,
-          "legend": {
+          {
             "show": true,
-            "values": false,
-            "min": false,
-            "max": false,
-            "current": false,
-            "total": false,
-            "avg": false,
-            "hideEmpty": true,
-            "hideZero": true
-          },
-          "nullPointMode": "connected",
-          "steppedLine": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "shared": true,
-            "sort": 2,
-            "msResolution": true
-          },
-          "timeFrom": null,
-          "timeShift": null,
-          "aliasColors": {},
-          "seriesOverrides": [],
-          "links": []
+            "min": null,
+            "max": null,
+            "logBase": 1,
+            "format": "short"
+          }
+        ],
+        "xaxis": {
+          "show": true
         }
-      ]
-    }
-  );
-}
+      }
+    ],
+    "title": "Row",
+    "collapse": false,
+    "editable": true
+  },
+  {
+    "height": "250px",
+    "panels": [
+      {
+        "title": "conns",
+        "error": false,
+        "span": 12,
+        "editable": true,
+        "type": "graph",
+        "id": 2,
+        "datasource": "cache_stats",
+        "renderer": "flot",
+        "grid": {
+          "threshold1": null,
+          "threshold2": null,
+          "threshold1Color": "rgba(216, 200, 27, 0.27)",
+          "threshold2Color": "rgba(234, 112, 112, 0.22)"
+        },
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "points": false,
+        "pointradius": 5,
+        "bars": false,
+        "stack": false,
+        "percentage": false,
+        "legend": {
+          "show": true,
+          "values": true,
+          "min": false,
+          "max": true,
+          "current": true,
+          "total": false,
+          "avg": false
+        },
+        "nullPointMode": "connected",
+        "steppedLine": false,
+        "tooltip": {
+          "value_type": "cumulative",
+          "shared": true,
+          "sort": 0,
+          "msResolution": false
+        },
+        "timeFrom": null,
+        "timeShift": null,
+        "targets": [
+          {
+            "measurement": "connections.1min",
+            "tags": {},
+            "query": `SELECT mean(value) FROM "monthly"."connections.1min" WHERE hostname= '${which}' and $timeFilter GROUP BY time(60s)`,
+            "rawQuery": true,
+            "refId": "A",
+            "policy": "default",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "value"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                }
+              ]
+            ],
+            "alias": "connections"
+          }
+        ],
+        "aliasColors": {},
+        "seriesOverrides": [],
+        "links": [],
+        "yaxes": [
+          {
+            "show": true,
+            "min": null,
+            "max": null,
+            "logBase": 1,
+            "format": "short"
+          },
+          {
+            "show": true,
+            "min": null,
+            "max": null,
+            "logBase": 1
+          }
+        ],
+        "xaxis": {
+          "show": true
+        }
+      }
+    ],
+    "title": "Row",
+    "collapse": false,
+    "editable": true
+  },
+  {
+    "title": "cpu and mem",
+    "height": "250px",
+    "editable": true,
+    "collapse": false,
+    "panels": [
+      {
+        "title": "CPU Usage",
+        "error": false,
+        "span": 6,
+        "editable": true,
+        "type": "graph",
+        "isNew": true,
+        "id": 3,
+        "targets": [
+          {
+            "refId": "A",
+            "policy": "default",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "tags": [
+              {
+                key: "host",
+                operator: "=",
+                value: which
+              }
+            ],
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "usage_system"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "cpu_system"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "usage_iowait"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "cpu_iowait"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "usage_user"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "cpu_user"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "usage_guest"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "cpu_guest"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "usage_steal"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "cpu_steal"
+                  ]
+                }
+              ]
+            ],
+            "measurement": "cpu",
+            "alias": "$col"
+          }
+        ],
+        "datasource": "telegraf",
+        "renderer": "flot",
+        "yaxes": [
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "percent"
+          },
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          }
+        ],
+        "xaxis": {
+          "show": true
+        },
+        "grid": {
+          "threshold1": null,
+          "threshold2": null,
+          "threshold1Color": "rgba(216, 200, 27, 0.27)",
+          "threshold2Color": "rgba(234, 112, 112, 0.22)"
+        },
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "points": false,
+        "pointradius": 5,
+        "bars": false,
+        "stack": true,
+        "percentage": false,
+        "legend": {
+          "show": true,
+          "values": false,
+          "min": false,
+          "max": false,
+          "current": false,
+          "total": false,
+          "avg": false
+        },
+        "nullPointMode": "connected",
+        "steppedLine": false,
+        "tooltip": {
+          "value_type": "individual",
+          "shared": true,
+          "msResolution": true,
+          "sort": 2
+        },
+        "timeFrom": null,
+        "timeShift": null,
+        "aliasColors": {},
+        "seriesOverrides": [],
+        "links": []
+      },
+      {
+        "title": "Memory Usage",
+        "error": false,
+        "span": 6,
+        "editable": true,
+        "type": "graph",
+        "isNew": true,
+        "id": 4,
+        "targets": [
+          {
+            "refId": "A",
+            "policy": "default",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "tags": [
+              {
+                key: "host",
+                operator: "=",
+                value: which
+              }
+            ],
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "used_percent"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "mem_used"
+                  ]
+                }
+              ]
+            ],
+            "measurement": "mem",
+            "alias": "$col"
+          }
+        ],
+        "datasource": "telegraf",
+        "renderer": "flot",
+        "yaxes": [
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "percent"
+          },
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          }
+        ],
+        "xaxis": {
+          "show": true
+        },
+        "grid": {
+          "threshold1": null,
+          "threshold2": null,
+          "threshold1Color": "rgba(216, 200, 27, 0.27)",
+          "threshold2Color": "rgba(234, 112, 112, 0.22)"
+        },
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "points": false,
+        "pointradius": 5,
+        "bars": false,
+        "stack": true,
+        "percentage": false,
+        "legend": {
+          "show": true,
+          "values": false,
+          "min": false,
+          "max": false,
+          "current": false,
+          "total": false,
+          "avg": false
+        },
+        "nullPointMode": "connected",
+        "steppedLine": false,
+        "tooltip": {
+          "value_type": "individual",
+          "shared": true,
+          "msResolution": true,
+          "sort": 0
+        },
+        "timeFrom": null,
+        "timeShift": null,
+        "aliasColors": {},
+        "seriesOverrides": [],
+        "links": []
+      }
+    ]
+  },
+  {
+    "title": "load avg and diskio",
+    "height": "250px",
+    "editable": true,
+    "collapse": false,
+    "panels": [
+      {
+        "title": "Load Average",
+        "error": false,
+        "span": 6,
+        "editable": true,
+        "type": "graph",
+        "isNew": true,
+        "id": 5,
+        "targets": [
+          {
+            "refId": "A",
+            "policy": "default",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "tags": [
+              {
+                key: "host",
+                operator: "=",
+                value: which
+              }
+            ],
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "load1"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "load1"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "load5"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "load5"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "load15"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "load15"
+                  ]
+                }
+              ]
+            ],
+            "measurement": "system",
+            "alias": "$col"
+          }
+        ],
+        "datasource": "telegraf",
+        "renderer": "flot",
+        "yaxes": [
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          },
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          }
+        ],
+        "xaxis": {
+          "show": true
+        },
+        "grid": {
+          "threshold1": null,
+          "threshold2": null,
+          "threshold1Color": "rgba(216, 200, 27, 0.27)",
+          "threshold2Color": "rgba(234, 112, 112, 0.22)"
+        },
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "points": false,
+        "pointradius": 5,
+        "bars": false,
+        "stack": false,
+        "percentage": false,
+        "legend": {
+          "show": true,
+          "values": false,
+          "min": false,
+          "max": false,
+          "current": false,
+          "total": false,
+          "avg": false
+        },
+        "nullPointMode": "connected",
+        "steppedLine": false,
+        "tooltip": {
+          "value_type": "cumulative",
+          "shared": true,
+          "msResolution": true,
+          "sort": 0
+        },
+        "timeFrom": null,
+        "timeShift": null,
+        "aliasColors": {},
+        "seriesOverrides": [],
+        "links": []
+      },
+      {
+        "title": "Read/Write Time",
+        "error": false,
+        "span": 6,
+        "editable": true,
+        "type": "graph",
+        "isNew": true,
+        "id": 6,
+        "targets": [
+          {
+            "refId": "A",
+            "policy": "default",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "tags": [
+              {
+                key: "host",
+                operator: "=",
+                value: which
+              }
+            ],
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "read_time"
+                  ]
+                },
+                {
+                  "type": "sum",
+                  "params": []
+                },
+                {
+                  "type": "non_negative_derivative",
+                  "params": [
+                    "10s"
+                  ]
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "read_time"
+                  ]
+                }
+              ]
+            ],
+            "measurement": "diskio",
+            "alias": "$col"
+          },
+          {
+            "refId": "B",
+            "policy": "default",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "tags": [
+              {
+                key: "host",
+                operator: "=",
+                value: which
+              }
+            ],
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "write_time"
+                  ]
+                },
+                {
+                  "type": "sum",
+                  "params": []
+                },
+                {
+                  "type": "non_negative_derivative",
+                  "params": [
+                    "10s"
+                  ]
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "write_time"
+                  ]
+                }
+              ]
+            ],
+            "measurement": "diskio",
+            "alias": "$col"
+          }
+        ],
+        "datasource": "telegraf",
+        "renderer": "flot",
+        "yaxes": [
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "ns"
+          },
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          }
+        ],
+        "xaxis": {
+          "show": true
+        },
+        "grid": {
+          "threshold1": null,
+          "threshold2": null,
+          "threshold1Color": "rgba(216, 200, 27, 0.27)",
+          "threshold2Color": "rgba(234, 112, 112, 0.22)"
+        },
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "points": false,
+        "pointradius": 5,
+        "bars": false,
+        "stack": false,
+        "percentage": false,
+        "legend": {
+          "show": true,
+          "values": false,
+          "min": false,
+          "max": false,
+          "current": false,
+          "total": false,
+          "avg": false
+        },
+        "nullPointMode": "connected",
+        "steppedLine": false,
+        "tooltip": {
+          "value_type": "cumulative",
+          "shared": true,
+          "msResolution": true,
+          "sort": 0
+        },
+        "timeFrom": null,
+        "timeShift": null,
+        "aliasColors": {},
+        "seriesOverrides": [],
+        "links": []
+      }
+    ]
+  },
+  {
+    "title": "Wrap Count and netstat",
+    "height": "250px",
+    "editable": true,
+    "collapse": false,
+    "panels": [
+      {
+        "title": "wrap count",
+        "error": false,
+        "span": 6,
+        "editable": true,
+        "type": "graph",
+        "isNew": true,
+        "id": 7,
+        "targets": [
+          {
+            "refId": "A",
+            "policy": "monthly",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "tags": [
+              {
+                key: "hostname",
+                operator: "=",
+                value: which
+              }
+            ],
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "vol1_wrap_count"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "vol1"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "vol2_wrap_count"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "vol2"
+                  ]
+                }
+              ]
+            ],
+            "measurement": "wrap_count.1min",
+            "alias": "$col"
+          }
+        ],
+        "datasource": "cache_stats",
+        "renderer": "flot",
+        "yaxes": [
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          },
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          }
+        ],
+        "xaxis": {
+          "show": true
+        },
+        "grid": {
+          "threshold1": null,
+          "threshold2": null,
+          "threshold1Color": "rgba(216, 200, 27, 0.27)",
+          "threshold2Color": "rgba(234, 112, 112, 0.22)"
+        },
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "points": false,
+        "pointradius": 5,
+        "bars": false,
+        "stack": false,
+        "percentage": false,
+        "legend": {
+          "show": true,
+          "values": false,
+          "min": false,
+          "max": false,
+          "current": false,
+          "total": false,
+          "avg": false
+        },
+        "nullPointMode": "connected",
+        "steppedLine": false,
+        "tooltip": {
+          "value_type": "cumulative",
+          "shared": true,
+          "sort": 0,
+          "msResolution": true
+        },
+        "timeFrom": null,
+        "timeShift": null,
+        "aliasColors": {},
+        "seriesOverrides": [],
+        "links": []
+      },
+      {
+        "title": "netstat",
+        "error": false,
+        "span": 6,
+        "editable": true,
+        "type": "graph",
+        "isNew": true,
+        "id": 8,
+        "targets": [
+          {
+            "refId": "A",
+            "policy": "default",
+            "dsType": "influxdb",
+            "resultFormat": "time_series",
+            "tags": [
+              {
+                key: "host",
+                operator: "=",
+                value: which
+              }
+            ],
+            "groupBy": [
+              {
+                "type": "time",
+                "params": [
+                  "$interval"
+                ]
+              },
+              {
+                "type": "fill",
+                "params": [
+                  "null"
+                ]
+              }
+            ],
+            "select": [
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_close"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_close"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_close_wait"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_close_wait"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_established"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_established"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_time_wait"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_time_wait"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_closing"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_closing"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_fin_wait1"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_fin_wait1"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_fin_wait2"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_fin_wait2"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_last_ack"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_last_ack"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_syn_recv"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_syn_recv"
+                  ]
+                }
+              ],
+              [
+                {
+                  "type": "field",
+                  "params": [
+                    "tcp_syn_sent"
+                  ]
+                },
+                {
+                  "type": "mean",
+                  "params": []
+                },
+                {
+                  "type": "alias",
+                  "params": [
+                    "tcp_syn_sent"
+                  ]
+                }
+              ]
+            ],
+            "measurement": "netstat",
+            "alias": "$col"
+          }
+        ],
+        "datasource": "telegraf",
+        "renderer": "flot",
+        "yaxes": [
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          },
+          {
+            "label": null,
+            "show": true,
+            "logBase": 1,
+            "min": null,
+            "max": null,
+            "format": "short"
+          }
+        ],
+        "xaxis": {
+          "show": true
+        },
+        "grid": {
+          "threshold1": null,
+          "threshold2": null,
+          "threshold1Color": "rgba(216, 200, 27, 0.27)",
+          "threshold2Color": "rgba(234, 112, 112, 0.22)"
+        },
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "points": false,
+        "pointradius": 5,
+        "bars": false,
+        "stack": false,
+        "percentage": false,
+        "legend": {
+          "show": true,
+          "values": false,
+          "min": false,
+          "max": false,
+          "current": false,
+          "total": false,
+          "avg": false,
+          "hideEmpty": true,
+          "hideZero": true
+        },
+        "nullPointMode": "connected",
+        "steppedLine": false,
+        "tooltip": {
+          "value_type": "cumulative",
+          "shared": true,
+          "sort": 2,
+          "msResolution": true
+        },
+        "timeFrom": null,
+        "timeShift": null,
+        "aliasColors": {},
+        "seriesOverrides": [],
+        "links": []
+      }
+    ]
+  }
+);
+
 return dashboard;

--- a/traffic_stats/grafana/traffic_ops_server.js
+++ b/traffic_stats/grafana/traffic_ops_server.js
@@ -42,1330 +42,1331 @@ dashboard = {
 
 let which = 'argName';
 
-if(ARGS.which !== undefined) {
+if (ARGS.which !== undefined) {
   which = ARGS.which;
 }
 
 // Set a title
 dashboard.title = which;
 
-dashboard.rows.push(
-  {
-    "height": "250px",
-    "panels": [
-      {
-        "title": "bandwidth",
-        "error": false,
-        "span": 12,
-        "editable": true,
-        "type": "graph",
-        "id": 1,
-        "datasource": "cache_stats",
-        "renderer": "flot",
-        "grid": {
-          "threshold1": null,
-          "threshold2": null,
-          "threshold1Color": "rgba(216, 200, 27, 0.27)",
-          "threshold2Color": "rgba(234, 112, 112, 0.22)"
-        },
-        "lines": true,
-        "fill": 1,
-        "linewidth": 2,
-        "points": false,
-        "pointradius": 5,
-        "bars": false,
-        "stack": false,
-        "percentage": false,
-        "legend": {
-          "show": true,
-          "values": true,
-          "min": false,
-          "max": true,
-          "current": true,
-          "total": false,
-          "avg": false
-        },
-        "nullPointMode": "connected",
-        "steppedLine": false,
-        "tooltip": {
-          "value_type": "cumulative",
-          "shared": true,
-          "sort": 0,
-          "msResolution": false
-        },
-        "timeFrom": null,
-        "timeShift": null,
-        "targets": [
-          {
-            "measurement": "bandwidth.1min",
-            "tags": {},
-            "query": `SELECT mean(value) FROM "monthly"."bandwidth.1min" WHERE hostname= '${which}' and $timeFilter GROUP BY time(60s)`,
-            "rawQuery": true,
-            "refId": "A",
-            "policy": "default",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
-                ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
+{
+  dashboard.rows.push(
+    {
+      "height": "250px",
+      "panels": [
+        {
+          "title": "bandwidth",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": "cache_stats",
+          "renderer": "flot",
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": true,
+            "min": false,
+            "max": true,
+            "current": true,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "sort": 0,
+            "msResolution": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "targets": [
+            {
+              "measurement": "bandwidth.1min",
+              "tags": {},
+              "query": `SELECT mean(value) FROM "monthly"."bandwidth.1min" WHERE hostname= '${which}' and $timeFilter GROUP BY time(60s)`,
+              "rawQuery": true,
+              "refId": "A",
+              "policy": "default",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "groupBy": [
                 {
-                  "type": "field",
+                  "type": "time",
                   "params": [
-                    "value"
+                    "$interval"
                   ]
                 },
                 {
-                  "type": "mean",
-                  "params": []
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
                 }
-              ]
-            ],
-            "alias": "bandwidth"
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "value"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  }
+                ]
+              ],
+              "alias": "bandwidth"
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "yaxes": [
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "logBase": 1,
+              "format": "Kbits"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "logBase": 1,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
           }
-        ],
-        "aliasColors": {},
-        "seriesOverrides": [],
-        "links": [],
-        "yaxes": [
-          {
-            "show": true,
-            "min": null,
-            "max": null,
-            "logBase": 1,
-            "format": "Kbits"
-          },
-          {
-            "show": true,
-            "min": null,
-            "max": null,
-            "logBase": 1,
-            "format": "short"
-          }
-        ],
-        "xaxis": {
-          "show": true
         }
-      }
-    ],
-    "title": "Row",
-    "collapse": false,
-    "editable": true
-  },
-  {
-    "height": "250px",
-    "panels": [
-      {
-        "title": "conns",
-        "error": false,
-        "span": 12,
-        "editable": true,
-        "type": "graph",
-        "id": 2,
-        "datasource": "cache_stats",
-        "renderer": "flot",
-        "grid": {
-          "threshold1": null,
-          "threshold2": null,
-          "threshold1Color": "rgba(216, 200, 27, 0.27)",
-          "threshold2Color": "rgba(234, 112, 112, 0.22)"
-        },
-        "lines": true,
-        "fill": 1,
-        "linewidth": 2,
-        "points": false,
-        "pointradius": 5,
-        "bars": false,
-        "stack": false,
-        "percentage": false,
-        "legend": {
-          "show": true,
-          "values": true,
-          "min": false,
-          "max": true,
-          "current": true,
-          "total": false,
-          "avg": false
-        },
-        "nullPointMode": "connected",
-        "steppedLine": false,
-        "tooltip": {
-          "value_type": "cumulative",
-          "shared": true,
-          "sort": 0,
-          "msResolution": false
-        },
-        "timeFrom": null,
-        "timeShift": null,
-        "targets": [
-          {
-            "measurement": "connections.1min",
-            "tags": {},
-            "query": `SELECT mean(value) FROM "monthly"."connections.1min" WHERE hostname= '${which}' and $timeFilter GROUP BY time(60s)`,
-            "rawQuery": true,
-            "refId": "A",
-            "policy": "default",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
-                ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
+      ],
+      "title": "Row",
+      "collapse": false,
+      "editable": true
+    },
+    {
+      "height": "250px",
+      "panels": [
+        {
+          "title": "conns",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 2,
+          "datasource": "cache_stats",
+          "renderer": "flot",
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": true,
+            "min": false,
+            "max": true,
+            "current": true,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "sort": 0,
+            "msResolution": false
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "targets": [
+            {
+              "measurement": "connections.1min",
+              "tags": {},
+              "query": `SELECT mean(value) FROM "monthly"."connections.1min" WHERE hostname= '${which}' and $timeFilter GROUP BY time(60s)`,
+              "rawQuery": true,
+              "refId": "A",
+              "policy": "default",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "groupBy": [
                 {
-                  "type": "field",
+                  "type": "time",
                   "params": [
-                    "value"
+                    "$interval"
                   ]
                 },
                 {
-                  "type": "mean",
-                  "params": []
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
                 }
-              ]
-            ],
-            "alias": "connections"
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "value"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  }
+                ]
+              ],
+              "alias": "connections"
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "yaxes": [
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "logBase": 1,
+              "format": "short"
+            },
+            {
+              "show": true,
+              "min": null,
+              "max": null,
+              "logBase": 1
+            }
+          ],
+          "xaxis": {
+            "show": true
           }
-        ],
-        "aliasColors": {},
-        "seriesOverrides": [],
-        "links": [],
-        "yaxes": [
-          {
-            "show": true,
-            "min": null,
-            "max": null,
-            "logBase": 1,
-            "format": "short"
-          },
-          {
-            "show": true,
-            "min": null,
-            "max": null,
-            "logBase": 1
-          }
-        ],
-        "xaxis": {
-          "show": true
         }
-      }
-    ],
-    "title": "Row",
-    "collapse": false,
-    "editable": true
-  },
-  {
-    "title": "cpu and mem",
-    "height": "250px",
-    "editable": true,
-    "collapse": false,
-    "panels": [
-      {
-        "title": "CPU Usage",
-        "error": false,
-        "span": 6,
-        "editable": true,
-        "type": "graph",
-        "isNew": true,
-        "id": 3,
-        "targets": [
-          {
-            "refId": "A",
-            "policy": "default",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "tags": [
-              {
-                key: "host",
-                operator: "=",
-                value: which
-              }
-            ],
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
+      ],
+      "title": "Row",
+      "collapse": false,
+      "editable": true
+    },
+    {
+      "title": "cpu and mem",
+      "height": "250px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "title": "CPU Usage",
+          "error": false,
+          "span": 6,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 3,
+          "targets": [
+            {
+              "refId": "A",
+              "policy": "default",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "tags": [
+                {
+                  key: "host",
+                  operator: "=",
+                  value: which
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "params": [
+                    "$interval"
+                  ]
+                },
+                {
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
+                }
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "usage_system"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "cpu_system"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "usage_iowait"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "cpu_iowait"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "usage_user"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "cpu_user"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "usage_guest"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "cpu_guest"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "usage_steal"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "cpu_steal"
+                    ]
+                  }
                 ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "usage_system"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "cpu_system"
-                  ]
-                }
               ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "usage_iowait"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "cpu_iowait"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "usage_user"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "cpu_user"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "usage_guest"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "cpu_guest"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "usage_steal"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "cpu_steal"
-                  ]
-                }
-              ]
-            ],
-            "measurement": "cpu",
-            "alias": "$col"
-          }
-        ],
-        "datasource": "telegraf",
-        "renderer": "flot",
-        "yaxes": [
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "percent"
+              "measurement": "cpu",
+              "alias": "$col"
+            }
+          ],
+          "datasource": "telegraf",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "percent"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
           },
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
-          }
-        ],
-        "xaxis": {
-          "show": true
-        },
-        "grid": {
-          "threshold1": null,
-          "threshold2": null,
-          "threshold1Color": "rgba(216, 200, 27, 0.27)",
-          "threshold2Color": "rgba(234, 112, 112, 0.22)"
-        },
-        "lines": true,
-        "fill": 1,
-        "linewidth": 2,
-        "points": false,
-        "pointradius": 5,
-        "bars": false,
-        "stack": true,
-        "percentage": false,
-        "legend": {
-          "show": true,
-          "values": false,
-          "min": false,
-          "max": false,
-          "current": false,
-          "total": false,
-          "avg": false
-        },
-        "nullPointMode": "connected",
-        "steppedLine": false,
-        "tooltip": {
-          "value_type": "individual",
-          "shared": true,
-          "msResolution": true,
-          "sort": 2
-        },
-        "timeFrom": null,
-        "timeShift": null,
-        "aliasColors": {},
-        "seriesOverrides": [],
-        "links": []
-      },
-      {
-        "title": "Memory Usage",
-        "error": false,
-        "span": 6,
-        "editable": true,
-        "type": "graph",
-        "isNew": true,
-        "id": 4,
-        "targets": [
-          {
-            "refId": "A",
-            "policy": "default",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "tags": [
-              {
-                key: "host",
-                operator: "=",
-                value: which
-              }
-            ],
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
-                ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "used_percent"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "mem_used"
-                  ]
-                }
-              ]
-            ],
-            "measurement": "mem",
-            "alias": "$col"
-          }
-        ],
-        "datasource": "telegraf",
-        "renderer": "flot",
-        "yaxes": [
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "percent"
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          {
-            "label": null,
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": true,
+          "percentage": false,
+          "legend": {
             "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
-          }
-        ],
-        "xaxis": {
-          "show": true
-        },
-        "grid": {
-          "threshold1": null,
-          "threshold2": null,
-          "threshold1Color": "rgba(216, 200, 27, 0.27)",
-          "threshold2Color": "rgba(234, 112, 112, 0.22)"
-        },
-        "lines": true,
-        "fill": 1,
-        "linewidth": 2,
-        "points": false,
-        "pointradius": 5,
-        "bars": false,
-        "stack": true,
-        "percentage": false,
-        "legend": {
-          "show": true,
-          "values": false,
-          "min": false,
-          "max": false,
-          "current": false,
-          "total": false,
-          "avg": false
-        },
-        "nullPointMode": "connected",
-        "steppedLine": false,
-        "tooltip": {
-          "value_type": "individual",
-          "shared": true,
-          "msResolution": true,
-          "sort": 0
-        },
-        "timeFrom": null,
-        "timeShift": null,
-        "aliasColors": {},
-        "seriesOverrides": [],
-        "links": []
-      }
-    ]
-  },
-  {
-    "title": "load avg and diskio",
-    "height": "250px",
-    "editable": true,
-    "collapse": false,
-    "panels": [
-      {
-        "title": "Load Average",
-        "error": false,
-        "span": 6,
-        "editable": true,
-        "type": "graph",
-        "isNew": true,
-        "id": 5,
-        "targets": [
-          {
-            "refId": "A",
-            "policy": "default",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "tags": [
-              {
-                key: "host",
-                operator: "=",
-                value: which
-              }
-            ],
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
-                ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "load1"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "load1"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "load5"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "load5"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "load15"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "load15"
-                  ]
-                }
-              ]
-            ],
-            "measurement": "system",
-            "alias": "$col"
-          }
-        ],
-        "datasource": "telegraf",
-        "renderer": "flot",
-        "yaxes": [
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
           },
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
-          }
-        ],
-        "xaxis": {
-          "show": true
-        },
-        "grid": {
-          "threshold1": null,
-          "threshold2": null,
-          "threshold1Color": "rgba(216, 200, 27, 0.27)",
-          "threshold2Color": "rgba(234, 112, 112, 0.22)"
-        },
-        "lines": true,
-        "fill": 1,
-        "linewidth": 2,
-        "points": false,
-        "pointradius": 5,
-        "bars": false,
-        "stack": false,
-        "percentage": false,
-        "legend": {
-          "show": true,
-          "values": false,
-          "min": false,
-          "max": false,
-          "current": false,
-          "total": false,
-          "avg": false
-        },
-        "nullPointMode": "connected",
-        "steppedLine": false,
-        "tooltip": {
-          "value_type": "cumulative",
-          "shared": true,
-          "msResolution": true,
-          "sort": 0
-        },
-        "timeFrom": null,
-        "timeShift": null,
-        "aliasColors": {},
-        "seriesOverrides": [],
-        "links": []
-      },
-      {
-        "title": "Read/Write Time",
-        "error": false,
-        "span": 6,
-        "editable": true,
-        "type": "graph",
-        "isNew": true,
-        "id": 6,
-        "targets": [
-          {
-            "refId": "A",
-            "policy": "default",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "tags": [
-              {
-                key: "host",
-                operator: "=",
-                value: which
-              }
-            ],
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
-                ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "read_time"
-                  ]
-                },
-                {
-                  "type": "sum",
-                  "params": []
-                },
-                {
-                  "type": "non_negative_derivative",
-                  "params": [
-                    "10s"
-                  ]
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "read_time"
-                  ]
-                }
-              ]
-            ],
-            "measurement": "diskio",
-            "alias": "$col"
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "individual",
+            "shared": true,
+            "msResolution": true,
+            "sort": 2
           },
-          {
-            "refId": "B",
-            "policy": "default",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "tags": [
-              {
-                key: "host",
-                operator: "=",
-                value: which
-              }
-            ],
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
-                ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": []
+        },
+        {
+          "title": "Memory Usage",
+          "error": false,
+          "span": 6,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 4,
+          "targets": [
+            {
+              "refId": "A",
+              "policy": "default",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "tags": [
                 {
-                  "type": "field",
+                  key: "host",
+                  operator: "=",
+                  value: which
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
                   "params": [
-                    "write_time"
+                    "$interval"
                   ]
                 },
                 {
-                  "type": "sum",
-                  "params": []
-                },
-                {
-                  "type": "non_negative_derivative",
+                  "type": "fill",
                   "params": [
-                    "10s"
-                  ]
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "write_time"
+                    "null"
                   ]
                 }
-              ]
-            ],
-            "measurement": "diskio",
-            "alias": "$col"
-          }
-        ],
-        "datasource": "telegraf",
-        "renderer": "flot",
-        "yaxes": [
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "ns"
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "used_percent"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "mem_used"
+                    ]
+                  }
+                ]
+              ],
+              "measurement": "mem",
+              "alias": "$col"
+            }
+          ],
+          "datasource": "telegraf",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "percent"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
           },
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
-          }
-        ],
-        "xaxis": {
-          "show": true
-        },
-        "grid": {
-          "threshold1": null,
-          "threshold2": null,
-          "threshold1Color": "rgba(216, 200, 27, 0.27)",
-          "threshold2Color": "rgba(234, 112, 112, 0.22)"
-        },
-        "lines": true,
-        "fill": 1,
-        "linewidth": 2,
-        "points": false,
-        "pointradius": 5,
-        "bars": false,
-        "stack": false,
-        "percentage": false,
-        "legend": {
-          "show": true,
-          "values": false,
-          "min": false,
-          "max": false,
-          "current": false,
-          "total": false,
-          "avg": false
-        },
-        "nullPointMode": "connected",
-        "steppedLine": false,
-        "tooltip": {
-          "value_type": "cumulative",
-          "shared": true,
-          "msResolution": true,
-          "sort": 0
-        },
-        "timeFrom": null,
-        "timeShift": null,
-        "aliasColors": {},
-        "seriesOverrides": [],
-        "links": []
-      }
-    ]
-  },
-  {
-    "title": "Wrap Count and netstat",
-    "height": "250px",
-    "editable": true,
-    "collapse": false,
-    "panels": [
-      {
-        "title": "wrap count",
-        "error": false,
-        "span": 6,
-        "editable": true,
-        "type": "graph",
-        "isNew": true,
-        "id": 7,
-        "targets": [
-          {
-            "refId": "A",
-            "policy": "monthly",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "tags": [
-              {
-                key: "hostname",
-                operator: "=",
-                value: which
-              }
-            ],
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
-                ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "vol1_wrap_count"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "vol1"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "vol2_wrap_count"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "vol2"
-                  ]
-                }
-              ]
-            ],
-            "measurement": "wrap_count.1min",
-            "alias": "$col"
-          }
-        ],
-        "datasource": "cache_stats",
-        "renderer": "flot",
-        "yaxes": [
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          {
-            "label": null,
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": true,
+          "percentage": false,
+          "legend": {
             "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
-          }
-        ],
-        "xaxis": {
-          "show": true
-        },
-        "grid": {
-          "threshold1": null,
-          "threshold2": null,
-          "threshold1Color": "rgba(216, 200, 27, 0.27)",
-          "threshold2Color": "rgba(234, 112, 112, 0.22)"
-        },
-        "lines": true,
-        "fill": 1,
-        "linewidth": 2,
-        "points": false,
-        "pointradius": 5,
-        "bars": false,
-        "stack": false,
-        "percentage": false,
-        "legend": {
-          "show": true,
-          "values": false,
-          "min": false,
-          "max": false,
-          "current": false,
-          "total": false,
-          "avg": false
-        },
-        "nullPointMode": "connected",
-        "steppedLine": false,
-        "tooltip": {
-          "value_type": "cumulative",
-          "shared": true,
-          "sort": 0,
-          "msResolution": true
-        },
-        "timeFrom": null,
-        "timeShift": null,
-        "aliasColors": {},
-        "seriesOverrides": [],
-        "links": []
-      },
-      {
-        "title": "netstat",
-        "error": false,
-        "span": 6,
-        "editable": true,
-        "type": "graph",
-        "isNew": true,
-        "id": 8,
-        "targets": [
-          {
-            "refId": "A",
-            "policy": "default",
-            "dsType": "influxdb",
-            "resultFormat": "time_series",
-            "tags": [
-              {
-                key: "host",
-                operator: "=",
-                value: which
-              }
-            ],
-            "groupBy": [
-              {
-                "type": "time",
-                "params": [
-                  "$interval"
-                ]
-              },
-              {
-                "type": "fill",
-                "params": [
-                  "null"
-                ]
-              }
-            ],
-            "select": [
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_close"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_close"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_close_wait"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_close_wait"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_established"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_established"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_time_wait"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_time_wait"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_closing"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_closing"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_fin_wait1"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_fin_wait1"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_fin_wait2"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_fin_wait2"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_last_ack"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_last_ack"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_syn_recv"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_syn_recv"
-                  ]
-                }
-              ],
-              [
-                {
-                  "type": "field",
-                  "params": [
-                    "tcp_syn_sent"
-                  ]
-                },
-                {
-                  "type": "mean",
-                  "params": []
-                },
-                {
-                  "type": "alias",
-                  "params": [
-                    "tcp_syn_sent"
-                  ]
-                }
-              ]
-            ],
-            "measurement": "netstat",
-            "alias": "$col"
-          }
-        ],
-        "datasource": "telegraf",
-        "renderer": "flot",
-        "yaxes": [
-          {
-            "label": null,
-            "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
           },
-          {
-            "label": null,
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "individual",
+            "shared": true,
+            "msResolution": true,
+            "sort": 0
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": []
+        }
+      ]
+    },
+    {
+      "title": "load avg and diskio",
+      "height": "250px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "title": "Load Average",
+          "error": false,
+          "span": 6,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 5,
+          "targets": [
+            {
+              "refId": "A",
+              "policy": "default",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "tags": [
+                {
+                  key: "host",
+                  operator: "=",
+                  value: which
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "params": [
+                    "$interval"
+                  ]
+                },
+                {
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
+                }
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "load1"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "load1"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "load5"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "load5"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "load15"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "load15"
+                    ]
+                  }
+                ]
+              ],
+              "measurement": "system",
+              "alias": "$col"
+            }
+          ],
+          "datasource": "telegraf",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
             "show": true,
-            "logBase": 1,
-            "min": null,
-            "max": null,
-            "format": "short"
-          }
-        ],
-        "xaxis": {
-          "show": true
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true,
+            "sort": 0
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": []
         },
-        "grid": {
-          "threshold1": null,
-          "threshold2": null,
-          "threshold1Color": "rgba(216, 200, 27, 0.27)",
-          "threshold2Color": "rgba(234, 112, 112, 0.22)"
+        {
+          "title": "Read/Write Time",
+          "error": false,
+          "span": 6,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 6,
+          "targets": [
+            {
+              "refId": "A",
+              "policy": "default",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "tags": [
+                {
+                  key: "host",
+                  operator: "=",
+                  value: which
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "params": [
+                    "$interval"
+                  ]
+                },
+                {
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
+                }
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "read_time"
+                    ]
+                  },
+                  {
+                    "type": "sum",
+                    "params": []
+                  },
+                  {
+                    "type": "non_negative_derivative",
+                    "params": [
+                      "10s"
+                    ]
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "read_time"
+                    ]
+                  }
+                ]
+              ],
+              "measurement": "diskio",
+              "alias": "$col"
+            },
+            {
+              "refId": "B",
+              "policy": "default",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "tags": [
+                {
+                  key: "host",
+                  operator: "=",
+                  value: which
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "params": [
+                    "$interval"
+                  ]
+                },
+                {
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
+                }
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "write_time"
+                    ]
+                  },
+                  {
+                    "type": "sum",
+                    "params": []
+                  },
+                  {
+                    "type": "non_negative_derivative",
+                    "params": [
+                      "10s"
+                    ]
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "write_time"
+                    ]
+                  }
+                ]
+              ],
+              "measurement": "diskio",
+              "alias": "$col"
+            }
+          ],
+          "datasource": "telegraf",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "ns"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "msResolution": true,
+            "sort": 0
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": []
+        }
+      ]
+    },
+    {
+      "title": "Wrap Count and netstat",
+      "height": "250px",
+      "editable": true,
+      "collapse": false,
+      "panels": [
+        {
+          "title": "wrap count",
+          "error": false,
+          "span": 6,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 7,
+          "targets": [
+            {
+              "refId": "A",
+              "policy": "monthly",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "tags": [
+                {
+                  key: "hostname",
+                  operator: "=",
+                  value: which
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "params": [
+                    "$interval"
+                  ]
+                },
+                {
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
+                }
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "vol1_wrap_count"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "vol1"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "vol2_wrap_count"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "vol2"
+                    ]
+                  }
+                ]
+              ],
+              "measurement": "wrap_count.1min",
+              "alias": "$col"
+            }
+          ],
+          "datasource": "cache_stats",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "sort": 0,
+            "msResolution": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": []
         },
-        "lines": true,
-        "fill": 1,
-        "linewidth": 2,
-        "points": false,
-        "pointradius": 5,
-        "bars": false,
-        "stack": false,
-        "percentage": false,
-        "legend": {
-          "show": true,
-          "values": false,
-          "min": false,
-          "max": false,
-          "current": false,
-          "total": false,
-          "avg": false,
-          "hideEmpty": true,
-          "hideZero": true
-        },
-        "nullPointMode": "connected",
-        "steppedLine": false,
-        "tooltip": {
-          "value_type": "cumulative",
-          "shared": true,
-          "sort": 2,
-          "msResolution": true
-        },
-        "timeFrom": null,
-        "timeShift": null,
-        "aliasColors": {},
-        "seriesOverrides": [],
-        "links": []
-      }
-    ]
-  }
-);
-
+        {
+          "title": "netstat",
+          "error": false,
+          "span": 6,
+          "editable": true,
+          "type": "graph",
+          "isNew": true,
+          "id": 8,
+          "targets": [
+            {
+              "refId": "A",
+              "policy": "default",
+              "dsType": "influxdb",
+              "resultFormat": "time_series",
+              "tags": [
+                {
+                  key: "host",
+                  operator: "=",
+                  value: which
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "params": [
+                    "$interval"
+                  ]
+                },
+                {
+                  "type": "fill",
+                  "params": [
+                    "null"
+                  ]
+                }
+              ],
+              "select": [
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_close"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_close"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_close_wait"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_close_wait"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_established"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_established"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_time_wait"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_time_wait"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_closing"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_closing"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_fin_wait1"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_fin_wait1"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_fin_wait2"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_fin_wait2"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_last_ack"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_last_ack"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_syn_recv"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_syn_recv"
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "type": "field",
+                    "params": [
+                      "tcp_syn_sent"
+                    ]
+                  },
+                  {
+                    "type": "mean",
+                    "params": []
+                  },
+                  {
+                    "type": "alias",
+                    "params": [
+                      "tcp_syn_sent"
+                    ]
+                  }
+                ]
+              ],
+              "measurement": "netstat",
+              "alias": "$col"
+            }
+          ],
+          "datasource": "telegraf",
+          "renderer": "flot",
+          "yaxes": [
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            },
+            {
+              "label": null,
+              "show": true,
+              "logBase": 1,
+              "min": null,
+              "max": null,
+              "format": "short"
+            }
+          ],
+          "xaxis": {
+            "show": true
+          },
+          "grid": {
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "hideEmpty": true,
+            "hideZero": true
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": true,
+            "sort": 2,
+            "msResolution": true
+          },
+          "timeFrom": null,
+          "timeShift": null,
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": []
+        }
+      ]
+    }
+  );
+}
 return dashboard;


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4541

I _think_ this fixes the issue where it would select multiple servers when "which" is specified with something that is contained in the hostnames of multiple servers. I've tested it in CDN-in-a-Box and everything appeared to be working, but for some reason about half of the graphs are trying to source their data from "telegraf", which looks like some kind of hold-over from when this was a Comcast internal project.

## Which Traffic Control components are affected by this PR?
- Traffic Stats

## What is the best way to verify this PR?
Open the scripted dashboard with a "which" value that is contained in multiple cache server hostnames. Verify that only the cache server with a hostname exactly matching `which` is selected. Unless there are multiple with the same hostname, which is totally allowed and can happen. Idk what the dashboard is supposed to do in that case.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**