### PR TITLE
Ds Active flag blueprint

### DIFF
--- a/blueprints/ds-active.md
+++ b/blueprints/ds-active.md
@@ -283,3 +283,14 @@ before then clients using Cache Servers for ongoing content delivery will be
 unaffected by the change. This allows operators to "drain" a Delivery Service
 for a while before setting it to "INACTIVE" and removing it from Cache Server
 configuration, thus minimizing client impact.
+
+Another that has been brought up is changing the name of the current `active`
+field to be `active-routed`, which would mean that Delivery Service will be
+routed, and adding another field called `active-cached` which would mean that
+the Delivery Service's configuration would be disseminated to the cache
+servers. Thus the same amount of flexibility could be achieved without making a
+breaking API change.
+
+The trade-off is that it would allow Delivery Services to be in a state where
+Traffic Router will direct clients to cache servers which are incapable of
+properly serving them content.

--- a/blueprints/ds-active.md
+++ b/blueprints/ds-active.md
@@ -104,6 +104,47 @@ that have `Active` values of `true` are returned. This must instead change to
 all those that are **NOT** `INACTIVE` and an `active` field must be added to
 the representations containing their "Activity State" value.
 
+##### `/cdns/{{CDN Name}}/snapshot/new`
+The Delivery Service representations returned by this endpoint are filtered
+such that - among other criteria - only those that have `Active` values of
+`true` are returned. This must instead change to all those that have `Active`
+values of "ACTIVE".
+
+No structural changes to the response payloads are strictly necessary, though
+this author would strongly encourage whoever implements the changes add the
+`active` field to the Delivery Service representations returned by this
+endpoint to help move us toward a single, unified representations of objects,
+and because it's a relatively small change to sneak in.
+
+##### `/snapshot`
+This endpoint currently creates Snapshots by selecting Delivery Services that
+are filtered such that - among other criteria - only those that have `Active`
+values of `true` are put into the newly created Snapshot. This must instead
+change to all those that have `Active` values of "Active".
+
+No structural changes to the response payloads are strictly necessary, though
+this author would suggest that whoever implements the changes take this
+opportunity to change the payload structure to conform to the API Guidelines
+(success messages belong in `success`-level Alerts, not as response objects).
+
+##### `/deliveryservices`
+The `active` property of objects returned by this endpoints methods is
+currently a boolean, and it must change to reflect the new enumerated string
+constant type described above.
+
+Furthermore, input objects must be parsed in accordance with the new type of
+the `active` property. If an input is given with any value that is not one of
+the enumerated string constants described above, the endpoint MUST respond with
+a 400 Bad Request error response, accompanied by an `error`-level Alert that
+explains why the request was rejected.
+
+##### `/deliveryservices/{{ID}}`
+Requires the same changes as `/deliveryservices`.
+
+##### `/deliveryservices/{{ID}}/safe`
+Requires the same changes as `/deliveryservices`, except that no changes are
+necessary to the processing of its inputs.
+
 #### Client Impact
 <!--
 *How* will this impact Traffic Ops REST API clients (Go, Python, Java)?

