### PR TITLE
Made admin user compliant with restrictions (API and TP)

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops/adduser.pl
+++ b/infrastructure/cdn-in-a-box/traffic_ops/adduser.pl
@@ -24,23 +24,27 @@ use strict;
 use Crypt::ScryptKDF qw{ scrypt_hash };
 
 if ($#ARGV < 2) {
-    die "Usage: $ARGV[0] <username> <password> <role>\n";
+    die "Usage: $ARGV[0] USERNAME PASSWORD [ROLE] [TENANT] [EMAIL] [FULL_NAME]\n";
 }
 
 my $username = shift // 'admin';
 my $password = shift or die "Password is required\n";
 my $role = shift // 'admin';
 my $tenant = shift // 'root';
+my $email = shift // 'admin@no-reply.trafficops.infra.ciab.test';
+my $full_name = shift // 'James Cole'
 
 # Skip the insert if the admin 'username' is already there.
 my $hashed_passwd = hash_pass( $password );
 print <<"EOSQL";
-INSERT INTO tm_user (username, role, local_passwd, confirm_local_passwd, tenant_id)
+INSERT INTO tm_user (username, role, local_passwd, confirm_local_passwd, tenant_id, email, full_name)
     VALUES  ('$username',
             (SELECT id FROM role WHERE name = '$role'),
             '$hashed_passwd',
             '$hashed_passwd',
-            (SELECT id FROM tenant WHERE name='$tenant'))
+            (SELECT id FROM tenant WHERE name='$tenant'),
+            '$email',
+            '$full_name')
     ON CONFLICT (username) DO UPDATE SET local_passwd='$hashed_passwd', confirm_local_passwd='$hashed_passwd';
 EOSQL
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/adduser.pl
+++ b/infrastructure/cdn-in-a-box/traffic_ops/adduser.pl
@@ -27,12 +27,12 @@ if ($#ARGV < 2) {
     die "Usage: $ARGV[0] USERNAME PASSWORD [ROLE] [TENANT] [EMAIL] [FULL_NAME]\n";
 }
 
-my $username = shift // 'admin';
+my $username = shift // $ENV{TO_ADMIN_USER};
 my $password = shift or die "Password is required\n";
 my $role = shift // 'admin';
 my $tenant = shift // 'root';
-my $email = shift // 'admin@no-reply.trafficops.infra.ciab.test';
-my $full_name = shift // 'James Cole'
+my $email = shift // $ENV{TO_EMAIL};
+my $full_name = shift // $ENV{TO_ADMIN_FULL_NAME};
 
 # Skip the insert if the admin 'username' is already there.
 my $hashed_passwd = hash_pass( $password );

--- a/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
@@ -44,7 +44,7 @@ done
 
 cat conf.js
 
-protractor conf.js --params.adminUser 'admin' --params.adminPassword 'twelve'
+protractor conf.js --params.adminUser "$TO_ADMIN_USER" --params.adminPassword "$TO_ADMIN_PASSWORD"
 rc=$?
 
 cp /portaltestresults/* /junit/

--- a/infrastructure/cdn-in-a-box/variables.env
+++ b/infrastructure/cdn-in-a-box/variables.env
@@ -70,6 +70,7 @@ TM_LOG_INFO=stdout
 TM_LOG_DEBUG=stdout
 TO_ADMIN_PASSWORD=twelve12
 TO_ADMIN_USER=admin
+TO_ADMIN_FULL_NAME=James Cole
 # Set TM_DEBUG_ENABLE to true`to debug Traffic Monitor with Delve
 TM_DEBUG_ENABLE=false
 # Set TO_DEBUG_ENABLE to true`to debug Traffic Ops with Delve

--- a/infrastructure/cdn-in-a-box/variables.env
+++ b/infrastructure/cdn-in-a-box/variables.env
@@ -68,7 +68,7 @@ TM_LOG_ERROR=stdout
 TM_LOG_WARNING=stdout
 TM_LOG_INFO=stdout
 TM_LOG_DEBUG=stdout
-TO_ADMIN_PASSWORD=twelve
+TO_ADMIN_PASSWORD=twelve12
 TO_ADMIN_USER=admin
 # Set TM_DEBUG_ENABLE to true`to debug Traffic Monitor with Delve
 TM_DEBUG_ENABLE=false


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Added an email and full name to the "admin" user created for CDN-in-a-Box, and changes its password to meet the minimum length requirement. Currently in CDN-in-a-Box, if you navigate to the "admin" user's user under "Users", you notice that it's missing the required "Full Name" field and the required "Email" field, and its password isn't long enough. This means that any small change you want to make to the user e.g. for testing purposes must minimally fix those three issues. After this PR, those would no longer be a problem.

Again, though, this _does change the CiaB "admin" user's password_. People using CiaB for testing _may_ be broken, but if done properly by sourcing `variables.env` and using `$TO_ADMIN_PASSWORD` it shouldn't make a difference.

## Which Traffic Control components are affected by this PR?
- CDN in a Box

## What is the best way to verify this PR?
Build and run CDN-in-a-Box; everything should work normally. Try authenticating as `$TO_ADMIN_USER` using `$TO_ADMIN_PASSWORD` and verify that works. Check that user's information to verify that the email and full name are present.

## The following criteria are ALL met by this PR
- [x] CiaB has no tests
- [x] Interface doesn't change so docs are unchanged
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**