### PR TITLE
Prohibit assigning topology-based delivery services to caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Traffic Ops: Added an API 3.0 endpoint, /api/3.0/topologies, to create, read, update and delete flexible topologies.
     - Traffic Ops: Added new `topology` field to the /api/3.0/deliveryservices APIs
     - Traffic Ops: Added support for `topology` query parameter to `GET /api/3.0/cachegroups` to return all cachegroups used in the given topology.
+    - Traffic Ops: Added validation to prohibit assigning caches to topology-based delivery services
     - Traffic Portal: Added the ability to create, read, update and delete flexible topologies.
     - Traffic Portal: Added the ability to assign topologies to delivery services
 - Updated /servers/details to use multiple interfaces in API v3

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -614,13 +614,13 @@ type DSServerIDs struct {
 }
 
 type CachegroupPostDSReq struct {
-	DeliveryServices []int64 `json:"deliveryServices"`
+	DeliveryServices []int `json:"deliveryServices"`
 }
 
 type CacheGroupPostDSResp struct {
 	ID               util.JSONIntStr `json:"id"`
 	ServerNames      []CacheName     `json:"serverNames"`
-	DeliveryServices []int64         `json:"deliveryServices"`
+	DeliveryServices []int           `json:"deliveryServices"`
 }
 
 type CacheGroupPostDSRespResponse struct {

--- a/traffic_ops/client/coordinate.go
+++ b/traffic_ops/client/coordinate.go
@@ -17,11 +17,9 @@ package client
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -131,25 +129,4 @@ func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, ReqInf, error) {
 	var alerts tc.Alerts
 	err = json.NewDecoder(resp.Body).Decode(&alerts)
 	return alerts, reqInf, nil
-}
-
-func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int64) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
-	uri := apiBase + `/cachegroups/` + strconv.Itoa(cgID) + `/deliveryservices`
-	req := tc.CachegroupPostDSReq{DeliveryServices: dsIDs}
-	reqBody, err := json.Marshal(req)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
-	if err != nil {
-		return tc.CacheGroupPostDSRespResponse{}, reqInf, err
-	}
-	reqResp, _, err := to.request(http.MethodPost, uri, reqBody)
-	if err != nil {
-		return tc.CacheGroupPostDSRespResponse{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
-	}
-	defer reqResp.Body.Close()
-
-	resp := tc.CacheGroupPostDSRespResponse{}
-	if err := json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
-		return tc.CacheGroupPostDSRespResponse{}, reqInf, errors.New("decoding response: " + err.Error())
-	}
-	return resp, reqInf, nil
 }

--- a/traffic_ops/client/deliveryservice.go
+++ b/traffic_ops/client/deliveryservice.go
@@ -103,6 +103,11 @@ const (
 	// to the associations between Delivery Services and their assigned Server(s).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryserviceserver.html
 	API_DELIVERY_SERVICE_SERVER = apiBase + "/deliveryserviceserver"
+
+	// API_DELIVERY_SERVICES_SERVERS is the API path on which Traffic Ops serves functionality related
+	// to the associations between a Delivery Service and its assigned Server(s).
+	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_servers.html
+	API_DELIVERY_SERVICES_SERVERS = apiBase + "/deliveryservices/%s/servers"
 )
 
 // GetDeliveryServicesByServer returns all of the (tenant-visible) Delivery Services assigned to

--- a/traffic_ops/client/server.go
+++ b/traffic_ops/client/server.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -301,10 +302,13 @@ func (to *Session) AssignDeliveryServiceIDsToServerID(server int, dsIDs []int, r
 	}
 
 	resp, remoteAddr, err := to.request(http.MethodPost, endpoint, reqBody)
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return tc.Alerts{}, reqInf, err
 	}
-	defer resp.Body.Close()
+	defer log.Close(resp.Body, "unable to close response body")
 	reqInf.RemoteAddr = remoteAddr
 	var alerts tc.Alerts
 	err = json.NewDecoder(resp.Body).Decode(&alerts)

