### PR TITLE
Fixed logging.yaml generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Ops, Traffic Monitor, Traffic Stats, and Grove are now compiled using Go version 1.14. This requires a Traffic Vault config update (see note below).
 - Existing installations **must** enable TLSv1.1 for Traffic Vault in order for Traffic Ops to reach it. See [Enabling TLS 1.1](https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_vault.html#tv-admin-enable-tlsv1-1) in the Traffic Vault administrator's guide for instructions.
 - Changed the `totalBytes` property of responses to GET requests to `/deliveryservice_stats` to the more appropriate `totalKiloBytes` in API 2.x
+- Fix to traffic_ops_ort to generate logging.yaml files correctly.
 
 ### Deprecated/Removed
 - The Traffic Ops `db/admin.pl` script has now been removed. Please use the `db/admin` binary instead.

--- a/lib/go-atscfg/loggingdotyaml.go
+++ b/lib/go-atscfg/loggingdotyaml.go
@@ -81,6 +81,7 @@ func MakeLoggingDotYAML(
 		}
 	}
 
+	var firstObject = true
 	for i := 0; i < maxLogObjects; i++ {
 		logObjectField := "LogObject"
 		if i > 0 {
@@ -99,7 +100,10 @@ func MakeLoggingDotYAML(
 			logObjectRollingSizeMb := paramData[logObjectField+".RollingSizeMb"]
 			logObjectFilters := paramData[logObjectField+".Filters"]
 
-			text += "\nlogs:\n"
+			if firstObject {
+				text += "\nlogs:\n"
+				firstObject = false
+			}
 			text += "- mode: " + logObjectType + "\n"
 			text += "  filename: " + logObjectFilename + "\n"
 			text += "  format: " + logObjectFormat + "\n"

--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -188,6 +188,7 @@ func getScope(cfgFile string, scopeParams map[string]string) tc.ATSConfigMetaDat
 		cfgFile == "drop_qstring.config",
 		cfgFile == "logs_xml.config",
 		cfgFile == "logging.config",
+		cfgFile == "logging.yaml",
 		cfgFile == "plugin.config",
 		cfgFile == "records.config",
 		cfgFile == "storage.config",


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?

The logging.yaml file was generating a separate logs section for each
log file. This was allowing the yaml parser in ATS to accept the file,
but fail to process any but one of the log files. This corrects that by
putting all the logs in the same object.
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any existing open issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops ORT

This does not change any existing functionality, it just updates the generation to be correct and to match the existing documentation.

## What is the best way to verify this PR?
Run ORT against a Traffic Ops instance to generate a config files for a cache that has multiple logging formats configured in a logging.yaml file.

Additionally, this functionality is verified in a unit test as part of lib/go-atscfg, so those unit tests should run and pass.
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

## If this is a bug fix, what versions of Traffic Control are affected?
This fixes a bug that was copied from Traffic Ops in Perl. So no version of Traffic Ops has ever properly rendered this file.
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] An update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
