### PR TITLE
Fixed snapshots passing cdnID in body not qstring

### DIFF
--- a/traffic_portal/app/src/common/api/CDNService.js
+++ b/traffic_portal/app/src/common/api/CDNService.js
@@ -176,7 +176,7 @@ var CDNService = function($http, locationUtils, messageModel, ENV) {
     };
 
     this.snapshot = function(cdn) {
-        return $http.put(ENV.api['root'] + '/snapshot', undefined, {params: {cdnID: cdn.id}}).then(
+        return $http.put(ENV.api['root'] + 'snapshot', undefined, {params: {cdnID: cdn.id}}).then(
             function(result) {
                 messageModel.setMessages([{level: 'success', text: 'Snapshot performed'}], true);
                 locationUtils.navigateToPath('/cdns/' + cdn.id);

--- a/traffic_portal/app/src/common/api/CDNService.js
+++ b/traffic_portal/app/src/common/api/CDNService.js
@@ -176,7 +176,7 @@ var CDNService = function($http, locationUtils, messageModel, ENV) {
     };
 
     this.snapshot = function(cdn) {
-        return $http.put(ENV.api['root'] + '/snapshot', {params: {cdnID: cdn.id}}).then(
+        return $http.put(ENV.api['root'] + '/snapshot', undefined, {params: {cdnID: cdn.id}}).then(
             function(result) {
                 messageModel.setMessages([{level: 'success', text: 'Snapshot performed'}], true);
                 locationUtils.navigateToPath('/cdns/' + cdn.id);


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4552 

Fixes Traffic Portal passing the cdnID in the request body instead of as a query string parameter.

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Run traffic portal and take a snapshot, verify it is successful.

## If this is a bug fix, what versions of Traffic Control are affected?
- master


## The following criteria are ALL met by this PR

- [x] This PR should be covered by existing tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**