### PR TITLE
Dsstats math fix

### DIFF
--- a/docs/source/api/v1/deliveryservice_stats.rst
+++ b/docs/source/api/v1/deliveryservice_stats.rst
@@ -143,7 +143,7 @@ Response Structure
 	:min:                    The minimum value that can be found in the requested data set
 	:ninetyEighthPercentile: Data points with values greater than or equal to this number constitute the "top" 2% of the data set
 	:ninetyFifthPercentile:  Data points with values greater than or equal to this number constitute the "top" 5% of the data set
-	:totalBytes:             When the ``metricType`` requested is ``kbps``, this will contain the total number of bytes transferred by the :term:`Delivery Service` within the requested time window. Note that fractional amounts are possible, as the data transfer rate will almost certainly not be cleanly divided by the requested time range.
+	:totalBytes:             When the ``metricType`` requested is ``kbps``, this will contain the total number of *kilobytes* - **not** *bytes* - transferred by the :term:`Delivery Service` within the requested time window. Note that fractional amounts are possible, as the data transfer rate will almost certainly not be cleanly divided by the requested time range.
 	:totalTransactions:      When the ``metricType`` requested is **not** ``kbps``, this will contain the total number of transactions completed by the :term:`Delivery Service` within the requested time window. Note that fractional amounts are possible, as the transaction rate will almost certainly not be cleanly divided by the requested time range.
 
 :version: A legacy field that seems to have been meant to indicate the API version used. Will always be "1.2"

--- a/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
@@ -277,7 +277,8 @@ func getDSSummary(client *influx.Client, conf *tc.TrafficDSStatsConfig, db strin
 
 	value := float64(s.Count*60) * s.Average
 	if conf.MetricType == "kbps" {
-		value /= 1000
+		// TotalBytes is actually in units of kB....
+		value /= 8
 		s.TotalBytes = &value
 	} else {
 		s.TotalTransactions = &value


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue.

When `/deliveryservice_stats` was written, an apparent math error was "corrected"
by making `totalBytes` contain the actual total number of bytes transferred for the
requested Delivery Service. However, historically the "error" was simply because the
field named "totalBytes" in fact contained kilobytes.

This PR changes the logic such that this is once again true, and updates the
documentation accordingly (v1 only, field name change PR pending for v2).

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Run a CDN, verify that stats output makes sense with kilobytes in the totalBytes field
of `/deliveryservice_stats` output.

## If this is a bug fix, what versions of Traffic Control are affected?
- 4.0

This should probably get backported to 4.0 at some point.

## The following criteria are ALL met by this PR

- [x] Tests for endpoints depending on external services don't exist
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**
