### PR TITLE
Queries with invalid type parameter should return 400s, not 500s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [4.0.0]: https://github.com/apache/trafficcontrol/compare/RELEASE-3.0.0...RELEASE-4.0.0
 [3.0.0]: https://github.com/apache/trafficcontrol/compare/RELEASE-2.2.0...RELEASE-3.0.0
 [2.2.0]: https://github.com/apache/trafficcontrol/compare/RELEASE-2.1.0...RELEASE-2.2.0
-
-
-[]: https://github.com/apache/trafficcontrol/issues/4703

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed audit logging from the `POST /api/x/serverchecks` Traffic Ops API endpoint in order to reduce audit log spam
 - Fixed audit logging from the `/jobs` APIs to bring them back to the same level of information provided by TO-Perl
 - Fixed update procedure of servers, so that if a server is linked to one or more delivery services, you cannot change its "cdn".
+- Fixed `cachegroups` READ endpoint, so that if a request is made with the `type` specified as a non integer value, you get back a `400` with error details, instead of a `500`.
 
 ### Changed
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed audit logging from the `POST /api/x/serverchecks` Traffic Ops API endpoint in order to reduce audit log spam
 - Fixed audit logging from the `/jobs` APIs to bring them back to the same level of information provided by TO-Perl
 - Fixed update procedure of servers, so that if a server is linked to one or more delivery services, you cannot change its "cdn".
