### PR TITLE
Cast InstallUtils::readJson()'s return value to hash type

### DIFF
--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -894,7 +894,7 @@ sub main {
         errorOut("File '$inputFile' not found") if ( !-f $inputFile );
 
         # read and store the input file
-        %userInput = InstallUtils::readJson($inputFile);
+        %userInput = %{InstallUtils::readJson($inputFile)};
     }
 
     # sanity check the defaults if running them automatically


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes the following errors when the `_postinstall` Perl script is run using a JSON input file:<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
    ```
    Reference found where even-sized list expected at /opt/traffic_ops/install/bin/_postinstall line 897.
    File '/opt/traffic_ops/install/data/profiles/' found in defaults but not config file
    Not a HASH reference at /opt/traffic_ops/install/bin/_postinstall line 357.
    ```
- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

<h2 id="verify-pr">What is the best way to verify this PR?</h2>
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
<details><summary>Build CDN-in-a-Box and run these commands (click to expand)</summary>

```bash
<<'JSON_INPUT_FILE' cat > configuration_file.json;
{
  "/opt/traffic_ops/app/conf/cdn.conf": [
    {
      "Generate a new secret?": "yes",
      "config_var": "genSecret"
    },
    {
      "Number of secrets to keep?": "2",
      "config_var": "keepSecrets"
    },
    {
      "Number of workers?": "12",
      "config_var": "workers"
    },
    {
      "Traffic Ops url?": "http://trafficops.infra.ciab.test:3000",
      "config_var": "base_url"
    }
  ],
  "/opt/traffic_ops/app/conf/ldap.conf": [
    {
      "Do you want to set up LDAP?": "no",
      "config_var": "setupLdap"
    }
  ],
  "/opt/traffic_ops/app/conf/production/database.conf": [
    {
      "Database type": "Pg",
      "config_var": "type"
    },
    {
      "Database name": "traffic_ops",
      "config_var": "dbname"
    },
    {
      "Database server hostname IP or FQDN": "db.infra.ciab.test",
      "config_var": "hostname"
    },
    {
      "Database port number": "5432",
      "config_var": "port"
    },
    {
      "Traffic Ops database user": "traffic_ops",
      "config_var": "user"
    },
    {
      "Traffic Ops database password": "twelve",
      "config_var": "password",
      "hidden": "1"
    }
  ],
  "/opt/traffic_ops/app/db/dbconf.yml": [
    {
      "Database server root (admin) username": "traffic_ops",
      "config_var": "pgUser"
    },
    {
      "Database server admin password": "twelve",
      "config_var": "pgPassword",
      "hidden": "1"
    },
    {
      "Download Maxmind Database?": "no",
      "config_var": "maxmind"
    }
  ],
  "/opt/traffic_ops/install/data/json/openssl_configuration.json": [
    {
      "Do you want to generate a certificate?": "yes",
      "config_var": "genCert"
    },
    {
      "Country Name (2 letter code)": "US",
      "config_var": "country"
    },
    {
      "State or Province Name (full name)": "CO",
      "config_var": "state"
    },
    {
      "Locality Name (eg, city)": "Denver",
      "config_var": "locality"
    },
    {
      "Organization Name (eg, company)": "Comcast",
      "config_var": "company"
    },
    {
      "Organizational Unit Name (eg, section)": "Traffic Control",
      "config_var": "org_unit"
    },
    {
      "Common Name (eg, your name or your server's hostname)": "trafficops.infra.ciab.test",
      "config_var": "common_name"
    },
    {
      "RSA Passphrase": "rsapass",
      "config_var": "rsaPassword",
      "hidden": "1"
    }
  ],
  "/opt/traffic_ops/install/data/json/profiles.json": [
    {
      "Traffic Ops url": "https://trafficops.infra.ciab.test",
      "config_var": "tm.url"
    },
    {
      "Human-readable CDN Name.  (No whitespace, please)": "CDN-in-a-Box",
      "config_var": "cdn_name"
    },
    {
      "DNS sub-domain for which your CDN is authoritative": "mycdn.ciab.test",
      "config_var": "dns_subdomain"
    }
  ],
  "/opt/traffic_ops/install/data/json/users.json": [
    {
      "Administration username for Traffic Ops": "admin",
      "config_var": "tmAdminUser"
    },
    {
      "Password for the admin user": "twelve",
      "config_var": "tmAdminPw",
      "hidden": "1"
    }
  ],
  "/opt/traffic_ops/install/data/profiles/": [
    {
      "Add custom profiles?": "no",
      "config_var": "custom_profiles"
    }
  ]
}
JSON_INPUT_FILE
docker cp configuration_file.json $(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/;
docker-compose exec trafficops-perl ../install/bin/_postinstall -a -cfile configuration_file.json;
```
</details>

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (7054433708)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (7054433708, #4587)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->
- [x] This PR includes tests in the [What is the best way to verify this PR?](#user-content-verify-pr) section
- [x] Bugfix, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
