### PR TITLE
[BACKPORT 4.1.x] Pin FFI gem version to 1.12.2 for Ruby 2.0 compatibility in Traffic Portal builder image

### DIFF
--- a/infrastructure/docker/build/Dockerfile-traffic_portal
+++ b/infrastructure/docker/build/Dockerfile-traffic_portal
@@ -42,8 +42,11 @@ RUN	yum -y install \
 		ruby-devel \
 		rubygems
 
-RUN	gem install rb-inotify -v 0.9.10 && \
-	gem install compass && \
+RUN	gem install \
+		# FFI 1.13 cannot be installed with Ruby 2.0
+		ffi:1.12.2 \
+		rb-inotify:0.9.10 \
+		compass && \
 	npm -g install bower grunt-cli
 
 # bower will not run as root by default


### PR DESCRIPTION
Backport https://github.com/apache/trafficcontrol/pull/4749 to 4.1.x.