### PR TITLE
Traffic Ops riak.conf: Accept a list of TLS versions to enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added ability to create multiple objects from generic API Create with a single POST.
 - Added debugging functionality to CDN-in-a-Box.
 - Added an SMTP server to CDN-in-a-Box.
+- Added the `"TLSVersions"` config option to Traffic Ops's `riak.conf` to optionally specify exactly which TLS versions should be used for communicating with Riak
 - Traffic Ops Golang Endpoints
   - /api/2.0 for all of the most recent route versions
   - /api/1.1/cachegroupparameters/{{cachegroupID}}/{{parameterID}} `(DELETE)`

--- a/docs/source/admin/traffic_ops.rst
+++ b/docs/source/admin/traffic_ops.rst
@@ -518,7 +518,7 @@ This file sets authentication options for connections to Traffic Vault. `traffic
 
 :password:      The password to use when authenticating with Traffic Vault
 :user:          The username to use when authenticating with Traffic Vault
-:MaxTLSVersion: Optional. This is the highest TLS version that Traffic Ops is allowed to use to connect to Traffic Vault. Valid values are "1.0", "1.1", "1.2", and "1.3". The default is "1.1".
+:TLSVersions:   Optional. This is an array of TLS versions that Traffic Ops will use to try to connect to Traffic Vault. If querying Traffic Vault fails using one version, it will try the next listed version next time (starting at the beginning of the list if it hits the end). Valid versions are ``"1.0"``, ``"1.1"``, ``"1.2"``, and ``"1.3"``.
 
 .. note:: Enabling TLS 1.1 in Traffic Vault itself is required for Traffic Ops to communicate with Traffic Vault. See :ref:`Enabling TLS 1.1 <tv-admin-enable-tlsv1.1>` for details.
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/config.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/config.sh
@@ -181,7 +181,10 @@ EOF
 cat <<-EOF >/opt/traffic_ops/app/conf/production/riak.conf
 {     "user": "$TV_RIAK_USER",
   "password": "$TV_RIAK_PASSWORD",
-  "MaxTLSVersion": "1.1"
+  "TLSVersions": [
+    "1.1",
+    "1.0"
+  ]
 }
 EOF
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/config.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/config.sh
@@ -182,8 +182,7 @@ cat <<-EOF >/opt/traffic_ops/app/conf/production/riak.conf
 {     "user": "$TV_RIAK_USER",
   "password": "$TV_RIAK_PASSWORD",
   "TLSVersions": [
-    "1.1",
-    "1.0"
+    "1.1"
   ]
 }
 EOF

--- a/traffic_ops/app/conf/development/riak.conf
+++ b/traffic_ops/app/conf/development/riak.conf
@@ -1,7 +1,10 @@
 {
 	"user": "riakuser",
 	"password": "password",
-	"MaxTLSVersion": "1.1",
+	"TLSVersions": [
+		"1.1",
+		"1.0"
+	],
 	"tlsConfig": {
 		"insecureSkipVerify": true
 	}

--- a/traffic_ops/app/conf/development/riak.conf
+++ b/traffic_ops/app/conf/development/riak.conf
@@ -2,8 +2,7 @@
 	"user": "riakuser",
 	"password": "password",
 	"TLSVersions": [
-		"1.1",
-		"1.0"
+		"1.1"
 	],
 	"tlsConfig": {
 		"insecureSkipVerify": true

--- a/traffic_ops/app/conf/integration/riak.conf
+++ b/traffic_ops/app/conf/integration/riak.conf
@@ -1,7 +1,10 @@
 {
 	"user": "riakuser",
 	"password": "password",
-	"MaxTLSVersion": "1.1",
+	"TLSVersions": [
+		"1.1",
+		"1.0"
+	],
 	"tlsConfig": {
 		"insecureSkipVerify": true
 	}

--- a/traffic_ops/app/conf/integration/riak.conf
+++ b/traffic_ops/app/conf/integration/riak.conf
@@ -2,8 +2,7 @@
 	"user": "riakuser",
 	"password": "password",
 	"TLSVersions": [
-		"1.1",
-		"1.0"
+		"1.1"
 	],
 	"tlsConfig": {
 		"insecureSkipVerify": true

--- a/traffic_ops/app/conf/production/riak.conf
+++ b/traffic_ops/app/conf/production/riak.conf
@@ -2,7 +2,6 @@
 	"user": "riakuser",
 	"password": "password",
 	"TLSVersions": [
-		"1.1",
-		"1.0"
+		"1.1"
 	]
 }

--- a/traffic_ops/app/conf/production/riak.conf
+++ b/traffic_ops/app/conf/production/riak.conf
@@ -1,5 +1,8 @@
 {
 	"user": "riakuser",
 	"password": "password",
-	"MaxTLSVersion": "1.1"
+	"TLSVersions": [
+		"1.1",
+		"1.0"
+	]
 }

--- a/traffic_ops/app/conf/test/riak.conf
+++ b/traffic_ops/app/conf/test/riak.conf
@@ -1,7 +1,10 @@
 {
 	"user": "riakuser",
 	"password": "password",
-	"MaxTLSVersion": "1.1",
+	"TLSVersions": [
+		"1.1",
+		"1.0"
+	],
 	"tlsConfig": {
 		"insecureSkipVerify": true
 	}

--- a/traffic_ops/app/conf/test/riak.conf
+++ b/traffic_ops/app/conf/test/riak.conf
@@ -2,8 +2,7 @@
 	"user": "riakuser",
 	"password": "password",
 	"TLSVersions": [
-		"1.1",
-		"1.0"
+		"1.1"
 	],
 	"tlsConfig": {
 		"insecureSkipVerify": true

--- a/traffic_ops/traffic_ops_golang/config/config_test.go
+++ b/traffic_ops/traffic_ops_golang/config/config_test.go
@@ -250,7 +250,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("expected blockStartup to be false but it was ", blockStartup)
 	}
 
-	expectedRiak := riaksvc.TOAuthOptions{AuthOptions: riak.AuthOptions{User: "riakuser", Password: "password", TlsConfig: &tls.Config{InsecureSkipVerify: true, MaxVersion: tls.VersionTLS11}}}
+	expectedRiak := riaksvc.AuthOptions{AuthOptions: riak.AuthOptions{User: "riakuser", Password: "password", TlsConfig: &tls.Config{InsecureSkipVerify: true, MaxVersion: tls.VersionTLS11}}}
 
 	if cfg.RiakAuthOptions.User != expectedRiak.User || cfg.RiakAuthOptions.Password != expectedRiak.Password || !reflect.DeepEqual(cfg.RiakAuthOptions.TlsConfig, expectedRiak.TlsConfig) {
 		t.Error(fmt.Printf("Error parsing riak conf expected: %++v but got: %++v\n", expectedRiak, cfg.RiakAuthOptions))

--- a/traffic_ops/traffic_ops_golang/config/config_test.go
+++ b/traffic_ops/traffic_ops_golang/config/config_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/riaksvc"
 	"github.com/basho/riak-go-client"
 	"io/ioutil"
 	"os"
@@ -162,12 +161,14 @@ const (
 	   {
 	       "user": "riakuser",
 	       "password": "password",
-	       "MaxTLSVersion": "1.1",
+	       "TLSVersions": [
+	            "1.1",
+	            "1.0"
+	       ],
 	       "tlsConfig": {
 	           "insecureSkipVerify": true
 	       }
-	   }
-	   	`
+	   }`
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -250,9 +251,13 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("expected blockStartup to be false but it was ", blockStartup)
 	}
 
-	expectedRiak := riaksvc.AuthOptions{AuthOptions: riak.AuthOptions{User: "riakuser", Password: "password", TlsConfig: &tls.Config{InsecureSkipVerify: true, MaxVersion: tls.VersionTLS11}}}
+	expectedRiak := riak.AuthOptions{
+		User:      "riakuser",
+		Password:  "password",
+		TlsConfig: &tls.Config{InsecureSkipVerify: true, MaxVersion: tls.VersionTLS11, MinVersion: tls.VersionTLS11},
+	}
 
-	if cfg.RiakAuthOptions.User != expectedRiak.User || cfg.RiakAuthOptions.Password != expectedRiak.Password || !reflect.DeepEqual(cfg.RiakAuthOptions.TlsConfig, expectedRiak.TlsConfig) {
+	if cfg.RiakAuthOptions.User != expectedRiak.User || cfg.RiakAuthOptions.Password != expectedRiak.Password || !reflect.DeepEqual(expectedRiak.TlsConfig, cfg.RiakAuthOptions.TlsConfig) {
 		t.Error(fmt.Printf("Error parsing riak conf expected: %++v but got: %++v\n", expectedRiak, cfg.RiakAuthOptions))
 	}
 

--- a/traffic_ops/traffic_ops_golang/config/config_test.go
+++ b/traffic_ops/traffic_ops_golang/config/config_test.go
@@ -162,8 +162,7 @@ const (
 	       "user": "riakuser",
 	       "password": "password",
 	       "TLSVersions": [
-	            "1.1",
-	            "1.0"
+	            "1.1"
 	       ],
 	       "tlsConfig": {
 	           "insecureSkipVerify": true

--- a/traffic_ops/traffic_ops_golang/riaksvc/riak_services.go
+++ b/traffic_ops/traffic_ops_golang/riaksvc/riak_services.go
@@ -55,7 +55,7 @@ var (
 	healthCheckInterval time.Duration
 )
 
-type TOAuthOptions struct {
+type AuthOptions struct {
 	riak.AuthOptions
 	MaxTLSVersion *string
 }
@@ -87,7 +87,7 @@ func (ri RiakStorageCluster) Execute(command riak.Command) error {
 	return ri.Cluster.Execute(command)
 }
 
-func setMaxTLSVersion(riakConfig *TOAuthOptions) error {
+func setMaxTLSVersion(riakConfig *AuthOptions) error {
 	if riakConfig.MaxTLSVersion == nil {
 		if riakConfig.TlsConfig.MaxVersion == 0 {
 			riakConfig.TlsConfig.MaxVersion = tls.VersionTLS11
@@ -117,7 +117,7 @@ func GetRiakConfig(riakConfigFile string) (bool, *riak.AuthOptions, error) {
 
 	riakConfBytes := []byte(riakConfString)
 
-	rconf := &TOAuthOptions{}
+	rconf := &AuthOptions{}
 	rconf.TlsConfig = &tls.Config{}
 	err = json.Unmarshal(riakConfBytes, &rconf)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/riaksvc/riak_services.go
+++ b/traffic_ops/traffic_ops_golang/riaksvc/riak_services.go
@@ -130,7 +130,6 @@ func setTLSVersion(riakConfig *AuthOptions) error {
 	} else if len(enabledVersions) == 0 {
 		// Default TLS versions if none given
 		enabledVersions[tls.VersionTLS11] = true
-		enabledVersions[tls.VersionTLS10] = true
 	}
 	// We initialize tlsOptions here
 	tlsOptions = &TLSOptions{Config: riakConfig.AuthOptions.TlsConfig, TLSVersions: make([]uint16, len(enabledVersions))}

--- a/traffic_ops/traffic_ops_golang/riaksvc/riak_services_test.go
+++ b/traffic_ops/traffic_ops_golang/riaksvc/riak_services_test.go
@@ -140,7 +140,7 @@ func TestDeleteObject(t *testing.T) {
 }
 
 func TestSetTLSVersion(t *testing.T) {
-	riakConfig := &TOAuthOptions{
+	riakConfig := &AuthOptions{
 		AuthOptions:   riak.AuthOptions{TlsConfig: &tls.Config{}},
 		MaxTLSVersion: nil,
 	}

--- a/traffic_ops/traffic_ops_golang/riaksvc/riak_services_test.go
+++ b/traffic_ops/traffic_ops_golang/riaksvc/riak_services_test.go
@@ -143,14 +143,14 @@ func TestDeleteObject(t *testing.T) {
 func TestRotateTLSVersion(t *testing.T) {
 	riakConfig := &AuthOptions{
 		AuthOptions: riak.AuthOptions{TlsConfig: &tls.Config{}},
-		TLSVersions: []string{},
+		TLSVersions: []string{"1.1", "1.0"},
 	}
 	expected := []uint16{tls.VersionTLS11, tls.VersionTLS10}
 	if err := setTLSVersion(riakConfig); err != nil {
 		t.Error("expected nil but got ", err)
 	}
 	if !reflect.DeepEqual(expected, tlsOptions.TLSVersions) {
-		t.Errorf("Expected the default enabled TLS versions to be %v, instead got %v", expected, tlsOptions.TLSVersions)
+		t.Errorf("Expected the enabled TLS versions to be %v, instead got %v", expected, tlsOptions.TLSVersions)
 	}
 
 	rotateTLSVersion()

--- a/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
@@ -210,8 +210,8 @@ func handleRequest(w http.ResponseWriter, r *http.Request, client *influx.Client
 		if summary != nil {
 			resp.Summary = &tc.TrafficDSStatsSummary{
 				TrafficStatsSummary: *summary,
-				TotalKiloBytes: kBs,
-				TotalTransactions: txns,
+				TotalKiloBytes:      kBs,
+				TotalTransactions:   txns,
 			}
 		} else {
 			resp.Summary = &tc.TrafficDSStatsSummary{}
@@ -278,8 +278,8 @@ func handleLegacyRequest(w http.ResponseWriter, r *http.Request, client *influx.
 		if summary != nil {
 			resp.Summary = &tc.LegacyTrafficDSStatsSummary{
 				TrafficStatsSummary: *summary,
-				TotalBytes: kBs,
-				TotalTransactions: txns,
+				TotalBytes:          kBs,
+				TotalTransactions:   txns,
 			}
 		} else {
 			resp.Summary = &tc.LegacyTrafficDSStatsSummary{}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
- [x] This PR is not related to any Issue.<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR updates the Traffic Ops config for communicating with Riak to accept a `"TLSVersions"` array instead of the single `"MaxTLSVersion"` value that #4573 added. It leaves TLS 1.1 as the default enabled version for communicating with Riak.

### Motivations for the config option name change
After #4573 was merged, some concerns were brought up about the fact that, even though the config option was named `MaxTLSVersion`, versions below `MaxTLSVersion` but greater than or equal to the default TLS minimum version were not tried. So the question became whether `MaxTLSVersion` was an accurate name for that config option. `TLSVersions` is more straightforward.

### Reasons for checking for a list of versions
- Without any additional config changes after #4573, Traffic Vaults that have TLS 1.0 and TLS 1.2 enabled but not TLS 1.1 are effectively unreachable by Traffic Ops. While we should still leave it up to our users as far as what TLS versions they want to enable, Traffic Ops should not be limited to either succeeding with 1 specific TLS version or failing to reach Traffic Vault.
- Even though Go 1.14.2 uses TLS 1.3 by default, its default `tls.Config.MinVersion` is TLS 1.0, so the fact that [basho/riak-go-client](https://github.com/basho/riak-go-client) doesn't attempt handshakes with TLS versions lower than the maximum version is a bug.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->
- CDN in a Box
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
* Run Traffic Ops unit tests
* Run Traffic Ops API tests to check for regressions
* Start CDN-in-a-Box, verify that Traffic Ops stores TLS keys in Traffic Vault
* Build docs, verify there are no warnings but also make sure they look nice

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (764aaf0abb)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
