### PR TITLE
Traffic Portal tests: Remove interactive browser.debugger() lines

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_portal_integration_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_portal_integration_test/Dockerfile
@@ -37,7 +37,7 @@ RUN curl -LO https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-x64.tar.xz
 # Use bsdtar, because regular tar doesn't work with Docker
 RUN yum install -y bsdtar
 RUN bsdtar --strip-components 1 -xzvf node-v* -C /usr/local
-RUN npm install -g protractor
+RUN npm install -g protractor@^7.0.0
 RUN npm install --save-dev jasmine-reporters@^2.0.0
 
 RUN sed -i "s/baseUrl: 'https:\/\/localhost:4443/baseUrl: 'https:\/\/trafficportal.infra.ciab.test:443/" /lang/traffic_portal/test/end_to_end/conf.js

--- a/traffic_portal/test/end_to_end/login/login-spec.js
+++ b/traffic_portal/test/end_to_end/login/login-spec.js
@@ -36,7 +36,6 @@ describe('Traffic Portal Login Test Suite', function() {
 		browser.driver.findElement(by.name('loginPass')).sendKeys('badPassword');
 		browser.driver.findElement(by.name('loginSubmit')).click();
 		browser.sleep(250);
-		browser.debugger();
 		expect(browser.driver.findElement(by.css('div.ng-binding')).getText()).toEqual('Invalid username or password.');
 	});
 
@@ -45,7 +44,6 @@ describe('Traffic Portal Login Test Suite', function() {
 		browser.driver.findElement(by.name('loginUsername')).sendKeys(browser.params.adminUser);
 		browser.driver.findElement(by.name('loginPass')).sendKeys(browser.params.adminPassword);
 		browser.driver.findElement(by.name('loginSubmit')).click();
-		browser.debugger();
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/cdns");
 	});
 });


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

<details><summary>Fixes <code>TypeError: browser.debugger is not a function</code> (expand to see log)</summary>

```
Failures:
1) Traffic Portal Login Test Suite should fail login to Traffic Portal with bad user
  Message:
    Failed: browser.debugger is not a function
  Stack:
    TypeError: browser.debugger is not a function
        at UserContext.<anonymous> (/lang/traffic_portal/test/end_to_end/login/login-spec.js:39:19)
        at /usr/local/lib/node_modules/protractor/node_modules/jasminewd2/index.js:112:25
        at new ManagedPromise (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/promise.js:1077:7)
        at ControlFlow.promise (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/promise.js:2505:12)
        at schedulerExecute (/usr/local/lib/node_modules/protractor/node_modules/jasminewd2/index.js:95:18)
        at TaskQueue.execute_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/promise.js:3084:14)
        at TaskQueue.executeNext_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/promise.js:3067:27)
        at asyncRun (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/promise.js:2974:25)
        at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/promise.js:668:7
        at process._tickCallback (internal/process/next_tick.js:68:7)
    From: Task: Run it("should fail login to Traffic Portal with bad user") in control flow
        at UserContext.<anonymous> (/usr/local/lib/node_modules/protractor/node_modules/jasminewd2/index.js:94:19)
        at /usr/local/lib/node_modules/protractor/node_modules/jasminewd2/index.js:64:48
        at ControlFlow.emit (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/events.js:62:21)
        at ControlFlow.shutdown_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/promise.js:2674:10)
        at shutdownTask_.MicroTask (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/promise.js:2599:53)
    From asynchronous test: 
    Error
        at Suite.<anonymous> (/lang/traffic_portal/test/end_to_end/login/login-spec.js:33:2)
        at Object.<anonymous> (/lang/traffic_portal/test/end_to_end/login/login-spec.js:22:1)
        at Module._compile (internal/modules/cjs/loader.js:689:30)
        at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
        at Module.load (internal/modules/cjs/loader.js:599:32)
        at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
```
</details>
That error causes all of the tests to fail. Currently, if it is fixed, then the TP tests pass.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Portal

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run the Traffic Portal integration test

In the CDN-in-a-Box directory:
```shell
docker-compose -f docker-compose.yml -f docker-compose.traffic-portal-test.yml up -d
docker-compose -f docker-compose.traffic-portal-test.yml logs -f
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (470ce9c0df)
- 4.1.0

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR fixes existing tests
- [x] Fixes tests, no documentation necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
