### PR TITLE
Fix some CIAB issues and add TC_LOC type to seeds.sql

### DIFF
--- a/infrastructure/cdn-in-a-box/edge/run.sh
+++ b/infrastructure/cdn-in-a-box/edge/run.sh
@@ -69,7 +69,7 @@ while [[ -z "$(testenrolled)" ]]; do
 done
 
 # Wait for SSL keys to exist
-until to-get "api/2.0/cdns/name/$CDN_NAME/sslkeys" && [[ "$(to-get api/2.0/cdns/name/$CDN_NAME/sslkeys)" != '{"response":[]}' ]]; do
+until [[ $(to-get api/2.0/cdns/name/$CDN_NAME/sslkeys | jq '.response | length') -gt 0 ]]; do
 	echo 'waiting for SSL keys to exist'
 	sleep 3
 done

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -74,7 +74,7 @@ to-enroll "to" ALL || (while true; do echo "enroll failed."; sleep 3 ; done)
 while true; do
   echo "Verifying that edge was associated to delivery service..."
 
-  edge_name="$(to-get 'api/2.0/servers?hostName=edge' 2>/dev/null | jq -r -c '.response|.hostName')"
+  edge_name="$(to-get 'api/2.0/servers?hostName=edge' 2>/dev/null | jq -r -c '.response[0]|.hostName')"
   ds_name=$(to-get 'api/2.0/deliveryservices' 2>/dev/null | jq -r -c '.response[] | select(.cdnName == "'"$CDN_NAME"'").xmlId')
   ds_id=$(to-get 'api/2.0/deliveryservices' 2>/dev/null | jq -r -c '.response[] | select(.cdnName == "'"$CDN_NAME"'").id')
   edge_verify=$(to-get "/api/2.0/deliveryservices/$ds_id/servers" | jq -r '.response[]|.hostName')

--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -267,7 +267,7 @@ to-enroll() {
 
 # Tests that this server exists in Traffic Ops
 function testenrolled() {
-	local tmp="$(to-get	'api/'$TO_API_VERSION'/servers?name='$MY_HOSTNAME'')"
+	local tmp="$(to-get	'api/'$TO_API_VERSION'/servers?hostName='$MY_HOSTNAME'')"
 	tmp=$(echo $tmp | jq '.response[]|select(.hostName=="'"$MY_HOSTNAME"'")')
 	echo "$tmp"
 }
@@ -307,7 +307,7 @@ to-add-sslkeys() {
 		json_response=$(to-post 'api/'$TO_API_VERSION'/deliveryservices/sslkeys/add' "$json_request")
 		if [[ -n "$json_response" ]] ; then
 			sleep 3
-			cdn_sslkeys_response=$(to-get "api/$TO_API_VERSION/cdns/name/$1/sslkeys" | jq '.response[] | length')
+			cdn_sslkeys_response=$(to-get "api/$TO_API_VERSION/cdns/name/$1/sslkeys" | jq '.response | length')
 			if ((cdn_sslkeys_response>0)); then
 				break
 			else

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/types/030-TC_LOC.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/types/030-TC_LOC.json
@@ -1,5 +1,0 @@
-{
-  "description": "Location for Traffic Control Component Servers",
-  "name": "TC_LOC",
-  "useInTable": "cachegroup"
-}

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/types/040-TR_LOC.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/types/040-TR_LOC.json
@@ -1,5 +1,0 @@
-{
-  "description": "Traffic Router Logical Site",
-  "name": "TR_LOC",
-  "useInTable": "cachegroup"
-}

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -768,6 +768,7 @@ insert into type (name, description, use_in_table) values ('EDGE_LOC', 'Edge Log
 insert into type (name, description, use_in_table) values ('MID_LOC', 'Mid Logical Location', 'cachegroup') ON CONFLICT (name) DO NOTHING;
 insert into type (name, description, use_in_table) values ('ORG_LOC', 'Origin Logical Site', 'cachegroup') ON CONFLICT (name) DO NOTHING;
 insert into type (name, description, use_in_table) values ('TR_LOC', 'Traffic Router Logical Location', 'cachegroup') ON CONFLICT (name) DO NOTHING;
+insert into type (name, description, use_in_table) values ('TC_LOC', 'Traffic Control Component Location', 'cachegroup') ON CONFLICT (name) DO NOTHING;
 
 -- to_extension types
 insert into type (name, description, use_in_table) values ('CHECK_EXTENSION_BOOL', 'Extension for checkmark in Server Check', 'to_extension') ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Recently, creating types other than for use in the servers table was
prohibited, so add a TC_LOC type to seeds.sql to be used for cachegroups
containing servers that don't match the existing set of cachegroup
types.

Remove the TC_LOC and TR_LOC types from being created by the CIAB
enroller and fix a few other bugs.

- [x] This PR is not related to any Issue


## Which Traffic Control components are affected by this PR?

- CDN in a Box
- Traffic Ops

## What is the best way to verify this PR?
Run CIAB, verify that it completes successfully.
Run `db/admin seed` and verify that it completes successfully.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] CIAB fix, tests unnecessary
- [x] CIAB fix, docs unnecessary
- [x] CHANGELOG.md update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

