### PR TITLE
Add Raw Remap Range Directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed update procedure of servers, so that if a server is linked to one or more delivery services, you cannot change its "cdn". [Related github issue](https://github.com/apache/trafficcontrol/issues/4116)
 - Fixed `POST /api/x/steering` and `PUT /api/x/steering` so that a steering target with an invalid `type` is no longer accepted. [Related github issue](https://github.com/apache/trafficcontrol/issues/3531)
 - Fixed `cachegroups` READ endpoint, so that if a request is made with the `type` specified as a non integer value, you get back a `400` with error details, instead of a `500`. [Related github issue](https://github.com/apache/trafficcontrol/issues/4703)
+- Added Delivery Service Raw Remap `__RANGE_DIRECTIVE__` directive to allow inserting the Range Directive after the Raw Remap text. This allows Raw Remaps which manipulate the Range.
 
 ### Changed
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -643,6 +643,13 @@ For HTTP and DNS-:ref:`Routed <ds-types>` Delivery Services, this will be added 
 	| remapText | In Traffic Ops source code and :ref:`to-api` requests/responses | unchanged (``text``, ``string`` etc.) |
 	+-----------+-----------------------------------------------------------------+---------------------------------------+
 
+Directives
+"""
+
+The Raw Remap text is ordinarily added at the end of the line, after everything else. However, it may be necessary to add Range Request Handling after the Raw Remap. For example, if you have a plugin which manipulates the Range header. In this case, you can insert the text ``__RANGE_DIRECTIVE__`` in the Raw Remap text, and the range request handling directives will be added at that point.
+
+For example, if you have an Apache Traffic Server lua plugin which manipulates the range, and are using Slice Range Request Handling which needs to run after your plugin, you can set a Raw Remap, ``@plugin=tslua.so @pparam=range.lua __RANGE_DIRECTIVE__``, and the ``@plugin=slice.so`` range directive will be inserted after your plugin.
+
 .. _ds-regex-remap:
 
 Regex Remap Expression


### PR DESCRIPTION
Adds a `__RANGE_DIRECTIVE__` to the Raw Remap processing, to insert the
Delivery Service Range Request Handling directives there, instead of
before the Raw Remap.

Normally, Raw Remap always needs to be at the end of the remap line,
but in some cases, specifically when custom remaps are modifying
the Range header, it's necessary to put the Range Request directives
(@plugin=slice.so, @plugin=cache_range_requests.so, etc) after
the custom Raw Remap text.

This makes that possible.

Tested manually, verified range directives are placed over `__RANGE_DIRECTIVE__` in the Raw Remap, range directives are placed as normally if no directive exists, range plugins aren't double-placed. Includes unit tests verifying same.

Fixes #4755 

Includes tests.
Includes docs.
Includes changelog.

- [x] This PR fixes #4755 

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests.
Create a Delivery Service with a Range Request Handling: Slice, and a Raw Remap of `sometext __RANGE_DIRECTIVE__`, queue updates, verify the `@plugin=slice.so` is after `sometext` in `remap.config` on the cache.
Remove `__RANGE_DIRECTIVE__` from the Delivery Service, queue, verify Raw Remap Text is at the end of the line like it should be.

## If this is a bug fix, what versions of Traffic Control are affected?
This is somewhat between a bug fix and a feature. It's a feature that fixes a critical issue in a new feature in 4.1, #4455

- master 
- 4.1

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information
