### PR TITLE
Servers table switch to ag-grid

### DIFF
--- a/traffic_portal/app/src/app.js
+++ b/traffic_portal/app/src/app.js
@@ -20,11 +20,15 @@
 'use strict';
 require('app-templates');
 
+var AgGrid = require("ag-grid-community");
+
 var App = function($urlRouterProvider) {
     $urlRouterProvider.otherwise('/');
 };
 
 App.$inject = ['$urlRouterProvider'];
+
+AgGrid.initialiseAgGridWithAngular1(angular);
 
 var trafficPortal = angular.module('trafficPortal', [
         'config',
@@ -42,6 +46,7 @@ var trafficPortal = angular.module('trafficPortal', [
         'angular-loading-bar',
         'moment-picker',
         'jsonFormatter',
+        'agGrid',
 
         // public modules
         require('./modules/public').name,
@@ -509,5 +514,3 @@ trafficPortal.factory('authInterceptor', function ($rootScope, $q, $window, $loc
 trafficPortal.config(function ($httpProvider) {
     $httpProvider.interceptors.push('authInterceptor');
 });
-
-

--- a/traffic_portal/app/src/app.js
+++ b/traffic_portal/app/src/app.js
@@ -20,15 +20,14 @@
 'use strict';
 require('app-templates');
 
-var AgGrid = require("ag-grid-community");
-
 var App = function($urlRouterProvider) {
     $urlRouterProvider.otherwise('/');
 };
 
+
 App.$inject = ['$urlRouterProvider'];
 
-AgGrid.initialiseAgGridWithAngular1(angular);
+agGrid.initialiseAgGridWithAngular1(angular);
 
 var trafficPortal = angular.module('trafficPortal', [
         'config',

--- a/traffic_portal/app/src/common/modules/table/_table.scss
+++ b/traffic_portal/app/src/common/modules/table/_table.scss
@@ -148,6 +148,11 @@ menu[type="contextmenu"] {
                 border: none;
                 width: 100%;
                 text-align: left;
+
+                &[disabled] {
+                    color: gray;
+                    background-color: #f5f5f5;
+                }
             }
         }
 

--- a/traffic_portal/app/src/common/modules/table/_table.scss
+++ b/traffic_portal/app/src/common/modules/table/_table.scss
@@ -107,3 +107,52 @@ th.center, td.center {
 .dt-button.btn-link {
     text-decoration: underline;
 }
+
+/* Table context menus */
+menu[type="contextmenu"] {
+    display: block;
+    position: fixed;
+    background-color: white;
+    padding: 0;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    border-radius: 3px;
+
+    ul {
+        display: block;
+        clear: both;
+        font-weight: normal;
+        line-height: 1.428571429;
+        white-space: nowrap;
+        padding: 0;
+        margin: 0;
+
+        li {
+            display: block;
+            clear: both;
+
+            &:hover {
+                color: #262626;
+                background-color: #f5f5f5;
+            }
+
+            a, button {
+                color: #333333;
+                text-decoration: none;
+                padding: 7px 20px;
+                display: block;
+                clear: both;
+            }
+
+            button {
+                background: transparent;
+                border: none;
+                width: 100%;
+                text-align: left;
+            }
+        }
+
+        hr.divider {
+            margin: 0;
+        }
+    }
+}

--- a/traffic_portal/app/src/common/modules/table/_table.scss
+++ b/traffic_portal/app/src/common/modules/table/_table.scss
@@ -161,3 +161,20 @@ menu[type="contextmenu"] {
         }
     }
 }
+
+button.menu-item-button {
+    color: #333333;
+    width: 100%;
+    background: transparent;
+    border: none;
+    text-align: inherit;
+    display: block;
+    clear: both;
+    padding: 3px 20px;
+    margin: 0;
+
+    &:hover {
+        color: #262626;
+        background-color: #f5f5f5;
+    }
+}

--- a/traffic_portal/app/src/common/modules/table/_table.scss
+++ b/traffic_portal/app/src/common/modules/table/_table.scss
@@ -162,7 +162,7 @@ menu[type="contextmenu"] {
     }
 }
 
-button.menu-item-button {
+div.dropdown button.menu-item-button {
     color: #333333;
     width: 100%;
     background: transparent;

--- a/traffic_portal/app/src/common/modules/table/cacheGroupServers/TableCacheGroupServersController.js
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupServers/TableCacheGroupServersController.js
@@ -19,8 +19,8 @@
 
 var TableCacheGroupsServersController = function(cacheGroup, servers, $controller, $scope, $state, $uibModal, cacheGroupService) {
 
-	// extends the TableServersController to inherit common methods
-	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
+	// extends the TableParentServersController to inherit common methods
+	angular.extend(this, $controller('TableParentServersController', { servers: servers, $scope: $scope }));
 
 	let cacheGroupServersTable;
 

--- a/traffic_portal/app/src/common/modules/table/cdnServers/TableCDNServersController.js
+++ b/traffic_portal/app/src/common/modules/table/cdnServers/TableCDNServersController.js
@@ -19,8 +19,8 @@
 
 var TableCDNServersController = function(cdn, servers, $controller, $scope) {
 
-	// extends the TableServersController to inherit common methods
-	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
+	// extends the TableParentServersController to inherit common methods
+	angular.extend(this, $controller('TableParentServersController', { servers: servers, $scope: $scope }));
 
 	let cdnServersTable;
 

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceServers/TableDeliveryServiceServersController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceServers/TableDeliveryServiceServersController.js
@@ -19,8 +19,8 @@
 
 var TableDeliveryServiceServersController = function(deliveryService, servers, $controller, $scope, $uibModal, deliveryServiceService, serverUtils) {
 
-	// extends the TableServersController to inherit common methods
-	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
+	// extends the TableParentServersController to inherit common methods
+	angular.extend(this, $controller('TableParentServersController', { servers: servers, $scope: $scope }));
 
 	let dsServersTable;
 

--- a/traffic_portal/app/src/common/modules/table/physLocationServers/TablePhysLocationServersController.js
+++ b/traffic_portal/app/src/common/modules/table/physLocationServers/TablePhysLocationServersController.js
@@ -19,8 +19,8 @@
 
 var TablePhysLocationServersController = function(physLocation, servers, $controller, $scope) {
 
-	// extends the TableServersController to inherit common methods
-	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
+	// extends the TableParentServersController to inherit common methods
+	angular.extend(this, $controller('TableParentServersController', { servers: servers, $scope: $scope }));
 
 	let physLocServersTable;
 

--- a/traffic_portal/app/src/common/modules/table/profileServers/TableProfileServersController.js
+++ b/traffic_portal/app/src/common/modules/table/profileServers/TableProfileServersController.js
@@ -19,8 +19,8 @@
 
 var TableProfileServersController = function(profile, servers, $controller, $scope) {
 
-	// extends the TableServersController to inherit common methods
-	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
+	// extends the TableParentServersController to inherit common methods
+	angular.extend(this, $controller('TableParentServersController', { servers: servers, $scope: $scope }));
 
 	let profileServersTable;
 

--- a/traffic_portal/app/src/common/modules/table/serverCapabilityServers/TableServerCapabilityServersController.js
+++ b/traffic_portal/app/src/common/modules/table/serverCapabilityServers/TableServerCapabilityServersController.js
@@ -19,8 +19,8 @@
 
 var TableServerCapabilityServersController = function(serverCapability, servers, $scope, $state, $controller, $uibModal, $window, locationUtils, serverService, messageModel) {
 
-	// extends the TableServersController to inherit common methods
-	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
+	// extends the TableParentServersController to inherit common methods
+	angular.extend(this, $controller('TableParentServersController', { servers: servers, $scope: $scope }));
 
 	var removeCapability = function(serverId) {
 		serverService.removeServerCapability(serverId, serverCapability.name)

--- a/traffic_portal/app/src/common/modules/table/servers/TableParentServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableParentServersController.js
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var TableParentServersController = function(servers, $scope, $state, $uibModal, $window, dateUtils, locationUtils, serverUtils, cdnService, serverService, statusService, propertiesModel, messageModel) {
+
+	let serversTable;
+
+	var getStatuses = function() {
+		statusService.getStatuses()
+			.then(function(result) {
+				$scope.statuses = result;
+			});
+	};
+
+	var queueServerUpdates = function(server) {
+		serverService.queueServerUpdates(server.id)
+			.then(
+				function() {
+					$scope.refresh();
+				}
+			);
+	};
+
+	var clearServerUpdates = function(server) {
+		serverService.clearServerUpdates(server.id)
+			.then(
+				function() {
+					$scope.refresh();
+				}
+			);
+	};
+
+	var queueCDNServerUpdates = function(cdnId) {
+		cdnService.queueServerUpdates(cdnId)
+			.then(
+				function() {
+					$scope.refresh();
+				}
+			);
+	};
+
+	var clearCDNServerUpdates = function(cdnId) {
+		cdnService.clearServerUpdates(cdnId)
+			.then(
+				function() {
+					$scope.refresh();
+				}
+			);
+	};
+
+	var confirmDelete = function(server) {
+		var params = {
+			title: 'Delete Server: ' + server.hostName,
+			key: server.hostName
+		};
+		var modalInstance = $uibModal.open({
+			templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
+			controller: 'DialogDeleteController',
+			size: 'md',
+			resolve: {
+				params: function () {
+					return params;
+				}
+			}
+		});
+		modalInstance.result.then(function() {
+			deleteServer(server);
+		}, function () {
+			// do nothing
+		});
+	};
+
+	var deleteServer = function(server) {
+		serverService.deleteServer(server.id)
+			.then(function(result) {
+				messageModel.setMessages(result.alerts, false);
+				$scope.refresh();
+			});
+	};
+
+	var confirmStatusUpdate = function(server) {
+		var modalInstance = $uibModal.open({
+			templateUrl: 'common/modules/dialog/select/status/dialog.select.status.tpl.html',
+			controller: 'DialogSelectStatusController',
+			size: 'md',
+			resolve: {
+				server: function() {
+					return server;
+				},
+				statuses: function() {
+					return $scope.statuses;
+				}
+			}
+		});
+		modalInstance.result.then(function(status) {
+			updateStatus(status, server);
+		}, function () {
+			// do nothing
+		});
+	};
+
+	var updateStatus = function(status, server) {
+		serverService.updateStatus(server.id, { status: status.id, offlineReason: status.offlineReason })
+			.then(
+				function(result) {
+					messageModel.setMessages(result.data.alerts, false);
+					$scope.refresh();
+				},
+				function(fault) {
+					messageModel.setMessages(fault.data.alerts, false);
+				}
+			);
+	};
+
+	$scope.servers = servers;
+
+	$scope.columns = [
+		{ "name": "Cache Group", "visible": true, "searchable": true },
+		{ "name": "CDN", "visible": true, "searchable": true },
+		{ "name": "Domain", "visible": true, "searchable": true },
+		{ "name": "Host", "visible": true, "searchable": true },
+		{ "name": "HTTPS Port", "visible": false, "searchable": false },
+		{ "name": "ID", "visible": false, "searchable": false },
+		{ "name": "ILO IP Address", "visible": true, "searchable": true },
+		{ "name": "ILO IP Gateway", "visible": false, "searchable": false },
+		{ "name": "ILO IP Netmask", "visible": false, "searchable": false },
+		{ "name": "ILO Username", "visible": false, "searchable": false },
+		{ "name": "Interface Name", "visible": false, "searchable": false },
+		{ "name": "IPv6 Address", "visible": true, "searchable": true },
+		{ "name": "IPv6 Gateway", "visible": false, "searchable": false },
+		{ "name": "Last Updated", "visible": false, "searchable": false },
+		{ "name": "Mgmt IP Address", "visible": false, "searchable": false },
+		{ "name": "Mgmt IP Gateway", "visible": false, "searchable": false },
+		{ "name": "Mgmt IP Netmask", "visible": false, "searchable": false },
+		{ "name": "Network Gateway", "visible": false, "searchable": false },
+		{ "name": "Network IP", "visible": true, "searchable": true },
+		{ "name": "Network MTU", "visible": false, "searchable": false },
+		{ "name": "Network Subnet", "visible": false, "searchable": false },
+		{ "name": "Offline Reason", "visible": false, "searchable": false },
+		{ "name": "Phys Location", "visible": true, "searchable": true },
+		{ "name": "Profile", "visible": true, "searchable": true },
+		{ "name": "Rack", "visible": false, "searchable": false },
+		{ "name": "Reval Pending", "visible": false, "searchable": false },
+		{ "name": "Router Hostname", "visible": false, "searchable": false },
+		{ "name": "Router Port Name", "visible": false, "searchable": false },
+		{ "name": "Status", "visible": true, "searchable": true },
+		{ "name": "TCP Port", "visible": false, "searchable": false },
+		{ "name": "Type", "visible": true, "searchable": true },
+		{ "name": "Update Pending", "visible": true, "searchable": true }
+	];
+
+	$scope.contextMenuItems = [
+		{
+			text: 'Open in New Tab',
+			click: function ($itemScope) {
+				$window.open('/#!/servers/' + $itemScope.s.id, '_blank');
+			}
+		},
+		null, // Divider
+		{
+			text: 'Navigate to Server FQDN',
+			click: function ($itemScope) {
+				$window.open('http://' + $itemScope.s.hostName + '.' + $itemScope.s.domainName, '_blank');
+			}
+		},
+		null, // Divider
+		{
+			text: 'Edit',
+			click: function ($itemScope) {
+				$scope.editServer($itemScope.s.id);
+			}
+		},
+		{
+			text: 'Delete',
+			click: function ($itemScope) {
+				confirmDelete($itemScope.s);
+			}
+		},
+		null, // Divider
+		{
+			text: 'Update Status',
+			click: function ($itemScope) {
+				confirmStatusUpdate($itemScope.s);
+			}
+		},
+		{
+			text: 'Queue Server Updates',
+			displayed: function ($itemScope) {
+				return serverUtils.isCache($itemScope.s) && !$itemScope.s.updPending;
+			},
+			click: function ($itemScope) {
+				queueServerUpdates($itemScope.s);
+			}
+		},
+		{
+			text: 'Clear Server Updates',
+			displayed: function ($itemScope) {
+				return serverUtils.isCache($itemScope.s) && $itemScope.s.updPending;
+			},
+			click: function ($itemScope) {
+				clearServerUpdates($itemScope.s);
+			}
+		},
+		{
+			text: 'Show Charts',
+			displayed: function () {
+				return propertiesModel.properties.servers.charts.show;
+			},
+			hasBottomDivider: function () {
+				return true;
+			},
+			hasTopDivider: function () {
+				return true;
+			},
+			click: function ($itemScope) {
+				$window.open(propertiesModel.properties.servers.charts.baseUrl + $itemScope.s.hostName, '_blank');
+			}
+		},
+		{
+			text: 'Manage Capabilities',
+			displayed: function ($itemScope) {
+				return serverUtils.isCache($itemScope.s);
+			},
+			hasTopDivider: function () {
+				return true;
+			},
+			click: function ($itemScope) {
+				locationUtils.navigateToPath('/servers/' + $itemScope.s.id + '/capabilities');
+			}
+		},
+		{
+			text: 'Manage Delivery Services',
+			displayed: function ($itemScope) {
+				return serverUtils.isEdge($itemScope.s) || serverUtils.isOrigin($itemScope.s);
+			},
+			hasTopDivider: function ($itemScope) {
+				return !serverUtils.isCache($itemScope.s);
+			},
+			click: function ($itemScope) {
+				locationUtils.navigateToPath('/servers/' + $itemScope.s.id + '/delivery-services');
+			}
+		},
+		{
+			text: 'View Config Files',
+			displayed: function ($itemScope) {
+				return serverUtils.isCache($itemScope.s);
+			},
+			click: function ($itemScope) {
+				locationUtils.navigateToPath('/servers/' + $itemScope.s.id + '/config-files');
+			}
+		}
+	];
+
+	$scope.editServer = function(id) {
+		locationUtils.navigateToPath('/servers/' + id);
+	};
+
+	$scope.createServer = function() {
+		locationUtils.navigateToPath('/servers/new');
+	};
+
+	$scope.confirmCDNQueueServerUpdates = function(cdn) {
+		var params;
+		if (cdn) {
+			params = {
+				title: 'Queue Server Updates: ' + cdn.name,
+				message: 'Are you sure you want to queue server updates for all ' + cdn.name + ' servers?'
+			};
+			var modalInstance = $uibModal.open({
+				templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
+				controller: 'DialogConfirmController',
+				size: 'md',
+				resolve: {
+					params: function () {
+						return params;
+					}
+				}
+			});
+			modalInstance.result.then(function() {
+				queueCDNServerUpdates(cdn.id);
+			}, function () {
+				// do nothing
+			});
+		} else {
+			params = {
+				title: 'Queue Server Updates',
+				message: "Please select a CDN"
+			};
+			var modalInstance = $uibModal.open({
+				templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+				controller: 'DialogSelectController',
+				size: 'md',
+				resolve: {
+					params: function () {
+						return params;
+					},
+					collection: function(cdnService) {
+						return cdnService.getCDNs();
+					}
+				}
+			});
+			modalInstance.result.then(function(cdn) {
+				queueCDNServerUpdates(cdn.id);
+			}, function () {
+				// do nothing
+			});
+		}
+	};
+
+	$scope.confirmCDNClearServerUpdates = function(cdn) {
+		var params;
+		if (cdn) {
+			params = {
+				title: 'Clear Server Updates: ' + cdn.name,
+				message: 'Are you sure you want to clear server updates for all ' + cdn.name + ' servers?'
+			};
+			var modalInstance = $uibModal.open({
+				templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
+				controller: 'DialogConfirmController',
+				size: 'md',
+				resolve: {
+					params: function () {
+						return params;
+					}
+				}
+			});
+			modalInstance.result.then(function() {
+				clearCDNServerUpdates(cdn.id);
+			}, function () {
+				// do nothing
+			});
+
+
+		} else {
+			params = {
+				title: 'Clear Server Updates',
+				message: "Please select a CDN"
+			};
+			var modalInstance = $uibModal.open({
+				templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+				controller: 'DialogSelectController',
+				size: 'md',
+				resolve: {
+					params: function () {
+						return params;
+					},
+					collection: function(cdnService) {
+						return cdnService.getCDNs();
+					}
+				}
+			});
+			modalInstance.result.then(function(cdn) {
+				clearCDNServerUpdates(cdn.id);
+			}, function () {
+				// do nothing
+			});
+		}
+	};
+
+	$scope.refresh = function() {
+		$state.reload(); // reloads all the resolves for the view
+	};
+
+	$scope.toggleVisibility = function(colName) {
+		const col = serversTable.column(colName + ':name');
+		col.visible(!col.visible());
+		serversTable.rows().invalidate().draw();
+	};
+
+	$scope.ssh = serverUtils.ssh;
+
+	$scope.isOffline = serverUtils.isOffline;
+
+	$scope.offlineReason = serverUtils.offlineReason;
+
+	$scope.getRelativeTime = dateUtils.getRelativeTime;
+
+	$scope.navigateToPath = locationUtils.navigateToPath;
+
+	var init = function () {
+		getStatuses();
+	};
+	init();
+
+	angular.element(document).ready(function () {
+		serversTable = $('#serversTable').DataTable({
+			"lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
+			"iDisplayLength": 25,
+			"aaSorting": [],
+			"columns": $scope.columns,
+			"initComplete": function(settings, json) {
+				try {
+					// need to create the show/hide column checkboxes and bind to the current visibility
+					$scope.columns = JSON.parse(localStorage.getItem('DataTables_serversTable_/')).columns;
+				} catch (e) {
+					console.error("Failure to retrieve required column info from localStorage (key=DataTables_serversTable_/):", e);
+				}
+			}
+		});
+	});
+
+};
+
+TableParentServersController.$inject = ['servers', '$scope', '$state', '$uibModal', '$window', 'dateUtils', 'locationUtils', 'serverUtils', 'cdnService', 'serverService', 'statusService', 'propertiesModel', 'messageModel'];
+module.exports = TableParentServersController;

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -71,45 +71,38 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "Cache Group",
 			field: "cachegroup",
 			hide: false,
-			searchable: true
 		},
 		{
 			headerName: "CDN",
 			field: "cdnName",
 			hide: false,
-			searchable: true
 		},
 		{
 			headerName: "Domain",
 			field: "domainName",
 			hide: false,
-			searchable: true
 		},
 		{
 			headerName: "Host",
 			field: "hostName",
 			hide: false,
-			searchable: true
 		},
 		{
 			headerName: "HTTPS Port",
 			field: "httpsPort",
 			hide: true,
-			searchable: false,
 			filter: "agNumberColumnFilter"
 		},
 		{
 			headerName: "ID",
 			field: "id",
 			hide: true,
-			searchable: true,
 			filter: "agNumberColumnFilter"
 		},
 		{
 			headerName: "ILO IP Address",
 			field: "iloIpAddress",
 			hide: true,
-			searchable: true,
 			cellRenderer: "sshCellRenderer",
 			onCellClicked: null
 		},
@@ -117,7 +110,6 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "ILO IP Gateway",
 			field: "iloIpGateway",
 			hide: true,
-			searchable: false,
 			cellRenderer: "sshCellRenderer",
 			onCellClicked: null
 		},
@@ -125,37 +117,31 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "ILO IP Netmask",
 			field: "iloIpNetmask",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "ILO Username",
 			field: "iloUsername",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Interface Name",
 			field: "interfaceName",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "IPv6 Address",
 			field: "ipv6Address",
 			hide: false,
-			searchable: true
 		},
 		{
 			headerName: "IPv6 Gateway",
 			field: "ipv6Gateway",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Last Updated",
 			field: "lastUpdated",
 			hide: true,
-			searchable: false,
 			filter: "agDateColumnFilter",
 			valueFormatter: dateCellFormatter
 		},
@@ -163,13 +149,11 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "Mgmt IP Address",
 			field: "mgmtIpAddress",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Mgmt IP Gateway",
 			field: "mgmtIpGateway",
 			hide: true,
-			searchable: false,
 			filter: true,
 			cellRenderer: "sshCellRenderer",
 			onCellClicked: null
@@ -178,7 +162,6 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "Mgmt IP Netmask",
 			field: "mgmtIpNetmask",
 			hide: true,
-			searchable: false,
 			filter: true,
 			cellRenderer: "sshCellRenderer",
 			onCellClicked: null
@@ -187,7 +170,6 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "Network Gateway",
 			field: "ipGateway",
 			hide: true,
-			searchable: true,
 			filter: true,
 			cellRenderer: "sshCellRenderer",
 			onCellClicked: null
@@ -196,7 +178,6 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "Network IP",
 			field: "ipAddress",
 			hide: false,
-			searchable: true,
 			filter: true,
 			cellRenderer: "sshCellRenderer",
 			onCellClicked: null
@@ -205,44 +186,37 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "Network MTU",
 			field: "interfaceMtu",
 			hide: true,
-			searchable: false,
 			filter: "agNumberColumnFilter"
 		},
 		{
 			headerName: "Network Subnet",
 			field: "ipNetmask",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Offline Reason",
 			field: "offlineReason",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Phys Location",
 			field: "physLocation",
 			hide: true,
-			searchable: true
 		},
 		{
 			headerName: "Profile",
 			field: "profile",
 			hide: false,
-			searchable: true
 		},
 		{
 			headerName: "Rack",
 			field: "rack",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Reval Pending",
 			field: "revalPending",
 			hide: true,
-			searchable: false,
 			filter: true,
 			cellRenderer: "updateCellRenderer"
 		},
@@ -250,38 +224,32 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			headerName: "Router Hostname",
 			field: "routerHostName",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Router Port Name",
 			field: "routerPortName",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Status",
 			field: "status",
 			hide: false,
-			searchable: true,
 			tooltip: offlineReasonTooltip
 		},
 		{
 			headerName: "TCP Port",
 			field: "tcpPort",
 			hide: true,
-			searchable: false
 		},
 		{
 			headerName: "Type",
 			field: "type",
 			hide: false,
-			searchable: true
 		},
 		{
 			headerName: "Update Pending",
 			field: "updPending",
 			hide: false,
-			searchable: true,
 			filter: true,
 			cellRenderer: "updateCellRenderer"
 		}
@@ -326,7 +294,6 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		onColumnResized: function(params) {
 			localStorage.setItem("servers_table_columns", JSON.stringify($scope.gridOptions.columnApi.getColumnState()));
 		},
-		menuTabs: 'columnsMenuTab',
 		tooltipShowDelay: 500,
 		allowContextMenuWithControlKey: true,
 		preventDefaultOnContextMenu: true,

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -379,6 +379,17 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		$scope.gridOptions.api.sizeColumnsToFit();
 	};
 
+	/** Downloads the table as a CSV */
+	$scope.exportCSV = function() {
+		// TODO: figure out how to reconcile clicking on a server taking you to it
+		// with row selection exports.
+		const params = {
+			allColumns: true,
+			fileName: "servers.csv",
+		};
+		$scope.gridOptions.api.exportDataAsCsv(params);
+	}
+
 
 	/**** Context menu functions ****/
 

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -326,12 +326,14 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			);
 	};
 
-	var confirmDelete = function(server) {
-		var params = {
-			title: 'Delete Server: ' + server.hostName,
-			key: server.hostName
+	$scope.confirmDelete = function(event) {
+		event.stopPropagation();
+
+		const params = {
+			title: 'Delete Server: ' + $scope.server.hostName,
+			key: $scope.server.hostName
 		};
-		var modalInstance = $uibModal.open({
+		const modalInstance = $uibModal.open({
 			templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
 			controller: 'DialogDeleteController',
 			size: 'md',
@@ -341,19 +343,20 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 				}
 			}
 		});
-		modalInstance.result.then(function() {
-			deleteServer(server);
-		}, function () {
-			// do nothing
-		});
-	};
-
-	var deleteServer = function(server) {
-		serverService.deleteServer(server.id)
-			.then(function(result) {
-				messageModel.setMessages(result.alerts, false);
-				$scope.refresh();
-			});
+		modalInstance.result.then(
+			function() {
+				serverService.deleteServer($scope.server.id).then(
+					function(result) {
+						messageModel.setMessages(result.alerts, false);
+						$scope.refresh();
+					}
+				);
+			},
+			function (err) {
+				// TODO: use template strings once the build can handle them.
+				console.error("Error deleting server", $scope.hostname + "." + $scope.domain, "(#" + String($scope.serverID) + "):", err);
+			}
+		);
 	};
 
 	var confirmStatusUpdate = function(server) {
@@ -395,6 +398,7 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 	$scope.columns = [];
 
 	$scope.serverlink = "/#!/servers/";
+	$scope.server = null;
 	$scope.hostname = "";
 	$scope.domain = "";
 	$scope.serverID = -1;
@@ -429,9 +433,7 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			$scope.menuStyle.left = String(params.event.pageX) + "px";
 			$scope.menuStyle.top = String(params.event.pageY) + "px";
 			$scope.serverlink = "/#!/servers/" + String(params.data.id);
-			$scope.hostname = params.data.hostName;
-			$scope.domain = params.data.domainName;
-			$scope.serverID = params.data.id;
+			$scope.server = params.data;
 			$scope.$apply();
 		}
 	};

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-
 var TableServersController = function(servers, $scope, $state, $uibModal, $window, dateUtils, locationUtils, serverUtils, cdnService, serverService, statusService, propertiesModel, messageModel, userModel) {
 
 	// browserify can't handle classes...
@@ -391,13 +390,11 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			);
 	};
 
-	console.time("server map");
 	$scope.servers = servers.map(function(x){x.lastUpdated = x.lastUpdated ? new Date(x.lastUpdated.replace("+00", "Z")) : x.lastUpdated;});
-	console.timeEnd("server map");
 
 	$scope.columns = [];
 
-	let menu = false;
+	$scope.serverlink = "/#!/servers/";
 
 	$scope.gridOptions = {
 		components: {
@@ -421,7 +418,14 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		tooltipShowDelay: 500,
 		getContextMenuItems: getContextMenu,
 		allowContextMenuWithControlKey: true,
-		preventDefaultContextMenu: true
+		preventDefaultOnContextMenu: true,
+		onCellContextMenu: function(params) {
+			params.event.preventDefault();
+			console.log(params);
+			$scope.showMenu = true;
+			$scope.serverlink = "/#!/servers/" + String(params.data.id);
+			$scope.$apply();
+		}
 	};
 
 	function getContextMenu(params) {
@@ -501,6 +505,13 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			}
 		];
 	}
+
+	$scope.menuStyle = {
+		left: 0,
+		top: 0,
+	};
+
+	$scope.showMenu = false;
 
 	$scope.createServer = function() {
 		locationUtils.navigateToPath('/servers/new');

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -165,6 +165,78 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
         { "name": "Update Pending", "visible": true, "searchable": true }
     ];
 
+    $scope.gridOptions = {
+        // columnDefs: [
+        //     { headerName: "Cache Group", field: "cachegroup"},
+        //     { headerName: "CDN", field: "cdnName"},
+        //     { headerName: "Domain", field: "domainName"},
+        //     { headerName: "Host", field: "hostName"},
+        //     { headerName: "HTTPS Port", field: "httpsPort"},
+        //     { headerName: "ID", field: "id"},
+        //     { headerName: "ILO IP Address", field: "iloIpAddress"},
+        //     { headerName: "ILO IP Gateway", field: "iloIpGateway"},
+        //     { headerName: "ILO IP Netmask", field: "iloIpNetmask"},
+        //     { headerName: "ILO Username", field: "iloUsername"},
+        //     { headerName: "Interface Name", field: "interfaceName"},
+        //     { headerName: "IPv6 Address", field: "ipv6Address"},
+        //     { headerName: "IPv6 Gateway", field: "ipv6Gateway"},
+        //     { headerName: "Last Updated", field: "lastUpdated"},
+        //     { headerName: "Mgmt IP Address", field: "mgmtIPAddress"},
+        //     { headerName: "Mgmt IP Gateway", field: "mgmtIPGateway"},
+        //     { headerName: "Mgmt IP Netmask", field: "mgmtIPNetmask"},
+        //     { headerName: "Network Gateway", field: "ipGateway"},
+        //     { headerName: "Network IP", field: "idAddress"},
+        //     { headerName: "Network MTU", field: "interfaceMtu"},
+        //     { headerName: "Network Subnet", field: "ipNetmask"},
+        //     { headerName: "Offline Reason", field: "offlineReason"},
+        //     { headerName: "Phys Location", field: "physLocation"},
+        //     { headerName: "Profile", field: "profile"},
+        //     { headerName: "Rack", field: "rack"},
+        //     { headerName: "Reval Pending", field: "revalPending"},
+        //     { headerName: "Router Hostname", field: "routerHostName"},
+        //     { headerName: "Router Port Name", field: "routerPortName"},
+        //     { headerName: "Status", field: "status"},
+        //     { headerName: "TCP Port", field: "tcpPort"},
+        //     { headerName: "Type", field: "type"},
+        //     { headerName: "Update Pending", field: "updPending" }
+        // ],
+        // rowData: servers.map(function(x) {
+        //     return {
+        //         cachegroup: x.cachegroup,
+        //         cdnName: x.cdnName,
+        //         domain: x.domainName,
+        //         hostName: x.hostName,
+        //         httpsPort: x.httpsPort,
+        //         id: x.id,
+        //         physLocation: x.physLocation,
+        //         profile: x.profile,
+        //         rack: "",
+        //         revalPending: x.revalPending,
+        //         routerHostName: "",
+        //         routerPortName: "",
+        //         status: x.status,
+        //         tcpPort: x.tcpPort,
+        //         type: x.type,
+        //         updPending: x.updPending
+        //     };
+        // }),
+        columnDefs:  [
+            {headerName: "Make", field: "make"},
+            {headerName: "Model", field: "model"},
+            {headerName: "Price", field: "price"}
+        ],
+        rowData: [
+            {make: "Toyota", model: "Celica", price: 35000},
+            {make: "Ford", model: "Mondeo", price: 32000},
+            {make: "Porsche", model: "Boxter", price: 72000}
+        ],
+        onGridReady: function(params) {
+            params.api.sizeColumnsToFit();
+        }
+    };
+
+    console.log(servers);
+
     $scope.contextMenuItems = [
         {
             text: 'Open in New Tab',

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -75,7 +75,7 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		},
 		{
 			headerName: "CDN",
-			field: "cdn",
+			field: "cdnName",
 			hide: false,
 			searchable: true
 		},

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -423,7 +423,7 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 	$scope.confirmStatusUpdate = function(server, event) {
 		event.stopPropagation();
 
-		var modalInstance = $uibModal.open({
+		const modalInstance = $uibModal.open({
 			templateUrl: 'common/modules/dialog/select/status/dialog.select.status.tpl.html',
 			controller: 'DialogSelectStatusController',
 			size: 'md',

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -407,11 +407,12 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 
 	$scope.columns = [];
 
-	$scope.serverlink = "/#!/servers/";
-	$scope.server = null;
-	$scope.hostname = "";
-	$scope.domain = "";
-	$scope.serverID = -1;
+	$scope.chartsBase = propertiesModel.properties.servers.charts.baseUrl;
+	$scope.server = {
+		hostName: "",
+		domainName: "",
+		id: -1
+	};
 
 	$scope.gridOptions = {
 		components: {
@@ -442,8 +443,8 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			$scope.showMenu = true;
 			$scope.menuStyle.left = String(params.event.pageX) + "px";
 			$scope.menuStyle.top = String(params.event.pageY) + "px";
-			$scope.serverlink = "/#!/servers/" + String(params.data.id);
 			$scope.server = params.data;
+			$scope.chartslink = propertiesModel.properties.servers.charts.baseUrl + params.data.hostName;
 			$scope.$apply();
 		}
 	};
@@ -529,6 +530,7 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 	$scope.isCache = serverUtils.isCache;
 	$scope.isEdge = serverUtils.isEdge;
 	$scope.isOrigin = serverUtils.isOrigin;
+	$scope.showCharts = propertiesModel.properties.servers.charts.show;
 
 	$scope.menuStyle = {
 		left: 0,

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -20,660 +20,633 @@
 
 var TableServersController = function(servers, $scope, $state, $uibModal, $window, dateUtils, locationUtils, serverUtils, cdnService, serverService, statusService, propertiesModel, messageModel, userModel) {
 
-    // browserify can't handle classes...
-    function SSHCellRenderer() {}
-    SSHCellRenderer.prototype.init = function(params) {
-        this.eGui = document.createElement("A");
-        this.eGui.href = "ssh://" + userModel.user.username + "@" + params.value;
-        this.eGui.setAttribute("target", "_blank");
-        this.eGui.textContent = params.value;
-    };
-    SSHCellRenderer.prototype.getGui = function() {return this.eGui;};
+	// browserify can't handle classes...
+	function SSHCellRenderer() {}
+	SSHCellRenderer.prototype.init = function(params) {
+		this.eGui = document.createElement("A");
+		this.eGui.href = "ssh://" + userModel.user.username + "@" + params.value;
+		this.eGui.setAttribute("target", "_blank");
+		this.eGui.textContent = params.value;
+	};
+	SSHCellRenderer.prototype.getGui = function() {return this.eGui;};
 
-    function UpdateCellRenderer() {}
-    UpdateCellRenderer.prototype.init = function(params) {
-        this.eGui = document.createElement("I");
-        this.eGui.setAttribute("aria-hidden", "true");
-        this.eGui.setAttribute("title", String(params.value));
-        this.eGui.classList.add("fa", "fa-lg");
-        if (params.value) {
-            this.eGui.classList.add("fa-check");
-        } else {
-            this.eGui.classList.add("fa-clock-o");
-        }
-    }
-    UpdateCellRenderer.prototype.getGui = function() {return this.eGui;};
+	function UpdateCellRenderer() {}
+	UpdateCellRenderer.prototype.init = function(params) {
+		this.eGui = document.createElement("I");
+		this.eGui.setAttribute("aria-hidden", "true");
+		this.eGui.setAttribute("title", String(params.value));
+		this.eGui.classList.add("fa", "fa-lg");
+		if (params.value) {
+			this.eGui.classList.add("fa-check");
+		} else {
+			this.eGui.classList.add("fa-clock-o");
+		}
+	}
+	UpdateCellRenderer.prototype.getGui = function() {return this.eGui;};
 
-    function offlineReasonTooltip(params) {
-        if (!params.value || !serverUtils.isOffline(params.value)) {
-            return;
-        }
-        return params.data.offlineReason;
-    }
+	function offlineReasonTooltip(params) {
+		if (!params.value || !serverUtils.isOffline(params.value)) {
+			return;
+		}
+		return params.data.offlineReason;
+	}
 
-    function dateCellFormatter(params) {
-        return dateUtils.getRelativeTime(params.value);
-    }
+	function dateCellFormatter(params) {
+		return dateUtils.getRelativeTime(params.value);
+	}
 
-    let serversTable;
+	let serversTable;
 
-    function editServer(params) {
-        $scope.editServer(params.data.id);
-        // Event is outside the digest cycle, so we need this to trigger one.
-        $scope.$apply();
-    }
+	function editServer(params) {
+		locationUtils.navigateToPath('/servers/' + params.data.id);
+		// Event is outside the digest cycle, so we need this to trigger one.
+		$scope.$apply();
+	}
 
-    const agColumns = [
-        {
-            headerName: "Cache Group",
-            field: "cachegroup",
-            hide: false,
-            searchable: true
-        },
-        {
-            headerName: "CDN",
-            field: "cdn",
-            hide: false,
-            searchable: true
-        },
-        {
-            headerName: "Domain",
-            field: "domainName",
-            hide: false,
-            searchable: true
-        },
-        {
-            headerName: "Host",
-            field: "hostName",
-            hide: false,
-            searchable: true
-        },
-        {
-            headerName: "HTTPS Port",
-            field: "httpsPort",
-            hide: true,
-            searchable: false,
-            filter: "agNumberColumnFilter"
-        },
-        {
-            headerName: "ID",
-            field: "id",
-            hide: true,
-            searchable: true,
-            filter: "agNumberColumnFilter"
-        },
-        {
-            headerName: "ILO IP Address",
-            field: "iloIpAddress",
-            hide: true,
-            searchable: true,
-            cellRenderer: "sshCellRenderer",
-            onCellClicked: null
-        },
-        {
-            headerName: "ILO IP Gateway",
-            field: "iloIpGateway",
-            hide: true,
-            searchable: false,
-            cellRenderer: "sshCellRenderer",
-            onCellClicked: null
-        },
-        {
-            headerName: "ILO IP Netmask",
-            field: "iloIpNetmask",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "ILO Username",
-            field: "iloUsername",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Interface Name",
-            field: "interfaceName",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "IPv6 Address",
-            field: "ipv6Address",
-            hide: false,
-            searchable: true
-        },
-        {
-            headerName: "IPv6 Gateway",
-            field: "ipv6Gateway",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Last Updated",
-            field: "lastUpdated",
-            hide: true,
-            searchable: false,
-            filter: "agDateColumnFilter",
-            valueFormatter: dateCellFormatter
-        },
-        {
-            headerName: "Mgmt IP Address",
-            field: "mgmtIpAddress",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Mgmt IP Gateway",
-            field: "mgmtIpGateway",
-            hide: true,
-            searchable: false,
-            filter: true,
-            cellRenderer: "sshCellRenderer",
-            onCellClicked: null
-        },
-        {
-            headerName: "Mgmt IP Netmask",
-            field: "mgmtIpNetmask",
-            hide: true,
-            searchable: false,
-            filter: true,
-            cellRenderer: "sshCellRenderer",
-            onCellClicked: null
-        },
-        {
-            headerName: "Network Gateway",
-            field: "ipGateway",
-            hide: true,
-            searchable: true,
-            filter: true,
-            cellRenderer: "sshCellRenderer",
-            onCellClicked: null
-        },
-        {
-            headerName: "Network IP",
-            field: "ipAddress",
-            hide: false,
-            searchable: true,
-            filter: true,
-            cellRenderer: "sshCellRenderer",
-            onCellClicked: null
-        },
-        {
-            headerName: "Network MTU",
-            field: "interfaceMtu",
-            hide: true,
-            searchable: false,
-            filter: "agNumberColumnFilter"
-        },
-        {
-            headerName: "Network Subnet",
-            field: "ipNetmask",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Offline Reason",
-            field: "offlineReason",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Phys Location",
-            field: "physLocation",
-            hide: true,
-            searchable: true
-        },
-        {
-            headerName: "Profile",
-            field: "profile",
-            hide: false,
-            searchable: true
-        },
-        {
-            headerName: "Rack",
-            field: "rack",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Reval Pending",
-            field: "revalPending",
-            hide: true,
-            searchable: false,
-            filter: true,
-            cellRenderer: "updateCellRenderer"
-        },
-        {
-            headerName: "Router Hostname",
-            field: "routerHostName",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Router Port Name",
-            field: "routerPortName",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Status",
-            field: "status",
-            hide: false,
-            searchable: true,
-            tooltip: offlineReasonTooltip
-        },
-        {
-            headerName: "TCP Port",
-            field: "tcpPort",
-            hide: true,
-            searchable: false
-        },
-        {
-            headerName: "Type",
-            field: "type",
-            hide: false,
-            searchable: true
-        },
-        {
-            headerName: "Update Pending",
-            field: "updPending",
-            hide: false,
-            searchable: true,
-            filter: true,
-            cellRenderer: "updateCellRenderer"
-        }
-    ];
+	const agColumns = [
+		{
+			headerName: "Cache Group",
+			field: "cachegroup",
+			hide: false,
+			searchable: true
+		},
+		{
+			headerName: "CDN",
+			field: "cdn",
+			hide: false,
+			searchable: true
+		},
+		{
+			headerName: "Domain",
+			field: "domainName",
+			hide: false,
+			searchable: true
+		},
+		{
+			headerName: "Host",
+			field: "hostName",
+			hide: false,
+			searchable: true
+		},
+		{
+			headerName: "HTTPS Port",
+			field: "httpsPort",
+			hide: true,
+			searchable: false,
+			filter: "agNumberColumnFilter"
+		},
+		{
+			headerName: "ID",
+			field: "id",
+			hide: true,
+			searchable: true,
+			filter: "agNumberColumnFilter"
+		},
+		{
+			headerName: "ILO IP Address",
+			field: "iloIpAddress",
+			hide: true,
+			searchable: true,
+			cellRenderer: "sshCellRenderer",
+			onCellClicked: null
+		},
+		{
+			headerName: "ILO IP Gateway",
+			field: "iloIpGateway",
+			hide: true,
+			searchable: false,
+			cellRenderer: "sshCellRenderer",
+			onCellClicked: null
+		},
+		{
+			headerName: "ILO IP Netmask",
+			field: "iloIpNetmask",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "ILO Username",
+			field: "iloUsername",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Interface Name",
+			field: "interfaceName",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "IPv6 Address",
+			field: "ipv6Address",
+			hide: false,
+			searchable: true
+		},
+		{
+			headerName: "IPv6 Gateway",
+			field: "ipv6Gateway",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Last Updated",
+			field: "lastUpdated",
+			hide: true,
+			searchable: false,
+			filter: "agDateColumnFilter",
+			valueFormatter: dateCellFormatter
+		},
+		{
+			headerName: "Mgmt IP Address",
+			field: "mgmtIpAddress",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Mgmt IP Gateway",
+			field: "mgmtIpGateway",
+			hide: true,
+			searchable: false,
+			filter: true,
+			cellRenderer: "sshCellRenderer",
+			onCellClicked: null
+		},
+		{
+			headerName: "Mgmt IP Netmask",
+			field: "mgmtIpNetmask",
+			hide: true,
+			searchable: false,
+			filter: true,
+			cellRenderer: "sshCellRenderer",
+			onCellClicked: null
+		},
+		{
+			headerName: "Network Gateway",
+			field: "ipGateway",
+			hide: true,
+			searchable: true,
+			filter: true,
+			cellRenderer: "sshCellRenderer",
+			onCellClicked: null
+		},
+		{
+			headerName: "Network IP",
+			field: "ipAddress",
+			hide: false,
+			searchable: true,
+			filter: true,
+			cellRenderer: "sshCellRenderer",
+			onCellClicked: null
+		},
+		{
+			headerName: "Network MTU",
+			field: "interfaceMtu",
+			hide: true,
+			searchable: false,
+			filter: "agNumberColumnFilter"
+		},
+		{
+			headerName: "Network Subnet",
+			field: "ipNetmask",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Offline Reason",
+			field: "offlineReason",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Phys Location",
+			field: "physLocation",
+			hide: true,
+			searchable: true
+		},
+		{
+			headerName: "Profile",
+			field: "profile",
+			hide: false,
+			searchable: true
+		},
+		{
+			headerName: "Rack",
+			field: "rack",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Reval Pending",
+			field: "revalPending",
+			hide: true,
+			searchable: false,
+			filter: true,
+			cellRenderer: "updateCellRenderer"
+		},
+		{
+			headerName: "Router Hostname",
+			field: "routerHostName",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Router Port Name",
+			field: "routerPortName",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Status",
+			field: "status",
+			hide: false,
+			searchable: true,
+			tooltip: offlineReasonTooltip
+		},
+		{
+			headerName: "TCP Port",
+			field: "tcpPort",
+			hide: true,
+			searchable: false
+		},
+		{
+			headerName: "Type",
+			field: "type",
+			hide: false,
+			searchable: true
+		},
+		{
+			headerName: "Update Pending",
+			field: "updPending",
+			hide: false,
+			searchable: true,
+			filter: true,
+			cellRenderer: "updateCellRenderer"
+		}
+	];
 
-    var getStatuses = function() {
-        statusService.getStatuses()
-            .then(function(result) {
-                $scope.statuses = result;
-            });
-    };
+	var getStatuses = function() {
+		statusService.getStatuses()
+			.then(function(result) {
+				$scope.statuses = result;
+			});
+	};
 
-    var queueServerUpdates = function(server) {
-        serverService.queueServerUpdates(server.id)
-            .then(
-                function() {
-                    $scope.refresh();
-                }
-            );
-    };
+	var queueServerUpdates = function(server) {
+		serverService.queueServerUpdates(server.id)
+			.then(
+				function() {
+					$scope.refresh();
+				}
+			);
+	};
 
-    var clearServerUpdates = function(server) {
-        serverService.clearServerUpdates(server.id)
-            .then(
-                function() {
-                    $scope.refresh();
-                }
-            );
-    };
+	var clearServerUpdates = function(server) {
+		serverService.clearServerUpdates(server.id)
+			.then(
+				function() {
+					$scope.refresh();
+				}
+			);
+	};
 
-    var queueCDNServerUpdates = function(cdnId) {
-        cdnService.queueServerUpdates(cdnId)
-            .then(
-                function() {
-                    $scope.refresh();
-                }
-            );
-    };
+	var queueCDNServerUpdates = function(cdnId) {
+		cdnService.queueServerUpdates(cdnId)
+			.then(
+				function() {
+					$scope.refresh();
+				}
+			);
+	};
 
-    var clearCDNServerUpdates = function(cdnId) {
-        cdnService.clearServerUpdates(cdnId)
-            .then(
-                function() {
-                    $scope.refresh();
-                }
-            );
-    };
+	var clearCDNServerUpdates = function(cdnId) {
+		cdnService.clearServerUpdates(cdnId)
+			.then(
+				function() {
+					$scope.refresh();
+				}
+			);
+	};
 
-    var confirmDelete = function(server) {
-        var params = {
-            title: 'Delete Server: ' + server.hostName,
-            key: server.hostName
-        };
-        var modalInstance = $uibModal.open({
-            templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
-            controller: 'DialogDeleteController',
-            size: 'md',
-            resolve: {
-                params: function () {
-                    return params;
-                }
-            }
-        });
-        modalInstance.result.then(function() {
-            deleteServer(server);
-        }, function () {
-            // do nothing
-        });
-    };
+	var confirmDelete = function(server) {
+		var params = {
+			title: 'Delete Server: ' + server.hostName,
+			key: server.hostName
+		};
+		var modalInstance = $uibModal.open({
+			templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
+			controller: 'DialogDeleteController',
+			size: 'md',
+			resolve: {
+				params: function () {
+					return params;
+				}
+			}
+		});
+		modalInstance.result.then(function() {
+			deleteServer(server);
+		}, function () {
+			// do nothing
+		});
+	};
 
-    var deleteServer = function(server) {
-        serverService.deleteServer(server.id)
-            .then(function(result) {
-                messageModel.setMessages(result.alerts, false);
-                $scope.refresh();
-            });
-    };
+	var deleteServer = function(server) {
+		serverService.deleteServer(server.id)
+			.then(function(result) {
+				messageModel.setMessages(result.alerts, false);
+				$scope.refresh();
+			});
+	};
 
-    var confirmStatusUpdate = function(server) {
-        var modalInstance = $uibModal.open({
-            templateUrl: 'common/modules/dialog/select/status/dialog.select.status.tpl.html',
-            controller: 'DialogSelectStatusController',
-            size: 'md',
-            resolve: {
-                server: function() {
-                    return server;
-                },
-                statuses: function() {
-                    return $scope.statuses;
-                }
-            }
-        });
-        modalInstance.result.then(function(status) {
-            updateStatus(status, server);
-        }, function () {
-            // do nothing
-        });
-    };
+	var confirmStatusUpdate = function(server) {
+		var modalInstance = $uibModal.open({
+			templateUrl: 'common/modules/dialog/select/status/dialog.select.status.tpl.html',
+			controller: 'DialogSelectStatusController',
+			size: 'md',
+			resolve: {
+				server: function() {
+					return server;
+				},
+				statuses: function() {
+					return $scope.statuses;
+				}
+			}
+		});
+		modalInstance.result.then(function(status) {
+			updateStatus(status, server);
+		}, function () {
+			// do nothing
+		});
+	};
 
-    var updateStatus = function(status, server) {
-        serverService.updateStatus(server.id, { status: status.id, offlineReason: status.offlineReason })
-            .then(
-                function(result) {
-                    messageModel.setMessages(result.data.alerts, false);
-                    $scope.refresh();
-                },
-                function(fault) {
-                    messageModel.setMessages(fault.data.alerts, false);
-                }
-            );
-    };
+	var updateStatus = function(status, server) {
+		serverService.updateStatus(server.id, { status: status.id, offlineReason: status.offlineReason })
+			.then(
+				function(result) {
+					messageModel.setMessages(result.data.alerts, false);
+					$scope.refresh();
+				},
+				function(fault) {
+					messageModel.setMessages(fault.data.alerts, false);
+				}
+			);
+	};
 
-    console.time("server map");
-    $scope.servers = servers.map(function(x){x.lastUpdated = x.lastUpdated ? new Date(x.lastUpdated.replace("+00", "Z")) : x.lastUpdated;});
-    console.timeEnd("server map");
+	console.time("server map");
+	$scope.servers = servers.map(function(x){x.lastUpdated = x.lastUpdated ? new Date(x.lastUpdated.replace("+00", "Z")) : x.lastUpdated;});
+	console.timeEnd("server map");
 
-    $scope.columns = [];
+	$scope.columns = [];
 
-    $scope.gridOptions = {
-        components: {
-            sshCellRenderer: SSHCellRenderer,
-            updateCellRenderer: UpdateCellRenderer
-        },
-        columnDefs: agColumns,
-        defaultColDef: {
-            filter: true,
-            onCellClicked: editServer,
-            sortable: true,
-            resizable: true
-        },
-        rowData: servers,
-        pagination: true,
-        rowBuffer: 0,
-        onGridReady: function(params) {
-            params.api.sizeColumnsToFit();
-        },
-        menuTabs: 'columnsMenuTab',
-        tooltipShowDelay: 500
-    };
+	let menu = false;
 
-    $scope.contextMenuItems = [
-        {
-            text: 'Open in New Tab',
-            click: function ($itemScope) {
-                $window.open('/#!/servers/' + $itemScope.s.id, '_blank');
-            }
-        },
-        null, // Divider
-        {
-            text: 'Navigate to Server FQDN',
-            click: function ($itemScope) {
-                $window.open('http://' + $itemScope.s.hostName + '.' + $itemScope.s.domainName, '_blank');
-            }
-        },
-        null, // Divider
-        {
-            text: 'Edit',
-            click: function ($itemScope) {
-                $scope.editServer($itemScope.s.id);
-            }
-        },
-        {
-            text: 'Delete',
-            click: function ($itemScope) {
-                confirmDelete($itemScope.s);
-            }
-        },
-        null, // Divider
-        {
-            text: 'Update Status',
-            click: function ($itemScope) {
-                confirmStatusUpdate($itemScope.s);
-            }
-        },
-        {
-            text: 'Queue Server Updates',
-            displayed: function ($itemScope) {
-                return serverUtils.isCache($itemScope.s) && !$itemScope.s.updPending;
-            },
-            click: function ($itemScope) {
-                queueServerUpdates($itemScope.s);
-            }
-        },
-        {
-            text: 'Clear Server Updates',
-            displayed: function ($itemScope) {
-                return serverUtils.isCache($itemScope.s) && $itemScope.s.updPending;
-            },
-            click: function ($itemScope) {
-                clearServerUpdates($itemScope.s);
-            }
-        },
-        {
-            text: 'Show Charts',
-            displayed: function () {
-                return propertiesModel.properties.servers.charts.show;
-            },
-            hasBottomDivider: function () {
-                return true;
-            },
-            hasTopDivider: function () {
-                return true;
-            },
-            click: function ($itemScope) {
-                $window.open(propertiesModel.properties.servers.charts.baseUrl + $itemScope.s.hostName, '_blank');
-            }
-        },
-        {
-            text: 'Manage Capabilities',
-            displayed: function ($itemScope) {
-                return serverUtils.isCache($itemScope.s);
-            },
-            hasTopDivider: function () {
-                return true;
-            },
-            click: function ($itemScope) {
-                locationUtils.navigateToPath('/servers/' + $itemScope.s.id + '/capabilities');
-            }
-        },
-        {
-            text: 'Manage Delivery Services',
-            displayed: function ($itemScope) {
-                return serverUtils.isEdge($itemScope.s) || serverUtils.isOrigin($itemScope.s);
-            },
-            hasTopDivider: function ($itemScope) {
-                return !serverUtils.isCache($itemScope.s);
-            },
-            click: function ($itemScope) {
-                locationUtils.navigateToPath('/servers/' + $itemScope.s.id + '/delivery-services');
-            }
-        },
-        {
-            text: 'View Config Files',
-            displayed: function ($itemScope) {
-                return serverUtils.isCache($itemScope.s);
-            },
-            click: function ($itemScope) {
-                locationUtils.navigateToPath('/servers/' + $itemScope.s.id + '/config-files');
-            }
-        }
-    ];
+	$scope.gridOptions = {
+		components: {
+			sshCellRenderer: SSHCellRenderer,
+			updateCellRenderer: UpdateCellRenderer
+		},
+		columnDefs: agColumns,
+		defaultColDef: {
+			filter: true,
+			onCellClicked: editServer,
+			sortable: true,
+			resizable: true
+		},
+		rowData: servers,
+		pagination: true,
+		rowBuffer: 0,
+		onGridReady: function(params) {
+			params.api.sizeColumnsToFit();
+		},
+		menuTabs: 'columnsMenuTab',
+		tooltipShowDelay: 500,
+		getContextMenuItems: getContextMenu,
+		allowContextMenuWithControlKey: true,
+		preventDefaultContextMenu: true
+	};
 
-    $scope.editServer = function(id) {
-        locationUtils.navigateToPath('/servers/' + id);
-    };
+	function getContextMenu(params) {
+		const serverID = params.node.data.id;
+		const hostname = params.node.data.hostName;
+		const domainName = params.node.data.domainName;
+		return [
+			{
+				name: "Open in New Tab",
+				action: function () {
+					$window.open("/#!/servers/" + String(serverID), "_blank");
+				}
+			},
+			"separator",
+			{
+				name: "Navigate to Server FQDN",
+				action: function () {
+					$window.open("http://" + hostname + "." + $itemScope.s.domainName, "_blank");
+				}
+			},
+			"separator",
+			{
+				name: "Edit",
+				action: function () {
+					editServer(params.node);
+				}
+			},
+			{
+				name: "Delete",
+				action: function () {
+					confirmDelete(params.node.data);
+				}
+			},
+			"separator",
+			{
+				name: "Update Status",
+				action: function () {
+					confirmStatusUpdate(params.node.data);
+				}
+			},
+			{
+				name: "Queue Server Updates",
+				disabled: !serverUtils.isCache(params.node.data) || node.data.updPending,
+				action: function () {
+					queueServerUpdates(params.node.data);
+				}
+			},
+			{
+				name: "Clear Server Updates",
+				disabled: !serverUtils.isCache(params.node.data) || !node.data.updPending,
+				action: function () {
+					clearServerUpdates(params.node.data);
+				}
+			},
+			"separator",
+			{
+				name: "Show Charts",
+				disabled: !propertiesModel.properties.servers.charts.show,
+				action: function () {
+					$window.open(propertiesModel.properties.servers.charts.baseUrl + hostname, "_blank");
+				}
+			},
+			"separator",
+			{
+				name: "Manage Capabilities",
+				disabled: !serverUtils.isCache($itemScope.s),
+				action: function () {
+					locationUtils.navigateToPath("/servers/" + String(serverID) + "/capabilities");
+				}
+			},
+			{
+				name: "Manage Delivery Services",
+				disabled: !serverUtils.isEdge(params.node.data) && serverUtils.isOrigin(params.node.data),
+				action: function () {
+					locationUtils.navigateToPath("/servers/" + String(serverID) + "/delivery-services");
+				}
+			}
+		];
+	}
 
-    $scope.createServer = function() {
-        locationUtils.navigateToPath('/servers/new');
-    };
+	$scope.createServer = function() {
+		locationUtils.navigateToPath('/servers/new');
+	};
 
-    $scope.confirmCDNQueueServerUpdates = function(cdn) {
-        var params;
-        if (cdn) {
-            params = {
-                title: 'Queue Server Updates: ' + cdn.name,
-                message: 'Are you sure you want to queue server updates for all ' + cdn.name + ' servers?'
-            };
-            var modalInstance = $uibModal.open({
-                templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
-                controller: 'DialogConfirmController',
-                size: 'md',
-                resolve: {
-                    params: function () {
-                        return params;
-                    }
-                }
-            });
-            modalInstance.result.then(function() {
-                queueCDNServerUpdates(cdn.id);
-            }, function () {
-                // do nothing
-            });
-        } else {
-            params = {
-                title: 'Queue Server Updates',
-                message: "Please select a CDN"
-            };
-            var modalInstance = $uibModal.open({
-                templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
-                controller: 'DialogSelectController',
-                size: 'md',
-                resolve: {
-                    params: function () {
-                        return params;
-                    },
-                    collection: function(cdnService) {
-                        return cdnService.getCDNs();
-                    }
-                }
-            });
-            modalInstance.result.then(function(cdn) {
-                queueCDNServerUpdates(cdn.id);
-            }, function () {
-                // do nothing
-            });
-        }
-    };
+	$scope.confirmCDNQueueServerUpdates = function(cdn) {
+		var params;
+		if (cdn) {
+			params = {
+				title: 'Queue Server Updates: ' + cdn.name,
+				message: 'Are you sure you want to queue server updates for all ' + cdn.name + ' servers?'
+			};
+			var modalInstance = $uibModal.open({
+				templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
+				controller: 'DialogConfirmController',
+				size: 'md',
+				resolve: {
+					params: function () {
+						return params;
+					}
+				}
+			});
+			modalInstance.result.then(function() {
+				queueCDNServerUpdates(cdn.id);
+			}, function () {
+				// do nothing
+			});
+		} else {
+			params = {
+				title: 'Queue Server Updates',
+				message: "Please select a CDN"
+			};
+			var modalInstance = $uibModal.open({
+				templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+				controller: 'DialogSelectController',
+				size: 'md',
+				resolve: {
+					params: function () {
+						return params;
+					},
+					collection: function(cdnService) {
+						return cdnService.getCDNs();
+					}
+				}
+			});
+			modalInstance.result.then(function(cdn) {
+				queueCDNServerUpdates(cdn.id);
+			}, function () {
+				// do nothing
+			});
+		}
+	};
 
-    $scope.confirmCDNClearServerUpdates = function(cdn) {
-        var params;
-        if (cdn) {
-            params = {
-                title: 'Clear Server Updates: ' + cdn.name,
-                message: 'Are you sure you want to clear server updates for all ' + cdn.name + ' servers?'
-            };
-            var modalInstance = $uibModal.open({
-                templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
-                controller: 'DialogConfirmController',
-                size: 'md',
-                resolve: {
-                    params: function () {
-                        return params;
-                    }
-                }
-            });
-            modalInstance.result.then(function() {
-                clearCDNServerUpdates(cdn.id);
-            }, function () {
-                // do nothing
-            });
+	$scope.confirmCDNClearServerUpdates = function(cdn) {
+		var params;
+		if (cdn) {
+			params = {
+				title: 'Clear Server Updates: ' + cdn.name,
+				message: 'Are you sure you want to clear server updates for all ' + cdn.name + ' servers?'
+			};
+			var modalInstance = $uibModal.open({
+				templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
+				controller: 'DialogConfirmController',
+				size: 'md',
+				resolve: {
+					params: function () {
+						return params;
+					}
+				}
+			});
+			modalInstance.result.then(function() {
+				clearCDNServerUpdates(cdn.id);
+			}, function () {
+				// do nothing
+			});
 
 
-        } else {
-            params = {
-                title: 'Clear Server Updates',
-                message: "Please select a CDN"
-            };
-            var modalInstance = $uibModal.open({
-                templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
-                controller: 'DialogSelectController',
-                size: 'md',
-                resolve: {
-                    params: function () {
-                        return params;
-                    },
-                    collection: function(cdnService) {
-                        return cdnService.getCDNs();
-                    }
-                }
-            });
-            modalInstance.result.then(function(cdn) {
-                clearCDNServerUpdates(cdn.id);
-            }, function () {
-                // do nothing
-            });
-        }
-    };
+		} else {
+			params = {
+				title: 'Clear Server Updates',
+				message: "Please select a CDN"
+			};
+			var modalInstance = $uibModal.open({
+				templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
+				controller: 'DialogSelectController',
+				size: 'md',
+				resolve: {
+					params: function () {
+						return params;
+					},
+					collection: function(cdnService) {
+						return cdnService.getCDNs();
+					}
+				}
+			});
+			modalInstance.result.then(function(cdn) {
+				clearCDNServerUpdates(cdn.id);
+			}, function () {
+				// do nothing
+			});
+		}
+	};
 
-    $scope.refresh = function() {
-        $state.reload(); // reloads all the resolves for the view
-    };
+	$scope.refresh = function() {
+		$state.reload(); // reloads all the resolves for the view
+	};
 
-    $scope.toggleVisibility = function(col) {
-        const visible = $scope.gridOptions.columnApi.getColumn(col).isVisible();
-        $scope.gridOptions.columnApi.setColumnVisible(col, !visible);
-        try {
-            colsVisible = $scope.gridOptions.columnApi.getAllColumns().map(function(x){return [x.colId, x.isVisible()]});
-            localStorage.setItem("servers_table_columns", JSON.stringify(colsVisible));
-        } catch (e) {
-            console.error("Failed to store column defs to local storage:", e);
-        }
-        $scope.gridOptions.api.sizeColumnsToFit();
-    };
+	$scope.toggleVisibility = function(col) {
+		const visible = $scope.gridOptions.columnApi.getColumn(col).isVisible();
+		$scope.gridOptions.columnApi.setColumnVisible(col, !visible);
+		try {
+			colsVisible = $scope.gridOptions.columnApi.getAllColumns().map(function(x){return [x.colId, x.isVisible()]});
+			localStorage.setItem("servers_table_columns", JSON.stringify(colsVisible));
+		} catch (e) {
+			console.error("Failed to store column defs to local storage:", e);
+		}
+		$scope.gridOptions.api.sizeColumnsToFit();
+	};
 
-    $scope.ssh = serverUtils.ssh;
+	$scope.isOffline = serverUtils.isOffline;
 
-    $scope.isOffline = serverUtils.isOffline;
+	$scope.offlineReason = serverUtils.offlineReason;
 
-    $scope.offlineReason = serverUtils.offlineReason;
+	$scope.getRelativeTime = dateUtils.getRelativeTime;
 
-    $scope.getRelativeTime = dateUtils.getRelativeTime;
+	var init = function () {
+		getStatuses();
+	};
+	init();
 
-    $scope.navigateToPath = locationUtils.navigateToPath;
-
-    var init = function () {
-        getStatuses();
-    };
-    init();
-
-    angular.element(document).ready(function () {
-        try {
-            // need to create the show/hide column checkboxes and bind to the current visibility
-            // TODO: figure out how to do this with getColumnState and setColumnState.
-            const colstates = JSON.parse(localStorage.getItem("servers_table_columns"));
-            if (colstates) {
-                for (let i = 0; i<colstates.length; ++i) {
-                    const colId = colstates[i][0];
-                    const isVisible = colstates[i][1];
-                    $scope.gridOptions.columnApi.setColumnVisible(colId, isVisible);
-                }
-            }
-        } catch (e) {
-            console.error("Failure to retrieve required column info from localStorage (key=servers_table_columns):", e);
-        }
-    });
+	angular.element(document).ready(function () {
+		try {
+			// need to create the show/hide column checkboxes and bind to the current visibility
+			// TODO: figure out how to do this with getColumnState and setColumnState.
+			const colstates = JSON.parse(localStorage.getItem("servers_table_columns"));
+			if (colstates) {
+				for (let i = 0; i<colstates.length; ++i) {
+					const colId = colstates[i][0];
+					const isVisible = colstates[i][1];
+					$scope.gridOptions.columnApi.setColumnVisible(colId, isVisible);
+				}
+			}
+		} catch (e) {
+			console.error("Failure to retrieve required column info from localStorage (key=servers_table_columns):", e);
+		}
+	});
 
 };
 

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -295,13 +295,9 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		serverService.queueServerUpdates(server.id).then($scope.refresh);
 	};
 
-	var clearServerUpdates = function(server) {
-		serverService.clearServerUpdates(server.id)
-			.then(
-				function() {
-					$scope.refresh();
-				}
-			);
+	$scope.clearServerUpdates = function(server, event) {
+		event.stopPropagation();
+		serverService.clearServerUpdates(server.id).then($scope.refresh);
 	};
 
 	var queueCDNServerUpdates = function(cdnId) {

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var TableServersController = function(servers, $scope, $state, $uibModal, $window, dateUtils, locationUtils, serverUtils, cdnService, serverService, statusService, propertiesModel, messageModel, userModel) {
+var TableServersController = function(servers, $scope, $state, $uibModal, $window, dateUtils, locationUtils, serverUtils, cdnService, serverService, statusService, propertiesModel, messageModel, userModel, $document) {
 
 	// browserify can't handle classes...
 	function SSHCellRenderer() {}
@@ -395,6 +395,9 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 	$scope.columns = [];
 
 	$scope.serverlink = "/#!/servers/";
+	$scope.hostname = "";
+	$scope.domain = "";
+	$scope.serverID = -1;
 
 	$scope.gridOptions = {
 		components: {
@@ -423,7 +426,12 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			params.event.preventDefault();
 			console.log(params);
 			$scope.showMenu = true;
+			$scope.menuStyle.left = String(params.event.pageX) + "px";
+			$scope.menuStyle.top = String(params.event.pageY) + "px";
 			$scope.serverlink = "/#!/servers/" + String(params.data.id);
+			$scope.hostname = params.data.hostName;
+			$scope.domain = params.data.domainName;
+			$scope.serverID = params.data.id;
 			$scope.$apply();
 		}
 	};
@@ -659,7 +667,13 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		}
 	});
 
+	$document.bind("click", function(e) {
+		$scope.showMenu = false;
+		e.stopPropagation();
+		$scope.$apply();
+	});
+
 };
 
-TableServersController.$inject = ['servers', '$scope', '$state', '$uibModal', '$window', 'dateUtils', 'locationUtils', 'serverUtils', 'cdnService', 'serverService', 'statusService', 'propertiesModel', 'messageModel', "userModel"];
+TableServersController.$inject = ['servers', '$scope', '$state', '$uibModal', '$window', 'dateUtils', 'locationUtils', 'serverUtils', 'cdnService', 'serverService', 'statusService', 'propertiesModel', 'messageModel', "userModel", "$document"];
 module.exports = TableServersController;

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -290,13 +290,9 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		);
 	};
 
-	var queueServerUpdates = function(server) {
-		serverService.queueServerUpdates(server.id)
-			.then(
-				function() {
-					$scope.refresh();
-				}
-			);
+	$scope.queueServerUpdates = function(server, event) {
+		event.stopPropagation();
+		serverService.queueServerUpdates(server.id).then($scope.refresh);
 	};
 
 	var clearServerUpdates = function(server) {
@@ -533,6 +529,10 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			}
 		];
 	}
+
+	$scope.isCache = serverUtils.isCache;
+	$scope.isEdge = serverUtils.isEdge;
+	$scope.isOrigin = serverUtils.isOrigin;
 
 	$scope.menuStyle = {
 		left: 0,

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -37,9 +37,9 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		this.eGui.setAttribute("title", String(params.value));
 		this.eGui.classList.add("fa", "fa-lg");
 		if (params.value) {
-			this.eGui.classList.add("fa-check");
-		} else {
 			this.eGui.classList.add("fa-clock-o");
+		} else {
+			this.eGui.classList.add("fa-check");
 		}
 	}
 	UpdateCellRenderer.prototype.getGui = function() {return this.eGui;};
@@ -381,7 +381,6 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		};
 		$scope.gridOptions.api.exportDataAsCsv(params);
 	}
-
 
 	/**** Context menu functions ****/
 

--- a/traffic_portal/app/src/common/modules/table/servers/index.js
+++ b/traffic_portal/app/src/common/modules/table/servers/index.js
@@ -18,4 +18,5 @@
  */
 
 module.exports = angular.module('trafficPortal.table.servers', [])
-    .controller('TableServersController', require('./TableServersController'));
+    .controller('TableServersController', require('./TableServersController'))
+    .controller('TableParentServersController', require('./TableParentServersController'));

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -85,7 +85,7 @@ under the License.
         </li>
         <hr class="divider"/>
         <li role="menuitem" ng-if="showCharts">
-            <a ng-href="chartsBase{{server.hostName}}" target="_blank">Show Charts</a>
+            <a ng-href="{{chartsBase}}{{server.hostName}}" target="_blank">Show Charts</a>
         </li>
         <hr class="divider"/>
         <li role="menuitem" ng-show="isCache(server)">

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -69,8 +69,13 @@ under the License.
         <li role="menuitem">
             <a ng-href="/#!/servers/{{server.id}}" target="_blank">Edit</a>
         </li>
-        <li role="divider">
-            <button type="button" ng-click="confirmDelete($event)">Delete</button>
+        <li role="menuitem">
+            <button type="button" ng-click="confirmDelete(server, $event)">Delete</button>
         </li>
+        <hr class="divider"/>
+        <li role="menuitem">
+            <button type="button" ng-click="confirmStatusUpdate(server, $event)">Update Status</button>
+        </li>
+
     </ul>
 </menu>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -76,6 +76,22 @@ under the License.
         <li role="menuitem">
             <button type="button" ng-click="confirmStatusUpdate(server, $event)">Update Status</button>
         </li>
-
+        <li role="menuitem">
+            <button type="button" ng-click="queueServerUpdates(server, $event)" ng-disabled="!isCache(server) || server.updPending">Queue Server Updates</button>
+        </li>
+        <li role="menuitem">
+            <button>Clear Server Updates</button>
+        </li>
+        <hr class="divider"/>
+        <li role="menuitem">
+            <a href="">Show Charts</a>
+        </li>
+        <hr class="divider"/>
+        <li role="menuitem">
+            <a href="">Manage Capabilities </a>
+        </li>
+        <li role="menuitem">
+            <a href="">Manage Delivery Services</a>
+        </li>
     </ul>
 </menu>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -23,7 +23,7 @@ under the License.
             <li class="active">Servers</li>
         </ol>
         <div class="pull-right">
-            <button class="btn btn-primary" name="createServersButton" title="Create Server" ng-click="createServer()"><i class="fa fa-plus"></i></button>
+            <a class="btn btn-primary" name="createServersButton" title="Create Server" href="#!/servers/new"><i class="fa fa-plus"></i></a>
             <button class="btn btn-default" title="Refresh" ng-click="refresh()"><i class="fa fa-refresh"></i></button>
             <div id="toggleColumns" class="btn-group" role="group" title="Select Table Columns" uib-dropdown is-open="columnSettings.isopen">
                 <button type="button" class="btn btn-default dropdown-toggle" uib-dropdown-toggle aria-haspopup="true" aria-expanded="false">
@@ -59,7 +59,7 @@ under the License.
 <menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu" ng-click="$event.stopPropagation()">
     <ul>
         <li role="menuitem">
-            <a ng-href="/#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>
+            <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>
         </li>
         <hr class="divider"/>
         <li role="menuitem">
@@ -67,7 +67,7 @@ under the License.
         </li>
         <hr class="divider"/>
         <li role="menuitem">
-            <a ng-href="/#!/servers/{{server.id}}" target="_blank">Edit</a>
+            <a ng-href="#!/servers/{{server.id}}" target="_blank">Edit</a>
         </li>
         <li role="menuitem">
             <button type="button" ng-click="confirmDelete(server, $event)">Delete</button>
@@ -88,7 +88,7 @@ under the License.
         </li>
         <hr class="divider"/>
         <li role="menuitem" ng-show="isCache(server)">
-            <a ng-href="/#!/servers/{{server.id}}/capabilities">Manage Capabilities</a>
+            <a ng-href="#!/servers/{{server.id}}/capabilities">Manage Capabilities</a>
         </li>
         <li role="menuitem" ng-show="isEdge(server) || isOrigin(server)">
             <a ng-href="#!/servers/{{server.id}}/delivery-services">Manage Delivery Services</a>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -59,7 +59,7 @@ under the License.
 <menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu" ng-click="$event.stopPropagation()">
     <ul>
         <li role="menuitem">
-            <a ng-href="{{serverlink}}" target="_blank">Open in New Tab</a>
+            <a ng-href="/#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>
         </li>
         <hr class="divider"/>
         <li role="menuitem">
@@ -83,15 +83,15 @@ under the License.
             <button type="button" ng-click="clearServerUpdates(server, $event)" ng-disabled="!isCache(server) || !server.updPending">Clear Server Updates</button>
         </li>
         <hr class="divider"/>
-        <li role="menuitem">
-            <a href="">Show Charts</a>
+        <li role="menuitem" ng-if="showCharts">
+            <a ng-href="chartsBase{{server.hostName}}" target="_blank">Show Charts</a>
         </li>
         <hr class="divider"/>
-        <li role="menuitem">
-            <a href="">Manage Capabilities </a>
+        <li role="menuitem" ng-show="isCache(server)">
+            <a ng-href="/#!/servers/{{server.id}}/capabilities">Manage Capabilities</a>
         </li>
-        <li role="menuitem">
-            <a href="">Manage Delivery Services</a>
+        <li role="menuitem" ng-show="isEdge(server) || isOrigin(server)">
+            <a ng-href="#!/servers/{{server.id}}/delivery-services">Manage Delivery Services</a>
         </li>
     </ul>
 </menu>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -16,12 +16,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<style type="text/css">
-    menu[type="contextmenu"] li:hover {
-        color: #262626;
-        background-color: #f5f5f5;
-    }
-</style>
 
 <div class="x_panel">
     <div class="x_title">
@@ -59,13 +53,22 @@ under the License.
     </div>
     <div class="x_content">
         <div style="height: 740px;" ag-grid="gridOptions" class="ag-theme-alpine"></div>
-        <menu class="dropdown-menu" style="display: block; position: fixed; background-color: white; padding: 0; box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175); border-radius: 3px;" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
-            <ul style="list-style: none; display: block; font-weight: normal; line-height: 1.428571429; white-space: nowrap; padding: 0; margin: 0;">
-                <li style="clear: both; display: block;" role="menuitem"><a style="color: #333333; text-decoration: none; padding: 7px 20px; display: block; clear: both;" ng-href="{{serverlink}}" target="_blank">Open in New Tab</a></li>
-                <hr class="divider" style="margin: 0"/>
-                <li style="clear: both; display: block;" role="menuitem"><a style="color: #333333; text-decoration: none; padding: 7px 20px; display: block; clear: both;" ng-href="http://{{hostname}}.{{domain}}" target="_blank">Navigate To Server FQDN</a></li>
-                <hr class="divider" style="margin: 0"/>
-                <li style="clear: both; display: block;" role="menuitem"><a style="color: #333333; text-decoration: none; padding: 7px 20px; display: block; clear: both;" ng-href="/#!/servers/{{serverID}}" target="_blank">Edit Server</a></li>
+        <menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu" ng-click="$event.stopPropagation()">
+            <ul>
+                <li role="menuitem">
+                    <a ng-href="{{serverlink}}" target="_blank">Open in New Tab</a>
+                </li>
+                <hr class="divider"/>
+                <li role="menuitem">
+                    <a ng-href="http://{{server.hostName}}.{{server.domainName}}" target="_blank">Navigate To Server FQDN</a>
+                </li>
+                <hr class="divider"/>
+                <li role="menuitem">
+                    <a ng-href="/#!/servers/{{server.id}}" target="_blank">Edit</a>
+                </li>
+                <li role="divider">
+                    <button type="button" ng-click="confirmDelete($event)">Delete</button>
+                </li>
             </ul>
         </menu>
     </div>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -16,6 +16,12 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+<style type="text/css">
+    menu[type="contextmenu"] li:hover {
+        color: #262626;
+        background-color: #f5f5f5;
+    }
+</style>
 
 <div class="x_panel">
     <div class="x_title">
@@ -52,10 +58,14 @@ under the License.
         <div class="clearfix"></div>
     </div>
     <div class="x_content">
-        <div style="height: 500px;" ag-grid="gridOptions" class="ag-theme-alpine"></div>
-        <menu ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
-            <ul>
-                <li role="menuitem"><a ng-href="{{serverlink}}" target="_blank">Open in New Tab</a></li>
+        <div style="height: 740px;" ag-grid="gridOptions" class="ag-theme-alpine"></div>
+        <menu class="dropdown-menu" style="display: block; position: fixed; background-color: white; padding: 0; box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175); border-radius: 3px;" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+            <ul style="list-style: none; display: block; font-weight: normal; line-height: 1.428571429; white-space: nowrap; padding: 0; margin: 0;">
+                <li style="clear: both; display: block;" role="menuitem"><a style="color: #333333; text-decoration: none; padding: 7px 20px; display: block; clear: both;" ng-href="{{serverlink}}" target="_blank">Open in New Tab</a></li>
+                <hr class="divider" style="margin: 0"/>
+                <li style="clear: both; display: block;" role="menuitem"><a style="color: #333333; text-decoration: none; padding: 7px 20px; display: block; clear: both;" ng-href="http://{{hostname}}.{{domain}}" target="_blank">Navigate To Server FQDN</a></li>
+                <hr class="divider" style="margin: 0"/>
+                <li style="clear: both; display: block;" role="menuitem"><a style="color: #333333; text-decoration: none; padding: 7px 20px; display: block; clear: both;" ng-href="/#!/servers/{{serverID}}" target="_blank">Edit Server</a></li>
             </ul>
         </menu>
     </div>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -138,7 +138,4 @@ under the License.
         </table>
     </div>
 </div>
-
-
-
-
+<div ag-grid="gridOptions" class="ag-theme-alpine"></div>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -46,6 +46,7 @@ under the License.
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="confirmCDNQueueServerUpdates(null)">Queue CDN Server Updates</a></li>
                     <li role="menuitem"><a ng-click="confirmCDNClearServerUpdates(null)">Clear CDN Server Updates</a></li>
+                    <li role="menuitem"><button class="menu-item-button" type="button" ng-click="exportCSV()">Export CSV</button></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -80,7 +80,7 @@ under the License.
             <button type="button" ng-click="queueServerUpdates(server, $event)" ng-disabled="!isCache(server) || server.updPending">Queue Server Updates</button>
         </li>
         <li role="menuitem">
-            <button>Clear Server Updates</button>
+            <button type="button" ng-click="clearServerUpdates(server, $event)" ng-disabled="!isCache(server) || !server.updPending">Clear Server Updates</button>
         </li>
         <hr class="divider"/>
         <li role="menuitem">

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -31,9 +31,9 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <menu ng-click="$event.stopPropagation()" class="column-settings dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem" ng-repeat="c in columns | orderBy:'name'">
+                    <li role="menuitem" ng-repeat="c in gridOptions.columnApi.getAllColumns() | orderBy:'colDef.headerName'">
                         <div class="checkbox">
-                            <label><input type="checkbox" ng-model="c.visible" ng-click="toggleVisibility(c.name)"> {{::c.name}}</label>
+                            <label><input type="checkbox" ng-checked="c.isVisible()" ng-click="toggleVisibility(c.colId)">{{::c.colDef.headerName}}</label>
                         </div>
                     </li>
                 </menu>
@@ -52,90 +52,6 @@ under the License.
         <div class="clearfix"></div>
     </div>
     <div class="x_content">
-        <br>
-        <table id="serversTable" class="table responsive-utilities jambo_table">
-            <thead>
-                <tr class="headings">
-                    <th>Cache Group</th>
-                    <th>CDN</th>
-                    <th>Domain</th>
-                    <th>Host</th>
-                    <th>HTTPS Port</th>
-                    <th>ID</th>
-                    <th>ILO IP Address</th>
-                    <th>ILO IP Gateway</th>
-                    <th>ILO IP Netmask</th>
-                    <th>ILO Username</th>
-                    <th>Interface Name</th>
-                    <th>IPv6 Address</th>
-                    <th>IPv6 Gateway</th>
-                    <th>Last Updated</th>
-                    <th>Mgmt IP Address</th>
-                    <th>Mgmt IP Gateway</th>
-                    <th>Mgmt IP Netmask</th>
-                    <th>Network Gateway</th>
-                    <th>Network IP</th>
-                    <th>Network MTU</th>
-                    <th>Network Subnet</th>
-                    <th>Offline Reason</th>
-                    <th>Phys Location</th>
-                    <th>Profile</th>
-                    <th>Rack</th>
-                    <th>Reval Pending</th>
-                    <th>Router Hostname</th>
-                    <th>Router Port Name</th>
-                    <th>Status</th>
-                    <th>TCP Port</th>
-                    <th>Type</th>
-                    <th>Update Pending</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr ng-click="editServer(s.id)" ng-repeat="s in ::servers" ng-class="::{'active': s.updPending}" context-menu="contextMenuItems">
-                    <td data-search="^{{::s.cachegroup}}$">{{::s.cachegroup}}</td>
-                    <td data-search="^{{::s.cdnName}}$">{{::s.cdnName}}</td>
-                    <td data-search="^{{::s.domainName}}$">{{::s.domainName}}</td>
-                    <td name="hostName" data-search="^{{::s.hostName}}$">{{::s.hostName}}</td>
-                    <td data-search="^{{::s.httpsPort}}$">{{::s.httpsPort}}</td>
-                    <td data-search="^{{::s.id}}$">{{::s.id}}</td>
-                    <td data-search="^{{::s.iloIpAddress}}$"><a ng-click="ssh(s.iloIpAddress, $event)">{{::s.iloIpAddress}}</a></td>
-                    <td data-search="^{{::s.iloIpGateway}}$"><a ng-click="ssh(s.iloIpGateway, $event)">{{::s.iloIpGateway}}</a></td>
-                    <td data-search="^{{::s.iloIpNetmask}}$">{{::s.iloIpNetmask}}</td>
-                    <td data-search="^{{::s.iloUsername}}$">{{::s.iloUsername}}</td>
-                    <td data-search="^{{::s.interfaceName}}$">{{::s.interfaceName}}</td>
-                    <td data-search="^{{::s.ip6Address}}$">{{::s.ip6Address}}</td>
-                    <td data-search="^{{::s.ip6Gateway}}$">{{::s.ip6Gateway}}</td>
-                    <td data-search="^{{::getRelativeTime(s.lastUpdated)}}$" data-order="{{::s.lastUpdated}}">{{::getRelativeTime(s.lastUpdated)}}</td>
-                    <td data-search="^{{::s.mgmtIpAddress}}$"><a ng-click="ssh(s.mgmtIpAddress, $event)">{{::s.mgmtIpAddress}}</a></td>
-                    <td data-search="^{{::s.mgmtIpGateway}}$"><a ng-click="ssh(s.mgmtIpGateway, $event)">{{::s.mgmtIpGateway}}</a></td>
-                    <td data-search="^{{::s.mgmtIpNetmask}}$">{{::s.mgmtIpNetmask}}</td>
-                    <td data-search="^{{::s.ipGateway}}$"><a ng-click="ssh(s.ipGateway, $event)">{{::s.ipGateway}}</a></td>
-                    <td data-search="^{{::s.ipAddress}}$"><a ng-click="ssh(s.ipAddress, $event)">{{::s.ipAddress}}</a></td>
-                    <td data-search="^{{::s.interfaceMtu}}$">{{::s.interfaceMtu}}</td>
-                    <td data-search="^{{::s.ipNetmask}}$">{{::s.ipNetmask}}</td>
-                    <td data-search="^{{::s.offlineReason}}$">{{::s.offlineReason}}</td>
-                    <td data-search="^{{::s.physLocation}}$">{{::s.physLocation}}</td>
-                    <td data-search="^{{::s.profile}}$">{{::s.profile}}</td>
-                    <td data-search="^{{::s.rack}}$">{{::s.rack}}</td>
-                    <td data-search="{{(s.revalPending) ? 'RVL' : ''}}" data-order="{{::s.revalPending}}">
-                        <i title="Reval Pending (RVL)" ng-show="s.revalPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
-                        <i title="Reval Applied" ng-show="!s.revalPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
-                    </td>
-                    <td data-search="^{{::s.routerHostName}}$">{{::s.routerHostName}}</td>
-                    <td data-search="^{{::s.routerPortName}}$">{{::s.routerPortName}}</td>
-                    <td data-search="^{{::s.status}}$">
-                        <span ng-if="!isOffline(s.status)">{{::s.status}}</span>
-                        <span ng-if="isOffline(s.status)" uib-popover="{{::offlineReason(s)}}" popover-title="Offline Reason" popover-trigger="mouseenter" popover-placement="bottom" popover-append-to-body="true">{{::s.status}}</span>
-                    </td>
-                    <td data-search="^{{::s.tcpPort}}$">{{::s.tcpPort}}</td>
-                    <td data-search="^{{::s.type}}$">{{::s.type}}</td>
-                    <td data-search="{{(s.updPending) ? 'UPD' : ''}}" data-order="{{::s.updPending}}">
-                        <i title="Updates Pending (UPD)" ng-show="s.updPending" class="fa fa-clock-o fa-lg" aria-hidden="true"></i>
-                        <i title="Updates Applied" ng-show="!s.updPending" class="fa fa-check fa-lg" aria-hidden="true"></i>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+        <div style="height: 500px;" ag-grid="gridOptions" class="ag-theme-alpine"></div>
     </div>
 </div>
-<div ag-grid="gridOptions" class="ag-theme-alpine"></div>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -57,7 +57,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu" ng-click="$event.stopPropagation()">
+<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>
@@ -68,7 +68,7 @@ under the License.
         </li>
         <hr class="divider"/>
         <li role="menuitem">
-            <a ng-href="#!/servers/{{server.id}}" target="_blank">Edit</a>
+            <a ng-href="#!/servers/{{server.id}}">Edit</a>
         </li>
         <li role="menuitem">
             <button type="button" ng-click="confirmDelete(server, $event)">Delete</button>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -53,23 +53,24 @@ under the License.
     </div>
     <div class="x_content">
         <div style="height: 740px;" ag-grid="gridOptions" class="ag-theme-alpine"></div>
-        <menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu" ng-click="$event.stopPropagation()">
-            <ul>
-                <li role="menuitem">
-                    <a ng-href="{{serverlink}}" target="_blank">Open in New Tab</a>
-                </li>
-                <hr class="divider"/>
-                <li role="menuitem">
-                    <a ng-href="http://{{server.hostName}}.{{server.domainName}}" target="_blank">Navigate To Server FQDN</a>
-                </li>
-                <hr class="divider"/>
-                <li role="menuitem">
-                    <a ng-href="/#!/servers/{{server.id}}" target="_blank">Edit</a>
-                </li>
-                <li role="divider">
-                    <button type="button" ng-click="confirmDelete($event)">Delete</button>
-                </li>
-            </ul>
-        </menu>
     </div>
 </div>
+
+<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu" ng-click="$event.stopPropagation()">
+    <ul>
+        <li role="menuitem">
+            <a ng-href="{{serverlink}}" target="_blank">Open in New Tab</a>
+        </li>
+        <hr class="divider"/>
+        <li role="menuitem">
+            <a ng-href="http://{{server.hostName}}.{{server.domainName}}" target="_blank">Navigate To Server FQDN</a>
+        </li>
+        <hr class="divider"/>
+        <li role="menuitem">
+            <a ng-href="/#!/servers/{{server.id}}" target="_blank">Edit</a>
+        </li>
+        <li role="divider">
+            <button type="button" ng-click="confirmDelete($event)">Delete</button>
+        </li>
+    </ul>
+</menu>

--- a/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/servers/table.servers.tpl.html
@@ -53,5 +53,10 @@ under the License.
     </div>
     <div class="x_content">
         <div style="height: 500px;" ag-grid="gridOptions" class="ag-theme-alpine"></div>
+        <menu ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+            <ul>
+                <li role="menuitem"><a ng-href="{{serverlink}}" target="_blank">Open in New Tab</a></li>
+            </ul>
+        </menu>
     </div>
 </div>

--- a/traffic_portal/app/src/common/modules/table/statusServers/TableStatusServersController.js
+++ b/traffic_portal/app/src/common/modules/table/statusServers/TableStatusServersController.js
@@ -19,8 +19,8 @@
 
 var TableStatusServersController = function(status, servers, $controller, $scope) {
 
-	// extends the TableServersController to inherit common methods
-	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
+	// extends the TableParentServersController to inherit common methods
+	angular.extend(this, $controller('TableParentServersController', { servers: servers, $scope: $scope }));
 
 	let statusServersTable;
 

--- a/traffic_portal/app/src/common/modules/table/typeServers/TableTypeServersController.js
+++ b/traffic_portal/app/src/common/modules/table/typeServers/TableTypeServersController.js
@@ -19,8 +19,8 @@
 
 var TableTypeServersController = function(type, servers, $controller, $scope) {
 
-	// extends the TableServersController to inherit common methods
-	angular.extend(this, $controller('TableServersController', { servers: servers, $scope: $scope }));
+	// extends the TableParentServersController to inherit common methods
+	angular.extend(this, $controller('TableParentServersController', { servers: servers, $scope: $scope }));
 
 	let typeServersTable;
 

--- a/traffic_portal/app/src/index.html
+++ b/traffic_portal/app/src/index.html
@@ -49,6 +49,7 @@ under the License.
         <div class="app container body" ui-view></div>
 
         <script src="resources/assets/js/shared-libs.js"></script>
+        <script src="resources/assets/js/ag-grid-community/dist/ag-grid-community.min.js"></script>
         <script src="resources/assets/js/app.js"></script>
         <script src="resources/assets/js/config.js"></script>
 

--- a/traffic_portal/grunt/browserify2.js
+++ b/traffic_portal/grunt/browserify2.js
@@ -25,6 +25,11 @@ module.exports = {
             expose: {
                 files: [
                     {
+                        cwd: "<%= globalConfig.importdir %>",
+                        src: ["ag-grid-community/dist/ag-grid-community.min.js"],
+                        rename: function () { return "ag-grid-community-min.js"; }
+                    },
+                    {
                         cwd: '<%= globalConfig.app %>/bower_components/',
                         src:
                             [
@@ -86,10 +91,15 @@ module.exports = {
             expose: {
                 files: [
                     {
+                        cwd: "<%= globalConfig.importdir %>",
+                        src: ["ag-grid-community/dist/ag-grid-community.min.js"],
+                        rename: function () { return "ag-grid-community.js"; }
+                    },
+                    {
                         cwd: '<%= globalConfig.app %>/bower_components/',
                         src:
                             [
-                                'angular/angular.js',
+                                // 'angular/angular.js',
                                 'angular-animate/angular-animate.js',
                                 'angular-bootstrap-contextmenu/contextMenu.js',
                                 'angular-bootstrap/ui-bootstrap.js',
@@ -105,6 +115,11 @@ module.exports = {
                                 'jquery/jquery.js',
                                 'json3/lib/json3.js'
                             ]
+                    },
+                    {
+                        cwd: "<%= globalConfig.importdir %>",
+                        src: ["angular/angular.min.js"],
+                        rename: function() {return "angular/angular.js";}
                     },
                     {
                         cwd: '<%= globalConfig.app %>/bower_components/',

--- a/traffic_portal/grunt/browserify2.js
+++ b/traffic_portal/grunt/browserify2.js
@@ -25,11 +25,6 @@ module.exports = {
             expose: {
                 files: [
                     {
-                        cwd: "<%= globalConfig.importdir %>",
-                        src: ["ag-grid-community/dist/ag-grid-community.min.js"],
-                        rename: function () { return "ag-grid-community-min.js"; }
-                    },
-                    {
                         cwd: '<%= globalConfig.app %>/bower_components/',
                         src:
                             [

--- a/traffic_portal/grunt/browserify2.js
+++ b/traffic_portal/grunt/browserify2.js
@@ -91,11 +91,6 @@ module.exports = {
             expose: {
                 files: [
                     {
-                        cwd: "<%= globalConfig.importdir %>",
-                        src: ["ag-grid-community/dist/ag-grid-community.min.js"],
-                        rename: function () { return "ag-grid-community.js"; }
-                    },
-                    {
                         cwd: '<%= globalConfig.app %>/bower_components/',
                         src:
                             [

--- a/traffic_portal/grunt/browserify2.js
+++ b/traffic_portal/grunt/browserify2.js
@@ -94,7 +94,7 @@ module.exports = {
                         cwd: '<%= globalConfig.app %>/bower_components/',
                         src:
                             [
-                                // 'angular/angular.js',
+                                'angular/angular.js',
                                 'angular-animate/angular-animate.js',
                                 'angular-bootstrap-contextmenu/contextMenu.js',
                                 'angular-bootstrap/ui-bootstrap.js',
@@ -110,11 +110,6 @@ module.exports = {
                                 'jquery/jquery.js',
                                 'json3/lib/json3.js'
                             ]
-                    },
-                    {
-                        cwd: "<%= globalConfig.importdir %>",
-                        src: ["angular/angular.min.js"],
-                        rename: function() {return "angular/angular.js";}
                     },
                     {
                         cwd: '<%= globalConfig.app %>/bower_components/',

--- a/traffic_portal/grunt/copy.js
+++ b/traffic_portal/grunt/copy.js
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -42,6 +42,13 @@ module.exports = {
                     'traffic_portal_release.json',
                     'traffic_portal_properties.json'
                 ]
+            },
+            {
+                expand: true,
+                dot: true,
+                cwd: "<%= globalConfig.importdir %>",
+                dest: "<%= globalConfig.resourcesdir %>/assets/js/",
+                src: ["ag-grid-community/dist/ag-grid-community.min.js"]
             }
         ]
     },
@@ -78,6 +85,13 @@ module.exports = {
                     'traffic_portal_release.json',
                     'traffic_portal_properties.json'
                 ]
+            },
+            {
+                expand: true,
+                dot: true,
+                cwd: "<%= globalConfig.importdir %>",
+                dest: "<%= globalConfig.resourcesdir %>/assets/js/",
+                src: ["ag-grid-community/dist/ag-grid-community.min.js"]
             }
         ]
     }

--- a/traffic_portal/grunt/globalConfig.js
+++ b/traffic_portal/grunt/globalConfig.js
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,6 +21,7 @@ module.exports = function() {
     var globalConfig = {
         app: 'app',
         resourcesdir: 'app/dist/public/resources',
+        importdir: "node_modules",
         distdir: 'app/dist',
         srcserverdir: './server',
         srcdir: 'app/src',

--- a/traffic_portal/package-lock.json
+++ b/traffic_portal/package-lock.json
@@ -118,11 +118,6 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
-    "angular": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.0.tgz",
-      "integrity": "sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg=="
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",

--- a/traffic_portal/package-lock.json
+++ b/traffic_portal/package-lock.json
@@ -83,6 +83,11 @@
         }
       }
     },
+    "ag-grid-community": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-23.2.0.tgz",
+      "integrity": "sha512-aG7Ghfu79HeqOCd50GhFSeZUX1Tw9BVUX1VKMuglkAcwYPTQjuYvYT7QVQB5FGzfFjcVq4a1QFfcgdoAcZYJIA=="
+    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -112,6 +117,11 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
+    },
+    "angular": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.0.tgz",
+      "integrity": "sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg=="
     },
     "ansi-regex": {
       "version": "2.1.1",

--- a/traffic_portal/package.json
+++ b/traffic_portal/package.json
@@ -32,7 +32,6 @@
     "time-grunt": "1.3.0"
   },
   "dependencies": {
-    "ag-grid-community": "^23.2.0",
-    "angular": "^1.8.0"
+    "ag-grid-community": "^23.2.0"
   }
 }

--- a/traffic_portal/package.json
+++ b/traffic_portal/package.json
@@ -30,5 +30,9 @@
     "requirejs": "2.3.6",
     "ssl-root-cas": "1.3.1",
     "time-grunt": "1.3.0"
+  },
+  "dependencies": {
+    "ag-grid-community": "^23.2.0",
+    "angular": "^1.8.0"
   }
 }

--- a/traffic_portal/test/end_to_end/deliveryServices/delivery-services-spec.js
+++ b/traffic_portal/test/end_to_end/deliveryServices/delivery-services-spec.js
@@ -114,7 +114,7 @@ describe('Traffic Portal Delivery Services Suite', function() {
 		first.click();
 		expect(first.isSelected()).toBe(false);
 		let tableColumns = element.all(by.css('#deliveryServicesTable tr:first-child td'));
-		expect(tableColumns.count()).toBe(10);
+		expect(tableColumns.count()).toBe(11);
 	});
 
 	it('should update the ANY_MAP delivery service', function() {

--- a/traffic_portal/test/end_to_end/servers/servers-spec.js
+++ b/traffic_portal/test/end_to_end/servers/servers-spec.js
@@ -41,11 +41,6 @@ describe('Traffic Portal Servers Test Suite', function() {
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/servers");
 	});
 
-	it('should verify CSV link exists ', function() {
-		console.log("Verify CSV button exists");
-		expect(element(by.css('.dt-button.buttons-csv')).isPresent()).toBe(true);
-	});
-
 	it('should open new Servers form page', function() {
 		console.log('Clicking on Create new server ' + mockVals.hostName);
 		browser.driver.findElement(by.name('createServersButton')).click();
@@ -81,20 +76,14 @@ describe('Traffic Portal Servers Test Suite', function() {
 		expect(first.isSelected()).toBe(true);
 		first.click();
 		expect(first.isSelected()).toBe(false);
-		let tableColumns = element.all(by.css('#serversTable tr:first-child td'));
-		expect(tableColumns.count()).toBe(11);
+		let tableColumns = element.all(by.css('.ag-header-cell'));
+		expect(tableColumns.count()).toBe(9);
 	});
 
 	it('should verify the new Server and then update Server', function() {
 		console.log('Verifying new server added and updating ' + mockVals.hostName);
 		browser.sleep(1000);
-		pageData.searchFilter.sendKeys(mockVals.hostName);
-		browser.sleep(250);
-		element.all(by.repeater('s in ::servers')).filter(function(row){
-			return row.element(by.name('hostName')).getText().then(function(val){
-				return val === mockVals.hostName;
-			});
-		}).get(0).click();
+		element(by.cssContainingText('.ag-cell', mockVals.hostName)).click()
 		browser.sleep(1000);
 		pageData.domainName.clear();
 		pageData.domainName.sendKeys('testupdated.com');


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4354 and fixes #2624 and fixes #2326

Switches the "/servers" table from jQuery datatables to agGrid, increasing load speed by a factor of about 14.

The new tables have a superset of the functionality of the old tables.

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Run Traffic Portal - preferably with a whole ton of servers so you can be impressed by the lightning fast load speed (at least compared to the jQuery data tables).

If #4747 isn't merged yet then you'll need to be using a version of TO that doesn't include the changes from #4700 .

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**