--- a/traffic_ops/client/util.go
+++ b/traffic_ops/client/util.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
 func get(to *Session, endpoint string, respStruct interface{}) (ReqInf, error) {
@@ -40,10 +42,13 @@ func del(to *Session, endpoint string, respStruct interface{}) (ReqInf, error) {
 func makeReq(to *Session, method, endpoint string, body []byte, respStruct interface{}) (ReqInf, error) {
 	resp, remoteAddr, err := to.request(method, endpoint, body) // TODO change to getBytesWithTTL
 	reqInf := ReqInf{RemoteAddr: remoteAddr, CacheHitStatus: CacheHitStatusMiss}
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return reqInf, err
 	}
-	defer resp.Body.Close()
+	defer log.Close(resp.Body, "unable to close response body")
 
 	bts, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/traffic_ops/ort/atstccfg/toreq/vendor/github.com/apache/trafficcontrol/traffic_ops/client/coordinate.go
+++ b/traffic_ops/ort/atstccfg/toreq/vendor/github.com/apache/trafficcontrol/traffic_ops/client/coordinate.go
@@ -133,7 +133,7 @@ func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, nil
 }
 
-func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int64) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
+func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
 	uri := apiBase + `/cachegroups/` + strconv.Itoa(cgID) + `/deliveryservices`
 	req := tc.CachegroupPostDSReq{DeliveryServices: dsIDs}
 	reqBody, err := json.Marshal(req)

--- a/traffic_ops/testing/api/v1/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v1/cachegroupsdeliveryservices_test.go
@@ -58,10 +58,10 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 	}
 	cgID := *clientCG.ID
 
-	dsIDs := []int64{}
+	dsIDs := []int{}
 	for _, ds := range dses {
 		if ds.CDNName == "cdn1" {
-			dsIDs = append(dsIDs, int64(ds.ID))
+			dsIDs = append(dsIDs, ds.ID)
 		}
 	}
 	if len(dsIDs) < 1 {

--- a/traffic_ops/testing/api/v2/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v2/cachegroupsdeliveryservices_test.go
@@ -58,10 +58,10 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 	}
 	cgID := *clientCG.ID
 
-	dsIDs := []int64{}
+	dsIDs := []int{}
 	for _, ds := range dses {
 		if *ds.CDNName == "cdn1" {
-			dsIDs = append(dsIDs, int64(*ds.ID))
+			dsIDs = append(dsIDs, *ds.ID)
 		}
 	}
 	if len(dsIDs) < 1 {

--- a/traffic_ops/testing/api/v3/crconfig_test.go
+++ b/traffic_ops/testing/api/v3/crconfig_test.go
@@ -76,7 +76,7 @@ func UpdateTestCRConfigSnapshot(t *testing.T) {
 		t.Error("GetDeliveryServiceByXMLIDNullable got unknown delivery service id")
 	}
 	anymapDSID := *res[0].ID
-	_, err = TOSession.CreateDeliveryServiceServers(anymapDSID, []int{serverID}, true)
+	_, _, err = TOSession.CreateDeliveryServiceServers(anymapDSID, []int{serverID}, true)
 	if err != nil {
 		t.Errorf("POST delivery service servers: %v", err)
 	}

--- a/traffic_ops/testing/api/v3/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_required_capabilities_test.go
@@ -206,7 +206,7 @@ func InvalidDeliveryServicesRequiredCapabilityAddition(t *testing.T) {
 	}
 
 	// Assign server to ds
-	_, err = TOSession.CreateDeliveryServiceServers(*dsID, []int{sID}, false)
+	_, _, err = TOSession.CreateDeliveryServiceServers(*dsID, []int{sID}, false)
 	if err != nil {
 		t.Fatalf("cannot CREATE server delivery service assignement: %v", err)
 	}

--- a/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
@@ -78,10 +78,10 @@ func AssignServersToTopologyBasedDeliveryService(t *testing.T) {
 
 	_, reqInf, err = TOSession.CreateDeliveryServiceServers(*ds[0].ID, []int{servers[0].ID}, false)
 	if err == nil {
-		t.Fatal("creating delliveryserviceserver assignment for topology-based delivery service - expected: error, actual: nil error")
+		t.Fatal("creating deliveryserviceserver assignment for topology-based delivery service - expected: error, actual: nil error")
 	}
 	if reqInf.StatusCode < http.StatusBadRequest || reqInf.StatusCode >= http.StatusInternalServerError {
-		t.Fatalf("creating delliveryserviceserver assignment for topology-based delivery service - expected: 400-level status code, actual: %d", reqInf.StatusCode)
+		t.Fatalf("creating deliveryserviceserver assignment for topology-based delivery service - expected: 400-level status code, actual: %d", reqInf.StatusCode)
 	}
 }
 

--- a/traffic_ops/testing/api/v3/servers_test.go
+++ b/traffic_ops/testing/api/v3/servers_test.go
@@ -121,7 +121,7 @@ func UpdateTestServers(t *testing.T) {
 	}
 
 	// Assign server to DS
-	_, err = TOSession.CreateDeliveryServiceServers(*dses[0].ID, []int{remoteServer.ID}, true)
+	_, _, err = TOSession.CreateDeliveryServiceServers(*dses[0].ID, []int{remoteServer.ID}, true)
 	if err != nil {
 		t.Fatalf("POST delivery service servers: %v", err)
 	}

--- a/traffic_ops/testing/api/v3/servers_to_deliveryservice_assignment_test.go
+++ b/traffic_ops/testing/api/v3/servers_to_deliveryservice_assignment_test.go
@@ -15,6 +15,7 @@ package v3
 */
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -24,6 +25,7 @@ func TestAssignments(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, Tenants, Topologies, DeliveryServices}, func() {
 		AssignTestDeliveryService(t)
 		AssignIncorrectTestDeliveryService(t)
+		AssignTopologyBasedDeliveryService(t)
 	})
 }
 
