### PR TITLE
Fix validation for an edge node parenting a mid node in a Topology

### DIFF
--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -104,8 +104,9 @@ func ValidationTestTopologies(t *testing.T) {
 			{Cachegroup: "cachegroup1", Parents: []int{0, 1, 2}},
 		}}},
 		{testCaseDescription: "an edge parenting a mid", Topology: tc.Topology{Name: "edge-parent-of-mid", Description: "Invalid because an edge is a parent of a mid", Nodes: []tc.TopologyNode{
-			{Cachegroup: "parentCachegroup", Parents: []int{1}},
-			{Cachegroup: "cachegroup1", Parents: []int{}},
+			{Cachegroup: "cachegroup1", Parents: []int{1}},
+			{Cachegroup: "parentCachegroup", Parents: []int{2}},
+			{Cachegroup: "cachegroup2", Parents: []int{}},
 		}}},
 		{testCaseDescription: "a leaf mid", Topology: tc.Topology{Name: "leaf-mid", Description: "Invalid because a mid is a leaf node", Nodes: []tc.TopologyNode{
 			{Cachegroup: "parentCachegroup", Parents: []int{1}},

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -79,13 +79,6 @@ func (topology *TOTopology) checkForEdgeParents(cacheGroups []tc.CacheGroupNulla
 				topology.Nodes[parentCacheGroupIndex].Cachegroup,
 				parentTerm,
 				node.Cachegroup))
-		case tc.CacheGroupMidTypeName:
-			errs = append(errs, fmt.Errorf(
-				"cachegroup %s's type is %s; it cannot parent a %s-typed cachegroup %s",
-				topology.Nodes[parentCacheGroupIndex].Cachegroup,
-				parentCacheGroupType,
-				cacheGroupType,
-				node.Cachegroup))
 		default:
 			errs = append(errs, fmt.Errorf(
 				"cachegroup %s's type is %s; it cannot parent a %s-typed cachegroup %s",

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -80,9 +80,15 @@ func (topology *TOTopology) checkForEdgeParents(cacheGroups []tc.CacheGroupNulla
 				parentTerm,
 				node.Cachegroup))
 		case tc.CacheGroupMidTypeName:
+			errs = append(errs, fmt.Errorf(
+				"cachegroup %s's type is %s; it cannot parent a %s-typed cachegroup %s",
+				topology.Nodes[parentCacheGroupIndex].Cachegroup,
+				parentCacheGroupType,
+				cacheGroupType,
+				node.Cachegroup))
 		default:
 			errs = append(errs, fmt.Errorf(
-				"cachegroup %s's type is %s; it cannot be a child of %s-typed cachegroup %s",
+				"cachegroup %s's type is %s; it cannot parent a %s-typed cachegroup %s",
 				topology.Nodes[parentCacheGroupIndex].Cachegroup,
 				parentCacheGroupType,
 				cacheGroupType,


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4806<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run the Traffic Ops API tests, make sure they pass

```shell script
go test ./v3 -test.v -cfg=../conf/traffic-ops-test.conf -fixtures=tc-fixtures.json -test.run 'TestMain|TestTopologies'
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
 - master (df9d6907c6)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] Intended behavior is unchanged, documentation is unnecessary
- [x] Fixed bug was not in a release, documentation is unnecessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
