### PR TITLE
Post ds handle empty xmlid

### DIFF
--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -448,9 +448,6 @@ func (ds *DeliveryServiceNullable) Validate(tx *sql.Tx) error {
 		"typeId":              validation.Validate(ds.TypeID, validation.Required, validation.Min(1)),
 		"xmlId":               validation.Validate(ds.XMLID, validation.Required, noSpaces, noPeriods, validation.Length(1, 48)),
 	})
-	//if ds.XMLID != nil && *ds.XMLID == "" {
-	//	errs = append(errs, errors.New("xmlId cannot be blank"))
-	//}
 	if err := ds.validateTypeFields(tx); err != nil {
 		errs = append(errs, errors.New("type fields: "+err.Error()))
 	}

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -446,8 +446,11 @@ func (ds *DeliveryServiceNullable) Validate(tx *sql.Tx) error {
 		"remapText":           validation.Validate(ds.RemapText, noLineBreaks),
 		"routingName":         validation.Validate(ds.RoutingName, isDNSName, noPeriods, validation.Length(1, 48)),
 		"typeId":              validation.Validate(ds.TypeID, validation.Required, validation.Min(1)),
-		"xmlId":               validation.Validate(ds.XMLID, noSpaces, noPeriods, validation.Length(1, 48)),
+		"xmlId":               validation.Validate(ds.XMLID, validation.NotNil, noSpaces, noPeriods, validation.Length(1, 48)),
 	})
+	if ds.XMLID != nil && *ds.XMLID == "" {
+		errs = append(errs, errors.New("xmlId cannot be blank"))
+	}
 	if err := ds.validateTypeFields(tx); err != nil {
 		errs = append(errs, errors.New("type fields: "+err.Error()))
 	}

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -446,11 +446,11 @@ func (ds *DeliveryServiceNullable) Validate(tx *sql.Tx) error {
 		"remapText":           validation.Validate(ds.RemapText, noLineBreaks),
 		"routingName":         validation.Validate(ds.RoutingName, isDNSName, noPeriods, validation.Length(1, 48)),
 		"typeId":              validation.Validate(ds.TypeID, validation.Required, validation.Min(1)),
-		"xmlId":               validation.Validate(ds.XMLID, validation.NotNil, noSpaces, noPeriods, validation.Length(1, 48)),
+		"xmlId":               validation.Validate(ds.XMLID, validation.Required, noSpaces, noPeriods, validation.Length(1, 48)),
 	})
-	if ds.XMLID != nil && *ds.XMLID == "" {
-		errs = append(errs, errors.New("xmlId cannot be blank"))
-	}
+	//if ds.XMLID != nil && *ds.XMLID == "" {
+	//	errs = append(errs, errors.New("xmlId cannot be blank"))
+	//}
 	if err := ds.validateTypeFields(tx); err != nil {
 		errs = append(errs, errors.New("type fields: "+err.Error()))
 	}

--- a/traffic_ops/testing/api/v2/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v2/cachegroupsdeliveryservices_test.go
@@ -38,9 +38,9 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 		t.Fatalf("cannot test cachegroups delivery services: expected no initial delivery service servers, actual %v", len(dss.Response))
 	}
 
-	dses, _, err := TOSession.GetDeliveryServices()
+	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
-		t.Errorf("cannot GET DeliveryServices: %v - %v", err, dses)
+		t.Fatalf("cannot GET DeliveryServices: %v - %v", err, dses)
 	}
 
 	clientCGs, _, err := TOSession.GetCacheGroupNullableByName(TestEdgeServerCacheGroupName)
