### PR TITLE
Add new header_rewrite fields for topology-based DSes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Traffic Ops: Added new `topology` field to the /api/3.0/deliveryservices APIs
     - Traffic Ops: Added support for `topology` query parameter to `GET /api/3.0/cachegroups` to return all cachegroups used in the given topology.
     - Traffic Ops: Added support for `topology` query parameter to `GET /api/3.0/deliveryservices` to return all delivery services that employ a given topology.
+    - Traffic Ops: Added new topology-based delivery service fields for header rewrites: `firstHeaderRewrite`, `innerHeaderRewrite`, `lastHeaderRewrite`
     - Traffic Ops: Added validation to prohibit assigning caches to topology-based delivery services
     - Traffic Portal: Added the ability to create, read, update and delete flexible topologies.
     - Traffic Portal: Added the ability to assign topologies to delivery services.

--- a/docs/source/api/v3/deliveryservice_requests.rst
+++ b/docs/source/api/v3/deliveryservice_requests.rst
@@ -101,6 +101,7 @@ Response Structure
 	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
 	:exampleURLs:                           An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
 	:fqPacingRate:                          The :ref:`ds-fqpr`
 	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
 	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -112,7 +113,9 @@ Response Structure
 	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
 	:infoUrl:                               An :ref:`ds-info-url`
 	:initialDispersion:                     The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
 	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -147,6 +150,7 @@ Response Structure
 	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
 	:tenant:                                The name of the :term:`Tenant` who owns this :term:`origin`
 	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
 	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
@@ -201,6 +205,7 @@ Response Structure
 					"dnsBypassTtl": null,
 					"dscp": 0,
 					"edgeHeaderRewrite": null,
+					"firstHeaderRewrite": null,
 					"geoLimit": 0,
 					"geoLimitCountries": null,
 					"geoLimitRedirectURL": null,
@@ -211,7 +216,9 @@ Response Structure
 					"id": 1,
 					"infoUrl": null,
 					"initialDispersion": 1,
+					"innerHeaderRewrite": null,
 					"ipv6RoutingEnabled": true,
+					"lastHeaderRewrite": null,
 					"lastUpdated": "0001-01-01 00:00:00+00",
 					"logsEnabled": true,
 					"longDesc": "Apachecon North America 2018",
@@ -244,6 +251,7 @@ Response Structure
 					"signed": false,
 					"sslKeyVersion": 1,
 					"tenantId": 1,
+					"topology": null,
 					"type": "HTTP",
 					"typeId": 1,
 					"xmlId": "demo1",
@@ -314,6 +322,7 @@ Request Structure
 	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
 	:exampleURLs:                   An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
 	:fqPacingRate:                  The :ref:`ds-fqpr`
 	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
 	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -325,7 +334,9 @@ Request Structure
 	:id:                            An integral, unique identifier for this :term:`Delivery Service`
 	:infoUrl:                       An :ref:`ds-info-url`
 	:initialDispersion:             The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
 	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -360,6 +371,7 @@ Request Structure
 	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
 	:tenant:                        The name of the :term:`Tenant` who owns this :term:`origin`
 	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
 	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
@@ -395,6 +407,7 @@ Request Structure
 			"dnsBypassTtl": null,
 			"dscp": 0,
 			"edgeHeaderRewrite": null,
+			"firstHeaderRewrite": null,
 			"geoLimit": 0,
 			"geoLimitCountries": null,
 			"geoLimitRedirectURL": null,
@@ -405,7 +418,9 @@ Request Structure
 			"id": 1,
 			"infoUrl": null,
 			"initialDispersion": 1,
+			"innerHeaderRewrite": null,
 			"ipv6RoutingEnabled": true,
+			"lastHeaderRewrite": null,
 			"lastUpdated": "2020-02-13 16:43:54+00",
 			"logsEnabled": true,
 			"longDesc": "Apachecon North America 2018",
@@ -449,6 +464,7 @@ Request Structure
 			"fqPacingRate": null,
 			"signingAlgorithm": null,
 			"tenant": "root",
+			"topology": null,
 			"trResponseHeaders": null,
 			"trRequestHeaders": null,
 			"consistentHashRegex": null,
