### PR TITLE
Servers fixes

### DIFF
--- a/traffic_control/clients/python/trafficops/restapi.py
+++ b/traffic_control/clients/python/trafficops/restapi.py
@@ -358,7 +358,7 @@ class RestApiSession(object):
 
 	def _do_operation(self,
 	                  operation, api_path, query_params=None, munchify=True, debug_response=False,
-	                  expected_status_codes=(200, 204,), *unused_args, **kwargs):
+	                  expected_status_codes=range(200, 300), *unused_args, **kwargs):
 		"""
 		Helper method to perform HTTP operation requests - This is a boilerplate process for HTTP
 		operations.

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -598,7 +598,7 @@ func getServers(params map[string]string, tx *sqlx.Tx, user *auth.CurrentUser) (
 		}
 		userErr, sysErr, _ := tenant.CheckID(tx.Tx, user, dsID)
 		if userErr != nil || sysErr != nil {
-			return nil, 0, errors.New("forbidden"), sysErr, http.StatusForbidden
+			return nil, 0, errors.New("Forbidden"), sysErr, http.StatusForbidden
 		}
 		// only if dsId is part of params: add join on deliveryservice_server table
 		queryAddition = `
@@ -1092,8 +1092,8 @@ func createV1(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	alerts := tc.CreateAlerts(tc.SuccessLevel, "Server created")
-	api.WriteAlertsObj(w, r, http.StatusCreated, alerts, server)
+	alerts := tc.CreateAlerts(tc.SuccessLevel, "server was created.")
+	api.WriteAlertsObj(w, r, http.StatusOK, alerts, server)
 
 	changeLogMsg := fmt.Sprintf("SERVER: %s.%s, ID: %d, ACTION: created", *server.HostName, *server.DomainName, *server.ID)
 	api.CreateChangeLogRawTx(api.ApiChange, changeLogMsg, inf.User, tx)
@@ -1147,8 +1147,8 @@ func createV2(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	alerts := tc.CreateAlerts(tc.SuccessLevel, "Server created")
-	api.WriteAlertsObj(w, r, http.StatusCreated, alerts, server)
+	alerts := tc.CreateAlerts(tc.SuccessLevel, "server was created.")
+	api.WriteAlertsObj(w, r, http.StatusOK, alerts, server)
 
 	changeLogMsg := fmt.Sprintf("SERVER: %s.%s, ID: %d, ACTION: created", *server.HostName, *server.DomainName, *server.ID)
 	api.CreateChangeLogRawTx(api.ApiChange, changeLogMsg, inf.User, tx)
@@ -1292,9 +1292,9 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if inf.Version.Major <= 1 {
-			api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Server deleted", serverV2.ServerNullableV11)
+			api.WriteRespAlertObj(w, r, tc.SuccessLevel, "server was deleted.", serverV2.ServerNullableV11)
 		} else {
-			api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Server deleted", serverV2)
+			api.WriteRespAlertObj(w, r, tc.SuccessLevel, "server was deleted.", serverV2)
 		}
 	}
 	changeLogMsg := fmt.Sprintf("SERVER: %s.%s, ID: %d, ACTION: deleted", *server.HostName, *server.DomainName, *server.ID)


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes is not related to any issue

Fixes changes to the v1/v2 API which modified the `POST /servers` response code from `200 OK` to `201 Created`, and also changes some alert messages in those versions back to their old content.

Also changes the TO Python client to no longer incorrectly reject successful responses as failures.

## Which Traffic Control components are affected by this PR?
- Traffic Control Client (Python)
- Traffic Ops

## What is the best way to verify this PR?
Create servers in v1/v2 - probably using the Python client to kill two birds with one stone - and ensure that the response code is 201. Also maybe verify the alert messages, if you care - nothing should depend on those exact words, but I changed them back just because.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**