### PR TITLE
Add ORT Inferring Location Parameters

### DIFF
--- a/lib/go-tc/ats.go
+++ b/lib/go-tc/ats.go
@@ -46,8 +46,8 @@ type ATSConfigMetaDataInfo struct {
 type ATSConfigMetaDataConfigFile struct {
 	FileNameOnDisk string `json:"fnameOnDisk"`
 	Location       string `json:"location"`
-	APIURI         string `json:"apiUri,omitempty"`
-	URL            string `json:"url,omitempty"`
+	APIURI         string `json:"apiUri,omitempty"` // APIURI is deprecated, do not use.
+	URL            string `json:"url,omitempty"`    // URL is deprecated, do not use.
 	Scope          string `json:"scope"`
 }
 

--- a/traffic_ops/testing/api/v1/atsconfig_meta_test.go
+++ b/traffic_ops/testing/api/v1/atsconfig_meta_test.go
@@ -54,7 +54,6 @@ func GetTestATSConfigMeta(t *testing.T) {
 	expected := tc.ATSConfigMetaDataConfigFile{
 		FileNameOnDisk: "hdr_rw_ds1.config",
 		Location:       "/remap/config/location/parameter",
-		APIURI:         "cdns/cdn1/configfiles/ats/hdr_rw_ds1.config", // expected suffix; config gen doesn't care about API version
 		URL:            "",
 		Scope:          "cdns",
 	}
@@ -74,9 +73,6 @@ func GetTestATSConfigMeta(t *testing.T) {
 		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
 	}
 	if expected.Location != actual.Location {
-		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
-	}
-	if !strings.HasSuffix(actual.APIURI, expected.APIURI) {
 		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
 	}
 	if actual.Scope != expected.Scope {
@@ -114,7 +110,6 @@ func GetTestATSConfigMetaMidHdrRw(t *testing.T) {
 	expected := tc.ATSConfigMetaDataConfigFile{
 		FileNameOnDisk: "hdr_rw_mid_ds1nat.config",
 		Location:       "/remap/config/location/parameter",
-		APIURI:         "cdns/cdn1/configfiles/ats/hdr_rw_mid_ds1nat.config", // expected suffix; config gen doesn't care about API version
 		URL:            "",
 		Scope:          "cdns",
 	}
@@ -134,9 +129,6 @@ func GetTestATSConfigMetaMidHdrRw(t *testing.T) {
 		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
 	}
 	if expected.Location != actual.Location {
-		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
-	}
-	if !strings.HasSuffix(actual.APIURI, expected.APIURI) {
 		t.Errorf("Getting server '"+server.HostName+"' config list: expected: %+v actual: %+v\n", expected, *actual)
 	}
 	if actual.Scope != expected.Scope {

--- a/traffic_ops_ort/atstccfg/atstccfg.go
+++ b/traffic_ops_ort/atstccfg/atstccfg.go
@@ -109,7 +109,7 @@ func main() {
 		os.Exit(config.ExitCodeErrGeneric)
 	}
 
-	configs, err := cfgfile.GetAllConfigs(toData, tccfg.RevalOnly)
+	configs, err := cfgfile.GetAllConfigs(toData, tccfg.RevalOnly, tccfg.Dir)
 	if err != nil {
 		log.Errorln("Getting config for'" + cfg.CacheHostName + "': " + err.Error())
 		os.Exit(config.ExitCodeErrGeneric)

--- a/traffic_ops_ort/atstccfg/cfgfile/cfgfile_test.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/cfgfile_test.go
@@ -21,7 +21,6 @@ package cfgfile
 
 import (
 	"bytes"
-
 	"math/rand"
 	"strings"
 	"testing"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg/config"
 )
 
@@ -125,7 +125,8 @@ func TestGetAllConfigsWriteConfigsDeterministic(t *testing.T) {
 	// TODO expand fake data. Currently, it's only making a remap.config.
 	toData := MakeFakeTOData()
 	revalOnly := false
-	configs, err := GetAllConfigs(toData, revalOnly)
+	cfgPath := "/etc/trafficserver/"
+	configs, err := GetAllConfigs(toData, revalOnly, cfgPath)
 	if err != nil {
 		t.Fatalf("error getting configs: " + err.Error())
 	}
@@ -138,7 +139,7 @@ func TestGetAllConfigsWriteConfigsDeterministic(t *testing.T) {
 	configStr = removeComments(configStr)
 
 	for i := 0; i < 10; i++ {
-		configs2, err := GetAllConfigs(toData, revalOnly)
+		configs2, err := GetAllConfigs(toData, revalOnly, cfgPath)
 		if err != nil {
 			t.Fatalf("error getting configs2: " + err.Error())
 		}
@@ -268,7 +269,7 @@ func randDS() *tc.DeliveryServiceNullable {
 	ds.MissLong = randFloat64()
 	ds.MultiSiteOrigin = randBool()
 	ds.OriginShield = randStr()
-	ds.OrgServerFQDN = randStr()
+	ds.OrgServerFQDN = util.StrPtr("http://" + *(randStr()))
 	ds.ProfileDesc = randStr()
 	ds.ProfileID = randInt()
 	ds.ProfileName = randStr()

--- a/traffic_ops_ort/atstccfg/cfgfile/routing.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/routing.go
@@ -37,29 +37,15 @@ var scopeConfigFileFuncs = map[string]func(toData *config.TOData, fileName strin
 
 // GetConfigFile returns the text of the generated config file, the MIME Content Type of the config file, and any error.
 func GetConfigFile(toData *config.TOData, fileInfo tc.ATSConfigMetaDataConfigFile) (string, string, string, error) {
-	path := fileInfo.APIURI
-	// TODO remove the URL path parsing. It's a legacy from when config files were endpoints in the meta config.
-	// We should replace it with actually calling the right file and name directly.
 	start := time.Now()
 	defer func() {
-		log.Infof("GetConfigFile %v took %v\n", path, time.Since(start).Round(time.Millisecond))
+		log.Infof("GetConfigFile %v took %v\n", fileInfo.FileNameOnDisk, time.Since(start).Round(time.Millisecond))
 	}()
-
-	pathParts := strings.Split(path, "/")
-	if len(pathParts) < 8 {
-		return "", "", "", errors.New("unknown config file '" + path + "'")
+	log.Infoln("GetConfigFile scope '" + fileInfo.Scope + "' fileName '" + fileInfo.FileNameOnDisk + "'")
+	if scopeConfigFileFunc, ok := scopeConfigFileFuncs[fileInfo.Scope]; ok {
+		return scopeConfigFileFunc(toData, fileInfo.FileNameOnDisk)
 	}
-	scope := pathParts[3]
-	resource := pathParts[4]
-	fileName := pathParts[7]
-
-	log.Infoln("GetConfigFile scope '" + scope + "' resource '" + resource + "' fileName '" + fileName + "'")
-
-	if scopeConfigFileFunc, ok := scopeConfigFileFuncs[scope]; ok {
-		return scopeConfigFileFunc(toData, fileName)
-	}
-
-	return "", "", "", errors.New("unknown config file '" + fileInfo.APIURI + "'")
+	return "", "", "", errors.New("unknown config file '" + fileInfo.FileNameOnDisk + "'")
 }
 
 type ConfigFilePrefixSuffixFunc struct {

--- a/traffic_ops_ort/atstccfg/config/config.go
+++ b/traffic_ops_ort/atstccfg/config/config.go
@@ -65,6 +65,7 @@ type Cfg struct {
 	TOTimeout       time.Duration
 	TOURL           *url.URL
 	TOUser          string
+	Dir             string
 }
 
 type TCCfg struct {
@@ -99,6 +100,7 @@ func GetCfg() (Cfg, error) {
 	setRevalStatusPtr := flag.StringP("set-reval-status", "a", "", "POSTs to Traffic Ops setting the revalidate status of the server. Must be 'true' or 'false'. Requires --set-queue-status also be set")
 	revalOnlyPtr := flag.BoolP("revalidate-only", "y", false, "Whether to exclude files not named 'regex_revalidate.config'")
 	disableProxyPtr := flag.BoolP("traffic-ops-disable-proxy", "p", false, "Whether to not use the Traffic Ops proxy specified in the GLOBAL Parameter tm.rev_proxy.url")
+	dirPtr := flag.StringP("dir", "D", "", "ATS config directory, used for config files without location parameters or with relative paths. May be blank. If blank and any required config file location parameter is missing or relative, will error.")
 
 	flag.Parse()
 
@@ -128,6 +130,7 @@ func GetCfg() (Cfg, error) {
 	setRevalStatus := *setRevalStatusPtr
 	revalOnly := *revalOnlyPtr
 	disableProxy := *disableProxyPtr
+	dir := *dirPtr
 
 	urlSourceStr := "argument" // for error messages
 	if toURL == "" {
@@ -186,6 +189,7 @@ func GetCfg() (Cfg, error) {
 		SetQueueStatus:  setQueueStatus,
 		RevalOnly:       revalOnly,
 		DisableProxy:    disableProxy,
+		Dir:             dir,
 	}
 	if err := log.InitCfg(cfg); err != nil {
 		return Cfg{}, errors.New("Initializing loggers: " + err.Error() + "\n")


### PR DESCRIPTION
Adds ORT location Parameter inference. If location Parameters do not exist
the files are created and added anyway with the directory determined
from the local ATS install, for:
- cache.config
- hosting.config
- ip_allow.config
- parent.config
- plugin.config
- records.config
- remap.config
- storage.config
- volume.config
- Delivery Services with
  - Edge Header Rewrite
  - Mid Header Rewrite,
  - Cache URL
  - URL Sig
  - URI Signing

Note this is not an exhaustive list of required files, and many files
must be dynamic and cannot be inferred.

But this does remove the unnecessary manual configuration for this list.
More files may be added in the future.

This also makes `location` Parameters with Relative Paths append them to the local installed ATS config directory.
So for example, the duplicated `location` `/etc/trafficserver/opt/trafficserver` Parameters everywhere can be changed to `location` value `.`, and the `set_dscp_30.config` `location` `/etc/trafficserver/opt/trafficserver/dscp` Parameters in the Default Profiles can be changed to `set_dscp_30.config` `location` `dscp`.

- [x] This PR is not related to any other Issue

I've manually tested in a production-like environment, verified ORT places server-wide configs like remap.config, as well as DS-specific configs like hdr_rw_dsname.config, without `location` Parameters. Also tested that relative paths like `""` and `.` work as expected.

Includes tests.
No docs, location Parameters aren't documented (maybe they should be, but that's outside the scope of this PR).
Includes changelog.

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests.
Run ORT against a Traffic Ops as a Server with no location Parameter on its Profile for remap.config, hdr_rw_dsname.config, and others in the above list, verify configs are still placed properly.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information

