### PR TITLE
Fix atscfg ip_allow gen not using v6 number param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Traffic Ops API v3
 - Added an optional readiness check service to cdn-in-a-box that exits successfully when it is able to get a `200 OK` from all delivery services
+- Fixed ORT config generation not using the coalesce_number_v6 Parameter.
 
 ### Changed
 

--- a/lib/go-atscfg/ipallowdotconfig.go
+++ b/lib/go-atscfg/ipallowdotconfig.go
@@ -124,7 +124,7 @@ func MakeIPAllowDotConfig(
 			case ParamCoalesceNumberV6:
 				if vi, err := strconv.Atoi(val); err != nil {
 					log.Warnln("MakeIPAllowDotConfig got param '" + name + "' val '" + val + "' not a number, ignoring!")
-				} else if coalesceNumberV6 != DefaultCoalesceMaskLenV6 {
+				} else if coalesceNumberV6 != DefaultCoalesceNumberV6 {
 					log.Warnln("MakeIPAllowDotConfig got multiple param '" + name + "' - ignoring  val '" + val + "'!")
 				} else {
 					coalesceNumberV6 = vi


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fixes ORT config generation not using the `coalesce_number_v6` Parameter.

Includes tests.
No docs, no interface change.
Includes changelog.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests.
Run ORT against a Traffic Ops with a custom `coalesce_number_v6` parameter, verify the generated ip_allow.config IPv6 addresses are collapsed according to the Parameter and not the default of 5.

## If this is a bug fix, what versions of Traffic Control are affected?
- 4.0.0

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
