### PR TITLE
removes deepcachingtype and routingname from emailed dsr struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed audit logging from the `/jobs` APIs to bring them back to the same level of information provided by TO-Perl
 - Fixed `maxRevalDurationDays` validation for `POST /api/1.x/user/current/jobs` and added that validation to the `/api/x/jobs` endpoints
 - Fixed update procedure of servers, so that if a server is linked to one or more delivery services, you cannot change its "cdn".
+- Fixed POST deliveryservices/request (designed to simple send an email) regression which erroneously required deepcachingtype and routing name.
 
 ### Changed
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.

--- a/docs/source/api/v1/deliveryservices_request.rst
+++ b/docs/source/api/v1/deliveryservices_request.rst
@@ -34,13 +34,6 @@ Request Structure
 :details: An object describing the actual parameters for the Delivery Service request
 
 	:customer:        Name of the customer associated with the :term:`Delivery Service`
-	:deepCachingType: An optional string describing when to do Deep Caching for this :term:`Delivery Service` - one of:
-
-		NEVER
-			Never use deep caching (default)
-		ALWAYS
-			Always use deep caching
-
 	:deliveryProtocol: The protocol used to retrieve content from the CDN - one of:
 
 		* http
@@ -68,7 +61,6 @@ Request Structure
 	:rangeRequestHandling:             A special string describing how the :term:`Delivery Service` should handle range requests
 	:rateLimitingGBPS:                 An optional field which, if defined, should contain the maximum allowed data transfer rate for the :term:`Delivery Service` in GigaBytes Per Second (GBPS)
 	:rateLimitingTPS:                  An optional field which, if defined, should contain the maximum allowed transaction rate for the :term:`Delivery Service` in Transactions Per Second (TPS)
-	:routingName:                      The routing name for the :term:`Delivery Service`, e.g. ``SomeRoutingName.DeliveryService_xml_id.CDNName.com``
 	:routingType:                      The :term:`Delivery Service`'s routing type, should be one of:
 
 		HTTP

--- a/docs/source/api/v2/deliveryservices_request.rst
+++ b/docs/source/api/v2/deliveryservices_request.rst
@@ -34,13 +34,6 @@ Request Structure
 :details: An object describing the actual parameters for the Delivery Service request
 
 	:customer:        Name of the customer associated with the :term:`Delivery Service`
-	:deepCachingType: An optional string describing when to do Deep Caching for this :term:`Delivery Service` - one of:
-
-		NEVER
-			Never use deep caching (default)
-		ALWAYS
-			Always use deep caching
-
 	:deliveryProtocol: The protocol used to retrieve content from the CDN - one of:
 
 		* http
@@ -68,7 +61,6 @@ Request Structure
 	:rangeRequestHandling:             A special string describing how the :term:`Delivery Service` should handle range requests
 	:rateLimitingGBPS:                 An optional field which, if defined, should contain the maximum allowed data transfer rate for the :term:`Delivery Service` in GigaBytes Per Second (GBPS)
 	:rateLimitingTPS:                  An optional field which, if defined, should contain the maximum allowed transaction rate for the :term:`Delivery Service` in Transactions Per Second (TPS)
-	:routingName:                      The routing name for the :term:`Delivery Service`, e.g. ``SomeRoutingName.DeliveryService_xml_id.CDNName.com``
 	:routingType:                      The :term:`Delivery Service`'s routing type, should be one of:
 
 		HTTP

--- a/docs/source/api/v3/deliveryservices_request.rst
+++ b/docs/source/api/v3/deliveryservices_request.rst
@@ -34,13 +34,6 @@ Request Structure
 :details: An object describing the actual parameters for the Delivery Service request
 
 	:customer:        Name of the customer associated with the :term:`Delivery Service`
-	:deepCachingType: An optional string describing when to do Deep Caching for this :term:`Delivery Service` - one of:
-
-		NEVER
-			Never use deep caching (default)
-		ALWAYS
-			Always use deep caching
-
 	:deliveryProtocol: The protocol used to retrieve content from the CDN - one of:
 
 		* http
@@ -68,7 +61,6 @@ Request Structure
 	:rangeRequestHandling:             A special string describing how the :term:`Delivery Service` should handle range requests
 	:rateLimitingGBPS:                 An optional field which, if defined, should contain the maximum allowed data transfer rate for the :term:`Delivery Service` in GigaBytes Per Second (GBPS)
 	:rateLimitingTPS:                  An optional field which, if defined, should contain the maximum allowed transaction rate for the :term:`Delivery Service` in Transactions Per Second (TPS)
-	:routingName:                      The routing name for the :term:`Delivery Service`, e.g. ``SomeRoutingName.DeliveryService_xml_id.CDNName.com``
 	:routingType:                      The :term:`Delivery Service`'s routing type, should be one of:
 
 		HTTP

--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -171,8 +171,6 @@ type DeliveryServiceRequestDetails struct {
 	ContentType string `json:"contentType"`
 	// Customer is the requesting customer - typically this is a Tenant.
 	Customer string `json:"customer"`
-	// DeepCachingType represents whether or not the Delivery Service should use Deep Caching.
-	DeepCachingType *DeepCachingType `json:"deepCachingType"`
 	// Delivery Protocol is the protocol clients should use to connect to the Delivery Service.
 	DeliveryProtocol *Protocol `json:"deliveryProtocol"`
 	// HasNegativeCachingCustomization indicates whether or not the resulting Delivery Service should
@@ -236,8 +234,6 @@ type DeliveryServiceRequestDetails struct {
 	// RateLimitingTPS is an optional rate limit for the requested Delivery Service in transactions
 	// per second.
 	RateLimitingTPS *uint `json:"rateLimitingTPS"`
-	// RoutingName is the top-level DNS label under which the Delivery Service should be requested.
-	RoutingName string `json:"routingName"`
 	// RoutingType is the type of routing Traffic Router should perform for the requested Delivery
 	// Service.
 	RoutingType *DSType `json:"routingType"`
@@ -274,16 +270,6 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 	err = validation.ValidateStruct(&details,
 		validation.Field(&details.ContentType, validation.Required),
 		validation.Field(&details.Customer, validation.Required),
-		validation.Field(&details.DeepCachingType, validation.By(
-			func(t interface{}) error {
-				if t == (*DeepCachingType)(nil) {
-					return errors.New("deepCachingType: required")
-				}
-				if *t.(*DeepCachingType) == DeepCachingTypeInvalid {
-					return errors.New("deepCachingType: invalid Deep Caching Type")
-				}
-				return nil
-			})),
 		validation.Field(&details.DeliveryProtocol, validation.By(
 			func(p interface{}) error {
 				if p == (*Protocol)(nil) {
@@ -339,7 +325,6 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 		validation.Field(&details.PeakTPSEstimate, validation.Required),
 		validation.Field(&details.QueryStringHandling, validation.Required),
 		validation.Field(&details.RangeRequestHandling, validation.Required),
-		validation.Field(&details.RoutingName, validation.Required),
 		validation.Field(&details.RoutingType, validation.By(
 			func(t interface{}) error {
 				if t == (*DSType)(nil) || *(t.(*DSType)) == "" {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Removes deepcachingtype and routingname which are not part of email version of deliveryservice request

- [x] This PR fixes #4735 

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Run the API tests
Perform a POST to 1.4/deliveryservices/request minus deepcachingtype and routingname as required per https://traffic-control-cdn.readthedocs.io/en/latest/api/v1/deliveryservices_request.html#post and ensure the post succeeds.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.0.0
- 4.1.0 (RC1)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
