### PR TITLE
Fix nil pointer dereference in sslkeys/add validation

### DIFF
--- a/lib/go-tc/deliveryservice_ssl_keys.go
+++ b/lib/go-tc/deliveryservice_ssl_keys.go
@@ -64,7 +64,7 @@ type DeliveryServiceSSLKeysV15 struct {
 }
 
 type DeliveryServiceSSLKeysReq struct {
-	AuthType        *string `json:authType,omitempty`
+	AuthType        *string `json:"authType,omitempty"`
 	CDN             *string `json:"cdn,omitempty"`
 	DeliveryService *string `json:"deliveryservice,omitempty"`
 	BusinessUnit    *string `json:"businessUnit,omitempty"`
@@ -137,7 +137,7 @@ func (r *DeliveryServiceAddSSLKeysReq) Validate(tx *sql.Tx) error {
 		if r.Certificate.Crt == "" {
 			errs = append(errs, "certificate.crt required")
 		}
-		if r.Certificate.CSR == "" && *r.AuthType != LetsEncryptAuthType {
+		if r.Certificate.CSR == "" && (r.AuthType == nil || *r.AuthType != LetsEncryptAuthType) {
 			errs = append(errs, "certificate.csr required")
 		}
 	}

--- a/lib/go-tc/deliveryservicesslkeys_test.go
+++ b/lib/go-tc/deliveryservicesslkeys_test.go
@@ -22,6 +22,8 @@ package tc
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-util"
 )
 
 // - Perl: 2018-08-21+14:26:06
@@ -90,5 +92,22 @@ func TestCDNDNSSECGenerateReqDateUnmarshalJSON(t *testing.T) {
 	s = `{"d": 42.0}`
 	if err := json.Unmarshal([]byte(s), &obj); err == nil {
 		t.Fatalf("unmarshalling invalid float CDNDNSSECGenerateReqDate: error expected, actual nil")
+	}
+}
+
+func TestSSLKeysReqValidate(t *testing.T) {
+	req := DeliveryServiceAddSSLKeysReq{}
+	req.CDN = util.StrPtr("foo")
+	req.DeliveryService = util.StrPtr("bar")
+	req.Key = util.StrPtr("bar")
+	ver := util.JSONIntStr(1)
+	req.Version = &ver
+	cert := DeliveryServiceSSLKeysCertificate{}
+	cert.Crt = ""
+	cert.CSR = ""
+	cert.Key = ""
+	req.Certificate = &cert
+	if err := req.Validate(nil); err == nil {
+		t.Error("expected validation to return an error")
 	}
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
If a request does not contain a CSR _and_ `authType` is nil, TO will dereference the nil pointer and panic, causing it to return a 500 internal server error. This fixes the validation to check for a nil pointer and return a proper 400 bad request.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Run the unit tests, verify they pass.

Example `curl` request that would 500 before but should now 400:
```
curl -kvs -H "$MOJO_COOKIE" -XPOST -d'{"key":"foo-ds","version":1,"certificate":{"crt":"","key":"","csr":""},"expiration":"0001-01-01T00:00:00Z","hostname":"*.foo-ds.mycdn.example.com","cdn":"foo-cdn","deliveryservice":"foo-ds"}' "https://<insert TO FQDN here>/api/2.0/deliveryservices/sslkeys/add"
```

## If this is a bug fix, what versions of Traffic Control are affected?

- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] Bugfix, docs not necessary
- [x] Bug was not released, so changelog is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
