### PR TITLE
Validation to prevent parentage cycles among different Topologies

### DIFF
--- a/traffic_ops/testing/api/v3/cachegroups_test.go
+++ b/traffic_ops/testing/api/v3/cachegroups_test.go
@@ -327,7 +327,7 @@ func DeleteTestCacheGroups(t *testing.T) {
 		}
 	}
 
-	// now delete the parentless cachess
+	// now delete the parentless cachegroups
 	for _, cg := range parentlessCacheGroups {
 		// Retrieve the CacheGroup by name so we can get the id for the Update
 		resp, _, err := TOSession.GetCacheGroupNullableByName(*cg.Name)

--- a/traffic_ops/testing/api/v3/cachegroups_test.go
+++ b/traffic_ops/testing/api/v3/cachegroups_test.go
@@ -293,7 +293,7 @@ func UpdateTestCacheGroups(t *testing.T) {
 }
 
 func DeleteTestCacheGroups(t *testing.T) {
-	var mids []tc.CacheGroupNullable
+	var parentlessCacheGroups []tc.CacheGroupNullable
 
 	// delete the edge caches.
 	for _, cg := range testData.CacheGroups {
@@ -302,10 +302,12 @@ func DeleteTestCacheGroups(t *testing.T) {
 		if err != nil {
 			t.Errorf("cannot GET CacheGroup by name: %v - %v", *cg.Name, err)
 		}
-		// Mids are parents and need to be deleted only after the children
-		// cachegroups are deleted.
-		if *cg.Type == "MID_LOC" {
-			mids = append(mids, cg)
+		cg = resp[0]
+
+		// Cachegroups that are parents (usually mids but sometimes edges)
+		// need to be deleted only after the children cachegroups are deleted.
+		if cg.ParentCachegroupID == nil && cg.SecondaryParentCachegroupID == nil {
+			parentlessCacheGroups = append(parentlessCacheGroups, cg)
 			continue
 		}
 		if len(resp) > 0 {
@@ -324,8 +326,9 @@ func DeleteTestCacheGroups(t *testing.T) {
 			}
 		}
 	}
-	// now delete the mid tier caches
-	for _, cg := range mids {
+
+	// now delete the parentless cachess
+	for _, cg := range parentlessCacheGroups {
 		// Retrieve the CacheGroup by name so we can get the id for the Update
 		resp, _, err := TOSession.GetCacheGroupNullableByName(*cg.Name)
 		if err != nil {

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -123,6 +123,21 @@
             "secondaryParentCachegroupName": "secondaryCachegroup",
             "shortName": "cg3",
             "typeName": "EDGE_LOC"
+        },
+        {
+            "latitude": 0,
+            "longitude": 0,
+            "name": "edge-parent1",
+            "shortName": "ep1",
+            "typeName": "EDGE_LOC"
+        },
+        {
+            "latitude": 0,
+            "longitude": 0,
+            "name": "has-edge-parent1",
+            "parentCachegroupName": "edge-parent1",
+            "shortName": "hep1",
+            "typeName": "EDGE_LOC"
         }
     ],
     "cdns": [

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -117,10 +117,15 @@ func ValidationTestTopologies(t *testing.T) {
 			{Cachegroup: "parentCachegroup", Parents: []int{2}},
 			{Cachegroup: "secondaryCachegroup", Parents: []int{1}},
 		}}},
+		{testCaseDescription: "a cycle across topologies", Topology: tc.Topology{Name: "cycle-with-4-tier-topology", Description: `Invalid because it contains a cycle when combined with the "4-tiers" topology`, Nodes: []tc.TopologyNode{
+			{Cachegroup: "parentCachegroup", Parents: []int{1}},
+			{Cachegroup: "parentCachegroup2", Parents: []int{}},
+			{Cachegroup: "cachegroup1", Parents: []int{0}},
+		}}},
 		{testCaseDescription: "a nonexistent cache group", Topology: tc.Topology{Name: "nonexistent-cg", Description: "Invalid because it references a cache group that does not exist", Nodes: []tc.TopologyNode{
 			{Cachegroup: "legitcachegroup", Parents: []int{0}},
 		}}},
-		{testCaseDescription: "an out-of-bounds parent index", Topology: tc.Topology{Name: "oob-parent", Description: "Invalid because it contains a parent", Nodes: []tc.TopologyNode{
+		{testCaseDescription: "an out-of-bounds parent index", Topology: tc.Topology{Name: "oob-parent", Description: "Invalid because it contains an out-of-bounds parent", Nodes: []tc.TopologyNode{
 			{Cachegroup: "cachegroup1", Parents: []int{7}},
 		}}},
 	}

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -122,6 +122,10 @@ func ValidationTestTopologies(t *testing.T) {
 			{Cachegroup: "parentCachegroup2", Parents: []int{}},
 			{Cachegroup: "cachegroup1", Parents: []int{0}},
 		}}},
+		{testCaseDescription: "a cycle across cache groups", Topology: tc.Topology{Name: "cycle-with-non-topology-cachegroups", Description: "Invalid because it contains a cycle when combined with a topology constructed from cache group parentage", Nodes: []tc.TopologyNode{
+			{Cachegroup: "edge-parent1", Parents: []int{1}},
+			{Cachegroup: "has-edge-parent1", Parents: []int{}},
+		}}},
 		{testCaseDescription: "a nonexistent cache group", Topology: tc.Topology{Name: "nonexistent-cg", Description: "Invalid because it references a cache group that does not exist", Nodes: []tc.TopologyNode{
 			{Cachegroup: "legitcachegroup", Parents: []int{0}},
 		}}},

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -138,9 +138,95 @@ func (topology *TOTopology) Validate() error {
 	for _, leafMid := range checkForLeafMids(topology.Nodes, cacheGroups) {
 		rules[fmt.Sprintf("node %v leaf mid", leafMid.Cachegroup)] = fmt.Errorf("cachegroup %v's type is %v; it cannot be a leaf (it must have at least 1 child)", leafMid.Cachegroup, tc.CacheGroupMidTypeName)
 	}
-	rules["topology cycles"] = checkForCycles(topology.Nodes)
+	_, rules["topology cycles"] = checkForCycles(topology.Nodes)
+	rules["super-topology cycles"] = topology.checkForCyclesAcrossTopologies()
 
 	return util.JoinErrs(tovalidate.ToErrors(rules))
+}
+
+func (topology *TOTopology) nodesInOtherTopologies() ([]tc.TopologyNode, map[string][]string, error) {
+	baseError := errors.New("unable to verify that there are no cycles across all topologies")
+	where := `WHERE name != $1`
+	query := selectQueryWithParentNames() + where
+	rows, err := topology.ReqInfo.Tx.Query(query, topology.Name)
+	if err != nil {
+		return nil, nil, baseError
+	}
+	defer log.Close(rows, "unable to close DB connection")
+
+	parentMapMap := map[string]map[string]bool{}
+	topologiesMapByCacheGroup := map[string]map[string]bool{}
+	for index := 0; rows.Next(); index++ {
+		var (
+			topologyName string
+			cacheGroup   string
+			parents      []string
+		)
+		topologyNode := tc.TopologyNode{}
+		topologyNode.Parents = []int{}
+		if err = rows.Scan(
+			&topologyName,
+			&cacheGroup,
+			pq.Array(&parents),
+		); err != nil {
+			return nil, nil, baseError
+		}
+		if _, exists := parentMapMap[cacheGroup]; !exists {
+			parentMapMap[cacheGroup] = map[string]bool{}
+		}
+		if _, exists := topologiesMapByCacheGroup[cacheGroup]; !exists {
+			topologiesMapByCacheGroup[cacheGroup] = map[string]bool{}
+		}
+		for _, parent := range parents {
+			parentMapMap[cacheGroup][parent] = true
+		}
+		topologiesMapByCacheGroup[cacheGroup][topologyName] = true
+	}
+
+	topologiesByCacheGroup := map[string][]string{}
+	// Build the list of topologies containing each cache group
+	for cacheGroup, topologiesMap := range topologiesMapByCacheGroup {
+		var topologies []string
+		for topology, _ := range topologiesMap {
+			topologies = append(topologies, topology)
+		}
+		topologiesByCacheGroup[cacheGroup] = topologies
+	}
+
+	// Add nodes for the topology we are validating
+	for _, node := range topology.Nodes {
+		if _, exists := parentMapMap[node.Cachegroup]; !exists {
+			parentMapMap[node.Cachegroup] = map[string]bool{}
+		}
+		for _, parentCacheGroupIndex := range node.Parents {
+			parentMapMap[node.Cachegroup][topology.Nodes[parentCacheGroupIndex].Cachegroup] = true
+		}
+	}
+
+	indexByCachegroup := map[string]int{}
+	var cacheGroups []string
+	index := 0
+	// Get an index for each cachegroup
+	for cacheGroup, _ := range parentMapMap {
+		cacheGroups = append(cacheGroups, cacheGroup)
+		indexByCachegroup[cacheGroup] = index
+		index++
+	}
+
+	var nodes []tc.TopologyNode
+	// Reduce parentMapMap to an array of TopologyNodes
+	// We can't rely on iterating through parentMapMap in the same order twice, so we iterate through
+	// cacheGroups instead
+	for _, cacheGroup := range cacheGroups {
+		parentMap := parentMapMap[cacheGroup]
+		node := tc.TopologyNode{Cachegroup: cacheGroup}
+		for parent, _ := range parentMap {
+			node.Parents = append(node.Parents, indexByCachegroup[parent])
+		}
+		nodes = append(nodes, node)
+	}
+
+	return nodes, topologiesByCacheGroup, nil
 }
 
 // Implementation of the Identifier, Validator interface functions
@@ -436,6 +522,22 @@ tc.id, tc.cachegroup,
 	(SELECT COALESCE (ARRAY_AGG (CAST (tcp.parent as INT) ORDER BY tcp.rank ASC)) AS parents
 	FROM topology_cachegroup tc2
 	INNER JOIN topology_cachegroup_parents tcp ON tc2.id = tcp.child
+	WHERE tc2.topology = tc.topology
+	AND tc2.cachegroup = tc.cachegroup
+	)
+FROM topology t
+JOIN topology_cachegroup tc on t.name = tc.topology
+`
+	return query
+}
+
+func selectQueryWithParentNames() string {
+	query := `
+SELECT t.name, tc.cachegroup,
+	(SELECT COALESCE (ARRAY_AGG (tcpc.cachegroup)) AS parents
+	FROM topology_cachegroup tc2
+	INNER JOIN topology_cachegroup_parents tcp ON tc2.id = tcp.child
+	INNER JOIN topology_cachegroup tcpc ON tcp.parent = tcpc.id
 	WHERE tc2.topology = tc.topology
 	AND tc2.cachegroup = tc.cachegroup
 	)


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4831<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run the API tests, make sure they pass:
```shell script
docker-compose up -d
docker-compose -f docker-compose.traffic-ops-test.yml up --build integration
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
Not a bug fix

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR includes additional validation for existing endpoints, no documentation necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
