### PR TITLE
Fix /servers dsId parameter

### DIFF
--- a/traffic_ops/testing/api/v3/servers_test.go
+++ b/traffic_ops/testing/api/v3/servers_test.go
@@ -17,6 +17,7 @@ package v3
 
 import (
 	"net/url"
+	"strconv"
 	"testing"
 )
 
@@ -25,6 +26,7 @@ func TestServers(t *testing.T) {
 		UpdateTestServers(t)
 		GetTestServersDetails(t)
 		GetTestServers(t)
+		GetTestServersQueryParameters(t)
 	})
 }
 
@@ -41,7 +43,6 @@ func CreateTestServers(t *testing.T) {
 			t.Errorf("could not CREATE servers: %v", err)
 		}
 	}
-
 }
 
 func GetTestServers(t *testing.T) {
@@ -73,6 +74,33 @@ func GetTestServersDetails(t *testing.T) {
 			t.Errorf("cannot GET Server Details by name: %v - %v", err, resp)
 		}
 	}
+}
+
+func GetTestServersQueryParameters(t *testing.T) {
+	if len(testData.DeliveryServices) < 1 {
+		t.Fatal("Need at least one server to test getting servers with query parameters")
+	}
+
+	dses, _, err := TOSession.GetDeliveryServicesNullable()
+	if err != nil {
+		t.Fatalf("Failed to get Delivery Services: %v", err)
+	}
+	if len(dses) < 1 {
+		t.Fatal("Failed to get at least one Delivery Service")
+	}
+
+	ds := dses[0]
+	if ds.ID == nil {
+		t.Fatal("Got Delivery Service with nil ID")
+	}
+
+	params := url.Values{}
+	params.Add("dsId", strconv.Itoa(*ds.ID))
+	_, _, err = TOSession.GetServers(&params)
+	if err != nil {
+		t.Fatalf("Failed to get server by Delivery Service ID: %v", err)
+	}
+	params.Del("dsId")
 }
 
 func UpdateTestServers(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -623,7 +623,7 @@ func getServers(params map[string]string, tx *sqlx.Tx, user *auth.CurrentUser) (
 
 	// TODO there's probably a cleaner way to do this by preparing a NamedStmt first and using its QueryRow method
 	var serverCount uint64
-	countRows, err := tx.NamedQuery(serverCountQuery+where, queryValues)
+	countRows, err := tx.NamedQuery(serverCountQuery+queryAddition+where, queryValues)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("failed to get servers count: %v", err), http.StatusInternalServerError
 	}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4789 

Fixes an internal server error that happens when requesting `GET /servers?dsid={{Delivery Service ID}}`.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Run the API/client integration tests

Make a request to `GET /servers` using the `dsId` query parameter, observe no internal server error.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**