### PR TITLE
Remove audit logging from POST /serverchecks endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fixed ORT config generation not using the coalesce_number_v6 Parameter.
+- Removed audit logging from the `POST /api/x/serverchecks` Traffic Ops API endpoint in order to reduce audit log spam
 
 ### Changed
 

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -149,9 +149,9 @@ func CreateUpdateServercheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	successMsg := "Server Check was successfully updated"
-	api.CreateChangeLogRawTx(api.ApiChange, successMsg, inf.User, inf.Tx.Tx)
-	api.WriteRespAlert(w, r, tc.SuccessLevel, successMsg)
+	// NOTE: this endpoint does not create an audit log entry in order to prevent
+	//       spamming the audit log with thousands of entries every minute
+	api.WriteRespAlert(w, r, tc.SuccessLevel, "Server Check was successfully updated")
 }
 
 func getServerID(id *int, hostname *string, tx *sql.Tx) (int, bool, error) {


### PR DESCRIPTION
##  What does this PR (Pull Request) do?
Since this endpoint gets called once a minute per server, this can
seriously spam the audit log.

- [x] This PR is not related to any issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Run the TO API tests, verify they pass, check to make sure no "Server Check was successfully updated" audit logs were created.

## If this is a bug fix, what versions of Traffic Control are affected?

- master
- 4.1.0-RC0
- 4.0.0

## The following criteria are ALL met by this PR

- [x] Minor audit log removal, no tests necessary
- [x] Minor audit log removal, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
