### PR TITLE
Make _postinstall work in Perl 5.26

### DIFF
--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -76,12 +76,12 @@ my $outputConfigFile = "/opt/traffic_ops/install/bin/configuration_file.json";
 
 my $inputFile = "";
 my $automatic = 0;
-my $defaultInputs;
+my %defaultInputs;
 
 # given a var to the hash of config_var and question, will return the question
 sub getConfigQuestion {
     my $var = shift;
-    foreach my $key ( keys $var ) {
+    foreach my $key ( keys %{ $var } ) {
         if ( $key ne "hidden" && $key ne "config_var" ) {
             return $key;
         }
@@ -122,18 +122,18 @@ sub getField {
 #  and returns the hash of answers
 
 sub getConfig {
-    my $userInput = shift;
+    my %userInput = %{$_[0]}; shift;
     my $fileName  = shift;
 
     my %config;
 
-    if ( !defined $userInput->{$fileName} ) {
+    if ( !defined $userInput{$fileName} ) {
         InstallUtils::logger( "No $fileName found in config", "error" );
     }
 
     InstallUtils::logger( "===========$fileName===========", "info" );
 
-    foreach my $var ( @{ $userInput->{$fileName} } ) {
+    foreach my $var ( @{ $userInput{$fileName} } ) {
         my $question = getConfigQuestion($var);
         my $hidden   = $var->{"hidden"} if ( exists $var->{"hidden"} );
         my $answer   = $config{ $var->{"config_var"} } = getField( $question, $var->{$question}, $hidden );
@@ -153,18 +153,18 @@ sub getConfig {
 # Generates a config file for the database based on the questions and answers in the input config file
 
 sub generateDbConf {
-    my $userInput    = shift;
+    my %userInput = %{$_[0]}; shift;
     my $dbFileName   = shift;
     my $toDBFileName = shift;
 
-    my %dbconf = getConfig( $userInput, $dbFileName );
+    my %dbconf = getConfig( \%userInput, $dbFileName );
     $dbconf{"description"} = "$dbconf{type} database on $dbconf{hostname}:$dbconf{port}";
     make_path( dirname($dbFileName), { mode => 0755 } );
     InstallUtils::writeJson( $dbFileName, \%dbconf );
     InstallUtils::logger( "Database configuration has been saved", "info" );
 
     # broken out into separate file/config area
-    my %todbconf = getConfig( $userInput, $toDBFileName );
+    my %todbconf = getConfig( \%userInput, $toDBFileName );
 
     # Check if the Postgres db is used and set the driver to be "postgres"
     my $dbDriver = $dbconf{type};
@@ -188,10 +188,10 @@ sub generateDbConf {
 # Generates a config file for the CDN
 
 sub generateCdnConf {
-    my $userInput = shift;
+    my %userInput = %{$_[0]}; shift;
     my $fileName  = shift;
 
-    my %cdnConfiguration = getConfig( $userInput, $fileName );
+    my %cdnConfiguration = getConfig( \%userInput, $fileName );
 
     # First, read existing one -- already loaded with a bunch of stuff
     my $cdnConf;
@@ -243,17 +243,16 @@ sub hash_pass {
 # Generates an LDAP config file
 
 sub generateLdapConf {
-    my $userInput = shift;
+    my %userInput = %{$_[0]}; shift;
     my $fileName  = shift;
-
-    my $useLdap = $userInput->{$fileName}[0]->{"Do you want to set up LDAP?"};
+    my $useLdap = %{@{$userInput{$fileName}}[0]}{"Do you want to set up LDAP?"};
 
     if ( !lc $useLdap =~ /^y(?:es)?/ ) {
         InstallUtils::logger( "Not setting up ldap", "info" );
         return;
     }
 
-    my %ldapConf = getConfig( $userInput, $fileName );
+    my %ldapConf = getConfig( \%userInput, $fileName );
     # convert any deprecated keys to the correct key name
     my %keys_converted = ( password => 'admin_pass', hostname => 'host' );
     for my $key (keys %ldapConf) {
@@ -281,11 +280,11 @@ sub generateLdapConf {
 }
 
 sub generateUsersConf {
-    my $userInput = shift;
+    my %userInput = %{$_[0]}; shift;
     my $fileName  = shift;
 
     my %user = ();
-    my %config = getConfig( $userInput, $fileName );
+    my %config = getConfig( \%userInput, $fileName );
 
     $user{username} = $config{tmAdminUser};
     $user{password} = hash_pass( $config{tmAdminPw} );
@@ -296,37 +295,37 @@ sub generateUsersConf {
 }
 
 sub generateProfilesDir {
-    my $userInput = shift;
+    my %userInput = %{$_[0]}; shift;
     my $fileName  = shift;
 
-    my $userIn = $userInput->{$fileName};
+    my $userIn = $userInput{$fileName};
 }
 
 sub generateOpenSSLConf {
-    my $userInput = shift;
+    my %userInput = %{$_[0]}; shift;
     my $fileName  = shift;
 
-    my %config = getConfig( $userInput, $fileName );
+    my %config = getConfig( \%userInput, $fileName );
     return \%config;
 }
 
 sub generateParamConf {
-    my $userInput = shift;
+    my %userInput = %{$_[0]}; shift;
     my $fileName  = shift;
 
-    my %config = getConfig( $userInput, $fileName );
+    my %config = getConfig( \%userInput, $fileName );
     InstallUtils::writeJson( $fileName, \%config );
     return \%config;
 }
 
 # check default values for missing config_var parameter
 sub sanityCheckDefaults {
-    foreach my $file ( ( keys $defaultInputs ) ) {
-        foreach my $defaultValue ( @{ $defaultInputs->{$file} } ) {
-            my $question = getConfigQuestion($defaultValue);
+    foreach my $file ( ( keys %defaultInputs ) ) {
+        foreach my $defaultValue ( @{ $defaultInputs{$file} } ) {
+            my $question = getConfigQuestion(\%$defaultValue);
 
-            if ( !defined $defaultValue->{"config_var"}
-                || $defaultValue->{"config_var"} eq "" )
+            if ( !defined %$defaultValue{"config_var"}
+                || %$defaultValue{"config_var"} eq "" )
             {
                 errorOut("Question '$question' in file '$file' has no config_var");
             }
@@ -340,19 +339,19 @@ sub sanityCheckDefaults {
 #  is not located in the input config file it will output a warning message.
 
 sub sanityCheckConfig {
-    my $userInput = shift;
+    my %userInput = %{$_[0]}; shift;
     my $diffs     = 0;
 
-    foreach my $file ( ( keys $defaultInputs ) ) {
-        if ( !defined $userInput->{$file} ) {
+    foreach my $file ( ( keys %defaultInputs ) ) {
+        if ( !defined $userInput{$file} ) {
             InstallUtils::logger( "File '$file' found in defaults but not config file", "warn" );
-            $userInput->{$file} = [];
+            @{$userInput{$file}} = [];
         }
 
-        foreach my $defaultValue ( @{ $defaultInputs->{$file} } ) {
+        foreach my $defaultValue ( @{ $defaultInputs{$file} } ) {
 
             my $found = 0;
-            foreach my $configValue ( @{ $userInput->{$file} } ) {
+            foreach my $configValue ( @{ $userInput{$file} } ) {
                 if ( $defaultValue->{"config_var"} eq $configValue->{"config_var"} ) {
                     $found = 1;
                 }
@@ -393,7 +392,7 @@ sub sanityCheckConfig {
                     $temp{"hidden"} .= "true";
                 }
 
-                push $userInput->{$file}, \%temp;
+                push @{ $userInput{$file} }, \%temp;
 
                 $diffs++;
             }
@@ -407,7 +406,7 @@ sub sanityCheckConfig {
 #  user input config file or if there are questions in the input config file which do not have answers
 
 sub getDefaults {
-    return {
+    return (
         $databaseConfFile => [
             {
                 "Database type" => "Pg",
@@ -576,8 +575,8 @@ sub getDefaults {
                 "DNS sub-domain for which your CDN is authoritative" => "cdn1.kabletown.net",
                 "config_var"                                         => "dns_subdomain"
             }
-        ]
-    };
+        ],
+    );
 }
 
 # carried over from old postinstall
@@ -832,7 +831,7 @@ sub main {
     ) or die($usageString);
 
     # stores the default questions and answers
-    $defaultInputs = getDefaults();
+    %defaultInputs = getDefaults();
 
     if ($help) {
         print $usageString;
@@ -867,7 +866,7 @@ sub main {
 	    $outputConfigFile = $dumpDefaults;
         }
         InstallUtils::logger( "Writing default configuration to $outputConfigFile", "info" );
-        InstallUtils::writeJson( $outputConfigFile, $defaultInputs );
+        InstallUtils::writeJson( $outputConfigFile, %defaultInputs );
         return;
     }
 
@@ -879,12 +878,12 @@ sub main {
     }
 
     # used to store the questions and answers provided by the user
-    my $userInput;
+    my %userInput;
 
     # if no input file provided use the defaults
     if ( $inputFile eq "" ) {
         InstallUtils::logger( "No input file given - using defaults", "info" );
-        $userInput = $defaultInputs;
+        %userInput = %defaultInputs;
     }
     else {
         InstallUtils::logger( "Using input file $inputFile", "info" );
@@ -893,25 +892,25 @@ sub main {
         errorOut("File '$inputFile' not found") if ( !-f $inputFile );
 
         # read and store the input file
-        $userInput = InstallUtils::readJson($inputFile);
+        %userInput = InstallUtils::readJson($inputFile);
     }
 
     # sanity check the defaults if running them automatically
     sanityCheckDefaults();
 
     # check the input config file against the defaults to check for missing questions
-    sanityCheckConfig($userInput) if ( $inputFile ne "" );
+    sanityCheckConfig(\%userInput) if ( $inputFile ne "" );
 
     chdir("/opt/traffic_ops/install/bin");
 
     # The generator functions handle checking input/default/automatic mode
     # todbconf will be used later when setting up the database
-    my $todbconf = generateDbConf( $userInput, $databaseConfFile, $dbConfFile );
-    generateLdapConf( $userInput, $ldapConfFile );
-    my $adminconf = generateUsersConf( $userInput, $usersConfFile );
-    my $custom_profile = generateProfilesDir( $userInput, $profilesConfFile );
-    my $opensslconf = generateOpenSSLConf( $userInput, $opensslConfFile );
-    my $paramconf = generateParamConf( $userInput, $paramConfFile );
+    my $todbconf = generateDbConf( \%userInput, $databaseConfFile, $dbConfFile );
+    generateLdapConf( \%userInput, $ldapConfFile );
+    my $adminconf = generateUsersConf( \%userInput, $usersConfFile );
+    my $custom_profile = generateProfilesDir( \%userInput, $profilesConfFile );
+    my $opensslconf = generateOpenSSLConf( \%userInput, $opensslConfFile );
+    my $paramconf = generateParamConf( \%userInput, $paramConfFile );
 
     if ( !-f $post_install_cfg ) {
         InstallUtils::writeJson( $post_install_cfg, {} );
@@ -919,7 +918,7 @@ sub main {
 
     setupMaxMind( $todbconf->{"maxmind"} );
     setupCertificates( $opensslconf );
-    generateCdnConf( $userInput, $cdnConfFile );
+    generateCdnConf( \%userInput, $cdnConfFile );
 
     my $dbh = Database::connect($databaseConfFile, $todbconf);
     if (!$dbh) {

--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -245,7 +245,8 @@ sub hash_pass {
 sub generateLdapConf {
     my %userInput = %{$_[0]}; shift;
     my $fileName  = shift;
-    my $useLdap = %{@{$userInput{$fileName}}[0]}{"Do you want to set up LDAP?"};
+    my %ldapInput = %{@{$userInput{$fileName}}[0]};
+    my $useLdap = $ldapInput{"Do you want to set up LDAP?"};
 
     if ( !lc $useLdap =~ /^y(?:es)?/ ) {
         InstallUtils::logger( "Not setting up ldap", "info" );
@@ -324,8 +325,9 @@ sub sanityCheckDefaults {
         foreach my $defaultValue ( @{ $defaultInputs{$file} } ) {
             my $question = getConfigQuestion(\%$defaultValue);
 
-            if ( !defined %$defaultValue{"config_var"}
-                || %$defaultValue{"config_var"} eq "" )
+            my %defaultValueHash = %$defaultValue;
+            if ( !defined $defaultValueHash{"config_var"}
+                || $defaultValueHash{"config_var"} eq "" )
             {
                 errorOut("Question '$question' in file '$file' has no config_var");
             }


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4577<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
- Documentation is not necessary because intended behavior does not change.
- See the "What is the best way to verify this PR?" section for a test

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Rebuild the Traffic Ops Perl container and start CDN-in-a-Box
2. Run this and verify it worked:
    ```bash
    <<'BASH_COMMANDS' docker-compose exec -T trafficops-perl bash;
        yum -y install centos-release-scl;
        yum -y install rh-perl526;
        sed -i 's|".*ciphers.*"|"https://[::]:60443?cert=/etc/pki/tls/certs/localhost.crt\&key=/etc/pki/tls/private/localhost.key\&verify=0x00\&ciphers=AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH:!ED"|g' conf/cdn.conf;
        rm -r local;
        <<'SCL_COMMANDS' scl enable rh-perl526 bash;
            cpanm -l ./local Carton Term::ReadKey;
            POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton;
            <<'POSTINSTALL_INPUT' perl ../install/bin/_postinstall;
    Pg
    traffic_ops
    db.infra.ciab.test
    5432
    traffic_ops
    twelve
    twelve
    traffic_ops
    twelve
    twelve
    no
    admin
    twelve
    twelve
    yes
    US
    CO
    Denver
    Comcast
    Traffic Control
    trafficops.infra.ciab.test
    rsapass
    rsapass
    https://trafficops.infra.ciab.test
    CDN-in-a-Box
    mycdn.ciab.test
    yes
    1
    443
    12
    http://trafficops.infra.ciab.test:3000
    /opt/traffic_ops/app/conf/ldap.conf
    POSTINSTALL_INPUT
    SCL_COMMANDS
    BASH_COMMANDS
    ```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '2697ebac'), in v3.0.0,
and in the current 3.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (9a7db19f5e)
- 4.0.0

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (9a7db19f5e)
- 4.0.0

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->
Additionally installing the `Term::ReadKey` module is only necessary when using `rh-perl526` on CentOS 7. It is not necessary on CentOS 7 using Perl 5.16 or on CentOS 8 using Perl 5.26, because in both cases, the `perl-TermReadKey` package is already installed as a dependency.
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->