### PR TITLE
Fix flaky DSS TO API test (sometimes CDN doesn't match)

### DIFF
--- a/traffic_ops/testing/api/v1/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v1/deliveryserviceservers_test.go
@@ -178,8 +178,7 @@ func CreateTestMSODSServerWithReqCap(t *testing.T) {
 }
 
 func DeleteTestDeliveryServiceServers(t *testing.T) {
-	dses, servers := getServersAndDSes(t)
-	ds, server := dses[0], servers[0]
+	ds, server := getServerAndDSofSameCDN(t)
 
 	_, err := TOSession.CreateDeliveryServiceServers(ds.ID, []int{server.ID}, true)
 	if err != nil {
@@ -223,7 +222,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 	}
 }
 
-func getServersAndDSes(t *testing.T) ([]tc.DeliveryService, []tc.ServerV1) {
+func getServerAndDSofSameCDN(t *testing.T) (tc.DeliveryService, tc.ServerV1) {
 	dses, _, err := TOSession.GetDeliveryServices()
 	if err != nil {
 		t.Fatalf("cannot GET DeliveryServices: %v", err)
@@ -240,5 +239,14 @@ func getServersAndDSes(t *testing.T) ([]tc.DeliveryService, []tc.ServerV1) {
 		t.Fatal("GET Servers returned no dses, must have at least 1 to test ds-servers")
 	}
 
-	return dses, servers
+	for _, ds := range dses {
+		for _, s := range servers {
+			if ds.CDNName == s.CDNName {
+				return ds, s
+			}
+		}
+	}
+	t.Fatal("expected at least one delivery service and server in the same CDN")
+
+	return tc.DeliveryService{}, tc.ServerV1{}
 }

--- a/traffic_ops/testing/api/v2/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v2/deliveryserviceservers_test.go
@@ -178,8 +178,7 @@ func CreateTestMSODSServerWithReqCap(t *testing.T) {
 }
 
 func DeleteTestDeliveryServiceServers(t *testing.T) {
-	dses, servers := getServersAndDSes(t)
-	ds, server := dses[0], servers[0]
+	ds, server := getServerAndDSofSameCDN(t)
 
 	_, err := TOSession.CreateDeliveryServiceServers(*ds.ID, []int{server.ID}, true)
 	if err != nil {
@@ -223,7 +222,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 	}
 }
 
-func getServersAndDSes(t *testing.T) ([]tc.DeliveryServiceNullable, []tc.Server) {
+func getServerAndDSofSameCDN(t *testing.T) (tc.DeliveryServiceNullable, tc.Server) {
 	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
 		t.Fatalf("cannot GET DeliveryServices: %v", err)
@@ -240,5 +239,14 @@ func getServersAndDSes(t *testing.T) ([]tc.DeliveryServiceNullable, []tc.Server)
 		t.Fatal("GET Servers returned no dses, must have at least 1 to test ds-servers")
 	}
 
-	return dses, servers
+	for _, ds := range dses {
+		for _, s := range servers {
+			if ds.CDNName != nil && *ds.CDNName == s.CDNName {
+				return ds, s
+			}
+		}
+	}
+	t.Fatal("expected at least one delivery service and server in the same CDN")
+
+	return tc.DeliveryServiceNullable{}, tc.Server{}
 }

--- a/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
@@ -239,8 +239,7 @@ func CreateTestMSODSServerWithReqCap(t *testing.T) {
 }
 
 func DeleteTestDeliveryServiceServers(t *testing.T) {
-	dses, servers := getServersAndDSes(t)
-	ds, server := dses[0], servers[0]
+	ds, server := getServerAndDSofSameCDN(t)
 	if server.ID == nil {
 		t.Fatalf("Got a server with a nil ID: %+v", server)
 	}
@@ -290,7 +289,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 	}
 }
 
-func getServersAndDSes(t *testing.T) ([]tc.DeliveryServiceNullable, []tc.ServerNullable) {
+func getServerAndDSofSameCDN(t *testing.T) (tc.DeliveryServiceNullable, tc.ServerNullable) {
 	dses, _, err := TOSession.GetDeliveryServicesNullable()
 	if err != nil {
 		t.Fatalf("cannot GET DeliveryServices: %v", err)
@@ -308,5 +307,14 @@ func getServersAndDSes(t *testing.T) ([]tc.DeliveryServiceNullable, []tc.ServerN
 		t.Fatal("GET Servers returned no dses, must have at least 1 to test ds-servers")
 	}
 
-	return dses, servers
+	for _, ds := range dses {
+		for _, s := range servers {
+			if ds.CDNName != nil && s.CDNName != nil && *ds.CDNName == *s.CDNName {
+				return ds, s
+			}
+		}
+	}
+	t.Fatal("expected at least one delivery service and server in the same CDN")
+
+	return tc.DeliveryServiceNullable{}, tc.ServerNullable{}
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Fix this flaky TO API test:
```
TestDeliveryServiceServers: deliveryserviceservers_test.go:186: POST delivery service servers: 400 Bad Request[400] - Error requesting Traffic Ops https://trafficops.infra.ciab.test:443/api/2.0/deliveryserviceserver {"alerts":[{"text":"server and delivery service CDNs do not match","level":"error"}]}
```

- [x] This PR is not related to any Issue


## Which Traffic Control components are affected by this PR?
- TO API tests

## What is the best way to verify this PR?
Run the v1/v2/v3 TO API tests, verify they pass.

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] no docs necessary
- [x] no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