--- a/blueprints/ds-active.md
+++ b/blueprints/ds-active.md
@@ -1,0 +1,208 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+# Delivery Services 'Active' field
+
+## Problem Description
+<!--
+*What* is being asked for?
+*Why* is this necessary?
+*How* will this be used?
+-->
+
+## Proposed Change
+<!--
+*How* will this be implemented (at a high level)?
+-->
+
+### Traffic Portal Impact
+<!--
+*How* will this impact Traffic Portal?
+What new UI changes will be required?
+Will entirely new pages/views be necessary?
+Will a new field be added to an existing form?
+How will the user interact with the new UI changes?
+-->
+
+### Traffic Ops Impact
+<!--
+*How* will this impact Traffic Ops (at a high level)?
+-->
+
+#### REST API Impact
+<!--
+*How* will this impact the Traffic Ops REST API?
+
+What new endpoints will be required?
+How will existing endpoints be changed?
+What will the requests and responses look like?
+What fields are required or optional?
+What are the defaults for optional fields?
+What are the validation constraints?
+-->
+
+#### Client Impact
+<!--
+*How* will this impact Traffic Ops REST API clients (Go, Python, Java)?
+
+If new endpoints are required, will corresponding client methods be added?
+-->
+
+#### Data Model / Database Impact
+<!--
+*How* will this impact the Traffic Ops data model?
+*How* will this impact the Traffic Ops database schema?
+
+What changes to the lib/go-tc structs will be required?
+What new tables and columns will be required?
+How will existing tables and columns be changed?
+What are the column data types and modifiers?
+What are the FK references and constraints?
+-->
+
+### ORT Impact
+<!--
+*How* will this impact ORT?
+-->
+
+### Traffic Monitor Impact
+<!--
+*How* will this impact Traffic Monitor?
+
+Will new profile parameters be required?
+-->
+
+### Traffic Router Impact
+<!--
+*How* will this impact Traffic Router?
+
+Will new profile parameters be required?
+How will the CRConfig be changed?
+How will changes in Traffic Ops data be reflected in the CRConfig?
+Will Traffic Router remain backwards-compatible with old CRConfigs?
+Will old Traffic Routers remain forwards-compatible with new CRConfigs?
+-->
+
+### Traffic Stats Impact
+<!--
+*How* will this impact Traffic Stats?
+-->
+
+### Traffic Vault Impact
+<!--
+*How* will this impact Traffic Vault?
+
+Will there be any new data stored in or removed from Riak?
+Will there be any changes to the Riak requests and responses?
+-->
+
+### Documentation Impact
+<!--
+*How* will this impact the documentation?
+
+What new documentation will be required?
+What existing documentation will need to be updated?
+-->
+
+### Testing Impact
+<!--
+*How* will this impact testing?
+
+What is the high-level test plan?
+How should this be tested?
+Can this be tested within the existing test frameworks?
+How should the existing frameworks be enhanced in order to test this properly?
+-->
+
+### Performance Impact
+<!--
+*How* will this impact performance?
+
+Are the changes expected to improve performance in any way?
+Is there anything particularly CPU, network, or storage-intensive to be aware of?
+What are the known bottlenecks to be aware of that may need to be addressed?
+-->
+
+### Security Impact
+<!--
+*How* will this impact overall security?
+
+Are there any security risks to be aware of?
+What privilege level is required for these changes?
+Do these changes increase the attack surface (e.g. new untrusted input)?
+How will untrusted input be validated?
+If these changes are used maliciously or improperly, what could go wrong?
+Will these changes adhere to multi-tenancy?
+Will data be protected in transit (e.g. via HTTPS or TLS)?
+Will these changes require sensitive data that should be encrypted at rest?
+Will these changes require handling of any secrets?
+Will new SQL queries properly use parameter binding?
+-->
+
+### Upgrade Impact
+<!--
+*How* will this impact the upgrade of an existing system?
+
+Will a database migration be required?
+Do the various components need to be upgraded in a specific order?
+Will this affect the ability to rollback an upgrade?
+Are there any special steps to be followed before an upgrade can be done?
+Are there any special steps to be followed during the upgrade?
+Are there any special steps to be followed after the upgrade is complete?
+-->
+
+### Operations Impact
+<!--
+*How* will this impact overall operation of the system?
+
+Will the changes make it harder to operate the system?
+Will the changes introduce new configuration that will need to be managed?
+Can the changes be easily automated?
+Do the changes have known limitations or risks that operators should be made aware of?
+Will the changes introduce new steps to be followed for existing operations?
+-->
+
+### Developer Impact
+<!--
+*How* will this impact other developers?
+
+Will it make it easier to set up a development environment?
+Will it make the code easier to maintain?
+What do other developers need to know about these changes?
+Are the changes straightforward, or will new developer instructions be necessary?
+-->
+
+## Alternatives
+<!--
+What are some of the alternative solutions for this problem?
+What are the pros and cons of each approach?
+What design trade-offs were made and why?
+-->
+
+## Dependencies
+<!--
+Are there any significant new dependencies that will be required?
+How were the dependencies assessed and chosen?
+How will the new dependencies be managed?
+Are the dependencies required at build-time, run-time, or both?
+-->
+
+## References
+<!--
+Include any references to external links here.
+-->

