### PR TITLE
Fix /jobs query params

### DIFF
--- a/traffic_ops/testing/api/v2/tc-fixtures.json
+++ b/traffic_ops/testing/api/v2/tc-fixtures.json
@@ -2582,6 +2582,14 @@
             }
         },
         {
+            "dsName": "ds2",
+            "request": {
+                "startTime": "2019-01-01 00:00:00",
+                "ttl": 80,
+                "regex": "/bar"
+            }
+        },
+        {
             "dsName": "ds1",
             "request": {
                 "startTime": "2019-01-01 00:00:00",

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -220,7 +220,7 @@ func (job *InvalidationJob) Read() ([]interface{}, error, error, int) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting accessible tenants for user - %v", err), http.StatusInternalServerError
 	}
-	if len(where) == 0 {
+	if len(where) > 0 {
 		where += " AND ds.tenant_id = ANY(:tenants) "
 	} else {
 		where = dbhelpers.BaseWhere + " ds.tenant_id = ANY(:tenants) "


### PR DESCRIPTION


## What does this PR (Pull Request) do?
Fix the logic that sets the WHERE clause so that the additions for query
params are kept in the query.

- [x] This PR fixes #4646

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Run the TO API v1 and v2 tests, verify they pass.

## If this is a bug fix, what versions of Traffic Control are affected?

- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] bugfix, no docs necessary
- [x] bug not released, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
