### PR TITLE
Fixing /api/1.1/servers/{id} endpoint to not return empty response

### DIFF
--- a/traffic_ops/testing/api/v1/servers_test.go
+++ b/traffic_ops/testing/api/v1/servers_test.go
@@ -16,8 +16,9 @@ package v1
 */
 
 import (
-	"github.com/apache/trafficcontrol/lib/go-tc"
 	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 func TestServers(t *testing.T) {
@@ -70,18 +71,18 @@ func UpdateTestServers(t *testing.T) {
 	var alert tc.Alerts
 	alert, _, err = TOSession.UpdateServerByID(remoteServer.ID, remoteServer)
 	if err != nil {
-		t.Fatalf("cannot UPDATE Server by ID: %v - %v", err, alert)
+		t.Errorf("cannot UPDATE Server by ID: %v - %v", err, alert)
 	}
 	// Retrieve the server to check rack and interfaceName values were updated
 	resp, _, err = TOSession.GetServerByID(remoteServer.ID)
 	if err != nil {
-		t.Fatalf("cannot GET Server by ID: %v - %v", remoteServer.ID, err)
+		t.Errorf("cannot GET Server by ID: %v - %v", remoteServer.ID, err)
 	}
 
 	respServer := resp[0]
 	if respServer.InterfaceName != updatedServerInterface || respServer.Rack != updatedServerRack {
-		t.Fatalf("results do not match actual: %s, expected: %s", respServer.InterfaceName, updatedServerInterface)
-		t.Fatalf("results do not match actual: %s, expected: %s", respServer.Rack, updatedServerRack)
+		t.Errorf("results do not match actual: %s, expected: %s", respServer.InterfaceName, updatedServerInterface)
+		t.Errorf("results do not match actual: %s, expected: %s", respServer.Rack, updatedServerRack)
 	}
 
 	// Assign server to DS and then attempt to update to a different type
@@ -116,7 +117,7 @@ func UpdateTestServers(t *testing.T) {
 	// Attempt Update - should fail
 	_, _, err = TOSession.UpdateServerByID(remoteServer.ID, remoteServer)
 	if err == nil {
-		t.Fatalf("expected error when updating Server Type of a server assigned to DSes")
+		t.Errorf("expected error when updating Server Type of a server assigned to DSes")
 	}
 
 }

--- a/traffic_ops/testing/api/v1/servers_test.go
+++ b/traffic_ops/testing/api/v1/servers_test.go
@@ -16,9 +16,8 @@ package v1
 */
 
 import (
-	"testing"
-
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"testing"
 )
 
 func TestServers(t *testing.T) {
@@ -71,19 +70,18 @@ func UpdateTestServers(t *testing.T) {
 	var alert tc.Alerts
 	alert, _, err = TOSession.UpdateServerByID(remoteServer.ID, remoteServer)
 	if err != nil {
-		t.Errorf("cannot UPDATE Server by hostname: %v - %v", err, alert)
+		t.Fatalf("cannot UPDATE Server by ID: %v - %v", err, alert)
 	}
-
 	// Retrieve the server to check rack and interfaceName values were updated
 	resp, _, err = TOSession.GetServerByID(remoteServer.ID)
 	if err != nil {
-		t.Errorf("cannot GET Server by ID: %v - %v", remoteServer.HostName, err)
+		t.Fatalf("cannot GET Server by ID: %v - %v", remoteServer.ID, err)
 	}
 
 	respServer := resp[0]
 	if respServer.InterfaceName != updatedServerInterface || respServer.Rack != updatedServerRack {
-		t.Errorf("results do not match actual: %s, expected: %s", respServer.InterfaceName, updatedServerInterface)
-		t.Errorf("results do not match actual: %s, expected: %s", respServer.Rack, updatedServerRack)
+		t.Fatalf("results do not match actual: %s, expected: %s", respServer.InterfaceName, updatedServerInterface)
+		t.Fatalf("results do not match actual: %s, expected: %s", respServer.Rack, updatedServerRack)
 	}
 
 	// Assign server to DS and then attempt to update to a different type
@@ -118,7 +116,7 @@ func UpdateTestServers(t *testing.T) {
 	// Attempt Update - should fail
 	_, _, err = TOSession.UpdateServerByID(remoteServer.ID, remoteServer)
 	if err == nil {
-		t.Errorf("expected error when updating Server Type of a server assigned to DSes")
+		t.Fatalf("expected error when updating Server Type of a server assigned to DSes")
 	}
 
 }

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -592,7 +592,7 @@ func ReadID(w http.ResponseWriter, r *http.Request) {
 		api.WriteAlertsObj(w, r, http.StatusOK, deprecationAlerts, servers)
 		return
 	}
-	legacyServers := make([]tc.ServerNullableV11, 0, 1)
+	legacyServers := make([]tc.ServerNullableV11, 0, len(servers))
 	for _, server := range servers {
 		legacyServer, err := server.ToServerV2()
 		if err != nil {

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -596,12 +596,13 @@ func ReadID(w http.ResponseWriter, r *http.Request) {
 	for _, server := range servers {
 		legacyServer, err := server.ToServerV2()
 		if err != nil {
+			api.HandleDeprecatedErr(w, r, tx, http.StatusInternalServerError, nil, fmt.Errorf("failed to convert servers to legacy format: %v", err), &alternative)
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, fmt.Errorf("failed to convert servers to legacy format: %v", err))
 			return
 		}
 		legacyServers = append(legacyServers, legacyServer.ServerNullableV11)
 	}
-	api.WriteResp(w, r, legacyServers)
+	api.WriteAlertsObj(w, r, http.StatusOK, deprecationAlerts, legacyServers)
 	return
 }
 


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4867  <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- Traffic Control Client Go <!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run the API v1 tests and make sure they all pass.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] I have explained why documentation is unnecessary
- [x] This PR does not include an update to CHANGELOG.md 
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
