### PR TITLE
Fix retrieval of Delivery Service Regexes

### DIFF
--- a/lib/go-tc/deliveryservice_regexes.go
+++ b/lib/go-tc/deliveryservice_regexes.go
@@ -51,6 +51,12 @@ type DeliveryServiceIDRegex struct {
 	Pattern   string `json:"pattern"`
 }
 
+type DeliveryServiceRegexesTest struct {
+	DSName string `json:"dsName"`
+	DSID   int
+	DeliveryServiceIDRegex
+}
+
 // DeliveryServiceRegexPost holds all of the information necessary to create a
 // new routing regular expression for a delivery service.
 type DeliveryServiceRegexPost struct {

--- a/lib/go-tc/deliveryservice_regexes.go
+++ b/lib/go-tc/deliveryservice_regexes.go
@@ -51,6 +51,7 @@ type DeliveryServiceIDRegex struct {
 	Pattern   string `json:"pattern"`
 }
 
+// Used to represent the entire deliveryservice_regex for testing
 type DeliveryServiceRegexesTest struct {
 	DSName string `json:"dsName"`
 	DSID   int

--- a/traffic_ops/client/deliveryservice_regexes.go
+++ b/traffic_ops/client/deliveryservice_regexes.go
@@ -1,0 +1,41 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	// See: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_id_regexes.html
+	API_DS_REGEXES = apiBase + "/deliveryservices/%v/regexes"
+)
+
+// GetDeliveryServiceRegexesByDSID gets DeliveryServiceRegexes by a DS id
+// also accepts an optional map of query parameters
+func (to *Session) GetDeliveryServiceRegexesByDSID(dsID int, params map[string]string) ([]tc.DeliveryServiceIDRegex, ReqInf, error) {
+	response := struct {
+		Response []tc.DeliveryServiceIDRegex `json:"response"`
+	}{}
+
+	reqInf, err := get(to, fmt.Sprintf(API_DS_REGEXES, dsID)+mapToQueryParameters(params), &response)
+	if err != nil {
+		return []tc.DeliveryServiceIDRegex{}, reqInf, err
+	}
+	return response.Response, reqInf, nil
+}

--- a/traffic_ops/testing/api/v2/deliveryservicesregexes_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservicesregexes_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestDeliveryServicesRegexes(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, DeliveryServicesRegexes}, func() {
-		TestQueryDSRegex(t)
+		QueryDSRegexTest(t)
 	})
 }
 
@@ -113,14 +113,24 @@ func loadDSRegexIDs(t *testing.T, test *tc.DeliveryServiceRegexesTest) {
 	test.DSID = *dses[0].ID
 }
 
