### PR TITLE
Fix OptionsDeleter audit log keys

### DIFF
--- a/traffic_ops/testing/api/v3/origins_test.go
+++ b/traffic_ops/testing/api/v3/origins_test.go
@@ -48,8 +48,10 @@ func CreateTestOrigins(t *testing.T) {
 
 func NotFoundDeleteTest(t *testing.T) {
 	_, _, err := TOSession.DeleteOriginByID(2020)
-	if !strings.Contains(err.Error(), "not found") {
-		t.Error("deleted origin with what should be a non-existent id")
+	if err == nil {
+		t.Error("deleting origin with what should be a non-existent id - expected: error, actual: nil error")
+	} else if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("deleted origin with what should be a non-existent id - expected: 'not found' error, actual: %s", err.Error())
 	}
 }
 

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -21,9 +21,11 @@ package v3
 
 import (
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-tc"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 type topologyTestCase struct {
@@ -128,6 +130,16 @@ func DeleteTestTopologies(t *testing.T) {
 		delResp, _, err := TOSession.DeleteTopology(top.Name)
 		if err != nil {
 			t.Fatalf("cannot DELETE topology: %v - %v", err, delResp)
+		}
+		deleteLog, _, err := TOSession.GetLogsByLimit(1)
+		if err != nil {
+			t.Fatalf("unable to get latest audit log entry")
+		}
+		if len(deleteLog) != 1 {
+			t.Fatalf("log entry length - expected: 1, actual: %d", len(deleteLog))
+		}
+		if !strings.Contains(*deleteLog[0].Message, top.Name) {
+			t.Errorf("topology deletion audit log entry - expected: message containing topology name '%s', actual: %s", top.Name, *deleteLog[0].Message)
 		}
 
 		topology, _, err := TOSession.GetTopology(top.Name)

--- a/traffic_ops/traffic_ops_golang/api/change_log.go
+++ b/traffic_ops/traffic_ops_golang/api/change_log.go
@@ -68,7 +68,7 @@ func CreateChangeLog(level string, action string, i Identifier, user *auth.Curre
 func CreateChangeLogBuildMsg(level string, action string, user *auth.CurrentUser, tx *sql.Tx, objType string, auditName string, keys map[string]interface{}) error {
 	keyStr := "{ "
 	for key, value := range keys {
-		keyStr += key + ":" + fmt.Sprintf("%v", value) + " "
+		keyStr += key + ": " + fmt.Sprintf("%v", value) + " "
 	}
 	keyStr += "}"
 	id, ok := keys["id"]

--- a/traffic_ops/traffic_ops_golang/api/change_log.go
+++ b/traffic_ops/traffic_ops_golang/api/change_log.go
@@ -68,7 +68,7 @@ func CreateChangeLog(level string, action string, i Identifier, user *auth.Curre
 func CreateChangeLogBuildMsg(level string, action string, user *auth.CurrentUser, tx *sql.Tx, objType string, auditName string, keys map[string]interface{}) error {
 	keyStr := "{ "
 	for key, value := range keys {
-		keyStr += key + ": " + fmt.Sprintf("%v", value) + " "
+		keyStr += key + ":" + fmt.Sprintf("%v", value) + " "
 	}
 	keyStr += "}"
 	id, ok := keys["id"]

--- a/traffic_portal/app/src/common/api/TopologyService.js
+++ b/traffic_portal/app/src/common/api/TopologyService.js
@@ -60,7 +60,7 @@ var TopologyService = function($http, ENV, locationUtils, messageModel) {
 				return result;
 			},
 			function(err) {
-				messageModel.setMessages(err.data.alerts, true);
+				messageModel.setMessages(err.data.alerts, false);
 				throw err;
 			}
 		);


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Fixed the audit logging of `OptionsDeleter` to set the keys on the to-be-deleted object so that they are included in the audit log entry when deleted.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Run the unit tests and TO API tests, verify they pass. Observe the deletion audit log entries, verify they contain the key/name of the deleted resource (specifically Topologies and Regions, which both use the `OptionsDeleter` interface).

## If this is a bug fix, what versions of Traffic Control are affected?

- master
- 4.1.0-RC0

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] bugfix, no docs necessary
- [x] unreleased (as of yet), so no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
