### PR TITLE
Add readiness container to ciab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [unreleased]
 ### Added
 - Traffic Ops API v3
+- Added an optional readiness check service to cdn-in-a-box that exits successfully when it is able to get a `200 OK` from all delivery services
 
 ### Changed
 

--- a/docs/source/admin/quick_howto/ciab.rst
+++ b/docs/source/admin/quick_howto/ciab.rst
@@ -94,6 +94,16 @@ While the components may be interacted with by the host using these ports, the t
 
 When the CDN is to be shut down, it is often best to do so using ``sudo docker-compose down -v`` due to the use of shared volumes in the system which might interfere with a proper initialization upon the next run.
 
+Readiness Check
+"""""""""""""""
+
+In order to check the "readiness" of your CDN, you can optionally start the Readiness Container, which will continually :manpage:`curl(1)` the :term:`Delivery Services` in your CDN until they all return successful responses before exiting successfully.
+
+.. code-block:: shell
+	:caption: Example Command to Run the Readiness Container
+
+	sudo docker-compose -f docker-compose.readiness.yml up
+
 variables.env
 """""""""""""
 .. literalinclude:: ../../../../infrastructure/cdn-in-a-box/variables.env

--- a/infrastructure/cdn-in-a-box/README.md
+++ b/infrastructure/cdn-in-a-box/README.md
@@ -52,6 +52,22 @@ Finally, run the test CDN using the command:
 docker-compose up --build
 ```
 
+## Readiness
+To know if your CDN in a Box has started up successfully and is ready to use,
+you can optionally start the "readiness" container which will test your CDN and
+exit successfully when your CDN in a Box is ready:
+
+```bash
+docker-compose -f docker-compose.readiness.yml up --build
+```
+
+If the container does not exit successfully after a reasonable amount of time,
+something might have gone wrong with the main CDN services. Because the
+container continually runs end-to-end CDN requests, it will never exit
+successfully if there are issues with the main CDN services that cause the
+requests to fail. Check the log output of the main CDN services to see what
+might be getting stuck.
+
 ## Components
 > The following assumes that the default configuration provided in
 > [`variables.env`](./variables.env) is used.

--- a/infrastructure/cdn-in-a-box/docker-compose.readiness.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.readiness.yml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This docker-compose file starts a readiness service that will exit
+# successfully when it is able to successfully curl all delivery
+# service example URLs.
+#
+# For example:
+#
+#     docker-compose -f docker-compose.yml -f docker-compose.readiness.yml up
+#
+# Or, start up the main services in the background and run the readiness
+# service in the foreground:
+#
+#     docker-compose up -d
+#     docker-compose -f docker-compose.readiness.yml up
+
+---
+version: '2.1'
+
+services:
+  readiness:
+    build:
+      context: ../..
+      dockerfile: infrastructure/cdn-in-a-box/readiness/Dockerfile
+    env_file:
+      - variables.env
+    hostname: readiness
+    domainname: infra.ciab.test
+    volumes:
+      - shared:/shared
+      - ./dns/set-dns.sh:/usr/local/sbin/set-dns.sh
+      - ./dns/insert-self-into-dns.sh:/usr/local/sbin/insert-self-into-dns.sh
+
+volumes:
+  shared:
+    external: false

--- a/infrastructure/cdn-in-a-box/docker-compose.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.yml
@@ -290,6 +290,7 @@ services:
       - shared:/shared
     hostname: dns
     domainname: infra.ciab.test
+
   smtp:
     build:
       context: .

--- a/infrastructure/cdn-in-a-box/readiness/Dockerfile
+++ b/infrastructure/cdn-in-a-box/readiness/Dockerfile
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM alpine:3.11
+
+RUN apk add --no-cache --update \
+  curl \
+  bind-tools \
+  net-tools \
+  jq \
+  bash
+
+# MANIFEST
+# to-access.sh (sourced, get to-get and env vars)
+# run.sh       (wait on TO, then to-get deliveryservices, then curl the exampleURLs)
+COPY ./infrastructure/cdn-in-a-box/traffic_ops/to-access.sh /opt/readiness/
+COPY ./infrastructure/cdn-in-a-box/readiness/run.sh /opt/readiness/
+
+WORKDIR /opt/readiness
+CMD ./run.sh

--- a/infrastructure/cdn-in-a-box/readiness/Dockerfile
+++ b/infrastructure/cdn-in-a-box/readiness/Dockerfile
@@ -27,8 +27,7 @@ RUN apk add --no-cache --update \
 # MANIFEST
 # to-access.sh (sourced, get to-get and env vars)
 # run.sh       (wait on TO, then to-get deliveryservices, then curl the exampleURLs)
-COPY ./infrastructure/cdn-in-a-box/traffic_ops/to-access.sh /opt/readiness/
-COPY ./infrastructure/cdn-in-a-box/readiness/run.sh /opt/readiness/
+COPY ./infrastructure/cdn-in-a-box/readiness/run.sh ./infrastructure/cdn-in-a-box/traffic_ops/to-access.sh /opt/readiness/
 
 WORKDIR /opt/readiness
 CMD ./run.sh

--- a/infrastructure/cdn-in-a-box/readiness/run.sh
+++ b/infrastructure/cdn-in-a-box/readiness/run.sh
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+set -eu
+
 start_time=$(date +%s)
 
 source to-access.sh
@@ -24,8 +26,8 @@ set-dns.sh
 insert-self-into-dns.sh
 
 while ! to-ping 2>/dev/null; do
-   echo waiting for trafficops
-   sleep 3
+    echo waiting for trafficops
+    sleep 3
 done
 
 while true; do
@@ -34,23 +36,23 @@ while true; do
     if [[ "${#exampleURLs[@]}" -eq 0 ]]; then
         echo waiting for delivery service example URLs
         continue
-    else
-        echo "example URLs: '${exampleURLs[@]}'"
-        success="true"
-        for u in "${exampleURLs[@]}"; do
-            status=$(curl -Lkvs --connect-timeout 2 -m5 -o /dev/null -w "%{http_code}" "$u")
-            if [[ "$status" -ne 200 ]]; then
-                echo "failed to curl delivery service example URL '$u' got status code '$status'"
-                success="false"
-                break
-            else
-                echo "successfully curled delivery service example URL '$u'"
-            fi
-        done
-        if [[ "$success" == "true" ]]; then
-            echo "successfully curled all delivery service example URLs '${exampleURLs[@]}'"
+    fi
+    echo "example URLs: '${exampleURLs[@]}'"
+
+    success="true"
+    for u in "${exampleURLs[@]}"; do
+        status=$(curl -Lkvs --connect-timeout 2 -m5 -o /dev/null -w "%{http_code}" "$u")
+        if [[ "$status" -ne 200 ]]; then
+            echo "failed to curl delivery service example URL '$u' got status code '$status'"
+            success="false"
             break
+        else
+            echo "successfully curled delivery service example URL '$u'"
         fi
+    done
+    if [[ "$success" == "true" ]]; then
+        echo "successfully curled all delivery service example URLs '${exampleURLs[@]}'"
+        break
     fi
 done
 

--- a/infrastructure/cdn-in-a-box/readiness/run.sh
+++ b/infrastructure/cdn-in-a-box/readiness/run.sh
@@ -32,7 +32,7 @@ done
 
 while true; do
     sleep 3
-    exampleURLs=($(to-get /api/${TO_API_VERSION}/deliveryservices | jq -r '.response[].exampleURLs[]'))
+    exampleURLs=($(to-get /api/${TO_API_VERSION}/deliveryservices | jq -r '.response[].exampleURLs[]' || true))
     if [[ "${#exampleURLs[@]}" -eq 0 ]]; then
         echo waiting for delivery service example URLs
         continue
@@ -41,7 +41,7 @@ while true; do
 
     success="true"
     for u in "${exampleURLs[@]}"; do
-        status=$(curl -Lkvs --connect-timeout 2 -m5 -o /dev/null -w "%{http_code}" "$u")
+        status=$(curl -Lkvs --connect-timeout 2 -m5 -o /dev/null -w "%{http_code}" "$u" || true)
         if [[ "$status" -ne 200 ]]; then
             echo "failed to curl delivery service example URL '$u' got status code '$status'"
             success="false"

--- a/infrastructure/cdn-in-a-box/readiness/run.sh
+++ b/infrastructure/cdn-in-a-box/readiness/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+start_time=$(date +%s)
+
+source to-access.sh
+
+set-dns.sh
+insert-self-into-dns.sh
+
+while ! to-ping 2>/dev/null; do
+   echo waiting for trafficops
+   sleep 3
+done
+
+while true; do
+    sleep 3
+    exampleURLs=($(to-get /api/${TO_API_VERSION}/deliveryservices | jq -r '.response[].exampleURLs[]'))
+    if [[ "${#exampleURLs[@]}" -eq 0 ]]; then
+        echo waiting for delivery service example URLs
+        continue
+    else
+        echo "example URLs: '${exampleURLs[@]}'"
+        success="true"
+        for u in "${exampleURLs[@]}"; do
+            status=$(curl -Lkvs --connect-timeout 2 -m5 -o /dev/null -w "%{http_code}" "$u")
+            if [[ "$status" -ne 200 ]]; then
+                echo "failed to curl delivery service example URL '$u' got status code '$status'"
+                success="false"
+                break
+            else
+                echo "successfully curled delivery service example URL '$u'"
+            fi
+        done
+        if [[ "$success" == "true" ]]; then
+            echo "successfully curled all delivery service example URLs '${exampleURLs[@]}'"
+            break
+        fi
+    fi
+done
+
+end_time=$(date +%s)
+delta=$((end_time - start_time))
+echo "completed readiness check in $delta seconds"

--- a/infrastructure/cdn-in-a-box/readiness/run.sh
+++ b/infrastructure/cdn-in-a-box/readiness/run.sh
@@ -25,7 +25,7 @@ source to-access.sh
 set-dns.sh
 insert-self-into-dns.sh
 
-while ! to-ping 2>/dev/null; do
+while ! to-ping; do
     echo waiting for trafficops
     sleep 3
 done
@@ -33,25 +33,25 @@ done
 while true; do
     sleep 3
     exampleURLs=($(to-get /api/${TO_API_VERSION}/deliveryservices | jq -r '.response[].exampleURLs[]' || true))
-    if [[ "${#exampleURLs[@]}" -eq 0 ]]; then
+    if ! exampeURLs=($(to-get "/api/${TO_API_VERSION}/deliveryservices" | jq -r '.response[].exampleURLs[]')) \
+            || [[ "${#exampleURLs[@]}" -eq 0 ]]; then
         echo waiting for delivery service example URLs
         continue
     fi
-    echo "example URLs: '${exampleURLs[@]}'"
+    echo "example URLs: '${exampleURLs[*]}'"
 
     success="true"
     for u in "${exampleURLs[@]}"; do
-        status=$(curl -Lkvs --connect-timeout 2 -m5 -o /dev/null -w "%{http_code}" "$u" || true)
-        if [[ "$status" -ne 200 ]]; then
+        if ! status=$(curl -Lkvs --connect-timeout 2 -m5 -o /dev/null -w "%{http_code}" "$u") \
+                || [[ "$status" -ne 200 ]]; then
             echo "failed to curl delivery service example URL '$u' got status code '$status'"
             success="false"
             break
-        else
-            echo "successfully curled delivery service example URL '$u'"
         fi
+        echo "successfully curled delivery service example URL '$u'"
     done
     if [[ "$success" == "true" ]]; then
-        echo "successfully curled all delivery service example URLs '${exampleURLs[@]}'"
+        echo "successfully curled all delivery service example URLs '${exampleURLs[*]}'"
         break
     fi
 done


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Today, there's not really a great way to tell when ciab is "ready", i.e.
all services have started up successfully, so that you can start using
it. Or, maybe you only care to know whether ciab started up successfully
or not, and that's it.

Traditionally, ciab being "successful" means that you can curl the
delivery service, so that's what the readiness container does. This way,
you can start up the "main" services in the background and start up the
"readiness" service in the foreground. When ciab is ready, the readiness
service will exit, and you can start using ciab. You no longer manually
have to watch the log output for things that _probably_ indicate ciab
started up successfully, or manually curl the delivery service in a
loop until it responds.

- [x] This PR is not related to any Issue


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
```
cd infrastructure/cdn-in-a-box
docker-compose up -d
docker-compose -f docker-compose.readiness.yml up
# wait until readiness container exits successfully, logging that
# it has successfully curled all the DS example URLs
```

## The following criteria are ALL met by this PR

- [x] ciab is a test
- [x] ciab enhancement doesn't require new docs
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