-func TestQueryDSRegex(t *testing.T) {
+func QueryDSRegexTest(t *testing.T) {
 	ds, _, err := TOSession.GetDeliveryServiceByXMLIDNullable("ds1")
 	if err != nil {
+		t.Fatalf("unable to get ds ds1: %v", err)
+	}
+	if len(ds) == 0 {
 		t.Fatal("unable to get ds ds1")
 	}
-	dsRegexes, _, err := TOSession.GetDeliveryServiceRegexesByDSID(*ds[0].ID, nil)
+	var dsID int
+	if ds[0].ID == nil {
+		t.Fatal("ds has a nil id")
+	} else {
+		dsID = *ds[0].ID
+	}
+
+	dsRegexes, _, err := TOSession.GetDeliveryServiceRegexesByDSID(dsID, nil)
 	if err != nil {
-		t.Fatal("unable to get ds_regex by id " + strconv.Itoa(*ds[0].ID))
+		t.Fatal("unable to get ds_regex by id " + strconv.Itoa(dsID))
 	}
 	if len(dsRegexes) != 3 {
 		t.Fatal("expected to get 3 ds_regex, got " + strconv.Itoa(len(dsRegexes)))
@@ -128,9 +138,9 @@ func TestQueryDSRegex(t *testing.T) {
 
 	params := make(map[string]string)
 	params["id"] = strconv.Itoa(dsRegexes[0].ID)
-	dsRegexes, _, err = TOSession.GetDeliveryServiceRegexesByDSID(*ds[0].ID, params)
+	dsRegexes, _, err = TOSession.GetDeliveryServiceRegexesByDSID(dsID, params)
 	if err != nil {
-		t.Fatalf("unable to get ds_regex by id %v with query param %v", *ds[0].ID, params["id"])
+		t.Fatalf("unable to get ds_regex by id %v with query param %v", dsID, params["id"])
 	}
 	if len(dsRegexes) != 1 {
 		t.Fatal("expected to get 1 ds_regex, got " + strconv.Itoa(len(dsRegexes)))

--- a/traffic_ops/testing/api/v2/deliveryservicesregexes_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservicesregexes_test.go
@@ -1,3 +1,18 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package v2
 
 import (

--- a/traffic_ops/testing/api/v2/deliveryservicesregexes_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservicesregexes_test.go
@@ -17,6 +17,7 @@ package v2
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -24,6 +25,7 @@ import (
 
 func TestDeliveryServicesRegexes(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices, DeliveryServicesRegexes}, func() {
+		TestQueryDSRegex(t)
 	})
 }
 
@@ -109,4 +111,28 @@ func loadDSRegexIDs(t *testing.T, test *tc.DeliveryServiceRegexesTest) {
 		t.Fatalf("unable to find ds by xmlid %v", test.DSName)
 	}
 	test.DSID = *dses[0].ID
+}
+
+func TestQueryDSRegex(t *testing.T) {
+	ds, _, err := TOSession.GetDeliveryServiceByXMLIDNullable("ds1")
+	if err != nil {
+		t.Fatal("unable to get ds ds1")
+	}
+	dsRegexes, _, err := TOSession.GetDeliveryServiceRegexesByDSID(*ds[0].ID, nil)
+	if err != nil {
+		t.Fatal("unable to get ds_regex by id " + strconv.Itoa(*ds[0].ID))
+	}
+	if len(dsRegexes) != 3 {
+		t.Fatal("expected to get 3 ds_regex, got " + strconv.Itoa(len(dsRegexes)))
+	}
+
+	params := make(map[string]string)
+	params["id"] = strconv.Itoa(dsRegexes[0].ID)
+	dsRegexes, _, err = TOSession.GetDeliveryServiceRegexesByDSID(*ds[0].ID, params)
+	if err != nil {
+		t.Fatalf("unable to get ds_regex by id %v with query param %v", *ds[0].ID, params["id"])
+	}
+	if len(dsRegexes) != 1 {
+		t.Fatal("expected to get 1 ds_regex, got " + strconv.Itoa(len(dsRegexes)))
+	}
 }

--- a/traffic_ops/testing/api/v2/tc-fixtures.json
+++ b/traffic_ops/testing/api/v2/tc-fixtures.json
@@ -705,6 +705,18 @@
             "typeName": "HOST_REGEXP",
             "setNumber": 1,
             "pattern" : ".*"
+        },
+        {
+            "dsName": "ds1",
+            "typeName": "HOST_REGEXP",
+            "setNumber": 2,
+            "pattern" : "\\d+"
+        },
+        {
+            "dsName": "ds2",
+            "typeName": "HOST_REGEXP",
+            "setNumber": 1,
+            "pattern" : ".*"
         }
     ],
     "deliveryservicesRequiredCapabilities": [

--- a/traffic_ops/testing/api/v2/tc-fixtures.json
+++ b/traffic_ops/testing/api/v2/tc-fixtures.json
@@ -699,6 +699,14 @@
             "anonymousBlockingEnabled": true
         }
     ],
+    "deliveryServicesRegexes": [
+        {
+            "dsName": "ds1",
+            "typeName": "HOST_REGEXP",
+            "setNumber": 1,
+            "pattern" : ".*"
+        }
+    ],
     "deliveryservicesRequiredCapabilities": [
         {
             "xmlID": "ds1",

--- a/traffic_ops/testing/api/v2/traffic_control_test.go
+++ b/traffic_ops/testing/api/v2/traffic_control_test.go
@@ -27,6 +27,7 @@ type TrafficControl struct {
 	CacheGroupParameterRequests          []tc.CacheGroupParameterRequest         `json:"cachegroupParameters"`
 	Capabilities                         []tc.Capability                         `json:"capability"`
 	Coordinates                          []tc.Coordinate                         `json:"coordinates"`
+	DeliveryServicesRegexes              []tc.DeliveryServiceRegexesTest         `json:"deliveryServicesRegexes"`
 	DeliveryServiceRequests              []tc.DeliveryServiceRequest             `json:"deliveryServiceRequests"`
 	DeliveryServiceRequestComments       []tc.DeliveryServiceRequestComment      `json:"deliveryServiceRequestComments"`
 	DeliveryServices                     []tc.DeliveryService                    `json:"deliveryservices"`

--- a/traffic_ops/testing/api/v2/withobjs_test.go
+++ b/traffic_ops/testing/api/v2/withobjs_test.go
@@ -43,6 +43,7 @@ const (
 	CDNFederations
 	Coordinates
 	DeliveryServices
+	DeliveryServicesRegexes
 	DeliveryServiceRequests
 	DeliveryServiceRequestComments
 	DeliveryServicesRequiredCapabilities
@@ -82,6 +83,7 @@ var withFuncs = map[TCObj]TCObjFuncs{
 	CDNFederations:                       {CreateTestCDNFederations, DeleteTestCDNFederations},
 	Coordinates:                          {CreateTestCoordinates, DeleteTestCoordinates},
 	DeliveryServices:                     {CreateTestDeliveryServices, DeleteTestDeliveryServices},
+	DeliveryServicesRegexes:              {CreateTestDeliveryServicesRegexes, DeleteTestDeliveryServicesRegexes},
 	DeliveryServiceRequests:              {CreateTestDeliveryServiceRequests, DeleteTestDeliveryServiceRequests},
 	DeliveryServiceRequestComments:       {CreateTestDeliveryServiceRequestComments, DeleteTestDeliveryServiceRequestComments},
 	DeliveryServicesRequiredCapabilities: {CreateTestDeliveryServicesRequiredCapabilities, DeleteTestDeliveryServicesRequiredCapabilities},

--- a/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
@@ -112,7 +112,7 @@ JOIN type as rt ON r.type = rt.id
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("getting accessible tenants for user - %v", err))
 	}
-	if len(where) == 0 {
+	if len(where) > 0 {
 		where += " AND ds.tenant_id = ANY(:tenants) "
 	} else {
 		where = dbhelpers.BaseWhere + " ds.tenant_id = ANY(:tenants) "
@@ -120,6 +120,7 @@ JOIN type as rt ON r.type = rt.id
 	queryValues["tenants"] = pq.Array(accessibleTenants)
 
 	query := q + where + " ORDER BY dsr.set_number ASC" + pagination
+
 	rows, err := inf.Tx.NamedQuery(query, queryValues)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("querying deliveryserviceregexes get: "+err.Error()))


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4602 

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Control Client <!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Ops

## What is the best way to verify this PR?
Run TO tests, verify `deliveryservices/{id}/regexes` works with both query and path parameters.
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
