### PR TITLE
TO API v3 followup fixes

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/Dockerfile
@@ -28,8 +28,9 @@ COPY ./infrastructure/cdn-in-a-box/ /go/src/github.com/apache/trafficcontrol/inf
 COPY ./vendor/ /go/src/github.com/apache/trafficcontrol/vendor/
 COPY ./traffic_ops/vendor/ /go/src/github.com/apache/trafficcontrol/traffic_ops/vendor/
 COPY ./lib/ /go/src/github.com/apache/trafficcontrol/lib/
-COPY ./traffic_ops/client/ /go/src/github.com/apache/trafficcontrol/traffic_ops/client/
 COPY ./traffic_ops/v1-client/ /go/src/github.com/apache/trafficcontrol/traffic_ops/v1-client/
+COPY ./traffic_ops/v2-client/ /go/src/github.com/apache/trafficcontrol/traffic_ops/v2-client/
+COPY ./traffic_ops/client/ /go/src/github.com/apache/trafficcontrol/traffic_ops/client/
 COPY ./traffic_ops/testing/api /go/src/github.com/apache/trafficcontrol/traffic_ops/testing/api
 COPY ./traffic_ops/traffic_ops_golang /go/src/github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang
 
@@ -37,6 +38,7 @@ COPY ./traffic_ops/traffic_ops_golang /go/src/github.com/apache/trafficcontrol/t
 WORKDIR /go/src/github.com/apache/trafficcontrol/traffic_ops/testing/api
 RUN CGO_ENABLED=0 go test -c ./v1* -ldflags="-w -s" -o traffic_ops_v1_integration_test
 RUN CGO_ENABLED=0 go test -c ./v2* -ldflags="-w -s" -o traffic_ops_v2_integration_test
+RUN CGO_ENABLED=0 go test -c ./v3* -ldflags="-w -s" -o traffic_ops_v3_integration_test
 
 FROM alpine:3.11
 
@@ -59,11 +61,15 @@ COPY ./infrastructure/cdn-in-a-box/traffic_ops/to-access.sh /opt/integration/app
 COPY ./infrastructure/cdn-in-a-box/traffic_ops_integration_test/config.sh /opt/integration/app/
 COPY ./traffic_ops/testing/api/v1/tc-fixtures.json /opt/integration/app/tc-fixtures-v1.json
 COPY ./traffic_ops/testing/api/v2/tc-fixtures.json /opt/integration/app/tc-fixtures-v2.json
+COPY ./traffic_ops/testing/api/v3/tc-fixtures.json /opt/integration/app/tc-fixtures-v3.json
 COPY --from=integration-builder \
     /go/src/github.com/apache/trafficcontrol/traffic_ops/testing/api/traffic_ops_v1_integration_test \
     /opt/integration/app/
 COPY --from=integration-builder \
     /go/src/github.com/apache/trafficcontrol/traffic_ops/testing/api/traffic_ops_v2_integration_test \
+    /opt/integration/app/
+COPY --from=integration-builder \
+    /go/src/github.com/apache/trafficcontrol/traffic_ops/testing/api/traffic_ops_v3_integration_test \
     /opt/integration/app/
 
 COPY --from=integration-builder \

--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/run.sh
@@ -43,10 +43,13 @@ source config.sh
 export v1=$?
 ./traffic_ops_v2_integration_test -test.v -cfg=traffic-ops-test.conf -fixtures=tc-fixtures-v2.json 2>&1 | ./go-junit-report --package-name=golang.test.toapi.v2 --set-exit-code > /junit/golang.test.toapi.v2.xml && find /junit -type 'f' | xargs chmod 664
 export v2=$?
+./traffic_ops_v3_integration_test -test.v -cfg=traffic-ops-test.conf -fixtures=tc-fixtures-v3.json 2>&1 | ./go-junit-report --package-name=golang.test.toapi.v3 --set-exit-code > /junit/golang.test.toapi.v3.xml && find /junit -type 'f' | xargs chmod 664
+export v3=$?
 
-cat /junit/golang.test.toapi.v1.xml /junit/golang.test.toapi.v2.xml
+cat /junit/golang.test.toapi.v1.xml /junit/golang.test.toapi.v2.xml /junit/golang.test.toapi.v3.xml
 
-if [ $v1 -eq 0 ] && [ $v2 -eq 0 ]
+
+if [ $v1 -eq 0 ] && [ $v2 -eq 0 ] && [ $v3 -eq 0 ]
 then
   echo "TO API tests success"
 else

