### PR TITLE
Add ORT/atstccfg Deterministic Config Generation

### DIFF
--- a/lib/go-atscfg/astatsdotconfig.go
+++ b/lib/go-atscfg/astatsdotconfig.go
@@ -23,6 +23,7 @@ const AstatsSeparator = "="
 const AstatsFileName = "astats.config"
 
 const ContentTypeAstatsDotConfig = ContentTypeTextASCII
+const LineCommentAstatsDotConfig = LineCommentHash
 
 func MakeAStatsDotConfig(
 	profileName string,

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -37,6 +37,8 @@ const HeaderCommentDateFormat = "Mon Jan 2 15:04:05 MST 2006"
 
 const ContentTypeTextASCII = `text/plain; charset=us-ascii`
 
+const LineCommentHash = "#"
+
 type ServerCapability string
 
 type ServerInfo struct {

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -21,6 +21,7 @@ package atscfg
 
 import (
 	"errors"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -103,10 +104,14 @@ func GenericProfileConfig(
 	separator string,
 ) string {
 	text := ""
+
+	lines := []string{}
 	for name, val := range paramData {
 		name = trimParamUnderscoreNumSuffix(name)
-		text += name + separator + val + "\n"
+		lines = append(lines, name+separator+val+"\n")
 	}
+	sort.Strings(lines)
+	text = strings.Join(lines, "")
 	return text
 }
 

--- a/lib/go-atscfg/atsdotrules.go
+++ b/lib/go-atscfg/atsdotrules.go
@@ -24,6 +24,7 @@ import (
 )
 
 const ContentTypeATSDotRules = ContentTypeTextASCII
+const LineCommentATSDotRules = LineCommentHash
 
 func MakeATSDotRules(
 	profileName string,

--- a/lib/go-atscfg/bgfetchdotconfig.go
+++ b/lib/go-atscfg/bgfetchdotconfig.go
@@ -24,6 +24,7 @@ import (
 )
 
 const ContentTypeBGFetchDotConfig = ContentTypeTextASCII
+const LineCommentBGFetchDotConfig = LineCommentHash
 
 func MakeBGFetchDotConfig(
 	cdnName tc.CDNName,

--- a/lib/go-atscfg/cachedotconfig.go
+++ b/lib/go-atscfg/cachedotconfig.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
@@ -60,10 +61,12 @@ func MakeCacheDotConfig(
 		}
 	}
 
-	text := ""
+	linesArr := []string{}
 	for line, _ := range lines {
-		text += line
+		linesArr = append(linesArr, line)
 	}
+	sort.Strings(linesArr)
+	text := strings.Join(linesArr, "")
 	if text == "" {
 		text = "\n" // If no params exist, don't send "not found," but an empty file. We know the profile exists.
 	}

--- a/lib/go-atscfg/cachedotconfig.go
+++ b/lib/go-atscfg/cachedotconfig.go
@@ -28,6 +28,7 @@ import (
 )
 
 const ContentTypeCacheDotConfig = ContentTypeTextASCII
+const LineCommentCacheDotConfig = LineCommentHash
 
 type ProfileDS struct {
 	Type       tc.DSType

--- a/lib/go-atscfg/cacheurldotconfig.go
+++ b/lib/go-atscfg/cacheurldotconfig.go
@@ -27,6 +27,7 @@ import (
 )
 
 const ContentTypeCacheURLDotConfig = ContentTypeTextASCII
+const LineCommentCacheURLDotConfig = LineCommentHash
 
 type CacheURLDS struct {
 	OrgServerFQDN string

--- a/lib/go-atscfg/chkconfig.go
+++ b/lib/go-atscfg/chkconfig.go
@@ -21,6 +21,7 @@ package atscfg
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 )
@@ -34,6 +35,17 @@ type ChkConfigEntry struct {
 	Val  string `json:"value"`
 }
 
+type ChkConfigEntries []ChkConfigEntry
+
+func (e ChkConfigEntries) Len() int { return len(e) }
+func (e ChkConfigEntries) Less(i, j int) bool {
+	if e[i].Name != e[j].Name {
+		return e[i].Name < e[j].Name
+	}
+	return e[i].Val < e[j].Val
+}
+func (e ChkConfigEntries) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+
 // MakeChkconfig returns the 'chkconfig' ATS config file endpoint.
 // This is a JSON object, and should be served with an 'application/json' Content-Type.
 func MakeChkconfig(
@@ -46,6 +58,9 @@ func MakeChkconfig(
 			chkconfig = append(chkconfig, ChkConfigEntry{Name: name, Val: val})
 		}
 	}
+
+	sort.Sort(ChkConfigEntries(chkconfig))
+
 	bts, err := json.Marshal(&chkconfig)
 	if err != nil {
 		// should never happen

--- a/lib/go-atscfg/chkconfig.go
+++ b/lib/go-atscfg/chkconfig.go
@@ -29,6 +29,7 @@ import (
 const ChkconfigFileName = `chkconfig`
 const ChkconfigParamConfigFile = `chkconfig`
 const ContentTypeChkconfig = ContentTypeTextASCII
+const LineCommentChkconfig = LineCommentHash
 
 type ChkConfigEntry struct {
 	Name string `json:"name"`

--- a/lib/go-atscfg/dropqstringdotconfig.go
+++ b/lib/go-atscfg/dropqstringdotconfig.go
@@ -22,6 +22,7 @@ package atscfg
 const DropQStringDotConfigFileName = "drop_qstring.config"
 const DropQStringDotConfigParamName = "content"
 const ContentTypeDropQStringDotConfig = ContentTypeTextASCII
+const LineCommentDropQStringDotConfig = LineCommentHash
 
 func MakeDropQStringDotConfig(
 	profileName string,

--- a/lib/go-atscfg/facts.go
+++ b/lib/go-atscfg/facts.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 const ContentType12MFacts = ContentTypeTextASCII
+const LineComment12MFacts = LineCommentHash
 
 func Make12MFacts(
 	profileName string,

--- a/lib/go-atscfg/headerrewritedotconfig.go
+++ b/lib/go-atscfg/headerrewritedotconfig.go
@@ -31,6 +31,7 @@ import (
 
 const HeaderRewritePrefix = "hdr_rw_"
 const ContentTypeHeaderRewriteDotConfig = ContentTypeTextASCII
+const LineCommentHeaderRewriteDotConfig = LineCommentHash
 
 const MaxOriginConnectionsNoMax = 0 // 0 indicates no limit on origin connections
 

--- a/lib/go-atscfg/hostingdotconfig.go
+++ b/lib/go-atscfg/hostingdotconfig.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -42,6 +43,7 @@ func MakeHostingDotConfig(
 ) string {
 	text := GenericHeaderComment(string(serverName), toToolName, toURL)
 
+	lines := []string{}
 	if _, ok := params[ParamRAMDrivePrefix]; ok {
 		nextVolume := 1
 		if _, ok := params[ParamDrivePrefix]; ok {
@@ -60,10 +62,14 @@ func MakeHostingDotConfig(
 			seenOrigins[origin] = struct{}{}
 			origin = strings.TrimPrefix(origin, `http://`)
 			origin = strings.TrimPrefix(origin, `https://`)
-			text += `hostname=` + origin + ` volume=` + strconv.Itoa(ramVolume) + "\n"
+			lines = append(lines, `hostname=`+origin+` volume=`+strconv.Itoa(ramVolume)+"\n")
 		}
 	}
 	diskVolume := 1 // note this will actually be the RAM (RAM_Drive_Prefix) volume if there is no Drive_Prefix parameter.
-	text += `hostname=*   volume=` + strconv.Itoa(diskVolume) + "\n"
+
+	lines = append(lines, `hostname=*   volume=`+strconv.Itoa(diskVolume)+"\n")
+
+	sort.Strings(lines)
+	text += strings.Join(lines, "")
 	return text
 }

--- a/lib/go-atscfg/hostingdotconfig.go
+++ b/lib/go-atscfg/hostingdotconfig.go
@@ -30,6 +30,7 @@ import (
 const HostingConfigFileName = `hosting.config`
 const HostingConfigParamConfigFile = `storage.config`
 const ContentTypeHostingDotConfig = ContentTypeTextASCII
+const LineCommentHostingDotConfig = LineCommentHash
 
 const ParamDrivePrefix = "Drive_Prefix"
 const ParamRAMDrivePrefix = "RAM_Drive_Prefix"

--- a/lib/go-atscfg/ipallowdotconfig.go
+++ b/lib/go-atscfg/ipallowdotconfig.go
@@ -32,6 +32,7 @@ import (
 
 const IPAllowConfigFileName = `ip_allow.config`
 const ContentTypeIPAllowDotConfig = ContentTypeTextASCII
+const LineCommentIPAllowDotConfig = LineCommentHash
 
 type IPAllowData struct {
 	Src    string

--- a/lib/go-atscfg/ipallowdotconfig.go
+++ b/lib/go-atscfg/ipallowdotconfig.go
@@ -21,6 +21,7 @@ package atscfg
 
 import (
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -36,6 +37,20 @@ type IPAllowData struct {
 	Src    string
 	Action string
 	Method string
+}
+
+type IPAllowDatas []IPAllowData
+
+func (is IPAllowDatas) Len() int      { return len(is) }
+func (is IPAllowDatas) Swap(i, j int) { is[i], is[j] = is[j], is[i] }
+func (is IPAllowDatas) Less(i, j int) bool {
+	if is[i].Src != is[j].Src {
+		return is[i].Src < is[j].Src
+	}
+	if is[i].Action != is[j].Action {
+		return is[i].Action < is[j].Action
+	}
+	return is[i].Method < is[j].Method
 }
 
 const ParamPurgeAllowIP = "purge_allow_ip"
@@ -232,6 +247,9 @@ func MakeIPAllowDotConfig(
 			Action: ActionAllow,
 			Method: MethodAll,
 		})
+
+		// order matters, so sort before adding the denys
+		sort.Sort(IPAllowDatas(ipAllowData))
 
 		// end with a deny
 		ipAllowData = append(ipAllowData, IPAllowData{

--- a/lib/go-atscfg/loggingdotconfig.go
+++ b/lib/go-atscfg/loggingdotconfig.go
@@ -30,6 +30,7 @@ const MaxLogObjects = 10
 
 const LoggingFileName = "logging.config"
 const ContentTypeLoggingDotConfig = ContentTypeTextASCII
+const LineCommentLoggingDotConfig = LineCommentHash
 
 // MakeStorageDotConfig creates storage.config for a given ATS Profile.
 // The paramData is the map of parameter names to values, for all parameters assigned to the given profile, with the config_file "storage.config".

--- a/lib/go-atscfg/loggingdotyaml.go
+++ b/lib/go-atscfg/loggingdotyaml.go
@@ -28,6 +28,7 @@ import (
 
 const LoggingYAMLFileName = "logging.yaml"
 const ContentTypeLoggingDotYAML = "application/yaml; charset=us-ascii" // Note YAML has no IANA standard mime type. This is one of several common usages, and is likely to be the standardized value. If you're reading this, please check IANA to see if YAML has been added, and change this to the IANA definition if so. Also note we include 'charset=us-ascii' because YAML is commonly UTF-8, but ATS is likely to be unable to handle UTF.
+const LineCommentLoggingDotYAML = LineCommentHash
 
 func MakeLoggingDotYAML(
 	profileName string,

--- a/lib/go-atscfg/logsdotxml.go
+++ b/lib/go-atscfg/logsdotxml.go
@@ -27,12 +27,18 @@ import (
 const LogsXMLFileName = "logs_xml.config"
 const ContentTypeLogsDotXML = `text/xml`
 
+const LineCommentLogsDotXML = `<!--`
+
 func MakeLogsXMLDotConfig(
 	profileName string,
 	paramData map[string]string, // GetProfileParamData(tx, profile.ID, LoggingYAMLFileName)
 	toToolName string, // tm.toolname global parameter (TODO: cache itself?)
 	toURL string, // tm.url global parameter (TODO: cache itself?)
 ) string {
+
+	// Note LineCommentLogsDotXML must be a single-line comment!
+	// But this file doesn't have a single-line format, so we use <!-- for the header and promise it's on a single line
+	// Note! if this file is ever changed to have multi-line comments, LineCommentLogsDotXML will have to be changed to the empty string.
 	hdrComment := GenericHeaderComment(profileName, toToolName, toURL)
 	hdrComment = strings.Replace(hdrComment, `# `, ``, -1)
 	hdrComment = strings.Replace(hdrComment, "\n", ``, -1)

--- a/lib/go-atscfg/packages.go
+++ b/lib/go-atscfg/packages.go
@@ -21,6 +21,7 @@ package atscfg
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 )
@@ -35,6 +36,17 @@ type Package struct {
 	Version string `json:"version"`
 }
 
+type Packages []Package
+
+func (ps Packages) Len() int { return len(ps) }
+func (ps Packages) Less(i, j int) bool {
+	if ps[i].Name != ps[j].Name {
+		return ps[i].Name < ps[j].Name
+	}
+	return ps[i].Version < ps[j].Version
+}
+func (ps Packages) Swap(i, j int) { ps[i], ps[j] = ps[j], ps[i] }
+
 // MakePackages returns the 'packages' ATS config file endpoint.
 // This is a JSON object, and should be served with an 'application/json' Content-Type.
 func MakePackages(
@@ -46,6 +58,7 @@ func MakePackages(
 			packages = append(packages, Package{Name: name, Version: version})
 		}
 	}
+	sort.Sort(Packages(packages))
 	bts, err := json.Marshal(&packages)
 	if err != nil {
 		// should never happen

--- a/lib/go-atscfg/packages.go
+++ b/lib/go-atscfg/packages.go
@@ -30,6 +30,7 @@ const PackagesFileName = `packages`
 const PackagesParamConfigFile = `package`
 
 const ContentTypePackages = ContentTypeTextASCII
+const LineCommentPackages = ""
 
 type Package struct {
 	Name    string `json:"name"`

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -170,8 +170,7 @@ func MakeParentDotConfig(
 	serverParams map[string]string, // getParentConfigServerProfileParams(serverID)
 	parentInfos map[OriginHost][]ParentInfo, // getParentInfo(profileID, parentCachegroupID, secondaryParentCachegroupID)
 ) string {
-
-	// parentInfos := makeParentInfo(serverInfo)
+	sort.Sort(ParentConfigDSTopLevelSortByName(parentConfigDSes))
 
 	nameVersionStr := GetNameVersionStringFromToolNameAndURL(toToolName, toURL)
 	hdr := HeaderCommentWithTOVersionStr(serverInfo.HostName, nameVersionStr)
@@ -256,8 +255,6 @@ func MakeParentDotConfig(
 
 		roundRobin := `round_robin=consistent_hash`
 		goDirect := `go_direct=false`
-
-		sort.Sort(ParentConfigDSTopLevelSortByName(parentConfigDSes))
 
 		for _, ds := range parentConfigDSes {
 			parents, secondaryParents := getParentStrs(ds, parentInfos[DeliveryServicesAllParentsKey], atsMajorVer)

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -32,6 +32,7 @@ import (
 )
 
 const ContentTypeParentDotConfig = ContentTypeTextASCII
+const LineCommentParentDotConfig = LineCommentHash
 
 const ParentConfigParamQStringHandling = "psel.qstring_handling"
 const ParentConfigParamMSOAlgorithm = "mso.algorithm"

--- a/lib/go-atscfg/plugindotconfig.go
+++ b/lib/go-atscfg/plugindotconfig.go
@@ -22,6 +22,7 @@ package atscfg
 const PluginSeparator = " "
 const PluginFileName = "plugin.config"
 const ContentTypePluginDotConfig = ContentTypeTextASCII
+const LineCommentPluginDotConfig = LineCommentHash
 
 func MakePluginDotConfig(
 	profileName string,

--- a/lib/go-atscfg/recordsdotconfig.go
+++ b/lib/go-atscfg/recordsdotconfig.go
@@ -26,6 +26,7 @@ import (
 const RecordsSeparator = " "
 const RecordsFileName = "records.config"
 const ContentTypeRecordsDotConfig = ContentTypeTextASCII
+const LineCommentRecordsDotConfig = LineCommentHash
 
 func MakeRecordsDotConfig(
 	profileName string,

--- a/lib/go-atscfg/regexremapdotconfig.go
+++ b/lib/go-atscfg/regexremapdotconfig.go
@@ -27,6 +27,7 @@ import (
 )
 
 const ContentTypeRegexRemapDotConfig = ContentTypeTextASCII
+const LineCommentRegexRemapDotConfig = LineCommentHash
 
 type CDNDS struct {
 	OrgServerFQDN string

--- a/lib/go-atscfg/regexrevalidatedotconfig.go
+++ b/lib/go-atscfg/regexrevalidatedotconfig.go
@@ -71,6 +71,7 @@ func MakeRegexRevalidateDotConfig(
 
 	maxDays := DefaultMaxRevalDurationDays
 	if maxDaysStrs := params[RegexRevalidateMaxRevalDurationDaysParamName]; len(maxDaysStrs) > 0 {
+		sort.Strings(maxDaysStrs)
 		if maxDays, err = strconv.Atoi(maxDaysStrs[0]); err != nil { // just use the first, if there were multiple params
 			log.Warnln("making regex revalidate config: max days param '" + maxDaysStrs[0] + "' is not an integer, using default value!")
 			maxDays = DefaultMaxRevalDurationDays

--- a/lib/go-atscfg/regexrevalidatedotconfig.go
+++ b/lib/go-atscfg/regexrevalidatedotconfig.go
@@ -41,6 +41,7 @@ const JobKeywordPurge = "PURGE"
 const RegexRevalidateMinTTL = time.Hour
 
 const ContentTypeRegexRevalidateDotConfig = ContentTypeTextASCII
+const LineCommentRegexRevalidateDotConfig = LineCommentHash
 
 type Job struct {
 	AssetURL string

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -32,6 +32,7 @@ import (
 const CacheURLParameterConfigFile = "cacheurl.config"
 const CacheKeyParameterConfigFile = "cachekey.config"
 const ContentTypeRemapDotConfig = ContentTypeTextASCII
+const LineCommentRemapDotConfig = LineCommentHash
 
 type RemapConfigDSData struct {
 	ID                       int

--- a/lib/go-atscfg/servercachedotconfig.go
+++ b/lib/go-atscfg/servercachedotconfig.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -39,6 +40,8 @@ func MakeServerCacheDotConfig(
 ) string {
 	text := GenericHeaderComment(string(serverName), toToolName, toURL)
 
+	lines := []string{}
+
 	seenOrigins := map[string]struct{}{}
 	for _, ds := range dses {
 		if ds.Type != tc.DSTypeHTTPNoCache {
@@ -51,12 +54,13 @@ func MakeServerCacheDotConfig(
 
 		originFQDN, originPort := GetOriginFQDNAndPort(ds.OrgServerFQDN)
 		if originPort != nil {
-			text += `dest_domain=` + originFQDN + ` port=` + strconv.Itoa(*originPort) + ` scheme=http action=never-cache` + "\n"
+			lines = append(lines, `dest_domain=`+originFQDN+` port=`+strconv.Itoa(*originPort)+` scheme=http action=never-cache`+"\n")
 		} else {
-			text += `dest_domain=` + originFQDN + ` scheme=http action=never-cache` + "\n"
+			lines = append(lines, `dest_domain=`+originFQDN+` scheme=http action=never-cache`+"\n")
 		}
 	}
-	return text
+	sort.Strings(lines)
+	return text + strings.Join(lines, "")
 }
 
 // TODO unit test

--- a/lib/go-atscfg/serverunknown.go
+++ b/lib/go-atscfg/serverunknown.go
@@ -83,3 +83,21 @@ func SortParams(params map[string][]string) []Param {
 	sort.Sort(Params(sortedParams))
 	return sortedParams
 }
+
+// GetServerUnknownConfigCommentType takes the same data as MakeUnknownConfig and returns the comment type for that config.
+// In particular, it returns # unless there is a 'header' parameter, in which case it returns an empty string.
+// Wwe don't actually know that the first characters of a custom header are a comment, or how many characters it might be.
+func GetServerUnknownConfigCommentType(
+	serverName tc.CacheName,
+	serverDomain string,
+	toToolName string,
+	toURL string,
+	params map[string][]string,
+) string {
+	for name, _ := range params {
+		if name == "header" {
+			return ""
+		}
+	}
+	return LineCommentHash
+}

--- a/lib/go-atscfg/setdscpdotconfig.go
+++ b/lib/go-atscfg/setdscpdotconfig.go
@@ -26,6 +26,7 @@ import (
 )
 
 const ContentTypeSetDSCPDotConfig = ContentTypeTextASCII
+const LineCommentSetDSCPDotConfig = LineCommentHash
 
 func MakeSetDSCPDotConfig(
 	cdnName tc.CDNName,

--- a/lib/go-atscfg/sslmulticertdotconfig.go
+++ b/lib/go-atscfg/sslmulticertdotconfig.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
@@ -58,15 +59,17 @@ func MakeSSLMultiCertDotConfig(
 	toURL string, // tm.url global parameter (TODO: cache itself?)
 	dses map[tc.DeliveryServiceName]SSLMultiCertDS,
 ) string {
-	text := GenericHeaderComment(string(cdnName), toToolName, toURL)
+	hdr := GenericHeaderComment(string(cdnName), toToolName, toURL)
 
 	dses = GetSSLMultiCertDotConfigDeliveryServices(dses)
 
+	lines := []string{}
 	for dsName, ds := range dses {
 		cerName, keyName := GetSSLMultiCertDotConfigCertAndKeyName(dsName, ds)
-		text += `ssl_cert_name=` + cerName + "\t" + ` ssl_key_name=` + keyName + "\n"
+		lines = append(lines, `ssl_cert_name=`+cerName+"\t"+` ssl_key_name=`+keyName+"\n")
 	}
-	return text
+	sort.Strings(lines)
+	return hdr + strings.Join(lines, "")
 }
 
 // GetSSLMultiCertDotConfigCertAndKeyName returns the cert file name and key file name for the given delivery service.

--- a/lib/go-atscfg/sslmulticertdotconfig.go
+++ b/lib/go-atscfg/sslmulticertdotconfig.go
@@ -28,6 +28,7 @@ import (
 )
 
 const ContentTypeSSLMultiCertDotConfig = ContentTypeTextASCII
+const LineCommentSSLMultiCertDotConfig = LineCommentHash
 const SSLMultiCertConfigFileName = `ssl_multicert.config`
 
 type SSLMultiCertDS struct {

--- a/lib/go-atscfg/storagedotconfig.go
+++ b/lib/go-atscfg/storagedotconfig.go
@@ -27,6 +27,7 @@ import (
 )
 
 const ContentTypeStorageDotConfig = ContentTypeTextASCII
+const LineCommentStorageDotConfig = LineCommentHash
 
 // MakeStorageDotConfig creates storage.config for a given ATS Profile.
 // The paramData is the map of parameter names to values, for all parameters assigned to the given profile, with the config_file "storage.config".

--- a/lib/go-atscfg/sysctldotconf.go
+++ b/lib/go-atscfg/sysctldotconf.go
@@ -22,6 +22,7 @@ package atscfg
 const SysctlSeparator = " = "
 const SysctlFileName = "sysctl.conf"
 const ContentTypeSysctlDotConf = ContentTypeTextASCII
+const LineCommentSysctlDotConf = LineCommentHash
 
 func MakeSysCtlDotConf(
 	profileName string,

--- a/lib/go-atscfg/unknownconfig.go
+++ b/lib/go-atscfg/unknownconfig.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -33,7 +34,7 @@ func MakeUnknownConfig(
 ) string {
 	hdr := GenericHeaderComment(profileName, toToolName, toURL)
 
-	text := ""
+	lines := []string{}
 	for paramName, paramVal := range paramData {
 		if paramName == "header" {
 			if paramVal == "none" {
@@ -42,9 +43,11 @@ func MakeUnknownConfig(
 				hdr = paramVal + "\n"
 			}
 		} else {
-			text += paramVal + "\n"
+			lines = append(lines, paramVal+"\n")
 		}
 	}
+	sort.Strings(lines)
+	text := strings.Join(lines, "")
 	text = strings.Replace(text, "__RETURN__", "\n", -1)
 	return hdr + text
 }

--- a/lib/go-atscfg/unknownconfig.go
+++ b/lib/go-atscfg/unknownconfig.go
@@ -51,3 +51,20 @@ func MakeUnknownConfig(
 	text = strings.Replace(text, "__RETURN__", "\n", -1)
 	return hdr + text
 }
+
+// GetUnknownConfigCommentType takes the same data as MakeUnknownConfig and returns the comment type for that config.
+// In particular, it returns # unless there is a 'header' parameter, in which case it returns an empty string.
+// Wwe don't actually know that the first characters of a custom header are a comment, or how many characters it might be.
+func GetUnknownConfigCommentType(
+	profileName string,
+	paramData map[string]string,
+	toToolName string,
+	toURL string,
+) string {
+	for paramName, _ := range paramData {
+		if paramName == "header" {
+			return ""
+		}
+	}
+	return LineCommentHash
+}

--- a/lib/go-atscfg/urisigningconfig.go
+++ b/lib/go-atscfg/urisigningconfig.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 const ContentTypeURISigningDotConfig = `application/json; charset=us-ascii`
+const LineCommentURISigningDotConfig = ""
 
 func MakeURISigningConfig(
 	uriSigningKeysBts []byte,

--- a/lib/go-atscfg/urlsigconfig.go
+++ b/lib/go-atscfg/urlsigconfig.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -37,14 +38,22 @@ func MakeURLSigConfig(
 	sep := " = "
 
 	text := hdr
+
+	paramLines := []string{}
 	for paramName, paramVal := range paramData {
 		if len(urlSigKeys) == 0 || !strings.HasPrefix(paramName, "key") {
-			text += paramName + sep + paramVal + "\n"
+			paramLines = append(paramLines, paramName+sep+paramVal+"\n")
 		}
 	}
+	sort.Strings(paramLines)
+	text += strings.Join(paramLines, "")
 
+	keyLines := []string{}
 	for key, val := range urlSigKeys {
-		text += key + sep + val + "\n"
+		keyLines = append(keyLines, key+sep+val+"\n")
 	}
+	sort.Strings(keyLines)
+	text += strings.Join(keyLines, "")
+
 	return text
 }

--- a/lib/go-atscfg/urlsigconfig.go
+++ b/lib/go-atscfg/urlsigconfig.go
@@ -26,6 +26,9 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
+const ContentTypeURLSig = ContentTypeTextASCII
+const LineCommentURLSig = LineCommentHash
+
 func MakeURLSigConfig(
 	profileName string,
 	urlSigKeys tc.URLSigKeys,

--- a/lib/go-atscfg/volumedotconfig.go
+++ b/lib/go-atscfg/volumedotconfig.go
@@ -24,6 +24,7 @@ import (
 )
 
 const ContentTypeVolumeDotConfig = ContentTypeTextASCII
+const LineCommentVolumeDotConfig = LineCommentHash
 
 // MakeVolumeDotConfig creates volume.config for a given ATS Profile.
 // The paramData is the map of parameter names to values, for all parameters assigned to the given profile, with the config_file "storage.config".

--- a/traffic_ops/ort/atstccfg/atstccfg.go
+++ b/traffic_ops/ort/atstccfg/atstccfg.go
@@ -50,6 +50,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
@@ -116,6 +117,8 @@ func main() {
 
 	modifyFilesData := plugin.ModifyFilesData{Cfg: tccfg, TOData: toData, Files: configs}
 	configs = plugins.ModifyFiles(modifyFilesData)
+
+	sort.Sort(config.ATSConfigFiles(configs))
 
 	if err := cfgfile.WriteConfigs(configs, os.Stdout); err != nil {
 		log.Errorln("Writing configs for '" + cfg.CacheHostName + "': " + err.Error())

--- a/traffic_ops/ort/atstccfg/atstccfg.go
+++ b/traffic_ops/ort/atstccfg/atstccfg.go
@@ -109,7 +109,7 @@ func main() {
 		os.Exit(config.ExitCodeErrGeneric)
 	}
 
-	configs, err := cfgfile.GetAllConfigs(tccfg, toData)
+	configs, err := cfgfile.GetAllConfigs(toData, tccfg.RevalOnly)
 	if err != nil {
 		log.Errorln("Getting config for'" + cfg.CacheHostName + "': " + err.Error())
 		os.Exit(config.ExitCodeErrGeneric)

--- a/traffic_ops/ort/atstccfg/cfgfile/all.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/all.go
@@ -36,7 +36,7 @@ import (
 )
 
 // GetAllConfigs gets all config files for cfg.CacheHostName.
-func GetAllConfigs(cfg config.TCCfg, toData *config.TOData) ([]config.ATSConfigFile, error) {
+func GetAllConfigs(toData *config.TOData, revalOnly bool) ([]config.ATSConfigFile, error) {
 	meta, err := GetMeta(toData)
 	if err != nil {
 		return nil, errors.New("creating meta: " + err.Error())
@@ -45,7 +45,7 @@ func GetAllConfigs(cfg config.TCCfg, toData *config.TOData) ([]config.ATSConfigF
 	hasSSLMultiCertConfig := false
 	configs := []config.ATSConfigFile{}
 	for _, fi := range meta.ConfigFiles {
-		if cfg.RevalOnly && fi.FileNameOnDisk != atscfg.RegexRevalidateFileName {
+		if revalOnly && fi.FileNameOnDisk != atscfg.RegexRevalidateFileName {
 			continue
 		}
 		txt, contentType, lineComment, err := GetConfigFile(toData, fi)

--- a/traffic_ops/ort/atstccfg/cfgfile/all.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/all.go
@@ -71,6 +71,7 @@ func GetAllConfigs(toData *config.TOData, revalOnly bool) ([]config.ATSConfigFil
 }
 
 const HdrConfigFilePath = "Path"
+const HdrLineComment = "Line-Comment"
 
 // WriteConfigs writes the given configs as a RFC2046§5.1 MIME multipart/mixed message.
 func WriteConfigs(configs []config.ATSConfigFile, output io.Writer) error {
@@ -94,7 +95,7 @@ func WriteConfigs(configs []config.ATSConfigFile, output io.Writer) error {
 	for _, cfg := range configs {
 		hdr := map[string][]string{
 			rfc.ContentType:   {cfg.ContentType},
-			"Line-Comment":    {cfg.LineComment},
+			HdrLineComment:    {cfg.LineComment},
 			HdrConfigFilePath: {filepath.Join(cfg.Location, cfg.FileNameOnDisk)},
 		}
 		partW, err := w.CreatePart(hdr)

--- a/traffic_ops/ort/atstccfg/cfgfile/astatsdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/astatsdotconfig.go
@@ -21,6 +21,7 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
@@ -33,6 +34,14 @@ func GetConfigFileProfileAstatsDotConfig(toData *config.TOData) (string, string,
 		}
 		if param.Name == "location" {
 			continue
+		}
+		if val, ok := paramData[param.Name]; ok {
+			if val < param.Value {
+				log.Errorln("data error: making astats.config: parameter '" + param.Name + "' had multiple values, ignoring '" + param.Value + "'")
+				continue
+			} else {
+				log.Errorln("data error: making astats.config: parameter '" + param.Name + "' had multiple values, ignoring '" + val + "'")
+			}
 		}
 		paramData[param.Name] = param.Value
 	}

--- a/traffic_ops/ort/atstccfg/cfgfile/astatsdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/astatsdotconfig.go
@@ -25,7 +25,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileAstatsDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileAstatsDotConfig(toData *config.TOData) (string, string, string, error) {
 	paramData := map[string]string{}
 	// TODO add configFile query param to profile/parameters endpoint, to only get needed data
 	for _, param := range toData.ServerParams {
@@ -46,5 +46,5 @@ func GetConfigFileProfileAstatsDotConfig(toData *config.TOData) (string, string,
 		paramData[param.Name] = param.Value
 	}
 
-	return atscfg.MakeAStatsDotConfig(toData.Server.Profile, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeAstatsDotConfig, nil
+	return atscfg.MakeAStatsDotConfig(toData.Server.Profile, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeAstatsDotConfig, atscfg.LineCommentAstatsDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/atsdotrules.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/atsdotrules.go
@@ -27,7 +27,7 @@ import (
 
 const ATSDotRulesFileName = StorageFileName
 
-func GetConfigFileProfileATSDotRules(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileATSDotRules(toData *config.TOData) (string, string, string, error) {
 	paramData := map[string]string{}
 	// TODO add configFile query param to profile/parameters endpoint, to only get needed data
 	for _, param := range toData.ServerParams {
@@ -47,5 +47,5 @@ func GetConfigFileProfileATSDotRules(toData *config.TOData) (string, string, err
 		}
 		paramData[param.Name] = param.Value
 	}
-	return atscfg.MakeATSDotRules(toData.Server.Profile, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeATSDotRules, nil
+	return atscfg.MakeATSDotRules(toData.Server.Profile, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeATSDotRules, atscfg.LineCommentATSDotRules, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/atsdotrules.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/atsdotrules.go
@@ -21,6 +21,7 @@ package cfgfile
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
@@ -35,6 +36,14 @@ func GetConfigFileProfileATSDotRules(toData *config.TOData) (string, string, err
 		}
 		if param.Name == "location" {
 			continue
+		}
+		if val, ok := paramData[param.Name]; ok {
+			if val < param.Value {
+				log.Errorln("data error: making ats.rules: parameter '" + param.Name + "' had multiple values, ignoring '" + param.Value + "'")
+				continue
+			} else {
+				log.Errorln("data error: making ats.rules: parameter '" + param.Name + "' had multiple values, ignoring '" + val + "'")
+			}
 		}
 		paramData[param.Name] = param.Value
 	}

--- a/traffic_ops/ort/atstccfg/cfgfile/bgfetchdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/bgfetchdotconfig.go
@@ -25,6 +25,6 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNBGFetchDotConfig(toData *config.TOData) (string, string, error) {
-	return atscfg.MakeBGFetchDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL), atscfg.ContentTypeBGFetchDotConfig, nil
+func GetConfigFileCDNBGFetchDotConfig(toData *config.TOData) (string, string, string, error) {
+	return atscfg.MakeBGFetchDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL), atscfg.ContentTypeBGFetchDotConfig, atscfg.LineCommentBGFetchDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/cachedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cachedotconfig.go
@@ -25,7 +25,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileCacheDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileCacheDotConfig(toData *config.TOData) (string, string, string, error) {
 	profileServerIDsMap := map[int]struct{}{}
 	for _, sv := range toData.Servers {
 		if sv.Profile != toData.Server.Profile {
@@ -65,5 +65,5 @@ func GetConfigFileProfileCacheDotConfig(toData *config.TOData) (string, string, 
 		profileDSes = append(profileDSes, atscfg.ProfileDS{Type: *ds.Type, OriginFQDN: &origin})
 	}
 
-	return atscfg.MakeCacheDotConfig(toData.Server.Profile, profileDSes, toData.TOToolName, toData.TOURL), atscfg.ContentTypeCacheDotConfig, nil
+	return atscfg.MakeCacheDotConfig(toData.Server.Profile, profileDSes, toData.TOToolName, toData.TOURL), atscfg.ContentTypeCacheDotConfig, atscfg.LineCommentCacheDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/cacheurldotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cacheurldotconfig.go
@@ -25,7 +25,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNCacheURL(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNCacheURL(toData *config.TOData, fileName string) (string, string, string, error) {
 	dsIDs := map[int]struct{}{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.ID != nil {
@@ -60,9 +60,9 @@ func GetConfigFileCDNCacheURL(toData *config.TOData, fileName string) (string, s
 
 	cfgDSes := atscfg.DeliveryServicesToCacheURLDSes(dsesWithServers)
 
-	return atscfg.MakeCacheURLDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, fileName, cfgDSes), atscfg.ContentTypeCacheURLDotConfig, nil
+	return atscfg.MakeCacheURLDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, fileName, cfgDSes), atscfg.ContentTypeCacheURLDotConfig, atscfg.LineCommentCacheURLDotConfig, nil
 }
 
-func GetConfigFileCDNCacheURLPlain(toData *config.TOData) (string, string, error) {
+func GetConfigFileCDNCacheURLPlain(toData *config.TOData) (string, string, string, error) {
 	return GetConfigFileCDNCacheURL(toData, "cacheurl.config")
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/cfgfile.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cfgfile.go
@@ -396,8 +396,12 @@ func ParamsToMap(params []tc.Parameter) map[string]string {
 	mp := map[string]string{}
 	for _, param := range params {
 		if val, ok := mp[param.Name]; ok {
-			log.Errorln("config generation got multiple parameters for name '" + param.Name + "' - using '" + val + "'")
-			continue
+			if val < param.Value {
+				log.Errorln("config generation got multiple parameters for name '" + param.Name + "' - ignoring '" + param.Value + "'")
+				continue
+			} else {
+				log.Errorln("config generation got multiple parameters for name '" + param.Name + "' - ignoring '" + val + "'")
+			}
 		}
 		mp[param.Name] = param.Value
 	}

--- a/traffic_ops/ort/atstccfg/cfgfile/cfgfile_test.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cfgfile_test.go
@@ -55,13 +55,13 @@ func TestWriteConfigs(t *testing.T) {
 
 	actual := buf.String()
 
-	expected0 := "Content-Type: text/plain\r\nPath: /my/config0/location/config0.txt\r\n\r\nconfig0\r\n"
+	expected0 := "Content-Type: text/plain\r\nLine-Comment: \r\nPath: /my/config0/location/config0.txt\r\n\r\nconfig0\r\n"
 
 	if !strings.Contains(actual, expected0) {
-		t.Errorf("WriteConfigs expecte '%v' actual '%v'", expected0, actual)
+		t.Errorf("WriteConfigs expected '%v' actual '%v'", expected0, actual)
 	}
 
-	expected1 := "Content-Type: text/csv\r\nPath: /my/config1/location/config1.txt\r\n\r\nconfig2,foo\r\n"
+	expected1 := "Content-Type: text/csv\r\nLine-Comment: \r\nPath: /my/config1/location/config1.txt\r\n\r\nconfig2,foo\r\n"
 	if !strings.Contains(actual, expected1) {
 		t.Errorf("WriteConfigs expected config1 '%v' actual '%v'", expected1, actual)
 	}

--- a/traffic_ops/ort/atstccfg/cfgfile/chkconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/chkconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerChkconfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileServerChkconfig(toData *config.TOData) (string, string, string, error) {
 	fileParams := map[string][]string{}
 	for _, param := range toData.ServerParams {
 		if param.ConfigFile != atscfg.ChkconfigParamConfigFile {
@@ -33,5 +33,5 @@ func GetConfigFileServerChkconfig(toData *config.TOData) (string, string, error)
 		fileParams[param.Name] = append(fileParams[param.Name], param.Value)
 	}
 
-	return atscfg.MakeChkconfig(fileParams), atscfg.ContentTypeChkconfig, nil
+	return atscfg.MakeChkconfig(fileParams), atscfg.ContentTypeChkconfig, atscfg.LineCommentChkconfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/dropqstringdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/dropqstringdotconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileDropQStringDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileDropQStringDotConfig(toData *config.TOData) (string, string, string, error) {
 	dropQStringVal := (*string)(nil)
 	for _, param := range toData.ServerParams {
 		if param.ConfigFile != atscfg.DropQStringDotConfigFileName {
@@ -37,5 +37,5 @@ func GetConfigFileProfileDropQStringDotConfig(toData *config.TOData) (string, st
 		break
 	}
 
-	return atscfg.MakeDropQStringDotConfig(toData.Server.Profile, toData.TOToolName, toData.TOURL, dropQStringVal), atscfg.ContentTypeDropQStringDotConfig, nil
+	return atscfg.MakeDropQStringDotConfig(toData.Server.Profile, toData.TOToolName, toData.TOURL, dropQStringVal), atscfg.ContentTypeDropQStringDotConfig, atscfg.LineCommentDropQStringDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/facts.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/facts.go
@@ -24,6 +24,6 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfile12MFacts(toData *config.TOData) (string, string, error) {
-	return atscfg.Make12MFacts(toData.Server.Profile, toData.TOToolName, toData.TOURL), atscfg.ContentType12MFacts, nil
+func GetConfigFileProfile12MFacts(toData *config.TOData) (string, string, string, error) {
+	return atscfg.Make12MFacts(toData.Server.Profile, toData.TOToolName, toData.TOURL), atscfg.ContentType12MFacts, atscfg.LineComment12MFacts, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/headerrewritedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/headerrewritedotconfig.go
@@ -28,7 +28,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNHeaderRewrite(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNHeaderRewrite(toData *config.TOData, fileName string) (string, string, string, error) {
 	dsName := strings.TrimSuffix(strings.TrimPrefix(fileName, atscfg.HeaderRewritePrefix), atscfg.ConfigSuffix) // TODO verify prefix and suffix? Perl doesn't
 
 	tcDS := tc.DeliveryServiceNullable{}
@@ -40,16 +40,16 @@ func GetConfigFileCDNHeaderRewrite(toData *config.TOData, fileName string) (stri
 		break
 	}
 	if tcDS.ID == nil {
-		return "", "", errors.New("ds '" + dsName + "' not found")
+		return "", "", "", errors.New("ds '" + dsName + "' not found")
 	}
 
 	if tcDS.CDNName == nil {
-		return "", "", errors.New("ds '" + dsName + "' missing cdn")
+		return "", "", "", errors.New("ds '" + dsName + "' missing cdn")
 	}
 
 	cfgDS, err := atscfg.HeaderRewriteDSFromDS(&tcDS)
 	if err != nil {
-		return "", "", errors.New("converting ds to config ds: " + err.Error())
+		return "", "", "", errors.New("converting ds to config ds: " + err.Error())
 	}
 
 	dsServers := FilterDSS(toData.DeliveryServiceServers, map[int]struct{}{cfgDS.ID: {}}, nil)
@@ -80,5 +80,5 @@ func GetConfigFileCDNHeaderRewrite(toData *config.TOData, fileName string) (stri
 		assignedEdges = append(assignedEdges, cfgServer)
 	}
 
-	return atscfg.MakeHeaderRewriteDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, cfgDS, assignedEdges), atscfg.ContentTypeHeaderRewriteDotConfig, nil
+	return atscfg.MakeHeaderRewriteDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, cfgDS, assignedEdges), atscfg.ContentTypeHeaderRewriteDotConfig, atscfg.LineCommentHeaderRewriteDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/headerrewritemiddotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/headerrewritemiddotconfig.go
@@ -28,7 +28,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNHeaderRewriteMid(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNHeaderRewriteMid(toData *config.TOData, fileName string) (string, string, string, error) {
 	dsName := strings.TrimSuffix(strings.TrimPrefix(fileName, atscfg.HeaderRewriteMidPrefix), atscfg.ConfigSuffix) // TODO verify prefix and suffix? Perl doesn't
 
 	tcDS := tc.DeliveryServiceNullable{}
@@ -40,16 +40,16 @@ func GetConfigFileCDNHeaderRewriteMid(toData *config.TOData, fileName string) (s
 		break
 	}
 	if tcDS.ID == nil {
-		return "", "", errors.New("ds '" + dsName + "' not found")
+		return "", "", "", errors.New("ds '" + dsName + "' not found")
 	}
 
 	if tcDS.CDNName == nil {
-		return "", "", errors.New("ds '" + dsName + "' missing cdn")
+		return "", "", "", errors.New("ds '" + dsName + "' missing cdn")
 	}
 
 	cfgDS, err := atscfg.HeaderRewriteDSFromDS(&tcDS)
 	if err != nil {
-		return "", "", errors.New("converting ds to config ds: " + err.Error())
+		return "", "", "", errors.New("converting ds to config ds: " + err.Error())
 	}
 
 	dsServers := FilterDSS(toData.DeliveryServiceServers, map[int]struct{}{cfgDS.ID: {}}, nil)
@@ -113,5 +113,5 @@ func GetConfigFileCDNHeaderRewriteMid(toData *config.TOData, fileName string) (s
 		assignedMids = append(assignedMids, cfgServer)
 	}
 
-	return atscfg.MakeHeaderRewriteMidDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, cfgDS, assignedMids), atscfg.ContentTypeHeaderRewriteDotConfig, nil
+	return atscfg.MakeHeaderRewriteMidDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, cfgDS, assignedMids), atscfg.ContentTypeHeaderRewriteDotConfig, atscfg.LineCommentHeaderRewriteDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/hostingdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/hostingdotconfig.go
@@ -31,7 +31,7 @@ import (
 const ServerHostingDotConfigMidIncludeInactive = false
 const ServerHostingDotConfigEdgeIncludeInactive = true
 
-func GetConfigFileServerHostingDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileServerHostingDotConfig(toData *config.TOData) (string, string, string, error) {
 	fileParams := ParamsToMap(FilterParams(toData.ServerParams, atscfg.HostingConfigParamConfigFile, "", "", ""))
 
 	cdnServers := map[tc.CacheName]tc.Server{}
@@ -59,7 +59,7 @@ func GetConfigFileServerHostingDotConfig(toData *config.TOData) (string, string,
 	dsServerMap := map[int]map[int]struct{}{} // set[dsID][serverID]
 	for _, dss := range dsServers {
 		if dss.Server == nil || dss.DeliveryService == nil {
-			return "", "", errors.New("deliveryserviceservers returned dss with nil values")
+			return "", "", "", errors.New("deliveryserviceservers returned dss with nil values")
 		}
 		if _, ok := dsServerMap[*dss.DeliveryService]; !ok {
 			dsServerMap[*dss.DeliveryService] = map[int]struct{}{}
@@ -121,5 +121,5 @@ func GetConfigFileServerHostingDotConfig(toData *config.TOData) (string, string,
 		origins = append(origins, origin)
 	}
 
-	return atscfg.MakeHostingDotConfig(tc.CacheName(toData.Server.HostName), toData.TOToolName, toData.TOURL, fileParams, origins), atscfg.ContentTypeHostingDotConfig, nil
+	return atscfg.MakeHostingDotConfig(tc.CacheName(toData.Server.HostName), toData.TOToolName, toData.TOURL, fileParams, origins), atscfg.ContentTypeHostingDotConfig, atscfg.LineCommentHostingDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/ipallowdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/ipallowdotconfig.go
@@ -28,20 +28,20 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerIPAllowDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileServerIPAllowDotConfig(toData *config.TOData) (string, string, string, error) {
 	fileParams := ParamsToMultiMap(FilterParams(toData.ServerParams, atscfg.IPAllowConfigFileName, "", "", ""))
 
 	cgMap := map[string]tc.CacheGroupNullable{}
 	for _, cg := range toData.CacheGroups {
 		if cg.Name == nil {
-			return "", "", errors.New("got cachegroup with nil name!'")
+			return "", "", "", errors.New("got cachegroup with nil name!'")
 		}
 		cgMap[*cg.Name] = cg
 	}
 
 	serverCG, ok := cgMap[toData.Server.Cachegroup]
 	if !ok {
-		return "", "", errors.New("server cachegroup not in cachegroups!")
+		return "", "", "", errors.New("server cachegroup not in cachegroups!")
 	}
 
 	childCGs := map[string]tc.CacheGroupNullable{}
@@ -59,5 +59,5 @@ func GetConfigFileServerIPAllowDotConfig(toData *config.TOData) (string, string,
 		}
 	}
 
-	return atscfg.MakeIPAllowDotConfig(tc.CacheName(toData.Server.HostName), tc.CacheType(toData.Server.Type), toData.TOToolName, toData.TOURL, fileParams, childServers), atscfg.ContentTypeIPAllowDotConfig, nil
+	return atscfg.MakeIPAllowDotConfig(tc.CacheName(toData.Server.HostName), tc.CacheType(toData.Server.Type), toData.TOToolName, toData.TOURL, fileParams, childServers), atscfg.ContentTypeIPAllowDotConfig, atscfg.LineCommentIPAllowDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/loggingdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/loggingdotconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileLoggingDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileLoggingDotConfig(toData *config.TOData) (string, string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.LoggingFileName, "", "", "location"))
-	return atscfg.MakeLoggingDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLoggingDotConfig, nil
+	return atscfg.MakeLoggingDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLoggingDotConfig, atscfg.LineCommentLoggingDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/loggingdotyaml.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/loggingdotyaml.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileLoggingDotYAML(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileLoggingDotYAML(toData *config.TOData) (string, string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.LoggingYAMLFileName, "", "", "location"))
-	return atscfg.MakeLoggingDotYAML(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLoggingDotYAML, nil
+	return atscfg.MakeLoggingDotYAML(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLoggingDotYAML, atscfg.LineCommentLoggingDotYAML, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/logsxmldotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/logsxmldotconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileLogsXMLDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileLogsXMLDotConfig(toData *config.TOData) (string, string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.LogsXMLFileName, "", "", "location"))
-	return atscfg.MakeLogsXMLDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLogsDotXML, nil
+	return atscfg.MakeLogsXMLDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeLogsDotXML, atscfg.LineCommentLogsDotXML, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/meta.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/meta.go
@@ -109,10 +109,7 @@ func GetMeta(toData *config.TOData) (*tc.ATSConfigMetaData, error) {
 		}
 	}
 
-	scopeParams := map[string]string{}
-	for _, param := range toData.ScopeParams {
-		scopeParams[param.ConfigFile] = param.Value
-	}
+	scopeParams := ParamsToMap(toData.ScopeParams)
 
 	locationParams := map[string]atscfg.ConfigProfileParams{}
 	for _, param := range toData.ServerParams {

--- a/traffic_ops/ort/atstccfg/cfgfile/packages.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/packages.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerPackages(toData *config.TOData) (string, string, error) {
+func GetConfigFileServerPackages(toData *config.TOData) (string, string, string, error) {
 	params := ParamsToMultiMap(FilterParams(toData.ServerParams, atscfg.PackagesParamConfigFile, "", "", ""))
-	return atscfg.MakePackages(params), atscfg.ContentTypePackages, nil
+	return atscfg.MakePackages(params), atscfg.ContentTypePackages, atscfg.LineCommentPackages, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/parentdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/parentdotconfig.go
@@ -33,18 +33,18 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, string, error) {
 	cgMap := map[string]tc.CacheGroupNullable{}
 	for _, cg := range toData.CacheGroups {
 		if cg.Name == nil {
-			return "", "", errors.New("got cachegroup with nil name!'")
+			return "", "", "", errors.New("got cachegroup with nil name!'")
 		}
 		cgMap[*cg.Name] = cg
 	}
 
 	serverCG, ok := cgMap[toData.Server.Cachegroup]
 	if !ok {
-		return "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' not found in CacheGroups")
+		return "", "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' not found in CacheGroups")
 	}
 
 	parentCGID := -1
@@ -52,15 +52,15 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 	if serverCG.ParentName != nil && *serverCG.ParentName != "" {
 		parentCG, ok := cgMap[*serverCG.ParentName]
 		if !ok {
-			return "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' parent '" + *serverCG.ParentName + "' not found in CacheGroups")
+			return "", "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' parent '" + *serverCG.ParentName + "' not found in CacheGroups")
 		}
 		if parentCG.ID == nil {
-			return "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
+			return "", "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
 		}
 		parentCGID = *parentCG.ID
 
 		if parentCG.Type == nil {
-			return "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
+			return "", "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
 		}
 		parentCGType = *parentCG.Type
 	}
@@ -70,15 +70,15 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 	if serverCG.SecondaryParentName != nil && *serverCG.SecondaryParentName != "" {
 		parentCG, ok := cgMap[*serverCG.SecondaryParentName]
 		if !ok {
-			return "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' secondary parent '" + *serverCG.SecondaryParentName + "' not found in CacheGroups")
+			return "", "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' secondary parent '" + *serverCG.SecondaryParentName + "' not found in CacheGroups")
 		}
 
 		if parentCG.ID == nil {
-			return "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
+			return "", "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
 		}
 		secondaryParentCGID = *parentCG.ID
 		if parentCG.Type == nil {
-			return "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
+			return "", "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
 		}
 
 		secondaryParentCGType = *parentCG.Type
@@ -107,10 +107,10 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 		log.Infoln("This cache Is Top Level!")
 		for _, cg := range toData.CacheGroups {
 			if cg.Type == nil {
-				return "", "", errors.New("cachegroup type is nil!")
+				return "", "", "", errors.New("cachegroup type is nil!")
 			}
 			if cg.Name == nil {
-				return "", "", errors.New("cachegroup type is nil!")
+				return "", "", "", errors.New("cachegroup type is nil!")
 			}
 
 			if *cg.Type != tc.CacheGroupOriginTypeName {
@@ -120,14 +120,14 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 		}
 	} else {
 		if toData.Server.Cachegroup == "" {
-			return "", "", errors.New("server cachegroup is nil!")
+			return "", "", "", errors.New("server cachegroup is nil!")
 		}
 		for _, cg := range toData.CacheGroups {
 			if cg.Type == nil {
-				return "", "", errors.New("cachegroup type is nil!")
+				return "", "", "", errors.New("cachegroup type is nil!")
 			}
 			if cg.Name == nil {
-				return "", "", errors.New("cachegroup type is nil!")
+				return "", "", "", errors.New("cachegroup type is nil!")
 			}
 
 			if *cg.Name == toData.Server.Cachegroup {
@@ -172,7 +172,7 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 	parentServerDSes := map[int]map[int]struct{}{} // map[serverID][dsID] // cgServerDSes
 	for _, dss := range cgDSServers {
 		if dss.Server == nil || dss.DeliveryService == nil {
-			return "", "", errors.New("getting parent.config cachegroup parent server delivery service servers: got dss with nil members!")
+			return "", "", "", errors.New("getting parent.config cachegroup parent server delivery service servers: got dss with nil members!")
 		}
 		if parentServerDSes[*dss.Server] == nil {
 			parentServerDSes[*dss.Server] = map[int]struct{}{}
@@ -194,12 +194,12 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 
 	atsMajorVer, err := atscfg.GetATSMajorVersionFromATSVersion(atsVersionParam)
 	if err != nil {
-		return "", "", errors.New("getting ATS major version from version parameter (profile '" + toData.Server.Profile + "' configFile 'package' name 'trafficserver'): " + err.Error())
+		return "", "", "", errors.New("getting ATS major version from version parameter (profile '" + toData.Server.Profile + "' configFile 'package' name 'trafficserver'): " + err.Error())
 	}
 
 	parentConfigParamsWithProfiles, err := TCParamsToParamsWithProfiles(toData.ParentConfigParams)
 	if err != nil {
-		return "", "", errors.New("unmarshalling parent.config parameters profiles: " + err.Error())
+		return "", "", "", errors.New("unmarshalling parent.config parameters profiles: " + err.Error())
 	}
 
 	// this is an optimization, to avoid looping over all params, for every DS. Instead, we loop over all params only once, and put them in a profile map.
@@ -455,7 +455,7 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 
 	parentInfos := atscfg.MakeParentInfo(&serverInfo, serverCDNDomain, profileCaches, originServers)
 
-	return atscfg.MakeParentDotConfig(&serverInfo, atsMajorVer, toData.TOToolName, toData.TOURL, parentConfigDSes, serverParams, parentInfos), atscfg.ContentTypeParentDotConfig, nil
+	return atscfg.MakeParentDotConfig(&serverInfo, atsMajorVer, toData.TOToolName, toData.TOURL, parentConfigDSes, serverParams, parentInfos), atscfg.ContentTypeParentDotConfig, atscfg.LineCommentParentDotConfig, nil
 }
 
 // GetDSOrigins takes a map[deliveryServiceID]DeliveryService, and returns a map[DeliveryServiceID]OriginURI.

--- a/traffic_ops/ort/atstccfg/cfgfile/plugindotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/plugindotconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfilePluginDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfilePluginDotConfig(toData *config.TOData) (string, string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.PluginFileName, "", "", "location"))
-	return atscfg.MakePluginDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypePluginDotConfig, nil
+	return atscfg.MakePluginDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypePluginDotConfig, atscfg.LineCommentPluginDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/recordsdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/recordsdotconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileRecordsDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileRecordsDotConfig(toData *config.TOData) (string, string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, atscfg.RecordsFileName, "", "", "location"))
-	return atscfg.MakeRecordsDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeRecordsDotConfig, nil
+	return atscfg.MakeRecordsDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeRecordsDotConfig, atscfg.LineCommentRecordsDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/regexremapdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/regexremapdotconfig.go
@@ -27,15 +27,15 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNRegexRemap(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNRegexRemap(toData *config.TOData, fileName string) (string, string, string, error) {
 	configSuffix := `.config`
 	if !strings.HasPrefix(fileName, atscfg.RegexRemapPrefix) || !strings.HasSuffix(fileName, configSuffix) {
-		return `{"alerts":[{"level":"error","text":"Error - regex remap file '` + fileName + `' not of the form 'regex_remap_*.config! Please file a bug with Traffic Control, this should never happen."}]}`, "", config.ErrBadRequest
+		return `{"alerts":[{"level":"error","text":"Error - regex remap file '` + fileName + `' not of the form 'regex_remap_*.config! Please file a bug with Traffic Control, this should never happen."}]}`, "", "", config.ErrBadRequest
 	}
 
 	dsName := strings.TrimSuffix(strings.TrimPrefix(fileName, atscfg.RegexRemapPrefix), configSuffix)
 	if dsName == "" {
-		return `{"alerts":[{"level":"error","text":"Error - regex remap file '` + fileName + `' has no delivery service name!"}]}`, "", config.ErrBadRequest
+		return `{"alerts":[{"level":"error","text":"Error - regex remap file '` + fileName + `' has no delivery service name!"}]}`, "", "", config.ErrBadRequest
 	}
 
 	// only send the requested DS to atscfg. The atscfg.Make will work correctly even if we send it other DSes, but this will prevent atscfg.DeliveryServicesToCDNDSes from logging errors about AnyMap and Steering DSes without origins.
@@ -50,10 +50,10 @@ func GetConfigFileCDNRegexRemap(toData *config.TOData, fileName string) (string,
 		ds = dsesDS
 	}
 	if ds.ID == nil {
-		return `{"alerts":[{"level":"error","text":"Error - delivery service '` + dsName + `' not found! Do you have a regex_remap_*.config location Parameter for a delivery service that doesn't exist?"}]}`, "", config.ErrNotFound
+		return `{"alerts":[{"level":"error","text":"Error - delivery service '` + dsName + `' not found! Do you have a regex_remap_*.config location Parameter for a delivery service that doesn't exist?"}]}`, "", "", config.ErrNotFound
 	}
 
 	cfgDSes := atscfg.DeliveryServicesToCDNDSes([]tc.DeliveryServiceNullable{ds})
 
-	return atscfg.MakeRegexRemapDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, fileName, cfgDSes), atscfg.ContentTypeRegexRemapDotConfig, nil
+	return atscfg.MakeRegexRemapDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, fileName, cfgDSes), atscfg.ContentTypeRegexRemapDotConfig, atscfg.LineCommentRegexRemapDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/regexrevalidatedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/regexrevalidatedotconfig.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNRegexRevalidateDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileCDNRegexRevalidateDotConfig(toData *config.TOData) (string, string, string, error) {
 	params := map[string][]string{}
 	for _, param := range toData.GlobalParams {
 		if param.ConfigFile != atscfg.RegexRevalidateFileName {
@@ -52,5 +52,5 @@ func GetConfigFileCDNRegexRevalidateDotConfig(toData *config.TOData) (string, st
 		jobs = append(jobs, job)
 	}
 
-	return atscfg.MakeRegexRevalidateDotConfig(tc.CDNName(toData.Server.CDNName), params, toData.TOToolName, toData.TOURL, jobs), atscfg.ContentTypeRegexRevalidateDotConfig, nil
+	return atscfg.MakeRegexRevalidateDotConfig(tc.CDNName(toData.Server.CDNName), params, toData.TOToolName, toData.TOURL, jobs), atscfg.ContentTypeRegexRevalidateDotConfig, atscfg.LineCommentRegexRevalidateDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/remapdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/remapdotconfig.go
@@ -32,7 +32,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, string, error) {
 	// TODO TOAPI add /servers?cdn=1 query param
 
 	atsVersionParam := ""
@@ -49,7 +49,7 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, e
 
 	atsMajorVer, err := atscfg.GetATSMajorVersionFromATSVersion(atsVersionParam)
 	if err != nil {
-		return "", "", errors.New("getting ATS major version from version parameter (profile '" + toData.Server.Profile + "' configFile 'package' name 'trafficserver'): " + err.Error())
+		return "", "", "", errors.New("getting ATS major version from version parameter (profile '" + toData.Server.Profile + "' configFile 'package' name 'trafficserver'): " + err.Error())
 	}
 
 	dsIDs := map[int]struct{}{}
@@ -183,7 +183,7 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, e
 
 	cacheKeyParamsWithProfiles, err := TCParamsToParamsWithProfiles(toData.CacheKeyParams)
 	if err != nil {
-		return "", "", errors.New("decoding cache key parameter profiles: " + err.Error())
+		return "", "", "", errors.New("decoding cache key parameter profiles: " + err.Error())
 	}
 
 	cacheKeyParamsWithProfilesMap := ParameterWithProfilesToMap(cacheKeyParamsWithProfiles)
@@ -223,14 +223,14 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, e
 	cgMap := map[string]tc.CacheGroupNullable{}
 	for _, cg := range toData.CacheGroups {
 		if cg.Name == nil {
-			return "", "", errors.New("got cachegroup with nil name!'")
+			return "", "", "", errors.New("got cachegroup with nil name!'")
 		}
 		cgMap[*cg.Name] = cg
 	}
 
 	serverCG, ok := cgMap[toData.Server.Cachegroup]
 	if !ok {
-		return "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' not found in CacheGroups")
+		return "", "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' not found in CacheGroups")
 	}
 
 	parentCGID := -1
@@ -238,15 +238,15 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, e
 	if serverCG.ParentName != nil && *serverCG.ParentName != "" {
 		parentCG, ok := cgMap[*serverCG.ParentName]
 		if !ok {
-			return "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' parent '" + *serverCG.ParentName + "' not found in CacheGroups")
+			return "", "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' parent '" + *serverCG.ParentName + "' not found in CacheGroups")
 		}
 		if parentCG.ID == nil {
-			return "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
+			return "", "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
 		}
 		parentCGID = *parentCG.ID
 
 		if parentCG.Type == nil {
-			return "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
+			return "", "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
 		}
 		parentCGType = *parentCG.Type
 	}
@@ -256,15 +256,15 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, e
 	if serverCG.SecondaryParentName != nil && *serverCG.SecondaryParentName != "" {
 		parentCG, ok := cgMap[*serverCG.SecondaryParentName]
 		if !ok {
-			return "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' secondary parent '" + *serverCG.SecondaryParentName + "' not found in CacheGroups")
+			return "", "", "", errors.New("server '" + toData.Server.HostName + "' cachegroup '" + toData.Server.Cachegroup + "' secondary parent '" + *serverCG.SecondaryParentName + "' not found in CacheGroups")
 		}
 
 		if parentCG.ID == nil {
-			return "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
+			return "", "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil ID!'")
 		}
 		secondaryParentCGID = *parentCG.ID
 		if parentCG.Type == nil {
-			return "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
+			return "", "", "", errors.New("got cachegroup '" + *parentCG.Name + "' with nil Type!'")
 		}
 
 		secondaryParentCGType = *parentCG.Type
@@ -288,7 +288,7 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, e
 		SecondaryParentCacheGroupType: secondaryParentCGType,
 		Type:                          toData.Server.Type,
 	}
-	return atscfg.MakeRemapDotConfig(tc.CacheName(toData.Server.HostName), toData.TOToolName, toData.TOURL, atsMajorVer, cacheURLParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapConfigDSData), atscfg.ContentTypeRemapDotConfig, nil
+	return atscfg.MakeRemapDotConfig(tc.CacheName(toData.Server.HostName), toData.TOToolName, toData.TOURL, atsMajorVer, cacheURLParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapConfigDSData), atscfg.ContentTypeRemapDotConfig, atscfg.LineCommentRemapDotConfig, nil
 }
 
 type DeliveryServiceRegexesSortByTypeThenSetNum []tc.DeliveryServiceRegex

--- a/traffic_ops/ort/atstccfg/cfgfile/servercachedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/servercachedotconfig.go
@@ -30,13 +30,13 @@ import (
 
 const ServerCacheDotConfigIncludeInactiveDSes = false // TODO move to lib/go-atscfg
 
-func GetConfigFileServerCacheDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileServerCacheDotConfig(toData *config.TOData) (string, string, string, error) {
 	// TODO TOAPI add /servers?cdn=1 query param
 
 	// TODO remove this, we generated the scope, we know it's right? Or should we have an extra safety check?
 	if !strings.HasPrefix(string(toData.Server.Type), tc.MidTypePrefix) {
 		// emulates Perl
-		return "", "", errors.New("Error - incorrect file scope for route used.  Please use the profiles route.")
+		return "", "", "", errors.New("Error - incorrect file scope for route used.  Please use the profiles route.")
 	}
 
 	dsData := map[tc.DeliveryServiceName]atscfg.ServerCacheConfigDS{}
@@ -54,5 +54,5 @@ func GetConfigFileServerCacheDotConfig(toData *config.TOData) (string, string, e
 
 	serverName := tc.CacheName(toData.Server.HostName)
 
-	return atscfg.MakeServerCacheDotConfig(serverName, toData.TOToolName, toData.TOURL, dsData), atscfg.ContentTypeCacheDotConfig, nil
+	return atscfg.MakeServerCacheDotConfig(serverName, toData.TOToolName, toData.TOURL, dsData), atscfg.ContentTypeCacheDotConfig, atscfg.LineCommentCacheDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/serverunknownconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/serverunknownconfig.go
@@ -25,7 +25,8 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileServerUnknownConfig(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileServerUnknownConfig(toData *config.TOData, fileName string) (string, string, string, error) {
 	params := ParamsToMultiMap(FilterParams(toData.ServerParams, fileName, "", "", ""))
-	return atscfg.MakeServerUnknown(tc.CacheName(toData.Server.HostName), toData.Server.DomainName, toData.TOToolName, toData.TOURL, params), atscfg.ContentTypeServerUnknownConfig, nil
+	lineComment := atscfg.GetServerUnknownConfigCommentType(tc.CacheName(toData.Server.HostName), toData.Server.DomainName, toData.TOToolName, toData.TOURL, params)
+	return atscfg.MakeServerUnknown(tc.CacheName(toData.Server.HostName), toData.Server.DomainName, toData.TOToolName, toData.TOURL, params), atscfg.ContentTypeServerUnknownConfig, lineComment, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/setdscpdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/setdscpdotconfig.go
@@ -27,11 +27,11 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNSetDSCP(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileCDNSetDSCP(toData *config.TOData, fileName string) (string, string, string, error) {
 	// TODO verify prefix, suffix, and that it's a number? Perl doesn't.
 	dscpNumStr := fileName
 	dscpNumStr = strings.TrimPrefix(dscpNumStr, "set_dscp_")
 	dscpNumStr = strings.TrimSuffix(dscpNumStr, ".config")
 
-	return atscfg.MakeSetDSCPDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, dscpNumStr), atscfg.ContentTypeSetDSCPDotConfig, nil
+	return atscfg.MakeSetDSCPDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, dscpNumStr), atscfg.ContentTypeSetDSCPDotConfig, atscfg.LineCommentSetDSCPDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/sslmulticertdotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/sslmulticertdotconfig.go
@@ -25,8 +25,8 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileCDNSSLMultiCertDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileCDNSSLMultiCertDotConfig(toData *config.TOData) (string, string, string, error) {
 	cfgDSes := atscfg.DeliveryServicesToSSLMultiCertDSes(toData.DeliveryServices)
 
-	return atscfg.MakeSSLMultiCertDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, cfgDSes), atscfg.ContentTypeSSLMultiCertDotConfig, nil
+	return atscfg.MakeSSLMultiCertDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, cfgDSes), atscfg.ContentTypeSSLMultiCertDotConfig, atscfg.LineCommentSSLMultiCertDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/storagedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/storagedotconfig.go
@@ -26,7 +26,7 @@ import (
 
 const StorageFileName = "storage.config"
 
-func GetConfigFileProfileStorageDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileStorageDotConfig(toData *config.TOData) (string, string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, StorageFileName, "", "", "location"))
-	return atscfg.MakeStorageDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeStorageDotConfig, nil
+	return atscfg.MakeStorageDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeStorageDotConfig, atscfg.LineCommentStorageDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/sysctldotconf.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/sysctldotconf.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileSysCtlDotConf(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileSysCtlDotConf(toData *config.TOData) (string, string, string, error) {
 	paramData := ParamsToMap(FilterParams(toData.ServerParams, atscfg.SysctlFileName, "", "", "location"))
-	return atscfg.MakeSysCtlDotConf(toData.Server.Profile, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeSysctlDotConf, nil
+	return atscfg.MakeSysCtlDotConf(toData.Server.Profile, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeSysctlDotConf, atscfg.LineCommentSysctlDotConf, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/sysctldotconf.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/sysctldotconf.go
@@ -25,17 +25,6 @@ import (
 )
 
 func GetConfigFileProfileSysCtlDotConf(toData *config.TOData) (string, string, error) {
-	paramData := map[string]string{}
-	// TODO add configFile query param to profile/parameters endpoint, to only get needed data
-	for _, param := range toData.ServerParams {
-		if param.ConfigFile != atscfg.SysctlFileName {
-			continue
-		}
-		if param.Name == "location" {
-			continue
-		}
-		paramData[param.Name] = param.Value
-	}
-
+	paramData := ParamsToMap(FilterParams(toData.ServerParams, atscfg.SysctlFileName, "", "", "location"))
 	return atscfg.MakeSysCtlDotConf(toData.Server.Profile, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeSysctlDotConf, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/unknownconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/unknownconfig.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileUnknownConfig(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileProfileUnknownConfig(toData *config.TOData, fileName string) (string, string, string, error) {
 	inScope := false
 	for _, scopeParam := range toData.ScopeParams {
 		if scopeParam.ConfigFile != fileName {
@@ -37,8 +37,11 @@ func GetConfigFileProfileUnknownConfig(toData *config.TOData, fileName string) (
 		break
 	}
 	if !inScope {
-		return `{"alerts":[{"level":"error","text":"Error - incorrect file scope for route used.  Please use the servers route."}]}`, "", config.ErrBadRequest
+		return `{"alerts":[{"level":"error","text":"Error - incorrect file scope for route used.  Please use the servers route."}]}`, "", "", config.ErrBadRequest
 	}
 	params := ParamsToMap(FilterParams(toData.ServerParams, fileName, "", "", "location"))
-	return atscfg.MakeUnknownConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeUnknownConfig, nil
+
+	commentType := atscfg.GetUnknownConfigCommentType(toData.Server.Profile, params, toData.TOToolName, toData.TOURL)
+	txt := atscfg.MakeUnknownConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL)
+	return txt, atscfg.ContentTypeUnknownConfig, commentType, nil
 }

--- a/traffic_ops/ort/atstccfg/cfgfile/urisigningconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/urisigningconfig.go
@@ -28,19 +28,19 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileURISigningConfig(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileProfileURISigningConfig(toData *config.TOData, fileName string) (string, string, string, error) {
 	dsName := GetDSFromURISigningConfigFileName(fileName)
 	if dsName == "" {
 		// extra safety, this should never happen, the routing shouldn't get here
-		return "", "", errors.New("getting ds name: malformed config file '" + fileName + "'")
+		return "", "", "", errors.New("getting ds name: malformed config file '" + fileName + "'")
 	}
 
 	uriSigningKeys, ok := toData.URISigningKeys[tc.DeliveryServiceName(dsName)]
 	if !ok {
-		return "", "", errors.New("no keys fetched for ds '" + dsName + "!")
+		return "", "", "", errors.New("no keys fetched for ds '" + dsName + "!")
 	}
 
-	return atscfg.MakeURISigningConfig(uriSigningKeys), atscfg.ContentTypeURISigningDotConfig, nil
+	return atscfg.MakeURISigningConfig(uriSigningKeys), atscfg.ContentTypeURISigningDotConfig, atscfg.LineCommentURISigningDotConfig, nil
 }
 
 // GetDSFromURISigningConfigFileName returns the DS of a URI Signing config file name.

--- a/traffic_ops/ort/atstccfg/cfgfile/urlsigconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/urlsigconfig.go
@@ -29,17 +29,7 @@ import (
 )
 
 func GetConfigFileProfileURLSigConfig(toData *config.TOData, fileName string) (string, string, error) {
-	paramData := map[string]string{}
-	// TODO add configFile query param to profile/parameters endpoint, to only get needed data
-	for _, param := range toData.ServerParams {
-		if param.ConfigFile != fileName {
-			continue
-		}
-		if param.Name == "location" {
-			continue
-		}
-		paramData[param.Name] = param.Value
-	}
+	paramData := ParamsToMap(FilterParams(toData.ServerParams, fileName, "", "", "location"))
 
 	dsName := GetDSFromURLSigConfigFileName(fileName)
 	if dsName == "" {

--- a/traffic_ops/ort/atstccfg/cfgfile/urlsigconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/urlsigconfig.go
@@ -28,21 +28,21 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg/config"
 )
 
-func GetConfigFileProfileURLSigConfig(toData *config.TOData, fileName string) (string, string, error) {
+func GetConfigFileProfileURLSigConfig(toData *config.TOData, fileName string) (string, string, string, error) {
 	paramData := ParamsToMap(FilterParams(toData.ServerParams, fileName, "", "", "location"))
 
 	dsName := GetDSFromURLSigConfigFileName(fileName)
 	if dsName == "" {
 		// extra safety, this should never happen, the routing shouldn't get here
-		return "", "", errors.New("getting ds name: malformed config file '" + fileName + "'")
+		return "", "", "", errors.New("getting ds name: malformed config file '" + fileName + "'")
 	}
 
 	urlSigKeys, ok := toData.URLSigKeys[tc.DeliveryServiceName(dsName)]
 	if !ok {
-		return "", "", errors.New("no keys fetched for ds '" + dsName + "!")
+		return "", "", "", errors.New("no keys fetched for ds '" + dsName + "!")
 	}
 
-	return atscfg.MakeURLSigConfig(toData.Server.Profile, urlSigKeys, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeParentDotConfig, nil
+	return atscfg.MakeURLSigConfig(toData.Server.Profile, urlSigKeys, paramData, toData.TOToolName, toData.TOURL), atscfg.ContentTypeURLSig, atscfg.LineCommentURLSig, nil
 }
 
 // GetDSFromURLSigConfigFileName returns the DS of a URLSig config file name.

--- a/traffic_ops/ort/atstccfg/cfgfile/volumedotconfig.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/volumedotconfig.go
@@ -26,7 +26,7 @@ import (
 
 const VolumeFileName = StorageFileName
 
-func GetConfigFileProfileVolumeDotConfig(toData *config.TOData) (string, string, error) {
+func GetConfigFileProfileVolumeDotConfig(toData *config.TOData) (string, string, string, error) {
 	params := ParamsToMap(FilterParams(toData.ServerParams, VolumeFileName, "", "", ""))
-	return atscfg.MakeVolumeDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeVolumeDotConfig, nil
+	return atscfg.MakeVolumeDotConfig(toData.Server.Profile, params, toData.TOToolName, toData.TOURL), atscfg.ContentTypeVolumeDotConfig, atscfg.LineCommentVolumeDotConfig, nil
 }

--- a/traffic_ops/ort/atstccfg/config/config.go
+++ b/traffic_ops/ort/atstccfg/config/config.go
@@ -201,6 +201,18 @@ type ATSConfigFile struct {
 	ContentType string
 }
 
+// ATSConfigFiles implements sort.Interface and sorts by the Location and then FileNameOnDisk, i.e. the full file path.
+type ATSConfigFiles []ATSConfigFile
+
+func (fs ATSConfigFiles) Len() int { return len(fs) }
+func (fs ATSConfigFiles) Less(i, j int) bool {
+	if fs[i].Location != fs[j].Location {
+		return fs[i].Location < fs[j].Location
+	}
+	return fs[i].FileNameOnDisk < fs[j].FileNameOnDisk
+}
+func (fs ATSConfigFiles) Swap(i, j int) { fs[i], fs[j] = fs[j], fs[i] }
+
 // TOData is the Traffic Ops data needed to generate configs.
 // See each field for details on the data required.
 // - If a field says 'must', the creation of TOData is guaranteed to do so, and users of the struct may rely on that.

--- a/traffic_ops/ort/atstccfg/config/config.go
+++ b/traffic_ops/ort/atstccfg/config/config.go
@@ -199,6 +199,7 @@ type ATSConfigFile struct {
 	tc.ATSConfigMetaDataConfigFile
 	Text        string
 	ContentType string
+	LineComment string
 }
 
 // ATSConfigFiles implements sort.Interface and sorts by the Location and then FileNameOnDisk, i.e. the full file path.

--- a/traffic_ops/ort/atstccfg/plugin/hello_world.go
+++ b/traffic_ops/ort/atstccfg/plugin/hello_world.go
@@ -41,6 +41,7 @@ func hello(d ModifyFilesData) []config.ATSConfigFile {
 
 	fi.Text = "Hello, World!\n"
 	fi.ContentType = "text/plain"
+	fi.LineComment = ""
 	fi.FileNameOnDisk = "hello.txt"
 	fi.Location = "/opt/trafficserver/etc/trafficserver/"
 

--- a/traffic_ops/ort/atstccfg/plugin/plugin_test.go
+++ b/traffic_ops/ort/atstccfg/plugin/plugin_test.go
@@ -34,6 +34,7 @@ func TestPlugin(t *testing.T) {
 			fi := config.ATSConfigFile{}
 			fi.Text = "testfile\n"
 			fi.ContentType = "text/plain"
+			fi.LineComment = ""
 			fi.FileNameOnDisk = "testfile.txt"
 			fi.Location = "/opt/trafficserver/etc/trafficserver/"
 			d.Files = append(d.Files, fi)


### PR DESCRIPTION
This changes ORT config gen to be deterministic. Configs should always be identical, except for the timestamp in the comment header.

This should make future changes much safer and easier to identify, easier to identify bugs, and just easier and safer to diff configs to see changes in general. With deterministic gen, diffing should be as simple as a line diff, e.g. the POSIX `diff` command.

- [x] This PR is not related to any other Issue 

Includes tests. No docs, no changelog, no documented interface change (we don't document config order).

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT and/or it's helper atstccfg multiple times, and verify the output files are identical except for the comment header timestamp.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information