--- a/blueprints/ds-active.md
+++ b/blueprints/ds-active.md
@@ -116,17 +116,6 @@ this author would strongly encourage whoever implements the changes add the
 endpoint to help move us toward a single, unified representations of objects,
 and because it's a relatively small change to sneak in.
 
-##### `/snapshot`
-This endpoint currently creates Snapshots by selecting Delivery Services that
-are filtered such that - among other criteria - only those that have `Active`
-values of `true` are put into the newly created Snapshot. This must instead
-change to all those that have `Active` values of "Active".
-
-No structural changes to the response payloads are strictly necessary, though
-this author would suggest that whoever implements the changes take this
-opportunity to change the payload structure to conform to the API Guidelines
-(success messages belong in `success`-level Alerts, not as response objects).
-
 ##### `/deliveryservices`
 The `active` property of objects returned by this endpoints methods is
 currently a boolean, and it must change to reflect the new enumerated string
@@ -138,6 +127,10 @@ the enumerated string constants described above, the endpoint MUST respond with
 a 400 Bad Request error response, accompanied by an `error`-level Alert that
 explains why the request was rejected.
 
+Finally, these changes must exist only in API v3. API v2 and lower must
+coalesce "ACTIVE" to `true` and either other value to `false` in output and
+perform the reverse operation on inputs to POST and PUT methods.
+
 ##### `/deliveryservices/{{ID}}`
 Requires the same changes as `/deliveryservices`.
 
@@ -145,153 +138,148 @@ Requires the same changes as `/deliveryservices`.
 Requires the same changes as `/deliveryservices`, except that no changes are
 necessary to the processing of its inputs.
 
+##### `/servers/{{ID}}/deliveryservices`
+Requires the same changes as `/deliveryservices`.
+
+##### `/snapshot`
+This endpoint currently creates Snapshots by selecting Delivery Services that
+are filtered such that - among other criteria - only those that have `Active`
+values of `true` are put into the newly created Snapshot. This must instead
+change to all those that have `Active` values of "Active".
+
+No structural changes to the response payloads are strictly necessary, though
+this author would suggest that whoever implements the changes take this
+opportunity to change the payload structure to conform to the API Guidelines
+(success messages belong in `success`-level Alerts, not as response objects).
+
+##### `/users/{{ID}}/deliveryservices`
+This legacy endpoint must be updated to handle the new data as stored in the
+database by coalescing "ACTIVE" to `true` and either other value to `false` in
+its response payload objects. Unless somehow by the time this comes around
+we've managed to get rid of API 1.x, which is the only version implementing
+this endpoint.
+
 #### Client Impact
-<!--
-*How* will this impact Traffic Ops REST API clients (Go, Python, Java)?
+Clients at or below API v2 should not need to change. The latest client version
+will change what structures it returns, but need not change functionally.
 
-If new endpoints are required, will corresponding client methods be added?
--->
-
-#### Data Model / Database Impact
-<!--
-*How* will this impact the Traffic Ops data model?
-*How* will this impact the Traffic Ops database schema?
-
-What changes to the lib/go-tc structs will be required?
-What new tables and columns will be required?
-How will existing tables and columns be changed?
-What are the column data types and modifiers?
-What are the FK references and constraints?
--->
+And the Python client, of course, is unstructured and so is unaffected.
 
 ### ORT Impact
-<!--
-*How* will this impact ORT?
--->
+`atstccfg` will need to change handling of logic for generating Delivery
+Service-based configuration to only consider Delivery Services that are
+"ACTIVE" or "PRIMED" using the latest (API v3-based) client instead of the old
+boolean-valued `active` flag.
 
 ### Traffic Monitor Impact
-<!--
-*How* will this impact Traffic Monitor?
+Traffic Monitor will need to update its polling logic to be able to parse
+payloads from the `/cdns/{{CDN Name}}/configs/monitoring` endpoint that have
+been modified as stated above. This should be done in a backward-compatible
+manner, such that it can parse either that format or the old, APIv2 format.
 
-Will new profile parameters be required?
--->
+## Documentation Impact
+For every endpoint that has been modified, accompanying documentation changes
+must be made. Further, the description of the `Active` property of a Delivery
+Service in the Delivery Services overview section must change to reflect the
+new type of that property.
 