--- a/traffic_ops/client/deliveryservice.go
+++ b/traffic_ops/client/deliveryservice.go
@@ -28,80 +28,80 @@ import (
 const (
 	// API_DELIVERY_SERVICES is the API path on which Traffic Ops serves Delivery Service
 	// information. More specific information is typically found on sub-paths of this.
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices.html
 	API_DELIVERY_SERVICES = apiBase + "/deliveryservices"
 
 	// API_DELIVERY_SERVICE_ID is the API path on which Traffic Ops serves information about
 	// a specific Delivery Service identified by an integral, unique identifier. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the ID
 	// of the Delivery Service of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_id.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id.html
 	API_DELIVERY_SERVICE_ID = API_DELIVERY_SERVICES + "/%v"
 
 	// API_DELIVERY_SERVICE_HEALTH is the API path on which Traffic Ops serves information about
 	// the 'health' of a specific Delivery Service identified by an integral, unique identifier. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the ID
 	// of the Delivery Service of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_id_health.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_health.html
 	API_DELIVERY_SERVICE_HEALTH = API_DELIVERY_SERVICE_ID + "/health"
 
 	// API_DELIVERY_SERVICE_CAPACITY is the API path on which Traffic Ops serves information about
 	// the 'capacity' of a specific Delivery Service identified by an integral, unique identifier. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the ID
 	// of the Delivery Service of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_id_capacity.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_capacity.html
 	API_DELIVERY_SERVICE_CAPACITY = API_DELIVERY_SERVICE_ID + "/capacity"
 
 	// API_DELIVERY_SERVICE_ELIGIBLE_SERVERS is the API path on which Traffic Ops serves information about
 	// the servers which are eligible to be assigned to a specific Delivery Service identified by an integral,
 	// unique identifier. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the ID of the Delivery Service of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_id_servers_eligible.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_servers_eligible.html
 	API_DELIVERY_SERVICE_ELIGIBLE_SERVERS = API_DELIVERY_SERVICE_ID + "/servers/eligible"
 
 	// API_DELIVERY_SERVICES_SAFE_UPDATE is the API path on which Traffic Ops provides the functionality to
 	// update the "safe" subset of properties of a Delivery Service identified by an integral, unique
 	// identifer. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the ID of the Delivery Service of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_id_safe.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_safe.html
 	API_DELIVERY_SERVICES_SAFE_UPDATE = API_DELIVERY_SERVICE_ID + "/safe"
 
 	// API_DELIVERY_SERVICE_XMLID_SSL_KEYS is the API path on which Traffic Ops serves information about
 	// and functionality relating to the SSL keys used by a Delivery Service identified by its XMLID. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the XMLID
 	// of the Delivery Service of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_xmlid_xmlid_sslkeys.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_xmlid_sslkeys.html
 	API_DELIVERY_SERVICE_XMLID_SSL_KEYS = API_DELIVERY_SERVICES + "/xmlid/%s/sslkeys"
 
 	// API_DELIVERY_SERVICE_URI_SIGNING_KEYS is the API path on which Traffic Ops serves information
 	// about and functionality relating to the URI-signing keys used by a Delivery Service identified
 	// by its XMLID. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the XMLID of the Delivery Service of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_xmlid_urisignkeys.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_urisignkeys.html
 	API_DELIVERY_SERVICES_URI_SIGNING_KEYS = API_DELIVERY_SERVICES + "/%s/urisignkeys"
 
 	// API_DELIVERY_SERVICES_URL_SIGNING_KEYS is the API path on which Traffic Ops serves information
 	// about and functionality relating to the URL-signing keys used by a Delivery Service identified
 	// by its XMLID. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the XMLID of the Delivery Service of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_xmlid_xmlid_urlkeys.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_xmlid_urlkeys.html
 	API_DELIVERY_SERVICES_URL_SIGNING_KEYS = API_DELIVERY_SERVICES + "/xmlid/%s/urlkeys"
 
 	// API_DELIVERY_SERVICES_REGEXES is the API path on which Traffic Ops serves Delivery Service
 	// 'regex' (Regular Expression) information.
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_regexes.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_regexes.html
 	API_DELIVERY_SERVICES_REGEXES = apiBase + "/deliveryservices_regexes"
 
 	// API_SERVER_DELIVERY_SERVICES is the API path on which Traffic Ops serves functionality
 	// related to the associations a specific server and its assigned Delivery Services. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the ID
 	// of the server of interest).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/servers_id_deliveryservices.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/servers_id_deliveryservices.html
 	API_SERVER_DELIVERY_SERVICES = apiBase + "/servers/%d/deliveryservices"
 
 	// API_DELIVERY_SERVICE_SERVER is the API path on which Traffic Ops serves functionality related
 	// to the associations between Delivery Services and their assigned Server(s).
-	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryserviceserver.html
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryserviceserver.html
 	API_DELIVERY_SERVICE_SERVER = apiBase + "/deliveryserviceserver"
 )
 

--- a/traffic_ops/client/deliveryservice_regexes.go
+++ b/traffic_ops/client/deliveryservice_regexes.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// See: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_id_regexes.html
+	// See: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_regexes.html
 	API_DS_REGEXES = apiBase + "/deliveryservices/%v/regexes"
 )
 