@@ -495,6 +511,7 @@ Response Structure
 	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
 	:exampleURLs:                           An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
 	:fqPacingRate:                          The :ref:`ds-fqpr`
 	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
 	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -506,7 +523,9 @@ Response Structure
 	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
 	:infoUrl:                               An :ref:`ds-info-url`
 	:initialDispersion:                     The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
 	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -541,6 +560,7 @@ Response Structure
 	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
 	:tenant:                                The name of the :term:`Tenant` who owns this :term:`origin`
 	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
 	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
@@ -600,6 +620,7 @@ Response Structure
 				"dnsBypassTtl": null,
 				"dscp": 0,
 				"edgeHeaderRewrite": null,
+				"firstHeaderRewrite": null,
 				"geoLimit": 0,
 				"geoLimitCountries": null,
 				"geoLimitRedirectURL": null,
@@ -610,7 +631,9 @@ Response Structure
 				"id": 1,
 				"infoUrl": null,
 				"initialDispersion": 1,
+				"innerHeaderRewrite": null,
 				"ipv6RoutingEnabled": true,
+				"lastHeaderRewrite": null,
 				"lastUpdated": "0001-01-01 00:00:00+00",
 				"logsEnabled": true,
 				"longDesc": "Apachecon North America 2018",
@@ -643,6 +666,7 @@ Response Structure
 				"signed": false,
 				"sslKeyVersion": 1,
 				"tenantId": 1,
+				"topology": null,
 				"type": "HTTP",
 				"typeId": 1,
 				"xmlId": "demo1",
@@ -710,6 +734,7 @@ Request Structure
 	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
 	:exampleURLs:                   An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
 	:fqPacingRate:                  The :ref:`ds-fqpr`
 	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
 	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -721,7 +746,9 @@ Request Structure
 	:id:                            An integral, unique identifier for this :term:`Delivery Service`
 	:infoUrl:                       An :ref:`ds-info-url`
 	:initialDispersion:             The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
 	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -756,6 +783,7 @@ Request Structure
 	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
 	:tenant:                        The name of the :term:`Tenant` who owns this :term:`origin`
 	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
 	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
@@ -811,6 +839,7 @@ Request Structure
 			"dnsBypassTtl": null,
 			"dscp": 0,
 			"edgeHeaderRewrite": null,
+			"firstHeaderRewrite": null,
 			"geoLimit": 0,
 			"geoLimitCountries": null,
 			"geoLimitRedirectURL": null,
@@ -821,7 +850,9 @@ Request Structure
 			"id": 1,
 			"infoUrl": null,
 			"initialDispersion": 1,
+			"innerHeaderRewrite": null,
 			"ipv6RoutingEnabled": true,
+			"lastHeaderRewrite": null,
 			"lastUpdated": "0001-01-01 00:00:00+00",
 			"logsEnabled": true,
 			"longDesc": "Apachecon North America 2018",
@@ -854,6 +885,7 @@ Request Structure
 			"signed": false,
 			"sslKeyVersion": 1,
 			"tenantId": 1,
+			"topology": null,
 			"type": "HTTP",
 			"typeId": 1,
 			"xmlId": "demo1",
@@ -907,10 +939,11 @@ Response Structure
 	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
 	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
 	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
 	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
 	:exampleURLs:                           An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
 	:fqPacingRate:                          The :ref:`ds-fqpr`
 	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
 	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -922,7 +955,9 @@ Response Structure
 	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
 	:infoUrl:                               An :ref:`ds-info-url`
 	:initialDispersion:                     The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
 	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -957,6 +992,7 @@ Response Structure
 	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
 	:tenant:                                The name of the :term:`Tenant` who owns this :term:`origin`
 	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
 	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
@@ -1016,6 +1052,7 @@ Response Structure
 				"dnsBypassTtl": null,
 				"dscp": 0,
 				"edgeHeaderRewrite": null,
+				"firstHeaderRewrite": null,
 				"geoLimit": 0,
 				"geoLimitCountries": null,
 				"geoLimitRedirectURL": null,
@@ -1026,7 +1063,9 @@ Response Structure
 				"id": 1,
 				"infoUrl": null,
 				"initialDispersion": 1,
+				"innerHeaderRewrite": null,
 				"ipv6RoutingEnabled": true,
+				"lastHeaderRewrite": null,
 				"lastUpdated": "0001-01-01 00:00:00+00",
 				"logsEnabled": true,
 				"longDesc": "Apachecon North America 2018",
