### PR TITLE
Add default sort to phys_locations

### DIFF
--- a/traffic_ops/client/phys_location.go
+++ b/traffic_ops/client/phys_location.go
@@ -78,9 +78,10 @@ func (to *Session) UpdatePhysLocationByID(id int, pl tc.PhysLocation) (tc.Alerts
 	return alerts, reqInf, nil
 }
 
-// Returns a list of PhysLocations
-func (to *Session) GetPhysLocations() ([]tc.PhysLocation, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, API_PHYS_LOCATIONS, nil)
+// Returns a list of PhysLocations with optional query parameters applied
+func (to *Session) GetPhysLocations(params map[string]string) ([]tc.PhysLocation, ReqInf, error) {
+	path := API_PHYS_LOCATIONS + mapToQueryParameters(params)
+	resp, remoteAddr, err := to.request(http.MethodGet, path, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
 		return nil, reqInf, err

--- a/traffic_ops/client/util.go
+++ b/traffic_ops/client/util.go
@@ -56,3 +56,16 @@ func makeReq(to *Session, method, endpoint string, body []byte, respStruct inter
 
 	return reqInf, nil
 }
+
+func mapToQueryParameters(params map[string]string) string {
+	path := ""
+	for key, value := range params {
+		if path == "" {
+			path += "?"
+		} else {
+			path += "&"
+		}
+		path += key + "=" + value
+	}
+	return path
+}

--- a/traffic_ops/testing/api/v1/phys_locations_test.go
+++ b/traffic_ops/testing/api/v1/phys_locations_test.go
@@ -17,12 +17,14 @@ package v1
 
 import (
 	"testing"
+	"sort"
 
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 func TestPhysLocations(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Parameters, Divisions, Regions, PhysLocations}, func() {
+		GetDefaultSortPhysLocationsTest(t)
 		UpdateTestPhysLocations(t)
 		GetTestPhysLocations(t)
 	})
@@ -103,5 +105,18 @@ func DeleteTestPhysLocations(t *testing.T) {
 				t.Errorf("expected PhysLocation name: %s to be deleted", cdn.Name)
 			}
 		}
+	}
+}
+
+func GetDefaultSortPhysLocationsTest(t *testing.T) {
+	resp, _, err := TOSession.GetPhysLocations()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	sorted := sort.SliceIsSorted(resp, func(i, j int) bool {
+		return resp[i].Name < resp[j].Name
+	})
+	if !sorted {
+		t.Error("expected response to be sorted by name")
 	}
 }

--- a/traffic_ops/testing/api/v2/phys_locations_test.go
+++ b/traffic_ops/testing/api/v2/phys_locations_test.go
@@ -16,6 +16,7 @@ package v2
 */
 
 import (
+	"sort"
 	"testing"
 
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
@@ -23,6 +24,8 @@ import (
 
 func TestPhysLocations(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Parameters, Divisions, Regions, PhysLocations}, func() {
+		GetDefaultSortPhysLocationsTest(t)
+		GetSortPhysLocationsTest(t)
 		UpdateTestPhysLocations(t)
 		GetTestPhysLocations(t)
 	})
@@ -75,6 +78,33 @@ func GetTestPhysLocations(t *testing.T) {
 		if err != nil {
 			t.Errorf("cannot GET PhysLocation by name: %v - %v", err, resp)
 		}
+	}
+
+}
+
+func GetSortPhysLocationsTest(t *testing.T) {
+	resp, _, err := TOSession.GetPhysLocations(map[string]string{"orderby": "id"})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	sorted := sort.SliceIsSorted(resp, func(i, j int) bool {
+		return resp[i].ID < resp[j].ID
+	})
+	if !sorted {
+		t.Error("expected response to be sorted by id")
+	}
+}
+
+func GetDefaultSortPhysLocationsTest(t *testing.T) {
+	resp, _, err := TOSession.GetPhysLocations(nil)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	sorted := sort.SliceIsSorted(resp, func(i, j int) bool {
+		return resp[i].Name < resp[j].Name
+	})
+	if !sorted {
+		t.Error("expected response to be sorted by name")
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -98,7 +98,12 @@ func (pl *TOPhysLocation) Validate() error {
 	return nil
 }
 
-func (pl *TOPhysLocation) Read() ([]interface{}, error, error, int) { return api.GenericRead(pl) }
+func (pl *TOPhysLocation) Read() ([]interface{}, error, error, int) {
+	if _, ok := pl.APIInfo().Params["orderby"]; !ok {
+		pl.APIInfo().Params["orderby"] = "name"
+	}
+	return api.GenericRead(pl)
+}
 func (pl *TOPhysLocation) Update() (error, error, int)              { return api.GenericUpdate(pl) }
 func (pl *TOPhysLocation) Create() (error, error, int)              { return api.GenericCreate(pl) }
 func (pl *TOPhysLocation) Delete() (error, error, int)              { return api.GenericDelete(pl) }


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #2794


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
Verify TO api default orders phys_locations by name and that it can be overridden.
Verify in TP that when adding a server, sites are sorted by name
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
