### PR TITLE
More Topologies validation

### DIFF
--- a/traffic_ops/client/job.go
+++ b/traffic_ops/client/job.go
@@ -160,7 +160,7 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 	}
 
 	resp, remoteAddr, err := to.request(http.MethodGet, path, nil)
-	reqInf := ReqInf{CacheHitStatusMiss, remoteAddr}
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
 		return nil, reqInf, err
 	}

--- a/traffic_ops/client/session.go
+++ b/traffic_ops/client/session.go
@@ -307,7 +307,7 @@ func NewNoAuthSession(toURL string, insecure bool, userAgent string, useCache bo
 	}, useCache)
 }
 
-// ErrUnlessOk returns the response an error if the given Response's status code is anything but 200 OK. This includes reading the Response.Body and Closing it. Otherwise, the given response and a nil error is returned.
+// ErrUnlessOk returns the response an error if the given Response's status code is anything but 200 OK. This includes reading the Response.Body and Closing it. Otherwise, the given response and a nil error are returned.
 func (to *Session) ErrUnlessOK(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
 	if err != nil {
 		return resp, remoteAddr, err

--- a/traffic_ops/client/session.go
+++ b/traffic_ops/client/session.go
@@ -394,6 +394,7 @@ func (to *Session) RawRequest(method, path string, body []byte) (*http.Response,
 type ReqInf struct {
 	CacheHitStatus CacheHitStatus
 	RemoteAddr     net.Addr
+	StatusCode     int
 }
 
 type CacheHitStatus string

--- a/traffic_ops/client/session.go
+++ b/traffic_ops/client/session.go
@@ -307,7 +307,7 @@ func NewNoAuthSession(toURL string, insecure bool, userAgent string, useCache bo
 	}, useCache)
 }
 
-// ErrUnlessOk returns nil and an error if the given Response's status code is anything but 200 OK. This includes reading the Response.Body and Closing it. Otherwise, the given response and error are returned unchanged.
+// ErrUnlessOk returns the response an error if the given Response's status code is anything but 200 OK. This includes reading the Response.Body and Closing it. Otherwise, the given response and a nil error is returned.
 func (to *Session) ErrUnlessOK(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
 	if err != nil {
 		return resp, remoteAddr, err
@@ -319,14 +319,14 @@ func (to *Session) ErrUnlessOK(resp *http.Response, remoteAddr net.Addr, err err
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotImplemented {
-		return nil, remoteAddr, errors.New("Traffic Ops Server returned 'Not Implemented', this client is probably newer than Traffic Ops, and you probably need to either upgrade Traffic Ops, or use a client whose version matches your Traffic Ops version.")
+		return resp, remoteAddr, errors.New("Traffic Ops Server returned 'Not Implemented', this client is probably newer than Traffic Ops, and you probably need to either upgrade Traffic Ops, or use a client whose version matches your Traffic Ops version.")
 	}
 
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, remoteAddr, readErr
+		return resp, remoteAddr, readErr
 	}
-	return nil, remoteAddr, errors.New(resp.Status + "[" + strconv.Itoa(resp.StatusCode) + "] - Error requesting Traffic Ops " + to.getURL(path) + " " + string(body))
+	return resp, remoteAddr, errors.New(resp.Status + "[" + strconv.Itoa(resp.StatusCode) + "] - Error requesting Traffic Ops " + to.getURL(path) + " " + string(body))
 }
 
 func (to *Session) getURL(path string) string { return to.URL + path }
@@ -385,7 +385,7 @@ func (to *Session) RawRequest(method, path string, body []byte) (*http.Response,
 
 	resp, err := to.Client.Do(req)
 	if err != nil {
-		return nil, remoteAddr, err
+		return resp, remoteAddr, err
 	}
 
 	return resp, remoteAddr, nil

--- a/traffic_ops/client/session.go
+++ b/traffic_ops/client/session.go
@@ -307,7 +307,9 @@ func NewNoAuthSession(toURL string, insecure bool, userAgent string, useCache bo
 	}, useCache)
 }
 
-// ErrUnlessOk returns the response an error if the given Response's status code is anything but 200 OK. This includes reading the Response.Body and Closing it. Otherwise, the given response and a nil error are returned.
+// ErrUnlessOk returns the response, the remote address, and an error if the given Response's status code is anything
+// but 200 OK. This includes reading the Response.Body and Closing it. Otherwise, the given response, the remote
+// address, and a nil error are returned.
 func (to *Session) ErrUnlessOK(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
 	if err != nil {
 		return resp, remoteAddr, err

--- a/traffic_ops/client/topology.go
+++ b/traffic_ops/client/topology.go
@@ -37,6 +37,9 @@ func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf
 		return nil, reqInf, err
 	}
 	resp, remoteAddr, err := to.request(http.MethodPost, ApiTopologies, reqBody)
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -52,6 +55,9 @@ func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf
 func (to *Session) GetTopologies() ([]tc.Topology, ReqInf, error) {
 	resp, remoteAddr, err := to.request(http.MethodGet, ApiTopologies, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -70,6 +76,9 @@ func (to *Session) GetTopology(name string) (*tc.Topology, ReqInf, error) {
 	reqUrl := fmt.Sprintf("%s?name=%s", ApiTopologies, url.QueryEscape(name))
 	resp, remoteAddr, err := to.request(http.MethodGet, reqUrl, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -96,10 +105,14 @@ func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyRespo
 	}
 	route := fmt.Sprintf("%s?name=%s", ApiTopologies, name)
 	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return nil, reqInf, err
 	}
 	defer log.Close(resp.Body, "unable to close response")
+
 	var response = new(tc.TopologyResponse)
 	err = json.NewDecoder(resp.Body).Decode(response)
 	return response, reqInf, err
@@ -110,10 +123,14 @@ func (to *Session) DeleteTopology(name string) (tc.Alerts, ReqInf, error) {
 	reqUrl := fmt.Sprintf("%s?name=%s", ApiTopologies, url.QueryEscape(name))
 	resp, remoteAddr, err := to.request(http.MethodDelete, reqUrl, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return tc.Alerts{}, reqInf, err
 	}
 	defer log.Close(resp.Body, "unable to close response")
+
 	var alerts tc.Alerts
 	if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
 		return tc.Alerts{}, reqInf, err

--- a/traffic_ops/client/topology.go
+++ b/traffic_ops/client/topology.go
@@ -18,130 +18,105 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/lib/go-tc"
 	"net"
 	"net/http"
 	"net/url"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
-const (
-	ApiTopologies = apiBase + "/topologies"
-)
+const ApiTopologies = apiBase + "/topologies"
 
 // CreateTopology creates a topology and returns the response.
-func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf, error, int) {
-	var (
-		statusCode = http.StatusNotAcceptable
-		remoteAddr net.Addr
-	)
+func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf, error) {
+	var remoteAddr net.Addr
 	reqBody, err := json.Marshal(top)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
 	resp, remoteAddr, err := to.request(http.MethodPost, ApiTopologies, reqBody)
-	if resp != nil {
-		statusCode = resp.StatusCode
-	}
 	if err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
 	defer log.Close(resp.Body, "unable to close response")
 	var topResp tc.TopologyResponse
 	if err = json.NewDecoder(resp.Body).Decode(&topResp); err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
-	return &topResp, reqInf, nil, statusCode
+	return &topResp, reqInf, nil
 }
 
 // GetTopologies returns all topologies.
-func (to *Session) GetTopologies() ([]tc.Topology, ReqInf, error, int) {
-	var statusCode = http.StatusNotAcceptable
+func (to *Session) GetTopologies() ([]tc.Topology, ReqInf, error) {
 	resp, remoteAddr, err := to.request(http.MethodGet, ApiTopologies, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		statusCode = resp.StatusCode
-	}
 	if err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
 	defer log.Close(resp.Body, "unable to close response")
 
 	var data tc.TopologiesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
 
-	return data.Response, reqInf, nil, statusCode
+	return data.Response, reqInf, nil
 }
 
 // GetTopology returns the given topology by name.
-func (to *Session) GetTopology(name string) (*tc.Topology, ReqInf, error, int) {
-	var statusCode = http.StatusNotAcceptable
+func (to *Session) GetTopology(name string) (*tc.Topology, ReqInf, error) {
 	reqUrl := fmt.Sprintf("%s?name=%s", ApiTopologies, url.QueryEscape(name))
 	resp, remoteAddr, err := to.request(http.MethodGet, reqUrl, nil)
-	if resp != nil {
-		statusCode = resp.StatusCode
-	}
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
 	defer log.Close(resp.Body, "unable to close response")
 
 	var data tc.TopologiesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
 
 	if len(data.Response) == 1 {
-		return &data.Response[0], reqInf, nil, statusCode
+		return &data.Response[0], reqInf, nil
 	}
-	return nil, reqInf, fmt.Errorf("expected one topology in response, instead got: %+v", data.Response), statusCode
+	return nil, reqInf, fmt.Errorf("expected one topology in response, instead got: %+v", data.Response)
 }
 
 // UpdateTopology updates a Topology by name.
-func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyResponse, ReqInf, error, int) {
-	var (
-		statusCode = http.StatusNotAcceptable
-		remoteAddr net.Addr
-	)
+func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyResponse, ReqInf, error) {
+	var remoteAddr net.Addr
 	reqBody, err := json.Marshal(t)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
 	route := fmt.Sprintf("%s?name=%s", ApiTopologies, name)
 	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
-	if resp != nil {
-		statusCode = resp.StatusCode
-	}
 	if err != nil {
-		return nil, reqInf, err, statusCode
+		return nil, reqInf, err
 	}
 	defer log.Close(resp.Body, "unable to close response")
 	var response = new(tc.TopologyResponse)
 	err = json.NewDecoder(resp.Body).Decode(response)
-	return response, reqInf, err, statusCode
+	return response, reqInf, err
 }
 
 // DeleteTopology deletes the given topology by name.
-func (to *Session) DeleteTopology(name string) (tc.Alerts, ReqInf, error, int) {
-	var statusCode = http.StatusNotAcceptable
+func (to *Session) DeleteTopology(name string) (tc.Alerts, ReqInf, error) {
 	reqUrl := fmt.Sprintf("%s?name=%s", ApiTopologies, url.QueryEscape(name))
 	resp, remoteAddr, err := to.request(http.MethodDelete, reqUrl, nil)
-	if resp != nil {
-		statusCode = resp.StatusCode
-	}
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return tc.Alerts{}, reqInf, err, statusCode
+		return tc.Alerts{}, reqInf, err
 	}
 	defer log.Close(resp.Body, "unable to close response")
 	var alerts tc.Alerts
 	if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
-		return tc.Alerts{}, reqInf, err, statusCode
+		return tc.Alerts{}, reqInf, err
 	}
-	return alerts, reqInf, nil, statusCode
+	return alerts, reqInf, nil
 }

--- a/traffic_ops/client/topology.go
+++ b/traffic_ops/client/topology.go
@@ -30,94 +30,118 @@ const (
 )
 
 // CreateTopology creates a topology and returns the response.
-func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf, error) {
-	var remoteAddr net.Addr
+func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf, error, int) {
+	var (
+		statusCode = http.StatusNotAcceptable
+		remoteAddr net.Addr
+	)
 	reqBody, err := json.Marshal(top)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
 	resp, remoteAddr, err := to.request(http.MethodPost, ApiTopologies, reqBody)
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
 	if err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
 	defer log.Close(resp.Body, "unable to close response")
 	var topResp tc.TopologyResponse
 	if err = json.NewDecoder(resp.Body).Decode(&topResp); err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
-	return &topResp, reqInf, nil
+	return &topResp, reqInf, nil, statusCode
 }
 
 // GetTopologies returns all topologies.
-func (to *Session) GetTopologies() ([]tc.Topology, ReqInf, error) {
+func (to *Session) GetTopologies() ([]tc.Topology, ReqInf, error, int) {
+	var statusCode = http.StatusNotAcceptable
 	resp, remoteAddr, err := to.request(http.MethodGet, ApiTopologies, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
 	if err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
 	defer log.Close(resp.Body, "unable to close response")
 
 	var data tc.TopologiesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
 
-	return data.Response, reqInf, nil
+	return data.Response, reqInf, nil, statusCode
 }
 
 // GetTopology returns the given topology by name.
-func (to *Session) GetTopology(name string) (*tc.Topology, ReqInf, error) {
+func (to *Session) GetTopology(name string) (*tc.Topology, ReqInf, error, int) {
+	var statusCode = http.StatusNotAcceptable
 	reqUrl := fmt.Sprintf("%s?name=%s", ApiTopologies, url.QueryEscape(name))
 	resp, remoteAddr, err := to.request(http.MethodGet, reqUrl, nil)
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
 	defer log.Close(resp.Body, "unable to close response")
 
 	var data tc.TopologiesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
 
 	if len(data.Response) == 1 {
-		return &data.Response[0], reqInf, nil
+		return &data.Response[0], reqInf, nil, statusCode
 	}
-	return nil, reqInf, fmt.Errorf("expected one topology in response, instead got: %+v", data.Response)
+	return nil, reqInf, fmt.Errorf("expected one topology in response, instead got: %+v", data.Response), statusCode
 }
 
 // UpdateTopology updates a Topology by name.
-func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyResponse, ReqInf, error) {
-	var remoteAddr net.Addr
+func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyResponse, ReqInf, error, int) {
+	var (
+		statusCode = http.StatusNotAcceptable
+		remoteAddr net.Addr
+	)
 	reqBody, err := json.Marshal(t)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
 	route := fmt.Sprintf("%s?name=%s", ApiTopologies, name)
 	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
 	if err != nil {
-		return nil, reqInf, err
+		return nil, reqInf, err, statusCode
 	}
 	defer log.Close(resp.Body, "unable to close response")
 	var response = new(tc.TopologyResponse)
 	err = json.NewDecoder(resp.Body).Decode(response)
-	return response, reqInf, err
+	return response, reqInf, err, statusCode
 }
 
 // DeleteTopology deletes the given topology by name.
-func (to *Session) DeleteTopology(name string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteTopology(name string) (tc.Alerts, ReqInf, error, int) {
+	var statusCode = http.StatusNotAcceptable
 	reqUrl := fmt.Sprintf("%s?name=%s", ApiTopologies, url.QueryEscape(name))
 	resp, remoteAddr, err := to.request(http.MethodDelete, reqUrl, nil)
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return tc.Alerts{}, reqInf, err
+		return tc.Alerts{}, reqInf, err, statusCode
 	}
 	defer log.Close(resp.Body, "unable to close response")
 	var alerts tc.Alerts
 	if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
-		return tc.Alerts{}, reqInf, err
+		return tc.Alerts{}, reqInf, err, statusCode
 	}
-	return alerts, reqInf, nil
+	return alerts, reqInf, nil, statusCode
 }

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -89,6 +89,9 @@ func ValidationTestTopologies(t *testing.T) {
 		{reasonToFail: "a nonexistent cache group", Topology: tc.Topology{Name: "nonexistent-cg", Description: "Invalid because it references a cache group that does not exist", Nodes: []tc.TopologyNode{
 			{Cachegroup: "legitcachegroup", Parents: []int{0}},
 		}}},
+		{reasonToFail: "an out-of-bounds parent index", Topology: tc.Topology{Name: "oob-parent", Description: "Invalid because it contains a parent", Nodes: []tc.TopologyNode{
+			{Cachegroup: "cachegroup1", Parents: []int{7}},
+		}}},
 	}
 	for _, testCase := range invalidTopologyTestCases {
 		_, _, err, statusCode := TOSession.CreateTopology(testCase.Topology)

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -98,6 +98,9 @@ func ValidationTestTopologies(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected POST with %v to return an error, actual: nil", testCase.reasonToFail)
 		}
+		if statusCode < 400 || statusCode >= 500 {
+			t.Fatalf("Expected a 400-level status code for topology %s but got %d", testCase.Topology.Name, statusCode)
+		}
 	}
 }
 

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -98,9 +98,6 @@ func ValidationTestTopologies(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected POST with %v to return an error, actual: nil", testCase.reasonToFail)
 		}
-		if statusCode < 400 || statusCode >= 500 {
-			t.Fatalf("Expected a 400-level status code for topology %s but got %d", testCase.Topology.Name, statusCode)
-		}
 	}
 }
 

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -44,7 +44,7 @@ func CreateTestTopologies(t *testing.T) {
 		err          error
 	)
 	for _, topology := range testData.Topologies {
-		if postResponse, _, err = TOSession.CreateTopology(topology); err != nil {
+		if postResponse, _, err, _ = TOSession.CreateTopology(topology); err != nil {
 			t.Fatalf("could not CREATE topology: %v", err)
 		}
 		postResponse.Response.LastUpdated = nil
@@ -88,14 +88,18 @@ func ValidationTestTopologies(t *testing.T) {
 		}}},
 	}
 	for _, testCase := range invalidTopologyTestCases {
-		if _, _, err := TOSession.CreateTopology(testCase.Topology); err == nil {
+		_, _, err, statusCode := TOSession.CreateTopology(testCase.Topology)
+		if err == nil {
 			t.Fatalf("expected POST with %v to return an error, actual: nil", testCase.reasonToFail)
+		}
+		if statusCode < 400 || statusCode >= 500 {
+			t.Fatalf("Expected a 400-level status code for topology %s but got %d", testCase.Topology.Name, statusCode)
 		}
 	}
 }
 
 func updateSingleTopology(topology tc.Topology) error {
-	updateResponse, _, err := TOSession.UpdateTopology(topology.Name, topology)
+	updateResponse, _, err, _ := TOSession.UpdateTopology(topology.Name, topology)
 	if err != nil {
 		return fmt.Errorf("cannot PUT topology: %v - %v", err, updateResponse)
 	}
@@ -125,12 +129,12 @@ func UpdateTestTopologies(t *testing.T) {
 
 func DeleteTestTopologies(t *testing.T) {
 	for _, top := range testData.Topologies {
-		delResp, _, err := TOSession.DeleteTopology(top.Name)
+		delResp, _, err, _ := TOSession.DeleteTopology(top.Name)
 		if err != nil {
 			t.Fatalf("cannot DELETE topology: %v - %v", err, delResp)
 		}
 
-		topology, _, err := TOSession.GetTopology(top.Name)
+		topology, _, err, _ := TOSession.GetTopology(top.Name)
 		if err == nil {
 			t.Fatalf("expected error trying to GET deleted topology: %s, actual: nil", top.Name)
 		}

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -93,11 +93,13 @@ func ValidationTestTopologies(t *testing.T) {
 			{Cachegroup: "cachegroup1", Parents: []int{7}},
 		}}},
 	}
+	var statusCode int
 	for _, testCase := range invalidTopologyTestCases {
-		_, _, err := TOSession.CreateTopology(testCase.Topology)
+		_, reqInf, err := TOSession.CreateTopology(testCase.Topology)
 		if err == nil {
 			t.Fatalf("expected POST with %v to return an error, actual: nil", testCase.reasonToFail)
 		}
+		statusCode = reqInf.StatusCode
 		if statusCode < 400 || statusCode >= 500 {
 			t.Fatalf("Expected a 400-level status code for topology %s but got %d", testCase.Topology.Name, statusCode)
 		}

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -86,6 +86,9 @@ func ValidationTestTopologies(t *testing.T) {
 			{Cachegroup: "parentCachegroup", Parents: []int{2}},
 			{Cachegroup: "secondaryCachegroup", Parents: []int{1}},
 		}}},
