### PR TITLE
Add the Vary: Accept-Encoding header to all TO responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Existing installations **must** enable TLSv1.1 for Traffic Vault in order for Traffic Ops to reach it. See [Enabling TLS 1.1](https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_vault.html#tv-admin-enable-tlsv1-1) in the Traffic Vault administrator's guide for instructions.
 - Changed the `totalBytes` property of responses to GET requests to `/deliveryservice_stats` to the more appropriate `totalKiloBytes` in API 2.x
 - Fix to traffic_ops_ort to generate logging.yaml files correctly.
+- Fixed issue #4650: add the "Vary: Accept-Encoding" header to all responses from Traffic Ops
 
 ### Deprecated/Removed
 - The Traffic Ops `db/admin.pl` script has now been removed. Please use the `db/admin` binary instead.

--- a/lib/go-rfc/http.go
+++ b/lib/go-rfc/http.go
@@ -35,6 +35,7 @@ const (
 	AcceptEncoding         = "Accept-Encoding"          // RFC7231§5.3.4
 	ContentDisposition     = "Content-Disposition"      // RFC6266
 	ApplicationOctetStream = "application/octet-stream" // RFC2046§4.5.2
+	Vary                   = "Vary"                     // RFC7231§7.1.4
 )
 
 // AcceptsGzip returns whether r accepts gzip encoding, per RFC7231§5.3.4.

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers.go
@@ -110,12 +110,14 @@ func TimeOutWrapper(timeout time.Duration) Middleware {
 //  - Adds default CORS headers to the response.
 //  - Adds the Whole-Content-SHA512 checksum header to the response.
 //  - Gzips the response and sets the Content-Encoding header, if the client sent an Accept-Encoding: gzip header.
+//  - Adds the Vary: Accept-Encoding header to the response
 func WrapHeaders(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie")
 		w.Header().Set("Access-Control-Allow-Methods", "POST,GET,OPTIONS,PUT,DELETE")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set(rfc.Vary, rfc.AcceptEncoding)
 		w.Header().Set("X-Server-Name", ServerName)
 		iw := &util.BodyInterceptor{W: w}
 		h(iw, r)

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -62,11 +63,12 @@ func TestWrapHeaders(t *testing.T) {
 		t.Error("Expected body", body, "got", w.Body.String())
 	}
 
-	expected := map[string]http.Header{
+	expected := map[string][]string{
 		"Access-Control-Allow-Credentials": nil,
 		"Access-Control-Allow-Headers":     nil,
 		"Access-Control-Allow-Methods":     nil,
 		"Access-Control-Allow-Origin":      nil,
+		rfc.Vary:                           {rfc.AcceptEncoding},
 		"Content-Type":                     nil,
 		"Whole-Content-Sha512":             nil,
 		"X-Server-Name":                    nil,
@@ -79,6 +81,8 @@ func TestWrapHeaders(t *testing.T) {
 	for k := range expected {
 		if _, ok := m[k]; !ok {
 			t.Error("Expected header", k, "not found")
+		} else if len(expected[k]) > 0 && !reflect.DeepEqual(expected[k], m[k]) {
+			t.Errorf("expected: %v, actual: %v", expected[k], m[k])
 		}
 	}
 }


### PR DESCRIPTION
##  What does this PR (Pull Request) do?

Because TO will gzip responses if requested with Accept-Encoding: gzip,
TO also needs to return the `Vary: Accept-Encoding` response header with
all requests in order for caches to return the correctly-encoded cached
content to clients.

- [x] This PR fixes #4650 

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Run the unit tests and TO API tests, verify they pass.

## If this is a bug fix, what versions of Traffic Control are affected?

- master
- 4.0.0
- 3.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] Bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)