### PR TITLE
Add Topology ATS Config Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.
 - Changed Traffic Portal to use Traffic Ops API v3
 - Changed ORT Config Generation to be deterministic, which will prevent spurious diffs when nothing actually changed.
+- Changed ORT to find the local ATS config directory and use it when location Parameters don't exist for many required configs, including all Delivery Service files (Header Rewrites, Regex Remap, URL Sig, URI Signing).
 - Changed the access logs in Traffic Ops to now show the route ID with every API endpoint call. The Route ID is appended to the end of the access log line.
 - [Multiple Interface Servers](https://github.com/apache/trafficcontrol/blob/master/blueprints/multi-interface-servers.md)
     - Interface data is constructed from IP Address/Gateway/Netmask (and their IPv6 counterparts) and Interface Name and Interface MTU fields on services. These **MUST** have proper, valid data before attempting to upgrade or the upgrade **WILL** fail. In particular IP fields need to be valid IP addresses/netmasks, and MTU must only be positive integers of at least 1280.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Traffic Ops: Added new topology-based delivery service fields for header rewrites: `firstHeaderRewrite`, `innerHeaderRewrite`, `lastHeaderRewrite`
     - Traffic Ops: Added validation to prohibit assigning caches to topology-based delivery services
     - Traffic Ops: Consider Topologies parentage when queueing or checking server updates
+    - ORT: Added Topologies to Config Generation.
     - Traffic Portal: Added the ability to create, read, update and delete flexible topologies.
     - Traffic Portal: Added the ability to assign topologies to delivery services.
     - Traffic Portal: Added the ability to view all delivery services and cache groups associated with a topology.

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -192,11 +192,12 @@ func getTopologyPlacement(cacheGroup tc.CacheGroupName, topology tc.Topology, ca
 	}
 
 	topologyHasChildren := false
+nodeFor:
 	for _, node := range topology.Nodes {
 		for _, parent := range node.Parents {
 			if parent == serverNodeIndex {
 				topologyHasChildren = true
-				break
+				break nodeFor
 			}
 		}
 	}

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -191,19 +191,19 @@ func getTopologyPlacement(cacheGroup tc.CacheGroupName, topology tc.Topology, ca
 		return TopologyPlacement{InTopology: false}
 	}
 
-	topologyHasChildren := false
+	topologyNodeHasChildren := false
 nodeFor:
 	for _, node := range topology.Nodes {
 		for _, parent := range node.Parents {
 			if parent == serverNodeIndex {
-				topologyHasChildren = true
+				topologyNodeHasChildren = true
 				break nodeFor
 			}
 		}
 	}
 
 	cacheTier := TopologyCacheTierFirst
-	if topologyHasChildren {
+	if topologyNodeHasChildren {
 		cacheTier = TopologyCacheTierInner
 	}
 

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -41,6 +41,8 @@ const ContentTypeTextASCII = `text/plain; charset=us-ascii`
 
 const LineCommentHash = "#"
 
+type TopologyName string
+
 type ServerCapability string
 
 type ServerInfo struct {
@@ -232,6 +234,14 @@ nodeFor:
 		}
 	}
 	return TopologyPlacement{InTopology: true, IsLastTier: isLastTier, CacheTier: cacheTier}
+}
+
+func MakeTopologyNameMap(topologies []tc.Topology) map[TopologyName]tc.Topology {
+	topoNames := map[TopologyName]tc.Topology{}
+	for _, to := range topologies {
+		topoNames[TopologyName(to.Name)] = to
+	}
+	return topoNames
 }
 
 func MakeCGMap(cgs []tc.CacheGroupNullable) map[tc.CacheGroupName]tc.CacheGroupNullable {

--- a/lib/go-atscfg/hostingdotconfig.go
+++ b/lib/go-atscfg/hostingdotconfig.go
@@ -106,7 +106,8 @@ func hostingMakeDSTopologies(dses []tc.DeliveryServiceNullable, topologies []tc.
 		if to, ok := topNames[*ds.Topology]; ok {
 			dsTops[tc.DeliveryServiceName(*ds.XMLID)] = to
 		} else if *ds.Topology != "" {
-			log.Errorln("Making remap.config for Delivery Service '" + *ds.XMLID + "': has topology '" + *ds.Topology + "', but that topology doesn't exist! Treating as if DS has no Topology!")
+			// TODO propogate this up, so context can be added higher up, once generation is changed to return errors (after config files are removed from the TO API)
+			log.Errorln("Making hosting.config for Delivery Service '" + *ds.XMLID + "': has topology '" + *ds.Topology + "', but that topology doesn't exist! Treating as if DS has no Topology!")
 		}
 	}
 	return dsTops

--- a/lib/go-atscfg/hostingdotconfig_test.go
+++ b/lib/go-atscfg/hostingdotconfig_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 )
 
 func TestMakeHostingDotConfig(t *testing.T) {
-	serverName := tc.CacheName("server0")
+	server := tc.Server{HostName: "server0"}
 	toToolName := "to0"
 	toURL := "trafficops.example.net"
 	params := map[string]string{
@@ -43,8 +44,14 @@ func TestMakeHostingDotConfig(t *testing.T) {
 		"https://origin4.example.net/",
 		"http://origin5.example.net/",
 	}
+	dses := []tc.DeliveryServiceNullable{}
+	for _, origin := range origins {
+		ds := tc.DeliveryServiceNullable{}
+		ds.OrgServerFQDN = util.StrPtr(origin)
+		dses = append(dses, ds)
+	}
 
-	txt := MakeHostingDotConfig(serverName, toToolName, toURL, params, origins)
+	txt := MakeHostingDotConfig(server, toToolName, toURL, params, dses, nil)
 
 	lines := strings.Split(txt, "\n")
 
@@ -81,6 +88,67 @@ func TestMakeHostingDotConfig(t *testing.T) {
 
 	if len(originFQDNs) > 0 {
 		t.Errorf("expected %+v actual %v\n", originFQDNs, "missing")
+	}
+}
+
+func TestMakeHostingDotConfigTopologiesIgnoreDSS(t *testing.T) {
+	server := tc.Server{HostName: "server0", Cachegroup: "edgeCG"}
+	toToolName := "to0"
+	toURL := "trafficops.example.net"
+	params := map[string]string{
+		ParamRAMDrivePrefix: "ParamRAMDrivePrefix-shouldnotappearinconfig",
+		ParamDrivePrefix:    "ParamDrivePrefix-shouldnotappearinconfig",
+		"somethingelse":     "somethingelse-shouldnotappearinconfig",
+	}
+
+	dsTopology := tc.DeliveryServiceNullable{}
+	dsTopology.OrgServerFQDN = util.StrPtr("https://origin0.example.net")
+	dsTopology.XMLID = util.StrPtr("ds-topology")
+	dsTopology.Topology = util.StrPtr("t0")
+	dsTopology.Active = util.BoolPtr(true)
+
+	dsTopologyWithoutServer := tc.DeliveryServiceNullable{}
+	dsTopologyWithoutServer.OrgServerFQDN = util.StrPtr("https://origin1.example.net")
+	dsTopologyWithoutServer.XMLID = util.StrPtr("ds-topology-without-server")
+	dsTopologyWithoutServer.Topology = util.StrPtr("t1")
+	dsTopologyWithoutServer.Active = util.BoolPtr(true)
+
+	dses := []tc.DeliveryServiceNullable{dsTopology, dsTopologyWithoutServer}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+		tc.Topology{
+			Name: "t1",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "otherEdgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+	}
+
+	txt := MakeHostingDotConfig(server, toToolName, toURL, params, dses, topologies)
+
+	if !strings.Contains(txt, "origin0") {
+		t.Errorf("expected origin0 in topology, actual %v\n", txt)
+	}
+	if strings.Contains(txt, "origin1") {
+		t.Errorf("expected no origin1 not in topology, actual %v\n", txt)
 	}
 }
 

--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -146,6 +146,8 @@ func AddMetaObjConfigDir(
 		configFilesM[fileName] = newFis
 	}
 
+	nameTopologies := MakeTopologyNameMap(topologies)
+
 	for _, ds := range dses {
 		if ds.XMLID == nil {
 			log.Errorln("meta config generation got Delivery Service with nil XMLID - not considering!")
@@ -156,13 +158,7 @@ func AddMetaObjConfigDir(
 		// Note we log errors, but don't return them.
 		// If an individual DS has an error, we don't want to break the rest of the CDN.
 		if ds.Topology != nil && *ds.Topology != "" {
-			topology := tc.Topology{}
-			for _, to := range topologies {
-				if to.Name == *ds.Topology {
-					topology = to
-					break
-				}
-			}
+			topology := nameTopologies[TopologyName(*ds.Topology)]
 
 			placement := getTopologyPlacement(tc.CacheGroupName(server.CacheGroupName), topology, cacheGroups)
 			switch placement.CacheTier {

--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -66,15 +66,13 @@ func MakeMetaConfig(
 	locationParams map[string]ConfigProfileParams, // map[configFile]params; 'location' and 'URL' Parameters on serverHostName's Profile
 	uriSignedDSes []tc.DeliveryServiceName,
 	scopeParams map[string]string, // map[configFileName]scopeParam
-	dsNames map[tc.DeliveryServiceName]struct{},
+	dses map[tc.DeliveryServiceName]tc.DeliveryServiceNullable,
 ) string {
-	// dses are only used when configDir is not empty
-	dses := map[tc.DeliveryServiceName]tc.DeliveryServiceNullable{}
-	for dsName, _ := range dsNames {
-		dses[dsName] = tc.DeliveryServiceNullable{}
-	}
-	configDir := ""
-	atsData, err := MakeMetaObj(serverHostName, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, configDir)
+	configDir := "" // this should only be used for Traffic Ops, which doesn't have a local ATS install config directory (and thus will fail if any location Parameters are missing or relative).
+	return MetaObjToMetaConfig(MakeMetaObj(serverHostName, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, configDir))
+}
+
+func MetaObjToMetaConfig(atsData tc.ATSConfigMetaData, err error) string {
 	if err != nil {
 		return "error creating meta config: " + err.Error()
 	}
@@ -197,7 +195,6 @@ func AddMetaObjConfigDir(
 			}
 		}
 	}
-	// TODO add location params for ds ensure garbage here
 
 	newFiles := []tc.ATSConfigMetaDataConfigFile{}
 	for _, fis := range configFilesM {

--- a/lib/go-atscfg/meta_test.go
+++ b/lib/go-atscfg/meta_test.go
@@ -114,8 +114,11 @@ func TestMakeMetaConfig(t *testing.T) {
 
 	scopeParams := map[string]string{"custom.config": string(tc.ATSConfigMetaDataConfigFileScopeProfiles)}
 
+	cgs := []tc.CacheGroupNullable{}
+	topologies := []tc.Topology{}
+
 	cfgPath := "/etc/foo/trafficserver"
-	cfg, err := MakeMetaObj(serverHostName, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, cfgPath)
+	cfg, err := MakeMetaObj(serverHostName, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, cgs, topologies, cfgPath)
 	if err != nil {
 		t.Fatalf("MakeMetaObj: " + err.Error())
 	}
@@ -291,7 +294,7 @@ func TestMakeMetaConfig(t *testing.T) {
 	}
 
 	server.Type = "MID"
-	cfg, err = MakeMetaObj(serverHostName, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, cfgPath)
+	cfg, err = MakeMetaObj(serverHostName, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, cgs, topologies, cfgPath)
 	if err != nil {
 		t.Fatalf("MakeMetaObj: " + err.Error())
 	}

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -165,24 +165,6 @@ type OriginURI struct {
 	Port   string
 }
 
-/*
-/api/x/topologies => topologies := map[string]*tc.Topology{}
-/api/x/deliveryservices =>	Topology *string
-
-type Topology struct {
-	Description string         `json:"description" db:"description"`
-	Name        string         `json:"name" db:"name"`
-	Nodes       []TopologyNode `json:"nodes"`
-	LastUpdated *TimeNoMod     `json:"lastUpdated" db:"last_updated"`
-}
-type TopologyNode struct {
-	Id          int        `json:"-" db:"id"`
-	Cachegroup  string     `json:"cachegroup" db:"cachegroup"`
-	Parents     []int      `json:"parents"`
-	LastUpdated *TimeNoMod `json:"-" db:"last_updated"`
-}
-*/
-
 func MakeParentDotConfig(
 	serverInfo *ServerInfo, // getServerInfoByHost OR getServerInfoByID
 	atsMajorVer int, // GetATSMajorVersion (TODO: determine if the cache itself [ORT via Yum] should produce this data, rather than asking TO?)

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -383,6 +383,10 @@ func GetTopologyParentConfigLine(
 	if err != nil {
 		return "", errors.New("getting topology parents for '" + string(ds.Name) + "': skipping! " + err.Error())
 	}
+	if len(parents) == 0 {
+		return "", errors.New("getting topology parents for '" + string(ds.Name) + "': no parents found! skipping! (Does your Topology have a CacheGroup with no servers in it?)")
+	}
+
 	txt += ` parent="` + strings.Join(parents, `;`) + `"`
 	if len(secondaryParents) > 0 {
 		txt += ` secondary_parent="` + strings.Join(secondaryParents, `;`) + `"`

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -95,7 +95,26 @@ func TestMakeParentDotConfig(t *testing.T) {
 		},
 	}
 
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos)
+	server := tc.Server{
+		CachegroupID: 42,
+		Cachegroup:   "myCG",
+		CDNName:      "myCDN",
+		CDNID:        43,
+		DomainName:   "serverdomain.example.net",
+		HostName:     "myserver",
+		ID:           44,
+		IPAddress:    "192.168.2.1",
+		ProfileID:    46,
+		Profile:      "MyProfileName",
+		TCPPort:      80,
+		Type:         "EDGE",
+	}
+	servers := []tc.Server{server}
+	topologies := []tc.Topology{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	parentConfigParams := []tc.Parameter{}
+
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
 
 	testComment(t, txt, serverName, toolName, toURL)
 
@@ -202,14 +221,32 @@ func TestMakeParentDotConfigCapabilities(t *testing.T) {
 		},
 	}
 
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos)
+	server := tc.Server{
+		CachegroupID: 42,
+		Cachegroup:   "myCG",
+		CDNName:      "myCDN",
+		CDNID:        43,
+		DomainName:   "serverdomain.example.net",
+		HostName:     "myserver",
+		ID:           44,
+		IPAddress:    "192.168.2.1",
+		ProfileID:    46,
+		Profile:      "MyProfileName",
+		TCPPort:      80,
+		Type:         "EDGE",
+	}
+	servers := []tc.Server{server}
+	topologies := []tc.Topology{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	parentConfigParams := []tc.Parameter{}
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
 
 	testComment(t, txt, serverName, toolName, toURL)
 
 	lines := strings.Split(txt, "\n")
 
 	if len(lines) != 4 {
-		t.Fatalf("expected 4 lines (comment, ds, dot remap, and empty newline), actual: '%+v'", len(lines))
+		t.Fatalf("expected 4 lines (comment, ds, dot remap, and empty newline), actual: '%+v' text %v", len(lines), txt)
 	}
 
 	for _, line := range lines {
@@ -314,7 +351,25 @@ func TestMakeParentDotConfigMSOSecondaryParent(t *testing.T) {
 		t.Fatal("server should have been top level, was not; cannot test MSO Secondary Parent")
 	}
 
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos)
+	server := tc.Server{
+		CachegroupID: 42,
+		Cachegroup:   "myCG",
+		CDNName:      "myCDN",
+		CDNID:        43,
+		DomainName:   "serverdomain.example.net",
+		HostName:     "myserver",
+		ID:           44,
+		IPAddress:    "192.168.2.1",
+		ProfileID:    46,
+		Profile:      "MyProfileName",
+		TCPPort:      80,
+		Type:         "EDGE",
+	}
+	servers := []tc.Server{server}
+	topologies := []tc.Topology{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	parentConfigParams := []tc.Parameter{}
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
 
 	testComment(t, txt, serverName, toolName, toURL)
 
@@ -322,5 +377,349 @@ func TestMakeParentDotConfigMSOSecondaryParent(t *testing.T) {
 
 	if !strings.Contains(txt, `secondary_parent="my-parent-1.my-parent-1-domain`) {
 		t.Errorf("expected secondary parent 'my-parent-1.my-parent-1-domain', actual: '%v'", txt)
+	}
+}
+
+func TestMakeParentDotConfigTopologies(t *testing.T) {
+	atsMajorVer := 7
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	parentConfigDSes := []ParentConfigDSTopLevel{
+		ParentConfigDSTopLevel{
+			ParentConfigDS: ParentConfigDS{
+				Name:            "ds0",
+				QStringIgnore:   tc.QStringIgnoreUseInCacheKeyAndPassUp,
+				OriginFQDN:      "http://ds0.example.net",
+				MultiSiteOrigin: false,
+				Type:            tc.DSTypeHTTP,
+				QStringHandling: "ds0qstringhandling",
+				// no Topology - test that generation works right with a DS with and one without
+			},
+		},
+		ParentConfigDSTopLevel{
+			ParentConfigDS: ParentConfigDS{
+				Name:            "ds1",
+				QStringIgnore:   tc.QStringIgnoreDrop,
+				OriginFQDN:      "http://ds1.example.net",
+				MultiSiteOrigin: false,
+				Type:            tc.DSTypeDNS,
+				QStringHandling: "ds1qstringhandling",
+				Topology:        "t0",
+			},
+		},
+	}
+
+	serverInfo := &ServerInfo{
+		CacheGroupID:                  42,
+		CDN:                           "myCDN",
+		CDNID:                         43,
+		DomainName:                    "serverdomain.example.net",
+		HostName:                      "myserver",
+		ID:                            44,
+		IP:                            "192.168.2.1",
+		ParentCacheGroupID:            45,
+		ParentCacheGroupType:          "myParentCGType",
+		ProfileID:                     46,
+		ProfileName:                   "MyProfileName",
+		Port:                          80,
+		SecondaryParentCacheGroupID:   47,
+		SecondaryParentCacheGroupType: "MySecondaryParentCGType",
+		Type:                          "EDGE",
+	}
+
+	serverParams := map[string]string{
+		ParentConfigParamQStringHandling: "myQStringHandlingParam",
+		ParentConfigParamAlgorithm:       tc.AlgorithmConsistentHash,
+		ParentConfigParamQString:         "myQstringParam",
+	}
+
+	parentInfos := map[OriginHost][]ParentInfo{
+		"ds1.example.net": []ParentInfo{
+			ParentInfo{
+				Host:            "my-parent-0",
+				Port:            80,
+				Domain:          "my-parent-0-domain",
+				Weight:          "1",
+				UseIP:           false,
+				Rank:            1,
+				IP:              "192.168.2.2",
+				PrimaryParent:   true,
+				SecondaryParent: true,
+			},
+		},
+	}
+
+	server := serverInfoToServer(serverInfo)
+	server.Cachegroup = "edgeCG"
+
+	servers := []tc.Server{server}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	parentConfigParams := []tc.Parameter{}
+
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	if !strings.Contains(txt, "dest_domain=ds0.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
+		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	}
+}
+
+// TestMakeParentDotConfigNotInTopologies tests when a given edge is NOT in a Topology, that it doesn't add a remap line.
+func TestMakeParentDotConfigNotInTopologies(t *testing.T) {
+	atsMajorVer := 7
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	parentConfigDSes := []ParentConfigDSTopLevel{
+		ParentConfigDSTopLevel{
+			ParentConfigDS: ParentConfigDS{
+				Name:            "ds0",
+				QStringIgnore:   tc.QStringIgnoreUseInCacheKeyAndPassUp,
+				OriginFQDN:      "http://ds0.example.net",
+				MultiSiteOrigin: false,
+				Type:            tc.DSTypeHTTP,
+				QStringHandling: "ds0qstringhandling",
+				Topology:        "t0",
+			},
+		},
+		ParentConfigDSTopLevel{
+			ParentConfigDS: ParentConfigDS{
+				Name:            "ds1",
+				QStringIgnore:   tc.QStringIgnoreDrop,
+				OriginFQDN:      "http://ds1.example.net",
+				MultiSiteOrigin: false,
+				Type:            tc.DSTypeDNS,
+				QStringHandling: "ds1qstringhandling",
+				// no Topology - test that generation works right with a DS with and one without
+			},
+		},
+	}
+
+	serverInfo := &ServerInfo{
+		CacheGroupID:                  42,
+		CDN:                           "myCDN",
+		CDNID:                         43,
+		DomainName:                    "serverdomain.example.net",
+		HostName:                      "myserver",
+		ID:                            44,
+		IP:                            "192.168.2.1",
+		ParentCacheGroupID:            45,
+		ParentCacheGroupType:          "myParentCGType",
+		ProfileID:                     46,
+		ProfileName:                   "MyProfileName",
+		Port:                          80,
+		SecondaryParentCacheGroupID:   47,
+		SecondaryParentCacheGroupType: "MySecondaryParentCGType",
+		Type:                          "EDGE",
+	}
+
+	serverParams := map[string]string{
+		ParentConfigParamQStringHandling: "myQStringHandlingParam",
+		ParentConfigParamAlgorithm:       tc.AlgorithmConsistentHash,
+		ParentConfigParamQString:         "myQstringParam",
+	}
+
+	parentInfos := map[OriginHost][]ParentInfo{
+		"ds1.example.net": []ParentInfo{
+			ParentInfo{
+				Host:            "my-parent-0",
+				Port:            80,
+				Domain:          "my-parent-0-domain",
+				Weight:          "1",
+				UseIP:           false,
+				Rank:            1,
+				IP:              "192.168.2.2",
+				PrimaryParent:   true,
+				SecondaryParent: true,
+			},
+		},
+	}
+
+	server := serverInfoToServer(serverInfo)
+	server.Cachegroup = "edgeCG"
+
+	servers := []tc.Server{server}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "otherEdgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	parentConfigParams := []tc.Parameter{}
+
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	if strings.Contains(txt, "dest_domain=ds0.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds0.example.net' to NOT contain Topology DS without this edge: '%v'", txt)
+	}
+	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
+	}
+}
+
+func TestMakeParentDotConfigTopologiesCapabilities(t *testing.T) {
+	atsMajorVer := 7
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	parentConfigDSes := []ParentConfigDSTopLevel{
+		ParentConfigDSTopLevel{
+			ParentConfigDS: ParentConfigDS{
+				Name:            "ds0",
+				QStringIgnore:   tc.QStringIgnoreUseInCacheKeyAndPassUp,
+				OriginFQDN:      "http://ds0.example.net",
+				MultiSiteOrigin: false,
+				Type:            tc.DSTypeHTTP,
+				QStringHandling: "ds0qstringhandling",
+				Topology:        "t0",
+			},
+		},
+		ParentConfigDSTopLevel{
+			ParentConfigDS: ParentConfigDS{
+				Name:            "ds1",
+				QStringIgnore:   tc.QStringIgnoreDrop,
+				OriginFQDN:      "http://ds1.example.net",
+				MultiSiteOrigin: false,
+				Type:            tc.DSTypeDNS,
+				QStringHandling: "ds1qstringhandling",
+				Topology:        "t0",
+				RequiredCapabilities: map[ServerCapability]struct{}{
+					"FOO": {},
+				},
+			},
+		},
+		ParentConfigDSTopLevel{
+			ParentConfigDS: ParentConfigDS{
+				Name:            "ds2",
+				QStringIgnore:   tc.QStringIgnoreDrop,
+				OriginFQDN:      "http://ds2.example.net",
+				MultiSiteOrigin: false,
+				Type:            tc.DSTypeDNS,
+				QStringHandling: "ds2qstringhandling",
+				Topology:        "t0",
+				RequiredCapabilities: map[ServerCapability]struct{}{
+					"BAR": {},
+				},
+			},
+		},
+	}
+
+	serverInfo := &ServerInfo{
+		CacheGroupID:                  42,
+		CDN:                           "myCDN",
+		CDNID:                         43,
+		DomainName:                    "serverdomain.example.net",
+		HostName:                      "myserver",
+		ID:                            44,
+		IP:                            "192.168.2.1",
+		ParentCacheGroupID:            45,
+		ParentCacheGroupType:          "myParentCGType",
+		ProfileID:                     46,
+		ProfileName:                   "MyProfileName",
+		Port:                          80,
+		SecondaryParentCacheGroupID:   47,
+		SecondaryParentCacheGroupType: "MySecondaryParentCGType",
+		Type:                          "EDGE",
+	}
+
+	serverParams := map[string]string{
+		ParentConfigParamQStringHandling: "myQStringHandlingParam",
+		ParentConfigParamAlgorithm:       tc.AlgorithmConsistentHash,
+		ParentConfigParamQString:         "myQstringParam",
+	}
+
+	parentInfos := map[OriginHost][]ParentInfo{
+		"ds1.example.net": []ParentInfo{
+			ParentInfo{
+				Host:            "my-parent-0",
+				Port:            80,
+				Domain:          "my-parent-0-domain",
+				Weight:          "1",
+				UseIP:           false,
+				Rank:            1,
+				IP:              "192.168.2.2",
+				PrimaryParent:   true,
+				SecondaryParent: true,
+			},
+		},
+	}
+
+	server := serverInfoToServer(serverInfo)
+	server.Cachegroup = "edgeCG"
+
+	servers := []tc.Server{server}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{
+		44: map[ServerCapability]struct{}{"FOO": {}},
+	}
+	parentConfigParams := []tc.Parameter{}
+
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	if !strings.Contains(txt, "dest_domain=ds0.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds0.example.net' without required capabilities: '%v'", txt)
+	}
+	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds1.example.net' with necessary required capabilities, actual: '%v'", txt)
+	}
+	if strings.Contains(txt, "dest_domain=ds2.example.net") {
+		t.Errorf("expected no parent 'dest_domain=ds2.example.net' without necessary required capabilities, actual: '%v'", txt)
 	}
 }

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -109,7 +109,35 @@ func TestMakeParentDotConfig(t *testing.T) {
 		TCPPort:      80,
 		Type:         "EDGE",
 	}
-	servers := []tc.Server{server}
+
+	mid0 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid0",
+		ID:         45,
+		IPAddress:  "192.168.2.2",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	mid1 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid1",
+		ID:         45,
+		IPAddress:  "192.168.2.3",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	servers := []tc.Server{server, *mid0, *mid1}
+
 	topologies := []tc.Topology{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	parentConfigParams := []tc.Parameter{}
@@ -236,7 +264,34 @@ func TestMakeParentDotConfigCapabilities(t *testing.T) {
 		TCPPort:      80,
 		Type:         "EDGE",
 	}
-	servers := []tc.Server{server}
+	mid0 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid0",
+		ID:         45,
+		IPAddress:  "192.168.2.2",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	mid1 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid1",
+		ID:         45,
+		IPAddress:  "192.168.2.3",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	servers := []tc.Server{server, *mid0, *mid1}
+
 	topologies := []tc.Topology{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	parentConfigParams := []tc.Parameter{}
@@ -367,7 +422,35 @@ func TestMakeParentDotConfigMSOSecondaryParent(t *testing.T) {
 		TCPPort:      80,
 		Type:         "EDGE",
 	}
-	servers := []tc.Server{server}
+
+	mid0 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid0",
+		ID:         45,
+		IPAddress:  "192.168.2.2",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	mid1 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid1",
+		ID:         45,
+		IPAddress:  "192.168.2.3",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	servers := []tc.Server{server, *mid0, *mid1}
+
 	topologies := []tc.Topology{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	parentConfigParams := []tc.Parameter{}
@@ -416,6 +499,7 @@ func TestMakeParentDotConfigTopologies(t *testing.T) {
 
 	serverInfo := &ServerInfo{
 		CacheGroupID:                  42,
+		CacheGroupName:                "edgeCG",
 		CDN:                           "myCDN",
 		CDNID:                         43,
 		DomainName:                    "serverdomain.example.net",
@@ -457,7 +541,33 @@ func TestMakeParentDotConfigTopologies(t *testing.T) {
 	server := serverInfoToServer(serverInfo)
 	server.Cachegroup = "edgeCG"
 
-	servers := []tc.Server{server}
+	mid0 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid0",
+		ID:         45,
+		IPAddress:  "192.168.2.2",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	mid1 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid1",
+		ID:         45,
+		IPAddress:  "192.168.2.3",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	servers := []tc.Server{server, *mid0, *mid1}
 
 	topologies := []tc.Topology{
 		tc.Topology{
@@ -485,7 +595,7 @@ func TestMakeParentDotConfigTopologies(t *testing.T) {
 		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
 	}
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
-		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
+		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
 	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
 		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
@@ -567,7 +677,33 @@ func TestMakeParentDotConfigNotInTopologies(t *testing.T) {
 	server := serverInfoToServer(serverInfo)
 	server.Cachegroup = "edgeCG"
 
-	servers := []tc.Server{server}
+	mid0 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid0",
+		ID:         45,
+		IPAddress:  "192.168.2.2",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	mid1 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid1",
+		ID:         45,
+		IPAddress:  "192.168.2.3",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	servers := []tc.Server{server, *mid0, *mid1}
 
 	topologies := []tc.Topology{
 		tc.Topology{
@@ -690,7 +826,33 @@ func TestMakeParentDotConfigTopologiesCapabilities(t *testing.T) {
 	server := serverInfoToServer(serverInfo)
 	server.Cachegroup = "edgeCG"
 
-	servers := []tc.Server{server}
+	mid0 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid0",
+		ID:         45,
+		IPAddress:  "192.168.2.2",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	mid1 := &tc.Server{
+		Cachegroup: "midCG",
+		CDNName:    "myCDN",
+		CDNID:      43,
+		DomainName: "serverdomain.example.net",
+		HostName:   "mymid1",
+		ID:         46,
+		IPAddress:  "192.168.2.3",
+		ProfileID:  46,
+		Profile:    "MyProfileName",
+		TCPPort:    80,
+		Type:       "EDGE",
+	}
+	servers := []tc.Server{server, *mid0, *mid1}
 
 	topologies := []tc.Topology{
 		tc.Topology{
@@ -709,6 +871,8 @@ func TestMakeParentDotConfigTopologiesCapabilities(t *testing.T) {
 
 	serverCapabilities := map[int]map[ServerCapability]struct{}{
 		44: map[ServerCapability]struct{}{"FOO": {}},
+		45: map[ServerCapability]struct{}{"FOO": {}},
+		46: map[ServerCapability]struct{}{"FOO": {}},
 	}
 	parentConfigParams := []tc.Parameter{}
 	cgs := []tc.CacheGroupNullable{}

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -113,8 +113,9 @@ func TestMakeParentDotConfig(t *testing.T) {
 	topologies := []tc.Topology{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	parentConfigParams := []tc.Parameter{}
+	cgs := []tc.CacheGroupNullable{}
 
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities, cgs)
 
 	testComment(t, txt, serverName, toolName, toURL)
 
@@ -239,7 +240,8 @@ func TestMakeParentDotConfigCapabilities(t *testing.T) {
 	topologies := []tc.Topology{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	parentConfigParams := []tc.Parameter{}
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+	cgs := []tc.CacheGroupNullable{}
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities, cgs)
 
 	testComment(t, txt, serverName, toolName, toURL)
 
@@ -369,7 +371,8 @@ func TestMakeParentDotConfigMSOSecondaryParent(t *testing.T) {
 	topologies := []tc.Topology{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	parentConfigParams := []tc.Parameter{}
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+	cgs := []tc.CacheGroupNullable{}
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities, cgs)
 
 	testComment(t, txt, serverName, toolName, toURL)
 
@@ -473,8 +476,8 @@ func TestMakeParentDotConfigTopologies(t *testing.T) {
 
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	parentConfigParams := []tc.Parameter{}
-
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+	cgs := []tc.CacheGroupNullable{}
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities, cgs)
 
 	testComment(t, txt, serverName, toolName, toURL)
 
@@ -583,8 +586,8 @@ func TestMakeParentDotConfigNotInTopologies(t *testing.T) {
 
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	parentConfigParams := []tc.Parameter{}
-
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+	cgs := []tc.CacheGroupNullable{}
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities, cgs)
 
 	testComment(t, txt, serverName, toolName, toURL)
 
@@ -708,8 +711,9 @@ func TestMakeParentDotConfigTopologiesCapabilities(t *testing.T) {
 		44: map[ServerCapability]struct{}{"FOO": {}},
 	}
 	parentConfigParams := []tc.Parameter{}
+	cgs := []tc.CacheGroupNullable{}
 
-	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities)
+	txt := MakeParentDotConfig(serverInfo, atsMajorVer, toolName, toURL, parentConfigDSes, serverParams, parentInfos, server, servers, topologies, parentConfigParams, serverCapabilities, cgs)
 
 	testComment(t, txt, serverName, toolName, toURL)
 

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -104,7 +104,6 @@ func makeDSTopologies(dses []RemapConfigDSData, topologies []tc.Topology) map[tc
 func GetServerConfigRemapDotConfigForMid(
 	atsMajorVersion int,
 	profilesCacheKeyConfigParams map[int]map[string]string,
-	serverInfo *ServerInfo,
 	dses []RemapConfigDSData,
 	header string,
 	server tc.Server,
@@ -226,7 +225,7 @@ func GetServerConfigRemapDotConfigForEdge(
 			}
 			remapText = BuildRemapLine(cacheURLConfigParams, atsMajorVersion, serverInfo, serverPackageParamData, remapText, ds, line.From, line.To, profilecacheKeyConfigParams)
 			if hasTopology {
-				remapText += " # topology" // debug
+				remapText += " # topology '" + topology.Name + "'"
 			}
 			remapText += "\n"
 		}

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -99,7 +99,10 @@ func TestMakeRemapDotConfig(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -202,7 +205,10 @@ func TestMakeRemapDotConfigMidLiveLocalExcluded(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -287,7 +293,10 @@ func TestMakeRemapDotConfigMid(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -386,7 +395,10 @@ func TestMakeRemapDotConfigNilOrigin(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -471,7 +483,10 @@ func TestMakeRemapDotConfigEmptyOrigin(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -584,7 +599,10 @@ func TestMakeRemapDotConfigDuplicateOrigins(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -669,7 +687,10 @@ func TestMakeRemapDotConfigNilMidRewrite(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -777,7 +798,10 @@ func TestMakeRemapDotConfigMidHasNoEdgeRewrite(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -876,7 +900,10 @@ func TestMakeRemapDotConfigMidQStringPassUpATS7CacheKey(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -982,7 +1009,10 @@ func TestMakeRemapDotConfigMidQStringPassUpATS5CacheURL(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1091,7 +1121,10 @@ func TestMakeRemapDotConfigMidProfileCacheKey(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1201,7 +1234,10 @@ func TestMakeRemapDotConfigMidRangeRequestHandling(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1304,7 +1340,10 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1435,7 +1474,10 @@ func TestMakeRemapDotConfigFirstExcludedSecondIncluded(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1548,7 +1590,10 @@ func TestMakeRemapDotConfigAnyMap(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1924,7 +1969,10 @@ func TestMakeRemapDotConfigEdgeMissingRemapData(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2010,7 +2058,10 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacement(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2113,7 +2164,10 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTP(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2216,7 +2270,10 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTPS(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2319,7 +2376,10 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTPToHTTPS(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2422,7 +2482,10 @@ func TestMakeRemapDotConfigEdgeRemapUnderscoreHTTPReplace(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2521,7 +2584,10 @@ func TestMakeRemapDotConfigEdgeDSCPRemap(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2620,7 +2686,10 @@ func TestMakeRemapDotConfigEdgeNoDSCPRemap(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2719,7 +2788,10 @@ func TestMakeRemapDotConfigEdgeHeaderRewrite(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2822,7 +2894,10 @@ func TestMakeRemapDotConfigEdgeHeaderRewriteEmpty(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2925,7 +3000,10 @@ func TestMakeRemapDotConfigEdgeHeaderRewriteNil(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3028,7 +3106,10 @@ func TestMakeRemapDotConfigEdgeSigningURLSig(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3126,7 +3207,10 @@ func TestMakeRemapDotConfigEdgeSigningURISigning(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3224,7 +3308,10 @@ func TestMakeRemapDotConfigEdgeSigningNone(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3322,7 +3409,10 @@ func TestMakeRemapDotConfigEdgeSigningEmpty(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3420,7 +3510,10 @@ func TestMakeRemapDotConfigEdgeSigningWrong(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3518,7 +3611,10 @@ func TestMakeRemapDotConfigEdgeQStringDropAtEdge(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3614,7 +3710,10 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUp(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3714,7 +3813,10 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpWithCacheKeyParameter(t *testi
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3813,7 +3915,10 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParam(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3908,7 +4013,10 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParamCacheURL(t *testi
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4010,7 +4118,10 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParamCacheURLAndDSCach
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4116,7 +4227,10 @@ func TestMakeRemapDotConfigMidQStringIgnorePassUpCacheURLParamCacheURLAndDSCache
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4219,7 +4333,10 @@ func TestMakeRemapDotConfigEdgeCacheURL(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4317,7 +4434,10 @@ func TestMakeRemapDotConfigEdgeCacheKeyParams(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4427,7 +4547,10 @@ func TestMakeRemapDotConfigEdgeRegexRemap(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4529,7 +4652,10 @@ func TestMakeRemapDotConfigEdgeRegexRemapEmpty(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4627,7 +4753,10 @@ func TestMakeRemapDotConfigEdgeRangeRequestNil(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4729,7 +4858,10 @@ func TestMakeRemapDotConfigEdgeRangeRequestDontCache(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4831,7 +4963,10 @@ func TestMakeRemapDotConfigEdgeRangeRequestBGFetch(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4934,7 +5069,10 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlice(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5041,7 +5179,10 @@ func TestMakeRemapDotConfigRawRemapRangeDirective(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5161,7 +5302,10 @@ func TestMakeRemapDotConfigRawRemapWithoutRangeDirective(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5274,7 +5418,10 @@ func TestMakeRemapDotConfigEdgeRangeRequestCache(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5376,7 +5523,10 @@ func TestMakeRemapDotConfigEdgeFQPacingNil(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5474,7 +5624,10 @@ func TestMakeRemapDotConfigEdgeFQPacingNegative(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5572,7 +5725,10 @@ func TestMakeRemapDotConfigEdgeFQPacingZero(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5670,7 +5826,10 @@ func TestMakeRemapDotConfigEdgeFQPacingPositive(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5772,7 +5931,10 @@ func TestMakeRemapDotConfigEdgeDNS(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5870,7 +6032,10 @@ func TestMakeRemapDotConfigEdgeDNSNoRoutingName(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5958,7 +6123,10 @@ func TestMakeRemapDotConfigEdgeRegexTypeNil(t *testing.T) {
 
 	server := serverInfoToServer(serverInfo)
 	topologies := []tc.Topology{}
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -6102,7 +6270,11 @@ func TestMakeRemapDotConfigTopologies(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
 
 	txt = strings.TrimSpace(txt)
 
@@ -6114,6 +6286,169 @@ func TestMakeRemapDotConfigTopologies(t *testing.T) {
 
 	if strings.Contains(txt, "origin1") {
 		t.Errorf("expected to not contain DS with edge not in topology, actual '%v'", txt)
+	}
+}
+
+func TestMakeRemapDotConfigTopologyCapabilities(t *testing.T) {
+	serverName := tc.CacheName("server0")
+	toToolName := "to0"
+	toURL := "trafficops.example.net"
+	atsMajorVersion := 7
+
+	cacheURLConfigParams := map[string]string{
+		"not_location": "notinconfig",
+	}
+
+	dsProfilesCacheKeyConfigParams := map[int]map[string]string{
+		46: map[string]string{
+			"cachekeykey": "cachekeyval",
+		},
+	}
+
+	serverPackageParamData := map[string]string{
+		"serverpkgval": "serverpkgval __HOSTNAME__ foo",
+	}
+
+	serverInfo := &ServerInfo{
+		CacheGroupID:                  42,
+		CDN:                           "mycdn",
+		CDNID:                         43,
+		DomainName:                    "mydomain",
+		HostName:                      string(serverName),
+		HTTPSPort:                     12443,
+		ID:                            44,
+		IP:                            "192.168.2.4",
+		ParentCacheGroupID:            45,
+		ParentCacheGroupType:          "CGType4",
+		ProfileID:                     46,
+		ProfileName:                   "MyProfile",
+		Port:                          12080,
+		SecondaryParentCacheGroupID:   47,
+		SecondaryParentCacheGroupType: "MySecondaryParentCG",
+		Type:                          "EDGE",
+	}
+
+	remapDSData := []RemapConfigDSData{
+		RemapConfigDSData{
+			ID:                       48,
+			Type:                     "HTTP_LIVE",
+			OriginFQDN:               util.StrPtr("origin0.example.test"),
+			MidHeaderRewrite:         util.StrPtr("mymidrewrite"),
+			CacheURL:                 util.StrPtr("mycacheurl"),
+			RangeRequestHandling:     util.IntPtr(0),
+			CacheKeyConfigParams:     map[string]string{"cachekeyparamname": "cachekeyparamval"},
+			RemapText:                util.StrPtr("myremaptext"),
+			EdgeHeaderRewrite:        util.StrPtr("myedgeheaderrewrite"),
+			SigningAlgorithm:         util.StrPtr("url_sig"),
+			Name:                     "mydsname0",
+			QStringIgnore:            util.IntPtr(0),
+			RegexRemap:               util.StrPtr("myregexremap"),
+			FQPacingRate:             util.IntPtr(0),
+			DSCP:                     0,
+			RoutingName:              util.StrPtr("myroutingname"),
+			MultiSiteOrigin:          util.StrPtr("mymso"),
+			Pattern:                  util.StrPtr("myregexpattern"),
+			RegexType:                util.StrPtr(string(tc.DSMatchTypeHostRegex)),
+			Domain:                   util.StrPtr("mydomain"),
+			RegexSetNumber:           util.StrPtr("myregexsetnum"),
+			OriginShield:             util.StrPtr("myoriginshield"),
+			ProfileID:                util.IntPtr(49),
+			Protocol:                 util.IntPtr(0),
+			AnonymousBlockingEnabled: util.BoolPtr(false),
+			Active:                   true,
+			Topology:                 "t0",
+		},
+		RemapConfigDSData{
+			ID:                       48,
+			Type:                     "HTTP_LIVE",
+			OriginFQDN:               util.StrPtr("origin1.example.test"),
+			MidHeaderRewrite:         util.StrPtr("mymidrewrite"),
+			CacheURL:                 util.StrPtr("mycacheurl"),
+			RangeRequestHandling:     util.IntPtr(0),
+			CacheKeyConfigParams:     map[string]string{"cachekeyparamname": "cachekeyparamval"},
+			RemapText:                util.StrPtr("myremaptext"),
+			EdgeHeaderRewrite:        util.StrPtr("myedgeheaderrewrite"),
+			SigningAlgorithm:         util.StrPtr("url_sig"),
+			Name:                     "mydsname1",
+			QStringIgnore:            util.IntPtr(0),
+			RegexRemap:               util.StrPtr("myregexremap"),
+			FQPacingRate:             util.IntPtr(0),
+			DSCP:                     0,
+			RoutingName:              util.StrPtr("myroutingname"),
+			MultiSiteOrigin:          util.StrPtr("mymso"),
+			Pattern:                  util.StrPtr("myregexpattern"),
+			RegexType:                util.StrPtr(string(tc.DSMatchTypeHostRegex)),
+			Domain:                   util.StrPtr("mydomain"),
+			RegexSetNumber:           util.StrPtr("myregexsetnum"),
+			OriginShield:             util.StrPtr("myoriginshield"),
+			ProfileID:                util.IntPtr(49),
+			Protocol:                 util.IntPtr(0),
+			AnonymousBlockingEnabled: util.BoolPtr(false),
+			Active:                   true,
+			Topology:                 "t1",
+		},
+	}
+
+	server := serverInfoToServer(serverInfo)
+	server.Cachegroup = "edgeCG"
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+		tc.Topology{
+			Name: "t1",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "otherEdgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+	}
+
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{
+		serverInfo.ID: map[ServerCapability]struct{}{
+			"capx": {},
+		},
+	}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{
+		remapDSData[0].ID: map[ServerCapability]struct{}{
+			"capx": {},
+		},
+	}
+
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
+
+	txt = strings.TrimSpace(txt)
+
+	testComment(t, txt, string(serverName), toToolName, toURL)
+
+	if !strings.Contains(txt, "origin0") {
+		t.Errorf("expected to contain DS with edge in topology, actual '%v'", txt)
+	}
+
+	if strings.Contains(txt, "origin1") {
+		t.Errorf("expected to not contain DS with edge not in topology, actual '%v'", txt)
+	}
+
+	serverCapabilities[serverInfo.ID] = map[ServerCapability]struct{}{}
+	txt = MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies, cgs, serverCapabilities, dsRequiredCapabilities)
+	if strings.Contains(txt, "origin1") {
+		t.Errorf("expected to not contain DS with edge missing required capabilities, actual '%v'", txt)
 	}
 }
 

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -52,7 +52,7 @@ func TestMakeRemapDotConfig(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -97,7 +97,9 @@ func TestMakeRemapDotConfig(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -153,7 +155,7 @@ func TestMakeRemapDotConfigMidLiveLocalExcluded(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -198,7 +200,9 @@ func TestMakeRemapDotConfigMidLiveLocalExcluded(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -236,7 +240,7 @@ func TestMakeRemapDotConfigMid(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -281,7 +285,9 @@ func TestMakeRemapDotConfigMid(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -333,7 +339,7 @@ func TestMakeRemapDotConfigNilOrigin(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -378,7 +384,9 @@ func TestMakeRemapDotConfigNilOrigin(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -416,7 +424,7 @@ func TestMakeRemapDotConfigEmptyOrigin(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -461,7 +469,9 @@ func TestMakeRemapDotConfigEmptyOrigin(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -499,7 +509,7 @@ func TestMakeRemapDotConfigDuplicateOrigins(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -572,7 +582,9 @@ func TestMakeRemapDotConfigDuplicateOrigins(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -610,7 +622,7 @@ func TestMakeRemapDotConfigNilMidRewrite(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -655,7 +667,9 @@ func TestMakeRemapDotConfigNilMidRewrite(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -716,7 +730,7 @@ func TestMakeRemapDotConfigMidHasNoEdgeRewrite(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -761,7 +775,9 @@ func TestMakeRemapDotConfigMidHasNoEdgeRewrite(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -813,7 +829,7 @@ func TestMakeRemapDotConfigMidQStringPassUpATS7CacheKey(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -858,7 +874,9 @@ func TestMakeRemapDotConfigMidQStringPassUpATS7CacheKey(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -917,7 +935,7 @@ func TestMakeRemapDotConfigMidQStringPassUpATS5CacheURL(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -962,7 +980,9 @@ func TestMakeRemapDotConfigMidQStringPassUpATS5CacheURL(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1024,7 +1044,7 @@ func TestMakeRemapDotConfigMidProfileCacheKey(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -1069,7 +1089,9 @@ func TestMakeRemapDotConfigMidProfileCacheKey(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1132,7 +1154,7 @@ func TestMakeRemapDotConfigMidRangeRequestHandling(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -1177,7 +1199,9 @@ func TestMakeRemapDotConfigMidRangeRequestHandling(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1232,7 +1256,7 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -1278,7 +1302,9 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1334,7 +1360,7 @@ func TestMakeRemapDotConfigFirstExcludedSecondIncluded(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -1407,7 +1433,9 @@ func TestMakeRemapDotConfigFirstExcludedSecondIncluded(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1445,7 +1473,7 @@ func TestMakeRemapDotConfigAnyMap(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -1518,7 +1546,9 @@ func TestMakeRemapDotConfigAnyMap(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1567,7 +1597,7 @@ func TestMakeRemapDotConfigEdgeMissingRemapData(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -1892,7 +1922,9 @@ func TestMakeRemapDotConfigEdgeMissingRemapData(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -1931,7 +1963,7 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacement(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -1976,7 +2008,9 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacement(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2032,7 +2066,7 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTP(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2077,7 +2111,9 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTP(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2133,7 +2169,7 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTPS(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2178,7 +2214,9 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTPS(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2234,7 +2272,7 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTPToHTTPS(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2279,7 +2317,9 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTPToHTTPS(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2335,7 +2375,7 @@ func TestMakeRemapDotConfigEdgeRemapUnderscoreHTTPReplace(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2380,7 +2420,9 @@ func TestMakeRemapDotConfigEdgeRemapUnderscoreHTTPReplace(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2432,7 +2474,7 @@ func TestMakeRemapDotConfigEdgeDSCPRemap(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2477,7 +2519,9 @@ func TestMakeRemapDotConfigEdgeDSCPRemap(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2529,7 +2573,7 @@ func TestMakeRemapDotConfigEdgeNoDSCPRemap(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2574,7 +2618,9 @@ func TestMakeRemapDotConfigEdgeNoDSCPRemap(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2626,7 +2672,7 @@ func TestMakeRemapDotConfigEdgeHeaderRewrite(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2671,7 +2717,9 @@ func TestMakeRemapDotConfigEdgeHeaderRewrite(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2727,7 +2775,7 @@ func TestMakeRemapDotConfigEdgeHeaderRewriteEmpty(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2772,7 +2820,9 @@ func TestMakeRemapDotConfigEdgeHeaderRewriteEmpty(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2828,7 +2878,7 @@ func TestMakeRemapDotConfigEdgeHeaderRewriteNil(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2873,7 +2923,9 @@ func TestMakeRemapDotConfigEdgeHeaderRewriteNil(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -2929,7 +2981,7 @@ func TestMakeRemapDotConfigEdgeSigningURLSig(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -2974,7 +3026,9 @@ func TestMakeRemapDotConfigEdgeSigningURLSig(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3025,7 +3079,7 @@ func TestMakeRemapDotConfigEdgeSigningURISigning(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3070,7 +3124,9 @@ func TestMakeRemapDotConfigEdgeSigningURISigning(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3121,7 +3177,7 @@ func TestMakeRemapDotConfigEdgeSigningNone(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3166,7 +3222,9 @@ func TestMakeRemapDotConfigEdgeSigningNone(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3217,7 +3275,7 @@ func TestMakeRemapDotConfigEdgeSigningEmpty(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3262,7 +3320,9 @@ func TestMakeRemapDotConfigEdgeSigningEmpty(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3313,7 +3373,7 @@ func TestMakeRemapDotConfigEdgeSigningWrong(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3358,7 +3418,9 @@ func TestMakeRemapDotConfigEdgeSigningWrong(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3409,7 +3471,7 @@ func TestMakeRemapDotConfigEdgeQStringDropAtEdge(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3454,7 +3516,9 @@ func TestMakeRemapDotConfigEdgeQStringDropAtEdge(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3503,7 +3567,7 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUp(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3548,7 +3612,9 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUp(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3601,7 +3667,7 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpWithCacheKeyParameter(t *testi
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3646,7 +3712,9 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpWithCacheKeyParameter(t *testi
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3698,7 +3766,7 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParam(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3743,7 +3811,9 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParam(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3791,7 +3861,7 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParamCacheURL(t *testi
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3836,7 +3906,9 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParamCacheURL(t *testi
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3891,7 +3963,7 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParamCacheURLAndDSCach
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -3936,7 +4008,9 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParamCacheURLAndDSCach
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -3995,7 +4069,7 @@ func TestMakeRemapDotConfigMidQStringIgnorePassUpCacheURLParamCacheURLAndDSCache
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4040,7 +4114,9 @@ func TestMakeRemapDotConfigMidQStringIgnorePassUpCacheURLParamCacheURLAndDSCache
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4096,7 +4172,7 @@ func TestMakeRemapDotConfigEdgeCacheURL(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4141,7 +4217,9 @@ func TestMakeRemapDotConfigEdgeCacheURL(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4192,7 +4270,7 @@ func TestMakeRemapDotConfigEdgeCacheKeyParams(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4237,7 +4315,9 @@ func TestMakeRemapDotConfigEdgeCacheKeyParams(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4300,7 +4380,7 @@ func TestMakeRemapDotConfigEdgeRegexRemap(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4345,7 +4425,9 @@ func TestMakeRemapDotConfigEdgeRegexRemap(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4400,7 +4482,7 @@ func TestMakeRemapDotConfigEdgeRegexRemapEmpty(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4445,7 +4527,9 @@ func TestMakeRemapDotConfigEdgeRegexRemapEmpty(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4496,7 +4580,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestNil(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4541,7 +4625,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestNil(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4596,7 +4682,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestDontCache(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4641,7 +4727,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestDontCache(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4696,7 +4784,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestBGFetch(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4741,7 +4829,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestBGFetch(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4796,7 +4886,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlice(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4842,7 +4932,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlice(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -4901,7 +4993,7 @@ func TestMakeRemapDotConfigRawRemapRangeDirective(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -4947,7 +5039,9 @@ func TestMakeRemapDotConfigRawRemapRangeDirective(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5019,7 +5113,7 @@ func TestMakeRemapDotConfigRawRemapWithoutRangeDirective(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5065,7 +5159,9 @@ func TestMakeRemapDotConfigRawRemapWithoutRangeDirective(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5131,7 +5227,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestCache(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5176,7 +5272,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestCache(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5231,7 +5329,7 @@ func TestMakeRemapDotConfigEdgeFQPacingNil(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5276,7 +5374,9 @@ func TestMakeRemapDotConfigEdgeFQPacingNil(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5327,7 +5427,7 @@ func TestMakeRemapDotConfigEdgeFQPacingNegative(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5372,7 +5472,9 @@ func TestMakeRemapDotConfigEdgeFQPacingNegative(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5423,7 +5525,7 @@ func TestMakeRemapDotConfigEdgeFQPacingZero(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5468,7 +5570,9 @@ func TestMakeRemapDotConfigEdgeFQPacingZero(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5519,7 +5623,7 @@ func TestMakeRemapDotConfigEdgeFQPacingPositive(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5564,7 +5668,9 @@ func TestMakeRemapDotConfigEdgeFQPacingPositive(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5619,7 +5725,7 @@ func TestMakeRemapDotConfigEdgeDNS(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5664,7 +5770,9 @@ func TestMakeRemapDotConfigEdgeDNS(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5715,7 +5823,7 @@ func TestMakeRemapDotConfigEdgeDNSNoRoutingName(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5760,7 +5868,9 @@ func TestMakeRemapDotConfigEdgeDNSNoRoutingName(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5801,7 +5911,7 @@ func TestMakeRemapDotConfigEdgeRegexTypeNil(t *testing.T) {
 		CDN:                           "mycdn",
 		CDNID:                         43,
 		DomainName:                    "mydomain",
-		HostName:                      "myhost",
+		HostName:                      string(serverName),
 		HTTPSPort:                     12443,
 		ID:                            44,
 		IP:                            "192.168.2.4",
@@ -5846,7 +5956,9 @@ func TestMakeRemapDotConfigEdgeRegexTypeNil(t *testing.T) {
 		},
 	}
 
-	txt := MakeRemapDotConfig(serverName, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData)
+	server := serverInfoToServer(serverInfo)
+	topologies := []tc.Topology{}
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
 
 	txt = strings.TrimSpace(txt)
 
@@ -5858,4 +5970,167 @@ func TestMakeRemapDotConfigEdgeRegexTypeNil(t *testing.T) {
 		t.Fatalf("expected no remaps for DS with nil regex type, actual: '%v' count %v", txt, len(txtLines))
 	}
 
+}
+
+func TestMakeRemapDotConfigTopologies(t *testing.T) {
+	serverName := tc.CacheName("server0")
+	toToolName := "to0"
+	toURL := "trafficops.example.net"
+	atsMajorVersion := 7
+
+	cacheURLConfigParams := map[string]string{
+		"not_location": "notinconfig",
+	}
+
+	dsProfilesCacheKeyConfigParams := map[int]map[string]string{
+		46: map[string]string{
+			"cachekeykey": "cachekeyval",
+		},
+	}
+
+	serverPackageParamData := map[string]string{
+		"serverpkgval": "serverpkgval __HOSTNAME__ foo",
+	}
+
+	serverInfo := &ServerInfo{
+		CacheGroupID:                  42,
+		CDN:                           "mycdn",
+		CDNID:                         43,
+		DomainName:                    "mydomain",
+		HostName:                      string(serverName),
+		HTTPSPort:                     12443,
+		ID:                            44,
+		IP:                            "192.168.2.4",
+		ParentCacheGroupID:            45,
+		ParentCacheGroupType:          "CGType4",
+		ProfileID:                     46,
+		ProfileName:                   "MyProfile",
+		Port:                          12080,
+		SecondaryParentCacheGroupID:   47,
+		SecondaryParentCacheGroupType: "MySecondaryParentCG",
+		Type:                          "EDGE",
+	}
+
+	remapDSData := []RemapConfigDSData{
+		RemapConfigDSData{
+			ID:                       48,
+			Type:                     "HTTP_LIVE",
+			OriginFQDN:               util.StrPtr("origin0.example.test"),
+			MidHeaderRewrite:         util.StrPtr("mymidrewrite"),
+			CacheURL:                 util.StrPtr("mycacheurl"),
+			RangeRequestHandling:     util.IntPtr(0),
+			CacheKeyConfigParams:     map[string]string{"cachekeyparamname": "cachekeyparamval"},
+			RemapText:                util.StrPtr("myremaptext"),
+			EdgeHeaderRewrite:        util.StrPtr("myedgeheaderrewrite"),
+			SigningAlgorithm:         util.StrPtr("url_sig"),
+			Name:                     "mydsname0",
+			QStringIgnore:            util.IntPtr(0),
+			RegexRemap:               util.StrPtr("myregexremap"),
+			FQPacingRate:             util.IntPtr(0),
+			DSCP:                     0,
+			RoutingName:              util.StrPtr("myroutingname"),
+			MultiSiteOrigin:          util.StrPtr("mymso"),
+			Pattern:                  util.StrPtr("myregexpattern"),
+			RegexType:                util.StrPtr(string(tc.DSMatchTypeHostRegex)),
+			Domain:                   util.StrPtr("mydomain"),
+			RegexSetNumber:           util.StrPtr("myregexsetnum"),
+			OriginShield:             util.StrPtr("myoriginshield"),
+			ProfileID:                util.IntPtr(49),
+			Protocol:                 util.IntPtr(0),
+			AnonymousBlockingEnabled: util.BoolPtr(false),
+			Active:                   true,
+			Topology:                 "t0",
+		},
+		RemapConfigDSData{
+			ID:                       48,
+			Type:                     "HTTP_LIVE",
+			OriginFQDN:               util.StrPtr("origin1.example.test"),
+			MidHeaderRewrite:         util.StrPtr("mymidrewrite"),
+			CacheURL:                 util.StrPtr("mycacheurl"),
+			RangeRequestHandling:     util.IntPtr(0),
+			CacheKeyConfigParams:     map[string]string{"cachekeyparamname": "cachekeyparamval"},
+			RemapText:                util.StrPtr("myremaptext"),
+			EdgeHeaderRewrite:        util.StrPtr("myedgeheaderrewrite"),
+			SigningAlgorithm:         util.StrPtr("url_sig"),
+			Name:                     "mydsname1",
+			QStringIgnore:            util.IntPtr(0),
+			RegexRemap:               util.StrPtr("myregexremap"),
+			FQPacingRate:             util.IntPtr(0),
+			DSCP:                     0,
+			RoutingName:              util.StrPtr("myroutingname"),
+			MultiSiteOrigin:          util.StrPtr("mymso"),
+			Pattern:                  util.StrPtr("myregexpattern"),
+			RegexType:                util.StrPtr(string(tc.DSMatchTypeHostRegex)),
+			Domain:                   util.StrPtr("mydomain"),
+			RegexSetNumber:           util.StrPtr("myregexsetnum"),
+			OriginShield:             util.StrPtr("myoriginshield"),
+			ProfileID:                util.IntPtr(49),
+			Protocol:                 util.IntPtr(0),
+			AnonymousBlockingEnabled: util.BoolPtr(false),
+			Active:                   true,
+			Topology:                 "t1",
+		},
+	}
+
+	server := serverInfoToServer(serverInfo)
+	server.Cachegroup = "edgeCG"
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+		tc.Topology{
+			Name: "t1",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "otherEdgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+	}
+
+	txt := MakeRemapDotConfig(server, toToolName, toURL, atsMajorVersion, cacheURLConfigParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapDSData, topologies)
+
+	txt = strings.TrimSpace(txt)
+
+	testComment(t, txt, string(serverName), toToolName, toURL)
+
+	if !strings.Contains(txt, "origin0") {
+		t.Errorf("expected to contain DS with edge in topology, actual '%v'", txt)
+	}
+
+	if strings.Contains(txt, "origin1") {
+		t.Errorf("expected to not contain DS with edge not in topology, actual '%v'", txt)
+	}
+}
+
+// serverInfoToServer is for tests, and does NOT copy all data, do NOT use for real code.
+func serverInfoToServer(si *ServerInfo) tc.Server {
+	return tc.Server{
+		CachegroupID: si.CacheGroupID,
+		CDNName:      string(si.CDN),
+		CDNID:        si.CDNID,
+		DomainName:   si.DomainName,
+		HostName:     si.HostName,
+		HTTPSPort:    si.HTTPSPort,
+		ID:           si.ID,
+		IPAddress:    si.IP,
+		ProfileID:    int(si.ProfileID),
+		Profile:      si.ProfileName,
+		TCPPort:      si.Port,
+		Type:         si.Type,
+	}
 }

--- a/lib/go-atscfg/topologyheaderrewritedotconfig.go
+++ b/lib/go-atscfg/topologyheaderrewritedotconfig.go
@@ -1,0 +1,140 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const HeaderRewriteFirstPrefix = HeaderRewritePrefix + "first_"
+const HeaderRewriteInnerPrefix = HeaderRewritePrefix + "inner_"
+const HeaderRewriteLastPrefix = HeaderRewritePrefix + "last_"
+
+func FirstHeaderRewriteConfigFileName(dsName string) string {
+	return HeaderRewriteFirstPrefix + dsName + ConfigSuffix
+}
+
+func InnerHeaderRewriteConfigFileName(dsName string) string {
+	return HeaderRewriteInnerPrefix + dsName + ConfigSuffix
+}
+
+func LastHeaderRewriteConfigFileName(dsName string) string {
+	return HeaderRewriteLastPrefix + dsName + ConfigSuffix
+}
+
+func MakeTopologyHeaderRewriteDotConfig(
+	server tc.Server,
+	toToolName string, // tm.toolname global parameter (TODO: cache itself?)
+	toURL string, // tm.url global parameter (TODO: cache itself?)
+	ds tc.DeliveryServiceNullable,
+	topologies []tc.Topology,
+	cacheGroupArr []tc.CacheGroupNullable,
+	servers []tc.Server,
+	serverCapabilities map[int]map[ServerCapability]struct{},
+	dsRequiredCapabilities map[ServerCapability]struct{},
+) string {
+	text := GenericHeaderComment(server.HostName, toToolName, toURL)
+
+	cacheGroups := MakeCGMap(cacheGroupArr)
+
+	if ds.Topology == nil || *ds.Topology == "" {
+		log.Errorln("Config generation: Topology Header Rewrite called for DS '" + *ds.XMLID + "' with no Topology! This should never be called, a DS with no topology should never have a First, Inner, or Last Header Rewrite config in the list of config files! Returning blank config!")
+		return text
+	}
+
+	topology := tc.Topology{}
+	for _, to := range topologies {
+		if to.Name == *ds.Topology {
+			topology = to
+			break
+		}
+	}
+	if topology.Name == "" {
+		log.Errorln("Config generation: Topology Header Rewrite called for DS '" + *ds.XMLID + "' but its Topology '" + *ds.Topology + "' not found in list of topologies! Returning blank config!")
+		return text
+	}
+
+	log.Errorf("DEBUG topo MakeTopologyHeaderRewriteDotConfig calling getTopologyPlacement cg '" + server.Cachegroup + "'\n")
+	serverPlacement := getTopologyPlacement(tc.CacheGroupName(server.Cachegroup), topology, cacheGroups)
+	if !serverPlacement.InTopology {
+		log.Errorln("Config generation: Topology Header Rewrite called for DS '" + *ds.XMLID + "' on server '" + server.HostName + "' is not in the DS's topology! Returning blank config!")
+		return text
+	}
+
+	headerRewrite := (*string)(nil)
+	switch serverPlacement.CacheTier {
+	case TopologyCacheTierFirst:
+		headerRewrite = ds.FirstHeaderRewrite
+	case TopologyCacheTierInner:
+		headerRewrite = ds.InnerHeaderRewrite
+	case TopologyCacheTierLast:
+		headerRewrite = ds.LastHeaderRewrite
+	default:
+		log.Errorln("Config generation: Topology Header Rewrite called for DS '" + *ds.XMLID + "' on server '" + server.HostName + "' got unknown topology cache tier '" + string(serverPlacement.CacheTier) + "'! Returning blank config!")
+		return text
+	}
+
+	if serverPlacement.CacheTier == TopologyCacheTierLast && ds.MaxOriginConnections != nil && *ds.MaxOriginConnections > 0 {
+		lastTierCacheCount := GetTopologyDSServerCount(dsRequiredCapabilities, tc.CacheGroupName(server.Cachegroup), servers, serverCapabilities)
+
+		maxOriginConnectionsPerServer := int(math.Round(float64(*ds.MaxOriginConnections) / float64(lastTierCacheCount)))
+		if maxOriginConnectionsPerServer < 1 {
+			maxOriginConnectionsPerServer = 1
+		}
+
+		text += "cond %{REMAP_PSEUDO_HOOK}\nset-config proxy.config.http.origin_max_connections " + strconv.Itoa(maxOriginConnectionsPerServer)
+		if headerRewrite == nil || *headerRewrite == "" {
+			text += " [L]"
+		} else {
+			text += "\n"
+		}
+	}
+
+	if headerRewrite != nil && *headerRewrite != "" {
+		text += *headerRewrite
+	}
+	text += "\n"
+	return text
+}
+
+// GetTopologyDSServerCount returns the number of servers in cg which will be used to serve ds.
+// This should only be used for DSes with Topologies.
+// It returns all servers in CG with the Capabilities of ds in cg.
+// It will not be the number of servers for Delivery Services not using Topologies, which use DeliveryService-Server assignments instead.
+func GetTopologyDSServerCount(dsRequiredCapabilities map[ServerCapability]struct{}, cg tc.CacheGroupName, servers []tc.Server, serverCapabilities map[int]map[ServerCapability]struct{}) int {
+	count := 0
+	for _, sv := range servers {
+		if sv.Cachegroup != string(cg) {
+			continue
+		}
+		if sv.Status != string(tc.CacheStatusReported) && sv.Status != string(tc.CacheStatusOnline) {
+			continue
+		}
+		if !HasRequiredCapabilities(serverCapabilities[sv.ID], dsRequiredCapabilities) {
+			continue
+		}
+		count++
+	}
+	return count
+}

--- a/lib/go-atscfg/topologyheaderrewritedotconfig.go
+++ b/lib/go-atscfg/topologyheaderrewritedotconfig.go
@@ -63,13 +63,8 @@ func MakeTopologyHeaderRewriteDotConfig(
 		return text
 	}
 
-	topology := tc.Topology{}
-	for _, to := range topologies {
-		if to.Name == *ds.Topology {
-			topology = to
-			break
-		}
-	}
+	nameTopologies := MakeTopologyNameMap(topologies)
+	topology := nameTopologies[TopologyName(*ds.Topology)]
 	if topology.Name == "" {
 		log.Errorln("Config generation: Topology Header Rewrite called for DS '" + *ds.XMLID + "' but its Topology '" + *ds.Topology + "' not found in list of topologies! Returning blank config!")
 		return text

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/meta.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/meta.go
@@ -92,7 +92,12 @@ func GetConfigMetaData(w http.ResponseWriter, r *http.Request) {
 		dses[name] = tc.DeliveryServiceNullable{}
 	}
 
-	txt := atscfg.MakeMetaConfig(tc.CacheName(serverName), server, tmParams.URL, tmParams.ReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses)
+	// This endpoint should not be used for new features with Topologies.
+	// If a new TO install is using Topologies, it must be upgraded to the latest ORT (which doesn't use this endpoint).
+	cgs := []tc.CacheGroupNullable{}
+	topologies := []tc.Topology{}
+
+	txt := atscfg.MakeMetaConfig(tc.CacheName(serverName), server, tmParams.URL, tmParams.ReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, cgs, topologies)
 	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(txt))
 }

--- a/traffic_ops/traffic_ops_golang/ats/atsserver/meta.go
+++ b/traffic_ops/traffic_ops_golang/ats/atsserver/meta.go
@@ -84,7 +84,15 @@ func GetConfigMetaData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	txt := atscfg.MakeMetaConfig(tc.CacheName(serverName), server, tmParams.URL, tmParams.ReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dsNames)
+	// DSes are only used by the Meta generation for inferring location Parameters, which can't be done anyway since TO doesn't have a local ATS install config directory.
+	// This would be fragile, and break if the Meta were changed to use them for anything else,
+	// Except this endpoint is going away shortly anyway, and is not used by ORT.
+	dses := map[tc.DeliveryServiceName]tc.DeliveryServiceNullable{}
+	for name, _ := range dsNames {
+		dses[name] = tc.DeliveryServiceNullable{}
+	}
+
+	txt := atscfg.MakeMetaConfig(tc.CacheName(serverName), server, tmParams.URL, tmParams.ReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses)
 	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
 	w.Write([]byte(txt))
 }

--- a/traffic_ops_ort/atstccfg/cfgfile/cachedotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/cachedotconfig.go
@@ -58,7 +58,7 @@ func GetConfigFileProfileCacheDotConfig(toData *config.TOData) (string, string, 
 		if *ds.OrgServerFQDN == "" {
 			continue // TODO warn? err?
 		}
-		if _, ok := dsIDs[*ds.ID]; !ok {
+		if _, ok := dsIDs[*ds.ID]; !ok && ds.Topology == nil {
 			continue
 		}
 		origin := *ds.OrgServerFQDN

--- a/traffic_ops_ort/atstccfg/cfgfile/cacheurldotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/cacheurldotconfig.go
@@ -52,7 +52,7 @@ func GetConfigFileCDNCacheURL(toData *config.TOData, fileName string) (string, s
 		if ds.Type != nil && (*ds.Type == tc.DSTypeAnyMap || *ds.Type == tc.DSTypeSteering) {
 			continue
 		}
-		if len(dssMap[*ds.ID]) == 0 {
+		if len(dssMap[*ds.ID]) == 0 && ds.Topology == nil {
 			continue
 		}
 		dsesWithServers = append(dsesWithServers, ds)

--- a/traffic_ops_ort/atstccfg/cfgfile/headerrewritedotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/headerrewritedotconfig.go
@@ -70,7 +70,7 @@ func GetConfigFileCDNHeaderRewrite(toData *config.TOData, fileName string) (stri
 		if server.CDNName != *tcDS.CDNName {
 			continue
 		}
-		if _, ok := dsServerIDs[server.ID]; !ok {
+		if _, ok := dsServerIDs[server.ID]; !ok && tcDS.Topology == nil {
 			continue
 		}
 		cfgServer, err := atscfg.HeaderRewriteServerFromServerNotNullable(server)

--- a/traffic_ops_ort/atstccfg/cfgfile/headerrewritemiddotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/headerrewritemiddotconfig.go
@@ -52,19 +52,6 @@ func GetConfigFileCDNHeaderRewriteMid(toData *config.TOData, fileName string) (s
 		return "", "", "", errors.New("converting ds to config ds: " + err.Error())
 	}
 
-	dsServers := FilterDSS(toData.DeliveryServiceServers, map[int]struct{}{cfgDS.ID: {}}, nil)
-
-	dsServerIDs := map[int]struct{}{}
-	for _, dss := range dsServers {
-		if dss.Server == nil || dss.DeliveryService == nil {
-			continue // TODO warn?
-		}
-		if *dss.DeliveryService != *tcDS.ID {
-			continue
-		}
-		dsServerIDs[*dss.Server] = struct{}{}
-	}
-
 	serverCGs := map[tc.CacheGroupName]struct{}{}
 	for _, sv := range toData.Servers {
 		if sv.CDNName != toData.Server.CDNName {

--- a/traffic_ops_ort/atstccfg/cfgfile/meta.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/meta.go
@@ -160,7 +160,7 @@ func GetMeta(toData *config.TOData, dir string) (*tc.ATSConfigMetaData, error) {
 			if ds.XMLID == nil {
 				continue // TODO log?
 			}
-			if _, ok := dssMap[*ds.ID]; !ok {
+			if _, ok := dssMap[*ds.ID]; !ok && ds.Topology == nil {
 				continue
 			}
 			dses[tc.DeliveryServiceName(*ds.XMLID)] = ds

--- a/traffic_ops_ort/atstccfg/cfgfile/meta.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/meta.go
@@ -80,6 +80,7 @@ func GetMeta(toData *config.TOData, dir string) (*tc.ATSConfigMetaData, error) {
 
 	serverInfo := atscfg.ServerInfo{
 		CacheGroupID:                  toData.Server.CachegroupID,
+		CacheGroupName:                toData.Server.Cachegroup,
 		CDN:                           tc.CDNName(toData.Server.CDNName),
 		CDNID:                         toData.Server.CDNID,
 		DomainName:                    toData.Server.DomainName,
@@ -197,7 +198,7 @@ func GetMeta(toData *config.TOData, dir string) (*tc.ATSConfigMetaData, error) {
 		uriSignedDSes = append(uriSignedDSes, tc.DeliveryServiceName(*ds.XMLID))
 	}
 
-	metaObj, err := atscfg.MakeMetaObj(tc.CacheName(toData.Server.HostName), &serverInfo, toURL, toReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, dir)
+	metaObj, err := atscfg.MakeMetaObj(tc.CacheName(toData.Server.HostName), &serverInfo, toURL, toReverseProxyURL, locationParams, uriSignedDSes, scopeParams, dses, toData.CacheGroups, toData.Topologies, dir)
 	if err != nil {
 		return nil, errors.New("generating: " + err.Error())
 	}

--- a/traffic_ops_ort/atstccfg/cfgfile/parentdotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/parentdotconfig.go
@@ -456,7 +456,7 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 
 	parentInfos := atscfg.MakeParentInfo(&serverInfo, serverCDNDomain, profileCaches, originServers)
 
-	return atscfg.MakeParentDotConfig(&serverInfo, atsMajorVer, toData.TOToolName, toData.TOURL, parentConfigDSes, serverParams, parentInfos, toData.Server, toData.Servers, toData.Topologies, toData.ParentConfigParams, toData.ServerCapabilities), atscfg.ContentTypeParentDotConfig, atscfg.LineCommentParentDotConfig, nil
+	return atscfg.MakeParentDotConfig(&serverInfo, atsMajorVer, toData.TOToolName, toData.TOURL, parentConfigDSes, serverParams, parentInfos, toData.Server, toData.Servers, toData.Topologies, toData.ParentConfigParams, toData.ServerCapabilities, toData.CacheGroups), atscfg.ContentTypeParentDotConfig, atscfg.LineCommentParentDotConfig, nil
 }
 
 // GetDSOrigins takes a map[deliveryServiceID]DeliveryService, and returns a map[DeliveryServiceID]OriginURI.

--- a/traffic_ops_ort/atstccfg/cfgfile/remapdotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/remapdotconfig.go
@@ -123,7 +123,7 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, s
 		// TODO sort by DS ID? the old Perl query does, but it shouldn't be necessary, except for determinism.
 		// TODO warn if no regexes?
 		for _, dsRegex := range dsRegexMap[tc.DeliveryServiceName(*ds.XMLID)] {
-			remapConfigDSData = append(remapConfigDSData, atscfg.RemapConfigDSData{
+			rds := atscfg.RemapConfigDSData{
 				ID:                       *ds.ID,
 				Type:                     *ds.Type,
 				OriginFQDN:               ds.OrgServerFQDN,
@@ -149,7 +149,17 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, s
 				Active:                   *ds.Active,
 				RangeSliceBlockSize:      ds.RangeSliceBlockSize,
 				Topology:                 dsTopology,
-			})
+			}
+			if ds.FirstHeaderRewrite != nil {
+				rds.FirstHeaderRewrite = *ds.FirstHeaderRewrite
+			}
+			if ds.InnerHeaderRewrite != nil {
+				rds.InnerHeaderRewrite = *ds.InnerHeaderRewrite
+			}
+			if ds.LastHeaderRewrite != nil {
+				rds.LastHeaderRewrite = *ds.LastHeaderRewrite
+			}
+			remapConfigDSData = append(remapConfigDSData, rds)
 		}
 	}
 
@@ -277,6 +287,7 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, s
 
 	serverInfo := &atscfg.ServerInfo{
 		CacheGroupID:                  toData.Server.CachegroupID,
+		CacheGroupName:                toData.Server.Cachegroup,
 		CDN:                           tc.CDNName(toData.Server.CDNName),
 		CDNID:                         toData.Server.CDNID,
 		DomainName:                    toData.CDN.DomainName, // note this is intentionally the CDN domain, not the server domain. It's what's remapped to.
@@ -293,7 +304,7 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, s
 		SecondaryParentCacheGroupType: secondaryParentCGType,
 		Type:                          toData.Server.Type,
 	}
-	return atscfg.MakeRemapDotConfig(toData.Server, toData.TOToolName, toData.TOURL, atsMajorVer, cacheURLParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapConfigDSData, toData.Topologies), atscfg.ContentTypeRemapDotConfig, atscfg.LineCommentRemapDotConfig, nil
+	return atscfg.MakeRemapDotConfig(toData.Server, toData.TOToolName, toData.TOURL, atsMajorVer, cacheURLParams, dsProfilesCacheKeyConfigParams, serverPackageParamData, serverInfo, remapConfigDSData, toData.Topologies, toData.CacheGroups, toData.ServerCapabilities, toData.DSRequiredCapabilities), atscfg.ContentTypeRemapDotConfig, atscfg.LineCommentRemapDotConfig, nil
 }
 
 type DeliveryServiceRegexesSortByTypeThenSetNum []tc.DeliveryServiceRegex

--- a/traffic_ops_ort/atstccfg/cfgfile/routing.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/routing.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg/config"
@@ -167,7 +168,12 @@ func GetConfigFileServer(toData *config.TOData, fileName string) (string, string
 	contentType := ""
 	lineComment := ""
 	err := error(nil)
-	if getCfgFunc, ok := ServerConfigFileFuncs()[fileName]; ok {
+
+	if strings.HasPrefix(fileName, atscfg.HeaderRewriteFirstPrefix) ||
+		strings.HasPrefix(fileName, atscfg.HeaderRewriteInnerPrefix) ||
+		strings.HasPrefix(fileName, atscfg.HeaderRewriteLastPrefix) {
+		txt, contentType, lineComment, err = GetConfigFileServerTopologyHeaderRewrite(toData, fileName)
+	} else if getCfgFunc, ok := ServerConfigFileFuncs()[fileName]; ok {
 		txt, contentType, lineComment, err = getCfgFunc(toData)
 	} else {
 		txt, contentType, lineComment, err = GetConfigFileServerUnknownConfig(toData, fileName)

--- a/traffic_ops_ort/atstccfg/cfgfile/topologyheaderrewritedotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/topologyheaderrewritedotconfig.go
@@ -1,0 +1,61 @@
+package cfgfile
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg/config"
+)
+
+func GetConfigFileServerTopologyHeaderRewrite(toData *config.TOData, fileName string) (string, string, string, error) {
+	dsName := fileName
+	dsName = strings.TrimSuffix(dsName, atscfg.ConfigSuffix)
+	dsName = strings.TrimPrefix(dsName, atscfg.HeaderRewriteFirstPrefix)
+	dsName = strings.TrimPrefix(dsName, atscfg.HeaderRewriteInnerPrefix)
+	dsName = strings.TrimPrefix(dsName, atscfg.HeaderRewriteLastPrefix)
+
+	tcDS := tc.DeliveryServiceNullable{}
+	for _, ds := range toData.DeliveryServices {
+		if ds.XMLID == nil || *ds.XMLID != dsName {
+			continue
+		}
+		tcDS = ds
+		break
+	}
+	if tcDS.ID == nil {
+		return "", "", "", errors.New("topology ds '" + dsName + "' not found")
+	}
+
+	return atscfg.MakeTopologyHeaderRewriteDotConfig(
+		toData.Server,
+		toData.TOToolName,
+		toData.TOURL,
+		tcDS,
+		toData.Topologies,
+		toData.CacheGroups,
+		toData.Servers,
+		toData.ServerCapabilities,
+		toData.DSRequiredCapabilities[*tcDS.ID],
+	), atscfg.ContentTypeHeaderRewriteDotConfig, atscfg.LineCommentHeaderRewriteDotConfig, nil
+}

--- a/traffic_ops_ort/atstccfg/config/config.go
+++ b/traffic_ops_ort/atstccfg/config/config.go
@@ -297,4 +297,8 @@ type TOData struct {
 
 	// SSLKeys must be all the ssl keys for the server's cdn.
 	SSLKeys []tc.CDNSSLKeys
+
+	// Topologies must be all the topologies for the server's cdn.
+	// May incude topologies of other cdns.
+	Topologies []tc.Topology
 }

--- a/traffic_ops_ort/atstccfg/getdata/getdata.go
+++ b/traffic_ops_ort/atstccfg/getdata/getdata.go
@@ -112,7 +112,11 @@ func WriteStatuses(cfg config.TCCfg, output io.Writer) error {
 // WriteUpdateStatus writes the Traffic Ops server update status to output.
 // Note this is identical to /api/1.x/servers/name/update_status except it omits the '[]' wrapper.
 func WriteServerUpdateStatus(cfg config.TCCfg, output io.Writer) error {
-	status, err := cfg.TOClient.GetServerUpdateStatus(tc.CacheName(cfg.CacheHostName))
+	status, unsupported, err := cfg.TOClientNew.GetServerUpdateStatus(tc.CacheName(cfg.CacheHostName))
+	if err == nil && unsupported {
+		log.Warnln("ORT newer than Traffic Ops, falling back to previous API Delivery Services!")
+		status, err = cfg.TOClient.GetServerUpdateStatus(tc.CacheName(cfg.CacheHostName))
+	}
 	if err != nil {
 		return errors.New("getting server update status: " + err.Error())
 	}

--- a/traffic_ops_ort/atstccfg/toreqnew/toreqnew.go
+++ b/traffic_ops_ort/atstccfg/toreqnew/toreqnew.go
@@ -76,7 +76,7 @@ func (cl *TOClient) GetCDNDeliveryServices(cdnID int) ([]tc.DeliveryServiceNulla
 	deliveryServices := []tc.DeliveryServiceNullable{}
 	unsupported := false
 	err := torequtil.GetRetry(cl.NumRetries, "cdn_"+strconv.Itoa(cdnID)+"_deliveryservices", &deliveryServices, func(obj interface{}) error {
-		toDSes, reqInf, err := cl.C.GetDeliveryServicesByCDNID(cdnID)
+		toDSes, reqInf, err := cl.C.GetDeliveryServicesByCDNID(cdnID, nil)
 		if err != nil {
 			if errStr := strings.ToLower(err.Error()); strings.Contains(errStr, "not found") || strings.Contains(errStr, "not impl") {
 				unsupported = true
@@ -101,7 +101,7 @@ func (cl *TOClient) GetTopologies() ([]tc.Topology, bool, error) {
 	topologies := []tc.Topology{}
 	unsupported := false
 	err := torequtil.GetRetry(cl.NumRetries, "topologies", &topologies, func(obj interface{}) error {
-		toTopologies, reqInf, err := cl.C.GetTopologies()
+		toTopologies, reqInf, err := cl.C.GetTopologies(nil)
 		if err != nil {
 			if errStr := strings.ToLower(err.Error()); strings.Contains(errStr, "not found") || strings.Contains(errStr, "not impl") {
 				unsupported = true


### PR DESCRIPTION
Adds Topologies to ATS Config Generation.

Includes tests.
No docs, docs already exist for Topologies, and details of config gen aren't documented.
Includes changelog.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests.
Create Topologies in TO/TP with a Server, and a Delivery Service. Run ORT on that Server, and verify the config generated is correct. Verify servers not in a topology aren't included. Verify DSes without Topologies still use DeliveryServiceServers appropriately. Verify ATS loads config and serves requests to the DS appropriately.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information
