### PR TITLE
Changed two column names

### DIFF
--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -130,12 +130,12 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 		},
 		{
 			headerName: "IPv6 Address",
-			field: "ipv6Address",
+			field: "ip6Address",
 			hide: false,
 		},
 		{
 			headerName: "IPv6 Gateway",
-			field: "ipv6Gateway",
+			field: "ip6Gateway",
 			hide: true,
 		},
 		{


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

The servers table names two if its columns "ipv6Address" and "ipv6Gateway". The legacy servers fields actually don't include those <kbd>v</kbd>s. So this removes them.

In point of fact, this doesn't fix anything. Since the table does not currently respect interfaces, the columns will always be empty anyway.

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
There's nothing to verify; the functionality doesn't work.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**