### PR TITLE
TP tests: Wait for Traffic Portal to start

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
@@ -28,9 +28,14 @@ set-dns.sh
 insert-self-into-dns.sh
 
 TO_URL="https://$TO_FQDN:$TO_PORT"
-while ! to-ping 2>/dev/null; do
-   echo "waiting for trafficops at '$TO_URL' fqdn '$TO_FQDN' host '$TO_HOST'"
+until to-ping 2>/dev/null; do
+   echo "waiting for Traffic Ops at '$TO_URL' fqdn '$TO_FQDN' host '$TO_HOST'"
    sleep 3
+done
+
+until [[ -e "${ENROLLER_DIR}/initial-load-done" ]]; do
+	echo 'Waiting for Traffic Ops Perl to finish seeding the Traffic Ops data so Traffic Portal will start...'
+	sleep 3;
 done
 
 nohup webdriver-manager start &

--- a/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
@@ -38,6 +38,20 @@ until [[ -e "${ENROLLER_DIR}/initial-load-done" ]]; do
 	sleep 3;
 done
 
+timeout_in_seconds=30
+start_time="$(date +%s)"
+date_in_seconds="$start_time"
+TP_URL="https://$TP_FQDN:$TP_PORT"
+until curl -sk "${TP_URL}/api/3.0/ping" || (( time - start_time >= timeout_in_seconds )); do
+	echo "waiting for Traffic Portal at '$TP_URL' fqdn '$TP_FQDN' host '$TP_HOST'"
+	time="$(date +%s)"
+	sleep 3;
+done
+
+if (( time - start_time >= timeout_in_seconds )); then
+	echo "Warning: Traffic Portal did not start after ${timeout_in_seconds} seconds.";
+fi;
+
 nohup webdriver-manager start &
 
 selenium_port=4444


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR makes the Traffic Portal integration test wait for up to 30 seconds after the Traffic Ops data load completes for Traffic Portal to start.

Without this, if all CDN-in-a-Box containers are started at the same time, the TP integration tests will start running before Traffic Portal itself is online, causing at least 1 test to fail.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
With CDN-in-a-Box completely stopped (and volumes removed), start it and the TP integration test.

```shell script
docker-compose up -d trafficportal trafficops trafficvault && \
docker-compose -f docker-compose.yml -f docker-compose.traffic-portal-test.yml up portal-integration-test
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (ff50ddbae4)
- 4.1.0

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR makes existing tests pass
- [x] Current TP tests documentation is sufficient
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
