### PR TITLE
Removed 'sudo' from CiaB Makefile

### DIFF
--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -76,19 +76,19 @@ traffic_stats/traffic_stats.rpm: ../../dist/traffic_stats-$(SPECIAL_SAUCE)
 
 # Dist rpms
 ../../dist/traffic_monitor-$(SPECIAL_SAUCE): $(TM_SOURCE)
-	sudo ../../pkg $(PKG_FLAGS) traffic_monitor_build
+	../../pkg $(PKG_FLAGS) traffic_monitor_build
 
 ../../dist/traffic_ops-$(SPECIAL_SAUCE): $(TO_SOURCE)
-	sudo ../../pkg $(PKG_FLAGS) traffic_ops_build
+	../../pkg $(PKG_FLAGS) traffic_ops_build
 
 ../../dist/traffic_portal-$(SPECIAL_SAUCE): $(TP_SOURCE)
-	sudo ../../pkg $(PKG_FLAGS) traffic_portal_build
+	../../pkg $(PKG_FLAGS) traffic_portal_build
 
 ../../dist/traffic_rou%er-$(SPECIAL_SAUCE) ../../dist/tomca%-$(SPECIAL_SEASONING): $(TR_SOURCE)
-	sudo ../../pkg $(PKG_FLAGS) traffic_router_build
+	../../pkg $(PKG_FLAGS) traffic_router_build
 
 ../../dist/traffic_stats-$(SPECIAL_SAUCE): $(TS_SOURCE)
-	sudo ../../pkg $(PKG_FLAGS) traffic_stats_build
+	../../pkg $(PKG_FLAGS) traffic_stats_build
 
 clean:
 	$(RM) traffic_monitor/traffic_monitor.rpm traffic_ops/traffic_ops.rpm traffic_portal/traffic_portal.rpm traffic_router/traffic_router.rpm traffic_router/tomcat.rpm edge/traffic_ops_ort.rpm mid/traffic_ops_ort.rpm traffic_stats/traffic_stats.rpm


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This just removes `sudo` from the CDN-in-a-Box's Makefile, which was only used to accommodate my specific weird setup on my laptop where a user in the `docker` group for some reason didn't have permissions to use Docker. If that specific use-case still exists, people can just do `sudo make` to accomplish the same thing.

## Which Traffic Control components are affected by this PR?
- CDN in a Box

## What is the best way to verify this PR?
Run `make very-clean && make`, then make sure all CDN-in-a-Box images can build. Shouldn't be necessary to actually run them. No tests because CDN-in-a-Box isn't tested.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
