### PR TITLE
Appropriate path join

### DIFF
--- a/lib/go-rfc/mimetype.go
+++ b/lib/go-rfc/mimetype.go
@@ -260,12 +260,12 @@ var MIME_HTML = MimeType{
 
 // MIME_CSS is a pre-defined MimeType for CSS data.
 var MIME_CSS = MimeType{
-	Name: "text/css",
+	Name:       "text/css",
 	Parameters: map[string]string{"charset": "utf-8"},
 }
 
 // MIME_JS is a pre-defined MimeType for JavaScript data.
 var MIME_JS = MimeType{
-	Name: "text/javascript",
+	Name:       "text/javascript",
 	Parameters: map[string]string{"charset": "utf-8"},
 }

--- a/traffic_monitor/srvhttp/srvhttp.go
+++ b/traffic_monitor/srvhttp/srvhttp.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -229,11 +230,11 @@ func DateStr(t time.Time) string {
 }
 
 func (s *Server) handleRootFunc(staticFileDir string) (http.HandlerFunc, error) {
-	return s.handleFile(staticFileDir + "index.html")
+	return s.handleFile(path.Join(staticFileDir, "index.html"))
 }
 
 func (s *Server) handleScriptFunc(staticFileDir string) (http.HandlerFunc, error) {
-	bytes, err := ioutil.ReadFile(staticFileDir + "script.js")
+	bytes, err := ioutil.ReadFile(path.Join(staticFileDir, "script.js"))
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +245,7 @@ func (s *Server) handleScriptFunc(staticFileDir string) (http.HandlerFunc, error
 }
 
 func (s *Server) handleStyleFunc(staticFileDir string) (http.HandlerFunc, error) {
-	bytes, err := ioutil.ReadFile(staticFileDir + "style.css")
+	bytes, err := ioutil.ReadFile(path.Join(staticFileDir, "style.css"))
 	if err != nil {
 		return nil, err
 	}

--- a/traffic_ops/client/crconfig.go
+++ b/traffic_ops/client/crconfig.go
@@ -67,4 +67,3 @@ func (to *Session) SnapshotCRConfigByID(id int) (tc.Alerts, ReqInf, error) {
 	err = json.NewDecoder(resp.Body).Decode(&alerts)
 	return alerts, reqInf, nil
 }
-

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -104,9 +104,9 @@ func (pl *TOPhysLocation) Read() ([]interface{}, error, error, int) {
 	}
 	return api.GenericRead(pl)
 }
-func (pl *TOPhysLocation) Update() (error, error, int)              { return api.GenericUpdate(pl) }
-func (pl *TOPhysLocation) Create() (error, error, int)              { return api.GenericCreate(pl) }
-func (pl *TOPhysLocation) Delete() (error, error, int)              { return api.GenericDelete(pl) }
+func (pl *TOPhysLocation) Update() (error, error, int) { return api.GenericUpdate(pl) }
+func (pl *TOPhysLocation) Create() (error, error, int) { return api.GenericCreate(pl) }
+func (pl *TOPhysLocation) Delete() (error, error, int) { return api.GenericDelete(pl) }
 
 func selectQuery() string {
 	return `


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

Fixes a (potential?) bug in Traffic Monitor. It was using direct string concatenation to create paths to statically served files for its UI, which - depending on your configuration file - can cause it to crash unexpectedly at startup. This PR makes it use the appropriate standard library function for concatenating path elements: `path.Join`.

I also did a `go fmt` after making the change which modified other, unrelated files. But it's just a `go fmt`, so shouldn't matter. In fact, I believe it's all whitespace changes.

## Which Traffic Control components are affected by this PR?
- Traffic Monitor

## What is the best way to verify this PR?
Run Traffic Monitor's unit tests. Build and start Traffic Monitor, confirm that it doesn't crash and the UI is accessible.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**