@@ -1059,6 +1098,7 @@ Response Structure
 				"signed": false,
 				"sslKeyVersion": 1,
 				"tenantId": 1,
+				"topology": null,
 				"type": "HTTP",
 				"typeId": 1,
 				"xmlId": "demo1",

--- a/docs/source/api/v3/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_assign.rst
@@ -79,6 +79,7 @@ Response Structure
 	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
 	:exampleURLs:                   An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
 	:fqPacingRate:                  The :ref:`ds-fqpr`
 	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
 	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -90,7 +91,9 @@ Response Structure
 	:id:                            An integral, unique identifier for this :term:`Delivery Service`
 	:infoUrl:                       An :ref:`ds-info-url`
 	:initialDispersion:             The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
 	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -125,6 +128,7 @@ Response Structure
 	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
 	:tenant:                        The name of the :term:`Tenant` who owns this :term:`origin`
 	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
 	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
@@ -186,6 +190,7 @@ Response Structure
 				"dnsBypassTtl": null,
 				"dscp": 0,
 				"edgeHeaderRewrite": null,
+				"firstHeaderRewrite": null,
 				"geoLimit": 0,
 				"geoLimitCountries": null,
 				"geoLimitRedirectURL": null,
@@ -196,7 +201,9 @@ Response Structure
 				"id": 1,
 				"infoUrl": null,
 				"initialDispersion": 1,
+				"innerHeaderRewrite": null,
 				"ipv6RoutingEnabled": true,
+				"lastHeaderRewrite": null,
 				"lastUpdated": "0001-01-01 00:00:00+00",
 				"logsEnabled": true,
 				"longDesc": "Apachecon North America 2018",
@@ -229,6 +236,7 @@ Response Structure
 				"signed": false,
 				"sslKeyVersion": null,
 				"tenantId": 1,
+				"topology": null,
 				"type": "HTTP",
 				"typeId": 1,
 				"xmlId": "demo1",

--- a/docs/source/api/v3/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_status.rst
@@ -80,6 +80,7 @@ Response Structure
 	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
 	:exampleURLs:                   An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
 	:fqPacingRate:                  The :ref:`ds-fqpr`
 	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
 	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -91,7 +92,9 @@ Response Structure
 	:id:                            An integral, unique identifier for this :term:`Delivery Service`
 	:infoUrl:                       An :ref:`ds-info-url`
 	:initialDispersion:             The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
 	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -126,6 +129,7 @@ Response Structure
 	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
 	:tenant:                        The name of the :term:`Tenant` who owns this :term:`origin`
 	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
 	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
@@ -187,6 +191,7 @@ Response Structure
 				"dnsBypassTtl": null,
 				"dscp": 0,
 				"edgeHeaderRewrite": null,
+				"firstHeaderRewrite": null,
 				"geoLimit": 0,
 				"geoLimitCountries": null,
 				"geoLimitRedirectURL": null,
@@ -197,7 +202,9 @@ Response Structure
 				"id": 1,
 				"infoUrl": null,
 				"initialDispersion": 1,
+				"innerHeaderRewrite": null,
 				"ipv6RoutingEnabled": true,
+				"lastHeaderRewrite": null,
 				"lastUpdated": "0001-01-01 00:00:00+00",
 				"logsEnabled": true,
 				"longDesc": "Apachecon North America 2018",
@@ -230,6 +237,7 @@ Response Structure
 				"signed": false,
 				"sslKeyVersion": null,
 				"tenantId": 1,
+				"topology": null,
 				"type": "HTTP",
 				"typeId": 1,
 				"xmlId": "demo1",

--- a/docs/source/api/v3/deliveryservices.rst
+++ b/docs/source/api/v3/deliveryservices.rst
@@ -90,6 +90,7 @@ Response Structure
 :ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 :edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
 :exampleURLs:               An array of :ref:`ds-example-urls`
+:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
 :fqPacingRate:              The :ref:`ds-fqpr`
 :geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
 :geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
@@ -101,7 +102,9 @@ Response Structure
 :id:                        An integral, unique identifier for this :term:`Delivery Service`
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
+:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -172,6 +175,7 @@ Response Structure
 		"dnsBypassTtl": null,
 		"dscp": 0,
 		"edgeHeaderRewrite": null,
