### PR TITLE
Ciab scope drop

### DIFF
--- a/infrastructure/cdn-in-a-box/docker-compose.readiness.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.readiness.yml
@@ -35,8 +35,8 @@ version: '2.1'
 services:
   readiness:
     build:
-      context: ../..
-      dockerfile: infrastructure/cdn-in-a-box/readiness/Dockerfile
+      context: .
+      dockerfile: readiness/Dockerfile
     env_file:
       - variables.env
     hostname: readiness

--- a/infrastructure/cdn-in-a-box/docker-compose.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.yml
@@ -58,10 +58,10 @@ services:
   # defined below
   trafficops:
     build:
-      context: ../..
-      dockerfile: infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
+      context: .
+      dockerfile: traffic_ops/Dockerfile-go
       args:
-        TRAFFIC_OPS_RPM: infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
+        TRAFFIC_OPS_RPM: traffic_ops/traffic_ops.rpm
     depends_on:
       - db
       - enroller

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.debugging.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.debugging.yml
@@ -66,10 +66,10 @@ services:
   trafficops-go-nondebug:
     image: trafficops-go
     build:
-      context: ../..
-      dockerfile: infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
+      context: .
+      dockerfile: traffic_ops/Dockerfile-go
       args:
-        TRAFFIC_OPS_RPM: infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
+        TRAFFIC_OPS_RPM: traffic_ops/traffic_ops.rpm
     command: /usr/bin/true
   # The trafficops-perl-nondebug service exists to ensure that the trafficops-perl
   # base image exists before building trafficmonitor-debug.

--- a/infrastructure/cdn-in-a-box/readiness/Dockerfile
+++ b/infrastructure/cdn-in-a-box/readiness/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --no-cache --update \
 # MANIFEST
 # to-access.sh (sourced, get to-get and env vars)
 # run.sh       (wait on TO, then to-get deliveryservices, then curl the exampleURLs)
-COPY ./infrastructure/cdn-in-a-box/readiness/run.sh ./infrastructure/cdn-in-a-box/traffic_ops/to-access.sh /opt/readiness/
+COPY readiness/run.sh traffic_ops/to-access.sh /opt/readiness/
 
 WORKDIR /opt/readiness
 CMD ./run.sh

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
@@ -45,18 +45,18 @@ FROM    trafficops-common-deps
 
 # Override TRAFFIC_OPS_RPM arg to use a different one using --build-arg TRAFFIC_OPS_RPM=...  Can be local file or http://...
 #
-ARG     TRAFFIC_OPS_RPM=infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm
+ARG TRAFFIC_OPS_RPM=traffic_ops/traffic_ops.rpm
 
-COPY    $TRAFFIC_OPS_RPM /
-RUN     to_rpm_filename="$(basename $TRAFFIC_OPS_RPM)" && \
-        rpm --install --nodeps --verbose --hash "$to_rpm_filename" && \
-        rm "$to_rpm_filename"
+COPY $TRAFFIC_OPS_RPM /
+RUN to_rpm_filename="$(basename $TRAFFIC_OPS_RPM)" && \
+    rpm --install --nodeps --verbose --hash "$to_rpm_filename" && \
+    rm "$to_rpm_filename"
 
-COPY    infrastructure/cdn-in-a-box/enroller/server_template.json \
-        infrastructure/cdn-in-a-box/traffic_ops/config.sh \
-        infrastructure/cdn-in-a-box/traffic_ops/run-go.sh \
-        infrastructure/cdn-in-a-box/traffic_ops/to-access.sh \
-        /
+COPY enroller/server_template.json \
+     traffic_ops/config.sh \
+     traffic_ops/run-go.sh \
+     traffic_ops/to-access.sh \
+     /
 
 WORKDIR /opt/traffic_ops/app
 EXPOSE  443

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go.dockerignore
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go.dockerignore
@@ -23,5 +23,5 @@
 # - https://github.com/docker/compose/pull/6865
 # - https://docs.docker.com/develop/develop-images/build_enhancements/
 *
-!infrastructure/cdn-in-a-box/enroller/
-!infrastructure/cdn-in-a-box/traffic_ops/
+!enroller/
+!traffic_ops/


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

There are a couple of CDN-in-a-Box services that take much longer to build than they ought to because of how long it takes to send the build context to the daemon - but don't actually need a context of that size. This reduces the services' contexts to only what is necessary for them to build.

## Which Traffic Control components are affected by this PR?
- CDN in a Box

## What is the best way to verify this PR?
Build CDN-in-a-Box

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**