@@ -60,8 +60,8 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 
 	dsIDs := []int64{}
 	for _, ds := range dses {
-		if ds.CDNName == "cdn1" {
-			dsIDs = append(dsIDs, int64(ds.ID))
+		if *ds.CDNName == "cdn1" {
+			dsIDs = append(dsIDs, int64(*ds.ID))
 		}
 	}
 	if len(dsIDs) < 1 {
@@ -70,10 +70,10 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 
 	resp, _, err := TOSession.SetCachegroupDeliveryServices(cgID, dsIDs)
 	if err != nil {
-		t.Errorf("setting cachegroup delivery services returned error: %v", err)
+		t.Fatalf("setting cachegroup delivery services returned error: %v", err)
 	}
 	if len(resp.Response.ServerNames) == 0 {
-		t.Error("setting cachegroup delivery services returned success, but no servers set")
+		t.Fatal("setting cachegroup delivery services returned success, but no servers set")
 	}
 
 	// Note this second post of the same cg-dses specifically tests a previous bug, where the query
@@ -90,10 +90,10 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 	for _, serverName := range resp.Response.ServerNames {
 		servers, _, err := TOSession.GetServerByHostName(string(serverName))
 		if err != nil {
-			t.Errorf("getting server: " + err.Error())
+			t.Fatalf("getting server: %v", err)
 		}
 		if len(servers) != 1 {
-			t.Errorf("getting servers: expected 1 got %v", len(servers))
+			t.Fatalf("getting servers: expected 1 got %v", len(servers))
 		}
 		server := servers[0]
 		serverID := server.ID

--- a/traffic_ops/testing/api/v2/capabilities_test.go
+++ b/traffic_ops/testing/api/v2/capabilities_test.go
@@ -22,9 +22,9 @@ package v2
 import (
 	"fmt"
 	"testing"
-)
 
-import "github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
 
 // These capabilities are defined during the setup process in todb.go.
 // ANY TIME THOSE ARE CHANGED THIS MUST BE UPDATED.
@@ -69,7 +69,7 @@ func CreateTestCapabilities(t *testing.T) {
 	dbInsertTemplate := `INSERT INTO capability (name, description) VALUES ('%v', '%v');`
 
 	for _, c := range testData.Capabilities {
-		err = execSQL(db, fmt.Sprintf(dbInsertTemplate, c.Name, c.Description), "capability")
+		err = execSQL(db, fmt.Sprintf(dbInsertTemplate, c.Name, c.Description))
 		if err != nil {
 			t.Errorf("could not create capability: %v", err)
 		}

--- a/traffic_ops/testing/api/v2/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservices_test.go
@@ -39,7 +39,22 @@ func TestDeliveryServices(t *testing.T) {
 		GetTestDeliveryServices(t)
 		DeliveryServiceMinorVersionsTest(t)
 		DeliveryServiceTenancyTest(t)
+		PostDeliveryServiceTest(t)
 	})
+}
+
+func PostDeliveryServiceTest(t *testing.T) {
+	ds := testData.DeliveryServices[0]
+	ds.XMLID = util.StrPtr("")
+	_, err := TOSession.CreateDeliveryServiceNullable(&ds)
+	if err == nil {
+		t.Fatal("Expected error with empty xmlid")
+	}
+	ds.XMLID = nil
+	_, err = TOSession.CreateDeliveryServiceNullable(&ds)
+	if err == nil {
+		t.Fatal("Expected error with nil xmlid")
+	}
 }
 
 func CreateTestDeliveryServices(t *testing.T) {

--- a/traffic_ops/testing/api/v2/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservices_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestDeliveryServices(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
-		AsdfTest(t)
 		GetAccessibleToTest(t)
 		UpdateTestDeliveryServices(t)
 		UpdateNullableTestDeliveryServices(t)
@@ -41,12 +40,6 @@ func TestDeliveryServices(t *testing.T) {
 		DeliveryServiceMinorVersionsTest(t)
 		DeliveryServiceTenancyTest(t)
 	})
-}
-
-func AsdfTest(t *testing.T) {
-	ds := testData.DeliveryServices[0]
-	t.Log(ds)
-
 }
 
 func CreateTestDeliveryServices(t *testing.T) {

--- a/traffic_ops/testing/api/v2/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservices_test.go
@@ -31,6 +31,7 @@ import (
 
 func TestDeliveryServices(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		AsdfTest(t)
 		GetAccessibleToTest(t)
 		UpdateTestDeliveryServices(t)
 		UpdateNullableTestDeliveryServices(t)
@@ -40,6 +41,11 @@ func TestDeliveryServices(t *testing.T) {
 		DeliveryServiceMinorVersionsTest(t)
 		DeliveryServiceTenancyTest(t)
 	})
+}
+
+func AsdfTest(t *testing.T) {
+	ds := testData.DeliveryServices[0]
+	t.Log(ds)
 }
 
 func CreateTestDeliveryServices(t *testing.T) {

--- a/traffic_ops/testing/api/v2/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservices_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestDeliveryServices(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
-		AsdfTest(t)
 		GetAccessibleToTest(t)
 		UpdateTestDeliveryServices(t)
 		UpdateNullableTestDeliveryServices(t)
@@ -41,11 +40,6 @@ func TestDeliveryServices(t *testing.T) {
 		DeliveryServiceMinorVersionsTest(t)
 		DeliveryServiceTenancyTest(t)
 	})
-}
-
-func AsdfTest(t *testing.T) {
-	ds := testData.DeliveryServices[0]
-	t.Log(ds)
 }
 
 func CreateTestDeliveryServices(t *testing.T) {

--- a/traffic_ops/testing/api/v2/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v2/deliveryserviceservers_test.go
@@ -181,7 +181,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 	dses, servers := getServersAndDSes(t)
 	ds, server := dses[0], servers[0]
 
-	_, err := TOSession.CreateDeliveryServiceServers(ds.ID, []int{server.ID}, true)
+	_, err := TOSession.CreateDeliveryServiceServers(*ds.ID, []int{server.ID}, true)
 	if err != nil {
 		t.Errorf("POST delivery service servers: %v", err)
 	}
@@ -193,7 +193,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 
 	found := false
 	for _, dss := range dsServers.Response {
-		if *dss.DeliveryService == ds.ID && *dss.Server == server.ID {
+		if *dss.DeliveryService == *ds.ID && *dss.Server == server.ID {
 			found = true
 			break
 		}
@@ -202,7 +202,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 		t.Error("POST delivery service servers returned success, but ds-server not in GET")
 	}
 
-	if _, _, err := TOSession.DeleteDeliveryServiceServer(ds.ID, server.ID); err != nil {
+	if _, _, err := TOSession.DeleteDeliveryServiceServer(*ds.ID, server.ID); err != nil {
 		t.Errorf("DELETE delivery service server: %v", err)
 	}
 
@@ -213,7 +213,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 
 	found = false
 	for _, dss := range dsServers.Response {
-		if *dss.DeliveryService == ds.ID && *dss.Server == server.ID {
+		if *dss.DeliveryService == *ds.ID && *dss.Server == server.ID {
 			found = true
 			break
 		}
@@ -223,8 +223,8 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 	}
 }
 
-func getServersAndDSes(t *testing.T) ([]tc.DeliveryService, []tc.Server) {
-	dses, _, err := TOSession.GetDeliveryServices()
+func getServersAndDSes(t *testing.T) ([]tc.DeliveryServiceNullable, []tc.Server) {
+	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
 		t.Fatalf("cannot GET DeliveryServices: %v", err)
 	}

--- a/traffic_ops/testing/api/v2/deliveryservicesideligible_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservicesideligible_test.go
@@ -26,7 +26,7 @@ func TestDeliveryServicesEligible(t *testing.T) {
 }
 
 func GetTestDeliveryServicesEligible(t *testing.T) {
-	dses, _, err := TOSession.GetDeliveryServices()
+	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServices: %v", err)
 	}
@@ -34,7 +34,7 @@ func GetTestDeliveryServicesEligible(t *testing.T) {
 		t.Error("GET DeliveryServices returned no delivery services, need at least 1 to test")
 	}
 	dsID := dses[0].ID
-	servers, _, err := TOSession.GetDeliveryServicesEligible(dsID)
+	servers, _, err := TOSession.GetDeliveryServicesEligible(*dsID)
 	if err != nil {
 		t.Errorf("getting delivery services eligible: %v", err)
 	}

--- a/traffic_ops/testing/api/v2/deliveryservicesregexes_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservicesregexes_test.go
@@ -48,7 +48,7 @@ func CreateTestDeliveryServicesRegexes(t *testing.T) {
 	for i, regex := range testData.DeliveryServicesRegexes {
 		loadDSRegexIDs(t, &regex)
 
-		err = execSQL(db, fmt.Sprintf(dbRegexInsertTemplate, regex.Pattern, regex.Type), "regex")
+		err = execSQL(db, fmt.Sprintf(dbRegexInsertTemplate, regex.Pattern, regex.Type))
 		if err != nil {
 			t.Fatalf("unable to create regex: %v", err)
 		}
@@ -59,7 +59,7 @@ func CreateTestDeliveryServicesRegexes(t *testing.T) {
 			t.Fatalf("unable to query regex: %v", err)
 		}
 
-		err = execSQL(db, fmt.Sprintf(dbDSRegexInsertTemplate, regex.DSID, regex.ID, regex.SetNumber), "deliveryservice_regex")
+		err = execSQL(db, fmt.Sprintf(dbDSRegexInsertTemplate, regex.DSID, regex.ID, regex.SetNumber))
 		if err != nil {
 			t.Fatalf("unable to create ds regex %v", err)
 		}
@@ -81,12 +81,12 @@ func DeleteTestDeliveryServicesRegexes(t *testing.T) {
 	}()
 
 	for _, regex := range testData.DeliveryServicesRegexes {
-		err = execSQL(db, fmt.Sprintf("DELETE FROM deliveryservice_regex WHERE deliveryservice = '%v' and regex ='%v';", regex.DSID, regex.ID), "regex")
+		err = execSQL(db, fmt.Sprintf("DELETE FROM deliveryservice_regex WHERE deliveryservice = '%v' and regex ='%v';", regex.DSID, regex.ID))
 		if err != nil {
 			t.Fatalf("unable to delete deliveryservice_regex by regex %v and ds %v: %v", regex.ID, regex.DSID, err)
 		}
 
-		err := execSQL(db, fmt.Sprintf("DELETE FROM regex WHERE Id = '%v';", regex.ID), "regex")
+		err := execSQL(db, fmt.Sprintf("DELETE FROM regex WHERE Id = '%v';", regex.ID))
 		if err != nil {
 			t.Fatalf("unable to delete regex %v: %v", regex.ID, err)
 		}

--- a/traffic_ops/testing/api/v2/federations_test.go
+++ b/traffic_ops/testing/api/v2/federations_test.go
@@ -82,13 +82,13 @@ func GetTestFederations(t *testing.T) {
 	}
 }
 
-func createFederationToDeliveryServiceAssociation() (int, tc.DeliveryService, tc.DeliveryService, error) {
-	dses, _, err := TOSession.GetDeliveryServices()
+func createFederationToDeliveryServiceAssociation() (int, tc.DeliveryServiceNullable, tc.DeliveryServiceNullable, error) {
+	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
-		return -1, tc.DeliveryService{}, tc.DeliveryService{}, fmt.Errorf("cannot GET DeliveryServices: %v - %v", err, dses)
+		return -1, tc.DeliveryServiceNullable{}, tc.DeliveryServiceNullable{}, fmt.Errorf("cannot GET DeliveryServices: %v - %v", err, dses)
 	}
 	if len(dses) == 0 {
-		return -1, tc.DeliveryService{}, tc.DeliveryService{}, errors.New("no delivery services, must have at least 1 ds to test federations deliveryservices")
+		return -1, tc.DeliveryServiceNullable{}, tc.DeliveryServiceNullable{}, errors.New("no delivery services, must have at least 1 ds to test federations deliveryservices")
 	}
 	ds := dses[0]
 	ds1 := dses[1]
@@ -98,7 +98,7 @@ func createFederationToDeliveryServiceAssociation() (int, tc.DeliveryService, tc
 	}
 	fedID := fedIDs[0]
 
-	_, err = TOSession.CreateFederationDeliveryServices(fedID, []int{ds.ID, ds1.ID}, true)
+	_, err = TOSession.CreateFederationDeliveryServices(fedID, []int{*ds.ID, *ds1.ID}, true)
 	if err != nil {
 		err = fmt.Errorf("creating federations delivery services: %v", err)
 	}
@@ -123,7 +123,7 @@ func PostDeleteTestFederationsDeliveryServices(t *testing.T) {
 	}
 
 	// Delete one of the Delivery Services from the Federation
-	_, _, err = TOSession.DeleteFederationDeliveryService(fedID, ds.ID)
+	_, _, err = TOSession.DeleteFederationDeliveryService(fedID, *ds.ID)
 	if err != nil {
 		t.Fatalf("cannot Delete Federation %v DeliveryService %v: %v", fedID, ds.ID, err)
 	}
@@ -140,7 +140,7 @@ func PostDeleteTestFederationsDeliveryServices(t *testing.T) {
 	}
 
 	// Attempt to delete the last one which should fail as you cannot remove the last
-	_, _, err = TOSession.DeleteFederationDeliveryService(fedID, ds1.ID)
+	_, _, err = TOSession.DeleteFederationDeliveryService(fedID, *ds1.ID)
 	if err == nil {
 		t.Fatal("expected to receive error from attempting to delete last Delivery Service from a Federation")
 	}
@@ -194,14 +194,14 @@ func AddFederationResolversForCurrentUserTest(t *testing.T) {
 
 	mappings := tc.DeliveryServiceFederationResolverMappingRequest{
 		tc.DeliveryServiceFederationResolverMapping{
-			DeliveryService: ds.XMLID,
+			DeliveryService: *ds.XMLID,
 			Mappings: tc.ResolverMapping{
 				Resolve4: []string{"0.0.0.0"},
 				Resolve6: []string{"::1"},
 			},
 		},
 		tc.DeliveryServiceFederationResolverMapping{
-			DeliveryService: ds1.XMLID,
+			DeliveryService: *ds1.XMLID,
 			Mappings: tc.ResolverMapping{
 				Resolve4: []string{"1.2.3.4/28"},
 				Resolve6: []string{"1234::/110"},

--- a/traffic_ops/testing/api/v2/servers_test.go
+++ b/traffic_ops/testing/api/v2/servers_test.go
@@ -87,7 +87,7 @@ func UpdateTestServers(t *testing.T) {
 	}
 
 	// Assign server to DS and then attempt to update to a different type
-	dses, _, err := TOSession.GetDeliveryServices()
+	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
 		t.Fatalf("cannot GET DeliveryServices: %v", err)
 	}
@@ -110,7 +110,7 @@ func UpdateTestServers(t *testing.T) {
 	}
 
 	// Assign server to DS
-	_, err = TOSession.CreateDeliveryServiceServers(dses[0].ID, []int{remoteServer.ID}, true)
+	_, err = TOSession.CreateDeliveryServiceServers(*dses[0].ID, []int{remoteServer.ID}, true)
 	if err != nil {
 		t.Fatalf("POST delivery service servers: %v", err)
 	}

--- a/traffic_ops/testing/api/v2/servers_to_deliveryservice_assignment_test.go
+++ b/traffic_ops/testing/api/v2/servers_to_deliveryservice_assignment_test.go
@@ -36,7 +36,7 @@ func AssignTestDeliveryService(t *testing.T) {
 	}
 	firstServer := rs[0]
 
-	rd, _, err := TOSession.GetDeliveryServiceByXMLIDNullable(testData.DeliveryServices[0].XMLID)
+	rd, _, err := TOSession.GetDeliveryServiceByXMLIDNullable(*testData.DeliveryServices[0].XMLID)
 	if err != nil {
 		t.Fatalf("Failed to fetch DS information: %v", err)
 	} else if len(rd) == 0 {
@@ -92,7 +92,7 @@ func AssignIncorrectTestDeliveryService(t *testing.T) {
 	}
 	server = &rs[0]
 
-	rd, _, err := TOSession.GetDeliveryServiceByXMLIDNullable(testData.DeliveryServices[0].XMLID)
+	rd, _, err := TOSession.GetDeliveryServiceByXMLIDNullable(*testData.DeliveryServices[0].XMLID)
 	if err != nil {
 		t.Fatalf("Failed to fetch DS information: %v", err)
 	} else if len(rd) == 0 {

--- a/traffic_ops/testing/api/v2/tc-fixtures.json
+++ b/traffic_ops/testing/api/v2/tc-fixtures.json
@@ -2572,6 +2572,32 @@
             "type": "STEERING_WEIGHT"
         }
     ],
+    "jobs": [
+        {
+            "dsName": "ds1",
+            "request": {
+                "startTime": "2019-01-01 00:00:00",
+                "ttl": 80,
+                "regex": "/foo"
+            }
+        },
+        {
+            "dsName": "ds2",
+            "request": {
+                "startTime": "2019-01-01 00:00:00",
+                "ttl": 80,
+                "regex": "/bar"
+            }
+        },
+        {
+            "dsName": "ds1",
+            "request": {
+                "startTime": "2019-01-01 00:00:00",
+                "ttl": 80,
+                "regex": "/foo"
+            }
+        }
+    ],
     "servercheck_extensions": [
         {
             "name": "ILO_PING",

--- a/traffic_ops/testing/api/v2/tc-fixtures.json
+++ b/traffic_ops/testing/api/v2/tc-fixtures.json
@@ -2572,32 +2572,6 @@
             "type": "STEERING_WEIGHT"
         }
     ],
-    "jobs": [
-        {
-            "dsName": "ds1",
-            "request": {
-                "startTime": "2019-01-01 00:00:00",
-                "ttl": 80,
-                "regex": "/foo"
-            }
-        },
-        {
-            "dsName": "ds2",
-            "request": {
-                "startTime": "2019-01-01 00:00:00",
-                "ttl": 80,
-                "regex": "/bar"
-            }
-        },
-        {
-            "dsName": "ds1",
-            "request": {
-                "startTime": "2019-01-01 00:00:00",
-                "ttl": 80,
-                "regex": "/foo"
-            }
-        }
-    ],
     "servercheck_extensions": [
         {
             "name": "ILO_PING",

--- a/traffic_ops/testing/api/v2/todb_test.go
+++ b/traffic_ops/testing/api/v2/todb_test.go
@@ -125,7 +125,7 @@ INSERT INTO role (name, description, priv_level) VALUES ('portal','Portal User',
 INSERT INTO role (name, description, priv_level) VALUES ('steering','Steering User', 15) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('federation','Role for Secondary CZF', 15) ON CONFLICT DO NOTHING;
 `
-	err := execSQL(db, sqlStmt, "role")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -141,7 +141,7 @@ INSERT INTO capability (name, description) VALUES ('asns-read', 'Read ASNs') ON 
 INSERT INTO capability (name, description) VALUES ('asns-write', 'Write ASNs') ON CONFLICT DO NOTHING;
 INSERT INTO capability (name, description) VALUES ('cache-groups-read', 'Read CGs') ON CONFLICT DO NOTHING;
 `
-	err := execSQL(db, sqlStmt, "capability")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -155,7 +155,7 @@ INSERT INTO api_capability (http_method, route, capability) VALUES ('POST', '/as
 INSERT INTO api_capability (http_method, route, capability) VALUES ('GET', '/cachegroups', 'cache-groups-read') ON CONFLICT DO NOTHING;
 `
 
-	err := execSQL(db, sqlStmt, "api_capability")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -167,7 +167,7 @@ func SetupRoleCapabilities(db *sql.DB) error {
 INSERT INTO role_capability (role_id, cap_name) VALUES (4,'all-write') ON CONFLICT DO NOTHING;
 INSERT INTO role_capability (role_id, cap_name) VALUES (4,'all-read') ON CONFLICT DO NOTHING;
 `
-	err := execSQL(db, sqlStmt, "role_capability")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -193,7 +193,7 @@ INSERT INTO tm_user (username, local_passwd, role, tenant_id) VALUES ('` + Confi
 INSERT INTO tm_user (username, local_passwd, role, tenant_id) VALUES ('` + Config.TrafficOps.Users.Federation + `','` + encryptedPassword + `', 6, 1);
 INSERT INTO tm_user (username, local_passwd, role, tenant_id) VALUES ('` + Config.TrafficOps.Users.Extension + `','` + encryptedPassword + `', 3, 1);
 `
-	err = execSQL(db, sqlStmt, "tm_user")
+	err = execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -209,7 +209,7 @@ func SetupTenants(db *sql.DB) error {
 INSERT INTO tenant (name, active, parent_id, last_updated) VALUES ('root', true, null, '2018-01-19 19:01:21.327262');
 INSERT INTO tenant (name, active, parent_id, last_updated) VALUES ('badtenant', true, 1, '2018-01-19 19:01:21.327262');
 `
-	err := execSQL(db, sqlStmt, "tenant")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -222,7 +222,7 @@ func SetupDeliveryServiceTmUsers(db *sql.DB) error {
 	sqlStmt := `
 INSERT INTO deliveryservice_tmuser (deliveryservice, tm_user_id, last_updated) VALUES (100, (SELECT id FROM tm_user where username = 'admin') , '2018-01-19 21:19:32.372969');
 `
-	err := execSQL(db, sqlStmt, "deliveryservice_tmuser")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -235,7 +235,7 @@ func SetupJobStatuses(db *sql.DB) error {
 	sqlStmt := `
 INSERT INTO job_status (id, name, description, last_updated) VALUES (1, 'PENDING', 'Job is queued, but has not been picked up by any agents yet', '2018-01-19 21:19:32.444857');
 `
-	err := execSQL(db, sqlStmt, "job_status")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -248,7 +248,7 @@ func SetupJobAgents(db *sql.DB) error {
 	sqlStmt := `
 INSERT INTO job_agent (id, name, description, active, last_updated) VALUES (1, 'agent1', 'Test Agent1', 0, '2018-01-19 21:19:32.448076');
 `
-	err := execSQL(db, sqlStmt, "job_agent")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -263,7 +263,7 @@ INSERT INTO job (id, agent, object_type, object_name, keyword, parameters, asset
 INSERT INTO job (id, agent, object_type, object_name, keyword, parameters, asset_url, asset_type, status, start_time, entered_time, job_user, last_updated, job_deliveryservice) VALUES (200, 1, null, null, 'PURGE', 'TTL:48h', 'http://cdn2.edge/job2/.*', 'file', 1, '2018-01-19 21:09:34.000000', '2018-01-19 21:09:34.000000', (SELECT id FROM tm_user where username = 'admin'), '2018-01-19 21:19:32.450915', 200);
 INSERT INTO job (id, agent, object_type, object_name, keyword, parameters, asset_url, asset_type, status, start_time, entered_time, job_user, last_updated, job_deliveryservice) VALUES (300, 1, null, null, 'PURGE', 'TTL:48h', 'http://cdn2.edge/job3/.*', 'file', 1, '2018-01-19 21:14:34.000000', '2018-01-19 21:14:34.000000', (SELECT id FROM tm_user where username = 'admin'), '2018-01-19 21:19:32.460870', 100);
 `
-	err := execSQL(db, sqlStmt, "job")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -278,7 +278,7 @@ INSERT INTO type (name, description, use_in_table) VALUES ('CHECK_EXTENSION_BOOL
 INSERT INTO type (name, description, use_in_table) VALUES ('CHECK_EXTENSION_NUM', 'Extension for int value in Server Check', 'to_extension');
 INSERT INTO type (name, description, use_in_table) VALUES ('CHECK_EXTENSION_OPEN_SLOT', 'Open slot for check in Server Status', 'to_extension');
 `
-	err := execSQL(db, sqlStmt, "type")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -292,7 +292,7 @@ func SetupToExtensions(db *sql.DB) error {
 INSERT INTO to_extension (name, version, info_url, isactive, script_file, servercheck_column_name, type) VALUES ('OPEN', '1.0.0', '-', false, '', 'aa', (SELECT id FROM type WHERE name = 'CHECK_EXTENSION_OPEN_SLOT'));
 INSERT INTO to_extension (name, version, info_url, isactive, script_file, servercheck_column_name, type) VALUES ('OPEN', '1.0.0', '-', false, '', 'ab', (SELECT id FROM type WHERE name = 'CHECK_EXTENSION_OPEN_SLOT'));
 	`
-	err := execSQL(db, sqlStmt, "to_extension")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -341,7 +341,7 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM tenant;
 	ALTER SEQUENCE tenant_id_seq RESTART WITH 1;
 `
-	err := execSQL(db, sqlStmt, "Tearing down")
+	err := execSQL(db, sqlStmt)
 	if err != nil {
 		return fmt.Errorf("exec failed %v", err)
 	}
@@ -349,9 +349,7 @@ func Teardown(db *sql.DB) error {
 }
 
 // execSQL ...
-func execSQL(db *sql.DB, sqlStmt string, dbTable string) error {
-
-	log.Debugln(dbTable + " data")
+func execSQL(db *sql.DB, sqlStmt string) error {
 	var err error
 
 	tx, err := db.Begin()

--- a/traffic_ops/testing/api/v2/traffic_control_test.go
+++ b/traffic_ops/testing/api/v2/traffic_control_test.go
@@ -54,5 +54,11 @@ type TrafficControl struct {
 	SteeringTargets                      []tc.SteeringTargetNullable             `json:"steeringTargets"`
 	Serverchecks                         []tc.ServercheckRequestNullable         `json:"serverchecks"`
 	Users                                []tc.User                               `json:"users"`
+	Jobs                                 []JobRequest                            `json:"jobs"`
 	InvalidationJobs                     []tc.InvalidationJobInput               `json:"invalidationJobs"`
+}
+
+type JobRequest struct {
+	DSName  string        `json:"dsName"`
+	Request tc.JobRequest `json:"request"`
 }

--- a/traffic_ops/testing/api/v2/traffic_control_test.go
+++ b/traffic_ops/testing/api/v2/traffic_control_test.go
@@ -30,7 +30,7 @@ type TrafficControl struct {
 	DeliveryServicesRegexes              []tc.DeliveryServiceRegexesTest         `json:"deliveryServicesRegexes"`
 	DeliveryServiceRequests              []tc.DeliveryServiceRequest             `json:"deliveryServiceRequests"`
 	DeliveryServiceRequestComments       []tc.DeliveryServiceRequestComment      `json:"deliveryServiceRequestComments"`
-	DeliveryServices                     []tc.DeliveryService                    `json:"deliveryservices"`
+	DeliveryServices                     []tc.DeliveryServiceNullable            `json:"deliveryservices"`
 	DeliveryServicesRequiredCapabilities []tc.DeliveryServicesRequiredCapability `json:"deliveryservicesRequiredCapabilities"`
 	Divisions                            []tc.Division                           `json:"divisions"`
 	Federations                          []tc.CDNFederation                      `json:"federations"`
@@ -54,11 +54,5 @@ type TrafficControl struct {
 	SteeringTargets                      []tc.SteeringTargetNullable             `json:"steeringTargets"`
 	Serverchecks                         []tc.ServercheckRequestNullable         `json:"serverchecks"`
 	Users                                []tc.User                               `json:"users"`
-	Jobs                                 []JobRequest                            `json:"jobs"`
 	InvalidationJobs                     []tc.InvalidationJobInput               `json:"invalidationJobs"`
-}
-
-type JobRequest struct {
-	DSName  string        `json:"dsName"`
-	Request tc.JobRequest `json:"request"`
 }

--- a/traffic_ops/testing/api/v2/types_test.go
+++ b/traffic_ops/testing/api/v2/types_test.go
@@ -52,7 +52,7 @@ func CreateTestTypes(t *testing.T) {
 		}
 
 		if typ.UseInTable != "server" {
-			err = execSQL(db, fmt.Sprintf(dbQueryTemplate, typ.Name, typ.Description, typ.UseInTable), "type")
+			err = execSQL(db, fmt.Sprintf(dbQueryTemplate, typ.Name, typ.Description, typ.UseInTable))
 		} else {
 			_, _, err = TOSession.CreateType(typ)
 		}
@@ -153,7 +153,7 @@ func DeleteTestTypes(t *testing.T) {
 		respType := resp[0]
 
 		if respType.UseInTable != "server" {
-			err := execSQL(db, fmt.Sprintf(dbDeleteTemplate, respType.Name), "type")
+			err := execSQL(db, fmt.Sprintf(dbDeleteTemplate, respType.Name))
 			if err != nil {
 				t.Fatalf("cannot DELETE Type by name: %v", err)
 			}

--- a/traffic_ops/testing/api/v2/user_test.go
+++ b/traffic_ops/testing/api/v2/user_test.go
@@ -394,13 +394,13 @@ func ForceDeleteTestUsers(t *testing.T) {
 
 	// there is a constraint that prevents users from being deleted when they have a log
 	q := `DELETE FROM log WHERE NOT tm_user = (SELECT id FROM tm_user WHERE username = 'admin')`
-	err = execSQL(db, q, "log")
+	err = execSQL(db, q)
 	if err != nil {
 		t.Errorf("cannot execute SQL: %s; SQL is %s", err.Error(), q)
 	}
 
 	q = `DELETE FROM tm_user WHERE username IN (` + strings.Join(usernames, ",") + `)`
-	err = execSQL(db, q, "tm_user")
+	err = execSQL(db, q)
 	if err != nil {
 		t.Errorf("cannot execute SQL: %s; SQL is %s", err.Error(), q)
 	}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4591. The usages of the deprecated `tc.DeliveryService` are all replaced with `tc.DeliveryServiceNullable` in the v2 tests (no test removals).

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
Verify passing xmlID as null and empty string to post `/deliveryservices/`, it should return a 400 error instead of a 500.
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->


<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
