### PR TITLE
Servers service interface fix

### DIFF
--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -433,7 +433,7 @@ func validateV3(s *tc.ServerNullable, tx *sql.Tx) (string, error) {
 		ruleName := fmt.Sprintf("interface '%s' ", iface.Name)
 		errs = append(errs, tovalidate.ToErrors(validation.Errors{
 			ruleName + "name":        validation.Validate(iface.Name, validation.Required),
-			ruleName + "mtu":         validation.Validate(iface.MaxBandwidth, validation.By(validateMTU)),
+			ruleName + "mtu":         validation.Validate(iface.MTU, validation.By(validateMTU)),
 			ruleName + "ipAddresses": validation.Validate(iface.IPAddresses, validation.Required),
 		})...)
 
@@ -475,6 +475,10 @@ func validateV3(s *tc.ServerNullable, tx *sql.Tx) (string, error) {
 				}
 			}
 		}
+	}
+
+	if !serviceAddrV6Found && !serviceAddrV4Found {
+		errs = append(errs, errors.New("a server must have at least one service address"))
 	}
 
 	errs = append(errs, validateCommon(&s.CommonServerProperties, tx)...)

--- a/traffic_ops/traffic_ops_golang/server/servers_test.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_test.go
@@ -554,6 +554,8 @@ func TestV3Validations(t *testing.T) {
 
 	testServer.Interfaces = []tc.ServerInterfaceInfo{}
 
+	typeRows = sqlmock.NewRows(typeCols).AddRow("EDGE", "server")
+	cdnRows = sqlmock.NewRows(cdnCols).AddRow(*testServer.CDNID)
 	mock.ExpectQuery("SELECT name, use_in_table").WillReturnRows(typeRows)
 	mock.ExpectQuery("SELECT").WillReturnRows(cdnRows)
 
@@ -566,6 +568,8 @@ func TestV3Validations(t *testing.T) {
 
 	testServer.Interfaces = nil
 
+	typeRows = sqlmock.NewRows(typeCols).AddRow("EDGE", "server")
+	cdnRows = sqlmock.NewRows(cdnCols).AddRow(*testServer.CDNID)
 	mock.ExpectQuery("SELECT name, use_in_table").WillReturnRows(typeRows)
 	mock.ExpectQuery("SELECT").WillReturnRows(cdnRows)
 
@@ -581,6 +585,8 @@ func TestV3Validations(t *testing.T) {
 	badIface.MTU = &badMTU
 	testServer.Interfaces = []tc.ServerInterfaceInfo{badIface}
 
+	typeRows = sqlmock.NewRows(typeCols).AddRow("EDGE", "server")
+	cdnRows = sqlmock.NewRows(cdnCols).AddRow(*testServer.CDNID)
 	mock.ExpectQuery("SELECT name, use_in_table").WillReturnRows(typeRows)
 	mock.ExpectQuery("SELECT").WillReturnRows(cdnRows)
 
@@ -595,6 +601,8 @@ func TestV3Validations(t *testing.T) {
 	badIface.IPAddresses = []tc.ServerIPAddress{}
 	testServer.Interfaces = []tc.ServerInterfaceInfo{badIface}
 
+	typeRows = sqlmock.NewRows(typeCols).AddRow("EDGE", "server")
+	cdnRows = sqlmock.NewRows(cdnCols).AddRow(*testServer.CDNID)
 	mock.ExpectQuery("SELECT name, use_in_table").WillReturnRows(typeRows)
 	mock.ExpectQuery("SELECT").WillReturnRows(cdnRows)
 
@@ -608,6 +616,8 @@ func TestV3Validations(t *testing.T) {
 	badIface.IPAddresses = nil
 	testServer.Interfaces = []tc.ServerInterfaceInfo{badIface}
 
+	typeRows = sqlmock.NewRows(typeCols).AddRow("EDGE", "server")
+	cdnRows = sqlmock.NewRows(cdnCols).AddRow(*testServer.CDNID)
 	mock.ExpectQuery("SELECT name, use_in_table").WillReturnRows(typeRows)
 	mock.ExpectQuery("SELECT").WillReturnRows(cdnRows)
 
@@ -627,6 +637,8 @@ func TestV3Validations(t *testing.T) {
 	badIface.IPAddresses = []tc.ServerIPAddress{badIP}
 	testServer.Interfaces = []tc.ServerInterfaceInfo{badIface}
 
+	typeRows = sqlmock.NewRows(typeCols).AddRow("EDGE", "server")
+	cdnRows = sqlmock.NewRows(cdnCols).AddRow(*testServer.CDNID)
 	mock.ExpectQuery("SELECT name, use_in_table").WillReturnRows(typeRows)
 	mock.ExpectQuery("SELECT").WillReturnRows(cdnRows)
 
@@ -639,6 +651,8 @@ func TestV3Validations(t *testing.T) {
 
 	testServer.Interfaces = []tc.ServerInterfaceInfo{goodInterface, goodInterface}
 
+	typeRows = sqlmock.NewRows(typeCols).AddRow("EDGE", "server")
+	cdnRows = sqlmock.NewRows(cdnCols).AddRow(*testServer.CDNID)
 	mock.ExpectQuery("SELECT name, use_in_table").WillReturnRows(typeRows)
 	mock.ExpectQuery("SELECT").WillReturnRows(cdnRows)
 
@@ -657,6 +671,8 @@ func TestV3Validations(t *testing.T) {
 	})
 	testServer.Interfaces = []tc.ServerInterfaceInfo{badIface}
 
+	typeRows = sqlmock.NewRows(typeCols).AddRow("EDGE", "server")
+	cdnRows = sqlmock.NewRows(cdnCols).AddRow(*testServer.CDNID)
 	mock.ExpectQuery("SELECT name, use_in_table").WillReturnRows(typeRows)
 	mock.ExpectQuery("SELECT").WillReturnRows(cdnRows)
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Due to false positives in the unit tests, the validation for API v3 servers was believed to be working but actually had a couple of holes:

- You could create servers with no service interfaces
- You could create servers with interface MTU < 1280

This PR fixes both the false positives and the actual validation.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Run the tests (which should now work)

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**