### PR TITLE
Fixes minor bugs with topology create/update UI

### DIFF
--- a/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
+++ b/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
@@ -93,6 +93,8 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 				node.parent = "";
 				node.secParent = "";
 			}
+			// marks the form as dirty thus enabling the save btn
+			$scope.topologyForm.dirty.$setDirty();
 			return true;
 		}
 	};
@@ -150,6 +152,8 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 			} else {
 				node.secParent = '';
 			}
+			// marks the form as dirty thus enabling the save btn
+			$scope.topologyForm.dirty.$setDirty();
 		});
 	};
 
@@ -157,6 +161,8 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 		if (node.cachegroup) {
 			removeSecParentReferences($scope.topologyTree, node.cachegroup);
 			scope.remove();
+			// marks the form as dirty thus enabling the save btn
+			$scope.topologyForm.dirty.$setDirty();
 		}
 	};
 
@@ -227,6 +233,8 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 			cacheGroupNodes.forEach(function(node) {
 				nodeData.children.unshift(node);
 			});
+			// marks the form as dirty thus enabling the save btn
+			$scope.topologyForm.dirty.$setDirty();
 		});
 	};
 

--- a/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
@@ -56,14 +56,17 @@ under the License.
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-danger" ng-show="!settings.isNew" ng-click="confirmDelete(topology)">Delete</button>
-                <button type="button" class="btn btn-success" ng-disabled="topologyForm.$invalid" ng-click="save(topology.name, topology.description, topologyTree)">{{settings.saveLabel}}</button>
+                <button type="button" class="btn btn-success" ng-disabled="topologyForm.$pristine || topologyForm.$invalid" ng-click="save(topology.name, topology.description, topologyTree)">{{settings.saveLabel}}</button>
             </div>
         </form>
     </div>
 </div>
 
 <script type="text/ng-template" id="nodes_renderer.html">
+    <!-- this hidden form field will make the form invalid (and disable the save btn) because it's a required field with no value -->
     <input name="error" ng-if="hasNodeError(node)" ng-model="error" type="hidden" required>
+    <!-- this hidden form field will mark the form as dirty (and enable the save btn) when the topology tree is modified in any way -->
+    <input name="dirty" ng-model="dirty" type="hidden">
     <div id="{{node.cachegroup}}" ui-tree-handle class="tree-node tree-node-content"
          ng-class="{ 'error': hasNodeError(node), 'origin': isOrigin(node), 'mid': isMid(node) }">
         <div class="tree-node-label pull-left">

--- a/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
@@ -21,7 +21,7 @@ under the License.
     <div class="x_title">
         <ol class="breadcrumb pull-left">
             <li><a ng-click="navigateToPath('/topologies')">Topologies</a></li>
-            <li class="active">{{topologyName}}</li>
+            <li class="active">{{::topologyName}}</li>
         </ol>
         <div class="clearfix"></div>
     </div>
@@ -69,20 +69,20 @@ under the License.
         <div class="tree-node-label pull-left">
             <a class="tree-toggle btn btn-primary btn-xs" ng-if="node.type !== 'ROOT' && hasChildren(node)" data-nodrag ng-click="toggle(this)">
                 <i class="fa" ng-class="collapsed ? 'fa-caret-right' : 'fa-caret-down'"></i>
-            </a> {{nodeLabel(node)}} <small>{{node.type}}</small>
+            </a> {{::nodeLabel(node)}} <small>{{::node.type}}</small>
         </div>
-        <div ng-if="hasNodeError(node)" class="error-msg">1+ child required for {{node.type}}</div>
+        <div ng-if="hasNodeError(node)" class="error-msg">1+ child required for {{::node.type}}</div>
         <div class="pull-right">
-            <a ng-show="node.cachegroup && node.parent" title="Set Secondary Parent Cache Group for {{node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="editSecParent(node)" style="margin-right: 8px;">
+            <a ng-show="node.cachegroup && node.parent" title="Set Secondary Parent Cache Group for {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="editSecParent(node)" style="margin-right: 8px;">
                 2nd: {{(node.secParent) ? node.secParent : 'None'}}
             </a>
-            <a ng-if="node.cachegroup" title="View Servers Assigned to {{node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="viewCacheGroupServers(node)" style="margin-right: 8px;">
+            <a ng-if="node.cachegroup" title="View Servers Assigned to {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="viewCacheGroupServers(node)" style="margin-right: 8px;">
                 <i class="fa fa-server"></i>
             </a>
             <a ng-disabled="node.type === 'EDGE_LOC'" title="{{(node.type !== 'EDGE_LOC') ? 'Add child cache groups to ' + nodeLabel(node) : 'Child cache groups cannot be added to EDGE_LOC cache groups'}}" class="btn btn-primary btn-xs" data-nodrag ng-click="addCacheGroups(node, this)" style="margin-right: 8px;">
                 <i class="fa fa-plus"></i>
             </a>
-            <a ng-if="node.cachegroup" title="Remove {{node.cachegroup}} Cache Group" class="btn btn-danger btn-xs" data-nodrag ng-click="deleteCacheGroup(node, this)">
+            <a ng-if="node.cachegroup" title="Remove {{::node.cachegroup}} Cache Group" class="btn btn-danger btn-xs" data-nodrag ng-click="deleteCacheGroup(node, this)">
                 <i class="fa fa-times"></i>
             </a>
         </div>