@@ -106,6 +108,65 @@ func AssignIncorrectTestDeliveryService(t *testing.T) {
 	alerts, _, err := TOSession.AssignDeliveryServiceIDsToServerID(server.ID, []int{*firstDS.ID}, false)
 	if err == nil {
 		t.Errorf("Expected bad assignment to fail, but it didn't! (alerts: %v)", alerts)
+	}
+
+	response, _, err := TOSession.GetServerIDDeliveryServices(server.ID)
+	t.Logf("response: %+v", response)
+	if err != nil {
+		t.Fatalf("Couldn't get Delivery Services assigned to Server '%+v': %v", *server, err)
+	}
+
+	var found bool
+	for _, ds := range response {
+
+		if ds.ID != nil && *ds.ID == *firstDS.ID {
+			found = true
+			break
+		}
+	}
+
+	if found {
+		t.Errorf(`Invalid Server/DS assignment was created!`)
+	}
+}
+
+func AssignTopologyBasedDeliveryService(t *testing.T) {
+	var server *tc.Server
+	for _, s := range testData.Servers {
+		if s.CDNName == "cdn1" && s.Type == string(tc.CacheTypeEdge) {
+			server = &s
+			break
+		}
+	}
+	if server == nil {
+		t.Fatalf("Couldn't find an EDGE server in CDN 'cdn1'!")
+	}
+
+	rs, _, err := TOSession.GetServerByHostName(server.HostName)
+	if err != nil {
+		t.Fatalf("Failed to fetch server information: %v", err)
+	} else if len(rs) == 0 {
+		t.Fatalf("Failed to fetch server information: No results returned!")
+	}
+	server = &rs[0]
+
+	rd, _, err := TOSession.GetDeliveryServiceByXMLIDNullable("ds-top")
+	if err != nil {
+		t.Fatalf("Failed to fetch DS information: %v", err)
+	} else if len(rd) == 0 {
+		t.Fatalf("Failed to fetch DS information: No results returned!")
+	}
+	firstDS := rd[0]
+
+	if firstDS.ID == nil {
+		t.Fatal("Fetch DS information returned unknown ID")
+	}
+	alerts, reqInf, err := TOSession.AssignDeliveryServiceIDsToServerID(server.ID, []int{*firstDS.ID}, false)
+	if err == nil {
+		t.Errorf("Expected bad assignment to fail, but it didn't! (alerts: %v)", alerts)
+	}
+	if reqInf.StatusCode < http.StatusBadRequest || reqInf.StatusCode >= http.StatusInternalServerError {
+		t.Fatalf("assigning Topology-based delivery service to server - expected: 400-level status code, actual: %d", reqInf.StatusCode)
 	}
 
 	response, _, err := TOSession.GetServerIDDeliveryServices(server.ID)

--- a/traffic_ops/testing/api/v3/serverservercapability_test.go
+++ b/traffic_ops/testing/api/v3/serverservercapability_test.go
@@ -186,7 +186,7 @@ func DeleteTestServerServerCapabilities(t *testing.T) {
 		dsReqCap := dsReqCapResp[0]
 
 		// Assign server to ds
-		_, err = TOSession.CreateDeliveryServiceServers(*dsReqCap.DeliveryServiceID, []int{*ssc.ServerID}, false)
+		_, _, err = TOSession.CreateDeliveryServiceServers(*dsReqCap.DeliveryServiceID, []int{*ssc.ServerID}, false)
 		if err != nil {
 			t.Fatalf("cannot CREATE server delivery service assignment: %v", err)
 		}

--- a/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
@@ -65,7 +65,7 @@ func QueueUpdates(w http.ResponseWriter, r *http.Request) {
 		}
 		reqObj.CDN = &cdn
 	}
-	cgID := int64(inf.IntParams["id"])
+	cgID := inf.IntParams["id"]
 	cgName, ok, err := dbhelpers.GetCacheGroupNameFromID(inf.Tx.Tx, cgID)
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting cachegroup name from ID '"+inf.Params["id"]+"': "+err.Error()))
@@ -88,7 +88,7 @@ func QueueUpdates(w http.ResponseWriter, r *http.Request) {
 		CDN:            *reqObj.CDN,
 		CacheGroupID:   cgID,
 	})