--- a/traffic_ops/client/traffic_monitor.go
+++ b/traffic_ops/client/traffic_monitor.go
@@ -29,7 +29,7 @@ import (
 // API_CDN_MONITORING_CONFIG is the API path on which Traffic Ops serves the CDN monitoring
 // configuration information. It is meant to be used with fmt.Sprintf to insert the necessary
 // path parameters (namely the Name of the CDN of interest).
-// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/cdns_name_configs_monitoring.html
+// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/cdns_name_configs_monitoring.html
 const API_CDN_MONITORING_CONFIG = apiBase + "/cdns/%s/configs/monitoring"
 
 // GetTrafficMonitorConfigMap is functionally identical to GetTrafficMonitorConfig, except that it

--- a/traffic_ops/testing/api/v3/cookie_test.go
+++ b/traffic_ops/testing/api/v3/cookie_test.go
@@ -42,7 +42,7 @@ func CookiesTest(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to json marshal login credentials")
 	}
-	path := "/api/2.0/user/login"
+	path := TestAPIBase + "/user/login"
 	loginResp, _, err := s.RawRequest(http.MethodPost, path, js)
 	if err != nil {
 		t.Fatal("unable to request POST /user/login")
@@ -54,7 +54,7 @@ func CookiesTest(t *testing.T) {
 	}
 	ensureCookie(loginResp, t)
 
-	cdnResp, _, err := s.RawRequest(http.MethodGet, "/api/2.0/cdns", nil)
+	cdnResp, _, err := s.RawRequest(http.MethodGet, TestAPIBase+"/cdns", nil)
 	if err != nil {
 		t.Fatal("unable to request GET /cdns")
 	}

--- a/traffic_ops/testing/api/v3/serverupdatestatus_test.go
+++ b/traffic_ops/testing/api/v3/serverupdatestatus_test.go
@@ -224,7 +224,7 @@ func TestServerQueueUpdate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to encode request body: %v", err)
 			}
-			path := fmt.Sprintf("/api/2.0/servers/%d/queue_update", s.ID)
+			path := fmt.Sprintf(TestAPIBase+"/servers/%d/queue_update", s.ID)
 			httpResp, _, err := TOSession.RawRequest(http.MethodPost, path, req)
 			if err != nil {
 				t.Fatalf("POST request failed: %v", err)

--- a/traffic_ops/testing/api/v3/traffic_ops_test.go
+++ b/traffic_ops/testing/api/v3/traffic_ops_test.go
@@ -1,4 +1,4 @@
-// Package v2 provides tests for the Traffic Ops API.
+// Package v3 provides tests for the Traffic Ops API.
 package v3
 
 /*
@@ -34,6 +34,8 @@ var (
 	testData           TrafficControl
 	includeSystemTests bool
 )
+
+const TestAPIBase = "/api/3.0"
 
 func TestMain(m *testing.M) {
 	configFileName := flag.String("cfg", "traffic-ops-test.conf", "The config file path")

--- a/traffic_ops/testing/api/v3/user_test.go
+++ b/traffic_ops/testing/api/v3/user_test.go
@@ -17,13 +17,13 @@ package v3
 import (
 	"bytes"
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"net/http"
 	"net/mail"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
@@ -90,7 +90,7 @@ func RolenameCapitalizationTest(t *testing.T) {
 	}`, *roles[0].ID, tenants[0].ID)
 
 	reader := strings.NewReader(blob)
-	request, err := http.NewRequest("POST", fmt.Sprintf("%v/api/2.0/users", TOSession.URL), reader)
+	request, err := http.NewRequest("POST", fmt.Sprintf("%v%s/users", TOSession.URL, TestAPIBase), reader)
 	if err != nil {
 		t.Errorf("could not make new request: %v", err)
 	}
@@ -106,7 +106,7 @@ func RolenameCapitalizationTest(t *testing.T) {
 		t.Error("incorrect json was returned for POST")
 	}
 
-	request, err = http.NewRequest("GET", fmt.Sprintf("%v/api/2.0/users?username=test_user", TOSession.URL), nil)
+	request, err = http.NewRequest("GET", fmt.Sprintf("%v%s/users?username=test_user", TOSession.URL, TestAPIBase), nil)
 	resp, err = TOSession.Client.Do(request)
 
 	buf = new(bytes.Buffer)


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fixes TO API integration test container, adds v3 TO API tests to it, fixes some TO API v3 tests that were still calling v2, fixed some comments that referenced v2 instead of v3.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- CDN in a Box
- TO API tests

## What is the best way to verify this PR?
Build and run the TO API test container against CIAB, make sure it builds properly and passes:
```
docker-compose -f docker-compose.traffic-ops-test.yml  build
docker-compose up --no-deps -d dns db smtp trafficops-perl trafficops
docker-compose -f docker-compose.traffic-ops-test.yml -f docker-compose.yml up integration
```
## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR

- [x] This PR fixes tests
- [x] This PR updates references to documentation
- [x] Changelog unnecessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)