+		"firstHeaderRewrite": null,
 		"geoLimit": 0,
 		"geoLimitCountries": null,
 		"geoLimitRedirectURL": null,
@@ -182,7 +186,9 @@ Response Structure
 		"id": 1,
 		"infoUrl": null,
 		"initialDispersion": 1,
+		"innerHeaderRewrite": null,
 		"ipv6RoutingEnabled": true,
+		"lastHeaderRewrite": null,
 		"lastUpdated": "2019-05-15 14:32:05+00",
 		"logsEnabled": true,
 		"longDesc": "Apachecon North America 2018",
@@ -273,6 +279,7 @@ Request Structure
 :dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
 :ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 :edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
 :fqPacingRate:              The :ref:`ds-fqpr`
 :geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
 :geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -283,7 +290,9 @@ Request Structure
 :httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
+:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -383,6 +392,7 @@ Response Structure
 :ecsEnabled:        		A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 :edgeHeaderRewrite: 		A set of :ref:`ds-edge-header-rw-rules`
 :exampleURLs:       		An array of :ref:`ds-example-urls`
+:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
 :fqPacingRate:      		The :ref:`ds-fqpr`
 :geoLimit:            		An integer that defines the :ref:`ds-geo-limit`
 :geoLimitCountries:  		A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
@@ -394,7 +404,9 @@ Response Structure
 :id:                  		An integral, unique identifier for this :term:`Delivery Service`
 :infoUrl:             		An :ref:`ds-info-url`
 :initialDispersion:   		The :ref:`ds-initial-dispersion`
+:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 :logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -472,6 +484,7 @@ Response Structure
 			"dnsBypassTtl": null,
 			"dscp": 0,
 			"edgeHeaderRewrite": null,
+			"firstHeaderRewrite": null,
 			"geoLimit": 0,
 			"geoLimitCountries": null,
 			"geoLimitRedirectURL": null,
@@ -482,7 +495,9 @@ Response Structure
 			"id": 2,
 			"infoUrl": null,
 			"initialDispersion": 1,
+			"innerHeaderRewrite": null,
 			"ipv6RoutingEnabled": false,
+			"lastHeaderRewrite": null,
 			"lastUpdated": "2018-11-19 19:45:49+00",
 			"logsEnabled": true,
 			"longDesc": "A Delivery Service created expressly for API documentation examples",

--- a/docs/source/api/v3/deliveryservices_id.rst
+++ b/docs/source/api/v3/deliveryservices_id.rst
@@ -50,6 +50,7 @@ Request Structure
 :dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
 :ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 :edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
 :fqPacingRate:              The :ref:`ds-fqpr`
 :geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
 :geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
@@ -60,7 +61,9 @@ Request Structure
 :httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
+:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/deliveryservices_id_safe.rst
+++ b/docs/source/api/v3/deliveryservices_id_safe.rst
@@ -84,6 +84,7 @@ Response Structure
 :ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 :edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
 :exampleURLs:               An array of :ref:`ds-example-urls`
+:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
 :fqPacingRate:              The :ref:`ds-fqpr`
 :geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
 :geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
@@ -95,7 +96,9 @@ Response Structure
 :id:                        An integral, unique identifier for this :term:`Delivery Service`
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
+:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -169,6 +172,7 @@ Response Structure
 			"dnsBypassTtl": null,
 			"dscp": 0,
 			"edgeHeaderRewrite": null,
+			"firstHeaderRewrite": null,
 			"geoLimit": 0,
 			"geoLimitCountries": null,
 			"geoLimitRedirectURL": null,
@@ -179,7 +183,9 @@ Response Structure
 			"id": 1,
 			"infoUrl": "this is not even a real URL",
 			"initialDispersion": 1,
+			"innerHeaderRewrite": null,
 			"ipv6RoutingEnabled": true,
+			"lastHeaderRewrite": null,
 			"lastUpdated": "2020-02-10 15:33:03+00",
 			"logsEnabled": true,
 			"longDesc": "longDesc1 is implicitly set to null in this example",

