### PR TITLE
Use prebuilt images to build Traffic Control components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added ability to create multiple objects from generic API Create with a single POST.
 - Added debugging functionality to CDN-in-a-Box.
 - Added an SMTP server to CDN-in-a-Box.
+- Cached builder Docker images on Docker Hub to speed up build time
 - Traffic Ops Golang Endpoints
   - /api/2.0 for all of the most recent route versions
   - /api/1.1/cachegroupparameters/{{cachegroupID}}/{{parameterID}} `(DELETE)`

--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -19,67 +19,67 @@ version: '2'
 
 services:
   source:
-    image: trafficcontrol_tarball
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-source
-      context: ../../..
+    image: trafficcontrol/source_tarballer
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-source
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
 
   traffic_monitor_build:
-    image: traffic_monitor_builder
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-traffic_monitor
-      context: ../../..
+    image: trafficcontrol/traffic_monitor_builder
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_monitor
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
 
   traffic_ops_build:
-    image: traffic_ops_builder
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-traffic_ops
-      context: ../../..
+    image: trafficcontrol/traffic_ops_builder
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_ops
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
 
   traffic_portal_build:
-    image: traffic_portal_builder
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-traffic_portal
-      context: ../../..
+    image: trafficcontrol/traffic_portal_builder
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_portal
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
 
   traffic_router_build:
-    image: traffic_router_builder
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-traffic_router
-      context: ../../..
+    image: trafficcontrol/traffic_router_builder
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_router
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
       - ../../../.m2:/root/.m2:z
 
   traffic_stats_build:
-    image: traffic_stats_builder
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-traffic_stats
-      context: ../../..
+    image: trafficcontrol/traffic_stats_builder
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_stats
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
 
   grove_build:
-    image: grove_builder
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-grove
-      context: ../../..
+    image: trafficcontrol/grove_builder
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-grove
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
 
   grovetccfg_build:
-    image: grovetccfg_builder
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-grovetccfg
-      context: ../../..
+    image: trafficcontrol/grovetccfg_builder
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-grovetccfg
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
 
@@ -90,9 +90,9 @@ services:
     command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']
 
   docs:
-    image: docs_builder
-    build:
-      dockerfile: infrastructure/docker/build/Dockerfile-docs
-      context: ../../..
+    image: trafficcontrol/docs_builder
+    #build:
+    #  dockerfile: infrastructure/docker/build/Dockerfile-docs
+    #  context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z

--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -19,7 +19,7 @@ version: '2'
 
 services:
   source:
-    image: trafficcontrol/source_tarballer
+    image: trafficcontrol/source_tarballer:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-source
     #  context: ../../..
@@ -27,7 +27,7 @@ services:
       - ../../..:/trafficcontrol:z
 
   traffic_monitor_build:
-    image: trafficcontrol/traffic_monitor_builder
+    image: trafficcontrol/traffic_monitor_builder:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_monitor
     #  context: ../../..
@@ -35,7 +35,7 @@ services:
       - ../../..:/trafficcontrol:z
 
   traffic_ops_build:
-    image: trafficcontrol/traffic_ops_builder
+    image: trafficcontrol/traffic_ops_builder:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_ops
     #  context: ../../..
@@ -43,7 +43,7 @@ services:
       - ../../..:/trafficcontrol:z
 
   traffic_portal_build:
-    image: trafficcontrol/traffic_portal_builder
+    image: trafficcontrol/traffic_portal_builder:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_portal
     #  context: ../../..
@@ -51,7 +51,7 @@ services:
       - ../../..:/trafficcontrol:z
 
   traffic_router_build:
-    image: trafficcontrol/traffic_router_builder
+    image: trafficcontrol/traffic_router_builder:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_router
     #  context: ../../..
@@ -60,7 +60,7 @@ services:
       - ../../../.m2:/root/.m2:z
 
   traffic_stats_build:
-    image: trafficcontrol/traffic_stats_builder
+    image: trafficcontrol/traffic_stats_builder:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-traffic_stats
     #  context: ../../..
@@ -68,7 +68,7 @@ services:
       - ../../..:/trafficcontrol:z
 
   grove_build:
-    image: trafficcontrol/grove_builder
+    image: trafficcontrol/grove_builder:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-grove
     #  context: ../../..
@@ -76,7 +76,7 @@ services:
       - ../../..:/trafficcontrol:z
 
   grovetccfg_build:
-    image: trafficcontrol/grovetccfg_builder
+    image: trafficcontrol/grovetccfg_builder:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-grovetccfg
     #  context: ../../..
@@ -90,7 +90,7 @@ services:
     command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']
 
   docs:
-    image: trafficcontrol/docs_builder
+    image: trafficcontrol/docs_builder:master
     #build:
     #  dockerfile: infrastructure/docker/build/Dockerfile-docs
     #  context: ../../..


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR:
    - Adds docker tags for prebuilt builder images to the build docker-compose.yml
    - is not related to any issue<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
    
Right now, building the RPMs requires first building the builder images, which takes 8.67 minutes on my Linux machine but almost certainly longer on MacOS. Since the builder images are mainly just yum installs, we can use prebuilt Docker images without losing flexibility in terms of the code in each component.

Besides time saved, the other benefit of using prebuilt builder images is that it improves CI reliability in that CI pipelines would no longer fail in cases where installing yum packages fails.

I left commented-out `build` fields in the docker-compose.yml for cases where someone wants to test a new builder image (e.g., new Go version).

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Build system

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run `./pkg -v` to verify that all of the components still build.

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->
- [x] Docker environment update, no tests necessary
- [x] Builders are not mentioned in the documentation, no docs change necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
