### PR TITLE
Create Flexible Topologies tables

### DIFF
--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -1503,6 +1503,23 @@ CREATE TABLE topology_cachegroup (
 ALTER TABLE topology_cachegroup OWNER TO traffic_ops;
 
 --
+-- Name: topology_cachegroup_parents; Type: TABLE; Schema: public; Owner: traffic_ops
+--
+
+CREATE TABLE topology_cachegroup_parents (
+    child bigint NOT NULL,
+    parent bigint NOT NULL,
+    rank integer NOT NULL,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT topology_cachegroup_parents_rank_check CHECK (((rank = 1) OR (rank = 2))),
+    CONSTRAINT unique_child_rank UNIQUE (child, rank),
+    CONSTRAINT unique_child_parent UNIQUE (child, parent)
+);
+
+
+ALTER TABLE topology_cachegroup_parents OWNER TO traffic_ops;
+
+--
 -- Name: type; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
@@ -2604,6 +2621,18 @@ CREATE INDEX origin_tenant_fkey ON origin USING btree (tenant);
 CREATE INDEX topology_cachegroup_cachegroup_fkey ON topology_cachegroup USING btree (cachegroup);
 
 --
+-- Name: topology_cachegroup_parents_child_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+--
+
+CREATE INDEX topology_cachegroup_parents_child_fkey ON topology_cachegroup_parents USING btree (child);
+
+--
+-- Name: topology_cachegroup_parents_parents_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+--
+
+CREATE INDEX topology_cachegroup_parents_parents_fkey ON topology_cachegroup_parents USING btree (parent);
+
+--
 -- Name: topology_cachegroup_topology_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
@@ -3271,6 +3300,20 @@ ALTER TABLE ONLY deliveryservice_tmuser
 
 ALTER TABLE ONLY topology_cachegroup
     ADD CONSTRAINT topology_cachegroup_cachegroup_fkey FOREIGN KEY (cachegroup) REFERENCES cachegroup(short_name) ON UPDATE CASCADE ON DELETE CASCADE;
+
+--
+-- Name: topology_cachegroup_parents topology_cachegroup_parents_child_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+--
+
+ALTER TABLE ONLY topology_cachegroup_parents
+    ADD CONSTRAINT topology_cachegroup_parents_child_fkey FOREIGN KEY (child) REFERENCES topology_cachegroup(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+--
+-- Name: topology_cachegroup_parents topology_cachegroup_parents_parent_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+--
+
+ALTER TABLE ONLY topology_cachegroup_parents
+    ADD CONSTRAINT topology_cachegroup_parents_parent_fkey FOREIGN KEY (parent) REFERENCES topology_cachegroup(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 --
 -- Name: topology_cachegroup topology_cachegroup_topology_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -1474,6 +1474,18 @@ ALTER TABLE to_extension_id_seq OWNER TO traffic_ops;
 
 ALTER SEQUENCE to_extension_id_seq OWNED BY to_extension.id;
 
+--
+-- Name: topology; Type: TABLE; Schema: public; Owner: traffic_ops
+--
+
+CREATE TABLE topology (
+    name text PRIMARY KEY NOT NULL,
+    description text NOT NULL,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE topology OWNER TO traffic_ops;
 
 --
 -- Name: type; Type: TABLE; Schema: public; Owner: traffic_ops

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -1488,6 +1488,21 @@ CREATE TABLE topology (
 ALTER TABLE topology OWNER TO traffic_ops;
 
 --
+-- Name: topology_cachegroup; Type: TABLE; Schema: public; Owner: traffic_ops
+--
+
+CREATE TABLE topology_cachegroup (
+    id bigint PRIMARY KEY NOT NULL,
+    topology text NOT NULL,
+    cachegroup text NOT NULL,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT unique_topology_cachegroup UNIQUE (topology, cachegroup)
+);
+
+
+ALTER TABLE topology_cachegroup OWNER TO traffic_ops;
+
+--
 -- Name: type; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
@@ -2582,6 +2597,18 @@ CREATE INDEX origin_cachegroup_fkey ON origin USING btree (cachegroup);
 
 CREATE INDEX origin_tenant_fkey ON origin USING btree (tenant);
 
+--
+-- Name: topology_cachegroup_cachegroup_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+--
+
+CREATE INDEX topology_cachegroup_cachegroup_fkey ON topology_cachegroup USING btree (cachegroup);
+
+--
+-- Name: topology_cachegroup_topology_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+--
+
+CREATE INDEX topology_cachegroup_topology_fkey ON topology_cachegroup USING btree (topology);
+
 
 --
 -- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
@@ -3238,6 +3265,19 @@ ALTER TABLE ONLY deliveryservice_tmuser
 ALTER TABLE ONLY deliveryservice_tmuser
     ADD CONSTRAINT fk_tm_user_id FOREIGN KEY (tm_user_id) REFERENCES tm_user(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
+--
+-- Name: topology_cachegroup topology_cachegroup_cachegroup_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+--
+
+ALTER TABLE ONLY topology_cachegroup
+    ADD CONSTRAINT topology_cachegroup_cachegroup_fkey FOREIGN KEY (cachegroup) REFERENCES cachegroup(short_name) ON UPDATE CASCADE ON DELETE CASCADE;
+
+--
+-- Name: topology_cachegroup topology_cachegroup_topology_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+--
+
+ALTER TABLE ONLY topology_cachegroup
+    ADD CONSTRAINT topology_cachegroup_topology_fkey FOREIGN KEY (topology) REFERENCES topology(name) ON UPDATE CASCADE ON DELETE CASCADE;
 
 --
 -- Name: fk_user_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops

--- a/traffic_ops/app/db/migrations/20200331031637_add_deliveryservice_topology.sql
+++ b/traffic_ops/app/db/migrations/20200331031637_add_deliveryservice_topology.sql
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+* License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE deliveryservice
+    ADD COLUMN topology text,
+    ADD CONSTRAINT deliveryservice_topology_fkey FOREIGN KEY (topology) REFERENCES topology (name) ON UPDATE CASCADE ON DELETE CASCADE;
+CREATE INDEX deliveryservice_topology_fkey ON deliveryservice USING btree (topology);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+ALTER TABLE deliveryservice DROP COLUMN topology;


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

This PR adds the `topology`, `topology_cachegroup`, and `topology_cachegroup_parents` tables to `create_tables.sql` and adds a migration to create the `topology` column in the `deliveryservice` table.

- [x] This PR fixes #4564<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

* The [existing documentation](https://traffic-control-cdn.readthedocs.io/en/release-4.0.0/development/traffic_ops.html#cmdoption-admin-arg-command) is sufficient for `create_tables.sql` and migrations.
* We do not currently lint or test `create_tables.sql` or migrations.
## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops database

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
- Confirm the database is initialized correctly in CDN-in-a-Box
- Confirm that the tables and columns mentioned in [the Flexible Topologies blueprint](https://github.com/rawlinp/trafficcontrol/blob/topologies-blueprint/blueprints/flexible-topologies.md#traffic-ops-database) are present, including foreign keys and constraints

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (2697ebac)
- 3.0.0
- 3.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
Not a bug fix.

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->