### PR TITLE
Permit edge -> edge topology node parentage

### DIFF
--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 type topologyTestCase struct {
-	reasonToFail string
+	testCaseDescription string
 	tc.Topology
 }
 
@@ -59,39 +59,39 @@ func CreateTestTopologies(t *testing.T) {
 
 func ValidationTestTopologies(t *testing.T) {
 	invalidTopologyTestCases := []topologyTestCase{
-		{reasonToFail: "no nodes", Topology: tc.Topology{Name: "empty-top", Description: "Invalid because there are no nodes", Nodes: []tc.TopologyNode{}}},
-		{reasonToFail: "a node listing itself as a parent", Topology: tc.Topology{Name: "self-parent", Description: "Invalid because a node lists itself as a parent", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "no nodes", Topology: tc.Topology{Name: "empty-top", Description: "Invalid because there are no nodes", Nodes: []tc.TopologyNode{}}},
+		{testCaseDescription: "a node listing itself as a parent", Topology: tc.Topology{Name: "self-parent", Description: "Invalid because a node lists itself as a parent", Nodes: []tc.TopologyNode{
 			{Cachegroup: "cachegroup1", Parents: []int{1}},
 			{Cachegroup: "parentCachegroup", Parents: []int{1}},
 		}}},
-		{reasonToFail: "duplicate parents", Topology: tc.Topology{}},
-		{reasonToFail: "too many parents", Topology: tc.Topology{Name: "duplicate-parents", Description: "Invalid because a node lists the same parent twice", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "duplicate parents", Topology: tc.Topology{}},
+		{testCaseDescription: "too many parents", Topology: tc.Topology{Name: "duplicate-parents", Description: "Invalid because a node lists the same parent twice", Nodes: []tc.TopologyNode{
 			{Cachegroup: "cachegroup1", Parents: []int{1, 1}},
 			{Cachegroup: "parentCachegroup", Parents: []int{}},
 		}}},
-		{reasonToFail: "too many parents", Topology: tc.Topology{Name: "too-many-parents", Description: "Invalid because a node has more than 2 parents", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "too many parents", Topology: tc.Topology{Name: "too-many-parents", Description: "Invalid because a node has more than 2 parents", Nodes: []tc.TopologyNode{
 			{Cachegroup: "parentCachegroup", Parents: []int{}},
 			{Cachegroup: "secondaryCachegroup", Parents: []int{}},
 			{Cachegroup: "parentCachegroup2", Parents: []int{}},
 			{Cachegroup: "cachegroup1", Parents: []int{0, 1, 2}},
 		}}},
-		{reasonToFail: "a parent edge", Topology: tc.Topology{Name: "parent-edge", Description: "Invalid because an edge is a parent", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "a parent edge", Topology: tc.Topology{Name: "parent-edge", Description: "Invalid because an edge is a parent", Nodes: []tc.TopologyNode{
 			{Cachegroup: "cachegroup1", Parents: []int{1}},
 			{Cachegroup: "cachegroup2", Parents: []int{}},
 		}}},
-		{reasonToFail: "a leaf mid", Topology: tc.Topology{Name: "leaf-mid", Description: "Invalid because a mid is a leaf node", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "a leaf mid", Topology: tc.Topology{Name: "leaf-mid", Description: "Invalid because a mid is a leaf node", Nodes: []tc.TopologyNode{
 			{Cachegroup: "parentCachegroup", Parents: []int{1}},
 			{Cachegroup: "secondaryCachegroup", Parents: []int{}},
 		}}},
-		{reasonToFail: "cyclical nodes", Topology: tc.Topology{Name: "cyclical-nodes", Description: "Invalid because it contains cycles", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "cyclical nodes", Topology: tc.Topology{Name: "cyclical-nodes", Description: "Invalid because it contains cycles", Nodes: []tc.TopologyNode{
 			{Cachegroup: "cachegroup1", Parents: []int{1, 2}},
 			{Cachegroup: "parentCachegroup", Parents: []int{2}},
 			{Cachegroup: "secondaryCachegroup", Parents: []int{1}},
 		}}},
-		{reasonToFail: "a nonexistent cache group", Topology: tc.Topology{Name: "nonexistent-cg", Description: "Invalid because it references a cache group that does not exist", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "a nonexistent cache group", Topology: tc.Topology{Name: "nonexistent-cg", Description: "Invalid because it references a cache group that does not exist", Nodes: []tc.TopologyNode{
 			{Cachegroup: "legitcachegroup", Parents: []int{0}},
 		}}},
-		{reasonToFail: "an out-of-bounds parent index", Topology: tc.Topology{Name: "oob-parent", Description: "Invalid because it contains a parent", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "an out-of-bounds parent index", Topology: tc.Topology{Name: "oob-parent", Description: "Invalid because it contains a parent", Nodes: []tc.TopologyNode{
 			{Cachegroup: "cachegroup1", Parents: []int{7}},
 		}}},
 	}
@@ -99,7 +99,7 @@ func ValidationTestTopologies(t *testing.T) {
 	for _, testCase := range invalidTopologyTestCases {
 		_, reqInf, err := TOSession.CreateTopology(testCase.Topology)
 		if err == nil {
-			t.Fatalf("expected POST with %v to return an error, actual: nil", testCase.reasonToFail)
+			t.Fatalf("expected POST with %v to return an error, actual: nil", testCase.testCaseDescription)
 		}
 		statusCode = reqInf.StatusCode
 		if statusCode < 400 || statusCode >= 500 {

--- a/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
@@ -20,6 +20,7 @@ package api
  */
 
 import (
+	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 )
@@ -32,6 +33,11 @@ type CRUDer interface {
 	APIInfoer
 	Identifier
 	Validator
+}
+
+type AlertsResponse interface {
+	// GetAlerts retrieves an array of alerts that were generated over the course of handling an endpoint.
+	GetAlerts() tc.Alerts
 }
 
 type Identifier interface {

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -69,10 +69,15 @@ func (topology *TOTopology) checkForEdgeParents(cacheGroups []tc.CacheGroupNulla
 		}
 		switch cacheGroupType := *cacheGroups[nodeIndex].Type; cacheGroupType {
 		case tc.CacheGroupEdgeTypeName:
+			parentTerm := "parent"
+			if parentIndex == 1 {
+				parentTerm = "secondary " + parentTerm
+			}
 			topology.Alerts.AddNewAlert(tc.WarnLevel, fmt.Sprintf(
-				"%s-typed cachegroup %s is a parent of %s, unexpected behavior may result",
+				"%s-typed cachegroup %s is a %s of %s, unexpected behavior may result",
 				parentCacheGroupType,
 				topology.Nodes[parentCacheGroupIndex].Cachegroup,
+				parentTerm,
 				node.Cachegroup))
 			break
 		case tc.CacheGroupMidTypeName:

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -53,17 +53,36 @@ func checkForSelfParents(nodes []tc.TopologyNode, index int) error {
 	return nil
 }
 
-func checkForEdgeParents(nodes []tc.TopologyNode, cachegroups []tc.CacheGroupNullable, nodeIndex int) error {
-	node := nodes[nodeIndex]
+// checkForEdgeParents returns an error if an index given in the parents array, adds a warning + returns a nil error if
+// an edge parents an edge, and returns an error if an edge parents a non-edge cachegroup.
+func (topology *TOTopology) checkForEdgeParents(cacheGroups []tc.CacheGroupNullable, nodeIndex int) error {
+	node := topology.Nodes[nodeIndex]
 	errs := make([]error, len(node.Parents))
-	for parentIndex, cachegroupIndex := range node.Parents {
-		if cachegroupIndex < 0 || cachegroupIndex >= len(cachegroups) {
-			errs = append(errs, fmt.Errorf("parent %d of cachegroup %s refers to a cachegroup at index %d, but no such cachegroup exists", parentIndex, node.Cachegroup, cachegroupIndex))
+	for parentIndex, parentCacheGroupIndex := range node.Parents {
+		if parentCacheGroupIndex < 0 || parentCacheGroupIndex >= len(topology.Nodes) {
+			errs = append(errs, fmt.Errorf("parent %d of cachegroup %s refers to a cachegroup at index %d, but no such cachegroup exists", parentIndex, node.Cachegroup, parentCacheGroupIndex))
 			break
 		}
-		cacheGroupType := cachegroups[cachegroupIndex].Type
-		if *cacheGroupType == tc.CacheGroupEdgeTypeName {
-			errs = append(errs, fmt.Errorf("cachegroup %v's type is %v; it cannot be a parent of %v", nodes[cachegroupIndex].Cachegroup, tc.CacheGroupEdgeTypeName, node.Cachegroup))
+		parentCacheGroupType := *cacheGroups[parentCacheGroupIndex].Type
+		if parentCacheGroupType != tc.CacheGroupEdgeTypeName {
+			continue
+		}
+		switch cacheGroupType := *cacheGroups[nodeIndex].Type; cacheGroupType {
+		case tc.CacheGroupEdgeTypeName:
+			topology.Alerts.AddNewAlert(tc.WarnLevel, fmt.Sprintf(
+				"%s-typed cachegroup %s is a parent of %s, unexpected behavior may result",
+				parentCacheGroupType,
+				topology.Nodes[parentCacheGroupIndex].Cachegroup,
+				node.Cachegroup))
+			break
+		case tc.CacheGroupMidTypeName:
+		default:
+			errs = append(errs, fmt.Errorf(
+				"cachegroup %s's type is %s; it cannot be a child of %s-typed cachegroup %s",
+				topology.Nodes[parentCacheGroupIndex].Cachegroup,
+				parentCacheGroupType,
+				cacheGroupType,
+				node.Cachegroup))
 		}
 	}
 	return util.JoinErrs(errs)

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -79,7 +79,6 @@ func (topology *TOTopology) checkForEdgeParents(cacheGroups []tc.CacheGroupNulla
 				topology.Nodes[parentCacheGroupIndex].Cachegroup,
 				parentTerm,
 				node.Cachegroup))
-			break
 		case tc.CacheGroupMidTypeName:
 		default:
 			errs = append(errs, fmt.Errorf(

--- a/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
+++ b/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
@@ -136,7 +136,7 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 				(node.parent && node.parent.name !== cg.name) &&
 				cacheGroupNamesInTopology.includes(cg.name) &&
 				((node.type === 'EDGE_LOC') || (cg.typeName === 'MID_LOC' || cg.typeName === 'ORG_LOC'));
-		});
+		}).sort(function(a,b) { return [a.name, b.name].sort().indexOf(b.name) === 0 ? 1 : -1; });
 
 		let params = {
 			title: 'Select a secondary parent',

--- a/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
+++ b/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
@@ -74,10 +74,10 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 				return false;
 			}
 
-			// EDGE_LOC cannot have children
-			if (parent.type === 'EDGE_LOC') {
+			// EDGE_LOC can only have EDGE_LOC children
+			if (parent.type === 'EDGE_LOC' && node.type !== 'EDGE_LOC') {
 				$anchorScroll(); // scrolls window to top
-				messageModel.setMessages([ { level: 'error', text: 'Cache groups of EDGE_LOC type must not have children.' } ], false);
+				messageModel.setMessages([ { level: 'error', text: 'EDGE_LOC cache groups can only have EDGE_LOC children.' } ], false);
 				return false;
 			}
 
@@ -124,14 +124,17 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 		buildCacheGroupNamesInTopology($scope.topologyTree, true);
 
 		/*  Cache groups that can act as a second parent include:
-			1. cache groups of type ORG_LOC or MID_LOC (not EDGE_LOC)
-			2. cache groups that are not currently acting as the primary parent
-			3. cache groups that exist currently in the topology
+			1. cache groups that are not the current cache group (you can't parent/sec parent yourself)
+			2. cache groups that are not currently acting as the primary parent (primary parent != sec parent)
+			3. cache groups that exist currently in the topology only
+			4a. any cache group types (ORG_LOC, MID_LOC, EDGE_LOC) if child cache group is EDGE_LOC
+			4b. only MID_LOC or ORG_LOC cache group types if child cache group is not EDGE_LOC
 		 */
 		let eligibleSecParentCandidates = cacheGroups.filter(function(cg) {
-			return cg.typeName !== 'EDGE_LOC' &&
+			return (node.cachegroup && node.cachegroup !== cg.name) &&
 				(node.parent && node.parent !== cg.name) &&
-				cacheGroupNamesInTopology.includes(cg.name);
+				cacheGroupNamesInTopology.includes(cg.name) &&
+				((node.type === 'EDGE_LOC') || (cg.typeName === 'MID_LOC' || cg.typeName === 'ORG_LOC'));
 		});
 
 		let params = {
@@ -139,7 +142,8 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 			message: 'Please select a secondary parent that is part of the ' + topology.name + ' topology',
 			key: 'name',
 			required: false,
-			selectedItemKeyValue: node.secParent
+			selectedItemKeyValue: node.secParent,
+			labelFunction: function(item) { return item['name'] + ' (' + item['typeName'] + ')' }
 		};
 		let modalInstance = $uibModal.open({
 			templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
@@ -178,11 +182,20 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 		scope.toggle();
 	};
 
-	$scope.hasNodeError = function(node) {
+	$scope.nodeError = function(node) {
+		// only EDGE_LOCs can serve as a leaf node on the topology
 		if (node.type !== 'EDGE_LOC' && node.children.length === 0) {
-			return true;
+			return node.type + ' requires 1+ child cache group';
 		}
-		return false;
+		return '';
+	};
+
+	$scope.nodeWarning = function(node) {
+		// only EDGE_LOCs with child EDGE_LOCs require special configuration
+		if (node.type === 'EDGE_LOC' && node.children.length > 0) {
+			return 'EDGE_LOC with EDGE_LOC children requires special config';
+		}
+		return '';
 	};
 
 	$scope.isOrigin = function(node) {
@@ -198,11 +211,6 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 	};
 
 	$scope.addCacheGroups = function(parent, scope) {
-
-		if (parent.type === 'EDGE_LOC') {
-			// can't add children to EDGE_LOC. button should be hidden anyhow.
-			return;
-		}
 
 		// cache groups already in the topology cannot be selected again for addition
 		buildCacheGroupNamesInTopology($scope.topologyTree, true);

--- a/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
+++ b/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
@@ -193,11 +193,11 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 
 	$scope.nodeWarning = function(node) {
 		// EDGE_LOCs with parent/secondary parent EDGE_LOCs require special configuration
-		if (node.parent) {
-			console.log(node.parent);
-		}
-		if ((node.parent && node.parent.type === 'EDGE_LOC') || (node.secParent && node.secParent.type === 'EDGE_LOC')) {
-			return 'Special Configuration Required';
+		let msg = 'Special Configuration Required';
+		if (node.parent && node.parent.type === 'EDGE_LOC') {
+			return msg + ' [EDGE_LOC Parent]';
+		} else if (node.secParent && node.secParent.type === 'EDGE_LOC') {
+			return msg + ' [EDGE_LOC 2nd Parent]';
 		}
 		return '';
 	};

--- a/traffic_portal/app/src/common/modules/form/topology/edit/FormEditTopologyController.js
+++ b/traffic_portal/app/src/common/modules/form/topology/edit/FormEditTopologyController.js
@@ -40,8 +40,8 @@ var FormEditTopologyController = function(topologies, cacheGroups, $scope, $cont
 	$scope.save = function(name, description, topologyTree) {
 		let normalizedTopology = topologyUtils.getNormalizedTopology(name, description, topologyTree);
 		topologyService.updateTopology(normalizedTopology).
-			then(function() {
-				messageModel.setMessages([ { level: 'success', text: 'Topology updated' } ], false);
+			then(function(result) {
+				messageModel.setMessages(result.data.alerts, false);
 			});
 	};
 

--- a/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
@@ -82,7 +82,7 @@ under the License.
         <div ng-if="nodeWarning(node)" class="error-msg">{{nodeWarning(node)}}</div>
         <div class="pull-right">
             <a ng-show="node.cachegroup && node.parent" title="Set Secondary Parent Cache Group for {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="editSecParent(node)" style="margin-right: 8px;">
-                2nd: {{(node.secParent) ? node.secParent : 'None'}}
+                2nd Parent: {{(node.secParent.name) ? node.secParent.name : ''}} [{{node.secParent.type}}]
             </a>
             <a ng-if="node.cachegroup" title="View Servers Assigned to {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="viewCacheGroupServers(node)" style="margin-right: 8px;">
                 <i class="fa fa-server"></i>

--- a/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
@@ -81,7 +81,7 @@ under the License.
         <div ng-if="nodeError(node)" class="error-msg">{{nodeError(node)}}</div>
         <div ng-if="nodeWarning(node)" class="error-msg">{{nodeWarning(node)}}</div>
         <div class="pull-right">
-            <a ng-show="node.cachegroup && node.parent" title="Set Secondary Parent Cache Group for {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="editSecParent(node)" style="margin-right: 8px;">
+            <a ng-show="node.cachegroup && node.parent.name" title="Set Secondary Parent Cache Group for {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="editSecParent(node)" style="margin-right: 8px;">
                 2nd Parent: {{(node.secParent.name) ? node.secParent.name : ''}} [{{node.secParent.type}}]
             </a>
             <a ng-if="node.cachegroup" title="View Servers Assigned to {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="viewCacheGroupServers(node)" style="margin-right: 8px;">

--- a/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
@@ -68,17 +68,18 @@ under the License.
 
 <script type="text/ng-template" id="nodes_renderer.html">
     <!-- this hidden form field will make the form invalid (and disable the save btn) because it's a required field with no value -->
-    <input name="error" ng-if="hasNodeError(node)" ng-model="error" type="hidden" required>
+    <input name="error" ng-if="nodeError(node)" ng-model="error" type="hidden" required>
     <!-- this hidden form field will mark the form as dirty (and enable the save btn) when the topology tree is modified in any way -->
     <input name="dirty" ng-model="dirty" type="hidden">
     <div id="{{node.cachegroup}}" ui-tree-handle class="tree-node tree-node-content"
-         ng-class="{ 'error': hasNodeError(node), 'origin': isOrigin(node), 'mid': isMid(node) }">
+         ng-class="{ 'error': nodeError(node), 'warning': nodeWarning(node), 'origin': isOrigin(node), 'mid': isMid(node) }">
         <div class="tree-node-label pull-left">
             <a class="tree-toggle btn btn-primary btn-xs" ng-if="node.type !== 'ROOT' && hasChildren(node)" data-nodrag ng-click="toggle(this)">
                 <i class="fa" ng-class="collapsed ? 'fa-caret-right' : 'fa-caret-down'"></i>
             </a> {{::nodeLabel(node)}} <small>{{::node.type}}</small>
         </div>
-        <div ng-if="hasNodeError(node)" class="error-msg">1+ child required for {{::node.type}}</div>
+        <div ng-if="nodeError(node)" class="error-msg">{{nodeError(node)}}</div>
+        <div ng-if="nodeWarning(node)" class="error-msg">{{nodeWarning(node)}}</div>
         <div class="pull-right">
             <a ng-show="node.cachegroup && node.parent" title="Set Secondary Parent Cache Group for {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="editSecParent(node)" style="margin-right: 8px;">
                 2nd: {{(node.secParent) ? node.secParent : 'None'}}
@@ -86,7 +87,7 @@ under the License.
             <a ng-if="node.cachegroup" title="View Servers Assigned to {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="viewCacheGroupServers(node)" style="margin-right: 8px;">
                 <i class="fa fa-server"></i>
             </a>
-            <a ng-disabled="node.type === 'EDGE_LOC'" title="{{(node.type !== 'EDGE_LOC') ? 'Add child cache groups to ' + nodeLabel(node) : 'Child cache groups cannot be added to EDGE_LOC cache groups'}}" class="btn btn-primary btn-xs" data-nodrag ng-click="addCacheGroups(node, this)" style="margin-right: 8px;">
+            <a title="Add child cache groups to {{nodeLabel(node)}}" class="btn btn-primary btn-xs" data-nodrag ng-click="addCacheGroups(node, this)" style="margin-right: 8px;">
                 <i class="fa fa-plus"></i>
             </a>
             <a ng-if="node.cachegroup" title="Remove {{::node.cachegroup}} Cache Group" class="btn btn-danger btn-xs" data-nodrag ng-click="deleteCacheGroup(node, this)">

--- a/traffic_portal/app/src/common/modules/form/topology/new/FormNewTopologyController.js
+++ b/traffic_portal/app/src/common/modules/form/topology/new/FormNewTopologyController.js
@@ -32,8 +32,8 @@ var FormNewTopologyController = function(topology, cacheGroups, $scope, $control
 	$scope.save = function(name, description, topologyTree) {
 		let normalizedTopology = topologyUtils.getNormalizedTopology(name, description, topologyTree);
 		topologyService.createTopology(normalizedTopology).
-			then(function() {
-				messageModel.setMessages([ { level: 'success', text: 'Topology created' } ], true);
+			then(function(result) {
+				messageModel.setMessages(result.data.alerts, true);
 				locationUtils.navigateToPath('/topologies');
 			});
 	};

--- a/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
@@ -108,7 +108,7 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, select
 			return (parent.cachegroup && parent.cachegroup !== cg.name) &&
 				usedCacheGroupNames.includes(cg.name) &&
 				((selectedType === 'EDGE_LOC') || (cg.typeName === 'MID_LOC' || cg.typeName === 'ORG_LOC'));
-		});
+		}).sort(function(a,b) { return [a.name, b.name].sort().indexOf(b.name) === 0 ? 1 : -1; });
 
 		if (eligibleSecParentCandidates.length === 0) {
 			$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: { name: parent.cachegroup, type: parent.type }, secParent: { name: '', type: ''} });

--- a/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
@@ -101,10 +101,13 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, select
 		/*  Cache groups that can act as a second parent include:
 			1. cache groups that are not currently acting as the primary parent
 			2. cache groups that exist currently in the topology
+			3a. any cache group types (ORG_LOC, MID_LOC, EDGE_LOC) if child cache group(s) are EDGE_LOC
+			3b. only MID_LOC or ORG_LOC cache group types if child cache group(s) are MID_LOC or ORG_LOC
 		 */
 		let eligibleSecParentCandidates = cacheGroups.filter(function(cg) {
 			return (parent.cachegroup && parent.cachegroup !== cg.name) &&
-				usedCacheGroupNames.includes(cg.name);
+				usedCacheGroupNames.includes(cg.name) &&
+				((selectedType === 'EDGE_LOC') || (cg.typeName === 'MID_LOC' || cg.typeName === 'ORG_LOC'));
 		});
 
 		if (eligibleSecParentCandidates.length === 0) {

--- a/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var TableSelectTopologyCacheGroupsController = function(parent, topology, cacheGroups, usedCacheGroupNames, $scope, $uibModal, $uibModalInstance, serverService) {
+var TableSelectTopologyCacheGroupsController = function(parent, topology, selectedType, cacheGroups, usedCacheGroupNames, $scope, $uibModal, $uibModalInstance, serverService) {
 
 	let selectedCacheGroups = [],
 		usedCacheGroupCount = 0;
@@ -59,17 +59,7 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, cacheG
 	$scope.parent = parent;
 
 	$scope.cacheGroups = cacheGroups.filter(function(cg) {
-		// displayed cache groups are filtered based on parent cache group type
-		if (parent.type === 'ROOT') {
-			// the topology root can have children of any kind (EDGE_LOC, MID_LOC, ORG_LOC)
-			return true;
-		} else if (parent.type === 'EDGE_LOC') {
-			// EDGE_LOC can only have EDGE_LOC children
-			return cg.typeName === 'EDGE_LOC';
-		} else {
-			// only EDGE_LOC and MID_LOC can be added farther down the topology tree (not root)
-			return (cg.typeName === 'EDGE_LOC' || cg.typeName === 'MID_LOC');
-		}
+		return cg.typeName === selectedType;
 	});
 
 	$scope.selectAll = function($event) {
@@ -201,5 +191,5 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, cacheG
 
 };
 
-TableSelectTopologyCacheGroupsController.$inject = ['parent', 'topology', 'cacheGroups', 'usedCacheGroupNames', '$scope', '$uibModal', '$uibModalInstance', 'serverService'];
+TableSelectTopologyCacheGroupsController.$inject = ['parent', 'topology', 'selectedType', 'cacheGroups', 'usedCacheGroupNames', '$scope', '$uibModal', '$uibModalInstance', 'serverService'];
 module.exports = TableSelectTopologyCacheGroupsController;

--- a/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
+++ b/traffic_portal/app/src/common/modules/table/topologyCacheGroups/TableSelectTopologyCacheGroupsController.js
@@ -111,7 +111,7 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, select
 		});
 
 		if (eligibleSecParentCandidates.length === 0) {
-			$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: parent.cachegroup, secParent: '' });
+			$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: { name: parent.cachegroup, type: parent.type }, secParent: { name: '', type: ''} });
 			return;
 		}
 		let params = {
@@ -153,14 +153,14 @@ var TableSelectTopologyCacheGroupsController = function(parent, topology, select
 			});
 			modalInstance.result.then(function(cg) {
 				// user selected a secondary parent
-				$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: parent.cachegroup, secParent: cg.name });
+				$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: { name: parent.cachegroup, type: parent.type }, secParent: { name: cg.name, type: cg.typeName } });
 			}, function () {
 				// user apparently changed their mind and doesn't want to select a secondary parent
-				$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: parent.cachegroup, secParent: '' });
+				$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: { name: parent.cachegroup, type: parent.type }, secParent: { name: '', type: ''} });
 			});
 		}, function () {
 			// user doesn't want to select a secondary parent
-			$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: parent.cachegroup, secParent: '' });
+			$uibModalInstance.close({ selectedCacheGroups: selectedCacheGroups, parent: { name: parent.cachegroup, type: parent.type }, secParent: { name: '', type: ''} });
 		});
 	};
 

--- a/traffic_portal/app/src/common/service/utils/TopologyUtils.js
+++ b/traffic_portal/app/src/common/service/utils/TopologyUtils.js
@@ -40,8 +40,8 @@ var TopologyUtils = function() {
 
 	let addNodeIndexes = function() {
 		normalizedTopology.nodes.forEach(function(currentNode) {
-			let parentNodeIndex = _.findIndex(normalizedTopology.nodes, function(node) { return currentNode.parent === node.cachegroup });
-			let secParentNodeIndex = _.findIndex(normalizedTopology.nodes, function(node) { return currentNode.secParent === node.cachegroup });
+			let parentNodeIndex = _.findIndex(normalizedTopology.nodes, function(node) { return currentNode.parent.name === node.cachegroup });
+			let secParentNodeIndex = _.findIndex(normalizedTopology.nodes, function(node) { return currentNode.secParent.name === node.cachegroup });
 			if (parentNodeIndex > -1) {
 				currentNode.parents.push(parentNodeIndex);
 				if (secParentNodeIndex > -1) {
@@ -79,8 +79,8 @@ var TopologyUtils = function() {
 				item.children = []
 			}
 			if (item.parents.length === 0) {
-				item.parent = "";
-				item.secParent = "";
+				item.parent = { name: '', type: '' };
+				item.secParent = { name: '', type: '' };
 				roots.push(item)
 			} else if (item.parents[0] in all) {
 				let p = all[item.parents[0]]
@@ -89,10 +89,12 @@ var TopologyUtils = function() {
 				}
 				p.children.push(item);
 				// add parent to each node
-				item.parent = all[item.parents[0]].cachegroup;
+				item.parent = { name: all[item.parents[0]].cachegroup, type: all[item.parents[0]].type };
 				// add secParent to each node
 				if (item.parents.length === 2 && item.parents[1] in all) {
-					item.secParent = all[item.parents[1]].cachegroup;
+					item.secParent = { name: all[item.parents[1]].cachegroup, type: all[item.parents[1]].type };
+				} else {
+					item.secParent = { name: '', type: '' };
 				}
 			}
 		});

--- a/traffic_portal/app/src/styles/main.scss
+++ b/traffic_portal/app/src/styles/main.scss
@@ -220,5 +220,10 @@ input[type="checkbox"].dirty {
     background-color: #f2dede;
     border-color: #f5c6cb;
   }
+  .tree-node.warning {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+  }
 
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4785

## Which Traffic Control components are affected by this PR?

- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
- Run the topologies API tests in CDN-in-a-Box, make sure they pass.
- In TP, create a topology where one or more edge_loc cache groups have a edge_loc parent or secondary parent. Ensure the warnings are displayed and can be save successfully. Also ensure that edge_loc cache groups can only parent edge_loc children.

## If this is a bug fix, what versions of Traffic Control are affected?
Includes a bug fix. `GET /topologies` used to return `null` for 0 topologies, now it returns an empty array.

- master (2dd9a0cdf1)

Otherwise, not a bug fix.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes Go docs
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
