### PR TITLE
Use cachegroupIndex to find cachegroup type, not parentIndex

### DIFF
--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -2403,7 +2403,7 @@
         },
         {
             "name": "secondary-parents",
-            "description": "A cachegroup with secondary parents",
+            "description": "A topology with secondary parents",
             "nodes": [
                 {
                     "cachegroup": "parentCachegroup",

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -2380,12 +2380,14 @@
             "description": "another topology",
             "nodes": [
                 {
-                  "cachegroup": "parentCachegroup",
-                  "parents": []
+                    "cachegroup": "parentCachegroup",
+                    "parents": []
                 },
                 {
                     "cachegroup": "cachegroup1",
-                    "parents": [0]
+                    "parents": [
+                        0
+                    ]
                 },
                 {
                     "cachegroup": "secondaryCachegroup",
@@ -2393,7 +2395,89 @@
                 },
                 {
                     "cachegroup": "cachegroup2",
-                    "parents": [2]
+                    "parents": [
+                        2
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "secondary-parents",
+            "description": "A cachegroup with secondary parents",
+            "nodes": [
+                {
+                    "cachegroup": "parentCachegroup",
+                    "parent": "",
+                    "secParent": "",
+                    "parents": []
+                },
+                {
+                    "cachegroup": "cachegroup1",
+                    "parent": "parentCachegroup",
+                    "secParent": "secondaryCachegroup",
+                    "parents": [
+                        0,
+                        2
+                    ]
+                },
+                {
+                    "cachegroup": "secondaryCachegroup",
+                    "parent": "",
+                    "secParent": "",
+                    "parents": []
+                },
+                {
+                    "cachegroup": "fallback1",
+                    "parent": "secondaryCachegroup",
+                    "secParent": "parentCachegroup",
+                    "parents": [
+                        2,
+                        0
+                    ]
+                },
+                {
+                    "cachegroup": "fallback2",
+                    "parent": "secondaryCachegroup",
+                    "secParent": "parentCachegroup",
+                    "parents": [
+                        2,
+                        0
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "4-tiers",
+            "description": "A 4-tier topology",
+            "nodes": [
+                {
+                    "cachegroup": "parentCachegroup",
+                    "parents": []
+                },
+                {
+                    "cachegroup": "parentCachegroup2",
+                    "parents": [
+                        0
+                    ]
+                },
+                {
+                    "cachegroup": "cachegroup1",
+                    "parents": [
+                        1
+                    ]
+                },
+                {
+                    "cachegroup": "secondaryCachegroup",
+                    "parents": [
+                        1,
+                        0
+                    ]
+                },
+                {
+                    "cachegroup": "fallback1",
+                    "parents": [
+                        3
+                    ]
                 }
             ]
         }

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -61,7 +61,7 @@ func checkForEdgeParents(nodes []tc.TopologyNode, cachegroups []tc.CacheGroupNul
 			errs = append(errs, fmt.Errorf("parent %d of cachegroup %s refers to a cachegroup at index %d, but no such cachegroup exists", parentIndex, node.Cachegroup, cachegroupIndex))
 			break
 		}
-		cacheGroupType := cachegroups[parentIndex].Type
+		cacheGroupType := cachegroups[cachegroupIndex].Type
 		if *cacheGroupType == tc.CacheGroupEdgeTypeName {
 			errs = append(errs, fmt.Errorf("cachegroup %v's type is %v; it cannot be a parent of %v", nodes[parentIndex].Cachegroup, tc.CacheGroupEdgeTypeName, node.Cachegroup))
 		}

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -63,7 +63,7 @@ func checkForEdgeParents(nodes []tc.TopologyNode, cachegroups []tc.CacheGroupNul
 		}
 		cacheGroupType := cachegroups[cachegroupIndex].Type
 		if *cacheGroupType == tc.CacheGroupEdgeTypeName {
-			errs = append(errs, fmt.Errorf("cachegroup %v's type is %v; it cannot be a parent of %v", nodes[parentIndex].Cachegroup, tc.CacheGroupEdgeTypeName, node.Cachegroup))
+			errs = append(errs, fmt.Errorf("cachegroup %v's type is %v; it cannot be a parent of %v", nodes[cachegroupIndex].Cachegroup, tc.CacheGroupEdgeTypeName, node.Cachegroup))
 		}
 	}
 	return util.JoinErrs(errs)


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4772 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Make Rob's cachegroups, POST his topology, and make sure it succeeds:

```json
{
  "name": "Foo",
  "description": "bar",
  "nodes": [
    {
      "cachegroup": "mid-west",
      "parent": "",
      "secParent": "",
      "parents": []
    },
    {
      "cachegroup": "sacramento-ca-usa",
      "parent": "mid-west",
      "secParent": "mid-east",
      "parents": [
        0,
        2
      ]
    },
    {
      "cachegroup": "mid-east",
      "parent": "",
      "secParent": "",
      "parents": []
    },
    {
      "cachegroup": "albany-ny-usa",
      "parent": "mid-east",
      "secParent": "mid-west",
      "parents": [
        2,
        0
      ]
    },
    {
      "cachegroup": "tallahassee-fl-usa",
      "parent": "mid-east",
      "secParent": "mid-west",
      "parents": [
        2,
        0
      ]
    }
  ]
}
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (c8db585c00)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] We are going to take out edge parentage validation anyway, so no tests
- [x] Bugfix, no documentation necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
