### PR TITLE
Parameter filtering should take the cdn name for filtering

### DIFF
--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
@@ -115,7 +115,6 @@ func Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetMonitoringJSON(tx *sql.Tx, cdnName string) (*Monitoring, error) {
-	fmt.Println("SRIJEET I'm HERE")
 	monitors, caches, routers, err := getMonitoringServers(tx, cdnName)
 	if err != nil {
 		return nil, fmt.Errorf("error getting servers: %v", err)

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
@@ -115,6 +115,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetMonitoringJSON(tx *sql.Tx, cdnName string) (*Monitoring, error) {
+	fmt.Println("SRIJEET I'm HERE")
 	monitors, caches, routers, err := getMonitoringServers(tx, cdnName)
 	if err != nil {
 		return nil, fmt.Errorf("error getting servers: %v", err)
@@ -377,17 +378,16 @@ AND ds.active = true
 
 func getConfig(tx *sql.Tx, cdnName string) (map[string]interface{}, error) {
 	// TODO remove 'like' in query? Slow?
-	query := fmt.Sprintf(`
+	query := `
 SELECT pr.name, pr.value
 FROM parameter pr
-JOIN profile p ON p.name LIKE '%s%%'
+JOIN profile p ON p.name LIKE $1
 JOIN profile_parameter pp ON pp.profile = p.id and pp.parameter = pr.id
 JOIN cdn c ON c.id=p.cdn
-WHERE pr.config_file = '%s'
-AND c.name='%s'
-`, tc.MonitorProfilePrefix, MonitorConfigFile, cdnName)
-
-	rows, err := tx.Query(query)
+WHERE pr.config_file = $2
+AND c.name = $3
+`
+	rows, err := tx.Query(query, tc.MonitorProfilePrefix+"%%", MonitorConfigFile, cdnName)
 	if err != nil {
 		return nil, err
 	}

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -454,7 +454,7 @@ func TestGetConfig(t *testing.T) {
 		t.Fatalf("creating transaction: %v", err)
 	}
 
-	sqlConfig, err := getConfig(tx)
+	sqlConfig, err := getConfig(tx, "")
 	if err != nil {
 		t.Errorf("getProfiles expected: nil error, actual: %v", err)
 	}

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -454,7 +454,7 @@ func TestGetConfig(t *testing.T) {
 		t.Fatalf("creating transaction: %v", err)
 	}
 
-	sqlConfig, err := getConfig(tx, "")
+	sqlConfig, err := getConfig(tx, "mycdn")
 	if err != nil {
 		t.Errorf("getProfiles expected: nil error, actual: %v", err)
 	}

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -21,8 +21,12 @@ package monitoring
 
 import (
 	"context"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/parameter"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -30,6 +34,71 @@ import (
 	"github.com/lib/pq"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
+
+func ExpectedGetParams() []parameter.TOParameter {
+	name := "peers.polling.interval"
+	value := "3000"
+	return []parameter.TOParameter{
+		{
+			api.APIInfoImpl{ReqInfo: nil},
+			tc.ParameterNullable{
+				ConfigFile:  nil,
+				ID:          nil,
+				LastUpdated: nil,
+				Name:        &name,
+				Profiles:    nil,
+				Secure:      nil,
+				Value:       &value,
+			},
+		},
+	}
+}
+
+func TestGetProfileWithParams(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	cdn := "mycdn"
+	mock.ExpectBegin()
+	expected := ExpectedGetParams()
+	MockGetParams(mock, expected, cdn)
+	mock.ExpectCommit()
+
+	dbCtx, _ := context.WithTimeout(context.TODO(), time.Duration(10)*time.Second)
+	tx, err := db.BeginTx(dbCtx, nil)
+	if err != nil {
+		t.Fatalf("creating transaction: %v", err)
+	}
+	defer tx.Commit()
+
+	actual, err := getConfig(tx, cdn)
+	if err != nil {
+		t.Fatalf("getConfig err expected: nil, actual: %v", err)
+	}
+
+	// Should be just one
+	for k, v := range actual {
+		if *expected[0].Name != k {
+			t.Fatalf("Expected param name %s doesn't match actual %s", *expected[0].Name, k)
+		}
+		if *expected[0].Value != strconv.Itoa(v.(int)) {
+			t.Fatalf("Expected param value %s doesn't match actual %s", *expected[0].Value, v)
+		}
+	}
+}
+
+func MockGetParams(mock sqlmock.Sqlmock, expected []parameter.TOParameter, cdn string) {
+	rows := sqlmock.NewRows([]string{"name", "value"})
+	for _, param := range expected {
+		n := param.Name
+		v := param.Value
+		rows = rows.AddRow(*n, *v)
+	}
+	mock.ExpectQuery("SELECT").WithArgs(tc.MonitorProfilePrefix+"%%", MonitorConfigFile, cdn).WillReturnRows(rows)
+}
 
 func TestGetMonitoringServers(t *testing.T) {
 	mockDB, mock, err := sqlmock.New()

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -515,7 +515,7 @@ func TestGetConfig(t *testing.T) {
 		rows = rows.AddRow(name, val)
 	}
 
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectQuery("SELECT").WithArgs(tc.MonitorProfilePrefix+"%%", MonitorConfigFile, "mycdn").WillReturnRows(rows)
 
 	dbCtx, _ := context.WithTimeout(context.TODO(), time.Duration(10)*time.Second)
 	tx, err := db.BeginTx(dbCtx, nil)

--- a/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
@@ -210,8 +210,8 @@ func handleRequest(w http.ResponseWriter, r *http.Request, client *influx.Client
 		if summary != nil {
 			resp.Summary = &tc.TrafficDSStatsSummary{
 				TrafficStatsSummary: *summary,
-				TotalKiloBytes: kBs,
-				TotalTransactions: txns,
+				TotalKiloBytes:      kBs,
+				TotalTransactions:   txns,
 			}
 		} else {
 			resp.Summary = &tc.TrafficDSStatsSummary{}
@@ -278,8 +278,8 @@ func handleLegacyRequest(w http.ResponseWriter, r *http.Request, client *influx.
 		if summary != nil {
 			resp.Summary = &tc.LegacyTrafficDSStatsSummary{
 				TrafficStatsSummary: *summary,
-				TotalBytes: kBs,
-				TotalTransactions: txns,
+				TotalBytes:          kBs,
+				TotalTransactions:   txns,
 			}
 		} else {
 			resp.Summary = &tc.LegacyTrafficDSStatsSummary{}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #1903 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- Traffic Monitor
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Run the api tests and unit tests.
Test it out on CiaB/ running a query in the DB.
In my CiaB setup, I had a couple of CDNs that were using profiles with common parameters. When I ran the query to get the configs for one of the CDNs, the other params showed up in the results as well. This is fixed with the current behavior.
Query without the fix: 
`SELECT pr.name, pr.value
FROM parameter pr
JOIN profile p ON p.name LIKE 'RASCAL%%'
JOIN profile_parameter pp ON pp.profile = p.id and pp.parameter = pr.id
WHERE pr.config_file = 'rascal-config.txt'`

Query with fix:
`SELECT pr.name, pr.value
FROM parameter pr
JOIN profile p ON p.name LIKE 'RASCAL%%'
JOIN profile_parameter pp ON pp.profile = p.id and pp.parameter = pr.id
JOIN cdn c ON c.id=p.cdn
WHERE pr.config_file = 'rascal-config.txt'
AND c.name='<ENTER YOUR CDN NAME HERE>'`
## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

master
## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] I have explained why tests are unnecessary
- [x] I have explained why documentation is unnecessary
- [x] This PR does not include an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
