### PR TITLE
Cachegroups API updates for Topologies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an optional readiness check service to cdn-in-a-box that exits successfully when it is able to get a `200 OK` from all delivery services
 - [Flexible Topologies (in progress)](https://github.com/apache/trafficcontrol/blob/master/blueprints/flexible-topologies.md)
     - Traffic Ops: Added an API 3.0 endpoint, /api/3.0/topologies, to create, read, update and delete flexible topologies.
+    - Traffic Ops: Added support for `topology` query parameter to `GET /api/3.0/cachegroups` to return all cachegroups used in the given topology.
     - Traffic Portal: Added the ability to create, read, update and delete flexible topologies.
 
 ### Fixed

--- a/docs/source/api/v2/cachegroups.rst
+++ b/docs/source/api/v2/cachegroups.rst
@@ -38,8 +38,6 @@ Request Structure
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| type      | no       | Return only :term:`Cache Groups` that are of the :ref:`cache-group-type` identified by this integral, unique identifier  |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
-	| topology  | no       | Return only :term:`Cache Groups` that are used in the Topology identified by this unique identifier                      |
-	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array      |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                 |

--- a/docs/source/api/v2/cachegroups.rst
+++ b/docs/source/api/v2/cachegroups.rst
@@ -38,6 +38,8 @@ Request Structure
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| type      | no       | Return only :term:`Cache Groups` that are of the :ref:`cache-group-type` identified by this integral, unique identifier  |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| topology  | no       | Return only :term:`Cache Groups` that are used in the Topology identified by this unique identifier                      |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array      |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                 |

--- a/docs/source/api/v3/cachegroups.rst
+++ b/docs/source/api/v3/cachegroups.rst
@@ -38,6 +38,8 @@ Request Structure
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| type      | no       | Return only :term:`Cache Groups` that are of the :ref:`cache-group-type` identified by this integral, unique identifier  |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| topology  | no       | Return only :term:`Cache Groups` that are used in the :term:`Topology` identified by this unique identifier              |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array      |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                 |

--- a/traffic_ops/client/cachegroup.go
+++ b/traffic_ops/client/cachegroup.go
@@ -156,7 +156,7 @@ func (to *Session) GetCacheGroupNullableByName(name string) ([]tc.CacheGroupNull
 	return data.Response, reqInf, nil
 }
 
-// GET a CacheGroup by the CacheGroup name.
+// GET a CacheGroup by the CacheGroup short name.
 func (to *Session) GetCacheGroupNullableByShortName(shortName string) ([]tc.CacheGroupNullable, ReqInf, error) {
 	route := fmt.Sprintf("%s?shortName=%s", API_CACHEGROUPS, url.QueryEscape(shortName))
 	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
@@ -188,4 +188,25 @@ func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, ReqInf, error) {
 		return tc.Alerts{}, reqInf, err
 	}
 	return alerts, reqInf, nil
+}
+
+func (to *Session) GetCacheGroupsByQueryParams(qparams url.Values) ([]tc.CacheGroupNullable, ReqInf, error) {
+	route := API_CACHEGROUPS
+	if len(qparams) > 0 {
+		route += "?" + qparams.Encode()
+	}
+
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheGroupsNullableResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/cachegroup.go
+++ b/traffic_ops/client/cachegroup.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -190,6 +191,7 @@ func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, nil
 }
 