--- a/docs/source/api/v3/servers_id_deliveryservices.rst
+++ b/docs/source/api/v3/servers_id_deliveryservices.rst
@@ -90,6 +90,7 @@ Response Structure
 :ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
 :edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
 :exampleURLs:               An array of :ref:`ds-example-urls`
+:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
 :fqPacingRate:              The :ref:`ds-fqpr`
 :geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
 :geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
@@ -101,7 +102,9 @@ Response Structure
 :id:                        An integral, unique identifier for this :term:`Delivery Service`
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
+:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
@@ -172,6 +175,7 @@ Response Structure
 		"dnsBypassTtl": null,
 		"dscp": 0,
 		"edgeHeaderRewrite": null,
+		"firstHeaderRewrite": null,
 		"geoLimit": 0,
 		"geoLimitCountries": null,
 		"geoLimitRedirectURL": null,
@@ -182,7 +186,9 @@ Response Structure
 		"id": 1,
 		"infoUrl": null,
 		"initialDispersion": 1,
+		"innerHeaderRewrite": null,
 		"ipv6RoutingEnabled": true,
+		"lastHeaderRewrite": null,
 		"lastUpdated": "2019-06-10 15:14:29+00",
 		"logsEnabled": true,
 		"longDesc": "Apachecon North America 2018",

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -142,7 +142,7 @@ Glossary
 	First-tier caches
 	First-tier cache server
 	First-tier cache servers
-		Closest to the client or end-user. The first tier in a :term:`Topology` is the tier that serves the client, which is typically composed of :term:`edge caches`.
+		Closest to the client or end-user. The first tier in a :term:`Topology` is the tier that serves the client, similar to the :term:`Edge-tier`.
 
 	forward proxy
 	forward proxies

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -137,6 +137,13 @@ Glossary
 
 		.. seealso:: Federations are currently only manageable by directly using the :ref:`to-api`. The endpoints related to federations are :ref:`to-api-federations`, :ref:`to-api-federation_resolvers`, :ref:`to-api-federations-id-deliveryservices`, :ref:`to-api-federations-id-deliveryservices-id`, :ref:`to-api-federations-id-federation_resolvers`, :ref:`to-api-federations-id-users`, and :ref:`to-api-federations-id-users-id`.
 
+	First-tier
+	First-tier cache
+	First-tier caches
+	First-tier cache server
+	First-tier cache servers
+		Closest to the client or end-user. The first tier in a :term:`Topology` is the tier that serves the client, which is typically composed of :term:`edge caches`.
+
 	forward proxy
 	forward proxies
 		A forward proxy acts on behalf of the client such that the :term:`origin server` is (potentially) unaware of the proxy's existence. All Mid-tier :term:`cache servers` in a Traffic Control based CDN are :dfn:`forward proxies`. In a :dfn:`forward proxy` scenario, the client is explicitly configured to use the the proxy's IP address and port as a :dfn:`forward proxy`. The client always connects to the :dfn:`forward proxy` for content. The content provider does not have to change the URL the client obtains, and is (potentially) unaware of the proxy in the middle.
@@ -224,6 +231,20 @@ Glossary
 
  	Health Protocol
  		The protocol to monitor the health of all the caches. See :ref:`health-proto`.
+
+	Inner-tier
+	Inner-tier cache
+	Inner-tier caches
+	Inner-tier cache server
+	Inner-tier cache servers
+		The tier between the First tier and the Last tier. The inner tier in a :term:`Topology` is the tier that forwards requests from other caches to other caches, i.e. caches in this tier do not directly serve the end-user and do not make requests to :term:`Origins`.
+
+	Last-tier
+	Last-tier cache
+	Last-tier caches
+	Last-tier cache server
+	Last-tier cache servers
+		The tier above the First and Inner tiers. The last tier in a :term:`Topology` is the tier that forwards requests from other caches to :term:`Origins`.
 
  	localization
  		Finding location on the network, or on planet earth

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -189,6 +189,8 @@ This field in general contains the contents of the a configuration file used by 
 
 .. tip:: Because this ultimately is the contents of an :abbr:`ATS (Apache Traffic Server)` configuration file, it can make use of the :ref:`ort-special-strings`.
 
+.. note:: This field cannot be used if the Delivery Service is assigned to a :term:`Topology`.
+
 .. _ds-ecs:
 
 EDNS0 Client Subnet Enabled