-- Fixed `cachegroups` READ endpoint, so that if a request is made with the `type` specified as a non integer value, you get back a `400` with error details, instead of a `500`.
+- Fixed `cachegroups` READ endpoint, so that if a request is made with the `type` specified as a non integer value, you get back a `400` with error details, instead of a `500`. [Related github issue](https://github.com/apache/trafficcontrol/issues/4703)
 
 ### Changed
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.
@@ -357,3 +357,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [4.0.0]: https://github.com/apache/trafficcontrol/compare/RELEASE-3.0.0...RELEASE-4.0.0
 [3.0.0]: https://github.com/apache/trafficcontrol/compare/RELEASE-2.2.0...RELEASE-3.0.0
 [2.2.0]: https://github.com/apache/trafficcontrol/compare/RELEASE-2.1.0...RELEASE-2.2.0
+
+
+[]: https://github.com/apache/trafficcontrol/issues/4703

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
@@ -40,7 +40,7 @@ type tester struct {
 	APIInfoImpl `json:"-"`
 	userErr     error //only for testing
 	sysErr      error //only for testing
-	errCode     int //only for testing
+	errCode     int   //only for testing
 }
 
 var cfg = config.Config{ConfigTrafficOpsGolang: config.ConfigTrafficOpsGolang{DBQueryTimeoutSeconds: 20}}

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -444,7 +444,13 @@ func (cg *TOCacheGroup) Read() ([]interface{}, error, error, int) {
 LEFT JOIN topology_cachegroup ON cachegroup.name = topology_cachegroup.cachegroup
 `
 	}
-
+	// If the type cannot be converted to an int, return 400
+	if cgType, ok := cg.ReqInfo.Params["type"]; ok {
+		_, err := strconv.Atoi(cgType)
+		if err != nil {
+			return nil, errors.New("cachegroup read: converting cachegroup type to integer " + err.Error()), nil, http.StatusBadRequest
+		}
+	}
 	query := baseSelect + where + orderBy + pagination
 	rows, err := cg.ReqInfo.Tx.NamedQuery(query, queryValues)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -337,9 +337,9 @@ func TestBadTypeParamCacheGroups(t *testing.T) {
 		t.Errorf("Read expected status code: Bad Request, actual: %v ", sc)
 	}
 	if userErr == nil {
-		t.Errorf("Read expected: user error with details %v, actual: nil", detail)
+		t.Fatalf("Read expected: user error with details %v, actual: nil", detail)
 	}
 	if userErr.Error() != detail {
-		t.Errorf("Read expected: user error with details %v, actual: %v", detail, userErr.Error())
+		t.Fatalf("Read expected: user error with details %v, actual: %v", detail, userErr.Error())
 	}
 }

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -274,7 +274,7 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestBadTypeParamCacheGroups (t *testing.T) {
+func TestBadTypeParamCacheGroups(t *testing.T) {
 	detail := `cachegroup read: converting cachegroup type to integer strconv.Atoi: parsing "wrong": invalid syntax`
 	mockDB, mock, err := sqlmock.New()
 	if err != nil {
@@ -336,7 +336,7 @@ func TestBadTypeParamCacheGroups (t *testing.T) {
 	if sc != http.StatusBadRequest {
 		t.Errorf("Read expected status code: Bad Request, actual: %v ", sc)
 	}
-	if userErr == nil{
+	if userErr == nil {
 		t.Errorf("Read expected: user error with details %v, actual: nil", detail)
 	}
 	if userErr.Error() != detail {

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -21,6 +21,7 @@ package cachegroup
 
 import (
 	"errors"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -270,5 +271,75 @@ func TestValidate(t *testing.T) {
 	err = c.Validate()
 	if err != nil {
 		t.Errorf("expected nil, got %s", err)
+	}
+}
+
+func TestBadTypeParamCacheGroups (t *testing.T) {
+	detail := `cachegroup read: converting cachegroup type to integer strconv.Atoi: parsing "wrong": invalid syntax`
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
+
+	testCGs := getTestCacheGroups()
+	rows := sqlmock.NewRows([]string{
+		"id",
+		"name",
+		"short_name",
+		"latitude",
+		"longitude",
+		"localization_methods",
+		"parent_cachegroup_id",
+		"parent_cachegroup_name",
+		"secondary_parent_cachegroup_id",
+		"secondary_parent_cachegroup_name",
+		"type_name",
+		"type_id",
+		"last_updated",
+		"fallbacks",
+		"fallbackToClosest",
+	})
+
+	for _, ts := range testCGs {
+		rows = rows.AddRow(
+			ts.ID,
+			ts.Name,
+			ts.ShortName,
+			ts.Latitude,
+			ts.Longitude,
+			[]byte("{DEEP_CZ,CZ,GEO}"),
+			ts.ParentCachegroupID,
+			ts.ParentName,
+			ts.SecondaryParentCachegroupID,
+			ts.SecondaryParentName,
+			ts.Type,
+			ts.TypeID,
+			ts.LastUpdated,
+			[]byte("{cachegroup2,cachegroup3}"),
+			ts.FallbackToClosest,
+		)
+	}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectCommit()
+
+	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"type": "wrong"}}
+	obj := TOCacheGroup{
+		api.APIInfoImpl{&reqInfo},
+		tc.CacheGroupNullable{},
+	}
+	_, userErr, _, sc := obj.Read()
+	if sc != http.StatusBadRequest {
+		t.Errorf("Read expected status code: Bad Request, actual: %v ", sc)
+	}
+	if userErr == nil{
+		t.Errorf("Read expected: user error with details %v, actual: nil", detail)
+	}
+	if userErr.Error() != detail {
+		t.Errorf("Read expected: user error with details %v, actual: %v", detail, userErr.Error())
 	}
 }

--- a/traffic_ops/traffic_ops_golang/server/servers_test.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_test.go
@@ -121,9 +121,9 @@ func TestUpdateServer(t *testing.T) {
 	mock.ExpectQuery("SELECT ARRAY").WillReturnRows(dsrows)
 
 	snv := tc.ServerNullableV11{
-		CDNID:            &testServers[0].CDNID,
-		FqdnTime:         time.Time{},
-		TypeID:           &testServers[0].TypeID,
+		CDNID:    &testServers[0].CDNID,
+		FqdnTime: time.Time{},
+		TypeID:   &testServers[0].TypeID,
 	}
 	sn := tc.ServerNullable{
 		ServerNullableV11: snv,
@@ -131,8 +131,8 @@ func TestUpdateServer(t *testing.T) {
 		IP6IsService:      nil,
 	}
 
-	s := &TOServer {
-		APIInfoImpl:    api.APIInfoImpl{
+	s := &TOServer{
+		APIInfoImpl: api.APIInfoImpl{
 			ReqInfo: &api.APIInfo{
 				Params:    nil,
 				IntParams: nil,


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4703  <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Setup TO locally and make a query like this `GET /api/3.0/cachegroups?type=WRONG`
This should return a 400, with the error details in it as the response.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