-	api.CreateChangeLogRawTx(api.ApiChange, "CACHEGROUP: "+string(cgName)+", ID: "+strconv.FormatInt(cgID, 10)+", ACTION: "+strings.Title(reqObj.Action)+"d CacheGroup server updates to the "+string(*reqObj.CDN)+" CDN", inf.User, inf.Tx.Tx)
+	api.CreateChangeLogRawTx(api.ApiChange, "CACHEGROUP: "+string(cgName)+", ID: "+strconv.Itoa(cgID)+", ACTION: "+strings.Title(reqObj.Action)+"d CacheGroup server updates to the "+string(*reqObj.CDN)+" CDN", inf.User, inf.Tx.Tx)
 }
 
 type QueueUpdatesResp struct {
@@ -96,10 +96,10 @@ type QueueUpdatesResp struct {
 	Action         string            `json:"action"`
 	ServerNames    []tc.CacheName    `json:"serverNames"`
 	CDN            tc.CDNName        `json:"cdn"`
-	CacheGroupID   int64             `json:"cachegroupID"`
+	CacheGroupID   int               `json:"cachegroupID"`
 }
 
-func queueUpdates(tx *sql.Tx, cgID int64, cdn tc.CDNName, queue bool) ([]tc.CacheName, error) {
+func queueUpdates(tx *sql.Tx, cgID int, cdn tc.CDNName, queue bool) ([]tc.CacheName, error) {
 	q := `
 UPDATE server SET upd_pending = $1
 WHERE server.cachegroup = $2

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -76,7 +76,7 @@ func (cgparam *TOCacheGroupParameter) Read() ([]interface{}, error, error, int) 
 		return nil, errors.New("cache group id must be an integer"), nil, http.StatusBadRequest
 	}
 
-	_, ok, err := dbhelpers.GetCacheGroupNameFromID(cgparam.ReqInfo.Tx.Tx, int64(cgID))
+	_, ok, err := dbhelpers.GetCacheGroupNameFromID(cgparam.ReqInfo.Tx.Tx, cgID)
 	if err != nil {
 		return nil, nil, err, http.StatusInternalServerError
 	} else if !ok {
@@ -170,7 +170,7 @@ func (cgparam *TOCacheGroupParameter) GetKeys() (map[string]interface{}, bool) {
 
 // Delete implements the api.CRUDer interface.
 func (cgparam *TOCacheGroupParameter) Delete() (error, error, int) {
-	_, ok, err := dbhelpers.GetCacheGroupNameFromID(cgparam.ReqInfo.Tx.Tx, int64(cgparam.CacheGroupID))
+	_, ok, err := dbhelpers.GetCacheGroupNameFromID(cgparam.ReqInfo.Tx.Tx, cgparam.CacheGroupID)
 	if err != nil {
 		return nil, err, http.StatusInternalServerError
 	} else if !ok {

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/unassigned_parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/unassigned_parameters.go
@@ -64,7 +64,7 @@ func (cgunparam *TOCacheGroupUnassignedParameter) Read() ([]interface{}, error, 
 		return nil, errors.New("cache group id must be an integer"), nil, http.StatusBadRequest
 	}
 
-	_, ok, err := dbhelpers.GetCacheGroupNameFromID(cgunparam.ReqInfo.Tx.Tx, int64(cgID))
+	_, ok, err := dbhelpers.GetCacheGroupNameFromID(cgunparam.ReqInfo.Tx.Tx, cgID)
 	if err != nil {
 		return nil, nil, err, http.StatusInternalServerError
 	} else if !ok {

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -617,7 +617,7 @@ WHERE
 	if err != nil {
 		return nil, errors.New("querying server host names and types: " + err.Error())
 	}
-	defer rows.Close()
+	defer log.Close(rows, "error closing rows")
 
 	servers := []ServerHostNameAndType{}
 	for rows.Next() {
@@ -645,7 +645,7 @@ WHERE
 	if err != nil {
 		return nil, errors.New("querying server host names and types: " + err.Error())
 	}
-	defer rows.Close()
+	defer log.Close(rows, "error closing rows")
 
 	servers := []ServerHostNameAndType{}
 	for rows.Next() {
@@ -753,7 +753,7 @@ WHERE
 	if err != nil {
 		return nil, errors.New("querying deliveryservice topologies: " + err.Error())
 	}
-	defer rows.Close()
+	defer log.Close(rows, "error closing rows")
 	dses := make([]int, 0)
 	for rows.Next() {
 		id := 0

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -598,6 +598,66 @@ func GetServerNameFromID(tx *sql.Tx, id int) (string, bool, error) {
 	return name, true, nil
 }
 
+type ServerHostNameAndType struct {
+	HostName string
+	Type     string
+}
+
+func GetServerHostNamesAndTypesFromIDs(tx *sql.Tx, ids []int) ([]ServerHostNameAndType, error) {
+	qry := `
+SELECT
+  s.host_name,
+  t.name
+FROM
+  server s JOIN type t ON s.type = t.id
+WHERE
+  s.id = ANY($1)
+`
+	rows, err := tx.Query(qry, pq.Array(ids))
+	if err != nil {
+		return nil, errors.New("querying server host names and types: " + err.Error())
+	}
+	defer rows.Close()
+
+	servers := []ServerHostNameAndType{}
+	for rows.Next() {
+		s := ServerHostNameAndType{}
+		if err := rows.Scan(&s.HostName, &s.Type); err != nil {
+			return nil, errors.New("scanning server host name and type: " + err.Error())
+		}
+		servers = append(servers, s)
+	}
+	return servers, nil
+}
+
+// GetServerTypesFromHostNames returns the host names and types of the given server host names or an error if any occur.
+func GetServerTypesFromHostNames(tx *sql.Tx, hostNames []string) ([]ServerHostNameAndType, error) {
+	qry := `
+SELECT
+  s.host_name,
+  t.name
+FROM
+  server s JOIN type t ON s.type = t.id
+WHERE
+  s.host_name = ANY($1)
+`
+	rows, err := tx.Query(qry, pq.Array(hostNames))
+	if err != nil {
+		return nil, errors.New("querying server host names and types: " + err.Error())
+	}
+	defer rows.Close()
+
+	servers := []ServerHostNameAndType{}
+	for rows.Next() {
+		s := ServerHostNameAndType{}
+		if err := rows.Scan(&s.HostName, &s.Type); err != nil {
+			return nil, errors.New("scanning server host name and type: " + err.Error())
+		}
+		servers = append(servers, s)
+	}
+	return servers, nil
+}
+
 func GetCDNDSes(tx *sql.Tx, cdn tc.CDNName) (map[tc.DeliveryServiceName]struct{}, error) {
 	dses := map[tc.DeliveryServiceName]struct{}{}
 	qry := `SELECT xml_id from deliveryservice where cdn_id = (select id from cdn where name = $1)`
@@ -666,7 +726,7 @@ func GetParamNameByID(tx *sql.Tx, id int) (string, bool, error) {
 }
 
 // GetCacheGroupNameFromID Get Cache Group name from a given ID
-func GetCacheGroupNameFromID(tx *sql.Tx, id int64) (tc.CacheGroupName, bool, error) {
+func GetCacheGroupNameFromID(tx *sql.Tx, id int) (tc.CacheGroupName, bool, error) {
 	name := ""
 	if err := tx.QueryRow(`SELECT name FROM cachegroup WHERE id = $1`, id).Scan(&name); err != nil {
 		if err == sql.ErrNoRows {
@@ -675,6 +735,34 @@ func GetCacheGroupNameFromID(tx *sql.Tx, id int64) (tc.CacheGroupName, bool, err
 		return "", false, errors.New("querying cachegroup ID: " + err.Error())
 	}
 	return tc.CacheGroupName(name), true, nil
+}
+
+// GetDeliveryServicesWithTopologies returns a list containing the delivery services in the given dsIDs
+// list that have a topology assigned. An error indicates unexpected errors that occurred when querying.
+func GetDeliveryServicesWithTopologies(tx *sql.Tx, dsIDs []int) ([]int, error) {
+	q := `
+SELECT
+  id
+FROM
+  deliveryservice
+WHERE
+  id = ANY($1::bigint[])
+  AND topology IS NOT NULL
+`
+	rows, err := tx.Query(q, pq.Array(dsIDs))
+	if err != nil {
+		return nil, errors.New("querying deliveryservice topologies: " + err.Error())
+	}
+	defer rows.Close()
+	dses := make([]int, 0)
+	for rows.Next() {
+		id := 0
+		if err := rows.Scan(&id); err != nil {
+			return nil, errors.New("scanning deliveryservice id: " + err.Error())
+		}
+		dses = append(dses, id)
+	}
+	return dses, nil
 }
 
 // GetFederationIDForUserIDByXMLID retrieves the ID of the Federation assigned to the user defined by

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
@@ -126,7 +126,7 @@ func TestGetCacheGroupByName(t *testing.T) {
 				mock.ExpectQuery("cachegroup").WillReturnRows(rows)
 			}
 			mock.ExpectCommit()
-			_, exists, err := GetCacheGroupNameFromID(db.MustBegin().Tx, int64(1))
+			_, exists, err := GetCacheGroupNameFromID(db.MustBegin().Tx, 1)
 			if testCase.storageError != nil && err == nil {
 				t.Errorf("Storage error expected: received no storage error")
 			}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -295,6 +295,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{3, 0}, http.MethodDelete, `deliveryserviceserver/{dsid}/{serverid}`, dsserver.Delete, auth.PrivLevelOperations, Authenticated, nil, 25321845233, noPerlBypass},
 		{api.Version{3, 0}, http.MethodPost, `deliveryservices/{xml_id}/servers$`, dsserver.GetCreateHandler, auth.PrivLevelOperations, Authenticated, nil, 24281812063, noPerlBypass},
 		{api.Version{3, 0}, http.MethodGet, `servers/{id}/deliveryservices$`, api.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, Authenticated, nil, 2331154113, noPerlBypass},
+		{api.Version{3, 0}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, Authenticated, nil, 2801282533, noPerlBypass},
 		{api.Version{3, 0}, http.MethodGet, `deliveryservices/{id}/servers$`, dsserver.GetReadAssigned, auth.PrivLevelReadOnly, Authenticated, nil, 23451212233, noPerlBypass},
 		{api.Version{3, 0}, http.MethodPost, `deliveryservices/request`, deliveryservicerequests.Request, auth.PrivLevelPortal, Authenticated, nil, 2408752993, noPerlBypass},
 
@@ -314,6 +315,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		//Server status
 		{api.Version{3, 0}, http.MethodPut, `servers/{id}/status$`, server.UpdateStatusHandler, auth.PrivLevelOperations, Authenticated, nil, 2766638513, noPerlBypass},
 		{api.Version{3, 0}, http.MethodPost, `servers/{id}/queue_update$`, server.QueueUpdateHandler, auth.PrivLevelOperations, Authenticated, nil, 21894713, noPerlBypass},
+		{api.Version{3, 0}, http.MethodGet, `servers/{host_name}/update_status$`, server.GetServerUpdateStatusHandler, auth.PrivLevelReadOnly, Authenticated, nil, 2384515993, noPerlBypass},
+		{api.Version{3, 0}, http.MethodPost, `servers/{id-or-name}/update$`, server.UpdateHandler, auth.PrivLevelOperations, Authenticated, nil, 143813233, noPerlBypass},
 
 		//Server: CRUD
 		{api.Version{3, 0}, http.MethodGet, `servers/?$`, api.ReadHandler(&server.TOServer{}), auth.PrivLevelReadOnly, Authenticated, nil, 27209592853, noPerlBypass},
@@ -414,11 +417,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{3, 0}, http.MethodPost, `deliveryservices/{dsid}/regexes/?$`, deliveryservicesregexes.Post, auth.PrivLevelOperations, Authenticated, nil, 2127378003, noPerlBypass},
 		{api.Version{3, 0}, http.MethodPut, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Put, auth.PrivLevelOperations, Authenticated, nil, 22483396913, noPerlBypass},
 		{api.Version{3, 0}, http.MethodDelete, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Delete, auth.PrivLevelOperations, Authenticated, nil, 22467316633, noPerlBypass},
-
-		//Servers
-		{api.Version{3, 0}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, Authenticated, nil, 2801282533, noPerlBypass},
-		{api.Version{3, 0}, http.MethodGet, `servers/{host_name}/update_status$`, server.GetServerUpdateStatusHandler, auth.PrivLevelReadOnly, Authenticated, nil, 2384515993, noPerlBypass},
-		{api.Version{3, 0}, http.MethodPost, `servers/{id-or-name}/update$`, server.UpdateHandler, auth.PrivLevelOperations, Authenticated, nil, 143813233, noPerlBypass},
 
 		//StaticDNSEntries
 		{api.Version{3, 0}, http.MethodGet, `staticdnsentries/?$`, api.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, Authenticated, nil, 2289394773, noPerlBypass},
@@ -661,6 +659,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{2, 0}, http.MethodDelete, `deliveryserviceserver/{dsid}/{serverid}`, dsserver.Delete, auth.PrivLevelOperations, Authenticated, nil, 2532184523, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPost, `deliveryservices/{xml_id}/servers$`, dsserver.GetCreateHandler, auth.PrivLevelOperations, Authenticated, nil, 2428181206, noPerlBypass},
 		{api.Version{2, 0}, http.MethodGet, `servers/{id}/deliveryservices$`, api.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, Authenticated, nil, 233115411, noPerlBypass},
+		{api.Version{2, 0}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, Authenticated, nil, 280128253, noPerlBypass},
 		{api.Version{2, 0}, http.MethodGet, `deliveryservices/{id}/servers$`, dsserver.GetReadAssigned, auth.PrivLevelReadOnly, Authenticated, nil, 2345121223, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPost, `deliveryservices/request`, deliveryservicerequests.Request, auth.PrivLevelPortal, Authenticated, nil, 240875299, noPerlBypass},
 
@@ -680,6 +679,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		//Server status
 		{api.Version{2, 0}, http.MethodPut, `servers/{id}/status$`, server.UpdateStatusHandler, auth.PrivLevelOperations, Authenticated, nil, 276663851, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPost, `servers/{id}/queue_update$`, server.QueueUpdateHandler, auth.PrivLevelOperations, Authenticated, nil, 2189471, noPerlBypass},
+		{api.Version{2, 0}, http.MethodGet, `servers/{host_name}/update_status$`, server.GetServerUpdateStatusHandler, auth.PrivLevelReadOnly, Authenticated, nil, 238451599, noPerlBypass},
+		{api.Version{2, 0}, http.MethodPost, `servers/{id-or-name}/update$`, server.UpdateHandler, auth.PrivLevelOperations, Authenticated, nil, 14381323, noPerlBypass},
 
 		//Server: CRUD
 		{api.Version{2, 0}, http.MethodGet, `servers/?$`, api.ReadHandler(&server.TOServer{}), auth.PrivLevelReadOnly, Authenticated, nil, 2720959285, noPerlBypass},
@@ -780,11 +781,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{2, 0}, http.MethodPost, `deliveryservices/{dsid}/regexes/?$`, deliveryservicesregexes.Post, auth.PrivLevelOperations, Authenticated, nil, 212737800, noPerlBypass},
 		{api.Version{2, 0}, http.MethodPut, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Put, auth.PrivLevelOperations, Authenticated, nil, 2248339691, noPerlBypass},
 		{api.Version{2, 0}, http.MethodDelete, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Delete, auth.PrivLevelOperations, Authenticated, nil, 2246731663, noPerlBypass},
-
-		//Servers
-		{api.Version{2, 0}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, Authenticated, nil, 280128253, noPerlBypass},
-		{api.Version{2, 0}, http.MethodGet, `servers/{host_name}/update_status$`, server.GetServerUpdateStatusHandler, auth.PrivLevelReadOnly, Authenticated, nil, 238451599, noPerlBypass},
-		{api.Version{2, 0}, http.MethodPost, `servers/{id-or-name}/update$`, server.UpdateHandler, auth.PrivLevelOperations, Authenticated, nil, 14381323, noPerlBypass},
 
 		//StaticDNSEntries
 		{api.Version{2, 0}, http.MethodGet, `staticdnsentries/?$`, api.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, Authenticated, nil, 228939477, noPerlBypass},
@@ -1058,6 +1054,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{1, 1}, http.MethodPost, `deliveryserviceserver$`, dsserver.GetReplaceHandler, auth.PrivLevelOperations, Authenticated, nil, 429799788, noPerlBypass},
 		{api.Version{1, 1}, http.MethodPost, `deliveryservices/{xml_id}/servers$`, dsserver.GetCreateHandler, auth.PrivLevelOperations, Authenticated, nil, 1428181206, noPerlBypass},
 		{api.Version{1, 1}, http.MethodGet, `servers/{id}/deliveryservices?(\/.json)?$`, api.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, Authenticated, nil, 133115411, noPerlBypass},
+		{api.Version{1, 3}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, Authenticated, nil, 880128253, noPerlBypass},
 		{api.Version{1, 1}, http.MethodGet, `deliveryservices/{id}/servers$`, dsserver.GetReadAssigned, auth.PrivLevelReadOnly, Authenticated, nil, 1345121223, noPerlBypass},
 		{api.Version{1, 1}, http.MethodGet, `deliveryservices/{id}/unassigned_servers$`, dsserver.GetReadUnassigned, auth.PrivLevelReadOnly, Authenticated, nil, 2023944221, noPerlBypass},
 		{api.Version{1, 1}, http.MethodPost, `deliveryservices/request`, deliveryservicerequests.Request, auth.PrivLevelPortal, Authenticated, nil, 740875299, perlBypass},
@@ -1080,6 +1077,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		//Server status
 		{api.Version{1, 1}, http.MethodPut, `servers/{id}/status$`, server.UpdateStatusHandler, auth.PrivLevelOperations, Authenticated, nil, 776663851, perlBypass},
 		{api.Version{1, 1}, http.MethodPost, `servers/{id}/queue_update$`, server.QueueUpdateHandler, auth.PrivLevelOperations, Authenticated, nil, 9189471, perlBypass},
+		{api.Version{1, 3}, http.MethodGet, `servers/{host_name}/update_status$`, server.GetServerUpdateStatusHandler, auth.PrivLevelReadOnly, Authenticated, nil, 438451599, noPerlBypass},
 
 		//Server: CRUD
 		{api.Version{1, 1}, http.MethodGet, `servers/?(\.json)?$`, api.ReadHandler(&server.TOServer{}), auth.PrivLevelReadOnly, Authenticated, nil, 1720959285, noPerlBypass},
@@ -1189,10 +1187,6 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{1, 1}, http.MethodPost, `deliveryservices/{dsid}/regexes/?(\.json)?$`, deliveryservicesregexes.Post, auth.PrivLevelOperations, Authenticated, nil, 412737800, noPerlBypass},
 		{api.Version{1, 1}, http.MethodPut, `deliveryservices/{dsid}/regexes/{regexid}?(\.json)?$`, deliveryservicesregexes.Put, auth.PrivLevelOperations, Authenticated, nil, 1248339691, noPerlBypass},
 		{api.Version{1, 1}, http.MethodDelete, `deliveryservices/{dsid}/regexes/{regexid}?(\.json)?$`, deliveryservicesregexes.Delete, auth.PrivLevelOperations, Authenticated, nil, 2046731663, noPerlBypass},
-
-		//Servers
-		{api.Version{1, 3}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, Authenticated, nil, 880128253, noPerlBypass},
-		{api.Version{1, 3}, http.MethodGet, `servers/{host_name}/update_status$`, server.GetServerUpdateStatusHandler, auth.PrivLevelReadOnly, Authenticated, nil, 438451599, noPerlBypass},
 
 		//StaticDNSEntries
 		{api.Version{1, 1}, http.MethodGet, `staticdnsentries/?(\.json)?$`, api.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, Authenticated, nil, 258939477, noPerlBypass},

--- a/traffic_ops/v1-client/coordinate.go
+++ b/traffic_ops/v1-client/coordinate.go
@@ -133,7 +133,7 @@ func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, nil
 }
 
-func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int64) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
+func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
 	uri := apiBase + `/cachegroups/` + strconv.Itoa(cgID) + `/deliveryservices`
 	req := tc.CachegroupPostDSReq{DeliveryServices: dsIDs}
 	reqBody, err := json.Marshal(req)

--- a/traffic_ops/v2-client/coordinate.go
+++ b/traffic_ops/v2-client/coordinate.go
@@ -133,7 +133,7 @@ func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, nil
 }
 
-func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int64) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
+func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
 	uri := apiBase + `/cachegroups/` + strconv.Itoa(cgID) + `/deliveryservices`
 	req := tc.CachegroupPostDSReq{DeliveryServices: dsIDs}
 	reqBody, err := json.Marshal(req)


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Update the following endpoints to prevent assigning caches to delivery services that have a topology assigned:
```
POST servers/{id}/deliveryservices
POST deliveryservices/{xml_id}/servers
POST deliveryserviceserver
POST cachegroups/{id}/deliveryservices
```

- [x] This PR is related to #4572 but does not complete it.

## Which Traffic Control components are affected by this PR?

- Traffic Control Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Run the unit tests. Run the TO API tests (negative tests were added for all 4 routes). Verify they all pass.

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] New validation, no docs changes necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)