### PR TITLE
Rewrote postinstall to Python (3.6+)

### DIFF
--- a/traffic_control/clients/python/pylint.rc
+++ b/traffic_control/clients/python/pylint.rc
@@ -259,7 +259,7 @@ redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
 
 # Format style used to check logging format string. `old` means using %
 # formatting, while `new` is for `{}` formatting.
-logging-format-style=new
+logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -523,7 +523,7 @@ def unmarshal_config(dct: dict) -> typing.Dict[str, typing.List[Question]]:
 		if not isinstance(questions, list):
 			raise ValueError(f"file '{file}' has malformed questions")
 
-		questions = []
+		qstns = []
 		for qstn in questions:
 			if not isinstance(qstn, dict):
 				raise ValueError(f"file '{file}' has a malformed question ({qstn})")
@@ -553,8 +553,8 @@ def unmarshal_config(dct: dict) -> typing.Dict[str, typing.List[Question]]:
 			if qstn:
 				logging.warning("Found unknown extra properties in question in '%s' (%r)", file, qstn.keys())
 
-			questions.append(Question(question, answer, cfg_var, hidden=hidden))
-		ret[file] = questions
+			qstns.append(Question(question, answer, cfg_var, hidden=hidden))
+		ret[file] = qstns
 
 	return ret
 

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python3
+
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import getpass
+import logging
+import sys
+import typing
+
+# Paths for output configuration files
+DATABASE_CONF_FILE = "/opt/traffic_ops/app/conf/production/database.conf"
+DB_CONF_FILE       = "/opt/traffic_ops/app/db/dbconf.yml"
+CDN_CONF_FILE      = "/opt/traffic_ops/app/conf/cdn.conf"
+LDAP_CONF_FILE     = "/opt/traffic_ops/app/conf/ldap.conf"
+USERS_CONF_FILE    = "/opt/traffic_ops/install/data/json/users.json"
+PROFILES_CONF_FILE = "/opt/traffic_ops/install/data/profiles/"
+OPENSSL_CONF_FILE  = "/opt/traffic_ops/install/data/json/openssl_configuration.json"
+PARAM_CONF_FILE    = "/opt/traffic_ops/install/data/json/profiles.json"
+
+CUSTOM_PROFILE_DIR = PROFILES_CONF_FILE + "custom"
+
+# Location of Traffic Ops profiles
+PROFILE_DIR = "/opt/traffic_ops/install/data/profiles/"
+POST_INSTALL_CFG = "/opt/traffic_ops/install/data/json/post_install.json"
+
+# Log file for the installer
+LOG_FILE = "/var/log/traffic_ops/postinstall.log"
+
+# Log file for CPAN output
+CPAN_LOG_FILE = "/var/log/traffic_ops/cpan.log"
+
+# Configuration file output with answers which can be used as input to postinstall
+OUTPUT_CONFIG_FILE = "/opt/traffic_ops/install/bin/configuration_file.json"
+
+def get_field(question: str, config_answer: str, hidden: bool = False) -> str:
+	if hidden:
+		while True:
+			pw = getpass.getpass(question)
+			if pw == getpass.getpass(f"Re-Enter {question}"):
+				return pw
+			print("Error: passwords do not match, try again", file=sys.stderr)
+
+	if config_answer:
+		ipt = input(f"{question} [{config_answer}]: ")
+		return ipt if ipt else config_answer
+	return input(question + ": ")
+
+def get_config(user_input: typing.Dict[str, typing.List[typing.Dict[str, str]]], fname: str, automatic: bool = False) -> dict:
+
+	if fname not in user_input:
+		raise ValueError(f"No {fname} found in config")
+
+	logging.info(f"==========={fname}===========")
+
+	config = {}
+
+	for var in user_input[fname]:
+		question = next(key for key in var.keys() if key != "hidden" and key != "config_var")
+		hidden = var.get("hidden")
+		answer = var.get(question) if automatic else get_field(question, var.get(question), hidden)
+
+		config[var.get(config_var)] = answer
+
+	return config
+
+def generate_db_conf(user_input: dict, fname: str, todb_fname: str, automatic: bool):
+	"""
+	"""
+	db_conf = get_config(user_input, fname, automatic)

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1249,15 +1249,15 @@ if __name__ == '__main__':
 	ARGS = PARSER.parse_args()
 
 	USED_LEGACY_ARGS = False
-	DEFAULTS = None
+	DEFAULTS_ARG = None
 	if ARGS.legacy_defaults:
 		if ARGS.defaults:
 			logging.error("cannot specify both '--defaults' and '-defaults'")
 			sys.exit(1)
 		USED_LEGACY_ARGS = True
-		DEFAULTS = ARGS.legacy_defaults
+		DEFAULTS_ARG = ARGS.legacy_defaults
 	else:
-		DEFAULTS = ARGS.defaults
+		DEFAULTS_ARG = ARGS.defaults
 
 	DEBUG = False
 	if ARGS.legacy_debug:
