### PR TITLE
Remove wrong error logs

### DIFF
--- a/traffic_ops/traffic_ops_golang/ats/atsserver/hostingdotconfig.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/hostingdotconfig.go
@@ -79,9 +79,6 @@ func GetHostingDotConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Errorf("hosting config DEBUG params %+v\n", params)
-	log.Errorf("hosting config DEBUG multiParams %+v\n", multiParams)
-
 	txt := atscfg.MakeHostingDotConfig(serverName, toToolName, toURL, params, origins)
 
 	w.Header().Set("Content-Type", "text/plain")
@@ -118,8 +115,6 @@ WHERE
 `
 	}
 	// Note the 'ds.cdn_id = s.cdn_id' in the query shouldn't be necessary, but it is, because there's no DB constraint.
-
-	log.Errorln("hosting config DEBUG qry QQ" + qry + "QQ")
 
 	rows, err := tx.Query(qry, serverName)
 	if err != nil {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Removes debug error logs that accidentally got left in.

It's only removing log messages, nothing to test.
No docs, no changelog,  no interface change.

Not actually a behavioral bug, but labelling minor bug, because it's not a feature and it's wrong.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

Observe code, observe logs are not errors  and should not exist.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
