### PR TITLE
Fixed weasel license error

### DIFF
--- a/traffic_ops/testing/api/v3/.gitignore
+++ b/traffic_ops/testing/api/v3/.gitignore
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 traffic-ops-test.conf


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue

My GHA pipeline caught this!

Because `.gitignore`s are now required to have licenses, the v3 API integration tests are now in violation of the license policy. This fixes it by adding the license.

## Which Traffic Control components are affected by this PR?
None. Or all, depending on what "affected" means.

## What is the best way to verify this PR?
Run weasel.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**