### PR TITLE
Removed some unused methods in TM, deprecated TO client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed ORT config generation not using the coalesce_number_v6 Parameter.
 
 ### Changed
+- Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.
 
 ### Deprecated
+- Deprecated the non-nullable `DeliveryService` Go struct and other structs that use it. `DeliveryServiceNullable` structs should be used instead.
 
 ### Removed
+- Removed deprecated Traffic Ops Go Client methods.
 
 ## [4.1.0] - 2020-04-23
 ### Added

--- a/infrastructure/cdn-in-a-box/enroller/enroller.go
+++ b/infrastructure/cdn-in-a-box/enroller/enroller.go
@@ -432,14 +432,14 @@ func enrollRegion(toSession *session, r io.Reader) error {
 
 func enrollStatus(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
-	var s tc.Status
+	var s tc.StatusNullable
 	err := dec.Decode(&s)
 	if err != nil && err != io.EOF {
 		log.Infof("error decoding Status: %s\n", err)
 		return err
 	}
 
-	alerts, _, err := toSession.CreateStatus(s)
+	alerts, _, err := toSession.CreateStatusNullable(s)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			log.Infof("status %s already exists\n", s.Name)

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -39,6 +39,7 @@ type GetDeliveryServiceResponse struct {
 }
 
 // DeliveryServicesResponse ...
+// Deprecated: use DeliveryServicesNullableResponse instead
 type DeliveryServicesResponse struct {
 	Response []DeliveryService `json:"response"`
 	Alerts
@@ -51,40 +52,37 @@ type DeliveryServicesNullableResponse struct {
 }
 
 // CreateDeliveryServiceResponse ...
+// Deprecated: use CreateDeliveryServiceNullableResponse instead
 type CreateDeliveryServiceResponse struct {
-	Response []DeliveryService      `json:"response"`
-	Alerts   []DeliveryServiceAlert `json:"alerts"`
+	Response []DeliveryService `json:"response"`
+	Alerts
 }
 
 // CreateDeliveryServiceNullableResponse ...
 type CreateDeliveryServiceNullableResponse struct {
 	Response []DeliveryServiceNullable `json:"response"`
-	Alerts   []DeliveryServiceAlert    `json:"alerts"`
+	Alerts
 }
 
 // UpdateDeliveryServiceResponse ...
+// Deprecated: use UpdateDeliveryServiceNullableResponse instead
 type UpdateDeliveryServiceResponse struct {
-	Response []DeliveryService      `json:"response"`
-	Alerts   []DeliveryServiceAlert `json:"alerts"`
+	Response []DeliveryService `json:"response"`
+	Alerts
 }
 
 // UpdateDeliveryServiceNullableResponse ...
 type UpdateDeliveryServiceNullableResponse struct {
 	Response []DeliveryServiceNullable `json:"response"`
-	Alerts   []DeliveryServiceAlert    `json:"alerts"`
-}
-
-// DeliveryServiceResponse ...
-type DeliveryServiceResponse struct {
-	Response DeliveryService        `json:"response"`
-	Alerts   []DeliveryServiceAlert `json:"alerts"`
+	Alerts
 }
 
 // DeleteDeliveryServiceResponse ...
 type DeleteDeliveryServiceResponse struct {
-	Alerts []DeliveryServiceAlert `json:"alerts"`
+	Alerts
 }
 
+// Deprecated: use DeliveryServiceNullable instead
 type DeliveryService struct {
 	DeliveryServiceV13
 	MaxOriginConnections      int      `json:"maxOriginConnections" db:"max_origin_connections"`
@@ -481,12 +479,6 @@ type DeliveryServiceMatch struct {
 	Pattern   string      `json:"pattern"`
 }
 
-// DeliveryServiceAlert ...
-type DeliveryServiceAlert struct {
-	Level string `json:"level"`
-	Text  string `json:"text"`
-}
-
 // DeliveryServiceStateResponse ...
 type DeliveryServiceStateResponse struct {
 	Response DeliveryServiceState `json:"response"`
@@ -632,10 +624,10 @@ type AssignedDsResponse struct {
 // DeliveryServiceSafeUpdateRequest represents a request to update the "safe" fields of a
 // Delivery Service.
 type DeliveryServiceSafeUpdateRequest struct {
-	DisplayName *string `json:"displayName`
+	DisplayName *string `json:"displayName"`
 	InfoURL     *string `json:"infoUrl"`
 	LongDesc    *string `json:"longDesc"`
-	LongDesc1   *string `json:"longDesc1`
+	LongDesc1   *string `json:"longDesc1"`
 }
 
 // Validate implements the github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.ParseValidator

--- a/lib/go-tc/enum_test.go
+++ b/lib/go-tc/enum_test.go
@@ -60,26 +60,4 @@ func TestDeepCachingType(t *testing.T) {
 			t.Errorf("Expected %v,  got %v", dc, new)
 		}
 	}
-
-	// make sure we get the right default when marshalled within a new delivery service
-	var ds DeliveryService
-	_, err := json.MarshalIndent(ds, ``, `  `)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	c = ds.DeepCachingType.String()
-	if c != "NEVER" {
-		t.Errorf(`Default "%s" expected to be "NEVER"`, c)
-	}
-
-	// make sure null values are handled properly
-	byt := []byte(`{"deepCachingType": null}`)
-	err = json.Unmarshal(byt, &ds)
-	if err != nil {
-		t.Errorf(`Expected to be able to unmarshall a null deepCachingType as "NEVER", instead got error "%v"`, err.Error())
-	}
-	c = ds.DeepCachingType.String()
-	if c != "NEVER" {
-		t.Errorf(`null deepCachingType expected to be "NEVER", got "%s"`, c)
-	}
 }

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -42,13 +42,6 @@ type ITrafficOpsSession interface {
 	LastCRConfig(cdn string) ([]byte, time.Time, error)
 	TrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, error)
 	Set(session *client.Session)
-	URL() (string, error)
-	User() (string, error)
-	Servers() ([]tc.Server, error)
-	Profiles() ([]tc.Profile, error)
-	Parameters(profileName string) ([]tc.Parameter, error)
-	DeliveryServices() ([]tc.DeliveryService, error)
-	CacheGroups() ([]tc.CacheGroupNullable, error)
 	CRConfigHistory() []CRConfigStat
 	BackupFileExists() bool
 }
@@ -191,22 +184,6 @@ func (s TrafficOpsSessionThreadsafe) get() *client.Session {
 		return nil
 	}
 	return *s.session
-}
-
-func (s TrafficOpsSessionThreadsafe) URL() (string, error) {
-	ss := s.get()
-	if ss == nil {
-		return "", ErrNilSession
-	}
-	return ss.URL, nil
-}
-
-func (s TrafficOpsSessionThreadsafe) User() (string, error) {
-	ss := s.get()
-	if ss == nil {
-		return "", ErrNilSession
-	}
-	return ss.UserName, nil
 }
 
 func (s TrafficOpsSessionThreadsafe) CRConfigHistory() []CRConfigStat {
@@ -540,49 +517,4 @@ func CreateMonitorConfig(crConfig tc.CRConfig, mc *tc.TrafficMonitorConfigMap) (
 		}
 	}
 	return mc, nil
-}
-
-func (s TrafficOpsSessionThreadsafe) Servers() ([]tc.Server, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	servers, _, error := ss.GetServers()
-	return servers, error
-}
-
-func (s TrafficOpsSessionThreadsafe) Profiles() ([]tc.Profile, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	profiles, _, error := ss.GetProfiles()
-	return profiles, error
-}
-
-func (s TrafficOpsSessionThreadsafe) Parameters(profileName string) ([]tc.Parameter, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	parameters, _, error := ss.GetParametersByProfileName(profileName)
-	return parameters, error
-}
-
-func (s TrafficOpsSessionThreadsafe) DeliveryServices() ([]tc.DeliveryService, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	deliveryServices, _, error := ss.GetDeliveryServices()
-	return deliveryServices, error
-}
-
-func (s TrafficOpsSessionThreadsafe) CacheGroups() ([]tc.CacheGroupNullable, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	cacheGroups, _, error := ss.GetCacheGroupsNullable()
-	return cacheGroups, error
 }

--- a/traffic_ops/client/job.go
+++ b/traffic_ops/client/job.go
@@ -109,8 +109,6 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 				path += "dsId=" + strconv.FormatInt(int64(d.(int)), 10)
 			case string:
 				path += "deliveryService=" + d.(string)
-			case tc.DeliveryService:
-				path += "deliveryService=" + d.(tc.DeliveryService).XMLID
 			case tc.DeliveryServiceNullable:
 				if d.(tc.DeliveryServiceNullable).XMLID != nil {
 					path += "deliveryService=" + *d.(tc.DeliveryServiceNullable).XMLID

--- a/traffic_ops/client/status.go
+++ b/traffic_ops/client/status.go
@@ -28,26 +28,6 @@ const (
 	API_STATUSES = apiBase + "/statuses"
 )
 
-// CreateStatus creates a Status.
-// Deprecated: Use CreateStatusNullable instead.
-func (to *Session) CreateStatus(status tc.Status) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(status)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_STATUSES, reqBody)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
-	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
-}
-
 // CreateStatusNullable creates a new status, using the tc.StatusNullable structure.
 func (to *Session) CreateStatusNullable(status tc.StatusNullable) (tc.Alerts, ReqInf, error) {
 

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -28,13 +28,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
-// Users gets an array of Users.
-// Deprecated: use GetUsers
-func (to *Session) Users() ([]tc.User, error) {
-	us, _, err := to.GetUsers()
-	return us, err
-}
-
 // GetUsers returns all users accessible from current user
 func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
 	data := tc.UsersResponse{}

--- a/traffic_ops/testing/api/v2/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v2/cachegroupsdeliveryservices_test.go
@@ -103,7 +103,7 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 		for _, dsID := range dsIDs {
 			found := false
 			for _, serverDS := range serverDSes {
-				if serverDS.ID == int(dsID) {
+				if *serverDS.ID == int(dsID) {
 					found = true
 					break
 				}

--- a/traffic_ops/testing/api/v3/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/cachegroupsdeliveryservices_test.go
@@ -103,7 +103,7 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 		for _, dsID := range dsIDs {
 			found := false
 			for _, serverDS := range serverDSes {
-				if serverDS.ID == int(dsID) {
+				if *serverDS.ID == int(dsID) {
 					found = true
 					break
 				}

--- a/traffic_ops/v2-client/deliveryservice.go
+++ b/traffic_ops/v2-client/deliveryservice.go
@@ -105,22 +105,10 @@ const (
 	API_DELIVERY_SERVICE_SERVER = apiBase + "/deliveryserviceserver"
 )
 
-// GetDeliveryServices returns a slice of Delivery Services.
-// Deprecated: Use GetDeliveryServicesNullable instead.
-func (to *Session) GetDeliveryServices() ([]tc.DeliveryService, ReqInf, error) {
-	var data tc.DeliveryServicesResponse
-	reqInf, err := get(to, API_DELIVERY_SERVICES, &data)
-	if err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
-}
-
 // GetDeliveryServicesByServer returns all of the (tenant-visible) Delivery Services assigned to
 // the server identified by the integral, unique identifier 'id'.
-func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryService, ReqInf, error) {
-	var data tc.DeliveryServicesResponse
+func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+	var data tc.DeliveryServicesNullableResponse
 
 	reqInf, err := get(to, fmt.Sprintf(API_SERVER_DELIVERY_SERVICES, id), &data)
 	if err != nil {
@@ -128,21 +116,6 @@ func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryService, Re
 	}
 
 	return data.Response, reqInf, nil
-}
-
-// GetDeliveryService returns the Delivery Service identified by the integral, unique identifier
-// 'id' (which must be passed as a string).
-// Deprecated: Use GetDeliveryServiceNullable instead.
-func (to *Session) GetDeliveryService(id string) (*tc.DeliveryService, ReqInf, error) {
-	var data tc.DeliveryServicesResponse
-	reqInf, err := get(to, API_DELIVERY_SERVICES+"?id="+id, &data)
-	if err != nil {
-		return nil, reqInf, err
-	}
-	if len(data.Response) == 0 {
-		return nil, reqInf, nil
-	}
-	return &data.Response[0], reqInf, nil
 }
 
 // GetDeliveryServicesNullable returns a slice of Delivery Services.
@@ -197,63 +170,6 @@ func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string) ([]tc.Deliver
 	}
 
 	return data.Response, reqInf, nil
-}
-
-// CreateDeliveryService creates the DeliveryService it's passed.
-// Deprecated: Use CreateDeliveryServiceNullable instead.
-func (to *Session) CreateDeliveryService(ds *tc.DeliveryService) (*tc.CreateDeliveryServiceResponse, error) {
-	if ds.TypeID == 0 && ds.Type.String() != "" {
-		ty, _, err := to.GetTypeByName(ds.Type.String())
-		if err != nil {
-			return nil, err
-		}
-		if len(ty) == 0 {
-			return nil, errors.New("no type named " + ds.Type.String())
-		}
-		ds.TypeID = ty[0].ID
-	}
-
-	if ds.CDNID == 0 && ds.CDNName != "" {
-		cdns, _, err := to.GetCDNByName(ds.CDNName)
-		if err != nil {
-			return nil, err
-		}
-		if len(cdns) == 0 {
-			return nil, errors.New("no CDN named " + ds.CDNName)
-		}
-		ds.CDNID = cdns[0].ID
-	}
-
-	if ds.ProfileID == 0 && ds.ProfileName != "" {
-		profiles, _, err := to.GetProfileByName(ds.ProfileName)
-		if err != nil {
-			return nil, err
-		}
-		if len(profiles) == 0 {
-			return nil, errors.New("no Profile named " + ds.ProfileName)
-		}
-		ds.ProfileID = profiles[0].ID
-	}
-
-	if ds.TenantID == 0 && ds.Tenant != "" {
-		ten, _, err := to.TenantByName(ds.Tenant)
-		if err != nil {
-			return nil, err
-		}
-		ds.TenantID = ten.ID
-	}
-
-	var data tc.CreateDeliveryServiceResponse
-	jsonReq, err := json.Marshal(ds)
-	if err != nil {
-		return nil, err
-	}
-	_, err = post(to, API_DELIVERY_SERVICES, jsonReq, &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return &data, nil
 }
 
 // CreateDeliveryServiceNullable creates the DeliveryService it's passed.
@@ -312,27 +228,10 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 	return &data, nil
 }
 
-// UpdateDeliveryService updates the DeliveryService matching the ID it's passed with
-// the DeliveryService it is passed.
-// Deprecated: Use UpdateDeliveryServiceNullable instead.
-func (to *Session) UpdateDeliveryService(id string, ds *tc.DeliveryService) (*tc.UpdateDeliveryServiceResponse, error) {
-	var data tc.UpdateDeliveryServiceResponse
-	jsonReq, err := json.Marshal(ds)
-	if err != nil {
-		return nil, err
-	}
-	_, err = put(to, fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), jsonReq, &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return &data, nil
-}
-
 // UpdateDeliveryServiceNullable updates the DeliveryService matching the ID it's
 // passed with the DeliveryService it is passed.
-func (to *Session) UpdateDeliveryServiceNullable(id string, ds *tc.DeliveryServiceNullable) (*tc.UpdateDeliveryServiceResponse, error) {
-	var data tc.UpdateDeliveryServiceResponse
+func (to *Session) UpdateDeliveryServiceNullable(id string, ds *tc.DeliveryServiceNullable) (*tc.UpdateDeliveryServiceNullableResponse, error) {
+	var data tc.UpdateDeliveryServiceNullableResponse
 	jsonReq, err := json.Marshal(ds)
 	if err != nil {
 		return nil, err
@@ -477,8 +376,8 @@ func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUp
 
 // GetAccessibleDeliveryServicesByTenant gets all delivery services associated with the given tenant, and all of
 // it's children.
-func (to *Session) GetAccessibleDeliveryServicesByTenant(tenantId int) ([]tc.DeliveryService, ReqInf, error) {
-	data := tc.DeliveryServicesResponse{}
+func (to *Session) GetAccessibleDeliveryServicesByTenant(tenantId int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+	data := tc.DeliveryServicesNullableResponse{}
 	reqInf, err := get(to, fmt.Sprintf("%v?accessibleTo=%v", API_DELIVERY_SERVICES, tenantId), &data)
 	return data.Response, reqInf, err
 }

--- a/traffic_ops/v2-client/job.go
+++ b/traffic_ops/v2-client/job.go
@@ -109,8 +109,6 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 				path += "dsId=" + strconv.FormatInt(int64(d.(int)), 10)
 			case string:
 				path += "deliveryService=" + d.(string)
-			case tc.DeliveryService:
-				path += "deliveryService=" + d.(tc.DeliveryService).XMLID
 			case tc.DeliveryServiceNullable:
 				if d.(tc.DeliveryServiceNullable).XMLID != nil {
 					path += "deliveryService=" + *d.(tc.DeliveryServiceNullable).XMLID

--- a/traffic_ops/v2-client/status.go
+++ b/traffic_ops/v2-client/status.go
@@ -28,26 +28,6 @@ const (
 	API_STATUSES = apiBase + "/statuses"
 )
 
-// CreateStatus creates a Status.
-// Deprecated: Use CreateStatusNullable instead.
-func (to *Session) CreateStatus(status tc.Status) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(status)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_STATUSES, reqBody)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
-	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
-}
-
 // CreateStatusNullable creates a new status, using the tc.StatusNullable structure.
 func (to *Session) CreateStatusNullable(status tc.StatusNullable) (tc.Alerts, ReqInf, error) {
 

--- a/traffic_ops/v2-client/user.go
+++ b/traffic_ops/v2-client/user.go
@@ -28,13 +28,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
-// Users gets an array of Users.
-// Deprecated: use GetUsers
-func (to *Session) Users() ([]tc.User, error) {
-	us, _, err := to.GetUsers()
-	return us, err
-}
-
 // GetUsers returns all users accessible from current user
 func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
 	data := tc.UsersResponse{}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes some unused methods in TM, removes some deprecated TO Go client methods, changed some TO Go client methods to use `DeliveryServiceNullable` structs instead of the non-nullable struct, and marked the non-nullable `DeliveryService` structs as deprecated.

- [x] This PR is related to #2546

## Which Traffic Control components are affected by this PR?

- CDN in a Box
- Documentation
- Grove
- Traffic Control Client (Go)
- Traffic Monitor

## What is the best way to verify this PR?
Run the Go unit tests, TO API tests (v1 - v3), make sure they all pass. Rebuild RPMs and CIAB, verify that the `readiness` container exits successfully.

## The following criteria are ALL met by this PR

- [x] This PR adjusts tests
- [x] No doc changes necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