+// GetCacheGroupsByQueryParams gets cache groups by the given query parameters.
 func (to *Session) GetCacheGroupsByQueryParams(qparams url.Values) ([]tc.CacheGroupNullable, ReqInf, error) {
 	route := API_CACHEGROUPS
 	if len(qparams) > 0 {
@@ -201,7 +203,7 @@ func (to *Session) GetCacheGroupsByQueryParams(qparams url.Values) ([]tc.CacheGr
 	if err != nil {
 		return nil, reqInf, err
 	}
-	defer resp.Body.Close()
+	defer log.Close(resp.Body, "unable to close cachegroups response body")
 
 	var data tc.CacheGroupsNullableResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -428,11 +428,11 @@ func (cg *TOCacheGroup) Read() ([]interface{}, error, error, int) {
 	// Query Parameters to Database Query column mappings
 	// see the fields mapped in the SQL query
 	queryParamsToQueryCols := map[string]dbhelpers.WhereColumnInfo{
-		"id":        dbhelpers.WhereColumnInfo{"cachegroup.id", api.IsInt},
-		"name":      dbhelpers.WhereColumnInfo{"cachegroup.name", nil},
-		"shortName": dbhelpers.WhereColumnInfo{"cachegroup.short_name", nil},
-		"type":      dbhelpers.WhereColumnInfo{"cachegroup.type", nil},
-		"topology":  dbhelpers.WhereColumnInfo{"topology_cachegroup.topology", nil},
+		"id":        {"cachegroup.id", api.IsInt},
+		"name":      {"cachegroup.name", nil},
+		"shortName": {"cachegroup.short_name", nil},
+		"type":      {"cachegroup.type", nil},
+		"topology":  {"topology_cachegroup.topology", nil},
 	}
 	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(cg.ReqInfo.Params, queryParamsToQueryCols)
 	if len(errs) > 0 {

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -88,23 +88,28 @@ func (cg *TOCacheGroup) SetID(i int) {
 // Is the cachegroup being used?
 func isUsed(tx *sqlx.Tx, ID int) (bool, error) {
 
+	var usedByTopology bool
 	var usedByServer bool
 	var usedByParent bool
 	var usedBySecondaryParent bool
 	var usedByASN bool
 
 	query := `SELECT
+    (SELECT id FROM topology_cachegroup WHERE topology_cachegroup.cachegroup = (SELECT name FROM cachegroup WHERE id = $1) LIMIT 1) IS NOT NULL,
     (SELECT id FROM server WHERE server.cachegroup = $1 LIMIT 1) IS NOT NULL,
     (SELECT id FROM cachegroup WHERE cachegroup.parent_cachegroup_id = $1 LIMIT 1) IS NOT NULL,
     (SELECT id FROM cachegroup WHERE cachegroup.secondary_parent_cachegroup_id = $1 LIMIT 1) IS NOT NULL,
     (SELECT id FROM asn WHERE cachegroup = $1 LIMIT 1) IS NOT NULL;`
 
-	err := tx.QueryRow(query, ID).Scan(&usedByServer, &usedByParent, &usedBySecondaryParent, &usedByASN)
+	err := tx.QueryRow(query, ID).Scan(&usedByTopology, &usedByServer, &usedByParent, &usedBySecondaryParent, &usedByASN)
 	if err != nil {
 		log.Errorf("received error: %++v from query execution", err)
 		return false, err
 	}
 	//Only return the immediate error
+	if usedByTopology {
+		return true, errors.New("cachegroup is in use by one or more topologies")
+	}
 	if usedByServer {
 		return true, errors.New("cachegroup is in use by one or more servers")
 	}
@@ -427,6 +432,7 @@ func (cg *TOCacheGroup) Read() ([]interface{}, error, error, int) {
 		"name":      dbhelpers.WhereColumnInfo{"cachegroup.name", nil},
 		"shortName": dbhelpers.WhereColumnInfo{"cachegroup.short_name", nil},
 		"type":      dbhelpers.WhereColumnInfo{"cachegroup.type", nil},
+		"topology":  dbhelpers.WhereColumnInfo{"topology_cachegroup.topology", nil},
 	}
 	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(cg.ReqInfo.Params, queryParamsToQueryCols)
 	if len(errs) > 0 {
@@ -658,7 +664,9 @@ FROM cachegroup
 LEFT JOIN coordinate ON coordinate.id = cachegroup.coordinate
 INNER JOIN type ON cachegroup.type = type.id
 LEFT JOIN cachegroup AS cgp ON cachegroup.parent_cachegroup_id = cgp.id
-LEFT JOIN cachegroup AS cgs ON cachegroup.secondary_parent_cachegroup_id = cgs.id`
+LEFT JOIN cachegroup AS cgs ON cachegroup.secondary_parent_cachegroup_id = cgs.id
+LEFT JOIN topology_cachegroup ON cachegroup.name = topology_cachegroup.cachegroup
+`
 }
 
 func multipleCacheGroupsWhere() string {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Add support for `topology` query param on `GET /api/3.0/cachegroups` API. Return a useful error message when attempting to delete a cachegroup that is used in a Topology.

- [x] This PR fixes #4570

## Which Traffic Control components are affected by this PR?

- Documentation
- Traffic Control Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Run the unit tests, verify they pass. Run the TO API tests, verify they pass. Attempt to delete a cachegroup that is assigned to a topology, verify that a useful error message is returned.

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)