### PR TITLE
fixed TR to use default watcher URL when parameter is not present

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/LetsEncryptDnsChallengeWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/LetsEncryptDnsChallengeWatcher.java
@@ -46,6 +46,7 @@ public class LetsEncryptDnsChallengeWatcher extends AbstractResourceWatcher {
 
     public LetsEncryptDnsChallengeWatcher() {
         setDatabaseUrl(DEFAULT_LE_DNS_CHALLENGE_URL);
+        setDefaultDatabaseUrl(DEFAULT_LE_DNS_CHALLENGE_URL);
     }
 
     @Override

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/SteeringWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/SteeringWatcher.java
@@ -26,6 +26,7 @@ public class SteeringWatcher extends AbstractResourceWatcher {
 
 	public SteeringWatcher() {
 		setDatabaseUrl(DEFAULT_STEERING_DATA_URL);
+		setDefaultDatabaseUrl(DEFAULT_STEERING_DATA_URL);
 	}
 
 	@Override

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -45,6 +45,7 @@ public abstract class AbstractServiceUpdater {
 	private static final Logger LOGGER = Logger.getLogger(AbstractServiceUpdater.class);
 
 	protected String dataBaseURL;
+	protected String defaultDatabaseURL;
 	protected String databaseName;
 	protected ScheduledExecutorService executorService;
 	private long pollingInterval;
@@ -65,6 +66,15 @@ public abstract class AbstractServiceUpdater {
 	 */
 	public String getDataBaseURL() {
 		return dataBaseURL;
+	}
+
+	/**
+	 * Gets the defaultDatabaseURL.
+	 *
+	 * @return the defaultDatabaseURL
+	 */
+	public String getDefaultDatabaseURL() {
+		return defaultDatabaseURL;
 	}
 
 	/**
@@ -218,6 +228,10 @@ public abstract class AbstractServiceUpdater {
 
 	public void setDatabaseUrl(final String url) {
 		this.dataBaseURL = url;
+	}
+
+	public void setDefaultDatabaseUrl(final String url) {
+		this.defaultDatabaseURL = url;
 	}
 
 	/**

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -69,15 +69,6 @@ public abstract class AbstractServiceUpdater {
 	}
 
 	/**
-	 * Gets the defaultDatabaseURL.
-	 *
-	 * @return the defaultDatabaseURL
-	 */
-	public String getDefaultDatabaseURL() {
-		return defaultDatabaseURL;
-	}
-
-	/**
 	 * Gets pollingInterval.
 	 *
 	 * @return the pollingInterval

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsWatcher.java
@@ -25,6 +25,7 @@ public class FederationsWatcher extends AbstractResourceWatcher {
     public static final String DEFAULT_FEDERATION_DATA_URL = "https://${toHostname}/api/2.0/federations/all";
     public FederationsWatcher() {
         setDatabaseUrl(DEFAULT_FEDERATION_DATA_URL);
+        setDefaultDatabaseUrl(DEFAULT_FEDERATION_DATA_URL);
     }
 
     @Override

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
@@ -57,7 +57,7 @@ public abstract class AbstractResourceWatcher extends AbstractServiceUpdater {
 		}
 
 		final WatcherConfig watcherConfig = new WatcherConfig(getWatcherConfigPrefix(), config, trafficOpsUtils);
-		final String resourceUrl = (watcherConfig.getUrl() != null && !watcherConfig.getUrl().isEmpty()) ? watcherConfig.getUrl() : getDataBaseURL();
+		final String resourceUrl = (watcherConfig.getUrl() != null && !watcherConfig.getUrl().isEmpty()) ? watcherConfig.getUrl() : getDefaultDatabaseURL();
 
 		final long pollingInterval = (watcherConfig.getInterval() > 0) ? watcherConfig.getInterval() : getPollingInterval();
 		final int configTimeout = (watcherConfig.getTimeout() > 0) ? watcherConfig.getTimeout() : this.timeout;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
@@ -57,7 +57,7 @@ public abstract class AbstractResourceWatcher extends AbstractServiceUpdater {
 		}
 
 		final WatcherConfig watcherConfig = new WatcherConfig(getWatcherConfigPrefix(), config, trafficOpsUtils);
-		final String resourceUrl = (watcherConfig.getUrl() != null && !watcherConfig.getUrl().isEmpty()) ? watcherConfig.getUrl() : getDefaultDatabaseURL();
+		final String resourceUrl = (watcherConfig.getUrl() != null && !watcherConfig.getUrl().isEmpty()) ? watcherConfig.getUrl() : defaultDatabaseURL;
 
 		final long pollingInterval = (watcherConfig.getInterval() > 0) ? watcherConfig.getInterval() : getPollingInterval();
 		final int configTimeout = (watcherConfig.getTimeout() > 0) ? watcherConfig.getTimeout() : this.timeout;

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
@@ -103,6 +103,7 @@ public class AbstractResourceWatcherTest {
         } else {
             config = ((ObjectNode) config).remove(federationsWatcher.getWatcherConfigPrefix() + ".polling.url");
         }
+        federationsWatcher.trafficOpsUtils.setConfig(config);
         federationsWatcher.configure(config);
         assertThat(federationsWatcher.getDataBaseURL(), endsWith(DEFAULT_FEDERATION_DATA_URL.split("api")[1]));
     }
@@ -113,7 +114,6 @@ public class AbstractResourceWatcherTest {
         CacheRegister cacheRegister = trafficRouter.getCacheRegister();
         JsonNode config = cacheRegister.getConfig();
         assertNull(config.get(federationsWatcher.getWatcherConfigPrefix() + ".polling.url"));
-        assertThat(steeringRegistry.getAll().size(), greaterThan(0));
         assertThat(federationsWatcher.getDataBaseURL(), endsWith(DEFAULT_FEDERATION_DATA_URL.split("api")[1]));
         assertThat(steeringWatcher.getDataBaseURL(), endsWith(DEFAULT_STEERING_DATA_URL.split("api")[1]));
 

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
@@ -108,5 +108,4 @@ public class AbstractResourceWatcherTest {
         assertThat(config.get(federationsWatcher.getWatcherConfigPrefix() + ".polling.url").asText(), endsWith("api/3.0/notAFederationsEndpoint"));
         assertThat(federationsWatcher.getDataBaseURL(), endsWith("api/3.0/notAFederationsEndpoint"));
     }
-
 }

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
@@ -1,0 +1,97 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.util;
+
+import com.comcast.cdn.traffic_control.traffic_router.core.TestBase;
+import com.comcast.cdn.traffic_control.traffic_router.core.ds.SteeringRegistry;
+import com.comcast.cdn.traffic_control.traffic_router.core.ds.SteeringWatcher;
+import com.comcast.cdn.traffic_control.traffic_router.core.edge.CacheRegister;
+import com.comcast.cdn.traffic_control.traffic_router.core.loc.*;
+import com.comcast.cdn.traffic_control.traffic_router.core.router.TrafficRouter;
+import com.comcast.cdn.traffic_control.traffic_router.core.router.TrafficRouterManager;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.context.ApplicationContext;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static com.comcast.cdn.traffic_control.traffic_router.core.ds.SteeringWatcher.DEFAULT_STEERING_DATA_URL;
+import static com.comcast.cdn.traffic_control.traffic_router.core.loc.FederationsWatcher.DEFAULT_FEDERATION_DATA_URL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.*;
+
+
+@Category(IntegrationTest.class)
+public class AbstractResourceWatcherTest {
+
+    private static final Logger LOGGER = Logger.getLogger(com.comcast.cdn.traffic_control.traffic_router.core.util.AbstractResourceWatcherTest.class);
+
+    private FederationsWatcher federationsWatcher;
+    private SteeringWatcher steeringWatcher;
+    private TrafficRouterManager trafficRouterManager;
+    private SteeringRegistry steeringRegistry;
+    private static ApplicationContext context;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        assertThat("Copy core/src/main/conf/traffic_monitor.properties to core/src/test/conf and set 'traffic_monitor.bootstrap.hosts' to a real traffic monitor", Files.exists(Paths.get(TestBase.monitorPropertiesPath)), equalTo(true));
+        context = TestBase.getContext();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        federationsWatcher = (FederationsWatcher) context.getBean("federationsWatcher");
+        steeringWatcher = (SteeringWatcher) context.getBean("steeringWatcher");
+        steeringRegistry = (SteeringRegistry) context.getBean("steeringRegistry");
+        trafficRouterManager = (TrafficRouterManager) context.getBean("trafficRouterManager");
+        trafficRouterManager.getTrafficRouter().setApplicationContext(context);
+
+        while (!federationsWatcher.isLoaded()) {
+            LOGGER.info("Waiting for a valid federations database before proceeding");
+            Thread.sleep(1000);
+        }
+
+        while (!steeringWatcher.isLoaded()) {
+            LOGGER.info("Waiting for a valid steering database before proceeding");
+            Thread.sleep(1000);
+        }
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        TrafficRouter trafficRouter = trafficRouterManager.getTrafficRouter();
+        CacheRegister cacheRegister = trafficRouter.getCacheRegister();
+        JsonNode config = cacheRegister.getConfig();
+        config = ((ObjectNode) config).put(federationsWatcher.getWatcherConfigPrefix() + ".polling.url", DEFAULT_FEDERATION_DATA_URL);
+        federationsWatcher.configure(config);
+        assertThat(federationsWatcher.getDataBaseURL(), endsWith(DEFAULT_FEDERATION_DATA_URL.split("api")[1]));
+    }
+
+    @Test
+    public void testWatchers() {
+        TrafficRouter trafficRouter = trafficRouterManager.getTrafficRouter();
+        CacheRegister cacheRegister = trafficRouter.getCacheRegister();
+        JsonNode config = cacheRegister.getConfig();
+        assertNull(config.get(federationsWatcher.getWatcherConfigPrefix() + ".polling.url"));
+        assertThat(steeringRegistry.getAll().size(), greaterThan(0));
+        assertThat(federationsWatcher.getDataBaseURL(), endsWith(DEFAULT_FEDERATION_DATA_URL.split("api")[1]));
+        assertThat(steeringWatcher.getDataBaseURL(), endsWith(DEFAULT_STEERING_DATA_URL.split("api")[1]));
+
+        String newFedsUrl = "https://${toHostname}/api/3.0/notAFederationsEndpoint";
+        config = ((ObjectNode) config).put(federationsWatcher.getWatcherConfigPrefix() + ".polling.url", newFedsUrl);
+        federationsWatcher.configure(config);
+        config = cacheRegister.getConfig();
+        assertThat(config.get(federationsWatcher.getWatcherConfigPrefix() + ".polling.url").asText(), endsWith("api/3.0/notAFederationsEndpoint"));
+        assertThat(federationsWatcher.getDataBaseURL(), endsWith("api/3.0/notAFederationsEndpoint"));
+    }
+
+}

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
@@ -1,3 +1,18 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.comcast.cdn.traffic_control.traffic_router.core.util;
 
 import com.comcast.cdn.traffic_control.traffic_router.core.TestBase;

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
@@ -19,7 +19,7 @@ import com.comcast.cdn.traffic_control.traffic_router.core.TestBase;
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.SteeringRegistry;
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.SteeringWatcher;
 import com.comcast.cdn.traffic_control.traffic_router.core.edge.CacheRegister;
-import com.comcast.cdn.traffic_control.traffic_router.core.loc.*;
+import com.comcast.cdn.traffic_control.traffic_router.core.loc.FederationsWatcher;
 import com.comcast.cdn.traffic_control.traffic_router.core.router.TrafficRouter;
 import com.comcast.cdn.traffic_control.traffic_router.core.router.TrafficRouterManager;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -41,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 
 
 @Category(IntegrationTest.class)
@@ -56,7 +56,7 @@ public class AbstractResourceWatcherTest {
     private static ApplicationContext context;
 
     @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
+    public static void setUpBeforeClass() {
         assertThat("Copy core/src/main/conf/traffic_monitor.properties to core/src/test/conf and set 'traffic_monitor.bootstrap.hosts' to a real traffic monitor", Files.exists(Paths.get(TestBase.monitorPropertiesPath)), equalTo(true));
         context = TestBase.getContext();
     }
@@ -82,7 +82,7 @@ public class AbstractResourceWatcherTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         TrafficRouter trafficRouter = trafficRouterManager.getTrafficRouter();
         CacheRegister cacheRegister = trafficRouter.getCacheRegister();
         JsonNode config = cacheRegister.getConfig();

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
@@ -62,7 +62,7 @@ public class AbstractResourceWatcherTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws InterruptedException {
         federationsWatcher = (FederationsWatcher) context.getBean("federationsWatcher");
         steeringWatcher = (SteeringWatcher) context.getBean("steeringWatcher");
         steeringRegistry = (SteeringRegistry) context.getBean("steeringRegistry");

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcherTest.java
@@ -73,7 +73,13 @@ public class AbstractResourceWatcherTest {
         TrafficRouter trafficRouter = trafficRouterManager.getTrafficRouter();
         CacheRegister cacheRegister = trafficRouter.getCacheRegister();
         JsonNode config = cacheRegister.getConfig();
-        oldFedUrl = config.get(federationsWatcher.getWatcherConfigPrefix() + ".polling.url") != null ? config.get(federationsWatcher.getWatcherConfigPrefix() + ".polling.url").asText() : "";
+
+        if(config.get(federationsWatcher.getWatcherConfigPrefix() + ".polling.url") != null) {
+            oldFedUrl = config.get(federationsWatcher.getWatcherConfigPrefix() + ".polling.url").asText();
+            config = ((ObjectNode) config).remove(federationsWatcher.getWatcherConfigPrefix() + ".polling.url");
+            federationsWatcher.trafficOpsUtils.setConfig(config);
+            federationsWatcher.configure(config);
+        }
 
         while (!federationsWatcher.isLoaded()) {
             LOGGER.info("Waiting for a valid federations database before proceeding");


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR fixes an issue in Traffic Router where if there is a polling url (for example, federationmapping.polling.url) parameter and it is later unlinked to the TR or removed then the value will continue to be used until the TR is restarted instead of reverting to using the default value for the poller.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

To recreate the problem:
Run cdn in a box, assign a new value to federationmapping.polling.url and snap (need to do this because the current parameter is the same as the default)
tail traffic router log for calls to get the federations and verify that it is using the new value
unlink the parameter from TR
verify that the old parameter is still used

To test solution:
do the same as above but at the end it should have reverted to using the default value

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master
- 4.1

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->
This PR does not include tests, docs, or changelog updates since it is a bug fix.

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
