### PR TITLE
Add ORT TO timeout option

### DIFF
--- a/traffic_ops/ort/atstccfg/config/config.go
+++ b/traffic_ops/ort/atstccfg/config/config.go
@@ -88,7 +88,7 @@ func GetCfg() (Cfg, error) {
 	logLocationWarnPtr := flag.StringP("log-location-warning", "w", "stderr", "Where to log warnings. May be a file path, stdout, stderr, or null.")
 	logLocationInfoPtr := flag.StringP("log-location-info", "i", "stderr", "Where to log information messages. May be a file path, stdout, stderr, or null.")
 	toInsecurePtr := flag.BoolP("traffic-ops-insecure", "s", false, "Whether to ignore HTTPS certificate errors from Traffic Ops. It is HIGHLY RECOMMENDED to never use this in a production environment, but only for debugging.")
-	toTimeoutMSPtr := flag.IntP("traffic-ops-timeout-milliseconds", "t", 60000, "Timeout in seconds for Traffic Ops requests.")
+	toTimeoutMSPtr := flag.IntP("traffic-ops-timeout-milliseconds", "t", 30000, "Timeout in seconds for Traffic Ops requests.")
 	versionPtr := flag.BoolP("version", "v", false, "Print version information and exit.")
 	listPluginsPtr := flag.BoolP("list-plugins", "l", false, "Print the list of plugins.")
 	helpPtr := flag.BoolP("help", "h", false, "Print usage information and exit")


### PR DESCRIPTION
Exposes the existing atstccfg Traffic Ops timeout as an ORT option.

Also changes the default timeout back to 30s, to match what ORT has
been forever.

This is actually a forward-port of a feature added to 4.0.x (ORT has changed enough, it couldn't easily be backported, had to be re-written).

I manually tested against a production-like Traffic Ops, default works, setting --to_timeout_ms flag works as expected, setting 1ms times out on the first request, setting 100ms succeeds for small requests and times out on the large DSS.

No tests, changes require TO, and ORT doesn't have an integration test framework yet.
No docs, no documented interface change (ORT flags aren't documented, besides the self-documenting script output)
No changelog, no interface change (4.0.x adds this flag, this PR is just adding it to master to match)

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT with the flag --to_timeout_ms, set it small, observe timeouts, set it large, observe success.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information