### PR TITLE
Fixed segfault in types test when a test fails

### DIFF
--- a/traffic_ops/testing/api/v2/types_test.go
+++ b/traffic_ops/testing/api/v2/types_test.go
@@ -39,7 +39,7 @@ func CreateTestTypes(t *testing.T) {
 	defer func() {
 		err := db.Close()
 		if err != nil {
-			t.Errorf("unable to close connection to db, error: %v", err.Error())
+			t.Errorf("unable to close connection to db, error: %v", err)
 		}
 	}()
 	dbQueryTemplate := "INSERT INTO type (name, description, use_in_table) VALUES ('%v', '%v', '%v');"
@@ -139,7 +139,7 @@ func DeleteTestTypes(t *testing.T) {
 	defer func() {
 		err := db.Close()
 		if err != nil {
-			t.Errorf("unable to close connection to db, error: %v", err.Error())
+			t.Errorf("unable to close connection to db, error: %v", err)
 		}
 	}()
 	dbDeleteTemplate := "DELETE FROM type WHERE name='%v';"
@@ -148,14 +148,14 @@ func DeleteTestTypes(t *testing.T) {
 		// Retrieve the Type by name so we can get the id for the Update
 		resp, _, err := TOSession.GetTypeByName(typ.Name)
 		if err != nil || len(resp) == 0 {
-			t.Fatalf("cannot GET Type by name: %v - %v", typ.Name, err.Error())
+			t.Fatalf("cannot GET Type by name: %v - %v", typ.Name, err)
 		}
 		respType := resp[0]
 
 		if respType.UseInTable != "server" {
 			err := execSQL(db, fmt.Sprintf(dbDeleteTemplate, respType.Name), "type")
 			if err != nil {
-				t.Fatalf("cannot DELETE Type by name: %v", err.Error())
+				t.Fatalf("cannot DELETE Type by name: %v", err)
 			}
 		} else {
 			delResp, _, err := TOSession.DeleteTypeByID(respType.ID)
@@ -167,7 +167,7 @@ func DeleteTestTypes(t *testing.T) {
 		// Retrieve the Type to see if it got deleted
 		types, _, err := TOSession.GetTypeByName(typ.Name)
 		if err != nil {
-			t.Errorf("error deleting Type name: %s", err.Error())
+			t.Errorf("error deleting Type name: %v", err)
 		}
 		if len(types) > 0 {
 			t.Errorf("expected Type name: %s to be deleted", typ.Name)


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #REPLACE_ME OR is not related to any Issue

There was a part of the types tests that looked something like:
```go
resp, err := toclient.SomeAPIFunc()
if err != nil || len(resp) == 0 {
	t.Fatalf("error: %v", err.Error())
}
```
When there was no error but the response was empty this caused a segfault as `err.Error` was dereferenced while `err` was `nil`. When using formatting like `t.Fatalf`/`fmt.Printf`/etc. it's not necessary to call `error.Error` for arguments formatted with `%v`, so the fix was simple: get rid of that call. For consistency and to maybe help avoid the same problem in the future as the codebase evolves, I removed calls to `error.Error` everywhere in the file where they weren't necessary (which was everywhere).

## Which Traffic Control components are affected by this PR?
- Traffic Control Client (Go) (tests)

## What is the best way to verify this PR?
Run the client/api integration tests. Hopefully they all pass, but if the DeleteTypesTest were to fail because there were no configured types in the database at the moment (which you could maybe force by removing all types from the test data? It might not get that far, though) it shouldn't segfault.

I wasn't able to reproduce whatever happened to make that check fail, unfortunately.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**
