### PR TITLE
Fix MaxRevalDurationDays validation for invalidation jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed ORT config generation not using the coalesce_number_v6 Parameter.
 - Removed audit logging from the `POST /api/x/serverchecks` Traffic Ops API endpoint in order to reduce audit log spam
 - Fixed audit logging from the `/jobs` APIs to bring them back to the same level of information provided by TO-Perl
+- Fixed `maxRevalDurationDays` validation for `POST /api/1.x/user/current/jobs` and added that validation to the `/api/x/jobs` endpoints
 
 ### Changed
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.

--- a/lib/go-tc/invalidationjobs.go
+++ b/lib/go-tc/invalidationjobs.go
@@ -336,7 +336,7 @@ func (job *UserInvalidationJobInput) Validate(tx *sql.Tx) error {
 	if job.StartTime == nil {
 		errs = append(errs, "startTime: cannot be blank")
 	} else if job.StartTime.After(time.Now().Add(twoDays)) {
-		errs = append(errs, "startTime: must be within two days!")
+		errs = append(errs, "startTime: must be within two days")
 	}
 
 	if job.Regex != nil && *(job.Regex) != "" {
@@ -350,7 +350,7 @@ func (job *UserInvalidationJobInput) Validate(tx *sql.Tx) error {
 		var id uint
 		if err := row.Scan(&id); err != nil {
 			log.Errorln(err.Error())
-			errs = append(errs, "No Delivery Service corresponding to 'dsId'!")
+			errs = append(errs, "no Delivery Service corresponding to 'dsId'")
 		}
 	}
 
@@ -360,11 +360,11 @@ func (job *UserInvalidationJobInput) Validate(tx *sql.Tx) error {
 		err := row.Scan(&maxDays)
 		maxHours := maxDays * 24
 		if err == sql.ErrNoRows && MaxTTL < *(job.TTL) {
-			errs = append(errs, "ttl: cannot exceed "+strconv.FormatUint(MaxTTL, 10)+"!")
-		} else if err == nil && maxHours < *(job.TTL) { //silently ignore other errors to
-			errs = append(errs, "ttl: cannot exceed "+strconv.FormatUint(maxHours, 10)+"!")
+			errs = append(errs, "ttl: cannot exceed "+strconv.FormatUint(MaxTTL, 10))
+		} else if err == nil && maxHours < *(job.TTL) { // silently ignore other errors
+			errs = append(errs, "ttl: cannot exceed "+strconv.FormatUint(maxHours, 10))
 		} else if *(job.TTL) < 1 {
-			errs = append(errs, "ttl: must be at least 1!")
+			errs = append(errs, "ttl: must be at least 1")
 		}
 	}
 

--- a/traffic_ops/client/job.go
+++ b/traffic_ops/client/job.go
@@ -35,6 +35,9 @@ func (to *Session) CreateInvalidationJob(job tc.InvalidationJobInput) (tc.Alerts
 		return tc.Alerts{}, reqInf, err
 	}
 	resp, remoteAddr, err := to.request(http.MethodPost, apiBase+`/jobs`, reqBody)
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return tc.Alerts{}, reqInf, err
 	}

--- a/traffic_ops/testing/api/v3/jobs_test.go
+++ b/traffic_ops/testing/api/v3/jobs_test.go
@@ -103,14 +103,14 @@ func CreateTestInvalidJob(t *testing.T) {
 	maxRevalDays := 0
 	foundMaxRevalDays := false
 	for _, p := range testData.Parameters {
-		if p.Name == "maxRevalDurationDays" {
-			maxRevalDays, err = strconv.Atoi(p.Value)
-			if err != nil {
-				t.Fatalf("unable to parse maxRevalDurationDays value '%s' to int", p.Value)
-			}
-			foundMaxRevalDays = true
-			break
+		if p.Name != "maxRevalDurationDays" {
+			continue
 		}
+		maxRevalDays, err = strconv.Atoi(p.Value)
+		if err != nil {
+			t.Fatalf("unable to parse maxRevalDurationDays value '%s' to int", p.Value)
+		}
+		foundMaxRevalDays = true
 	}
 	if !foundMaxRevalDays {
 		t.Fatalf("expected: parameter named maxRevalDurationDays, actual: not found")

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -2628,32 +2628,6 @@
             "type": "STEERING_WEIGHT"
         }
     ],
-    "jobs": [
-        {
-            "dsName": "ds1",
-            "request": {
-                "startTime": "2019-01-01 00:00:00",
-                "ttl": 80,
-                "regex": "/foo"
-            }
-        },
-        {
-            "dsName": "ds2",
-            "request": {
-                "startTime": "2019-01-01 00:00:00",
-                "ttl": 80,
-                "regex": "/bar"
-            }
-        },
-        {
-            "dsName": "ds1",
-            "request": {
-                "startTime": "2019-01-01 00:00:00",
-                "ttl": 80,
-                "regex": "/foo"
-            }
-        }
-    ],
     "servercheck_extensions": [
         {
             "name": "ILO_PING",
@@ -2694,6 +2668,12 @@
             "regex": "/.*",
             "startTime": 4117118271000,
             "ttl": "121m"
+        },
+        {
+            "deliveryService": "ds1",
+            "regex": "/foo",
+            "startTime": 4117118271000,
+            "ttl": 2160
         },
         {
             "deliveryService":  "ds2",

--- a/traffic_ops/testing/api/v3/traffic_control_test.go
+++ b/traffic_ops/testing/api/v3/traffic_control_test.go
@@ -55,11 +55,5 @@ type TrafficControl struct {
 	SteeringTargets                      []tc.SteeringTargetNullable             `json:"steeringTargets"`
 	Serverchecks                         []tc.ServercheckRequestNullable         `json:"serverchecks"`
 	Users                                []tc.User                               `json:"users"`
-	Jobs                                 []JobRequest                            `json:"jobs"`
 	InvalidationJobs                     []tc.InvalidationJobInput               `json:"invalidationJobs"`
-}
-
-type JobRequest struct {
-	DSName  string        `json:"dsName"`
-	Request tc.JobRequest `json:"request"`
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fix the validation of invalidation job TTLs per the `maxRevalDurationsDays` parameter. The broken validation was not converting days to hours before doing the validation. This PR also adds that validation to the `/jobs` endpoints because it was missing.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Run the unit tests and TO API tests. Verify they pass. Manually `POST /api/1.4/user/current/jobs` with a ttl that higher than the value of the `maxRevalDurationDays` parameter (x 24). Example request json below:
```
{
  "startTime": "2020-05-26 16:48:32",
  "dsId": 442,
  "regex": "/foobar",
  "ttl": 3000
}
```

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.0
- 4.1.0-RC0

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
