### PR TITLE
Fixed hiding query parameter parsing errors from client

### DIFF
--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
@@ -206,14 +207,7 @@ func (job *InvalidationJob) Read() ([]interface{}, error, error, int) {
 
 	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(job.APIInfo().Params, queryParamsToSQLCols)
 	if len(errs) > 0 {
-		var b strings.Builder
-		b.WriteString("Reading jobs:")
-		for _, err := range errs {
-			b.WriteString("\n\t")
-			b.WriteString(err.Error())
-		}
-
-		return nil, nil, errors.New(b.String()), http.StatusInternalServerError
+		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest
 	}
 
 	accessibleTenants, err := tenant.GetUserTenantIDListTx(job.APIInfo().Tx.Tx, job.APIInfo().User.TenantID)


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4658

The `GET /jobs` endpoint was hiding errors derived from parsing pagination, sorting, and filtering query parameters. This fixes that.


## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Try and fail to reproduce the error in #4658

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0
- 4.1 (RC0)

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**