@@ -233,6 +235,16 @@ The maximum bytes per second a :term:`cache server` will deliver on any single T
 	+==============+=================================================================================+=======================================+
 	| FQPacingRate | Traffic Ops source code, Delivery Service objects returned by the :ref:`to-api` | unchanged (``int``, ``integer`` etc.) |
 	+--------------+---------------------------------------------------------------------------------+---------------------------------------+
+
+.. _ds-first-header-rw-rules:
+
+First Header Rewrite Rules
+--------------------------
+This field in general contains the contents of the a configuration file used by the `ATS Header Rewrite Plugin <https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/header_rewrite.en.html>`_ when serving content for this Delivery Service - on :term:`First-tier cache servers`.
+
+.. tip:: Because this ultimately is the contents of an :abbr:`ATS (Apache Traffic Server)` configuration file, it can make use of the :ref:`ort-special-strings`.
+
+.. note:: This field can only be used if the Delivery Service is assigned to a :term:`Topology`.
 
 .. _ds-geo-limit:
 
@@ -405,6 +417,26 @@ Initial Dispersion
 ------------------
 The number of :term:`Edge-tier cache servers` across which a particular asset will be distributed within each :term:`Cache Group`. For most use-cases, this should be 1, meaning that all clients requesting a particular asset will be directed to 1 :term:`cache server` per :term:`Cache Group`. Depending on the popularity and size of assets, consider increasing this number in order to spread the request load across more than 1 :term:`cache server`. The larger this number, the more copies of a particular asset are stored in a :term:`Cache Group`, which can "pollute" caches (if load distribution is unnecessary) and decreases caching efficiency (due to cache misses if the asset is not requested enough to stay "fresh" in all the caches).
 
+.. _ds-inner-header-rw-rules:
+
+Inner Header Rewrite Rules
+--------------------------
+This field in general contains the contents of the a configuration file used by the `ATS Header Rewrite Plugin <https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/header_rewrite.en.html>`_ when serving content for this Delivery Service - on :term:`Inner-tier cache servers`.
+
+.. tip:: Because this ultimately is the contents of an :abbr:`ATS (Apache Traffic Server)` configuration file, it can make use of the :ref:`ort-special-strings`.
+
+.. note:: This field can only be used if the Delivery Service is assigned to a :term:`Topology`.
+
+.. _ds-last-header-rw-rules:
+
+Last Header Rewrite Rules
+-------------------------
+This field in general contains the contents of the a configuration file used by the `ATS Header Rewrite Plugin <https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/header_rewrite.en.html>`_ when serving content for this Delivery Service - on :term:`Last-tier cache servers`.
+
+.. tip:: Because this ultimately is the contents of an :abbr:`ATS (Apache Traffic Server)` configuration file, it can make use of the :ref:`ort-special-strings`.
+
+.. note:: This field can only be used if the Delivery Service is assigned to a :term:`Topology`.
+
 .. _ds-logs-enabled:
 
 Logs Enabled
@@ -502,6 +534,8 @@ Mid Header Rewrite Rules
 This field in general contains the contents of the a configuration file used by the `ATS Header Rewrite Plugin <https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/plugins/header_rewrite.en.html>`_ when serving content for this Delivery Service - on :term:`Mid-tier cache servers`.
 
 .. tip:: Because this ultimately is the contents of an :abbr:`ATS (Apache Traffic Server)` configuration file, it can make use of the :ref:`ort-special-strings`.
+
+.. note:: This field cannot be used if the Delivery Service is assigned to a :term:`Topology`.
 
 .. _ds-origin-url:
 

--- a/traffic_ops/app/db/migrations/2020061622101648_add_new_header_rewrite.sql
+++ b/traffic_ops/app/db/migrations/2020061622101648_add_new_header_rewrite.sql
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+ALTER TABLE deliveryservice
+    ADD COLUMN first_header_rewrite text,
+    ADD COLUMN inner_header_rewrite text,
+    ADD COLUMN last_header_rewrite text;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE deliveryservice
+    DROP COLUMN first_header_rewrite,
+    DROP COLUMN inner_header_rewrite,
+    DROP COLUMN last_header_rewrite;