@@ -1293,7 +1293,7 @@ if __name__ == '__main__':
 		EXIT_CODE = main(
 		ARGS.automatic,
 		DEBUG,
-		DEFAULTS,
+		DEFAULTS_ARG,
 		CFILE,
 		os.path.abspath(ARGS.root_directory),
 		ARGS.ops_user,

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env -S sh -c 'PATH="${PATH}:/usr/libexec" exec "$(type -p python platform-python | head -n1)" "$0" "$@"'
+#!/usr/bin/env python3
 # There's a bug in asteroid with Python 3.9's NamedTuple being
 # recognized for the dynamically generated class that it is. Should be fixed
-# with the next release, but 'till then...
+# with the next release, but 'til then...
 #pylint:disable=inherit-non-class
 """
 This script is meant as a drop-in replacement for the old _postinstall Perl script.

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -850,6 +850,7 @@ def generate_cdn_conf(questions: typing.List[Question], fname: str, automatic: b
 
 	with open(path, "w+") as conf_file:
 		json.dump(existing_conf, conf_file, indent="\t")
+		print(file=conf_file)
 	logging.info("CDN configuration has been saved")
 
 def db_connection_string(dbconf: dict) -> str:

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -575,7 +575,13 @@ def setup_maxmind(maxmind_answer: str, root: str):
 	cmd = [wget, "https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz"]
 	# Perl ignored errors downloading the databases, so we do too
 	try:
-		subprocess.run(cmd, capture_output=True, check=True, universal_newlines=True)
+		subprocess.run(
+			cmd,
+			stderr=subprocess.PIPE,
+			stdout=subprocess.PIPE,
+			check=True,
+			universal_newlines=True
+		)
 	except subprocess.SubprocessError as e:
 		logging.error("Failed to download MaxMind data")
 		logging.debug("(ipv4) Exception: %s", e)
@@ -584,7 +590,13 @@ def setup_maxmind(maxmind_answer: str, root: str):
 		"https://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz"
 	)
 	try:
-		subprocess.run(cmd, capture_output=True, check=True, universal_newlines=True)
+		subprocess.run(
+			cmd,
+			stderr=subprocess.PIPE,
+			stdout=subprocess.PIPE,
+			check=True,
+			universal_newlines=True
+		)
 	except subprocess.SubprocessError as e:
 		logging.error("Failed to download MaxMind data")
 		logging.debug("(ipv6) Exception: %s", e)
@@ -601,7 +613,13 @@ def exec_openssl(description: str, *cmd_args) -> bool:
 	cmd = ["/usr/bin/openssl", *cmd_args]
 
 	while True:
-		proc = subprocess.run(cmd, capture_output=True, universal_newlines=True, check=False)
+		proc = subprocess.run(
+			cmd,
+			stderr=subprocess.PIPE,
+			stdout=subprocess.PIPE,
+			universal_newlines=True,
+			check=False
+		)
 		if proc.returncode == 0:
 			return True
 
@@ -878,7 +896,13 @@ def exec_psql(conn_str: str, query: str) -> str:
 	:returns: The comma-separated columns of each line-delimited row of the results of the query.
 	"""
 	cmd = ["/usr/bin/psql", "--tuples-only", "-d", conn_str, "-c", query]
-	proc = subprocess.run(cmd, capture_output=True, universal_newlines=True, check=False)
+	proc = subprocess.run(
+		cmd,
+		stderr=subprocess.PIPE,
+		stdout=subprocess.PIPE,
+		universal_newlines=True,
+		check=False
+	)
 	if proc.returncode != 0:
 		logging.debug("psql exec failed; stderr: %s\n\tstdout: %s", proc.stderr, proc.stdout)
 		raise OSError("failed to execute database query")
@@ -893,7 +917,13 @@ def invoke_db_admin_pl(action: str, root: str):
 	# should be fixed at some point, IMO, but for now this works.
 	os.chdir(path)
 	cmd = [os.path.join(path, "db/admin"), "--env=production", action]
-	proc = subprocess.run(cmd, capture_output=True, universal_newlines=True, check=False)
+	proc = subprocess.run(
+		cmd,
+		stderr=subprocess.PIPE,
+		stdout=subprocess.PIPE,
+		universal_newlines=True,
+		check=False
+	)
 	if proc.returncode != 0:
 		logging.debug("admin exec failed; stderr: %s\n\tstdout: %s", proc.stderr, proc.stdout)
 		raise OSError(f"Database {action} failed")
@@ -1153,13 +1183,19 @@ no_database: bool
 		logging.info("Starting Traffic Ops")
 		try:
 			cmd = ["/sbin/service", "traffic_ops", "restart"]
-			subprocess.run(cmd, capture_output=True, universal_newlines=True, check=True)
+			subprocess.run(
+				cmd,
+				stderr=subprocess.PIPE,
+				stdout=subprocess.PIPE,
+				universal_newlines=True,
+				check=True
+			)
 		except subprocess.CalledProcessError as e:
 			logging.critical("Failed to restart Traffic Ops, return code %s: %s", e.returncode, e)
 			logging.debug("stderr: %s\n\tstdout: %s", e.stderr, e.stdout)
 			return 1
 		except (OSError, subprocess.SubprocessError) as e:
-			logging.critical("Failed to restart Traffic Ops: unknown error occurred")
+			logging.critical("Failed to restart Traffic Ops: unknown error occurred: %s", e)
 			return 1
 		# Perl didn't actually do any "waiting" before reporting success, so
 		# neither do we

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python3
+"""
+>>> [c for c in [[a for a in b if not a.config_var] for b in DEFAULTS.values()] if c]
+[]
+"""
 
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +18,10 @@
 # limitations under the License.
 #
 
+import argparse
 import getpass
 import logging
+import os
 import sys
 import typing
 
@@ -43,6 +49,90 @@ CPAN_LOG_FILE = "/var/log/traffic_ops/cpan.log"
 
 # Configuration file output with answers which can be used as input to postinstall
 OUTPUT_CONFIG_FILE = "/opt/traffic_ops/install/bin/configuration_file.json"
+
+class Question():
+
+	def __init__(self, question: str, default: str, config_var: str, hidden: bool = False):
+		self.question = question
+		self.default = default
+		self.config_var = config_var
+		self.hidden = hidden
+
+	def __str__(self) -> str:
+		if self.default:
+			return f"{self.question} [{self.default}]: "
+		return f"{self.question}: "
+
+	def __repr__(self) -> str:
+		return f"Question(question='{self.question}', default='{self.default}', config_var='{self.config_var}', hidden={self.hidden})"
+
+	def ask(self) -> str:
+		if self.hidden:
+			while True:
+				pw = getpass.getpass(self)
+				if pw == getpass.getpass(f"Re-Enter {self.question}"):
+					return pw
+				print("Error: passwords do not match, try again")
+		ipt = input(self)
+		return ipt if ipt else self.default
+
+
+# The default question/answer set
+DEFAULTS = {
+	DATABASE_CONF_FILE: [
+		Question("Database type", "Pg", "type"),
+		Question("Database name", "traffic_ops", "dbname"),
+		Question("Database server hostname IP or FQDN", "localhost", "hostname"),
+		Question("Database port number", "5432", "port"),
+		Question("Traffic Ops database user", "traffic_ops", "user"),
+		Question("Password for Traffic Ops database user", "", "password", hidden=True)
+	],
+	DB_CONF_FILE: [
+		Question("Database server root (admin) user", "postgres", "pgUser"),
+		Question("Password for database server admin", "", "pgPassword", hidden=True),
+		Question("Download Maxmind Database?", "yes", "maxmind")
+	],
+	CDN_CONF_FILE: [
+		Question("Generate a new secret?", "yes", "genSecret"),
+		Question("Number of secrets to keep?", "1", "keepSecrets"),
+		Question("Port to serve on?", "443", "port"),
+		Question("Number of workers?", "12", "workers"),
+		Question("Traffic Ops url?", "http://localhost:3000", "base_url"),
+		Question("ldap.conf location?", "/opt/traffic_ops/app/conf/ldap.conf", "ldap_conf_location")
+	],
+	LDAP_CONF_FILE:[
+		Question("Do you want to set up LDAP?", "no", "setupLdap"),
+		Question("LDAP server hostname", "", "host"),
+		Question("LDAP Admin DN", "", "admin_dn"),
+		Question("LDAP Admin Password", "", "admin_pass", hidden=True),
+		Question("LDAP Search Base", "", "search_base"),
+		Question("LDAP Search Query", "", "search_query"),
+		Question("LDAP Skip TLS verify", "", "insecure"),
+		Question("LDAP Timeout Seconds", "", "ldap_timeout_secs")
+	],
+	USERS_CONF_FILE: [
+		Question("Administration username for Traffic Ops", "admin", "tmAdminUser"),
+		Question("Password for the admin user", "", "tmAdminPw", hidden=True)
+	],
+	PROFILES_CONF_FILE: [
+		Question("Add custom profiles?", "no", "custom_profiles")
+	],
+	OPENSSL_CONF_FILE: [
+		Question("Do you want to generate a certificate?", "yes", "genCert"),
+		Question("Country Name (2 letter code)", "", "country"),
+		Question("State or Province Name (full name)", "", "state"),
+		Question("Locality Name (eg, city)", "", "locality"),
+		Question("Organization Name (eg, company)", "", "company"),
+		Question("Organizational Unit Name (eg, section)", "", "org_unit"),
+		Question("Common Name (eg, your name or your server's hostname)", "", "common_name"),
+		Question("RSA Passphrase", "CHANGEME!!", "rsaPassword", hidden=True)
+	],
+	PARAM_CONF_FILE: [
+		Question("Traffic Ops url", "https://localhost", "tm.url"),
+		Question("Human-readable CDN Name. (No whitespace, please)", "kabletown_cdn", "cdn_name"),
+		Question("DNS sub-domain for which your CDN is authoritative", "cdn1.kabletown.net", "dns_subdomain")
+	]
+}
 
 def get_field(question: str, config_answer: str, hidden: bool = False) -> str:
 	if hidden:
@@ -79,3 +169,82 @@ def generate_db_conf(user_input: dict, fname: str, todb_fname: str, automatic: b
 	"""
 	"""
 	db_conf = get_config(user_input, fname, automatic)
+
+def sanity_check_config(cfg: dict):
+	diffs = 0
+
+	for fname, file in DEFAULTS:
+		if fname not in cfg:
+			logging.warning("File '%s' found in defaults but not config file", fname)
+			cfg[fname] = []
+
+		for defaultValue in file:
+			for configValue in cfg[fname]:
+				if defaultValue["config_var"] == configValue.get("config_var"):
+					break
+			else:
+				continue
+
+
+
+def main(automatic: bool, debug: bool, defaults: str = None, cfile: str = None) -> int:
+	if debug:
+		logging.getLogger().setLevel(logging.DEBUG)
+	else:
+		logging.getLogger().setLevel(logging.INFO)
+
+	# At this point, the Perl script... unzipped its own logfile?
+
+	logging.info("Starting postinstall")
+	# The Perl printed this whether or not the logger was actually at the debug level
+	# so we do too
+	logging.info("Debug is on")
+
+	if automatic:
+		logging.info("Running in automatic mode")
+
+	if defaults is not None:
+		try:
+			if defaults:
+				try:
+					with open(defaults, "w") as fd:
+						json.dump(DEFAULTS, fd, indent="\t")
+				except OSError as e:
+					logging.critical("Writing output: %s", e)
+					return 1
+			else:
+				json.dump(DEFAULTS, sys.stdout, indent="\t")
+		except ValueError as e:
+			logging.critical("Converting defaults to JSON: %s", e)
+			return 1
+		return 0
+
+	userInput = None
+	if not cfile:
+		logging.info("No input file given - using defaults")
+		userInput = DEFAULTS
+	else:
+		logging.info("Using input file %s", cfile)
+		try:
+			with open(cfile) as fd:
+				userInput = json.load(fd)
+			sanity_check_config(userInput)
+		except (OSError, ValueError) as e:
+			logging.critical("Reading in input file '%s': %s", cfile, e)
+			return 1
+	return 0
+
+if __name__ == '__main__':
+	parser = argparse.ArgumentParser()
+	parser.add_argument("-a", "--automatic", help="If there are questions in the config file which do not have answers, the script will look to the defaults for the answer. If the answer is not in the defaults the script will exit", action="store_true")
+	parser.add_argument("--cfile", help="An input config file used to ask and answer questions", type=str, default=None)
+	parser.add_argument("--debug", help="Enables verbose output", action="store_true")
+	parser.add_argument("--defaults", help="Writes out a configuration file with defaults which can be used as input", type=str, nargs="?", default=None, const="")
+	parser.add_argument("-n", "--no-root", help="Enable running as a non-root user (may cause failure)", action="store_true")
+
+	args = parser.parse_args()
+
+	if not args.no_root and os.getuid() != 0:
+		logging.error("You must run this script as the root user")
+		sys.exit(1)
+	sys.exit(main(args.automatic, args.debug, args.defaults, args.cfile))

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -83,7 +83,7 @@ POST_INSTALL_CFG = "/opt/traffic_ops/install/data/json/post_install.json"
 # Python, instead, outputs to stdout. This is breaking, but more flexible. Change it?
 # OUTPUT_CONFIG_FILE = "/opt/traffic_ops/install/bin/configuration_file.json"
 
-class Question():
+class Question:
 	"""
 	Question represents a single question to be asked of the user, to determine a configuration
 	value.
@@ -155,7 +155,7 @@ class User(typing.NamedTuple):
 	#: The user's password - IN PLAINTEXT.
 	password: str
 
-class SSLConfig():
+class SSLConfig:
 	"""SSLConfig bundles the options for generating new (self-signed) SSL certificates"""
 
 	def __init__(self, gen_cert: bool, cfg_map: typing.Dict[str, str]):
@@ -723,7 +723,7 @@ def setup_certificates(conf: SSLConfig, root: str, ops_user: str, ops_group: str
 	logging.info(log_msg, certpath)
 
 	cdn_conf_path = os.path.join(root, "opt/traffic_ops/app/conf/cdn.conf")
-	cdn_conf = None
+
 	try:
 		with open(cdn_conf_path) as conf_file:
 			cdn_conf = json.load(conf_file)
@@ -1055,7 +1055,6 @@ no_database: bool
 			return 1
 		return 0
 
-	user_input = None
 	if not cfile:
 		logging.info("No input file given - using defaults")
 		user_input = DEFAULTS

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -745,7 +745,7 @@ def setup_certificates(conf: SSLConfig, root: str, ops_user: str, ops_group: str
 		not hypnotoad["listen"] or
 		not isinstance(hypnotoad["listen"][0], str)
 	):
-		log_msg = """	The "listen" portion of {} is missing from {}
+		log_msg = """	The "listen" portion of %s is missing from %s
 	Please ensure it contains the same structure as the one originally installed"""
 		logging.error(log_msg, cdn_conf_path, cdn_conf_path)
 		return 1
@@ -753,11 +753,11 @@ def setup_certificates(conf: SSLConfig, root: str, ops_user: str, ops_group: str
 	listen = hypnotoad["listen"][0]
 
 	if f"cert={certpath}" not in listen or f"key={keypath}" not in listen:
-		log_msg = """	The "listen" portion of {} is:
-	{}
+		log_msg = """	The "listen" portion of %s is:
+	%s
 	and does not reference the same "cert=" and "key=" values as are created here.
-	Please modify {} to add the following as parameters:
-	?cert={}&key={}"""
+	Please modify %s to add the following as parameters:
+	?cert=%s&key=%s"""
 		logging.error(log_msg, cdn_conf_path, listen, cdn_conf_path, certpath, keypath)
 		return 1
 

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -450,7 +450,7 @@ def unmarshal_config(dct: dict) -> typing.Dict[str, typing.List[Question]]:
 	"""
 	ret = {}
 	for file, questions in dct.items():
-		if isinstance(questions, list):
+		if not isinstance(questions, list):
 			raise ValueError(f"file '{file}' has malformed questions")
 
 		qs = []

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env -S sh -c 'PATH="${PATH}:/usr/libexec" exec "$(type -p python platform-python | head -n1)" "$0" "$@"'
 # There's a bug in asteroid with Python 3.9's NamedTuple being
 # recognized for the dynamically generated class that it is. Should be fixed
 # with the next release, but 'till then...

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -244,7 +244,7 @@ cat <<- EOF > "$ROOT_DIR/defaults.json"
 }
 EOF
 
-"$MY_DIR/postinstall.py" --no-root --root-directory="$ROOT_DIR" --no-restart-to --no-database --ops-user="$(whoami)" --ops-group="$(whoami)" --automatic --cfile="$ROOT_DIR/defaults.json" --debug 2>"$ROOT_DIR/stderr" | tee "$ROOT_DIR/stdout"
+"$MY_DIR/postinstall.py" --no-root --root-directory="$ROOT_DIR" --no-restart-to --no-database --ops-user="$(whoami)" --ops-group="$(id -gn)" --automatic --cfile="$ROOT_DIR/defaults.json" --debug 2>"$ROOT_DIR/stderr" | tee "$ROOT_DIR/stdout"
 
 if grep -q 'ERROR' $ROOT_DIR/stderr; then
 	echo "Errors found in script logs" >&2;

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -47,6 +47,8 @@ mkdir "$ROOT_DIR/opt/traffic_ops/install/bin";
 
 readonly MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )";
 
+# defaults.json is used as input into the `--cfile` option of postinstall.py
+# for testing purposes
 cat <<- EOF > "$ROOT_DIR/defaults.json"
 {
 	"/opt/traffic_ops/app/conf/production/database.conf": [

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -246,7 +246,7 @@ EOF
 
 "$MY_DIR/postinstall.py" --no-root --root-directory="$ROOT_DIR" --no-restart-to --no-database --ops-user="$(whoami)" --ops-group="$(whoami)" --automatic --cfile="$ROOT_DIR/defaults.json" --debug 2>"$ROOT_DIR/stderr" | tee "$ROOT_DIR/stdout"
 
-if [[ ! -z "$(grep 'ERROR' $ROOT_DIR/stderr)" ]]; then
+if grep -q 'ERROR' $ROOT_DIR/stderr; then
 	echo "Errors found in script logs" >&2;
 	cat "$ROOT_DIR/stderr";
 	cat "$ROOT_DIR/stdout";

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -254,7 +254,8 @@ if grep -q 'ERROR' $ROOT_DIR/stderr; then
 fi
 
 USERS_JSON_FILE="$ROOT_DIR/opt/traffic_ops/install/data/json/users.json";
-USERS_TEST="
+
+/usr/bin/python3 <<EOF
 import json
 import sys
 
@@ -288,9 +289,7 @@ if not password.startswith('SCRYPT:16384:8:1:') or len(password.split(':')) != 6
 	exit(1)
 
 exit(0)
-"
-
-/usr/bin/python3 -c "$USERS_TEST";
+EOF
 
 POST_INSTALL_JSON="$ROOT_DIR/opt/traffic_ops/install/data/json/post_install.json";
 if [[ "$(cat $POST_INSTALL_JSON)" != "{}" ]]; then

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -32,7 +32,16 @@ mkdir "$ROOT_DIR/etc/pki/tls/private";
 mkdir -p "$ROOT_DIR/opt/traffic_ops/app/public/routing";
 mkdir "$ROOT_DIR/opt/traffic_ops/app/db";
 mkdir -p "$ROOT_DIR/opt/traffic_ops/app/conf/production";
-echo "{\"hypnotoad\":{\"listen\":[\"https://[::]:60443?cert=$ROOT_DIR/etc/pki/tls/certs/localhost.crt&key=$ROOT_DIR/etc/pki/tls/private/localhost.key\"]}}" > "$ROOT_DIR/opt/traffic_ops/app/conf/cdn.conf";
+cat > "$ROOT_DIR/opt/traffic_ops/app/conf/cdn.conf" <<EOF
+{
+	"hypnotoad": {
+		"listen": [
+			"https://[::]:60443?cert=$ROOT_DIR/etc/pki/tls/certs/localhost.crt&key=$ROOT_DIR/etc/pki/tls/private/localhost.key"
+		]
+	}
+}
+EOF
+
 mkdir -p "$ROOT_DIR/opt/traffic_ops/install/data/json";
 mkdir "$ROOT_DIR/opt/traffic_ops/install/bin";
 

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e;
+
+if [[ ! -x /usr/bin/python3 ]]; then
+	echo "Python 3.6+ is required to run - or test - postinstall.py" >&2;
+	exit 1;
+fi
+
+ROOT_DIR="$(mktemp -d)";
+
+trap 'rm -rf $ROOT_DIR' EXIT;
+
+mkdir -p "$ROOT_DIR/etc/pki/tls/certs";
+mkdir "$ROOT_DIR/etc/pki/tls/private";
+mkdir -p "$ROOT_DIR/opt/traffic_ops/app/public/routing";
+mkdir "$ROOT_DIR/opt/traffic_ops/app/db";
+mkdir -p "$ROOT_DIR/opt/traffic_ops/app/conf/production";
+echo "{\"hypnotoad\":{\"listen\":[\"https://[::]:60443?cert=$ROOT_DIR/etc/pki/tls/certs/localhost.crt&key=$ROOT_DIR/etc/pki/tls/private/localhost.key\"]}}" > "$ROOT_DIR/opt/traffic_ops/app/conf/cdn.conf";
+mkdir -p "$ROOT_DIR/opt/traffic_ops/install/data/json";
+mkdir "$ROOT_DIR/opt/traffic_ops/install/bin";
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cat <<- EOF > "$ROOT_DIR/defaults.json"
+{
+	"/opt/traffic_ops/app/conf/production/database.conf": [
+		{
+			"Database type": "Pg",
+			"config_var": "type",
+			"hidden": false
+		},
+		{
+			"Database name": "traffic_ops",
+			"config_var": "dbname",
+			"hidden": false
+		},
+		{
+			"Database server hostname IP or FQDN": "localhost",
+			"config_var": "hostname",
+			"hidden": false
+		},
+		{
+			"Database port number": "5432",
+			"config_var": "port",
+			"hidden": false
+		},
+		{
+			"Traffic Ops database user": "traffic_ops",
+			"config_var": "user",
+			"hidden": false
+		},
+		{
+			"Password for Traffic Ops database user": "twelve",
+			"config_var": "password",
+			"hidden": true
+		}
+	],
+	"/opt/traffic_ops/app/db/dbconf.yml": [
+		{
+			"Database server root (admin) user": "postgres",
+			"config_var": "pgUser",
+			"hidden": false
+		},
+		{
+			"Password for database server admin": "twelve",
+			"config_var": "pgPassword",
+			"hidden": true
+		},
+		{
+			"Download Maxmind Database?": "no",
+			"config_var": "maxmind",
+			"hidden": false
+		}
+	],
+	"/opt/traffic_ops/app/conf/cdn.conf": [
+		{
+			"Generate a new secret?": "yes",
+			"config_var": "genSecret",
+			"hidden": false
+		},
+		{
+			"Number of secrets to keep?": "1",
+			"config_var": "keepSecrets",
+			"hidden": false
+		},
+		{
+			"Port to serve on?": "443",
+			"config_var": "port",
+			"hidden": false
+		},
+		{
+			"Number of workers?": "12",
+			"config_var": "workers",
+			"hidden": false
+		},
+		{
+			"Traffic Ops url?": "http://localhost:3000",
+			"config_var": "base_url",
+			"hidden": false
+		},
+		{
+			"ldap.conf location?": "/opt/traffic_ops/app/conf/ldap.conf",
+			"config_var": "ldap_conf_location",
+			"hidden": false
+		}
+	],
+	"/opt/traffic_ops/app/conf/ldap.conf": [
+		{
+			"Do you want to set up LDAP?": "no",
+			"config_var": "setupLdap",
+			"hidden": false
+		},
+		{
+			"LDAP server hostname": "",
+			"config_var": "host",
+			"hidden": false
+		},
+		{
+			"LDAP Admin DN": "",
+			"config_var": "admin_dn",
+			"hidden": false
+		},
+		{
+			"LDAP Admin Password": "",
+			"config_var": "admin_pass",
+			"hidden": true
+		},
+		{
+			"LDAP Search Base": "",
+			"config_var": "search_base",
+			"hidden": false
+		},
+		{
+			"LDAP Search Query": "",
+			"config_var": "search_query",
+			"hidden": false
+		},
+		{
+			"LDAP Skip TLS verify": "",
+			"config_var": "insecure",
+			"hidden": false
+		},
+		{
+			"LDAP Timeout Seconds": "",
+			"config_var": "ldap_timeout_secs",
+			"hidden": false
+		}
+	],
+	"/opt/traffic_ops/install/data/json/users.json": [
+		{
+			"Administration username for Traffic Ops": "admin",
+			"config_var": "tmAdminUser",
+			"hidden": false
+		},
+		{
+			"Password for the admin user": "twelve",
+			"config_var": "tmAdminPw",
+			"hidden": true
+		}
+	],
+	"/opt/traffic_ops/install/data/profiles/": [
+		{
+			"Add custom profiles?": "no",
+			"config_var": "custom_profiles",
+			"hidden": false
+		}
+	],
+	"/opt/traffic_ops/install/data/json/openssl_configuration.json": [
+		{
+			"Do you want to generate a certificate?": "yes",
+			"config_var": "genCert",
+			"hidden": false
+		},
+		{
+			"Country Name (2 letter code)": "US",
+			"config_var": "country",
+			"hidden": false
+		},
+		{
+			"State or Province Name (full name)": "Colorado",
+			"config_var": "state",
+			"hidden": false
+		},
+		{
+			"Locality Name (eg, city)": "Denver",
+			"config_var": "locality",
+			"hidden": false
+		},
+		{
+			"Organization Name (eg, company)": "Comcast",
+			"config_var": "company",
+			"hidden": false
+		},
+		{
+			"Organizational Unit Name (eg, section)": "Viper",
+			"config_var": "org_unit",
+			"hidden": false
+		},
+		{
+			"Common Name (eg, your name or your server's hostname)": "cdn",
+			"config_var": "common_name",
+			"hidden": false
+		},
+		{
+			"RSA Passphrase": "testquest",
+			"config_var": "rsaPassword",
+			"hidden": true
+		}
+	],
+	"/opt/traffic_ops/install/data/json/profiles.json": [
+		{
+			"Traffic Ops url": "https://localhost",
+			"config_var": "tm.url",
+			"hidden": false
+		},
+		{
+			"Human-readable CDN Name. (No whitespace, please)": "kabletown_cdn",
+			"config_var": "cdn_name",
+			"hidden": false
+		},
+		{
+			"DNS sub-domain for which your CDN is authoritative": "cdn1.kabletown.net",
+			"config_var": "dns_subdomain",
+			"hidden": false
+		}
+	]
+}
+EOF
+
+"$MY_DIR/postinstall.py" --no-root --root-directory="$ROOT_DIR" --no-restart-to --no-database --ops-user="$(whoami)" --ops-group="$(whoami)" --automatic --cfile="$ROOT_DIR/defaults.json" --debug 2>"$ROOT_DIR/stderr" | tee "$ROOT_DIR/stdout"
+
+if [[ ! -z "$(grep 'ERROR' $ROOT_DIR/stderr)" ]]; then
+	echo "Errors found in script logs" >&2;
+	cat "$ROOT_DIR/stderr";
+	cat "$ROOT_DIR/stdout";
+	exit 1;
+fi
+
+USERS_JSON_FILE="$ROOT_DIR/opt/traffic_ops/install/data/json/users.json";
+USERS_TEST="
+import json
+import sys
+
+try:
+	with open('$USERS_JSON_FILE') as fd:
+		users_json = json.load(fd)
+except Exception as e:
+	print('Error loading users.json file:', e, file=sys.stderr)
+	exit(1)
+
+if not isinstance(users_json, dict) or len(users_json) != 2 or 'username' not in users_json or 'password' not in users_json:
+	print('Malformed users.json file - not an object or incorrect keys', file=sys.stderr)
+	exit(1)
+
+username = users_json['username']
+if not isinstance(username, str):
+	print('Username is not a string in users.json:', username, file=sys.stderr)
+	exit(1)
+
+if username != 'admin':
+	print('Incorrect username in users.json, expected: admin, got:', username, file=sys.stderr)
+	exit(1)
+
+password = users_json['password']
+if not isinstance(password, str):
+	print('Password is not a string in users.json:', password, file=sys.stderr)
+	exit(1)
+
+if not password.startswith('SCRYPT:16384:8:1:') or len(password.split(':')) != 6:
+	print('Malformed password field in users.json:', password, file=sys.stderr)
+	exit(1)
+
+exit(0)
+"
+
+/usr/bin/python3 -c "$USERS_TEST";
+
+POST_INSTALL_JSON="$ROOT_DIR/opt/traffic_ops/install/data/json/post_install.json";
+if [[ "$(cat $POST_INSTALL_JSON)" != "{}" ]]; then
+	echo "Incorrect post_install.json, expected: {}, got: $(cat $POST_INSTALL_JSON)" >&2;
+	exit 1;
+fi
+
+PROFILES_JSON_EXPECTED="{
+	\"tm.url\": \"https://localhost\",
+	\"cdn_name\": \"kabletown_cdn\",
+	\"dns_subdomain\": \"cdn1.kabletown.net\"
+}";
+
+PROFILES_JSON_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/install/data/json/profiles.json)";
+if [[ "$PROFILES_JSON_ACTUAL" != "$PROFILES_JSON_EXPECTED" ]]; then
+	echo "Incorrect profiles.json, expected: $PROFILES_JSON_EXPECTED, got: $PROFILES_JSON_ACTUAL" >&2;
+	exit 1;
+fi
+
+DB_CONF_EXPECTED="production:
+    driver: postgres
+    open: host=localhost port=5432 user=traffic_ops password=twelve dbname=traffic_ops sslmode=disable";
+
+DB_CONF_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/app/db/dbconf.yml)";
+if [[ "$DB_CONF_ACTUAL" != "$DB_CONF_EXPECTED" ]]; then
+	echo "Incorrect dbconf.yml, expected:" >&2;
+	echo "$DB_CONF_EXPECTED" >&2;
+	echo "got:" >&2;
+	echo "$DB_CONF_ACTUAL" >&2;
+	exit 1;
+fi
+
+CDN_CONF_TEST="
+import json
+import string
+import sys
+
+try:
+	with(open('$ROOT_DIR/opt/traffic_ops/app/conf/cdn.conf')) as fd:
+		conf = json.load(fd)
+except Exception as e:
+	print('Error loading cdn.conf file:', e, file=sys.stderr)
+	exit(1)
+
+if not isinstance(conf, dict) or len(conf) != 4 or 'hypnotoad' not in conf or 'secrets' not in conf or 'to' not in conf or 'traffic_ops_golang' not in conf:
+	print('Malformed cdn.conf file - not an object or missing keys', file=sys.stderr)
+	exit(1)
+
+if not isinstance(conf['hypnotoad'], dict) or len(conf['hypnotoad']) != 1 or 'listen' not in conf['hypnotoad'] or not isinstance(conf['hypnotoad']['listen'], list) or len(conf['hypnotoad']['listen']) != 1 or not insinstance(conf['hypnotoad']['listen'][0], str):
+	print('Malformed hypnotoad object in cdn.conf:', conf['hypnotoad'], file=sys.stderr)
+	exit(1)
+
+listen = 'https://[::]:6443?cert=$ROOT_DIR/etc/pki/tls/certs/localhost.crt&key=$ROOT_DIR/etc/pki/tls/private/localhost.key'
+if conf['hypnotoad']['listen'][0] != listen:
+	print('Incorrect hypnotoad.listen[0] in cdn.conf, expected:', listen, 'got:', conf['hypnotoad']['listen'][0], file=sys.stderr)
+	exit(1)
+
+if not isinstance(conf['secrets'], list) or len(conf['secrets']) != 1 or not isinstance(conf['secrets'][0], str):
+	print('Malformed secrets object in cdn.conf:', conf['secrets'], file=sys.stderr)
+	exit(1)
+
+if len(conf['secrets'][0]) != 12 or any(True for x in conf['secrets'][0] if x not in string.ascii_letters + string.digits + '_'):
+	print('Incorrect secret in cdn.conf, expected 12 word characters, got:', conf['secrets'][0], file=sys.stderr)
+	exit(1)
+
+if not isinstance(conf['to'], dict) or 'base_url' not in conf['to'] or len(conf['to']) != 1 or not isinstance(conf['to']['base_url'], str):
+	print('Malformed to object in cdn.conf:', conf['to'])
+	exit(1)
+
+if conf['to']['base_url'] != 'http://localhost:3000':
+	print('Incorrect to.base_url in cdn.conf, expected: http://localhost:3000, got:', conf['to']['base_url'], file=sys.stderr)
+	exit(1)
+
+if not isinstance(conf['traffic_ops_golang'], dict) or len(conf['traffic_ops_golang']) != 3 or 'port' not in conf['traffic_ops_golang'] or 'log_location_error' not in conf['traffic_ops_golang'] or 'log_location_event' not in conf['traffic_ops_golang']:
+	print('Malformed traffic_ops_golang object in cdn.conf:' conf['traffic_ops_golang'], sys.stderr)
+	exit(1)
+
+if conf['traffic_ops_golang']['port'] != '443':
+	print('Incorrect traffic_ops_golang.port, expected: 443, got:', conf['traffic_ops_golang']['port'], file=sys.stderr)
+	exit(1)
+
+if conf['traffic_ops_golang']['log_location_error'] != '$ROOT_DIR/var/log/traffic_ops/error.log':
+	print('Incorrect traffic_ops_golang.log_location_error in cdn.conf, expected: $ROOT_DIR/var/log/traffic_ops/error.log, got:', conf['traffic_ops_golang']['log_location_error'], file=sys.stderr)
+	exit(1)
+
+if conf['traffic_ops_golang']['log_location_event'] != '$ROOT_DIR/var/log/traffic_ops/access.log':
+	print('Incorrect traffic_ops_golang.log_location_event in cdn.conf, expected: $ROOT_DIR/var/log/traffic_ops/access.log, got:', conf['traffic_ops_golang']['log_location_event'], file=sys.stderr)
+	exit(1)
+
+exit(0)
+";
+
+/usr/bin/python3 -c "#CDN_CONF_TEST";
+
+
+DATABASE_CONF_EXPECTED='{
+	"type": "Pg",
+	"dbname": "traffic_ops",
+	"hostname": "localhost",
+	"port": "5432",
+	"user": "traffic_ops",
+	"password": "twelve",
+	"description": "Pg database on localhost:5432"
+}';
+
+DATABASE_CONF_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/app/conf/production/database.conf)";
+if [[ "$DATABASE_CONF_ACTUAL" != "$DATABASE_CONF_EXPECTED" ]]; then
+	echo "Incorrect database.conf, expected: $DATABASE_CONF_EXPECTED, got $DATABASE_CONF_ACTUAL" >&2;
+	exit 1;
+fi
+
+CSR_FILE="$ROOT_DIR/etc/pki/tls/certs/localhost.csr";
+CSR_FILE_TYPE="$(file $CSR_FILE)";
+if [[ "$CSR_FILE_TYPE" != "$CSR_FILE: PEM certificate request" ]]; then
+	echo "Incorrect csr file, expected a PEM certificate request, got: $CSR_FILE_TYPE" >&2;
+	exit 1;
+fi
+
+CERT_FILE="$ROOT_DIR/etc/pki/tls/certs/localhost.crt";
+CERT_FILE_TYPE="$(file $CERT_FILE)";
+if [[ "$CERT_FILE_TYPE" != "$CERT_FILE: PEM certificate" ]]; then
+	echo "Incorrect cert file, expected a PEM certificate, got: $CERT_FILE_TYPE" >&2;
+	exit 1;
+fi
+
+KEY_FILE="$ROOT_DIR/etc/pki/tls/private/localhost.key";
+KEY_FILE_TYPE="$(file $KEY_FILE)";
+if [[ "$KEY_FILE_TYPE" != "$KEY_FILE: PEM RSA private key" ]]; then
+	echo "Incorrect key file, expected PEM RSA private key, got: $KEY_FILE_TYPE" >&2;
+	exit 1;
+fi

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -378,7 +378,7 @@ if not isinstance(conf['traffic_ops_golang'], dict) or len(conf['traffic_ops_gol
 	print('Malformed traffic_ops_golang object in cdn.conf:', conf['traffic_ops_golang'], sys.stderr)
 	exit(1)
 
-if conf['traffic_ops_golang']['port'] != '443':
+if conf['traffic_ops_golang']['port'] != 443:
 	print('Incorrect traffic_ops_golang.port, expected: 443, got:', conf['traffic_ops_golang']['port'], file=sys.stderr)
 	exit(1)
 

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -339,11 +339,11 @@ if not isinstance(conf, dict) or len(conf) != 4 or 'hypnotoad' not in conf or 's
 	print('Malformed cdn.conf file - not an object or missing keys', file=sys.stderr)
 	exit(1)
 
-if not isinstance(conf['hypnotoad'], dict) or len(conf['hypnotoad']) != 1 or 'listen' not in conf['hypnotoad'] or not isinstance(conf['hypnotoad']['listen'], list) or len(conf['hypnotoad']['listen']) != 1 or not insinstance(conf['hypnotoad']['listen'][0], str):
+if not isinstance(conf['hypnotoad'], dict) or len(conf['hypnotoad']) != 1 or 'listen' not in conf['hypnotoad'] or not isinstance(conf['hypnotoad']['listen'], list) or len(conf['hypnotoad']['listen']) != 1 or not isinstance(conf['hypnotoad']['listen'][0], str):
 	print('Malformed hypnotoad object in cdn.conf:', conf['hypnotoad'], file=sys.stderr)
 	exit(1)
 
-listen = 'https://[::]:6443?cert=$ROOT_DIR/etc/pki/tls/certs/localhost.crt&key=$ROOT_DIR/etc/pki/tls/private/localhost.key'
+listen = 'https://[::]:60443?cert=$ROOT_DIR/etc/pki/tls/certs/localhost.crt&key=$ROOT_DIR/etc/pki/tls/private/localhost.key'
 if conf['hypnotoad']['listen'][0] != listen:
 	print('Incorrect hypnotoad.listen[0] in cdn.conf, expected:', listen, 'got:', conf['hypnotoad']['listen'][0], file=sys.stderr)
 	exit(1)
@@ -365,7 +365,7 @@ if conf['to']['base_url'] != 'http://localhost:3000':
 	exit(1)
 
 if not isinstance(conf['traffic_ops_golang'], dict) or len(conf['traffic_ops_golang']) != 3 or 'port' not in conf['traffic_ops_golang'] or 'log_location_error' not in conf['traffic_ops_golang'] or 'log_location_event' not in conf['traffic_ops_golang']:
-	print('Malformed traffic_ops_golang object in cdn.conf:' conf['traffic_ops_golang'], sys.stderr)
+	print('Malformed traffic_ops_golang object in cdn.conf:', conf['traffic_ops_golang'], sys.stderr)
 	exit(1)
 
 if conf['traffic_ops_golang']['port'] != '443':
@@ -383,7 +383,7 @@ if conf['traffic_ops_golang']['log_location_event'] != '$ROOT_DIR/var/log/traffi
 exit(0)
 ";
 
-/usr/bin/python3 -c "#CDN_CONF_TEST";
+/usr/bin/python3 -c "$CDN_CONF_TEST";
 
 
 DATABASE_CONF_EXPECTED='{

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -23,7 +23,7 @@ if [[ ! -x /usr/bin/python3 ]]; then
 	exit 1;
 fi
 
-ROOT_DIR="$(mktemp -d)";
+readonly ROOT_DIR="$(mktemp -d)";
 
 trap 'rm -rf $ROOT_DIR' EXIT;
 
@@ -45,7 +45,7 @@ EOF
 mkdir -p "$ROOT_DIR/opt/traffic_ops/install/data/json";
 mkdir "$ROOT_DIR/opt/traffic_ops/install/bin";
 
-MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+readonly MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )";
 
 cat <<- EOF > "$ROOT_DIR/defaults.json"
 {
@@ -262,7 +262,7 @@ if grep -q 'ERROR' $ROOT_DIR/stderr; then
 	exit 1;
 fi
 
-USERS_JSON_FILE="$ROOT_DIR/opt/traffic_ops/install/data/json/users.json";
+readonly USERS_JSON_FILE="$ROOT_DIR/opt/traffic_ops/install/data/json/users.json";
 
 /usr/bin/python3 <<EOF
 import json
@@ -300,29 +300,29 @@ if not password.startswith('SCRYPT:16384:8:1:') or len(password.split(':')) != 6
 exit(0)
 EOF
 
-POST_INSTALL_JSON="$ROOT_DIR/opt/traffic_ops/install/data/json/post_install.json";
+readonly POST_INSTALL_JSON="$ROOT_DIR/opt/traffic_ops/install/data/json/post_install.json";
 if [[ "$(cat $POST_INSTALL_JSON)" != "{}" ]]; then
 	echo "Incorrect post_install.json, expected: {}, got: $(cat $POST_INSTALL_JSON)" >&2;
 	exit 1;
 fi
 
-PROFILES_JSON_EXPECTED="{
+readonly PROFILES_JSON_EXPECTED="{
 	\"tm.url\": \"https://localhost\",
 	\"cdn_name\": \"kabletown_cdn\",
 	\"dns_subdomain\": \"cdn1.kabletown.net\"
 }";
 
-PROFILES_JSON_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/install/data/json/profiles.json)";
+readonly PROFILES_JSON_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/install/data/json/profiles.json)";
 if [[ "$PROFILES_JSON_ACTUAL" != "$PROFILES_JSON_EXPECTED" ]]; then
 	echo "Incorrect profiles.json, expected: $PROFILES_JSON_EXPECTED, got: $PROFILES_JSON_ACTUAL" >&2;
 	exit 1;
 fi
 
-DB_CONF_EXPECTED="production:
+readonly DB_CONF_EXPECTED="production:
     driver: postgres
     open: host=localhost port=5432 user=traffic_ops password=twelve dbname=traffic_ops sslmode=disable";
 
-DB_CONF_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/app/db/dbconf.yml)";
+readonly DB_CONF_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/app/db/dbconf.yml)";
 if [[ "$DB_CONF_ACTUAL" != "$DB_CONF_EXPECTED" ]]; then
 	echo "Incorrect dbconf.yml, expected:" >&2;
 	echo "$DB_CONF_EXPECTED" >&2;
@@ -331,7 +331,7 @@ if [[ "$DB_CONF_ACTUAL" != "$DB_CONF_EXPECTED" ]]; then
 	exit 1;
 fi
 
-CDN_CONF_TEST="
+/usr/bin/python3 <<EOF
 import json
 import string
 import sys
@@ -389,12 +389,9 @@ if conf['traffic_ops_golang']['log_location_event'] != '$ROOT_DIR/var/log/traffi
 	exit(1)
 
 exit(0)
-";
+EOF
 
-/usr/bin/python3 -c "$CDN_CONF_TEST";
-
-
-DATABASE_CONF_EXPECTED='{
+readonly DATABASE_CONF_EXPECTED='{
 	"type": "Pg",
 	"dbname": "traffic_ops",
 	"hostname": "localhost",
@@ -404,28 +401,28 @@ DATABASE_CONF_EXPECTED='{
 	"description": "Pg database on localhost:5432"
 }';
 
-DATABASE_CONF_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/app/conf/production/database.conf)";
+readonly DATABASE_CONF_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/app/conf/production/database.conf)";
 if [[ "$DATABASE_CONF_ACTUAL" != "$DATABASE_CONF_EXPECTED" ]]; then
 	echo "Incorrect database.conf, expected: $DATABASE_CONF_EXPECTED, got $DATABASE_CONF_ACTUAL" >&2;
 	exit 1;
 fi
 
-CSR_FILE="$ROOT_DIR/etc/pki/tls/certs/localhost.csr";
-CSR_FILE_TYPE="$(file $CSR_FILE)";
+readonly CSR_FILE="$ROOT_DIR/etc/pki/tls/certs/localhost.csr";
+readonly CSR_FILE_TYPE="$(file $CSR_FILE)";
 if [[ "$CSR_FILE_TYPE" != "$CSR_FILE: PEM certificate request" ]]; then
 	echo "Incorrect csr file, expected a PEM certificate request, got: $CSR_FILE_TYPE" >&2;
 	exit 1;
 fi
 
-CERT_FILE="$ROOT_DIR/etc/pki/tls/certs/localhost.crt";
-CERT_FILE_TYPE="$(file $CERT_FILE)";
+readonly CERT_FILE="$ROOT_DIR/etc/pki/tls/certs/localhost.crt";
+readonly CERT_FILE_TYPE="$(file $CERT_FILE)";
 if [[ "$CERT_FILE_TYPE" != "$CERT_FILE: PEM certificate" ]]; then
 	echo "Incorrect cert file, expected a PEM certificate, got: $CERT_FILE_TYPE" >&2;
 	exit 1;
 fi
 
-KEY_FILE="$ROOT_DIR/etc/pki/tls/private/localhost.key";
-KEY_FILE_TYPE="$(file $KEY_FILE)";
+readonly KEY_FILE="$ROOT_DIR/etc/pki/tls/private/localhost.key";
+readonly KEY_FILE_TYPE="$(file $KEY_FILE)";
 if [[ "$KEY_FILE_TYPE" != "$KEY_FILE: PEM RSA private key" ]]; then
 	echo "Incorrect key file, expected PEM RSA private key, got: $KEY_FILE_TYPE" >&2;
 	exit 1;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
This PR features a rewrite of postinstall to Python3 (specifically the `_postinstall` Perl script). This is important because the Perl version of the script depended upon multiple libraries installed as dependencies of the Perl version of Traffic Ops - and if we are ever to get rid of that TO version things that depend on its dependencies will need to be reworked.

The new `postinstall.py` script has no dependencies outside of the Python3 standard library, and features several unit tests and an end-to-end test bash script whereas the Perl version had only a single unit test (executed at run time on every run).

To be clear, though, it - like the Perl script it is intended to replace - has dependencies on external programs including `wget`, `openssl` and `psql`. `wget` is only needed for Maxmind download support, so it could possibly be removed as the hard-coded URLs don't work anyway, but is left in for consistency with the old script. Besides that, its only external dependencies are already dependencies of TO - even the Go version - and the Python3 interpreter itself.

Finally, I should mention that this doesn't actually replace the old script, which is totally untouched, but provides the new Python script as an alternative. Many machines running TO in the wild may not have Python3 installed yet, so it may be too soon yet to require that for TO installations/upgrades.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
To run the doctests, use `python -m doctest path/to/postinstall.py`. That should output nothing and exit successfully (my `python` is a Python3 interpreter, if yours is Python2 then ~~upgrade please, Python2 is dead~~ you'll need to use `python3 -m doctest path/to/postinstall.py` instead).

To run the end-to-end tests, use the `postinstall.test.sh` script, which should also output nothing (except spitting out some ssl keys/certs/requests in the current directory) and exit successfully.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary - this isn't actually used yet. It does have docstrings and a `-h`/`--help` option, though
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**