--- a/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
@@ -79,7 +79,7 @@ under the License.
             <a ng-if="node.cachegroup" title="View Servers Assigned to {{node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="viewCacheGroupServers(node)" style="margin-right: 8px;">
                 <i class="fa fa-server"></i>
             </a>
-            <a ng-disabled="node.type === 'EDGE_LOC'" title="{{(node.type !== 'EDGE_LOC') ? 'Add cache groups to ' + node.cachegroup : 'Cache groups cannot be added to EDGE_LOC cache groups'}}" class="btn btn-primary btn-xs" data-nodrag ng-click="addCacheGroups(node, this)" style="margin-right: 8px;">
+            <a ng-disabled="node.type === 'EDGE_LOC'" title="{{(node.type !== 'EDGE_LOC') ? 'Add child cache groups to ' + nodeLabel(node) : 'Child cache groups cannot be added to EDGE_LOC cache groups'}}" class="btn btn-primary btn-xs" data-nodrag ng-click="addCacheGroups(node, this)" style="margin-right: 8px;">
                 <i class="fa fa-plus"></i>
             </a>
             <a ng-if="node.cachegroup" title="Remove {{node.cachegroup}} Cache Group" class="btn btn-danger btn-xs" data-nodrag ng-click="deleteCacheGroup(node, this)">

--- a/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
@@ -31,10 +31,8 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, cacheG
 			if (cg['used'] === true) {
 				return cg;
 			}
-			if (selected && visibleCacheGroupIds.includes(cg.id)) {
-				cg['selected'] = true;
-			} else {
-				cg['selected'] = false;
+			if (visibleCacheGroupIds.includes(cg.id)) {
+				cg['selected'] = selected;
 			}
 			return cg;
 		});
@@ -54,12 +52,7 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, cacheG
 	};
 
 	let updateSelectedCount = function() {
-		let visibleCacheGroupIds = $('#availableCacheGroupsTable tr.cg-row').map(
-			function() {
-				return parseInt($(this).attr('id'));
-			}).get();
-
-		selectedCacheGroups = $scope.cacheGroups.filter(function(cg) { return visibleCacheGroupIds.includes(cg.id) && cg['selected'] === true && !cg['used'] } );
+		selectedCacheGroups = $scope.cacheGroups.filter(function(cg) { return cg['selected'] === true && !cg['used'] } );
 		$('div.selected-count').html('<strong><span class="text-success">' + selectedCacheGroups.length + ' selected</span><span> | ' + usedCacheGroupCount + ' already used in topology</span></strong>');
 	};
 
@@ -174,7 +167,7 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, cacheG
 	angular.element(document).ready(function () {
 		decorateCacheGroups();
 
-		$('#availableCacheGroupsTable').DataTable({
+		let availableCacheGroupsTable = $('#availableCacheGroupsTable').DataTable({
 			"scrollY": "60vh",
 			"paging": false,
 			"order": [[ 1, 'asc' ]],
@@ -190,6 +183,9 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, cacheG
 			],
 			"stateSave": false
 		});
+		availableCacheGroupsTable.on( 'search.dt', function () {
+			$("#selectAllCB").removeAttr("checked"); // uncheck the all box when filtering
+		} );
 	});
 
 };

--- a/traffic_portal/app/src/common/modules/table/topologyCacheGroups/table.selectTopologyCacheGroups.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/topologyCacheGroups/table.selectTopologyCacheGroups.tpl.html
@@ -21,7 +21,7 @@ under the License.
 
 <div class="modal-header">
     <button type="button" class="close" ng-click="cancel()"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-    <h3 class="modal-title">Add Cache Groups to {{(parent.cachegroup) ? parent.cachegroup : 'ROOT'}}</h3>
+    <h3 class="modal-title">Add Child Cache Groups to {{(parent.cachegroup) ? parent.cachegroup : 'ROOT'}}</h3>
 </div>
 <div class="modal-body">
     <table id="availableCacheGroupsTable" class="table responsive-utilities jambo_table" style="table-layout:fixed; width:100%;">


### PR DESCRIPTION
## What does this PR (Pull Request) do?

The following items related to topology CRUD in TP were fixed with this PR:

1. the "add cachegroups to <cachegroup>" tooltip for the + button says "add child cachgroups to <cachegroup>" instead. Also, the title on the modal when adding child cachegroups says the same thing.
2. replaced some 2 way binding with 1 way binding as it was unnecessary and not good for performance if not needed.
3.  only enables the save button when a change is made. currently it is always enabled.
4. preserves selections when selecting cachegroups to add to a topology. previously, when selecting child cachegroups to add to a cachegroup, if you select a cachegroup then add text to the search box that filters out the selected cachegroup, then submit, it will discard your previous selections

- [x] This PR is not related to any Issue 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?

Navigate to https://tp.domain.net/#!/topologies and edit an existing topology or create a new one and:

1. ensure that `child` is added to the `+` tooltip and also to the modal title as mentioned above.
2. not sure how to verify one way vs. 2 way binding.
3. ensure save button is disabled by default when editing a topology and only enables once a change is made.
4. add child cachegroups to a topology. select a few, filter, select a few more, submit and make sure all selections are added to the topology.

## If this is a bug fix, what versions of Traffic Control are affected?
master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [ ] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
