### PR TITLE
Fix cachegroups DB query join with topology_cachegroup

### DIFF
--- a/traffic_ops/testing/api/v3/cachegroups_test.go
+++ b/traffic_ops/testing/api/v3/cachegroups_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestCacheGroups(t *testing.T) {
 	WithObjs(t, []TCObj{Types, Parameters, CacheGroups, Topologies}, func() {
+		GetTestCacheGroups(t)
 		GetTestCacheGroupsByName(t)
 		GetTestCacheGroupsByShortName(t)
 		GetTestCacheGroupsByTopology(t)
@@ -63,6 +64,28 @@ func CreateTestCacheGroups(t *testing.T) {
 			t.Error("Fallbacks are null")
 		}
 
+	}
+}
+
+func GetTestCacheGroups(t *testing.T) {
+	resp, _, err := TOSession.GetCacheGroupsByQueryParams(url.Values{})
+	if err != nil {
+		t.Errorf("cannot GET CacheGroups %v - %v", err, resp)
+	}
+	expectedCachegroups := make(map[string]struct{})
+	for _, cg := range testData.CacheGroups {
+		expectedCachegroups[*cg.Name] = struct{}{}
+	}
+	foundCachegroups := make(map[string]struct{})
+	for _, cg := range resp {
+		if _, expected := expectedCachegroups[*cg.Name]; !expected {
+			t.Errorf("got unexpected cachegroup: %s", *cg.Name)
+		}
+		if _, found := foundCachegroups[*cg.Name]; !found {
+			foundCachegroups[*cg.Name] = struct{}{}
+		} else {
+			t.Errorf("GET returned duplicate cachegroup: %s", *cg.Name)
+		}
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -438,8 +438,14 @@ func (cg *TOCacheGroup) Read() ([]interface{}, error, error, int) {
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest
 	}
+	baseSelect := SelectQuery()
+	if _, ok := cg.ReqInfo.Params["topology"]; ok {
+		baseSelect += `
+LEFT JOIN topology_cachegroup ON cachegroup.name = topology_cachegroup.cachegroup
+`
+	}
 
-	query := SelectQuery() + where + orderBy + pagination
+	query := baseSelect + where + orderBy + pagination
 	rows, err := cg.ReqInfo.Tx.NamedQuery(query, queryValues)
 	if err != nil {
 		return nil, nil, errors.New("cachegroup read: querying: " + err.Error()), http.StatusInternalServerError
@@ -665,7 +671,6 @@ LEFT JOIN coordinate ON coordinate.id = cachegroup.coordinate
 INNER JOIN type ON cachegroup.type = type.id
 LEFT JOIN cachegroup AS cgp ON cachegroup.parent_cachegroup_id = cgp.id
 LEFT JOIN cachegroup AS cgs ON cachegroup.secondary_parent_cachegroup_id = cgs.id
-LEFT JOIN topology_cachegroup ON cachegroup.name = topology_cachegroup.cachegroup
 `
 }
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

After support was added for the `?topology` query parameter in the `GET /cachegroups` API, it was found that duplicate cachegroups would be returned if a cachegroup was used in more than one topology. This PR fixes that query to only join on `topology_cachegroup` if the `?topology` query parameter is given.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Run the unit tests and TO API tests, verify they pass.

## If this is a bug fix, what versions of Traffic Control are affected?

- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] bugfix, no docs necessary
- [x] unreleased bug, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)