### PR TITLE
[BACKPORT 4.1.x] deep caching type and routing name are optional (#4756)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed the `GET /api/x/jobs` and `GET /api/x/jobs/:id` Traffic Ops API routes to allow falling back to Perl via the routing blacklist
 - Fixed audit logging from the `/jobs` APIs to bring them back to the same level of information provided by TO-Perl
 - Fixed #4541: traffic_ops_server.js searches based on which= and can find data for multiple servers
+- Fixed POST deliveryservices/request (designed to simple send an email) regression which erroneously required deep caching type and routing name. [Related github issue](https://github.com/apache/trafficcontrol/issues/4735)
 - Fixed `maxRevalDurationDays` validation for `POST /api/1.x/user/current/jobs` and added that validation to the `/api/x/jobs` endpoints
 
 ### Deprecated/Removed

--- a/docs/source/api/v1/deliveryservices_request.rst
+++ b/docs/source/api/v1/deliveryservices_request.rst
@@ -68,7 +68,7 @@ Request Structure
 	:rangeRequestHandling:             A special string describing how the :term:`Delivery Service` should handle range requests
 	:rateLimitingGBPS:                 An optional field which, if defined, should contain the maximum allowed data transfer rate for the :term:`Delivery Service` in GigaBytes Per Second (GBPS)
 	:rateLimitingTPS:                  An optional field which, if defined, should contain the maximum allowed transaction rate for the :term:`Delivery Service` in Transactions Per Second (TPS)
-	:routingName:                      The routing name for the :term:`Delivery Service`, e.g. ``SomeRoutingName.DeliveryService_xml_id.CDNName.com``
+	:routingName:                      An optional field which, if defined, should contain the routing name for the :term:`Delivery Service`, e.g. ``SomeRoutingName.DeliveryService_xml_id.CDNName.com``
 	:routingType:                      The :term:`Delivery Service`'s routing type, should be one of:
 
 		HTTP

--- a/docs/source/api/v2/deliveryservices_request.rst
+++ b/docs/source/api/v2/deliveryservices_request.rst
@@ -68,7 +68,7 @@ Request Structure
 	:rangeRequestHandling:             A special string describing how the :term:`Delivery Service` should handle range requests
 	:rateLimitingGBPS:                 An optional field which, if defined, should contain the maximum allowed data transfer rate for the :term:`Delivery Service` in GigaBytes Per Second (GBPS)
 	:rateLimitingTPS:                  An optional field which, if defined, should contain the maximum allowed transaction rate for the :term:`Delivery Service` in Transactions Per Second (TPS)
-	:routingName:                      The routing name for the :term:`Delivery Service`, e.g. ``SomeRoutingName.DeliveryService_xml_id.CDNName.com``
+	:routingName:                      An optional field which, if defined, should contain the routing name for the :term:`Delivery Service`, e.g. ``SomeRoutingName.DeliveryService_xml_id.CDNName.com``
 	:routingType:                      The :term:`Delivery Service`'s routing type, should be one of:
 
 		HTTP

--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -276,10 +276,7 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 		validation.Field(&details.Customer, validation.Required),
 		validation.Field(&details.DeepCachingType, validation.By(
 			func(t interface{}) error {
-				if t == (*DeepCachingType)(nil) {
-					return errors.New("deepCachingType: required")
-				}
-				if *t.(*DeepCachingType) == DeepCachingTypeInvalid {
+				if t != (*DeepCachingType)(nil) && *t.(*DeepCachingType) == DeepCachingTypeInvalid {
 					return errors.New("deepCachingType: invalid Deep Caching Type")
 				}
 				return nil
@@ -339,7 +336,6 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 		validation.Field(&details.PeakTPSEstimate, validation.Required),
 		validation.Field(&details.QueryStringHandling, validation.Required),
 		validation.Field(&details.RangeRequestHandling, validation.Required),
-		validation.Field(&details.RoutingName, validation.Required),
 		validation.Field(&details.RoutingType, validation.By(
 			func(t interface{}) error {
 				if t == (*DSType)(nil) || *(t.(*DSType)) == "" {


### PR DESCRIPTION
Backport #4756 to 4.1.x.