### PR TITLE
Fix /users/register DB query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Fix to traffic_ops_ort.pl to strip specific comment lines before checking if a file has changed.  Also promoted a changed file message from DEBUG to ERROR for report mode.
 - Fixed Traffic Portal regenerating CDN DNSSEC keys with the wrong effective date
+- Fixed issue #4583: POST /users/register internal server error caused by failing DB query
 - Type mutation through the api is now restricted to only those types that apply to the "server" table
 - Updated The Traffic Ops Python, Go and Java clients to use API version 2.0 (when possible)
 - Updated CDN-in-a-Box scripts and enroller to use TO API version 2.0

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -99,7 +99,11 @@ type User struct {
 	RegistrationSent     *TimeNoMod `json:"registrationSent" db:"registration_sent"`
 	LocalPassword        *string    `json:"localPasswd,omitempty" db:"local_passwd"`
 	ConfirmLocalPassword *string    `json:"confirmLocalPasswd,omitempty" db:"confirm_local_passwd"`
-	RoleName             *string    `json:"roleName,omitempty" db:"-"`
+	// NOTE: RoleName db:"-" tag is required due to clashing with the DB query here:
+	// https://github.com/apache/trafficcontrol/blob/3b5dd406bf1a0bb456c062b0f6a465ec0617d8ef/traffic_ops/traffic_ops_golang/user/user.go#L197
+	// It's done that way in order to maintain "rolename" vs "roleName" JSON field capitalization for the different users APIs.
+	// TODO: make the breaking API change to make all user APIs use "roleName" consistently.
+	RoleName *string `json:"roleName,omitempty" db:"-"`
 	commonUserFields
 }
 

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -208,7 +208,7 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 
 	var role string
 	var tenant string
-	user, exists, err := dbhelpers.GetUserByEmail(inf.Tx, req.Email.Address.Address)
+	user, exists, err := dbhelpers.GetUserByEmail(req.Email.Address.Address, inf.Tx.Tx)
 	if err != nil {
 		errCode = http.StatusInternalServerError
 		sysErr = fmt.Errorf("Checking for existing user with email %s: %v", req.Email, err)


### PR DESCRIPTION
## What does this PR (Pull Request) do?

The query was failing with the following:

    missing destination name rolename in *tc.User

This indicates that the struct was missing a "db:rolename" tag for that
field, but simply adding that tag would break the /users API due to it
using a special struct for GetUsers.

Instead, convert from sqlx.StructScan to plain sql.Scan, which avoids
any unintended side-effects caused by changing the User struct tags.

Fixes #4583.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
The the TO API v1 and v2 tests, verify they still pass. Manually register a new user, verify that TO gets to at least the point where the email _would_ be sent if SMTP was enabled. If not enabled, you should see this expected error in the TO API logs instead of the DB query failure:

    SMTP is not enabled; mail cannot be sent

That means it got past the DB error in #4583, but ideally, this would be manually verified in an environment that has SMTP enabled.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.0

## The following criteria are ALL met by this PR

- [x] Existing TO API tests cover most of this functionality, but they don't support email
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)