### PR TITLE
Fix ORT Reval getting DSS when it doesn't need it

### DIFF
--- a/traffic_ops/ort/atstccfg/cfgfile/cfgfile.go
+++ b/traffic_ops/ort/atstccfg/cfgfile/cfgfile.go
@@ -301,10 +301,10 @@ func GetTOData(cfg config.TCCfg) (*config.TOData, error) {
 		return nil
 	}
 
-	fs := []func() error{dssF, serversF, cgF, scopeParamsF, jobsF}
+	fs := []func() error{serversF, cgF, scopeParamsF, jobsF}
 	if !cfg.RevalOnly {
 		// skip data not needed for reval, if we're reval-only
-		fs = append([]func() error{dsrF, cacheKeyParamsF, parentConfigParamsF, capsF, dsCapsF}, fs...)
+		fs = append([]func() error{dssF, dsrF, cacheKeyParamsF, parentConfigParamsF, capsF, dsCapsF}, fs...)
 	}
 	errs := runParallel(fs)
 	return toData, util.JoinErrs(errs)


### PR DESCRIPTION
This is a large scalability increase for ORT Reval mode.

Reval doesn't actually need DSS. The meta needs it, but only for
config files that aren't regex_revalidate.config.

This is a big load decrease on TO, for many servers doing revals
at once.

I manually tested, generation is identical. Both edges and mids generate identical with and without this change. Files diff identical except for the timestamp header and random multipart boundary.

No tests, this is in the TO request part of ORT, and ORT doesn't have a Integration Test Framework yet.
No docs, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT, in both Reval and syncds mode, verify output has not changed. 

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information