### PR TITLE
Fix traffic_ops_ort.pl improper JSON referencing

### DIFF
--- a/traffic_ops/ort/traffic_ops_ort.pl
+++ b/traffic_ops/ort/traffic_ops_ort.pl
@@ -833,7 +833,7 @@ sub check_revalidate_state {
 			( $log_level >> $ERROR ) && print "ERROR status file $status_file does not exist.\n";
 		}
 
-		for my $status ( @{$statuses->{'response'}} ) {
+		for my $status ( @{$statuses} ) {
 			next if ( $status->{name} eq $my_status );
 			my $other_status = $status_dir . "/" . $status->{name};
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

ORT was exiting with this error:

> Not a HASH reference at /opt/ort/traffic_ops_ort.pl line 836.

Because the JSON returned from atstccfg is not wrapped in a "response"
object. This fixes that error.

- [x] This PR is not related to any Issue


## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run ORT in syncds mode without this fix, verify it exits early with the above error. With this fix, try it again and verify ORT completes successfully.

## If this is a bug fix, what versions of Traffic Control are affected?

- master

## The following criteria are ALL met by this PR

- [x] ORT doesn't have tests
- [x] bugfix, no docs necessary
- [x] bug not released, no changelog required
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information

This is what `atstccfg` returns for the `$statuses` json: 
```
[
    {
        "description": "Server is Offline. Not active in any configuration.",
        "id": 1,
        "lastUpdated": "0001-01-01 00:00:00+00",
        "name": "OFFLINE"
    },
    {
        "description": "Server is online.",
        "id": 2,
        "lastUpdated": "0001-01-01 00:00:00+00",
        "name": "ONLINE"
    },
    {
        "description": "Server is online and reported in the health protocol.",
        "id": 3,
        "lastUpdated": "0001-01-01 00:00:00+00",
        "name": "REPORTED"
    },
    {
        "description": "Sever is administrative down and does not receive traffic.",
        "id": 4,
        "lastUpdated": "0001-01-01 00:00:00+00",
        "name": "ADMIN_DOWN"
    },
    {
        "description": "Server is ignored by traffic router.",
        "id": 5,
        "lastUpdated": "0001-01-01 00:00:00+00",
        "name": "CCR_IGNORE"
    },
    {
        "description": "Pre Production. Not active in any configuration.",
        "id": 6,
        "lastUpdated": "0001-01-01 00:00:00+00",
        "name": "PRE_PROD"
    }
]
```
As you can see, there is no `"response"` field to key on.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
