### PR TITLE
Uncomment Perl routes for /jobs and /jobs/:id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an optional readiness check service to cdn-in-a-box that exits successfully when it is able to get a `200 OK` from all delivery services
 
 ### Fixed
+- Fixed the `GET /api/x/jobs` and `GET /api/x/jobs/:id` Traffic Ops API routes to allow falling back to Perl via the routing blacklist
 - Fixed ORT config generation not using the coalesce_number_v6 Parameter.
 
 ### Changed

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -660,8 +660,8 @@ sub api_routes {
 	$r->post("/api/$version/isos")->over( authenticated => 1, not_ldap => 1 )->to( 'Iso#generate', namespace => $namespace );
 
 	# -- JOBS (CURRENTLY LIMITED TO INVALIDATE CONTENT (PURGE) JOBS)
-	# $r->get("/api/$version/jobs")->over( authenticated => 1, not_ldap => 1 )->to( 'Job#index', namespace => $namespace );
-	# $r->get("/api/$version/jobs/:id" => [ id => qr/\d+/ ] )->over( authenticated => 1, not_ldap => 1 )->to( 'Job#show', namespace => $namespace );
+	$r->get("/api/$version/jobs")->over( authenticated => 1, not_ldap => 1 )->to( 'Job#index', namespace => $namespace );
+	$r->get("/api/$version/jobs/:id" => [ id => qr/\d+/ ] )->over( authenticated => 1, not_ldap => 1 )->to( 'Job#show', namespace => $namespace );
 
 	# -- JOBS: CURRENT USER (CURRENTLY LIMITED TO INVALIDATE CONTENT (PURGE) JOBS)
 	$r->get("/api/$version/user/current/jobs")->over( authenticated => 1, not_ldap => 1 )->to( 'Job#get_current_user_jobs', namespace => $namespace );


### PR DESCRIPTION
## What does this PR (Pull Request) do?

These routes need to be uncommented in the Perl routes in order for us
to fall back to them via the TO API routing blacklist. Otherwise,
falling back to these routes causes TO to 404.


- [x] This PR is not related to any issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Configure the TO API routing blacklist to have the /jobs API endpoints fall back to Perl:
```
    "traffic_ops_golang" : {
        ...
        "routing_blacklist": {
            "ignore_unknown_routes": false,
            "perl_routes": [1966782041, 2085189426],
            "disabled_routes": []
        },
```

Then request `GET /api/1.4/jobs` and `GET /api/1.4/jobs/:id` endpoints, verify that they don't 404 and that they return jobs data successfully from TO-Perl.

## If this is a bug fix, what versions of Traffic Control are affected?

- master
- 4.1.0-RC0
- 4.0.0

## The following criteria are ALL met by this PR

- [x] Minor route uncommenting, no tests necessary
- [x] Minor route uncommenting, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)