+		{reasonToFail: "a nonexistent cache group", Topology: tc.Topology{Name: "nonexistent-cg", Description: "Invalid because it references a cache group that does not exist", Nodes: []tc.TopologyNode{
+			{Cachegroup: "legitcachegroup", Parents: []int{0}},
+		}}},
 	}
 	for _, testCase := range invalidTopologyTestCases {
 		_, _, err, statusCode := TOSession.CreateTopology(testCase.Topology)

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -44,7 +44,7 @@ func CreateTestTopologies(t *testing.T) {
 		err          error
 	)
 	for _, topology := range testData.Topologies {
-		if postResponse, _, err, _ = TOSession.CreateTopology(topology); err != nil {
+		if postResponse, _, err = TOSession.CreateTopology(topology); err != nil {
 			t.Fatalf("could not CREATE topology: %v", err)
 		}
 		postResponse.Response.LastUpdated = nil
@@ -94,7 +94,7 @@ func ValidationTestTopologies(t *testing.T) {
 		}}},
 	}
 	for _, testCase := range invalidTopologyTestCases {
-		_, _, err, statusCode := TOSession.CreateTopology(testCase.Topology)
+		_, _, err := TOSession.CreateTopology(testCase.Topology)
 		if err == nil {
 			t.Fatalf("expected POST with %v to return an error, actual: nil", testCase.reasonToFail)
 		}
@@ -105,7 +105,7 @@ func ValidationTestTopologies(t *testing.T) {
 }
 
 func updateSingleTopology(topology tc.Topology) error {
-	updateResponse, _, err, _ := TOSession.UpdateTopology(topology.Name, topology)
+	updateResponse, _, err := TOSession.UpdateTopology(topology.Name, topology)
 	if err != nil {
 		return fmt.Errorf("cannot PUT topology: %v - %v", err, updateResponse)
 	}
@@ -135,12 +135,12 @@ func UpdateTestTopologies(t *testing.T) {
 
 func DeleteTestTopologies(t *testing.T) {
 	for _, top := range testData.Topologies {
-		delResp, _, err, _ := TOSession.DeleteTopology(top.Name)
+		delResp, _, err := TOSession.DeleteTopology(top.Name)
 		if err != nil {
 			t.Fatalf("cannot DELETE topology: %v - %v", err, delResp)
 		}
 
-		topology, _, err, _ := TOSession.GetTopology(top.Name)
+		topology, _, err := TOSession.GetTopology(top.Name)
 		if err == nil {
 			t.Fatalf("expected error trying to GET deleted topology: %s, actual: nil", top.Name)
 		}

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -125,8 +125,8 @@ func (topology *TOTopology) Validate() error {
 		for _, leafMid := range checkForLeafMids(topology.Nodes, cacheGroups) {
 			rules[fmt.Sprintf("node %v leaf mid", leafMid.Cachegroup)] = fmt.Errorf("cachegroup %v's type is %v; it cannot be a leaf (it must have at least 1 child)", leafMid.Cachegroup, tc.CacheGroupMidTypeName)
 		}
+		rules["topology cycles"] = checkForCycles(topology.Nodes)
 	}
-	rules["topology cycles"] = checkForCycles(topology.Nodes)
 
 	errs := tovalidate.ToErrors(rules)
 	return util.JoinErrs(errs)

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -116,20 +116,24 @@ func (topology *TOTopology) Validate() error {
 		}
 	}
 	rules["duplicate cachegroup name"] = checkUniqueCacheGroupNames(topology.Nodes)
-
-	if cacheGroupsExist {
-		for index, node := range topology.Nodes {
-			rules[fmt.Sprintf("parent '%v' edge type", node.Cachegroup)] = checkForEdgeParents(topology.Nodes, cacheGroups, index)
-		}
-
-		for _, leafMid := range checkForLeafMids(topology.Nodes, cacheGroups) {
-			rules[fmt.Sprintf("node %v leaf mid", leafMid.Cachegroup)] = fmt.Errorf("cachegroup %v's type is %v; it cannot be a leaf (it must have at least 1 child)", leafMid.Cachegroup, tc.CacheGroupMidTypeName)
-		}
-		rules["topology cycles"] = checkForCycles(topology.Nodes)
+	if !cacheGroupsExist {
+		return util.JoinErrs(tovalidate.ToErrors(rules))
 	}
 
-	errs := tovalidate.ToErrors(rules)
-	return util.JoinErrs(errs)
+	for index, node := range topology.Nodes {
+		rules[fmt.Sprintf("parent '%v' edge type", node.Cachegroup)] = checkForEdgeParents(topology.Nodes, cacheGroups, index)
+	}
+	/* Only perform further checks if everything so far is valid */
+	if err = util.JoinErrs(tovalidate.ToErrors(rules)); err != nil {
+		return err
+	}
+
+	for _, leafMid := range checkForLeafMids(topology.Nodes, cacheGroups) {
+		rules[fmt.Sprintf("node %v leaf mid", leafMid.Cachegroup)] = fmt.Errorf("cachegroup %v's type is %v; it cannot be a leaf (it must have at least 1 child)", leafMid.Cachegroup, tc.CacheGroupMidTypeName)
+	}
+	rules["topology cycles"] = checkForCycles(topology.Nodes)
+
+	return util.JoinErrs(tovalidate.ToErrors(rules))
 }
 
 // Implementation of the Identifier, Validator interface functions

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -57,9 +57,14 @@ func checkForEdgeParents(nodes []tc.TopologyNode, cachegroups []tc.CacheGroupNul
 	node := nodes[nodeIndex]
 	errs := make([]error, len(node.Parents))
 	for parentIndex := range node.Parents {
-		cacheGroupType := cachegroups[node.Parents[parentIndex]].Type
+		cachegroupIndex := node.Parents[parentIndex]
+		if cachegroupIndex < 0 || cachegroupIndex >= len(cachegroups) {
+			errs = append(errs, fmt.Errorf("parent %d of cachegroup %s refers to a cachegroup at index %d, but no such cachegroup exists", parentIndex, node.Cachegroup, cachegroupIndex))
+			break
+		}
+		cacheGroupType := cachegroups[parentIndex].Type
 		if *cacheGroupType == tc.CacheGroupEdgeTypeName {
-			errs[parentIndex] = fmt.Errorf("cachegroup %v's type is %v; it cannot be a parent of %v", nodes[parentIndex].Cachegroup, tc.CacheGroupEdgeTypeName, node.Cachegroup)
+			errs = append(errs, fmt.Errorf("cachegroup %v's type is %v; it cannot be a parent of %v", nodes[parentIndex].Cachegroup, tc.CacheGroupEdgeTypeName, node.Cachegroup))
 		}
 	}
 	return util.JoinErrs(errs)

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -56,8 +56,7 @@ func checkForSelfParents(nodes []tc.TopologyNode, index int) error {
 func checkForEdgeParents(nodes []tc.TopologyNode, cachegroups []tc.CacheGroupNullable, nodeIndex int) error {
 	node := nodes[nodeIndex]
 	errs := make([]error, len(node.Parents))
-	for parentIndex := range node.Parents {
-		cachegroupIndex := node.Parents[parentIndex]
+	for parentIndex, cachegroupIndex := range node.Parents {
 		if cachegroupIndex < 0 || cachegroupIndex >= len(cachegroups) {
 			errs = append(errs, fmt.Errorf("parent %d of cachegroup %s refers to a cachegroup at index %d, but no such cachegroup exists", parentIndex, node.Cachegroup, cachegroupIndex))
 			break


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4691 by checking whether a parent node's index exists<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
- This PR fixes a bug by only performing further validation on a topology if all of its nodes' cachegroups exist
- Adds a status code check to the negative API tests to enure that POSTing invalid topologies returns only 400-level response status codes, not 500-level

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Control Client (Go)<!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run Traffic Ops API tests, verify they still pass:
```shell script
docker-compose -f docker-compose.yml -f docker-compose.traffic-ops-test.yml up
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (88f4f2aad0)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (88f4f2aad0)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR is a bugfix, no documentation necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