--- a/traffic_ops/testing/api/v3/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_test.go
@@ -37,6 +37,7 @@ func TestDeliveryServices(t *testing.T) {
 		UpdateDeliveryServiceWithInvalidRemapText(t)
 		UpdateDeliveryServiceWithInvalidSliceRangeRequest(t)
 		UpdateDeliveryServiceWithInvalidTopology(t)
+		UpdateDeliveryServiceTopologyHeaderRewriteFields(t)
 		GetTestDeliveryServices(t)
 		DeliveryServiceMinorVersionsTest(t)
 		DeliveryServiceTenancyTest(t)
@@ -224,6 +225,46 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected at least one CLIENT_STEERING delivery service")
+	}
+}
+
+// UpdateDeliveryServiceWithInvalidHeaderRewriteFields ensures that a delivery service can only use firstHeaderRewrite,
+// innerHeaderRewrite, or lastHeadeRewrite if a topology is assigned.
+func UpdateDeliveryServiceTopologyHeaderRewriteFields(t *testing.T) {
+	dses, _, err := TOSession.GetDeliveryServicesNullable()
+	if err != nil {
+		t.Fatalf("cannot GET Delivery Services: %v", err)
+	}
+	foundTopology := false
+	for _, ds := range dses {
+		if ds.Topology != nil {
+			foundTopology = true
+		}
+		ds.FirstHeaderRewrite = util.StrPtr("foo")
+		ds.InnerHeaderRewrite = util.StrPtr("bar")
+		ds.LastHeaderRewrite = util.StrPtr("baz")
+		_, err := TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*ds.ID), &ds)
+		if ds.Topology != nil && err != nil {
+			t.Errorf("expected: no error updating topology-based header rewrite fields for topology-based DS, actual: %v", err)
+		}
+		if ds.Topology == nil && err == nil {
+			t.Errorf("expected: error updating topology-based header rewrite fields for non-topology-based DS, actual: nil")
+		}
+		ds.FirstHeaderRewrite = nil
+		ds.InnerHeaderRewrite = nil
+		ds.LastHeaderRewrite = nil
+		ds.EdgeHeaderRewrite = util.StrPtr("foo")
+		ds.MidHeaderRewrite = util.StrPtr("bar")
+		_, err = TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*ds.ID), &ds)
+		if ds.Topology != nil && err == nil {
+			t.Errorf("expected: error updating legacy header rewrite fields for topology-based DS, actual: nil")
+		}
+		if ds.Topology == nil && err != nil {
+			t.Errorf("expected: no error updating legacy header rewrite fields for non-topology-based DS, actual: %v", err)
+		}
+	}
+	if !foundTopology {
+		t.Errorf("expected: at least one topology-based delivery service, actual: none found")
 	}
 }
 

--- a/traffic_ops/testing/api/v3/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_test.go
@@ -228,7 +228,7 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 	}
 }
 