-### Traffic Router Impact
-<!--
-*How* will this impact Traffic Router?
+## Testing Impact
+All Traffic Ops API changes should be accompanied by associated client/API
+integration tests, and Traffic Monitor's ability to parse the new payload
+format in a backward-compatible manner should be accompanied by a corresponding
+test.
 
-Will new profile parameters be required?
-How will the CRConfig be changed?
-How will changes in Traffic Ops data be reflected in the CRConfig?
-Will Traffic Router remain backwards-compatible with old CRConfigs?
-Will old Traffic Routers remain forwards-compatible with new CRConfigs?
--->
+When Traffic Portal is updated to make use of the newest API version its
+associated UI changes should be accompanied by associated one or more tests.
 
-### Traffic Stats Impact
-<!--
-*How* will this impact Traffic Stats?
--->
+## Performance Impact
+This should positively impact performance in some cases where a Cache Server is
+assigned to/within a Topology used by a Delivery Service that is "INACTIVE",
+which was previously a concept that was incapable of being expressed by Traffic
+Control. Thus, some configuration generation work may be avoided.
 
-### Traffic Vault Impact
-<!--
-*How* will this impact Traffic Vault?
+## Security Impact
+> _"Are there any security risks to be aware of?"_
 
-Will there be any new data stored in or removed from Riak?
-Will there be any changes to the Riak requests and responses?
--->
+No, I don't believe so.
 
-### Documentation Impact
-<!--
-*How* will this impact the documentation?
+> _"What privilege level is required for these changes?"_
 
-What new documentation will be required?
-What existing documentation will need to be updated?
--->
+To make the changes? "Committer," I guess. If this question is about Traffic
+Ops API Roles/Capabilities/Permissions, I suppose a better answer would be
+"unchanged".
 
-### Testing Impact
-<!--
-*How* will this impact testing?
+> _"Do these changes increase the attack surface (e.g. new untrusted input)?"_
 
-What is the high-level test plan?
-How should this be tested?
-Can this be tested within the existing test frameworks?
-How should the existing frameworks be enhanced in order to test this properly?
--->
+No, not "new", just different. As far as "attack surface," though, that depends
+and is further discussed two questions down.
 
-### Performance Impact
-<!--
-*How* will this impact performance?
+> _"How will untrusted input be validated?"_
 
-Are the changes expected to improve performance in any way?
-Is there anything particularly CPU, network, or storage-intensive to be aware of?
-What are the known bottlenecks to be aware of that may need to be addressed?
--->
+It's an enumerated type. So the input must be one of the enumerated string
+constant values.
 
-### Security Impact
-<!--
-*How* will this impact overall security?
+> _"If these changes are used maliciously or improperly, what could go wrong?"_
 
-Are there any security risks to be aware of?
-What privilege level is required for these changes?
-Do these changes increase the attack surface (e.g. new untrusted input)?
-How will untrusted input be validated?
-If these changes are used maliciously or improperly, what could go wrong?
-Will these changes adhere to multi-tenancy?
-Will data be protected in transit (e.g. via HTTPS or TLS)?
-Will these changes require sensitive data that should be encrypted at rest?
-Will these changes require handling of any secrets?
-Will new SQL queries properly use parameter binding?
--->
+Typically I'm told "we trust operators" and since you need an operator role to
+modify Delivery Services that would translate to an answer of "nothing that
+matters". But to be more specific, you can now remove the ability of Cache
+Servers to serve content for a Delivery Service, which can negatively impact
+clients who are in the process of fetching object series or fragments from a
+Cache Server. So use with caution.
 
-### Upgrade Impact
-<!--
-*How* will this impact the upgrade of an existing system?
+> _"Will these changes adhere to multi-tenancy?"_
 
-Will a database migration be required?
-Do the various components need to be upgraded in a specific order?
-Will this affect the ability to rollback an upgrade?
-Are there any special steps to be followed before an upgrade can be done?
-Are there any special steps to be followed during the upgrade?
-Are there any special steps to be followed after the upgrade is complete?
--->
+Tenancy rules unchanged, so yes.
 
-### Operations Impact
-<!--
-*How* will this impact overall operation of the system?
+> _"Will data be protected in transit (e.g. via HTTPS or TLS)?"_
 
