### PR TITLE
Fix a couple TR NullPointerExceptions when no caches are available

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/edge/Node.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/edge/Node.java
@@ -194,24 +194,20 @@ public class Node extends DefaultHashable {
 		}
 
 		for (final InetRecord record : ipAddresses) {
-			if (record.getAddress() == ip4 && !ipv4Available) {
+			if (record.getAddress().equals(ip4) && !ipv4Available) {
 				newlyUnavailable.add(record);
-				LOGGER.debug("disabling IPv4 address " + record.getAddress());
 			}
-			if (record.getAddress() == ip6 && !ipv6Available) {
+			if (record.getAddress().equals(ip6) && !ipv6Available) {
 				newlyUnavailable.add(record);
-				LOGGER.debug("disabling IPv6 address " + record.getAddress());
 			}
 		}
 
 		for (final InetRecord record : unavailableIpAddresses) {
-			if (record.getAddress() == ip4 && ipv4Available) {
+			if (record.getAddress().equals(ip4) && ipv4Available) {
 				newlyAvailable.add(record);
-				LOGGER.debug("enabling IPv4 address " + record.getAddress());
 			}
-			if (record.getAddress() == ip6 && ipv6Available) {
+			if (record.getAddress().equals(ip6) && ipv6Available) {
 				newlyAvailable.add(record);
-				LOGGER.debug("enabling IPv6 address " + record.getAddress());
 			}
 		}
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Fixes a Null Pointer Exception (where there are no available caches for a requested DS) and converts some `==` usage to `.equals()` (since I believe we want to compare the actual IP addresses and not the pointer references). Also, change the method for determining whether a given IP address is IPv4 or IPv6 to match what is used elsewhere in similar cases (since `getByName` can have the side-effect of doing DNS lookups).

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Router

## What is the best way to verify this PR?
Run the TR unit tests, verify they still pass:
```
mvn clean test -Djava.library.path=/usr/local/opt/tomcat-native/lib
```
Make a request for a DS that doesn't have any available caches, make sure that `editCacheListForIpVersion` does not throw a `NullPointerException`.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.1.0-RC1

## The following criteria are ALL met by this PR

- [x] Fairly minor fixes, performed manual tests to validate since there aren't pre-existing unit tests in this specific area (as far as I can tell)
- [x] Bugfix, docs unnecessary
- [x] Unreleased bug, changelog entry unnecessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)