-// UpdateDeliveryServiceWithInvalidHeaderRewriteFields ensures that a delivery service can only use firstHeaderRewrite,
+// UpdateDeliveryServiceTopologyHeaderRewriteFields ensures that a delivery service can only use firstHeaderRewrite,
 // innerHeaderRewrite, or lastHeadeRewrite if a topology is assigned.
 func UpdateDeliveryServiceTopologyHeaderRewriteFields(t *testing.T) {
 	dses, _, err := TOSession.GetDeliveryServicesNullable()

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -767,7 +767,10 @@
             "type": "HTTP_LIVE_NATNL",
             "xmlId": "ds-top",
             "anonymousBlockingEnabled": false,
-            "topology": "my-topology"
+            "topology": "my-topology",
+            "firstHeaderRewrite": "first header rewrite",
+            "innerHeaderRewrite": "inner header rewrite",
+            "lastHeaderRewrite": "last header rewrite"
         },
         {
             "active": true,

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -320,7 +320,11 @@ func createV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, reqDS t
 		&ds.TypeID,
 		&ds.XMLID,
 		&ds.EcsEnabled,
-		&ds.RangeSliceBlockSize)
+		&ds.RangeSliceBlockSize,
+		&ds.FirstHeaderRewrite,
+		&ds.InnerHeaderRewrite,
+		&ds.LastHeaderRewrite,
+	)
 
 	if err != nil {
 		usrErr, sysErr, code := api.ParseDBError(err)
@@ -700,13 +704,19 @@ func updateV15(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, reqDS *
 	// query the DB for existing 3.0 fields in order to "upgrade" this 1.5 request into a 3.0 request
 	query := `
 SELECT
-  ds.topology
+  ds.topology,
+  ds.first_header_rewrite,
+  ds.inner_header_rewrite,
+  ds.last_header_rewrite
 FROM
   deliveryservice ds
 WHERE
   ds.id = $1`
 	if err := inf.Tx.Tx.QueryRow(query, *reqDS.ID).Scan(
 		&dsV30.Topology,
+		&dsV30.FirstHeaderRewrite,
+		&dsV30.InnerHeaderRewrite,
+		&dsV30.LastHeaderRewrite,
 	); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, http.StatusNotFound, fmt.Errorf("delivery service ID %d not found", *dsV30.ID), nil
@@ -823,6 +833,9 @@ func updateV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, reqDS *
 		&ds.EcsEnabled,
 		&ds.RangeSliceBlockSize,
 		&ds.Topology,
+		&ds.FirstHeaderRewrite,
+		&ds.InnerHeaderRewrite,
+		&ds.LastHeaderRewrite,
 		&ds.ID)
 
 	if err != nil {
@@ -1180,6 +1193,7 @@ func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *s
 			&ds.DSCP,
 			&ds.EcsEnabled,
 			&ds.EdgeHeaderRewrite,
+			&ds.FirstHeaderRewrite,
 			&ds.GeoLimitRedirectURL,
 			&ds.GeoLimit,
 			&ds.GeoLimitCountries,
@@ -1191,7 +1205,9 @@ func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *s
 			&ds.ID,
 			&ds.InfoURL,
 			&ds.InitialDispersion,
+			&ds.InnerHeaderRewrite,
 			&ds.IPV6RoutingEnabled,
+			&ds.LastHeaderRewrite,
 			&ds.LastUpdated,
 			&ds.LogsEnabled,
 			&ds.LongDesc,
@@ -1696,6 +1712,7 @@ ds.dns_bypass_ttl,
 ds.dscp,
 ds.ecs_enabled,
 ds.edge_header_rewrite,
+ds.first_header_rewrite,
 ds.geolimit_redirect_url,
 ds.geo_limit,
 ds.geo_limit_countries,
@@ -1707,7 +1724,9 @@ ds.http_bypass_fqdn,
 ds.id,
 ds.info_url,
 ds.initial_dispersion,
+ds.inner_header_rewrite,
 ds.ipv6_routing_enabled,
+ds.last_header_rewrite,
 ds.last_updated,
 ds.logs_enabled,
 ds.long_desc,
@@ -1815,8 +1834,11 @@ consistent_hash_regex=$51,
 max_origin_connections=$52,
 ecs_enabled=$53,
 range_slice_block_size=$54,
-topology=$55
-WHERE id=$56
+topology=$55,
+first_header_rewrite=$56,
+inner_header_rewrite=$57,
+last_header_rewrite=$58
+WHERE id=$59
 RETURNING last_updated
 `
 }
@@ -1878,9 +1900,12 @@ tr_response_headers,
 type,
 xml_id,
 ecs_enabled,
-range_slice_block_size
+range_slice_block_size,
+first_header_rewrite,
+inner_header_rewrite,
+last_header_rewrite
 )
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45,$46,$47,$48,$49,$50,$51,$52,$53,$54,$55)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45,$46,$47,$48,$49,$50,$51,$52,$53,$54,$55,$56,$57,$58)
 RETURNING id, last_updated
 `
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Add the new `firstHeaderRewrite`, `innerHeaderRewrite`, and `lastHeaderRewrite` fields to delivery services. These fields can only be used when the delivery service is assigned to a topology and are mutually exclusive with `edgeHeaderRewrite` and `midHeaderRewrite`, which can **not** be used if the delivery service is assigned to a topology.

**NOTE:** this PR intentionally does *not* create and link "location" parameters for these new header rewrite fields, because this extra information is unnecessary for client-side config generation via `atstccfg` and would just lead to a load of unnecessary complexity. Additionally, I think we should get rid of "location" parameters altogether, so increasing and perpetuating their usage is not ideal.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Run the unit tests and TO API tests, verify they pass. Build the docs, verify nothing broke. View the rendered documentation changes, make sure they look correct.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)