### PR TITLE
adds slice plugin to collection used to display magic numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed audit logging from the `POST /api/x/serverchecks` Traffic Ops API endpoint in order to reduce audit log spam
 - Fixed audit logging from the `/jobs` APIs to bring them back to the same level of information provided by TO-Perl
 - Fixed `maxRevalDurationDays` validation for `POST /api/1.x/user/current/jobs` and added that validation to the `/api/x/jobs` endpoints
+- Fixed slice plugin error in delivery service request view. [Related github issue](https://github.com/apache/trafficcontrol/issues/4770)
 - Fixed update procedure of servers, so that if a server is linked to one or more delivery services, you cannot change its "cdn". [Related github issue](https://github.com/apache/trafficcontrol/issues/4116)
 - Fixed `POST /api/x/steering` and `PUT /api/x/steering` so that a steering target with an invalid `type` is no longer accepted. [Related github issue](https://github.com/apache/trafficcontrol/issues/3531)
 - Fixed `cachegroups` READ endpoint, so that if a request is made with the `type` specified as a non integer value, you get back a `400` with error details, instead of a `500`. [Related github issue](https://github.com/apache/trafficcontrol/issues/4703)

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -118,7 +118,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
     $scope.activeInactive = [
         { value: true, label: 'Active' },
         { value: false, label: 'Not Active'}
-    ]
+    ];
 
     $scope.signingAlgos = [
         { value: null, label: 'None' },
@@ -177,7 +177,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
     $scope.deepCachingTypes = [
         { value: 'NEVER', label: 'NEVER' },
         { value: 'ALWAYS', label: 'ALWAYS' }
-    ]
+    ];
 
     $scope.dispersions = [
         { value: 1, label: '1 - OFF' },
@@ -195,7 +195,8 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
     $scope.rrhs = [
         { value: 0, label: "Don't cache Range Requests" },
         { value: 1, label: "Use the background_fetch plugin" },
-        { value: 2, label: "Use the cache_range_requests plugin" }
+        { value: 2, label: "Use the cache_range_requests plugin" },
+        { value: 3, label: "Use the slice plugin" }
     ];
 
     $scope.msoAlgos = [


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4770 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
0. Run the UI tests.
1. ensure that ds requests are enabled in traffic_portal_properties.json
2. find a ds w/ range request handling set to slice plugin (or create/update one to have this selected.)
3. change the rr handling value to something other than slice and view the delivery service request and ensure the old (current) value (slice) is displayed properly.

## If this is a bug fix, what versions of Traffic Control are affected?
- master 
- 4.1.0 (RC1)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