-Will the changes make it harder to operate the system?
-Will the changes introduce new configuration that will need to be managed?
-Can the changes be easily automated?
-Do the changes have known limitations or risks that operators should be made aware of?
-Will the changes introduce new steps to be followed for existing operations?
--->
+The Traffic Ops API (at least the Go implementation) only serves content over
+HTTPS as far as I'm aware, so yes.
+
+> _"Will these changes require sensitive data that should be encrypted at rest?"_
+
+No.
+
+> _"Will these changes require handling of any secrets?"_
+
+This feels like the same question as directly above it, but no.
+
+> _"Will new SQL queries properly use parameter binding?"_
+
+That this question needs to be asked is simultaneously baffling to me because I
+don't know of any SQL library for any language that would tell you to do
+anything else and horrifying to me because of what it implies about the past.
+
+## Upgrade Impact
+Traffic Monitor changes are backward-compatible, so no impact there. Traffic
+Ops changes follow the API "version-promise" and so upgrades have no more or
+less impact than any other breaking API change - if you keep using v2 you won't
+even notice.
+
+## Operations Impact
+Operators that use raw API requests will need to be made aware of the changes
+and their semantic meaning(s) - which should be covered handily by the
+documentation. Operators using Traffic Portal will need the same information
+when it is upgraded to use API v3 and provides the new UI for Delivery
+Service's "Active" property.
 
 ### Developer Impact
-<!--
-*How* will this impact other developers?
-
-Will it make it easier to set up a development environment?
-Will it make the code easier to maintain?
-What do other developers need to know about these changes?
-Are the changes straightforward, or will new developer instructions be necessary?
--->
+Developers should be largely unaffected except for merge conflicts. Though it's
+difficult to guess the full scope of what can and will be worked on by anyone.
 
 ## Alternatives
-<!--
-What are some of the alternative solutions for this problem?
-What are the pros and cons of each approach?
-What design trade-offs were made and why?
--->
+The one big alternative that was considered was making `active=false` mean "not
+routed and not present in Cache Server configuration". However, this meant
+losing the "in-between" state that "PRIMED" provides. So when a Delivery
+Service is taken out of service, it would mean that the very next "queue
+updates" that was done would remove it from Cache Server configuration even if
+a Snapshot has not been taken. This results in clients being routed to Cache
+Servers that cannot serve the content they requested.
 
-## Dependencies
-<!--
-Are there any significant new dependencies that will be required?
-How were the dependencies assessed and chosen?
-How will the new dependencies be managed?
-Are the dependencies required at build-time, run-time, or both?
--->
-
-## References
-<!--
-Include any references to external links here.
--->
+By contrast, when setting a Delivery Service to "PRIMED", clients will no
+longer be routed for that Delivery Service but even if updates are queued
+before then clients using Cache Servers for ongoing content delivery will be
+unaffected by the change. This allows operators to "drain" a Delivery Service
+for a while before setting it to "INACTIVE" and removing it from Cache Server
+configuration, thus minimizing client impact.


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is related to #3746

Adds a blueprint for changing the "active" property of Delivery Services from a boolean to an enumerated string constant like:

```typescript
/**
 * This defines what other components of ATC will consider a Delivery Service
 * "active".
 *
 * It's not an object exposed through the API in its own right, just a
 * specification of the allowed values.
*/
enum DeliveryServiceActiveState {
	/**
	 * A Delivery Service that is ”active” is one that is functionally
	 * in service, and fully capable of delivering content.
	 *
	 * This means that its configuration is deployed to Cache Servers and it is
	 * available for routing traffic.
	*/
	ACTIVE = 'ACTIVE',
	/**
	 * A Delivery Service that is ”inactive” is not available for
	 * routing and has not had its configuration distributed to its assigned
	 * Cache Servers.
	*/
	INACTIVE = 'INACTIVE',
	/**
	 * A Delivery Service that is ”primed” has had its configuration
	 * distributed to the various servers required to serve its content.
	 * However, the content itself is still inaccessible via routing.
	*/
	PRIMED = 'PRIMED'
}
```

For more details, refer to the blueprint.

## Which Traffic Control components are affected by this PR?
None - blueprint.

## What is the best way to verify this PR?
Read the blueprint.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**
