### PR TITLE
Fixed filtering query parameters in the /servers API

### DIFF
--- a/traffic_ops/testing/api/v3/servers_test.go
+++ b/traffic_ops/testing/api/v3/servers_test.go
@@ -144,6 +144,23 @@ func GetTestServersQueryParameters(t *testing.T) {
 		}
 		params.Del("profileId")
 	}
+
+	cgs, _, err := TOSession.GetCacheGroupsNullable()
+	if err != nil {
+		t.Fatalf("Failed to get Cache Groups: %v", err)
+	}
+	if len(cgs) < 1 {
+		t.Fatal("Failed to get at least one Cache Group")
+	}
+	if cgs[0].ID == nil {
+		t.Fatal("Cache Group found with no ID")
+	}
+
+	params.Add("parentCacheGroup", strconv.Itoa(*cgs[0].ID))
+	if _, _, err = TOSession.GetServers(&params); err != nil {
+		t.Errorf("Error getting servers by parentCacheGroup: %v", err)
+	}
+	params.Del("parentCacheGroup")
 }
 
 func UpdateTestServers(t *testing.T) {

--- a/traffic_ops/testing/api/v3/servers_test.go
+++ b/traffic_ops/testing/api/v3/servers_test.go
@@ -77,10 +77,6 @@ func GetTestServersDetails(t *testing.T) {
 }
 
 func GetTestServersQueryParameters(t *testing.T) {
-	if len(testData.DeliveryServices) < 1 {
-		t.Fatal("Need at least one server to test getting servers with query parameters")
-	}
-
 	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
 		t.Fatalf("Failed to get Delivery Services: %v", err)
@@ -101,6 +97,64 @@ func GetTestServersQueryParameters(t *testing.T) {
 		t.Fatalf("Failed to get server by Delivery Service ID: %v", err)
 	}
 	params.Del("dsId")
+
+	if len(testData.Servers) < 1 {
+		t.Fatal("Need at least one server to test getting servers with query parameters")
+	}
+
+	server := testData.Servers[0]
+	if server.HostName == nil {
+		t.Fatal("Test server had nil hostname")
+	}
+
+	params.Add("hostName", *server.HostName)
+	resp, _, err := TOSession.GetServers(nil)
+	if err != nil {
+		t.Fatalf("Failed to get server '%s': %v", *server.HostName, err)
+	}
+	params.Del("hostName")
+
+	if len(resp.Response) < 1 {
+		t.Fatalf("Failed to get at least one server with hostname '%s'", *server.HostName)
+	}
+
+	s := resp.Response[0]
+
+	params.Add("type", s.Type)
+	if _, _, err := TOSession.GetServers(&params); err != nil {
+		t.Errorf("Error getting servers by type: %v", err)
+	}
+	params.Del("type")
+
+	if s.CachegroupID == nil {
+		t.Error("Found server with no Cache Group ID")
+	} else {
+		params.Add("cachegroup", strconv.Itoa(*s.CachegroupID))
+		if _, _, err := TOSession.GetServers(&params); err != nil {
+			t.Errorf("Error getting servers by Cache Group ID: %v", err)
+		}
+		params.Del("cachegroup")
+	}
+
+	if s.Status == nil {
+		t.Error("Found server with no status")
+	} else {
+		params.Add("status", *s.Status)
+		if _, _, err := TOSession.GetServers(&params); err != nil {
+			t.Errorf("Error getting servers by status: %v", err)
+		}
+		params.Del("status")
+	}
+
+	if s.ProfileID == nil {
+		t.Error("Found server with no Profile ID")
+	} else {
+		params.Add("profileId", strconv.Itoa(*s.ProfileID))
+		if _, _, err := TOSession.GetServers(&params); err != nil {
+			t.Errorf("Error getting servers by Profile ID: %v", err)
+		}
+		params.Del("profileId")
+	}
 }
 
 func UpdateTestServers(t *testing.T) {

--- a/traffic_ops/testing/api/v3/servers_test.go
+++ b/traffic_ops/testing/api/v3/servers_test.go
@@ -98,24 +98,13 @@ func GetTestServersQueryParameters(t *testing.T) {
 	}
 	params.Del("dsId")
 
-	if len(testData.Servers) < 1 {
-		t.Fatal("Need at least one server to test getting servers with query parameters")
-	}
-
-	server := testData.Servers[0]
-	if server.HostName == nil {
-		t.Fatal("Test server had nil hostname")
-	}
-
-	params.Add("hostName", *server.HostName)
 	resp, _, err := TOSession.GetServers(nil)
 	if err != nil {
-		t.Fatalf("Failed to get server '%s': %v", *server.HostName, err)
+		t.Fatalf("Failed to get servers: %v", err)
 	}
-	params.Del("hostName")
 
 	if len(resp.Response) < 1 {
-		t.Fatalf("Failed to get at least one server with hostname '%s'", *server.HostName)
+		t.Fatalf("Failed to get at least one server")
 	}
 
 	s := resp.Response[0]
@@ -282,7 +271,6 @@ func UpdateTestServers(t *testing.T) {
 	} else {
 		t.Logf("type change update alerts: %+v", alerts)
 	}
-
 }
 
 func DeleteTestServers(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/crconfig/servers.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/servers.go
@@ -102,7 +102,7 @@ type ServerUnion struct {
 
 type ServerAndHost struct {
 	Server ServerUnion
-	Host string
+	Host   string
 }
 
 const DefaultWeightMultiplier = 1000.0

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -48,7 +48,8 @@ import (
 	"github.com/lib/pq"
 )
 
-const serversJoin = `
+const serversFromAndJoin = `
+FROM server AS s
 JOIN cachegroup cg ON s.cachegroup = cg.id
 JOIN cdn cdn ON s.cdn_id = cdn.id
 JOIN phys_location pl ON s.phys_location = pl.id
@@ -59,8 +60,7 @@ JOIN type t ON s.type = t.id
 
 const serverCountQuery = `
 SELECT COUNT(s.id)
-FROM server AS s
-` + serversJoin
+` + serversFromAndJoin
 
 
 const selectQuery = `
@@ -101,8 +101,7 @@ SELECT
 	s.upd_pending AS upd_pending,
 	s.xmpp_id,
 	s.xmpp_passwd
-FROM server AS s
-` + serversJoin
+` + serversFromAndJoin
 
 const InterfacesArray = `
 ARRAY ( SELECT (

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -62,7 +62,6 @@ const serverCountQuery = `
 SELECT COUNT(s.id)
 ` + serversFromAndJoin
 
-
 const selectQuery = `
 SELECT
 	cg.name AS cachegroup,
@@ -714,7 +713,7 @@ func getServers(params map[string]string, tx *sqlx.Tx, user *auth.CurrentUser) (
 			return nil, serverCount, nil, fmt.Errorf("getting server interfaces: %v", err), http.StatusInternalServerError
 		}
 
-		if _, ok := servers[server]; !ok  {
+		if _, ok := servers[server]; !ok {
 			continue
 		}
 

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -48,9 +48,7 @@ import (
 	"github.com/lib/pq"
 )
 
-const serverCountQuery = `
-SELECT COUNT(s.id)
-FROM server AS s
+const serversJoin = `
 JOIN cachegroup cg ON s.cachegroup = cg.id
 JOIN cdn cdn ON s.cdn_id = cdn.id
 JOIN phys_location pl ON s.phys_location = pl.id
@@ -58,6 +56,12 @@ JOIN profile p ON s.profile = p.id
 JOIN status st ON s.status = st.id
 JOIN type t ON s.type = t.id
 `
+
+const serverCountQuery = `
+SELECT COUNT(s.id)
+FROM server AS s
+` + serversJoin
+
 
 const selectQuery = `
 SELECT
@@ -98,13 +102,8 @@ SELECT
 	s.xmpp_id,
 	s.xmpp_passwd
 FROM server AS s
-JOIN cachegroup cg ON s.cachegroup = cg.id
-JOIN cdn cdn ON s.cdn_id = cdn.id
-JOIN phys_location pl ON s.phys_location = pl.id
-JOIN profile p ON s.profile = p.id
-JOIN status st ON s.status = st.id
-JOIN type t ON s.type = t.id
-`
+` + serversJoin
+
 const InterfacesArray = `
 ARRAY ( SELECT (
 		json_build_object (

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -51,6 +51,12 @@ import (
 const serverCountQuery = `
 SELECT COUNT(s.id)
 FROM server AS s
+JOIN cachegroup cg ON s.cachegroup = cg.id
+JOIN cdn cdn ON s.cdn_id = cdn.id
+JOIN phys_location pl ON s.phys_location = pl.id
+JOIN profile p ON s.profile = p.id
+JOIN status st ON s.status = st.id
+JOIN type t ON s.type = t.id
 `
 
 const selectQuery = `

--- a/traffic_ops/traffic_ops_golang/server/servers_test.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_test.go
@@ -94,15 +94,15 @@ func getTestServers() []ServerAndInterfaces {
 	iface := tc.ServerInterfaceInfo{
 		IPAddresses: []tc.ServerIPAddress{
 			tc.ServerIPAddress{
-				Address: testServer.IPAddress,
-				Gateway: nil,
+				Address:        testServer.IPAddress,
+				Gateway:        nil,
 				ServiceAddress: true,
 			},
 		},
 		MaxBandwidth: nil,
-		Monitor: true,
-		MTU: &mtu,
-		Name: testServer.InterfaceName,
+		Monitor:      true,
+		MTU:          &mtu,
+		Name:         testServer.InterfaceName,
 	}
 
 	servers = append(servers, ServerAndInterfaces{Server: testServer, Interface: iface})
@@ -486,7 +486,7 @@ func TestGetMidServers(t *testing.T) {
 
 	if serverMap[mid[0]].CachegroupID == nil {
 		t.Error("getMidServers expected: CachegroupID == 2, actual: nil")
-	} else if *(serverMap[mid[0]].CachegroupID) != 2  {
+	} else if *(serverMap[mid[0]].CachegroupID) != 2 {
 		t.Errorf("getMidServers expected: CachegroupID == 2, actual: %v", *(serverMap[mid[0]].CachegroupID))
 	}
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4795

Fixes the filtering query parameters of `/servers`.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Run the API/client integration tests

Make requests that filter servers by type, cdn, cachegroup, profile, physical location, and/or status.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**