### PR TITLE
traffic_ops_ort.pl transliteration to go

### DIFF
--- a/.dependency_license
+++ b/.dependency_license
@@ -123,6 +123,8 @@ traffic_portal/app/src/assets/js/dataTables.buttons\..*, MIT
 traffic_portal/app/src/assets/js/buttons.html5\..*, MIT
 traffic_ops/traffic_ops_golang/vendor/github\.com/dgrijalva/.*, MIT
 traffic_ops/traffic_ops_golang/vendor/github\.com/lestrrat-go/.*, MIT
+traffic_ops_ort/vendor/github\.com/gofrs/flock/.*, BSD
+traffic_ops_ort/vendor/github\.com/pborman/getopt/.*, BSD
 
 # Ignored - Do not report.
 \.DS_Store, Ignore # Created automatically OSX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 ### Added
+- Traffic Ops Ort: Adds a transliteration of the traffic_ops_ort.pl perl script to the go language. See traffic_ops_ort/t3c/README.md.
 - Traffic Ops API v3
 - Added an optional readiness check service to cdn-in-a-box that exits successfully when it is able to get a `200 OK` from all delivery services
 - [Flexible Topologies (in progress)](https://github.com/apache/trafficcontrol/blob/master/blueprints/flexible-topologies.md)

--- a/LICENSE
+++ b/LICENSE
@@ -465,3 +465,11 @@ For the go-acme/lego (version 2.7.2) component:
 For the google/uuid (version 1.1.1) component:
 @traffic_ops/traffic_ops_golang/vendor/github.com/google/uuid/*
 ./traffic_ops/traffic_ops_golang/vendor/github.com/google/uuid/LICENSE
+
+For the gofrs/flock component:
+@traffic_ops_ort/vendor/github.com/gofrs/flock/*
+./traffic_ops_ort/vendor/github.com/gofrs/flock/LICENSE
+
+For the pborman/getopt component:
+@traffic_ops_ort/vendor/github.com/pborman/getopt/*
+./traffic_ops_ort/vendor/github.com/pborman/getopt/LICENSE

--- a/lib/go-rfc/http.go
+++ b/lib/go-rfc/http.go
@@ -28,17 +28,18 @@ import (
 )
 
 const (
-	ApplicationJSON        = "application/json"         // RFC4627§6
-	Gzip                   = "gzip"                     // RFC7230§4.2.3
-	ContentType            = "Content-Type"             // RFC7231§3.1.1.5
-	ContentEncoding        = "Content-Encoding"         // RFC7231§3.1.2.2
-	ContentTypeTextPlain   = "text/plain"               // RFC2046§4.1
-	AcceptEncoding         = "Accept-Encoding"          // RFC7231§5.3.4
-	ContentDisposition     = "Content-Disposition"      // RFC6266
-	ApplicationOctetStream = "application/octet-stream" // RFC2046§4.5.2
-	Vary                   = "Vary"                     // RFC7231§7.1.4
-	IfModifiedSince        = "If-Modified-Since"        // RFC7232§3.3
-	LastModified           = "Last-Modified"            // RFC7232§2.2
+	ApplicationJSON           = "application/json"         // RFC4627§6
+	Gzip                      = "gzip"                     // RFC7230§4.2.3
+	ContentType               = "Content-Type"             // RFC7231§3.1.1.5
+	ContentEncoding           = "Content-Encoding"         // RFC7231§3.1.2.2
+	ContentTypeTextPlain      = "text/plain"               // RFC2046§4.1
+	ContentTypeMultiPartMixed = "multipart/mixed"          // RFC1341§7.2
+	AcceptEncoding            = "Accept-Encoding"          // RFC7231§5.3.4
+	ContentDisposition        = "Content-Disposition"      // RFC6266
+	ApplicationOctetStream    = "application/octet-stream" // RFC2046§4.5.2
+	Vary                      = "Vary"                     // RFC7231§7.1.4
+	IfModifiedSince           = "If-Modified-Since"        // RFC7232§3.3
+	LastModified              = "Last-Modified"            // RFC7232§2.2
 )
 
 // AcceptsGzip returns whether r accepts gzip encoding, per RFC7231§5.3.4.

--- a/traffic_ops_ort/build/build_rpm.sh
+++ b/traffic_ops_ort/build/build_rpm.sh
@@ -64,6 +64,9 @@ initBuildArea() {
 	(cd atstccfg;
 	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
 
+	(cd t3c;
+	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+
 	cp -p traffic_ops_ort.pl "$dest";
 	cp -p supermicro_udev_mapper.pl "$dest";
 	mkdir -p "${dest}/atstccfg";

--- a/traffic_ops_ort/build/traffic_ops_ort.spec
+++ b/traffic_ops_ort/build/traffic_ops_ort.spec
@@ -45,6 +45,13 @@ godir=src/github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg
 	cp "$TC_DIR"/traffic_ops_ort/atstccfg/atstccfg .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
+# copy t3c binary
+got3cdir=src/github.com/apache/trafficcontrol/traffic_ops_ort/t3c
+( mkdir -p "$got3cdir" && \
+	cd "$got3cdir" && \
+	cp "$TC_DIR"/traffic_ops_ort/t3c/t3c .
+) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
+
 
 %install
 mkdir -p ${RPM_BUILD_ROOT}/opt/ort
@@ -53,6 +60,9 @@ cp -p ${RPM_SOURCE_DIR}/traffic_ops_ort-%{version}/supermicro_udev_mapper.pl ${R
 
 src=src/github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg
 cp -p "$src"/atstccfg ${RPM_BUILD_ROOT}/opt/ort
+
+t3csrc=src/github.com/apache/trafficcontrol/traffic_ops_ort/t3c
+cp -p "$t3csrc"/t3c ${RPM_BUILD_ROOT}/opt/ort
 
 %clean
 rm -rf ${RPM_BUILD_ROOT}
@@ -64,5 +74,6 @@ rm -rf ${RPM_BUILD_ROOT}
 /opt/ort/traffic_ops_ort.pl
 /opt/ort/supermicro_udev_mapper.pl
 /opt/ort/atstccfg
+/opt/ort/t3c
 
 %changelog

--- a/traffic_ops_ort/t3c/README.md
+++ b/traffic_ops_ort/t3c/README.md
@@ -1,0 +1,113 @@
+# T3C
+
+t3c is a transliteration of traffic_ops_ort.pl script to the go language.
+It is designed to replace the traffic_ops_ort.pl perl script and it is used to apply 
+configuration from Traffic Control, stored in Traffic Ops, to the cache.
+
+Typical usage is to install T3C on the cache machine, and then run it periodically via a CRON job.
+
+**NOTE** T3C requires and uses /opt/ort/atstccfg
+
+## Options
+
+T3C has the following command-line options:
+
+
+long option                             | short | default | description
+--------------------------------------- | ------| ------- | ------------------------------------------------------------------------------------
+--cache-hostname=[hostname]             | -H    | ""      | override the short hostname of the OS for config generation.
+--dispersion=[seconds]                  | -D    | 300     | wait a random number of seconds between 0 and [seconds] before starting.
+--login-dispersion=[seconds]            | -l    | 0       | wait a random number of seconds between 0 and [seconds] before login.
+--log-location-debug=[value]            | -d    | stdout  | Where to log debugs. May be a file path, stdout, stderr, or null
+--log-location-error=[value]            | -e    | stdout  | Where to log errors. May be a file path, stdout, stderr, or null
+--log-location-info=[value]             | -i    | stdout  | Where to log info messages. May be a file path, stdout, stderr, or null
+--log-location-warn=[value]             | -w    | stdout  | Where to log warning messages. May be a file path, stdout, stderr, or null
+--num-retries=[number]                  | -r    | 3       | retry connection to Traffic Ops URL [number] times.
+--rev-proxy-disable=['true' or 'false'] | -p    | false   | bypass the reverse proxy even if one has been configured.
+--reval-wait-time=[seconds]             | -T    | 60      | wait a random number of seconds between 0 and [seconds] before revlidation
+--run-mode=[mode]                       | -m    | report  | The mode of operation, where mode is [badass|report|revalidate|syncds].
+--skip-os-check=['true' or 'false']     | -s    | false   | bypass the check for a supported CentOS version.
+--traffic-ops-timeout-milliseconds=[ms] | -t    | 30000   | The Traffic Ops request timeout in milliseconds.
+--traffic-ops-password=[password]       | -P    | ""      | TrafficOps password. Required if not set with the environment variable TO_PASS
+--traffic-ops-url=[url]                 | -u    | ""      | TrafficOps URL. Required if not set with the environment variable TO_URL
+--traffic-ops-user=[username]           | -U    | ""      | TrafficOps username. Required if not set with the environment variable TO_USER
+--trafficserver-home=[directory]        | -R    | ""      | Used to specify an alternate install location for ATS, otherwise its set from the RPM.
+--wait-for-parents=['true' or 'false']  | -W    | true    | do not update if parent_pending = 1 in the update json.
+
+# Modes
+
+T3C can be run in a number of modes.
+
+The syncds mode is the normal mode of operation, which should typically be run periodically via cron or a similar tool.
+
+The badass mode is typically an emergency-fix mode, which will override and replace all files with the configuration generated from the current Traffic Ops data, regardless whether T3C (presumably incorrectly) thinks the files need updating or not. It is recommended to run this mode when something goes wrong, and the configuration on the cache is incorrect, and the data in Traffic Ops and config generation is believed to be correct. It is not recommended to run this in normal operation; use syncds mode for normal operation.
+
+The revalidate mode will apply Revalidations from Traffic Ops (regex_revalidate.config) but no other configuration. This mode was intended to quickly apply revalidations when T3C took a long time to run. It is less relevant with T3C's current speed, but may still be useful on slow networks or very large deployments.
+
+mode        | description
+------------| ---
+report      | prints config differences and exits (default)
+badass      | attempts to fix all config differences that it can
+syncds      | syncs delivery services with what is configured in Traffic Ops
+revalidate  | checks for updated revalidations in Traffic Ops and applies them
+
+# Behavior
+
+When T3C is run, it will:
+
+1. Delete all of its temporary directories over a week old. Currently, the base temp directory is hard-coded to /tmp/ort.
+1. Determine if Updates have been Queued on the server (by checking the Server's Update Pending or Revalidate Pending flag in Traffic Ops).
+    1. If Updates were not queued and the script is running in syncds mode (the normal mode), exit.
+1. Get the config files from Traffic Ops, via atstccfg.
+1. Process CentOS Yum packages.
+    1. These are specified via Parameters on the Server's Profile, with the Config File 'package', where the Parameter Name is the package name, and the Parameter Value is the package version.
+    1. Uninstall any packages which are installed but whose version does not match.
+    1. Install all packages in the Server Profile.
+1. Process chkconfig directives.
+    1. These are specified via Parameters on the Server's Profile, with the Config File 'chkconfig', where the Parameter Name is the package name, and the Parameter Value is the chkconfig directive line.
+    1. All chkconfig directives in the Server's Profile are applied to the CentOS chkconfig.
+    1. **NOTE** the default profiles distributed by Traffic Control have an ATS chkconfig with a runlevel before networking is enabled, which is likely incorrect.
+    1. **NOTE** this is not used by CentOS 7+ and ATS 7+. SystemD does not use chkconfig, and ATS 7+ uses a SystemD script not an init script.
+1. Process each config file
+    1. If T3C is in revalidate mode, this will only be regex_revalidate.config
+    1. Perform any special processing. See [Special Processing](#special-processing).
+    1. If a file exists at the path of the file, load it from disk and compare the two.
+    1. If there are no changes, don't apply the new file.
+    1. If there are changes, backup the existing file in the temp directory, and write the new file.
+1. If configuration was changed which requires an ATS reload to apply, perform a service reload of ATS.
+1. If configuration was changed which requires an ATS restart to apply, and T3C is in badass mode, perform a service restart of ATS.
+1. If a sysctl.conf config file was changed, and T3C is in badass mode, run `sysctl -p`.
+1. If a ntpd.conf config file was changed, and T3C is in badass mode, perform a service restart of ntpd.
+1. Update Traffic Ops to unset the Update Pending or Revalidate Pending flag of this Server.
+
+# Special Processing
+
+Certain config files perform extra processing.
+
+## Global replacements
+
+All config files have certain text directives replaced. This is done by the atstccfg config generator before the file is returned to T3C.
+
+* `__SERVER_TCP_PORT__` is replaced with the Server's Port from Traffic Ops; unless the server's port is 80, 0, or null, in which case any occurrences preceded by a colon are removed.
+* `__CACHE_IPV4__` is replaced with the Server's IP address from Traffic Ops.
+* `__HOSTNAME__` is replaced with the Server's (short) HostName from Traffic Ops.
+* `__FULL_HOSTNAME__` is replaced with the Server's HostName, a dot, and the Server's DomainName from Traffic Ops (i.e. the Server's Fully Qualified Domain Name).
+* `__RETURN__` is replaced with a newline character, and any whitespace before or after it is removed.
+
+## remap.config
+
+T3C processes `##OVERRIDE##` directives in the remap.config file.
+
+The ##OVERRIDE## template string allows the Delivery Service Raw Remap Text field to override to fully override the Delivery Service’s line in the remap.config ATS configuration file, generated by Traffic Ops. The end result is the original, generated line commented out, prepended with ##OVERRIDDEN## and the ##OVERRIDE## rule is activated in its place. This behavior is used to incrementally deploy plugins used in this configuration file. Normally, this entails cloning the Delivery Service that will have the plugin, ensuring it is assigned to a subset of the cache servers that serve the Delivery Service content, then using this ##OVERRIDE## rule to create a remap.config rule that will use the plugin, overriding the normal rule. Simply grow the subset over time at the desired rate to slowly deploy the plugin. When it encompasses all cache servers that serve the original Delivery Service’s content, the “override Delivery Service” can be deleted and the original can use a non-##OVERRIDE## Raw Remap Text to add the plugin.
+
+## 50-ats.rules
+
+This is presumed to be a udev file for devices which are block devices to be used as disk storage by ATS.
+
+T3C verifies all devices in the file are owned by the owner listed in the file, and logs errors otherwise.
+
+T3C verifies all devices in the file do not have filesystems. If any device has a filesystem, T3C assumes it was a mistake to assign as an ATS storage device, and logs a fatal error.
+
+# Trivia
+
+T3C stands for "TrafficOps Cache Control and Configuration.", 3 C's.

--- a/traffic_ops_ort/t3c/config/config.go
+++ b/traffic_ops_ort/t3c/config/config.go
@@ -1,0 +1,406 @@
+package config
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/pborman/getopt/v2"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var TSHome string = "/opt/trafficserver"
+
+const (
+	StatusDir          = "/opt/ort/status"
+	AtsTcConfig        = "/opt/ort/atstccfg"
+	Chkconfig          = "/sbin/chkconfig"
+	Service            = "/sbin/service"
+	SystemCtl          = "/bin/systemctl"
+	TmpBase            = "/tmp/ort"
+	TrafficCtl         = "/bin/traffic_ctl"
+	TrafficServerOwner = "ats"
+)
+
+type Mode int
+
+const (
+	BadAss     Mode = 0
+	Report     Mode = 1
+	Revalidate Mode = 2
+	SyncDS     Mode = 3
+)
+
+func (m Mode) String() string {
+	switch m {
+	case 0:
+		return "BadAss"
+	case 1:
+		return "Report"
+	case 2:
+		return "Revalidate"
+	case 3:
+		return "SyncDS"
+	}
+	return ""
+}
+
+type SvcManagement int
+
+const (
+	Unknown SvcManagement = 0
+	SystemD SvcManagement = 1
+	SystemV SvcManagement = 2 // legacy System V Init.
+)
+
+func (s SvcManagement) String() string {
+	switch s {
+	case Unknown:
+		return "Unknown"
+	case SystemD:
+		return "SystemD"
+	case SystemV:
+		return "SystemV"
+	}
+	return "Unknown"
+}
+
+type Cfg struct {
+	Dispersion          time.Duration
+	LogLocationDebug    string
+	LogLocationErr      string
+	LogLocationInfo     string
+	LogLocationWarn     string
+	LoginDispersion     time.Duration
+	CacheHostName       string
+	SvcManagement       SvcManagement
+	Retries             int
+	RevalWaitTime       time.Duration
+	ReverseProxyDisable bool
+	RunMode             Mode
+	SkipOSCheck         bool
+	TOTimeoutMS         time.Duration
+	TOUser              string
+	TOPass              string
+	TOURL               string
+	WaitForParents      bool
+	YumOptions          string
+}
+
+func (cfg Cfg) ErrorLog() log.LogLocation   { return log.LogLocation(cfg.LogLocationErr) }
+func (cfg Cfg) WarningLog() log.LogLocation { return log.LogLocation(cfg.LogLocationWarn) }
+func (cfg Cfg) InfoLog() log.LogLocation    { return log.LogLocation(cfg.LogLocationInfo) }
+func (cfg Cfg) DebugLog() log.LogLocation   { return log.LogLocation(cfg.LogLocationDebug) }
+func (cfg Cfg) EventLog() log.LogLocation   { return log.LogLocation(log.LogLocationNull) } // event logging is not used.
+
+func directoryExists(dir string) (bool, os.FileInfo) {
+	info, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return info.IsDir(), info
+}
+
+// derives the ATS Installation directory from
+// the rpm config file list.
+func GetTSPackageHome() string {
+	var dir []string
+	var output bytes.Buffer
+	var tsHome string = ""
+	var files []string
+
+	cmd := exec.Command("/bin/rpm", "-q", "-c", "trafficserver")
+	cmd.Stdout = &output
+	err := cmd.Run()
+	// on error or if the trafficserver rpm is not installed indicated
+	// by a return code of '1', return an empty string.
+	if err != nil || cmd.ProcessState.ExitCode() == 1 {
+		return ""
+	} else {
+		responseStr := string(output.Bytes())
+		files = strings.Split(responseStr, "\n")
+	}
+
+	if files != nil && err == nil { // trafficserver is installed, derive TSHome
+		for ii := range files {
+			line := strings.TrimSpace(files[ii])
+			if strings.Contains(line, "etc/trafficserver") {
+				dir = strings.Split(line, "/etc")
+				break
+			}
+		}
+		if dir != nil && len(dir) >= 0 {
+			if ok, _ := directoryExists(dir[0]); ok == true {
+				tsHome = dir[0]
+			}
+		}
+	}
+	return tsHome
+}
+
+func GetCfg() (Cfg, error) {
+	var err error
+
+	dispersionPtr := getopt.IntLong("dispersion", 'D', 300, "[seconds] wait a random number of seconds between 0 and [seconds] before starting, default 300")
+	loginDispersionPtr := getopt.IntLong("login-dispersion", 'l', 0, "[seconds] wait a random number of seconds between 0 and [seconds] before login to traffic ops, default 0")
+	logLocationDebugPtr := getopt.StringLong("log-location-debug", 'd', "", "Where to log debugs. May be a file path, stdout, stderr, or null, default ''")
+	logLocationErrorPtr := getopt.StringLong("log-location-error", 'e', "stderr", "Where to log errors. May be a file path, stdout, stderr, or null, default stderr")
+	logLocationInfoPtr := getopt.StringLong("log-location-info", 'i', "stderr", "Where to log info. May be a file path, stdout, stderr, or null, default stderr")
+	logLocationWarnPtr := getopt.StringLong("log-location-warning", 'w', "stderr", "Where to log warnings. May be a file path, stdout, stderr, or null, default stderr")
+	cacheHostNamePtr := getopt.StringLong("cache-host-name", 'H', "", "Host name of the cache to generate config for. Must be the server host name in Traffic Ops, not a URL, and not the FQDN")
+	retriesPtr := getopt.IntLong("num-retries", 'r', 3, "[number] retry connection to Traffic Ops URL [number] times, default is 3")
+	revalWaitTimePtr := getopt.IntLong("reval-wait-time", 'T', 60, "[seconds] wait a random number of seconds between 0 and [seconds] before revlidation, default is 60")
+	reverseProxyDisablePtr := getopt.BoolLong("reverse-proxy-disable", 'p', "[false | true] bypass the reverse proxy even if one has been configured default is false")
+	runModePtr := getopt.StringLong("run-mode", 'm', "report", "[badass | report | revalidate | syncds] run mode, default is 'report'")
+	skipOSCheckPtr := getopt.BoolLong("skip-os-check", 's', "[false | true] skip os check, default is false")
+	toTimeoutMSPtr := getopt.IntLong("traffic-ops-timeout-milliseconds", 't', 30000, "Timeout in milli-seconds for Traffic Ops requests, default is 30000")
+	toURLPtr := getopt.StringLong("traffic-ops-url", 'u', "", "Traffic Ops URL. Must be the full URL, including the scheme. Required. May also be set with the environment variable TO_URL")
+	toUserPtr := getopt.StringLong("traffic-ops-user", 'U', "", "Traffic Ops username. Required. May also be set with the environment variable TO_USER")
+	toPassPtr := getopt.StringLong("traffic-ops-password", 'P', "", "Traffic Ops password. Required. May also be set with the environment variable TO_PASS")
+	tsHomePtr := getopt.StringLong("trafficserver-home", 'R', "", "Trafficserver Package directory. May also be set with the environment variable TS_HOME")
+	waitForParentsPtr := getopt.BoolLong("wait-for-parents", 'W', "[true | false] do not update if parent_pending = 1 in the update json. default is false, wait for parents")
+	helpPtr := getopt.BoolLong("help", 'h', "Print usage information and exit")
+	getopt.Parse()
+
+	dispersion := time.Second * time.Duration(*dispersionPtr)
+	loginDispersion := time.Second * time.Duration(*loginDispersionPtr)
+	logLocationDebug := *logLocationDebugPtr
+	logLocationError := *logLocationErrorPtr
+	logLocationInfo := *logLocationInfoPtr
+	logLocationWarn := *logLocationWarnPtr
+
+	var cacheHostName string
+	if len(*cacheHostNamePtr) > 0 {
+		cacheHostName = *cacheHostNamePtr
+	} else {
+		cacheHostName, err = os.Hostname()
+		if err != nil {
+			return Cfg{}, errors.New("Could not get the hostname from the O.S., please supply a hostname: " + err.Error())
+		}
+	}
+
+	retries := *retriesPtr
+	revalWaitTime := time.Second * time.Duration(*revalWaitTimePtr)
+	reverseProxyDisable := *reverseProxyDisablePtr
+	skipOsCheck := *skipOSCheckPtr
+	toTimeoutMS := time.Millisecond * time.Duration(*toTimeoutMSPtr)
+	toURL := *toURLPtr
+	toUser := *toUserPtr
+	toPass := *toPassPtr
+	waitForParents := *waitForParentsPtr
+	help := *helpPtr
+
+	if help {
+		Usage()
+		return Cfg{}, nil
+	}
+
+	runModeStr := strings.ToUpper(*runModePtr)
+	runMode := Mode(Report)
+	switch runModeStr {
+	case "REPORT":
+		runMode = Report
+	case "BADASS":
+		runMode = BadAss
+	case "SYNCDS":
+		runMode = SyncDS
+	case "REVALIDATE":
+		runMode = Revalidate
+	default:
+		Usage()
+		return Cfg{}, errors.New(runModeStr + " is an invalid mode.")
+	}
+
+	urlSourceStr := "argument" // for error messages
+	if toURL == "" {
+		urlSourceStr = "environment variable"
+		toURL = os.Getenv("TO_URL")
+	}
+	if toUser == "" {
+		toUser = os.Getenv("TO_USER")
+	}
+	if *toPassPtr == "" {
+		toPass = os.Getenv("TO_PASS")
+	}
+	// set TSHome
+	if *tsHomePtr != "" {
+		TSHome = *tsHomePtr
+		fmt.Printf("\nset TSHome from command line: '%s'\n\n", TSHome)
+	}
+	if *tsHomePtr == "" {
+		tsHome := os.Getenv("TS_HOME") // check for the environment variable.
+		if tsHome != "" {
+			fmt.Printf("\nset TSHome from TS_HOME environment variable '%s'\n\n", TSHome)
+		} else { // finally check using the config file listing from the rpm package.
+			tsHome = GetTSPackageHome()
+			if tsHome != "" {
+				TSHome = tsHome
+				fmt.Printf("\nset TSHome from the RPM config file  list '%s'\n\n", TSHome)
+			} else {
+				fmt.Printf("\nno override for TSHome was found, using the configured default: '%s'\n\n", TSHome)
+			}
+		}
+	}
+
+	usageStr := "basic usage: t3c  --traffic-ops-url=myurl --traffic-ops-user=myuser --traffic-ops-password=mypass --cache-host-name=my-cache"
+	if strings.TrimSpace(toURL) == "" {
+		return Cfg{}, errors.New("Missing required argument --traffic-ops-url or TO_URL environment variable. " + usageStr)
+	}
+	if strings.TrimSpace(toUser) == "" {
+		return Cfg{}, errors.New("Missing required argument --traffic-ops-user or TO_USER environment variable. " + usageStr)
+	}
+	if strings.TrimSpace(toPass) == "" {
+		return Cfg{}, errors.New("Missing required argument --traffic-ops-password or TO_PASS environment variable. " + usageStr)
+	}
+	if strings.TrimSpace(cacheHostName) == "" {
+		return Cfg{}, errors.New("Missing required argument --cache-host-name. " + usageStr)
+	}
+
+	toURLParsed, err := url.Parse(toURL)
+	if err != nil {
+		return Cfg{}, errors.New("parsing Traffic Ops URL from " + urlSourceStr + " '" + toURL + "': " + err.Error())
+	} else if err = validateURL(toURLParsed); err != nil {
+		return Cfg{}, errors.New("invalid Traffic Ops URL from " + urlSourceStr + " '" + toURL + "': " + err.Error())
+	}
+
+	svcManagement := getOSSvcManagement()
+	yumOptions := os.Getenv("YUM_OPTIONS")
+
+	cfg := Cfg{
+		Dispersion:          dispersion,
+		LogLocationDebug:    logLocationDebug,
+		LogLocationErr:      logLocationError,
+		LogLocationInfo:     logLocationInfo,
+		LogLocationWarn:     logLocationWarn,
+		LoginDispersion:     loginDispersion,
+		CacheHostName:       cacheHostName,
+		SvcManagement:       svcManagement,
+		Retries:             retries,
+		RevalWaitTime:       revalWaitTime,
+		ReverseProxyDisable: reverseProxyDisable,
+		RunMode:             runMode,
+		SkipOSCheck:         skipOsCheck,
+		TOTimeoutMS:         toTimeoutMS,
+		TOUser:              toUser,
+		TOPass:              toPass,
+		TOURL:               toURL,
+		WaitForParents:      waitForParents,
+		YumOptions:          yumOptions,
+	}
+
+	if err = log.InitCfg(cfg); err != nil {
+		return Cfg{}, errors.New("Initializing loggers: " + err.Error() + "\n")
+	}
+
+	printConfig(cfg)
+
+	return cfg, nil
+}
+
+func validateURL(u *url.URL) error {
+	if u == nil {
+		return errors.New("nil url")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("scheme expected 'http' or 'https', actual '" + u.Scheme + "'")
+	}
+	if strings.TrimSpace(u.Host) == "" {
+		return errors.New("no host")
+	}
+	return nil
+}
+
+func isCommandAvailable(name string) bool {
+	cmd := exec.Command("/bin/sh", "-c", name, "--version")
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func getOSSvcManagement() SvcManagement {
+	var _svcManager SvcManagement
+
+	if isCommandAvailable(SystemCtl) {
+		_svcManager = SystemD
+	} else if isCommandAvailable(Service) {
+		_svcManager = SystemV
+	}
+	if !isCommandAvailable(Chkconfig) {
+		return Unknown
+	}
+
+	// we have what we need
+	return _svcManager
+}
+
+func printConfig(cfg Cfg) {
+	log.Debugf("Dispersion: %d\n", cfg.Dispersion)
+	log.Debugf("LogLocationDebug: %s\n", cfg.LogLocationDebug)
+	log.Debugf("LogLocationErr: %s\n", cfg.LogLocationErr)
+	log.Debugf("LogLocationInfo: %s\n", cfg.LogLocationInfo)
+	log.Debugf("LogLocationWarn: %s\n", cfg.LogLocationWarn)
+	log.Debugf("LoginDispersion: %d\n", cfg.LoginDispersion)
+	log.Debugf("CacheHostName: %s\n", cfg.CacheHostName)
+	log.Debugf("SvcManagement: %s\n", cfg.SvcManagement)
+	log.Debugf("Retries: %d\n", cfg.Retries)
+	log.Debugf("RevalWaitTime: %d\n", cfg.RevalWaitTime)
+	log.Debugf("ReverseProxyDisable: %t\n", cfg.ReverseProxyDisable)
+	log.Debugf("RunMode: %s\n", cfg.RunMode)
+	log.Debugf("SkipOSCheck: %t\n", cfg.SkipOSCheck)
+	log.Debugf("TOTimeoutMS: %d\n", cfg.TOTimeoutMS)
+	log.Debugf("TOUser: %s\n", cfg.TOUser)
+	log.Debugf("TOPass: %s\n", cfg.TOPass)
+	log.Debugf("TOURL: %s\n", cfg.TOURL)
+	log.Debugf("TSHome: %s\n", TSHome)
+	log.Debugf("WaitForParents: %t\n", cfg.WaitForParents)
+	log.Debugf("YumOptions: %s\n", cfg.YumOptions)
+}
+
+func Usage() {
+	fmt.Println("Usage: t3c [options]")
+	fmt.Println("\t[options]:")
+	fmt.Println("\t  --dispersion=[time in seconds] | -D, [time in seconds] wait a random number between 0 and <time in seconds> before starting, default = 300s")
+	fmt.Println("\t  --login-dispersion=[time in seconds] | -l, [time in seconds] wait a random number between 0 and <time in seconds> befor login, default = 0")
+	fmt.Println("\t  --log-location-debug=[value] | -d [value], Where to log debugs. May be a file path, stdout, stderr, or null, default stdout")
+	fmt.Println("\t  --log-location-error=[value] | -e [value], Where to log errors. May be a file path, stdout, stderr, or null, default stdout")
+	fmt.Println("\t  --log-location-info=[value] | -i [value], Where to log info. May be a file path, stdout, stderr, or null, default stdout")
+	fmt.Println("\t  --log-location-warning=[value] | -w [value], Where to log warnings. May be a file path, stdout, stderr, or null, default stdout")
+	fmt.Println("\t  --run-mode=[mode] | -m [mode] where mode is one of [ report | badass | syncds | revalidate ], default = report")
+	fmt.Println("\t  --cache-hostname=[hostname] | -H [hostname], Host name of the cache to generate config for. Must be the server host name in Traffic Ops, not a URL, and not the FQDN")
+	fmt.Println("\t  --num-retries=[number] | -r [number], retry connection to Traffic Ops URL [number] times, default is 3")
+	fmt.Println("\t  --reval-wait-time=[seconds] | -T [seconds] wait a random number of seconds between 0 and [seconds] before revlidation, default is 60")
+	fmt.Println("\t  --rev-proxy-disable=[true|false] | -p [true|false] bypass the reverse proxy even if one has been configured, default = false")
+	fmt.Println("\t  --skip-os-check=[true|false] | -s [true | false] bypass the check for a supported CentOS version. default = false")
+	fmt.Println("\t  --traffic-ops-timeout-milliseconds=[milliseconds] | -t [milliseconds] the Traffic Ops request timeout in milliseconds. Default = 30000 (30 seconds)")
+	fmt.Println("\t  --traffic-ops-url=[url] | -u [url], Traffic Ops URL. Must be the full URL, including the scheme. Required. May also be set with the environment variable TO_URL")
+	fmt.Println("\t  --traffic-ops-user=[username] | -U [username], Traffic Ops username. Required. May also be set with the environment variable TO_USER")
+	fmt.Println("\t  --traffic-ops-password=[password] | -P [password], Traffic Ops password. Required. May also be set with the environment variable TO_PASS")
+	fmt.Println("\t  --trafficserver-home=[value] | -R [value], Trafficserver Package directory. May also be set with the environment variable TS_HOME")
+	fmt.Println("\t  --wait-for-parents | -W [true | false] do not update if parent_pending = 1 in the update json. default = true, wait for parents\n")
+	fmt.Println("\t  --help | -h, Print usage information and exit")
+}

--- a/traffic_ops_ort/t3c/t3c.go
+++ b/traffic_ops_ort/t3c/t3c.go
@@ -1,0 +1,193 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"fmt"
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/t3c/config"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/t3c/torequest"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/t3c/util"
+	"os"
+	"time"
+)
+
+// exit codes
+const (
+	Success           = 0
+	AlreadyRunning    = 132
+	ConfigFilesError  = 133
+	ConfigError       = 134
+	GeneralFailure    = 135
+	PackagingError    = 136
+	RevalidationError = 137
+	ServicesError     = 138
+	SyncDSError       = 139
+	UserCheckError    = 140
+)
+
+func runSysctl(cfg config.Cfg) {
+	if cfg.RunMode == config.BadAss {
+		_, rc, err := util.ExecCommand("/usr/sbin/sysctl", "-p")
+		if err != nil {
+			log.Errorln("sysctl -p failed")
+		} else if rc == 0 {
+			log.Debugf("sysctl -p ran succesfully.")
+		}
+	}
+}
+
+func main() {
+	var syncdsUpdate torequest.UpdateStatus
+	var lock util.FileLock
+	cfg, err := config.GetCfg()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(ConfigError)
+	} else if cfg == (config.Cfg{}) { // user used the --help option
+		os.Exit(Success)
+	}
+	trops := torequest.NewTrafficOpsReq(cfg)
+
+	// if doing os checks, insure there is a 'systemctl' or 'service' and 'chkconfig' commands.
+	if !cfg.SkipOSCheck && cfg.SvcManagement == config.Unknown {
+		log.Errorln("OS checks are enabled and unable to find any know service management tools.")
+	}
+
+	// create and clean the config.TmpBase (/tmp/ort)
+	if !util.MkDir(config.TmpBase, cfg) {
+		os.Exit(GeneralFailure)
+	} else if !util.CleanTmpDir() {
+		os.Exit(GeneralFailure)
+	}
+	if cfg.RunMode != config.Report {
+		if !lock.GetLock(config.TmpBase + "/to_ort.lock") {
+			os.Exit(AlreadyRunning)
+		}
+	}
+
+	fmt.Println(time.Now().Format(time.UnixDate))
+
+	if !util.CheckUser(cfg) {
+		lock.UnlockAndExit(UserCheckError)
+	}
+
+	toolName := trops.GetHeaderComment()
+	log.Debugf("toolname: %s\n", toolName)
+
+	// if running in Revalidate mode, check to see if it's
+	// necessary to continue
+	if cfg.RunMode == config.Revalidate {
+		syncdsUpdate, err = trops.CheckRevalidateState(false)
+		if err != nil || syncdsUpdate == torequest.UpdateTropsNotNeeded {
+			if err != nil {
+				log.Errorln(err)
+			}
+			os.Exit(RevalidationError)
+		}
+	} else {
+		syncdsUpdate, err = trops.CheckSyncDSState()
+		if err != nil {
+			log.Errorln(err)
+			os.Exit(SyncDSError)
+		}
+		if cfg.RunMode == config.SyncDS && syncdsUpdate == torequest.UpdateTropsNotNeeded {
+			os.Exit(Success)
+		}
+	}
+
+	log.Debugf("Preparing to fetch the config files for %s, cfg.RunMode: %s, syncdsUpdate: %s\n", cfg.CacheHostName, cfg.RunMode, syncdsUpdate)
+
+	err = trops.GetConfigFileList()
+	if err != nil {
+		log.Errorf("Unable to continue: %s\n", err)
+		os.Exit(ConfigFilesError)
+	}
+
+	if cfg.RunMode == config.Revalidate {
+		log.Infoln("======== Revalidating, no package processing needed ========")
+	} else {
+		log.Infoln("======== Start processing packages  ========")
+		err = trops.ProcessPackages()
+		if err != nil {
+			log.Errorf("Error processing packages: %s\n", err)
+			os.Exit(PackagingError)
+		}
+
+		// check and make sure packages are enabled for startup
+		err = trops.CheckSystemServices()
+		if err != nil {
+			log.Errorf("Error verifying system services: %s\n", err.Error())
+			os.Exit(ServicesError)
+		}
+	}
+
+	syncdsUpdate, err = trops.ProcessConfigFiles()
+	if err != nil {
+		log.Errorf("Error while processing config files: %s\n", err.Error())
+	}
+
+	if trops.RemapConfigReload == true {
+		cfg, ok := trops.GetConfigFile("remap.config")
+		_, rc, err := util.ExecCommand("/usr/bin/touch", cfg.Path)
+		if err != nil {
+			log.Errorf("failed to update the remap.config for reloading: %s\n", err.Error())
+		} else if rc == 0 && ok == true {
+			log.Infoln("updated the remap.config for reloading.")
+		}
+	}
+
+	// start trafficserver
+	result := trops.StartServices(&syncdsUpdate)
+	if !result {
+		log.Errorf("failed to start services.\n")
+		os.Exit(ServicesError)
+	}
+
+	// start 'teakd' if installed.
+	if trops.IsPackageInstalled("teakd") {
+		svcStatus, pid, err := util.GetServiceStatus("teakd")
+		if err != nil {
+			log.Errorf("not starting 'teakd', error getting 'teakd' run status: %s\n", err)
+		} else if svcStatus == util.SvcNotRunning {
+			running, err := util.ServiceStart("teakd", "start")
+			if err != nil {
+				log.Errorf("'teakd' was not started: %s\n", err)
+			} else if running {
+				log.Infoln("service 'teakd' started.")
+			} else if svcStatus == util.SvcRunning {
+				log.Infof("service 'teakd' was already running, pid: %s\n", pid)
+			}
+		}
+	}
+
+	// reload sysctl
+	if trops.SysCtlReload == true {
+		runSysctl(cfg)
+	}
+
+	// update Traffic Ops
+	result, err = trops.UpdateTrafficOps(&syncdsUpdate)
+	if err != nil {
+		log.Errorf("failed to update Traffic Ops: %s\n", err.Error())
+	} else if result {
+		log.Infoln("Traffic Ops has been updated.")
+	}
+}

--- a/traffic_ops_ort/t3c/torequest/torequest.go
+++ b/traffic_ops_ort/t3c/torequest/torequest.go
@@ -1,0 +1,1488 @@
+package torequest
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/t3c/config"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/t3c/util"
+	"io"
+	"io/ioutil"
+	"mime"
+	"mime/multipart"
+	"net/mail"
+	"net/textproto"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type UpdateStatus int
+
+const (
+	UpdateTropsNotNeeded  UpdateStatus = 0
+	UpdateTropsNeeded     UpdateStatus = 1
+	UpdateTropsSuccessful UpdateStatus = 2
+	UpdateTropsFailed     UpdateStatus = 3
+)
+
+type Package struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type TrafficOpsReq struct {
+	Cfg                  config.Cfg
+	pkgs                 map[string]bool // map of installed packages
+	plugins              map[string]bool // map of verified plugins
+	configFiles          map[string]*ConfigFile
+	baseBackupDir        string
+	TrafficCtlReload     bool   // a traffic_ctl_reload is required
+	SysCtlReload         bool   // a reload of the sysctl.conf is required
+	NtpdRestart          bool   // ntpd needs restarting
+	TeakdRestart         bool   // a restart of teakd is required
+	TrafficServerRestart bool   // a trafficserver restart is required
+	RemapConfigReload    bool   // remap.config should be reloaded
+	unixTimeStr          string // unix time string at program startup.
+}
+
+type ConfigFile struct {
+	Header            textproto.MIMEHeader
+	Name              string // file name
+	Dir               string // install directory
+	Path              string // full path
+	Service           string // service assigned to
+	CfgBackup         string // location to backup the config at 'Path'
+	TropsBackup       string // location to backup the TrafficOps Version
+	AuditComplete     bool   // audit is complete
+	AuditFailed       bool   // audit failed
+	ChangeApplied     bool   // a change has been applied
+	ChangeNeeded      bool   // change required
+	PreReqFailed      bool   // failed plugin prerequiste check
+	RemapPluginConfig bool   // file is a remap plugin config file
+	Body              []byte
+	Perm              os.FileMode // default file permissions
+	Uid               int         // owner uid, default is 0
+	Gid               int         // owner gid, default is 0
+}
+
+func (u UpdateStatus) String() string {
+	var result string
+	switch u {
+	case 0:
+		result = "UpdateTropsNotNeeded"
+	case 1:
+		result = "UpdateTropsNeeded"
+	case 2:
+		result = "UpdateTropsSuccessful"
+	case 3:
+		result = "UpdateTropsFailed"
+	}
+	return result
+}
+
+// commentsFilter is used to remove comment
+// lines from config files while making
+// comparisons.
+func commentsFilter(body []string) []string {
+	var newlines []string
+
+	newlines = make([]string, 0)
+
+	for ii := range body {
+		line := body[ii]
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		newlines = append(newlines, line)
+	}
+
+	return newlines
+}
+
+// newLineFilter removes carriage returns
+// from config files while making comparisons.
+func newLineFilter(str string) string {
+	str = strings.ReplaceAll(str, "\r\n", "\n")
+	return strings.TrimSpace(str)
+}
+
+// unencodeFilter translates HTML escape
+// sequences while making config file comparisons.
+func unencodeFilter(body []string) []string {
+	var newlines []string
+
+	newlines = make([]string, 0)
+	sp := regexp.MustCompile(`\s+`)
+	el := regexp.MustCompile(`^\s+|\s+$`)
+	am := regexp.MustCompile(`amp;`)
+	lt := regexp.MustCompile(`&lt;`)
+	gt := regexp.MustCompile(`&gt;`)
+
+	for ii := range body {
+		s := body[ii]
+		s = sp.ReplaceAllString(s, " ")
+		s = el.ReplaceAllString(s, "")
+		s = am.ReplaceAllString(s, "")
+		s = lt.ReplaceAllString(s, "<")
+		s = gt.ReplaceAllString(s, ">")
+		s = strings.TrimSpace(s)
+		newlines = append(newlines, s)
+	}
+
+	return newlines
+}
+
+// DumpConfigFiles is used for debugging
+func (r *TrafficOpsReq) DumpConfigFiles() {
+	for _, cfg := range r.configFiles {
+		fmt.Printf("Name: %s, Dir: %s, Service: %s\n",
+			cfg.Name, cfg.Dir, cfg.Service)
+	}
+}
+
+// NewTrafficOpsReq returns a new TrafficOpsReq object.
+func NewTrafficOpsReq(cfg config.Cfg) *TrafficOpsReq {
+	unixTimeString := strconv.FormatInt(time.Now().Unix(), 10)
+
+	return &TrafficOpsReq{
+		Cfg:           cfg,
+		pkgs:          make(map[string]bool),
+		plugins:       make(map[string]bool),
+		configFiles:   make(map[string]*ConfigFile),
+		baseBackupDir: config.TmpBase + "/" + unixTimeString,
+		unixTimeStr:   unixTimeString,
+	}
+}
+
+// atsTcExec is a wrapper to run an atstccfg command.
+func (r *TrafficOpsReq) atsTcExec(cmdstr string) ([]byte, error) {
+	log.Debugf("cmdstr: %s\n", cmdstr)
+	result, err := r.atsTcExecCommand(cmdstr, -1, -1)
+	return result, err
+}
+
+// atsTcExecCommand is used to run the atstccfg command.
+func (r *TrafficOpsReq) atsTcExecCommand(cmdstr string, queueState int, revalState int) ([]byte, error) {
+	args := []string{
+		"--traffic-ops-timeout-milliseconds=" + strconv.FormatInt(int64(r.Cfg.TOTimeoutMS), 10),
+		"--traffic-ops-disable-proxy=" + strconv.FormatBool(r.Cfg.ReverseProxyDisable),
+		"--traffic-ops-user=" + r.Cfg.TOUser,
+		"--traffic-ops-password=" + r.Cfg.TOPass,
+		"--traffic-ops-url=" + r.Cfg.TOURL,
+		"--cache-host-name=" + r.Cfg.CacheHostName,
+		"--log-location-error=" + r.Cfg.LogLocationErr,
+		"--log-location-info=" + r.Cfg.LogLocationInfo,
+		"--log-location-warning=" + r.Cfg.LogLocationWarn,
+	}
+
+	switch cmdstr {
+	case "chkconfig":
+		args = append(args, "--get-data=chkconfig")
+	case "packages":
+		args = append(args, "--get-data=packages")
+	case "statuses":
+		args = append(args, "--get-data=statuses")
+	case "system-info":
+		args = append(args, "--get-data=system-info")
+	case "update-status":
+		args = append(args, "--get-data=update-status")
+	case "send-update":
+		var queueStatus string = "false"
+		var revalStatus string = "false"
+		if queueState > 0 {
+			queueStatus = "true"
+		}
+		if revalState > 0 {
+			revalStatus = "true"
+		}
+		args = append(args, "--set-queue-status="+queueStatus)
+		args = append(args, "--set-reval-status="+revalStatus)
+	case "get-config-files":
+		if r.Cfg.RunMode == config.Revalidate {
+			args = append(args, "--revalidate-only")
+		}
+	default:
+		return nil, errors.New("invalid command '" + cmdstr + "'")
+	}
+
+	cmd := exec.Command(config.AtsTcConfig, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+// backUpFile makes a backup of a config file.
+func (r *TrafficOpsReq) backUpFile(cfg *ConfigFile) error {
+
+	// init backup directories
+	configBkupDir := filepath.Join(r.baseBackupDir, cfg.Service, "/config_bkp")
+	cfg.CfgBackup = filepath.Join(configBkupDir, cfg.Name)
+	tropsBkupDir := filepath.Join(r.baseBackupDir, cfg.Service, "/config_trops")
+	cfg.TropsBackup = filepath.Join(tropsBkupDir, cfg.Name)
+
+	fileExists, _ := util.FileExists(cfg.Path)
+	if fileExists {
+		// create config file backup directory
+		err := os.MkdirAll(configBkupDir, 0755)
+		if err != nil {
+			return errors.New("Unable to create config backup directory '" + configBkupDir + "': " + err.Error())
+		}
+
+		// backup the config file
+		data, err := r.readCfgFile(cfg, "")
+		if err != nil {
+			return errors.New("Unable to read the config file '" + cfg.Path + "': " + err.Error())
+		}
+		_, err = r.writeCfgFile(cfg, configBkupDir, data)
+		if err != nil {
+			return errors.New("Failed to write the config file: " + err.Error())
+		}
+
+	} else {
+		log.Debugf("Config file: %s doesn't exist. No need to back up.\n", cfg.Name)
+	}
+
+	// backup the traffic ops file.
+	err := os.MkdirAll(tropsBkupDir, 0755)
+	if err != nil {
+		return errors.New("Unable to create Trops backup directory '" + tropsBkupDir + "': " + err.Error())
+	}
+	_, err = r.writeCfgFile(cfg, tropsBkupDir, cfg.Body)
+	if err != nil {
+		return errors.New("Failed to write the config file from traffic ops: " + err.Error())
+	}
+
+	// backup the current config file.
+	return nil
+}
+
+// checkConfigFile checks and audits config files.
+func (r *TrafficOpsReq) checkConfigFile(cfg *ConfigFile) error {
+	if cfg.Name == "" {
+		cfg.AuditFailed = true
+		return errors.New("Config file name is empty is empty, skipping further checks.")
+	}
+
+	if cfg.Dir == "" {
+		return errors.New("No location information for " + cfg.Name)
+	}
+	// return if audit has already been done.
+	if cfg.AuditComplete == true {
+		return nil
+	}
+
+	if !util.MkDir(cfg.Dir, r.Cfg) {
+		return errors.New("Unable to create the directory '" + cfg.Dir + " for " + "'" + cfg.Name + "'")
+	}
+
+	log.Debugf("======== Start processing config file: %s ========\n", cfg.Name)
+
+	if cfg.Name == "remap.config" {
+		err := r.processRemapOverrides(cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	// perform plugin verification
+	if cfg.Name == "remap.config" || cfg.Name == "plugin.config" {
+		err := r.verifyPlugins(cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	// apply traffic ops data filters in preparation for comparison
+	// to data on disk.
+	tropsData := strings.Split(string(cfg.Body), "\n")
+	tropsData = unencodeFilter(tropsData)
+	tropsData = commentsFilter(tropsData)
+
+	var diskData []string
+	fileExists, _ := util.FileExists(cfg.Path)
+	if fileExists {
+		data, err := r.readCfgFile(cfg, "")
+		if err != nil {
+			return errors.New("reading from '" + cfg.Path + "' failed: " + err.Error())
+		}
+		diskData = strings.Split(string(data), "\n")
+	} else { // file doesn't exist on, it's new from Traffic Ops.
+		cfg.AuditComplete = true
+		cfg.ChangeNeeded = true
+		log.Infof("No such file on disk, '%s'\n", cfg.Path)
+	}
+
+	// apply disk file data filters in preparation for comparison
+	// to data from traffic ops
+	diskData = unencodeFilter(diskData)
+	diskData = commentsFilter(diskData)
+
+	// apply final new line filters disk and traffic ops data for comparison
+	disk := strings.Join(diskData, "\n")
+	disk = newLineFilter(disk)
+
+	trops := strings.Join(tropsData, "\n")
+	trops = newLineFilter(trops)
+
+	if disk != trops {
+		cfg.ChangeNeeded = true
+		log.Infof("change needed to %s\n", cfg.Name)
+		err := r.backUpFile(cfg)
+		if err != nil {
+			return errors.New("unable to back up '" + cfg.Name + "': " + err.Error())
+		}
+	} else {
+		cfg.ChangeNeeded = false
+		log.Infof("All lines match TrOps for config file: %s\n", cfg.Name)
+	}
+
+	if cfg.Name == "50-ats.rules" {
+		err := r.processUdevRules(cfg)
+		if err != nil {
+			return errors.New("unable to process udev rules in '" + cfg.Name + "': " + err.Error())
+		}
+	}
+
+	log.Infof("======== End processing config file: %s for service: %s ========\n", cfg.Name, cfg.Service)
+	cfg.AuditComplete = true
+
+	return nil
+}
+
+// checkPlugin verifies ATS plugin requirements are satisfied.
+func (r *TrafficOpsReq) checkPlugin(plugin string) error {
+	// already verified
+	if r.plugins[plugin] == true {
+		return nil
+	}
+	pluginFile := filepath.Join(config.TSHome, "/libexec/trafficserver/", plugin)
+	pkgs, err := util.PackageInfo("pkg-provides", pluginFile)
+	if err != nil {
+		return errors.New("unable to verify plugin " + pluginFile + ": " + err.Error())
+	}
+	if len(pkgs) == 0 || pkgs == nil { // no package is installed that provides the plugin.
+		return errors.New(plugin + ": Package for plugin: " + plugin + ", is not installed.")
+	}
+	_, ok := r.pkgs[pkgs[0]]
+	if !ok {
+		return errors.New(plugin + ": Package for plugin: " + plugin + ", is not installed.")
+	}
+	return nil
+}
+
+// checkStatusFiles insures that the cache status files reflect
+// the status retrieved from Traffic Ops.
+func (r *TrafficOpsReq) checkStatusFiles(svrStatus string) error {
+	if svrStatus == "" {
+		return errors.New("Returning; did not find status from Traffic Ops!")
+	} else {
+		log.Debugf("Found %s status from Traffic Ops.\n", svrStatus)
+	}
+	statusFile := filepath.Join(config.StatusDir, svrStatus)
+	fileExists, _ := util.FileExists(statusFile)
+	if !fileExists {
+		log.Errorf("status file %s does not exist.\n", statusFile)
+	}
+	statuses, err := r.getStatuses()
+	if err != nil {
+		return fmt.Errorf("could not retrieves a statuses list from Traffic Ops: %s\n", err)
+	}
+
+	for f := range statuses {
+		otherStatus := filepath.Join(config.StatusDir, statuses[f])
+		if otherStatus == statusFile {
+			continue
+		}
+		fileExists, _ := util.FileExists(otherStatus)
+		if r.Cfg.RunMode != config.Report && fileExists {
+			log.Errorf("Removing other status file %s that exists\n", otherStatus)
+			err = os.Remove(otherStatus)
+			if err != nil {
+				log.Errorf("Error removing %s: %s\n", otherStatus, err)
+			}
+		}
+	}
+
+	if r.Cfg.RunMode != config.Report {
+		if !util.MkDir(config.StatusDir, r.Cfg) {
+			return fmt.Errorf("unable to create '%s'\n", config.StatusDir)
+		}
+		fileExists, _ := util.FileExists(statusFile)
+		if !fileExists {
+			err = util.Touch(statusFile)
+			if err != nil {
+				return fmt.Errorf("unable to touch %s - %s\n", statusFile, err)
+			}
+		}
+	}
+	return nil
+}
+
+// getStatuses fetches a list of cache statuses from Traffic ops.
+func (r *TrafficOpsReq) getStatuses() ([]string, error) {
+	var statuses []tc.StatusNullable
+	sl := []string{}
+	out, err := r.atsTcExec("statuses")
+	if err != nil {
+		log.Errorln(err)
+		return nil, err
+	}
+	if err = json.Unmarshal(out, &statuses); err != nil {
+		log.Errorln(err)
+		return nil, err
+	} else {
+		for val := range statuses {
+			if statuses[val].Name != nil {
+				sl = append(sl, *statuses[val].Name)
+			}
+		}
+	}
+
+	return sl, nil
+}
+
+// getUpdateStatus retrieves the update statuse for a cache from Traffic Ops.
+func (r *TrafficOpsReq) getUpdateStatus() (*tc.ServerUpdateStatus, error) {
+	var status tc.ServerUpdateStatus
+	out, err := r.atsTcExec("update-status")
+	if err != nil {
+		log.Errorln(err)
+		return nil, err
+	}
+	if err = json.Unmarshal(out, &status); err != nil {
+		log.Errorln(err)
+		return nil, err
+	}
+	log.Debugf("ServerUpdateStatus: %#v\n", status)
+	return &status, nil
+}
+
+// processRemapOverrides processes remap overrides found from Traffic Ops.
+func (r *TrafficOpsReq) processRemapOverrides(cfg *ConfigFile) error {
+	from := ""
+	newlines := []string{}
+	lineCount := 0
+	overrideCount := 0
+	overridenCount := 0
+	overrides := map[string]int{}
+	data := cfg.Body
+
+	if len(data) > 0 {
+		lines := strings.Split(string(data), "\n")
+		for ii := range lines {
+			str := lines[ii]
+			fields := strings.Fields(str)
+			if str == "" || len(fields) < 2 {
+				continue
+			}
+			lineCount++
+			from = fields[1]
+
+			_, ok := overrides[from]
+			if ok == true { // check if this line should be overriden
+				newstr := "##OVERRIDDEN## " + str
+				newlines = append(newlines, newstr)
+				overridenCount++
+			} else if fields[0] == "##OVERRIDE##" { // check for an override
+				from = fields[2]
+				newlines = append(newlines, "##OVERRIDE##")
+				// remove the ##OVERRIDE## comment along with the trailing space
+				newstr := strings.TrimPrefix(str, "##OVERRIDE## ")
+				// save the remap 'from field' to overrides.
+				overrides[from] = 1
+				newlines = append(newlines, newstr)
+				overrideCount++
+			} else { // no override is necessary
+				newlines = append(newlines, str)
+			}
+		}
+	} else {
+		return errors.New("The " + cfg.Name + " file is empty, nothing to process.")
+	}
+	if overrideCount > 0 {
+		log.Infof("Overrode %d old remap rule(s) with %d new remap rule(s).\n",
+			overridenCount, overrideCount)
+		newdata := strings.Join(newlines, "\n")
+		// strings.Join doesn't add a newline character to
+		// the last element in the array and we need one
+		// when the data is written out to a file.
+		if !strings.HasSuffix(newdata, "\n") {
+			newdata = newdata + "\n"
+		}
+		body := []byte(newdata)
+		cfg.Body = body
+	}
+	return nil
+}
+
+// processUdevRules verifies disk drive device ownership and mode
+func (r *TrafficOpsReq) processUdevRules(cfg *ConfigFile) error {
+	var udevDevices map[string]string
+
+	data := string(cfg.Body)
+	lines := strings.Split(data, "\n")
+
+	udevDevices = make(map[string]string)
+	for ii := range lines {
+		var owner string
+		var device string
+		line := lines[ii]
+		if strings.HasPrefix(line, "KERNEL==") {
+			vals := strings.Split(line, "\"")
+			if len(vals) >= 3 {
+				device = vals[1]
+				owner = vals[3]
+				if owner == "root" {
+					continue
+				}
+				userInfo, err := user.Lookup(owner)
+				if err != nil {
+					log.Errorf("no such user on this system: '%s'\n", owner)
+					continue
+				} else {
+					devPath := "/dev/" + device
+					fileExists, fileInfo := util.FileExists(devPath)
+					if fileExists {
+						udevDevices[device] = devPath
+						log.Infof("Found device in 50-ats.rules: %s\n", devPath)
+						if statStruct, ok := fileInfo.Sys().(*syscall.Stat_t); ok {
+							uid := strconv.Itoa(int(statStruct.Uid))
+							if uid != userInfo.Uid {
+								log.Errorf("Device %s is owned by uid %s, not %s (%s)\n", devPath, uid, owner, userInfo.Uid)
+							} else {
+								log.Infof("Ownership for disk device %s, is okay\n", devPath)
+							}
+						} else {
+							log.Errorf("Unable to read device owner info for %s\n", devPath)
+						}
+					}
+				}
+			}
+		}
+	}
+	fs, err := ioutil.ReadDir("/proc/fs/ext4")
+	if err != nil {
+		log.Errorln("unable to read /proc/fs/ext4, cannot audit disks for filesystem usage.")
+	} else {
+		for _, disk := range fs {
+			for k, _ := range udevDevices {
+				if strings.HasPrefix(k, disk.Name()) {
+					log.Warnf("Device %s has an active partition and filesystem!!!!\n", k)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// readCfgFile reads a config file and return its contents.
+func (r *TrafficOpsReq) readCfgFile(cfg *ConfigFile, dir string) ([]byte, error) {
+	var data []byte
+	var fullFileName string
+	if dir == "" {
+		fullFileName = cfg.Path
+	} else {
+		fullFileName = dir + "/" + cfg.Name
+	}
+
+	info, err := os.Stat(fullFileName)
+	if err != nil {
+		return nil, err
+	}
+	size := info.Size()
+
+	fd, err := os.Open(fullFileName)
+	if err != nil {
+		return nil, err
+	}
+	data = make([]byte, size)
+	c, err := fd.Read(data)
+	if err != nil || int64(c) != size {
+		return nil, errors.New("unable to completely read from '" + cfg.Name + "': " + err.Error())
+	}
+	fd.Close()
+
+	return data, nil
+}
+
+// replaceCfgFile replaces an ATS configuration file with one from Traffic Ops.
+func (r *TrafficOpsReq) replaceCfgFile(cfg *ConfigFile) error {
+	if r.Cfg.RunMode == config.BadAss || r.Cfg.RunMode == config.SyncDS || r.Cfg.RunMode == config.Revalidate {
+
+		log.Infof("Copying '%s' to '%s'\n", cfg.TropsBackup, cfg.Path)
+		data, err := util.ReadFile(cfg.TropsBackup)
+		if err != nil {
+			return errors.New("Unable to read the config file '" + cfg.TropsBackup + "': " + err.Error())
+		}
+		_, err = r.writeCfgFile(cfg, "", data)
+		if err != nil {
+			return errors.New("Failed to write the new config file: " + err.Error())
+		} else {
+			cfg.ChangeApplied = true
+			if cfg.RemapPluginConfig == true { // trafficserver config reload is required
+				r.TrafficCtlReload = true
+				r.RemapConfigReload = true
+			}
+			if cfg.Name == "plugin.config" { // trafficserver restart is required
+				r.TrafficServerRestart = true
+			} else if cfg.Name == "remap.config" {
+				r.TrafficCtlReload = true
+				r.RemapConfigReload = true
+			} else if cfg.Name == "sysctl.conf" { // sysctl reload is required
+				r.SysCtlReload = true
+			} else if cfg.Name == "ssl_multicert.config" {
+				r.TrafficCtlReload = true
+			} else if cfg.Name == "ntpd.conf" { // ntpd reload is required
+				r.NtpdRestart = true
+			}
+			log.Debugf("Setting change applied for '%s'\n", cfg.Name)
+		}
+	} else {
+		log.Infof("You elected not to replace %s with the version from Traffic Ops.\n", cfg.Name)
+		cfg.ChangeApplied = false
+	}
+	return nil
+}
+
+func (r *TrafficOpsReq) sleepTimer(serverStatus *tc.ServerUpdateStatus) {
+	randDispSec := time.Duration(0)
+	revalClockSec := time.Duration(0)
+
+	if r.Cfg.Dispersion > 0 {
+		randDispSec = util.RandomDuration(r.Cfg.Dispersion) / time.Second
+	}
+	if r.Cfg.RevalWaitTime > 0 {
+		revalClockSec = r.Cfg.RevalWaitTime / time.Second
+	}
+
+	if serverStatus.UseRevalPending && r.Cfg.RunMode != config.BadAss {
+		log.Infoln("Performing a revalidation check before sleeping...")
+		_, err := r.RevalidateWhileSleeping()
+		if err != nil {
+			log.Errorf("Revalidation check completed with error: %s\n", err)
+		} else {
+			log.Infoln("Revalidation check complete.")
+		}
+	}
+	if randDispSec < revalClockSec || serverStatus.UseRevalPending == false || r.Cfg.RunMode == config.BadAss {
+		log.Infof("Sleeping for %d seconds: ", randDispSec)
+	} else {
+		log.Infof("%d seconds until next revalidation check.\n", revalClockSec)
+		log.Infof("%d seconds remaining in dispersion sleep period\n", randDispSec)
+		log.Infof("Sleeping for %d seconds: ", revalClockSec)
+	}
+
+	for randDispSec > 0 {
+		fmt.Printf(".")
+		time.Sleep(time.Second)
+		revalClockSec--
+		if revalClockSec < 1 && r.Cfg.RunMode != config.BadAss && serverStatus.UseRevalPending {
+			fmt.Printf("\n")
+			log.Infoln("Interrupting dispersion sleep period for revalidation check.")
+			_, err := r.RevalidateWhileSleeping()
+			if r.Cfg.RevalWaitTime > 0 {
+				revalClockSec = r.Cfg.RevalWaitTime / time.Second
+			}
+			if err != nil {
+				log.Errorf("Revalidation check completed with error: %s\n", err)
+			} else {
+				log.Infoln("Revalidation check complete.")
+			}
+			if revalClockSec < randDispSec {
+				log.Infof("Revalidation check complete. %d seconds until next revalidation check.", revalClockSec)
+				log.Infof("%d seconds remaining in dispersion sleep period\n", randDispSec)
+				log.Infof("Sleeping for %d seconds: ", revalClockSec)
+			} else {
+				log.Infof("Revalidation check complete. %d seconds remaining in dispersion sleep period.\n", randDispSec)
+				log.Infof("Sleeping for %d seconds: ", randDispSec)
+			}
+		}
+		randDispSec--
+	}
+	fmt.Printf("\n")
+}
+
+// writeCfgFile writes the 'data' from Traffic Ops to an ATS config file.
+func (r *TrafficOpsReq) writeCfgFile(cfg *ConfigFile, dir string, data []byte) (int, error) {
+	var fullFileName string
+
+	if dir == "" {
+		fullFileName = cfg.Path
+	} else {
+		fullFileName = dir + "/" + cfg.Name
+	}
+
+	fd, err := os.OpenFile(fullFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, cfg.Perm)
+	if err != nil {
+		return 0, errors.New("unable to open '" + fullFileName + "' for writing: " + err.Error())
+	}
+
+	c, err := fd.Write(data)
+	if err != nil {
+		return 0, errors.New("error writing to '" + fullFileName + "': " + err.Error())
+	}
+	fd.Close()
+
+	if cfg.Service == "trafficserver" {
+		err = os.Chown(fullFileName, cfg.Uid, cfg.Gid)
+	} else {
+		err = os.Chown(fullFileName, 0, 0)
+	}
+	if err != nil {
+		return 0, errors.New("error changing ownership on '" + fullFileName + "': " + err.Error())
+	}
+
+	return c, nil
+}
+
+// verifyPlugins is used to verify that the plugin found
+// in plugin.config or from a remap.config is installed.
+func (r *TrafficOpsReq) verifyPlugins(cfg *ConfigFile) error {
+
+	log.Debugf("Checking plugins for %s\n", cfg.Name)
+
+	str := string(cfg.Body)
+	lines := strings.Split(str, "\n")
+	if cfg.Name == "plugin.config" {
+		for ii := range lines {
+			line := strings.TrimSpace(lines[ii])
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				plugin := fields[0]
+				// already verified
+				if r.plugins[plugin] == true {
+					continue
+				}
+				err := r.checkPlugin(plugin)
+				if err != nil {
+					cfg.PreReqFailed = true
+					return err
+				} else {
+					r.plugins[plugin] = true
+					log.Infof("Plugin %s has been verified.\n", plugin)
+				}
+			}
+		}
+	} else if cfg.Name == "remap.config" && len(lines) > 0 {
+		for ii := range lines {
+			line := lines[ii]
+			if strings.HasPrefix(line, "#") || line == "" {
+				continue
+			}
+			plugins := strings.Split(line, "@plugin=")
+			if len(plugins) > 0 {
+				for jj := range plugins {
+					var plugin string = ""
+					var plugin_config string = ""
+					if jj > 0 {
+						params := strings.Split(plugins[jj], "@pparam=")
+						param_length := len(params)
+						if param_length > 0 {
+							switch param_length {
+							case 1:
+								plugin = strings.TrimSpace(params[0])
+								plugin_config = ""
+							default:
+								plugin = strings.TrimSpace(params[0])
+								plugin_config = strings.TrimSpace(params[1])
+							}
+						}
+						if strings.HasSuffix(plugin, ".so") {
+							// already verified
+							if r.plugins[plugin] == true {
+								continue
+							}
+							err := r.checkPlugin(plugin)
+							if err != nil {
+								cfg.PreReqFailed = true
+								return err
+							} else {
+								r.plugins[plugin] = true
+								log.Infof("Plugin %s has been verified.\n", plugin)
+							}
+						}
+						if plugin_config != "" {
+							if strings.HasPrefix(plugin_config, "proxy.config") || strings.HasPrefix(plugin_config, "-") {
+								continue
+							} else {
+								plugin_config = filepath.Base(plugin_config)
+								cfg, ok := r.configFiles[plugin_config]
+								if ok {
+									cfg.RemapPluginConfig = true
+									log.Debugf("%s is a remap plugin config file\n", plugin_config)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// CheckSystemServices is used to verify that packages installed
+// are enabled for startup.
+func (r *TrafficOpsReq) CheckSystemServices() error {
+	if r.Cfg.RunMode == config.BadAss {
+		out, err := r.atsTcExec("chkconfig")
+		if err != nil {
+			log.Errorln(err)
+			return err
+		} else {
+			var result []map[string]string
+			if err = json.Unmarshal(out, &result); err != nil {
+				return err
+			}
+			for ii := range result {
+				name := result[ii]["name"]
+				value := result[ii]["value"]
+				arrv := strings.Fields(value)
+				var level []string
+				var enabled bool = false
+				for jj := range arrv {
+					nv := strings.Split(arrv[jj], ":")
+					if len(nv) == 2 && strings.Contains(nv[1], "on") {
+						level = append(level, nv[0])
+						enabled = true
+					}
+				}
+				if enabled == true {
+					if r.Cfg.SvcManagement == config.SystemD {
+						out, rc, err := util.ExecCommand("/bin/systemctl", "enable", name)
+						if err != nil {
+							log.Errorf(string(out))
+							return errors.New("Unable to enable service " + name + ": " + err.Error())
+						}
+						if rc == 0 {
+							log.Infof("The %s service has been enabled\n", name)
+						}
+					} else if r.Cfg.SvcManagement == config.SystemV {
+						levelValue := strings.Join(level, "")
+						_, rc, err := util.ExecCommand("/bin/chkconfig", "--level", levelValue, name, "on")
+						if err != nil {
+							return errors.New("Unable to enable service " + name + ": " + err.Error())
+						}
+						if rc == 0 {
+							log.Infof("The %s service has been enabled\n", name)
+						}
+					} else {
+						log.Errorf("Unable to insure %s service is enabled, SvcMananagement type is %s\n", name, r.Cfg.SvcManagement)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// IsPackageInstalled returns true/false if the named rpm package is installed.
+// the prefix before the version is matched.
+func (r *TrafficOpsReq) IsPackageInstalled(name string) bool {
+	for k, v := range r.pkgs {
+		if strings.HasPrefix(k, name) {
+			return v
+		}
+	}
+	return false
+}
+
+// GetConfigFile fetchs a 'Configfile' by file name.
+func (r *TrafficOpsReq) GetConfigFile(name string) (*ConfigFile, bool) {
+	cfg, ok := r.configFiles[name]
+	return cfg, ok
+}
+
+// GetConfigFileList fetches and parses the multipart config files
+// for a cache from traffic ops and loads them into the configFiles map.
+func (r *TrafficOpsReq) GetConfigFileList() error {
+	var atsUid int = 0
+	var atsGid int = 0
+
+	atsUser, err := user.Lookup(config.TrafficServerOwner)
+	if err != nil {
+		log.Errorf("could not lookup the trafficserver, '%s', owner uid, using uid/gid 0",
+			config.TrafficServerOwner)
+	} else {
+		atsUid, err = strconv.Atoi(atsUser.Uid)
+		if err != nil {
+			log.Errorf("could not parse the ats UID.")
+			atsUid = 0
+		}
+		atsGid, err = strconv.Atoi(atsUser.Gid)
+		if err != nil {
+			log.Errorf("could not parse the ats GID.")
+			atsUid = 0
+		}
+	}
+
+	fBytes, err := r.atsTcExec("get-config-files")
+	if err != nil {
+		return err
+	}
+	buf := bytes.NewBuffer(fBytes)
+	var hdr string
+	for {
+		hdr, err = buf.ReadString('\n')
+		if err != nil {
+			return err
+		} else {
+			if strings.HasPrefix(hdr, "Content-Type: multipart/mixed") {
+				break
+			}
+		}
+	}
+	// split on the ": " to trim off the leading space
+	har := strings.Split(hdr, ": ")
+	if len(har) > 1 && (har[0] != rfc.ContentType || !strings.HasPrefix(har[1], rfc.ContentTypeMultiPartMixed)) {
+		return errors.New("invalid config file data received from Traffic Ops, not in multipart format.")
+	}
+	msg := &mail.Message{
+		Header: map[string][]string{har[0]: {har[1]}},
+		Body:   bytes.NewReader(buf.Bytes()),
+	}
+	mediaType, params, err := mime.ParseMediaType(msg.Header.Get(rfc.ContentType))
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(mediaType, rfc.ContentTypeMultiPartMixed) {
+		mr := multipart.NewReader(msg.Body, params["boundary"])
+		// if the configFiles map is not empty, create a new map
+		// and the old map will be garbage collected.
+		if len(r.configFiles) > 0 {
+			log.Infoln("intializing a new configFiles map")
+			r.configFiles = make(map[string]*ConfigFile)
+		}
+		for {
+			p, err := mr.NextPart()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			dataBytes, err := ioutil.ReadAll(p)
+			if err != nil {
+				return err
+			}
+			path := p.Header.Get("Path")
+			if path != "" {
+				cf := &ConfigFile{
+					Header: p.Header,
+					Name:   filepath.Base(path),
+					Path:   path,
+					Dir:    filepath.Dir(path),
+					Body:   dataBytes,
+					Uid:    atsUid,
+					Gid:    atsGid,
+					Perm:   0644,
+				}
+				r.configFiles[cf.Name] = cf
+			}
+		}
+	}
+	return nil
+}
+
+// GetHeaderComment looks up the tm.toolname parameter from traffic ops.
+func (r *TrafficOpsReq) GetHeaderComment() string {
+	var toolName string = ""
+	out, err := r.atsTcExec("system-info")
+	if err != nil {
+		log.Errorln(err)
+	} else {
+		var result map[string]interface{}
+		if err = json.Unmarshal(out, &result); err != nil {
+			log.Errorln(err)
+		} else {
+			tn := result["tm.toolname"]
+			if tn, ok := tn.(string); ok {
+				toolName = tn
+				log.Infof("Found tm.toolname: %v\n", toolName)
+			} else {
+				log.Errorln("Did not find tm.toolname!")
+			}
+		}
+	}
+	return toolName
+}
+
+// CheckRevalidateState retrieves and returns the revalidate status from Traffic Ops.
+func (r *TrafficOpsReq) CheckRevalidateState(sleepOverride bool) (UpdateStatus, error) {
+	updateStatus := UpdateTropsNotNeeded
+	log.Infoln("Checking revalidate state.")
+
+	if r.Cfg.RunMode == config.Revalidate || sleepOverride {
+		serverStatus, err := r.getUpdateStatus()
+		log.Infof("my status: %s\n", serverStatus.Status)
+		if err != nil {
+			log.Errorln(err)
+			return updateStatus, err
+		} else {
+			if serverStatus.UseRevalPending == false {
+				log.Errorln("Update URL: Instant invalidate is not enabled.  Separated revalidation requires upgrading to Traffic Ops version 2.2 and enabling this feature.")
+				return UpdateTropsNotNeeded, nil
+			}
+			if serverStatus.RevalPending == true {
+				log.Errorln("Traffic Ops is signaling that a revalidation is waiting to be applied.")
+				updateStatus = UpdateTropsNeeded
+				if serverStatus.ParentRevalPending == true {
+					log.Errorln("Traffic Ops is signaling that my parents need to revalidate.")
+					// no update needed until my parents are updated.
+					updateStatus = UpdateTropsNotNeeded
+				}
+			} else if serverStatus.RevalPending == false && r.Cfg.RunMode == config.Revalidate {
+				log.Errorln("In revalidate mode, but no update needs to be applied. I'm outta here.")
+				return UpdateTropsNotNeeded, nil
+			} else {
+				log.Errorln("Traffic Ops is signaling that no revalidations are waiting to be applied.")
+				return UpdateTropsNotNeeded, nil
+			}
+		}
+
+		err = r.checkStatusFiles(serverStatus.Status)
+		if err != nil {
+			log.Errorln(err)
+		}
+	}
+
+	return updateStatus, nil
+}
+
+// CheckSYncDSState retrieves and returns the DS Update status from Traffic Ops.
+func (r *TrafficOpsReq) CheckSyncDSState() (UpdateStatus, error) {
+	updateStatus := UpdateTropsNotNeeded
+	randDispSec := time.Duration(0)
+	if r.Cfg.Dispersion > 0 {
+		randDispSec = util.RandomDuration(r.Cfg.Dispersion)
+	}
+	log.Debugln("Checking syncds state.")
+	if r.Cfg.RunMode == config.SyncDS || r.Cfg.RunMode == config.BadAss || r.Cfg.RunMode == config.Report {
+		serverStatus, err := r.getUpdateStatus()
+		if err != nil {
+			log.Errorln(err)
+			return updateStatus, err
+		}
+
+		if serverStatus.UpdatePending {
+			if r.Cfg.Dispersion > 0 {
+				log.Infof("Sleeping for %ds (dispersion) before proceeding with updates.\n\n", (randDispSec / time.Second))
+				r.sleepTimer(serverStatus)
+			}
+			updateStatus = UpdateTropsNeeded
+			log.Errorln("Traffic Ops is signaling that an update is waiting to be applied")
+
+			if serverStatus.ParentPending && r.Cfg.WaitForParents && !serverStatus.UseRevalPending {
+				log.Errorln("Traffic Ops is signaling that my parents need an update.")
+				if r.Cfg.RunMode == config.SyncDS {
+					log.Infof("In syncds mode, sleeping for %ds to see if the update my parents need is cleared.", randDispSec/time.Second)
+					r.sleepTimer(serverStatus)
+					serverStatus, err = r.getUpdateStatus()
+					if err != nil {
+						return updateStatus, err
+					}
+					if serverStatus.ParentPending || serverStatus.ParentRevalPending {
+						log.Errorln("My parents still need an update, bailing.")
+						return UpdateTropsNotNeeded, nil
+					} else {
+						log.Debugln("The update on my parents cleared; continuing.")
+					}
+				}
+			} else {
+				log.Debugf("Traffic Ops is signaling that my parents do not need an update, or wait_for_parents is false.")
+			}
+		} else if r.Cfg.RunMode == config.SyncDS {
+			log.Errorln("In syncds mode, but no syncds update needs to be applied.  Running revalidation before exiting.")
+			r.RevalidateWhileSleeping()
+			return UpdateTropsNotNeeded, nil
+		} else {
+			log.Errorln("Traffic Ops is signaling that no update is waiting to be applied.")
+		}
+
+		// check local status files.
+		err = r.checkStatusFiles(serverStatus.Status)
+		if err != nil {
+			log.Errorln(err)
+		}
+	}
+	return updateStatus, nil
+}
+
+// ProcessConfigFiles processes all config files retrieved from Traffic Ops.
+func (r *TrafficOpsReq) ProcessConfigFiles() (UpdateStatus, error) {
+	var updateStatus UpdateStatus = UpdateTropsNotNeeded
+
+	log.Infoln(" ======== Start processing config files ========")
+
+	for _, cfg := range r.configFiles {
+		// add service metadata
+		if strings.Contains(cfg.Path, "/opt/trafficserver/") || strings.Contains(cfg.Dir, "udev") {
+			cfg.Service = "trafficserver"
+			if r.Cfg.RunMode == config.SyncDS && !r.IsPackageInstalled("trafficserver") {
+				return UpdateTropsFailed, errors.New("In syncds mode, but trafficserver isn't installed. Bailing.")
+			}
+		} else if strings.Contains(cfg.Path, "/opt/ort") && strings.Contains(cfg.Name, "12M_facts") {
+			cfg.Service = "puppet"
+		} else if strings.Contains(cfg.Path, "cron") || strings.Contains(cfg.Name, "sysctl.conf") || strings.Contains(cfg.Name, "50-ats.rules") || strings.Contains(cfg.Name, "cron") {
+			cfg.Service = "system"
+		} else if strings.Contains(cfg.Path, "ntp.conf") {
+			cfg.Service = "ntpd"
+		} else {
+			cfg.Service = "unknown"
+		}
+
+		log.Debugf("In %s mode, I'm about to process config file: %s, service: %s\n", r.Cfg.RunMode, cfg.Path, cfg.Service)
+
+		err := r.checkConfigFile(cfg)
+		if err != nil {
+			log.Errorln(err)
+		}
+	}
+
+	changesRequired := 0
+
+	for _, cfg := range r.configFiles {
+		if cfg.ChangeNeeded &&
+			!cfg.ChangeApplied &&
+			cfg.AuditComplete &&
+			!cfg.PreReqFailed &&
+			!cfg.AuditFailed {
+
+			changesRequired++
+			if cfg.Name == "plugin.config" && r.configFiles["remap.config"].PreReqFailed == true {
+				updateStatus = UpdateTropsFailed
+				log.Errorln("plugin.config changed however, prereqs failed for remap.config so I am skipping updates for plugin.config")
+				continue
+			} else if cfg.Name == "remap.config" && r.configFiles["plugin.config"].PreReqFailed == true {
+				updateStatus = UpdateTropsFailed
+				log.Errorln("remap.config changed however, prereqs failed for plugin.config so I am skipping updates for remap.config")
+				continue
+			} else {
+				log.Debugf("All Prereqs passed for replacing %s on disk with that in Traffic Ops.\n", cfg.Name)
+				err := r.replaceCfgFile(cfg)
+				if err != nil {
+					log.Errorf("failed to replace the config file, '%s',  on disk with data in Traffic Ops.\n", cfg.Name)
+				}
+			}
+		}
+	}
+
+	if updateStatus != UpdateTropsFailed && changesRequired > 0 {
+		return UpdateTropsNeeded, nil
+	}
+
+	return updateStatus, nil
+}
+
+// ProcessPackages retrievies a list of required RPM's from Traffic Ops
+// and determines which need to be installed or removed on the cache.
+func (r *TrafficOpsReq) ProcessPackages() error {
+	var pkgs []Package
+	var install []string   // install package list.
+	var uninstall []string // uninstall package list
+
+	// get the package list for this cache from Traffic Ops.
+	out, err := r.atsTcExec("packages")
+	if err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(out, &pkgs); err != nil {
+		return err
+	}
+
+	// loop through the package list to build an install and uninstall list.
+	for ii := range pkgs {
+		var instpkg string // installed package
+		var reqpkg string  // required package
+		log.Infof("Processing package %s-%s\n", pkgs[ii].Name, pkgs[ii].Version)
+		// check to see if any package by name is installed.
+		arr, err := util.PackageInfo("pkg-query", pkgs[ii].Name)
+		if err != nil {
+			return err
+		}
+		// go needs the ternary operator :)
+		if len(arr) == 1 {
+			instpkg = arr[0]
+		} else {
+			instpkg = ""
+		}
+		// check if the full package version is installed
+		fullPackage := pkgs[ii].Name + "-" + pkgs[ii].Version
+
+		if instpkg == fullPackage {
+			log.Infof("%s Currently installed and not marked for removal\n", reqpkg)
+			r.pkgs[fullPackage] = true
+			continue
+		} else if instpkg != "" { // the installed package needs upgrading.
+			log.Infof("%s Currently installed and marked for removal\n", instpkg)
+			uninstall = append(uninstall, instpkg)
+			// the required package needs installing.
+			log.Infof("%s is Not installed and is marked for installation.\n", fullPackage)
+			install = append(install, fullPackage)
+			// get a list of packages that depend on this one and mark dependencies
+			// for deletion.
+			arr, err = util.PackageInfo("pkg-requires", instpkg)
+			if err != nil {
+				return err
+			}
+			if len(arr) > 0 {
+				for jj := range arr {
+					log.Infof("%s is Currently installed and depends on %s and needs to be removed.", arr[jj], instpkg)
+					uninstall = append(uninstall, arr[jj])
+				}
+			}
+		} else {
+			// the required package needs installing.
+			log.Infof("%s is Not installed and is marked for installation.\n", fullPackage)
+			log.Errorf("%s is Not installed and is marked for installation.\n", fullPackage)
+			install = append(install, fullPackage)
+		}
+	}
+	log.Debugf("number of packages requiring installation: %d\n", len(install))
+	if r.Cfg.RunMode == config.Report {
+		log.Errorf("number of packages requiring installation: %d\n", len(install))
+	}
+	log.Debugf("number of packages requiring removal: %d\n", len(uninstall))
+	if r.Cfg.RunMode == config.Report {
+		log.Errorf("number of packages requiring removal: %d\n", len(uninstall))
+	}
+
+	if len(install) > 0 {
+		for ii := range install {
+			result, err := util.PackageAction("info", install[ii])
+			if err != nil || result != true {
+				return errors.New("Package " + install[ii] + " is not available to install: " + err.Error())
+			}
+		}
+		log.Infoln("All packages available.. proceding..")
+
+		// uninstall packages marked for removal
+		if len(install) > 0 && r.Cfg.RunMode == config.BadAss {
+			for jj := range uninstall {
+				log.Infof("Uninstalling %s\n", install[jj])
+				r, err := util.PackageAction("remove", uninstall[jj])
+				if err != nil {
+					return errors.New("Unable to uninstall " + uninstall[jj] + " : " + err.Error())
+				} else if r == true {
+					log.Infof("Package %s was uninstalled\n", uninstall[jj])
+				}
+			}
+
+			// install the required packages
+			for jj := range install {
+				pkg := install[jj]
+				log.Infof("Installing %s\n", pkg)
+				result, err := util.PackageAction("install", pkg)
+				if err != nil {
+					return errors.New("Unable to install " + pkg + " : " + err.Error())
+				} else if result == true {
+					r.pkgs[pkg] = true
+					log.Infof("Package %s was installed\n", pkg)
+				}
+			}
+		}
+	}
+	if r.Cfg.RunMode == config.Report && len(install) > 0 {
+		for ii := range install {
+			log.Errorf("\nIn Report mode and %s needs installation.\n", install[ii])
+			return errors.New("In Report mode and packages need installation")
+		}
+	}
+	return nil
+}
+
+func (r *TrafficOpsReq) RevalidateWhileSleeping() (UpdateStatus, error) {
+	updateStatus, err := r.CheckRevalidateState(true)
+	if err != nil {
+		return updateStatus, err
+	}
+	if updateStatus != 0 {
+		r.Cfg.RunMode = config.Revalidate
+		err = r.GetConfigFileList()
+		if err != nil {
+			return updateStatus, err
+		}
+
+		updateStatus, err := r.ProcessConfigFiles()
+		if err != nil {
+			return updateStatus, err
+		}
+
+		result := r.StartServices(&updateStatus)
+		if !result {
+			return updateStatus, errors.New("failed to start services.")
+		}
+
+		// update Traffic Ops
+		_, err = r.UpdateTrafficOps(&updateStatus)
+		if err != nil {
+			log.Errorf("failed to update Traffic Ops: %s\n", err.Error())
+		}
+
+		r.TrafficCtlReload = false
+	}
+
+	return updateStatus, nil
+}
+
+func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus) bool {
+	startSuccess := true
+
+	// start ATS
+	if r.IsPackageInstalled("trafficserver") {
+		svcStatus, _, err := util.GetServiceStatus("trafficserver")
+		if err != nil {
+			log.Errorf("error getting 'trafficserver' run status: %s", err)
+			startSuccess = false
+		} else if r.Cfg.RunMode == config.BadAss {
+			if svcStatus == util.SvcRunning {
+				running, err := util.ServiceStart("trafficserver", "restart")
+				if err != nil {
+					log.Errorf("failed to restart trafficserver.")
+					startSuccess = false
+				} else if running {
+					log.Infof("trafficserver has been restarted.")
+					if r.TrafficCtlReload {
+						log.Infoln("trafficserver was just started, no need to run 'traffic_ctl config reload'")
+						r.TrafficCtlReload = false
+					}
+				}
+			} else {
+				running, err := util.ServiceStart("trafficserver", "start")
+				if err != nil {
+					startSuccess = false
+					log.Errorf("trafficserver failed to start, running 'traffic_ctl config reload' will also fail: %s\n", err.Error())
+				} else if running {
+					log.Infoln("trafficserver was successfully started.")
+					r.TrafficServerRestart = false
+					if r.TrafficCtlReload {
+						log.Infoln("trafficserver was just started, no need to run 'traffic_ctl config reload'")
+						r.TrafficCtlReload = false
+					}
+				}
+			}
+		}
+
+		if svcStatus == util.SvcRunning && r.TrafficCtlReload && !r.TrafficServerRestart {
+			switch r.Cfg.RunMode {
+			case config.Report:
+				log.Errorln("ATS configuration has changed.  'traffic_ctl config reload' needs to be run")
+				break
+			case config.BadAss:
+				fallthrough
+			case config.SyncDS:
+				fallthrough
+			case config.Revalidate:
+				log.Infoln("ATS configuration has changed, Running 'traffic_ctl config reload' now.")
+				_, _, err := util.ExecCommand(config.TSHome+config.TrafficCtl, "config", "reload")
+				if err != nil {
+					if *syncdsUpdate == UpdateTropsNeeded {
+						*syncdsUpdate = UpdateTropsFailed
+						log.Errorf("ATS configuration has change and 'traffic_ctl config reload' has failed, check ATS logs: %s", err.Error())
+						startSuccess = false
+					}
+				} else {
+					if *syncdsUpdate == UpdateTropsNeeded {
+						log.Infoln("ATS 'traffic_ctl config reload' was successful")
+						*syncdsUpdate = UpdateTropsSuccessful
+					}
+				}
+			default:
+				log.Errorln("ATS configuration has changed.  'traffic_ctl config reload was not run.")
+			}
+		} else if r.TrafficCtlReload && (!startSuccess || svcStatus != util.SvcRunning) {
+			log.Errorln("ATS configuration has changed.  The new config will be picked up the next time ATS is started.")
+			if *syncdsUpdate == UpdateTropsNeeded {
+				*syncdsUpdate = UpdateTropsSuccessful
+				log.Errorln("'traffic_ctl config reload' was not run but, Traffic Ops is being updated anyway.")
+			}
+		}
+	} else {
+		log.Errorln("trafficserver is not installed.")
+	}
+
+	return startSuccess
+}
+
+func (r *TrafficOpsReq) UpdateTrafficOps(syncdsUpdate *UpdateStatus) (bool, error) {
+	var updateResult bool
+
+	serverStatus, err := r.getUpdateStatus()
+	if err != nil {
+		return false, errors.New("failed to update Traffic Ops: " + err.Error())
+	}
+
+	if *syncdsUpdate == UpdateTropsNotNeeded && (serverStatus.UpdatePending == true || serverStatus.RevalPending == true) {
+		updateResult = true
+		log.Errorln("Traffic Ops is signaling that an update is ready to be applied but, none was found! Clearing update state in Traffic Ops anyway.")
+	} else if *syncdsUpdate == UpdateTropsNotNeeded {
+		log.Errorln("Traffic Ops does not require and update at this time")
+		return true, nil
+	} else if *syncdsUpdate == UpdateTropsFailed {
+		log.Errorln("Traffic Ops requires an update but, applying the update locally failed.  Traffic Ops is not being updated.")
+		return true, nil
+	} else if *syncdsUpdate == UpdateTropsSuccessful {
+		updateResult = true
+		log.Errorln("Traffic Ops requires an update and it was applied successfully.  Clearing update state in Traffic Ops.")
+	}
+
+	if updateResult {
+		switch r.Cfg.RunMode {
+		case config.Report:
+			log.Errorln("In Report mode and Traffic Ops needs updated you should probably do that manually.")
+			break
+		case config.BadAss:
+			fallthrough
+		case config.SyncDS:
+			if serverStatus.RevalPending {
+				_, err = r.atsTcExecCommand("send-update", 0, 1)
+			} else {
+				_, err = r.atsTcExecCommand("send-update", 0, 0)
+			}
+		case config.Revalidate:
+			_, err = r.atsTcExecCommand("send-update", 1, 0)
+		}
+		if err != nil {
+			return false, errors.New("Traffic Ops Update failed: " + err.Error())
+		} else {
+			log.Errorln("Traffic Ops has been updated.")
+		}
+	}
+	return true, nil
+}

--- a/traffic_ops_ort/t3c/torequest/torequest_test.go
+++ b/traffic_ops_ort/t3c/torequest/torequest_test.go
@@ -1,0 +1,150 @@
+package torequest
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"github.com/apache/trafficcontrol/traffic_ops_ort/t3c/config"
+	"testing"
+)
+
+var testCfg config.Cfg = config.Cfg{
+	Dispersion:          300,
+	LogLocationDebug:    "stdout",
+	LogLocationErr:      "stdout",
+	LogLocationInfo:     "stdout",
+	LogLocationWarn:     "stdout",
+	LoginDispersion:     60,
+	CacheHostName:       "cache-01.cdn.com",
+	SvcManagement:       config.SystemD,
+	Retries:             3,
+	RevalWaitTime:       2,
+	ReverseProxyDisable: false,
+	RunMode:             config.Revalidate,
+	SkipOSCheck:         false,
+	TOTimeoutMS:         1000,
+	TOUser:              "mickey",
+	TOPass:              "mouse",
+	TOURL:               "http://mouse.com",
+	WaitForParents:      false,
+	YumOptions:          "none",
+}
+
+func TestCommentsFilter(t *testing.T) {
+	input := []string{"#\n", "#\n", "#this is a comment\n", "proxy.http.retries: 10\n"}
+
+	output := commentsFilter(input)
+	length := len(output)
+	if length != 1 {
+		t.Fatal("commentsFilter() failed, expected a length of '1'")
+	}
+	if output[0] != "proxy.http.retries: 10\n" {
+		t.Errorf("commentsFilter() failed, expected 'proxy.http.retries: 10' actual '" +
+			output[0] + "'")
+	}
+}
+
+func TestNewLineFilter(t *testing.T) {
+	input := "the quick brown fox\r\njumped over\r\nthe lazy dogs\r\nback\n"
+	expected := "the quick brown fox\njumped over\nthe lazy dogs\nback"
+
+	output := newLineFilter(input)
+	if output != expected {
+		t.Errorf("newLineFilter() failed, expected '" + expected + "', actual '" + output)
+	}
+}
+
+func TestUnencodeFilter(t *testing.T) {
+	input := []string{" the  quick&lt;p&gt;brown&amp;fox"}
+	expected := "the quick<p>brown&fox"
+
+	output := unencodeFilter(input)
+
+	length := len(output)
+	if length != 1 {
+		t.Errorf("unencodeFilter() failed, expected a length of '1'")
+	}
+	if output[0] != expected {
+		t.Errorf("unencodeFilter() failed, expected '" + expected + "' actual '" + output[0] + "'")
+	}
+}
+
+func TestNewTrafficOpsReq(t *testing.T) {
+	trops := NewTrafficOpsReq(testCfg)
+	bkupDir := config.TmpBase + "/" + trops.unixTimeStr
+
+	if trops.baseBackupDir != bkupDir {
+		t.Errorf("NewTrafficOpsReq() failed, expected '" + bkupDir + " ' actual '" + trops.baseBackupDir + "'")
+	}
+}
+
+func TestIsPackageInstalled(t *testing.T) {
+	trops := NewTrafficOpsReq(testCfg)
+	trops.pkgs["trafficserver"] = true
+
+	if trops.isPackageInstalled("mouse") {
+		t.Errorf("isPackageInstalled() failed, expected 'false' got 'true'.")
+	}
+
+	if !trops.isPackageInstalled("trafficserver") {
+		t.Errorf("isPackageInstalled() failed, expected 'true' got 'false'.")
+	}
+
+	trops.pkgs["trafficserver"] = false
+	if trops.isPackageInstalled("trafficserver") {
+		t.Errorf("isPackageInstalled() failed, expected 'false' got 'true'.")
+	}
+}
+
+func TestGetConfigFile(t *testing.T) {
+	trops := NewTrafficOpsReq(testCfg)
+
+	cfgFile := ConfigFile{
+		Name:              "remap.config",
+		Dir:               "/tmp",
+		Path:              "/tmp/trafficserver/remap.config",
+		Service:           "trafficserver",
+		CfgBackup:         "/tmp/trafficserver/backup",
+		TropsBackup:       "/tmp/trafficops/backu",
+		AuditComplete:     true,
+		AuditFailed:       false,
+		ChangeApplied:     true,
+		ChangeNeeded:      false,
+		PreReqFailed:      false,
+		RemapPluginConfig: false,
+		Body:              nil,
+		Uid:               100,
+		Gid:               100,
+	}
+
+	trops.configFiles["remap.config"] = &cfgFile
+
+	_, ok := trops.GetConfigFile("parent.config")
+	if ok {
+		t.Errorf("GetConfigFile('parent.config') failed, expected 'false' got 'true'.")
+	}
+
+	cfg, ok := trops.GetConfigFile("remap.config")
+	if !ok {
+		t.Errorf("GetConfigFile('remap.config') failed, expected 'true' got 'false'.")
+	}
+	if cfg.Name != "remap.config" {
+		t.Errorf("GetConfigFile('remap.config') failed, expected 'remap.config' got '" + cfg.Name + "'.")
+	}
+}

--- a/traffic_ops_ort/t3c/util/util.go
+++ b/traffic_ops_ort/t3c/util/util.go
@@ -1,0 +1,408 @@
+package util
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/t3c/config"
+	"github.com/gofrs/flock"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const OneWeek = 604800
+
+type FileLock struct {
+	f_lock    *flock.Flock
+	is_locked bool
+}
+
+type ServiceStatus int
+
+const (
+	SvcNotRunning ServiceStatus = 0
+	SvcRunning    ServiceStatus = 1
+	SvcUnknown    ServiceStatus = 2
+)
+
+func (s ServiceStatus) String() string {
+	switch s {
+	case 0:
+		return "SvcNotRunning"
+	case 1:
+		return "SvcRunning"
+	case 2:
+		fallthrough
+	default:
+		return "SvcUnknown"
+	}
+}
+
+// Try to get a file lock, non-blocking.
+func (f *FileLock) GetLock(lockFile string) bool {
+	f.f_lock = flock.New(lockFile)
+	is_locked, err := f.f_lock.TryLock()
+	f.is_locked = is_locked
+
+	if err != nil { // some OS error attempting to obtain a file lock
+		log.Errorf("unable to obtain a lock on %s\n", lockFile)
+		return false
+	}
+	if !f.is_locked { // another process is running.
+		log.Errorf("Another t3c process is already running, try again later\n")
+		return false
+	}
+
+	return f.is_locked
+}
+
+// Releases a file lock and exits with the given status code.
+func (f *FileLock) UnlockAndExit(code int) {
+	if f.is_locked {
+		f.f_lock.Unlock()
+	}
+	os.Exit(code)
+}
+
+func DirectoryExists(dir string) (bool, os.FileInfo) {
+	info, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return info.IsDir(), info
+}
+
+func ExecCommand(fullCommand string, arg ...string) ([]byte, int, error) {
+	var output bytes.Buffer
+	cmd := exec.Command(fullCommand, arg...)
+	cmd.Stdout = &output
+	err := cmd.Run()
+	return output.Bytes(), cmd.ProcessState.ExitCode(), err
+}
+
+func FileExists(fn string) (bool, os.FileInfo) {
+	info, err := os.Stat(fn)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return !info.IsDir(), info
+}
+
+func ReadFile(fn string) ([]byte, error) {
+	var data []byte
+	info, err := os.Stat(fn)
+	if err != nil {
+		return nil, err
+	}
+	size := info.Size()
+
+	fd, err := os.Open(fn)
+	if err != nil {
+		return nil, err
+	}
+	data = make([]byte, size)
+	c, err := fd.Read(data)
+	if err != nil || int64(c) != size {
+		return nil, errors.New("unable to completely read from '" + fn + "': " + err.Error())
+	}
+	fd.Close()
+
+	return data, nil
+}
+
+func GetServiceStatus(name string) (ServiceStatus, int, error) {
+	var pid int = -1
+	var active bool = false
+
+	output, rc, err := ExecCommand("/usr/sbin/service", name, "status")
+	// service is down
+	if rc == 3 {
+		return SvcNotRunning, pid, nil
+	} else if err != nil {
+		return SvcUnknown, pid, errors.New("could not get status for service '" + name + "'\n")
+	}
+	lines := strings.Split(string(output), "\n")
+	for ii := range lines {
+		line := strings.TrimSpace(lines[ii])
+		if strings.Contains(line, "Active: active") {
+			active = true
+		}
+		if active && strings.Contains(line, "Main PID: ") {
+			fmt.Sscanf(line, "Main PID: %d", &pid)
+		}
+	}
+
+	if active {
+		return SvcRunning, pid, nil
+	} else {
+		return SvcNotRunning, pid, nil
+	}
+}
+
+// start or restart the service 'service'. cmd is 'start | restart'
+func ServiceStart(service string, cmd string) (bool, error) {
+	log.Infof("ServiceStart called for '%s'\n", service)
+	svcStatus, pid, err := GetServiceStatus(service)
+	if err != nil {
+		return false, errors.New("Could not get status for '" + service + "' : " + err.Error())
+	} else if svcStatus == SvcRunning && cmd == "start" {
+		log.Infof("service '%s' is already running, pid: %d\n", service, pid)
+	} else {
+		_, rc, err := ExecCommand("/usr/sbin/service", service, cmd)
+		if err != nil {
+			return false, errors.New("Could not " + cmd + " the '" + service + "' service: " + err.Error())
+		} else if rc == 0 {
+			// service was sucessfully started
+			return true, nil
+		}
+	}
+	// not started, service is already running
+	return false, nil
+}
+
+func WriteFile(fn string, data []byte, perm os.FileMode) (int, error) {
+	return WriteFileWithOwner(fn, data, -1, -1, perm)
+}
+
+func WriteFileWithOwner(fn string, data []byte, uid int, gid int, perm os.FileMode) (int, error) {
+	fd, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return 0, errors.New("unable to open '" + fn + "' for writing: " + err.Error())
+	}
+
+	c, err := fd.Write(data)
+	if err != nil {
+		return 0, errors.New("error writing to '" + fn + "': " + err.Error())
+	}
+	fd.Close()
+
+	if uid > -1 && gid > -1 {
+		err = os.Chown(fn, uid, gid)
+		if err != nil {
+			return 0, errors.New("error changing ownership on '" + fn + "': " + err.Error())
+		}
+	}
+	return c, nil
+}
+
+func PackageAction(cmdstr string, name string) (bool, error) {
+	var rc int = -1
+	var err error = nil
+	var result bool = false
+
+	switch cmdstr {
+	case "info":
+		_, rc, err = ExecCommand("/usr/bin/yum", "info", name)
+	case "install":
+		_, rc, err = ExecCommand("/usr/bin/yum", "install", "-y", name)
+	case "remove":
+		_, rc, err = ExecCommand("/usr/bin/yum", "remove", "-y", name)
+	}
+
+	if rc == 0 {
+		result = true
+		err = nil
+	}
+	return result, err
+}
+
+// runs the rpm command.
+// if the return code from rpm == 0, then a valid package list is returned.
+//
+// if the return code is 1, the the 'name' queried for is not part of a
+//   package or is not installed.
+//
+// otherwise, if the return code is not 0 or 1 and error is set, a general
+// rpm command execution error is assumed and the error is returned.
+func PackageInfo(cmdstr string, name string) ([]string, error) {
+	var result []string
+	switch cmdstr {
+	case "cfg-files": // returns a list of the package configuration files.
+		output, rc, err := ExecCommand("/bin/rpm", "-q", "-c", name)
+		if rc == 1 { // rpm package for 'name' was not found.
+			return nil, nil
+		} else if rc == 0 { // add the package name the file belongs to.
+			log.Debugf("output from cfg-files query: %s\n", string(output))
+			files := strings.Split(string(output), "\n")
+			for ii := range files {
+				result = append(result, strings.TrimSpace(files[ii]))
+			}
+			log.Debugf("result length: %d, result: %s\n", len(result), string(output))
+		} else if err != nil {
+			return nil, err
+		}
+	case "file-query": // returns the rpm name that owns the file 'name'
+		output, rc, err := ExecCommand("/bin/rpm", "-q", "-f", name)
+		if rc == 1 { // file is not part of any package.
+			return nil, nil
+		} else if rc == 0 { // add the package name the file belongs to.
+			log.Debugf("output from file-query: %s\n", string(output))
+			result = append(result, string(strings.TrimSpace(string(output))))
+			log.Debugf("result length: %d, result: %s\n", len(result), string(output))
+		} else if err != nil {
+			return nil, err
+		}
+	case "pkg-provides": // returns the package name that provides 'name'
+		output, rc, err := ExecCommand("/bin/rpm", "-q", "--whatprovides", name)
+		log.Debugf("pkg-provides - name: %s, output: %s\n", name, output)
+		if rc == 1 { // no package provides 'name'
+			return nil, nil
+		} else if rc == 0 {
+			pkgs := strings.Split(string(output), "\n")
+			for ii := range pkgs {
+				result = append(result, strings.TrimSpace(pkgs[ii]))
+			}
+		} else if err != nil {
+			return nil, err
+		}
+	case "pkg-query": // returns the package name for 'name'.
+		output, rc, err := ExecCommand("/bin/rpm", "-q", name)
+		if rc == 1 { // the package is not installed.
+			return nil, nil
+		} else if rc == 0 { // add the rpm name
+			result = append(result, string(strings.TrimSpace(string(output))))
+		} else if err != nil {
+			return nil, err
+		}
+	case "pkg-requires": // returns a list of packages that requires package 'name'
+		output, rc, err := ExecCommand("/bin/rpm", "-q", "--whatrequires", name)
+		if rc == 1 { // no package reuires package 'name'
+			return nil, nil
+		} else if rc == 0 {
+			pkgs := strings.Split(string(output), "\n")
+			for ii := range pkgs {
+				result = append(result, strings.TrimSpace(pkgs[ii]))
+			}
+		} else if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func RandomDuration(max time.Duration) time.Duration {
+	rand.Seed(time.Now().UnixNano())
+	return time.Duration(rand.Int63n(int64(max)))
+}
+
+func CheckUser(cfg config.Cfg) bool {
+	result := true
+	userInfo, err := user.Current()
+
+	if err != nil {
+		log.Errorf("could not obtain the current user info: %s\n", err.Error())
+		return false
+	}
+
+	switch cfg.RunMode {
+	case config.BadAss:
+		fallthrough
+	case config.SyncDS:
+		if userInfo.Username != "root" {
+			log.Errorf("Only the root user may run in BadAss, or SyncDS mode, current user: %s\n",
+				userInfo.Username)
+			result = false
+		}
+	default:
+		log.Infof("current mode: %s, run user: %s\n", cfg.RunMode, userInfo.Username)
+	}
+	return result
+}
+
+func CleanTmpDir() bool {
+	now := time.Now().Unix()
+
+	if len(config.TmpBase) == 0 || !strings.HasPrefix(config.TmpBase, "/") {
+		log.Errorf("config.TmpBase is misconfigured: '%s', refusing to remove any files or directories.", config.TmpBase)
+		return false
+	}
+
+	files, err := ioutil.ReadDir(config.TmpBase)
+	if err != nil {
+		log.Errorf("opening %s: %v\n", config.TmpBase, err)
+		return false
+	}
+	for _, f := range files {
+		// remove any directory and its contents under the config.TmpBase (/tmp/ort) that
+		// is more than a week old.
+		if f.IsDir() && (now-f.ModTime().Unix()) > OneWeek {
+			dir := filepath.Join(config.TmpBase, f.Name())
+			if dir == "/" {
+				log.Errorf("config.TmpBase is incorrectly configured, refusing to remove '/'. check config.TmpBase.")
+				return false
+			}
+			if f.Name() == "." || f.Name() == ".." {
+				continue
+			}
+			err = os.RemoveAll(dir)
+			if err != nil {
+				log.Errorf("could not remove '%s': %v\n", dir, err)
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func MkDir(name string, cfg config.Cfg) bool {
+	fileInfo, err := os.Stat(name)
+	if err == nil && fileInfo.Mode().IsDir() {
+		log.Debugf("the directory '%s' already exists", name)
+		return true
+	}
+	if err != nil {
+		if cfg.RunMode != config.Report {
+			if err != nil { // the path does not exist.
+				err = os.Mkdir(name, 0755)
+				if err != nil {
+					log.Errorf("unable to create the directory '%s': %v", name, err)
+					return false
+				}
+			} else if fileInfo.Mode().IsDir() {
+				log.Debugf("the directory: %s, already exists\n", name)
+			} else {
+				log.Errorf("there is a file named, '%s' that is not a directory: %v", name, err)
+				return false
+			}
+		} else {
+			log.Infof("the directory %s does not exist and was not created, runMode: %s", name, cfg.RunMode)
+			return true
+		}
+	}
+	return false
+}
+
+func Touch(fn string) error {
+	myfile, err := os.Create(fn)
+	if err != nil {
+		return err
+	}
+	myfile.Close()
+	return nil
+}

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/.gitignore
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/.travis.yml
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go:
+  - 1.10.x
+  - 1.11.x
+script: go test -v -check.vv -race ./...
+sudo: false
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/LICENSE
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2015, Tim Heckman
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of linode-netint nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/README.md
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/README.md
@@ -1,0 +1,41 @@
+# flock
+[![TravisCI Build Status](https://img.shields.io/travis/gofrs/flock/master.svg?style=flat)](https://travis-ci.org/gofrs/flock)
+[![GoDoc](https://img.shields.io/badge/godoc-flock-blue.svg?style=flat)](https://godoc.org/github.com/gofrs/flock)
+[![License](https://img.shields.io/badge/license-BSD_3--Clause-brightgreen.svg?style=flat)](https://github.com/gofrs/flock/blob/master/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gofrs/flock)](https://goreportcard.com/report/github.com/gofrs/flock)
+
+`flock` implements a thread-safe sync.Locker interface for file locking. It also
+includes a non-blocking TryLock() function to allow locking without blocking execution.
+
+## License
+`flock` is released under the BSD 3-Clause License. See the `LICENSE` file for more details.
+
+## Go Compatibility
+This package makes use of the `context` package that was introduced in Go 1.7. As such, this
+package has an implicit dependency on Go 1.7+.
+
+## Installation
+```
+go get -u github.com/gofrs/flock
+```
+
+## Usage
+```Go
+import "github.com/gofrs/flock"
+
+fileLock := flock.New("/var/lock/go-lock.lock")
+
+locked, err := fileLock.TryLock()
+
+if err != nil {
+	// handle locking error
+}
+
+if locked {
+	// do work
+	fileLock.Unlock()
+}
+```
+
+For more detailed usage information take a look at the package API docs on
+[GoDoc](https://godoc.org/github.com/gofrs/flock).

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/appveyor.yml
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/appveyor.yml
@@ -1,0 +1,25 @@
+version: '{build}'
+
+build: false
+deploy: false
+
+clone_folder: 'c:\gopath\src\github.com\gofrs\flock'
+
+environment:
+  GOPATH: 'c:\gopath'
+  GOVERSION: '1.11'
+
+init:
+  - git config --global core.autocrlf input
+
+install:
+  - rmdir c:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.msi
+  - msiexec /i go%GOVERSION%.windows-amd64.msi /q
+  - set Path=c:\go\bin;c:\gopath\bin;%Path%
+  - go version
+  - go env
+
+test_script:
+  - go get -t ./...
+  - go test -race -v ./...

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/flock.go
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/flock.go
@@ -1,0 +1,127 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+// Package flock implements a thread-safe interface for file locking.
+// It also includes a non-blocking TryLock() function to allow locking
+// without blocking execution.
+//
+// Package flock is released under the BSD 3-Clause License. See the LICENSE file
+// for more details.
+//
+// While using this library, remember that the locking behaviors are not
+// guaranteed to be the same on each platform. For example, some UNIX-like
+// operating systems will transparently convert a shared lock to an exclusive
+// lock. If you Unlock() the flock from a location where you believe that you
+// have the shared lock, you may accidentally drop the exclusive lock.
+package flock
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+)
+
+// Flock is the struct type to handle file locking. All fields are unexported,
+// with access to some of the fields provided by getter methods (Path() and Locked()).
+type Flock struct {
+	path string
+	m    sync.RWMutex
+	fh   *os.File
+	l    bool
+	r    bool
+}
+
+// New returns a new instance of *Flock. The only parameter
+// it takes is the path to the desired lockfile.
+func New(path string) *Flock {
+	return &Flock{path: path}
+}
+
+// NewFlock returns a new instance of *Flock. The only parameter
+// it takes is the path to the desired lockfile.
+//
+// Deprecated: Use New instead.
+func NewFlock(path string) *Flock {
+	return New(path)
+}
+
+// Close is equivalent to calling Unlock.
+//
+// This will release the lock and close the underlying file descriptor.
+// It will not remove the file from disk, that's up to your application.
+func (f *Flock) Close() error {
+	return f.Unlock()
+}
+
+// Path returns the path as provided in NewFlock().
+func (f *Flock) Path() string {
+	return f.path
+}
+
+// Locked returns the lock state (locked: true, unlocked: false).
+//
+// Warning: by the time you use the returned value, the state may have changed.
+func (f *Flock) Locked() bool {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.l
+}
+
+// RLocked returns the read lock state (locked: true, unlocked: false).
+//
+// Warning: by the time you use the returned value, the state may have changed.
+func (f *Flock) RLocked() bool {
+	f.m.RLock()
+	defer f.m.RUnlock()
+	return f.r
+}
+
+func (f *Flock) String() string {
+	return f.path
+}
+
+// TryLockContext repeatedly tries to take an exclusive lock until one of the
+// conditions is met: TryLock succeeds, TryLock fails with error, or Context
+// Done channel is closed.
+func (f *Flock) TryLockContext(ctx context.Context, retryDelay time.Duration) (bool, error) {
+	return tryCtx(ctx, f.TryLock, retryDelay)
+}
+
+// TryRLockContext repeatedly tries to take a shared lock until one of the
+// conditions is met: TryRLock succeeds, TryRLock fails with error, or Context
+// Done channel is closed.
+func (f *Flock) TryRLockContext(ctx context.Context, retryDelay time.Duration) (bool, error) {
+	return tryCtx(ctx, f.TryRLock, retryDelay)
+}
+
+func tryCtx(ctx context.Context, fn func() (bool, error), retryDelay time.Duration) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	for {
+		if ok, err := fn(); ok || err != nil {
+			return ok, err
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(retryDelay):
+			// try again
+		}
+	}
+}
+
+func (f *Flock) setFh() error {
+	// open a new os.File instance
+	// create it if it doesn't exist, and open the file read-only.
+	fh, err := os.OpenFile(f.path, os.O_CREATE|os.O_RDONLY, os.FileMode(0600))
+	if err != nil {
+		return err
+	}
+
+	// set the filehandle on the struct
+	f.fh = fh
+	return nil
+}

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_example_test.go
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_example_test.go
@@ -1,0 +1,72 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Copyright 2018 The Gofrs. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package flock_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+func ExampleFlock_Locked() {
+	f := flock.New(os.TempDir() + "/go-lock.lock")
+	f.TryLock() // unchecked errors here
+
+	fmt.Printf("locked: %v\n", f.Locked())
+
+	f.Unlock()
+
+	fmt.Printf("locked: %v\n", f.Locked())
+	// Output: locked: true
+	// locked: false
+}
+
+func ExampleFlock_TryLock() {
+	// should probably put these in /var/lock
+	fileLock := flock.New(os.TempDir() + "/go-lock.lock")
+
+	locked, err := fileLock.TryLock()
+
+	if err != nil {
+		// handle locking error
+	}
+
+	if locked {
+		fmt.Printf("path: %s; locked: %v\n", fileLock.Path(), fileLock.Locked())
+
+		if err := fileLock.Unlock(); err != nil {
+			// handle unlock error
+		}
+	}
+
+	fmt.Printf("path: %s; locked: %v\n", fileLock.Path(), fileLock.Locked())
+}
+
+func ExampleFlock_TryLockContext() {
+	// should probably put these in /var/lock
+	fileLock := flock.New(os.TempDir() + "/go-lock.lock")
+
+	lockCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	locked, err := fileLock.TryLockContext(lockCtx, 678*time.Millisecond)
+
+	if err != nil {
+		// handle locking error
+	}
+
+	if locked {
+		fmt.Printf("path: %s; locked: %v\n", fileLock.Path(), fileLock.Locked())
+
+		if err := fileLock.Unlock(); err != nil {
+			// handle unlock error
+		}
+	}
+
+	fmt.Printf("path: %s; locked: %v\n", fileLock.Path(), fileLock.Locked())
+}

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_test.go
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_test.go
@@ -1,0 +1,290 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Copyright 2018 The Gofrs. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package flock_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct {
+	path  string
+	flock *flock.Flock
+}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (t *TestSuite) SetUpTest(c *C) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "go-flock-")
+	c.Assert(err, IsNil)
+	c.Assert(tmpFile, Not(IsNil))
+
+	t.path = tmpFile.Name()
+
+	defer os.Remove(t.path)
+	tmpFile.Close()
+
+	t.flock = flock.New(t.path)
+}
+
+func (t *TestSuite) TearDownTest(c *C) {
+	t.flock.Unlock()
+	os.Remove(t.path)
+}
+
+func (t *TestSuite) TestNew(c *C) {
+	var f *flock.Flock
+
+	f = flock.New(t.path)
+	c.Assert(f, Not(IsNil))
+	c.Check(f.Path(), Equals, t.path)
+	c.Check(f.Locked(), Equals, false)
+	c.Check(f.RLocked(), Equals, false)
+}
+
+func (t *TestSuite) TestFlock_Path(c *C) {
+	var path string
+	path = t.flock.Path()
+	c.Check(path, Equals, t.path)
+}
+
+func (t *TestSuite) TestFlock_Locked(c *C) {
+	var locked bool
+	locked = t.flock.Locked()
+	c.Check(locked, Equals, false)
+}
+
+func (t *TestSuite) TestFlock_RLocked(c *C) {
+	var locked bool
+	locked = t.flock.RLocked()
+	c.Check(locked, Equals, false)
+}
+
+func (t *TestSuite) TestFlock_String(c *C) {
+	var str string
+	str = t.flock.String()
+	c.Assert(str, Equals, t.path)
+}
+
+func (t *TestSuite) TestFlock_TryLock(c *C) {
+	c.Assert(t.flock.Locked(), Equals, false)
+	c.Assert(t.flock.RLocked(), Equals, false)
+
+	var locked bool
+	var err error
+
+	locked, err = t.flock.TryLock()
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, true)
+	c.Check(t.flock.Locked(), Equals, true)
+	c.Check(t.flock.RLocked(), Equals, false)
+
+	locked, err = t.flock.TryLock()
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, true)
+
+	// make sure we just return false with no error in cases
+	// where we would have been blocked
+	locked, err = flock.New(t.path).TryLock()
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, false)
+}
+
+func (t *TestSuite) TestFlock_TryRLock(c *C) {
+	c.Assert(t.flock.Locked(), Equals, false)
+	c.Assert(t.flock.RLocked(), Equals, false)
+
+	var locked bool
+	var err error
+
+	locked, err = t.flock.TryRLock()
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, true)
+	c.Check(t.flock.Locked(), Equals, false)
+	c.Check(t.flock.RLocked(), Equals, true)
+
+	locked, err = t.flock.TryRLock()
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, true)
+
+	// shared lock should not block.
+	flock2 := flock.New(t.path)
+	locked, err = flock2.TryRLock()
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, true)
+
+	// make sure we just return false with no error in cases
+	// where we would have been blocked
+	t.flock.Unlock()
+	flock2.Unlock()
+	t.flock.Lock()
+	locked, err = flock.New(t.path).TryRLock()
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, false)
+}
+
+func (t *TestSuite) TestFlock_TryLockContext(c *C) {
+	// happy path
+	ctx, cancel := context.WithCancel(context.Background())
+	locked, err := t.flock.TryLockContext(ctx, time.Second)
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, true)
+
+	// context already canceled
+	cancel()
+	locked, err = flock.New(t.path).TryLockContext(ctx, time.Second)
+	c.Assert(err, Equals, context.Canceled)
+	c.Check(locked, Equals, false)
+
+	// timeout
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	locked, err = flock.New(t.path).TryLockContext(ctx, time.Second)
+	c.Assert(err, Equals, context.DeadlineExceeded)
+	c.Check(locked, Equals, false)
+}
+
+func (t *TestSuite) TestFlock_TryRLockContext(c *C) {
+	// happy path
+	ctx, cancel := context.WithCancel(context.Background())
+	locked, err := t.flock.TryRLockContext(ctx, time.Second)
+	c.Assert(err, IsNil)
+	c.Check(locked, Equals, true)
+
+	// context already canceled
+	cancel()
+	locked, err = flock.New(t.path).TryRLockContext(ctx, time.Second)
+	c.Assert(err, Equals, context.Canceled)
+	c.Check(locked, Equals, false)
+
+	// timeout
+	t.flock.Unlock()
+	t.flock.Lock()
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	locked, err = flock.New(t.path).TryRLockContext(ctx, time.Second)
+	c.Assert(err, Equals, context.DeadlineExceeded)
+	c.Check(locked, Equals, false)
+}
+
+func (t *TestSuite) TestFlock_Unlock(c *C) {
+	var err error
+
+	err = t.flock.Unlock()
+	c.Assert(err, IsNil)
+
+	// get a lock for us to unlock
+	locked, err := t.flock.TryLock()
+	c.Assert(err, IsNil)
+	c.Assert(locked, Equals, true)
+	c.Assert(t.flock.Locked(), Equals, true)
+	c.Check(t.flock.RLocked(), Equals, false)
+
+	_, err = os.Stat(t.path)
+	c.Assert(os.IsNotExist(err), Equals, false)
+
+	err = t.flock.Unlock()
+	c.Assert(err, IsNil)
+	c.Check(t.flock.Locked(), Equals, false)
+	c.Check(t.flock.RLocked(), Equals, false)
+}
+
+func (t *TestSuite) TestFlock_Lock(c *C) {
+	c.Assert(t.flock.Locked(), Equals, false)
+	c.Check(t.flock.RLocked(), Equals, false)
+
+	var err error
+
+	err = t.flock.Lock()
+	c.Assert(err, IsNil)
+	c.Check(t.flock.Locked(), Equals, true)
+	c.Check(t.flock.RLocked(), Equals, false)
+
+	// test that the short-circuit works
+	err = t.flock.Lock()
+	c.Assert(err, IsNil)
+
+	//
+	// Test that Lock() is a blocking call
+	//
+	ch := make(chan error, 2)
+	gf := flock.New(t.path)
+	defer gf.Unlock()
+
+	go func(ch chan<- error) {
+		ch <- nil
+		ch <- gf.Lock()
+		close(ch)
+	}(ch)
+
+	errCh, ok := <-ch
+	c.Assert(ok, Equals, true)
+	c.Assert(errCh, IsNil)
+
+	err = t.flock.Unlock()
+	c.Assert(err, IsNil)
+
+	errCh, ok = <-ch
+	c.Assert(ok, Equals, true)
+	c.Assert(errCh, IsNil)
+	c.Check(t.flock.Locked(), Equals, false)
+	c.Check(t.flock.RLocked(), Equals, false)
+	c.Check(gf.Locked(), Equals, true)
+	c.Check(gf.RLocked(), Equals, false)
+}
+
+func (t *TestSuite) TestFlock_RLock(c *C) {
+	c.Assert(t.flock.Locked(), Equals, false)
+	c.Check(t.flock.RLocked(), Equals, false)
+
+	var err error
+
+	err = t.flock.RLock()
+	c.Assert(err, IsNil)
+	c.Check(t.flock.Locked(), Equals, false)
+	c.Check(t.flock.RLocked(), Equals, true)
+
+	// test that the short-circuit works
+	err = t.flock.RLock()
+	c.Assert(err, IsNil)
+
+	//
+	// Test that RLock() is a blocking call
+	//
+	ch := make(chan error, 2)
+	gf := flock.New(t.path)
+	defer gf.Unlock()
+
+	go func(ch chan<- error) {
+		ch <- nil
+		ch <- gf.RLock()
+		close(ch)
+	}(ch)
+
+	errCh, ok := <-ch
+	c.Assert(ok, Equals, true)
+	c.Assert(errCh, IsNil)
+
+	err = t.flock.Unlock()
+	c.Assert(err, IsNil)
+
+	errCh, ok = <-ch
+	c.Assert(ok, Equals, true)
+	c.Assert(errCh, IsNil)
+	c.Check(t.flock.Locked(), Equals, false)
+	c.Check(t.flock.RLocked(), Equals, false)
+	c.Check(gf.Locked(), Equals, false)
+	c.Check(gf.RLocked(), Equals, true)
+}

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_unix.go
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_unix.go
@@ -1,0 +1,195 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package flock
+
+import (
+	"os"
+	"syscall"
+)
+
+// Lock is a blocking call to try and take an exclusive file lock. It will wait
+// until it is able to obtain the exclusive file lock. It's recommended that
+// TryLock() be used over this function. This function may block the ability to
+// query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already exclusive-locked, this function short-circuits and returns
+// immediately assuming it can take the mutex lock.
+//
+// If the *Flock has a shared lock (RLock), this may transparently replace the
+// shared lock with an exclusive lock on some UNIX-like operating systems. Be
+// careful when using exclusive locks in conjunction with shared locks
+// (RLock()), because calling Unlock() may accidentally release the exclusive
+// lock that was once a shared lock.
+func (f *Flock) Lock() error {
+	return f.lock(&f.l, syscall.LOCK_EX)
+}
+
+// RLock is a blocking call to try and take a shared file lock. It will wait
+// until it is able to obtain the shared file lock. It's recommended that
+// TryRLock() be used over this function. This function may block the ability to
+// query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already shared-locked, this function short-circuits and returns
+// immediately assuming it can take the mutex lock.
+func (f *Flock) RLock() error {
+	return f.lock(&f.r, syscall.LOCK_SH)
+}
+
+func (f *Flock) lock(locked *bool, flag int) error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(); err != nil {
+			return err
+		}
+	}
+
+	if err := syscall.Flock(int(f.fh.Fd()), flag); err != nil {
+		shouldRetry, reopenErr := f.reopenFDOnError(err)
+		if reopenErr != nil {
+			return reopenErr
+		}
+
+		if !shouldRetry {
+			return err
+		}
+
+		if err = syscall.Flock(int(f.fh.Fd()), flag); err != nil {
+			return err
+		}
+	}
+
+	*locked = true
+	return nil
+}
+
+// Unlock is a function to unlock the file. This file takes a RW-mutex lock, so
+// while it is running the Locked() and RLocked() functions will be blocked.
+//
+// This function short-circuits if we are unlocked already. If not, it calls
+// syscall.LOCK_UN on the file and closes the file descriptor. It does not
+// remove the file from disk. It's up to your application to do.
+//
+// Please note, if your shared lock became an exclusive lock this may
+// unintentionally drop the exclusive lock if called by the consumer that
+// believes they have a shared lock. Please see Lock() for more details.
+func (f *Flock) Unlock() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	// if we aren't locked or if the lockfile instance is nil
+	// just return a nil error because we are unlocked
+	if (!f.l && !f.r) || f.fh == nil {
+		return nil
+	}
+
+	// mark the file as unlocked
+	if err := syscall.Flock(int(f.fh.Fd()), syscall.LOCK_UN); err != nil {
+		return err
+	}
+
+	f.fh.Close()
+
+	f.l = false
+	f.r = false
+	f.fh = nil
+
+	return nil
+}
+
+// TryLock is the preferred function for taking an exclusive file lock. This
+// function takes an RW-mutex lock before it tries to lock the file, so there is
+// the possibility that this function may block for a short time if another
+// goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking. If we are unable to get the exclusive
+// file lock, the function will return false instead of waiting for the lock. If
+// we get the lock, we also set the *Flock instance as being exclusive-locked.
+func (f *Flock) TryLock() (bool, error) {
+	return f.try(&f.l, syscall.LOCK_EX)
+}
+
+// TryRLock is the preferred function for taking a shared file lock. This
+// function takes an RW-mutex lock before it tries to lock the file, so there is
+// the possibility that this function may block for a short time if another
+// goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking. If we are unable to get the shared file
+// lock, the function will return false instead of waiting for the lock. If we
+// get the lock, we also set the *Flock instance as being share-locked.
+func (f *Flock) TryRLock() (bool, error) {
+	return f.try(&f.r, syscall.LOCK_SH)
+}
+
+func (f *Flock) try(locked *bool, flag int) (bool, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return true, nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(); err != nil {
+			return false, err
+		}
+	}
+
+	var retried bool
+retry:
+	err := syscall.Flock(int(f.fh.Fd()), flag|syscall.LOCK_NB)
+
+	switch err {
+	case syscall.EWOULDBLOCK:
+		return false, nil
+	case nil:
+		*locked = true
+		return true, nil
+	}
+	if !retried {
+		if shouldRetry, reopenErr := f.reopenFDOnError(err); reopenErr != nil {
+			return false, reopenErr
+		} else if shouldRetry {
+			retried = true
+			goto retry
+		}
+	}
+
+	return false, err
+}
+
+// reopenFDOnError determines whether we should reopen the file handle
+// in readwrite mode and try again. This comes from util-linux/sys-utils/flock.c:
+//  Since Linux 3.4 (commit 55725513)
+//  Probably NFSv4 where flock() is emulated by fcntl().
+func (f *Flock) reopenFDOnError(err error) (bool, error) {
+	if err != syscall.EIO && err != syscall.EBADF {
+		return false, nil
+	}
+	if st, err := f.fh.Stat(); err == nil {
+		// if the file is able to be read and written
+		if st.Mode()&0600 == 0600 {
+			f.fh.Close()
+			f.fh = nil
+
+			// reopen in read-write mode and set the filehandle
+			fh, err := os.OpenFile(f.path, os.O_CREATE|os.O_RDWR, os.FileMode(0600))
+			if err != nil {
+				return false, err
+			}
+			f.fh = fh
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_winapi.go
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_winapi.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package flock
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32, _         = syscall.LoadLibrary("kernel32.dll")
+	procLockFileEx, _   = syscall.GetProcAddress(kernel32, "LockFileEx")
+	procUnlockFileEx, _ = syscall.GetProcAddress(kernel32, "UnlockFileEx")
+)
+
+const (
+	winLockfileFailImmediately = 0x00000001
+	winLockfileExclusiveLock   = 0x00000002
+	winLockfileSharedLock      = 0x00000000
+)
+
+// Use of 0x00000000 for the shared lock is a guess based on some the MS Windows
+// `LockFileEX` docs, which document the `LOCKFILE_EXCLUSIVE_LOCK` flag as:
+//
+// > The function requests an exclusive lock. Otherwise, it requests a shared
+// > lock.
+//
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
+
+func lockFileEx(handle syscall.Handle, flags uint32, reserved uint32, numberOfBytesToLockLow uint32, numberOfBytesToLockHigh uint32, offset *syscall.Overlapped) (bool, syscall.Errno) {
+	r1, _, errNo := syscall.Syscall6(
+		uintptr(procLockFileEx),
+		6,
+		uintptr(handle),
+		uintptr(flags),
+		uintptr(reserved),
+		uintptr(numberOfBytesToLockLow),
+		uintptr(numberOfBytesToLockHigh),
+		uintptr(unsafe.Pointer(offset)))
+
+	if r1 != 1 {
+		if errNo == 0 {
+			return false, syscall.EINVAL
+		}
+
+		return false, errNo
+	}
+
+	return true, 0
+}
+
+func unlockFileEx(handle syscall.Handle, reserved uint32, numberOfBytesToLockLow uint32, numberOfBytesToLockHigh uint32, offset *syscall.Overlapped) (bool, syscall.Errno) {
+	r1, _, errNo := syscall.Syscall6(
+		uintptr(procUnlockFileEx),
+		5,
+		uintptr(handle),
+		uintptr(reserved),
+		uintptr(numberOfBytesToLockLow),
+		uintptr(numberOfBytesToLockHigh),
+		uintptr(unsafe.Pointer(offset)),
+		0)
+
+	if r1 != 1 {
+		if errNo == 0 {
+			return false, syscall.EINVAL
+		}
+
+		return false, errNo
+	}
+
+	return true, 0
+}

--- a/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_windows.go
+++ b/traffic_ops_ort/vendor/github.com/gofrs/flock/flock_windows.go
@@ -1,0 +1,140 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package flock
+
+import (
+	"syscall"
+)
+
+// ErrorLockViolation is the error code returned from the Windows syscall when a
+// lock would block and you ask to fail immediately.
+const ErrorLockViolation syscall.Errno = 0x21 // 33
+
+// Lock is a blocking call to try and take an exclusive file lock. It will wait
+// until it is able to obtain the exclusive file lock. It's recommended that
+// TryLock() be used over this function. This function may block the ability to
+// query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already locked, this function short-circuits and returns
+// immediately assuming it can take the mutex lock.
+func (f *Flock) Lock() error {
+	return f.lock(&f.l, winLockfileExclusiveLock)
+}
+
+// RLock is a blocking call to try and take a shared file lock. It will wait
+// until it is able to obtain the shared file lock. It's recommended that
+// TryRLock() be used over this function. This function may block the ability to
+// query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already locked, this function short-circuits and returns
+// immediately assuming it can take the mutex lock.
+func (f *Flock) RLock() error {
+	return f.lock(&f.r, winLockfileSharedLock)
+}
+
+func (f *Flock) lock(locked *bool, flag uint32) error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(); err != nil {
+			return err
+		}
+	}
+
+	if _, errNo := lockFileEx(syscall.Handle(f.fh.Fd()), flag, 0, 1, 0, &syscall.Overlapped{}); errNo > 0 {
+		return errNo
+	}
+
+	*locked = true
+	return nil
+}
+
+// Unlock is a function to unlock the file. This file takes a RW-mutex lock, so
+// while it is running the Locked() and RLocked() functions will be blocked.
+//
+// This function short-circuits if we are unlocked already. If not, it calls
+// UnlockFileEx() on the file and closes the file descriptor. It does not remove
+// the file from disk. It's up to your application to do.
+func (f *Flock) Unlock() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	// if we aren't locked or if the lockfile instance is nil
+	// just return a nil error because we are unlocked
+	if (!f.l && !f.r) || f.fh == nil {
+		return nil
+	}
+
+	// mark the file as unlocked
+	if _, errNo := unlockFileEx(syscall.Handle(f.fh.Fd()), 0, 1, 0, &syscall.Overlapped{}); errNo > 0 {
+		return errNo
+	}
+
+	f.fh.Close()
+
+	f.l = false
+	f.r = false
+	f.fh = nil
+
+	return nil
+}
+
+// TryLock is the preferred function for taking an exclusive file lock. This
+// function does take a RW-mutex lock before it tries to lock the file, so there
+// is the possibility that this function may block for a short time if another
+// goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking. If we are unable to get the exclusive
+// file lock, the function will return false instead of waiting for the lock. If
+// we get the lock, we also set the *Flock instance as being exclusive-locked.
+func (f *Flock) TryLock() (bool, error) {
+	return f.try(&f.l, winLockfileExclusiveLock)
+}
+
+// TryRLock is the preferred function for taking a shared file lock. This
+// function does take a RW-mutex lock before it tries to lock the file, so there
+// is the possibility that this function may block for a short time if another
+// goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking. If we are unable to get the shared file
+// lock, the function will return false instead of waiting for the lock. If we
+// get the lock, we also set the *Flock instance as being shared-locked.
+func (f *Flock) TryRLock() (bool, error) {
+	return f.try(&f.r, winLockfileSharedLock)
+}
+
+func (f *Flock) try(locked *bool, flag uint32) (bool, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return true, nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(); err != nil {
+			return false, err
+		}
+	}
+
+	_, errNo := lockFileEx(syscall.Handle(f.fh.Fd()), flag|winLockfileFailImmediately, 0, 1, 0, &syscall.Overlapped{})
+
+	if errNo > 0 {
+		if errNo == ErrorLockViolation || errNo == syscall.ERROR_IO_PENDING {
+			return false, nil
+		}
+
+		return false, errNo
+	}
+
+	*locked = true
+
+	return true, nil
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/.travis.yml
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+  - "1.11"
+  - "1.12"
+  - tip
+
+script:
+  - go test -v ./...

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/AUTHORS
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/AUTHORS
@@ -1,0 +1,1 @@
+Paul Borman <paul@borman.com>

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/CONTRIBUTING.md
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# How to contribute
+
+We definitely welcome patches and contribution to this project!
+
+### Legal requirements
+
+In order to protect both you and ourselves, you will need to sign the
+[Contributor License Agreement](https://cla.developers.google.com/clas).
+
+You may have already signed it for other Google projects.

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/LICENSE
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2017 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google, nor the names of other
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/README.md
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/README.md
@@ -1,0 +1,226 @@
+# getopt ![build status](https://travis-ci.org/pborman/getopt.svg?branch=master)
+
+Package getopt provides traditional getopt processing for implementing
+commands that use traditional command lines.  The standard Go flag package
+cannot be used to write a program that parses flags the way ls or ssh does,
+for example.  There are two versions, v1 and v2, both named getopt, that
+use the following import paths:
+
+```
+	"github.com/pborman/getopt"     // version 1
+	"github.com/pborman/getopt/v2"  // version 2
+```
+
+This README describes version 2 of the package, which has a simplified API.
+
+## Usage
+
+Getopt supports functionality found in both the standard BSD getopt as well
+as (one of the many versions of) the GNU getopt_long.  Being a Go package,
+this package makes common usage easy, but still enables more controlled usage
+if needed.
+
+Typical usage:
+
+```
+	Declare flags and have getopt return pointers to the values.
+	helpFlag := getopt.Bool('?', "display help")
+	cmdFlag := getopt.StringLong("command", 'c', "default", "the command")
+
+	Declare flags against existing variables.
+	var (
+		fileName = "/the/default/path"
+		timeout = time.Second * 5
+		verbose bool
+	)
+	func init() {
+		getopt.Flag(&verbose, 'v', "be verbose")
+		getopt.FlagLong(&fileName, "path", 0, "the path")
+		getopt.FlagLong(&timeout, "timeout", 't', "some timeout")
+	}
+
+	func main() {
+		Parse the program arguments
+		getopt.Parse()
+		Get the remaining positional parameters
+		args := getopt.Args()
+		...
+```
+
+If you don't want the program to exit on error, use getopt.Getopt:
+
+```
+		err := getopt.Getopt(nil)
+		if err != nil {
+			code to handle error
+			fmt.Fprintln(os.Stderr, err)
+		}
+```
+
+## Flag Syntax
+
+Support is provided for both short (-f) and long (--flag) options.  A single
+option may have both a short and a long name.  Each option may be a flag or a
+value.  A value takes an argument.
+
+Declaring no long names causes this package to process arguments like the
+traditional BSD getopt.
+
+Short flags may be combined into a single parameter.  For example, "-a -b -c"
+may also be expressed "-abc".  Long flags must stand on their own "--alpha
+--beta"
+
+Values require an argument.  For short options the argument may either be
+immediately following the short name or as the next argument.  Only one short
+value may be combined with short flags in a single argument; the short value
+must be after all short flags.  For example, if f is a flag and v is a value,
+then:
+
+```
+	-vvalue    (sets v to "value")
+	-v value   (sets v to "value")
+	-fvvalue   (sets f, and sets v to "value")
+	-fv value  (sets f, and sets v to "value")
+	-vf value  (set v to "f" and value is the first parameter)
+```
+
+For the long value option val:
+
+```
+	--val value (sets val to "value")
+	--val=value (sets val to "value")
+	--valvalue  (invalid option "valvalue")
+```
+
+Values with an optional value only set the value if the value is part of the
+same argument.  In any event, the option count is increased and the option is
+marked as seen.
+
+```
+	-v -f          (sets v and f as being seen)
+	-vvalue -f     (sets v to "value" and sets f)
+	--val -f       (sets v and f as being seen)
+	--val=value -f (sets v to "value" and sets f)
+```
+
+There is no convience function defined for making the value optional.  The
+SetOptional method must be called on the actual Option.
+
+```
+	v := String("val", 'v', "", "the optional v")
+	Lookup("v").SetOptional()
+
+	var s string
+	FlagLong(&s, "val", 'v', "the optional v).SetOptional()
+```
+
+Parsing continues until the first non-option or "--" is encountered.
+
+The short name "-" can be used, but it either is specified as "-" or as part
+of a group of options, for example "-f-".  If there are no long options
+specified then "--f" could also be used.  If "-" is not declared as an option
+then the single "-" will also terminate the option processing but unlike
+"--", the "-" will be part of the remaining arguments.
+
+## Advanced Usage
+
+Normally the parsing is performed by calling the Parse function.  If it is
+important to see the order of the options then the Getopt function should be
+used.  The standard Parse function does the equivalent of:
+
+```
+func Parse() {
+	if err := getopt.Getopt(os.Args, nil); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		s.usage()
+		os.Exit(1)
+	}
+}
+```
+
+When calling Getopt it is the responsibility of the caller to print any
+errors.
+
+Normally the default option set, CommandLine, is used.  Other option sets may
+be created with New.
+
+After parsing, the sets Args will contain the non-option arguments.  If an
+error is encountered then Args will begin with argument that caused the
+error.
+
+It is valid to call a set's Parse a second time to amend the current set of
+flags or values.  As an example:
+
+```
+	var a = getopt.Bool('a', "", "The a flag")
+	var b = getopt.Bool('b', "", "The a flag")
+	var cmd = ""
+
+	var opts = getopt.CommandLine
+
+	opts.Parse(os.Args)
+	if opts.NArgs() > 0 {
+		cmd = opts.Arg(0)
+		opts.Parse(opts.Args())
+	}
+```
+
+If called with set to { "prog", "-a", "cmd", "-b", "arg" } then both a and
+b would be set, cmd would be set to "cmd", and opts.Args() would return {
+"arg" }.
+
+Unless an option type explicitly prohibits it, an option may appear more than
+once in the arguments.  The last value provided to the option is the value.
+
+## Builtin Types
+
+The Flag and FlagLong functions support most standard Go types.  For the
+list, see the description of FlagLong below for a list of supported types.
+
+There are also helper routines to allow single line flag declarations.  These
+types are: Bool, Counter, Duration, Enum, Int16, Int32, Int64, Int, List,
+Signed, String, Uint16, Uint32, Uint64, Uint, and Unsigned.
+
+Each comes in a short and long flavor, e.g., Bool and BoolLong and include
+functions to set the flags on the standard command line or for a specific Set
+of flags.
+
+Except for the Counter, Enum, Signed and Unsigned types, all of these types
+can be declared using Flag and FlagLong by passing in a pointer to the
+appropriate type.
+
+## Declaring New Flag Types
+
+A pointer to any type that implements the Value interface may be passed to
+Flag or FlagLong.
+
+## VALUEHELP
+
+All non-flag options are created with a "valuehelp" as the last parameter.
+Valuehelp should be 0, 1, or 2 strings.  The first string, if provided, is
+the usage message for the option.  If the second string, if provided, is the
+name to use for the value when displaying the usage.  If not provided the
+term "value" is assumed.
+
+The usage message for the option created with
+
+```
+	StringLong("option", 'o', "defval", "a string of letters")
+```
+
+is
+
+```
+	-o, -option=value
+```
+while the usage message for the option created with
+
+```
+	StringLong("option", 'o', "defval", "a string of letters", "string")
+```
+
+is
+
+```
+	-o, -option=string
+```

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/bool.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/bool.go
@@ -1,0 +1,74 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+)
+
+type boolValue bool
+
+func (b *boolValue) Set(value string, opt Option) error {
+	switch strings.ToLower(value) {
+	case "", "1", "true", "on", "t":
+		*b = true
+	case "0", "false", "off", "f":
+		*b = false
+	default:
+		return fmt.Errorf("invalid value for bool %s: %q", opt.Name(), value)
+	}
+	return nil
+}
+
+func (b *boolValue) String() string {
+	if *b {
+		return "true"
+	}
+	return "false"
+}
+
+// Bool creates a flag option that is a bool.  Bools normally do not take a
+// value however one can be assigned by using the long form of the option:
+//
+//  --option=true
+//  --o=false
+//
+// Its value is case insenstive and one of true, false, t, f, on, off, t and 0.
+func Bool(name rune, helpvalue ...string) *bool {
+	return CommandLine.Bool(name, helpvalue...)
+}
+
+func (s *Set) Bool(name rune, helpvalue ...string) *bool {
+	var p bool
+	s.BoolVarLong(&p, "", name, helpvalue...)
+	return &p
+}
+
+func BoolLong(name string, short rune, helpvalue ...string) *bool {
+	return CommandLine.BoolLong(name, short, helpvalue...)
+}
+
+func (s *Set) BoolLong(name string, short rune, helpvalue ...string) *bool {
+	var p bool
+	s.BoolVarLong(&p, name, short, helpvalue...)
+	return &p
+}
+
+func BoolVar(p *bool, name rune, helpvalue ...string) Option {
+	return CommandLine.BoolVar(p, name, helpvalue...)
+}
+
+func (s *Set) BoolVar(p *bool, name rune, helpvalue ...string) Option {
+	return s.BoolVarLong(p, "", name, helpvalue...)
+}
+
+func BoolVarLong(p *bool, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.BoolVarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) BoolVarLong(p *bool, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*boolValue)(p), name, short, helpvalue...).SetFlag()
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/bool_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/bool_test.go
@@ -1,0 +1,106 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var boolTests = []struct {
+	where string
+	in    []string
+	f     bool
+	fc    int
+	opt   bool
+	optc  int
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		false, 0,
+		false, 0,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-f", "--opt"},
+		true, 1,
+		true, 1,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--f", "--opt"},
+		true, 1,
+		true, 1,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-ff", "-f", "--opt", "--opt"},
+		true, 3,
+		true, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--opt", "--opt=false"},
+		false, 0,
+		false, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-f", "false"},
+		true, 1,
+		false, 0,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-f=false"},
+		true, 1,
+		false, 0,
+		"test: unknown option: -=\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-f", "false"},
+		true, 1,
+		false, 0,
+		"",
+	},
+}
+
+func TestBool(t *testing.T) {
+	for x, tt := range boolTests {
+		reset()
+		f := Bool('f')
+		opt := BoolLong("opt", 0)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *f, tt.f; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.opt; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := GetCount('f'), tt.fc; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := GetCount("opt"), tt.optc; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/breakup_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/breakup_test.go
@@ -1,0 +1,34 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"testing"
+)
+
+var breakupTests = []struct {
+	in  string
+	max int
+	out []string
+}{
+	{"", 8, []string{}},
+	{"a fox", 8, []string{"a fox"}},
+	{"a foxhound is sly", 2, []string{"a", "foxhound", "is", "sly"}},
+	{"a foxhound is sly", 5, []string{"a", "foxhound", "is", "sly"}},
+	{"a foxhound is sly", 6, []string{"a", "foxhound", "is sly"}},
+	{"a foxhound is sly", 7, []string{"a", "foxhound", "is sly"}},
+	{"a foxhound is sly", 8, []string{"a", "foxhound", "is sly"}},
+	{"a foxhound is sly", 9, []string{"a", "foxhound", "is sly"}},
+	{"a foxhound is sly", 10, []string{"a foxhound", "is sly"}},
+}
+
+func TestBreakup(t *testing.T) {
+	for x, tt := range breakupTests {
+		out := breakup(tt.in, tt.max)
+		if badSlice(out, tt.out) {
+			t.Errorf("#%d: got %v, want %v", x, out, tt.out)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/counter.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/counter.go
@@ -1,0 +1,81 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type counterValue int
+
+func (b *counterValue) Set(value string, opt Option) error {
+	if value == "" {
+		*b++
+	} else {
+		v, err := strconv.ParseInt(value, 0, strconv.IntSize)
+		if err != nil {
+			if e, ok := err.(*strconv.NumError); ok {
+				switch e.Err {
+				case strconv.ErrRange:
+					err = fmt.Errorf("value out of range: %s", value)
+				case strconv.ErrSyntax:
+					err = fmt.Errorf("not a valid number: %s", value)
+				}
+			}
+			return err
+		}
+		*b = counterValue(v)
+	}
+	return nil
+}
+
+func (b *counterValue) String() string {
+	return strconv.Itoa(int(*b))
+}
+
+// Counter creates a counting flag stored as an int.  Each time the option
+// is seen while parsing the value is incremented.  The value of the counter
+// may be explicitly set by using the long form:
+//
+//  --counter=5
+//  --c=5
+//
+// Further instances of the option will increment from the set value.
+func Counter(name rune, helpvalue ...string) *int {
+	return CommandLine.Counter(name, helpvalue...)
+}
+
+func (s *Set) Counter(name rune, helpvalue ...string) *int {
+	var p int
+	s.CounterVarLong(&p, "", name, helpvalue...)
+	return &p
+}
+
+func CounterLong(name string, short rune, helpvalue ...string) *int {
+	return CommandLine.CounterLong(name, short, helpvalue...)
+}
+
+func (s *Set) CounterLong(name string, short rune, helpvalue ...string) *int {
+	var p int
+	s.CounterVarLong(&p, name, short, helpvalue...)
+	return &p
+}
+
+func CounterVar(p *int, name rune, helpvalue ...string) Option {
+	return CommandLine.CounterVar(p, name, helpvalue...)
+}
+
+func (s *Set) CounterVar(p *int, name rune, helpvalue ...string) Option {
+	return s.CounterVarLong(p, "", name, helpvalue...)
+}
+
+func CounterVarLong(p *int, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.CounterVarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) CounterVarLong(p *int, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*counterValue)(p), name, short, helpvalue...).SetFlag()
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/counter_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/counter_test.go
@@ -1,0 +1,91 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var counterTests = []struct {
+	where string
+	in    []string
+	c     int
+	cnt   int
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		0,
+		0,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-c", "--cnt"},
+		1,
+		1,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-cc", "-c", "--cnt", "--cnt"},
+		3,
+		2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--c=17", "--cnt=42"},
+		17,
+		42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--cnt=false"},
+		0, 0,
+		"test: not a valid number: false\n",
+	},
+}
+
+func TestCounter(t *testing.T) {
+	for x, tt := range counterTests {
+		reset()
+		c := Counter('c')
+		cnt := CounterLong("cnt", 0)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *c, tt.c; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *cnt, tt.cnt; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+
+	reset()
+	c := 5
+	opt := CounterVar(&c, 'c')
+	parse([]string{"test", "-c"})
+	if c != 6 {
+		t.Errorf("got %d, want 6", c)
+	}
+	if opt.Count() != 1 {
+		t.Errorf("got %d, want 1", c)
+	}
+	Reset()
+	if c != 5 {
+		t.Errorf("got %d, want 5", c)
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/duration.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/duration.go
@@ -1,0 +1,56 @@
+// Copyright 2015 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "time"
+
+type durationValue time.Duration
+
+func (d *durationValue) Set(value string, opt Option) error {
+	v, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	*d = durationValue(v)
+	return nil
+}
+
+func (d *durationValue) String() string {
+	return time.Duration(*d).String()
+}
+
+// Duration creates an option that parses its value as a time.Duration.
+func Duration(name rune, value time.Duration, helpvalue ...string) *time.Duration {
+	return CommandLine.Duration(name, value, helpvalue...)
+}
+
+func (s *Set) Duration(name rune, value time.Duration, helpvalue ...string) *time.Duration {
+	return s.DurationLong("", name, value, helpvalue...)
+}
+
+func DurationLong(name string, short rune, value time.Duration, helpvalue ...string) *time.Duration {
+	return CommandLine.DurationLong(name, short, value, helpvalue...)
+}
+
+func (s *Set) DurationLong(name string, short rune, value time.Duration, helpvalue ...string) *time.Duration {
+	s.DurationVarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func DurationVar(p *time.Duration, name rune, helpvalue ...string) Option {
+	return CommandLine.DurationVar(p, name, helpvalue...)
+}
+
+func (s *Set) DurationVar(p *time.Duration, name rune, helpvalue ...string) Option {
+	return s.DurationVarLong(p, "", name, helpvalue...)
+}
+
+func DurationVarLong(p *time.Duration, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.DurationVarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) DurationVarLong(p *time.Duration, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*durationValue)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/duration_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/duration_test.go
@@ -1,0 +1,73 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+var durationTests = []struct {
+	where string
+	in    []string
+	d     time.Duration
+	dur   time.Duration
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-d", "1s", "--duration", "2s"},
+		time.Second, 2 * time.Second,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-d1s", "-d2s"},
+		2 * time.Second, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-d1"},
+		17, 42,
+		"test: time: missing unit in duration 1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "--duration", "foo"},
+		17, 42,
+		"test: time: invalid duration foo\n",
+	},
+}
+
+func TestDuration(t *testing.T) {
+	for x, tt := range durationTests {
+		reset()
+		d := Duration('d', 17)
+		opt := DurationLong("duration", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *d, tt.d; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.dur; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/enum.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/enum.go
@@ -1,0 +1,73 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "errors"
+
+type enumValue string
+
+var enumValues = make(map[*enumValue]map[string]struct{})
+
+func (s *enumValue) Set(value string, opt Option) error {
+	es, ok := enumValues[s]
+	if !ok || es == nil {
+		return errors.New("this option has no values")
+	}
+	if _, ok := es[value]; !ok {
+		return errors.New("invalid value: " + value)
+	}
+	*s = enumValue(value)
+	return nil
+}
+
+func (s *enumValue) String() string {
+	return string(*s)
+}
+
+// Enum creates an option that can only be set to one of the enumerated strings
+// passed in values.  Passing nil or an empty slice results in an option that
+// will always fail.
+func Enum(name rune, values []string, helpvalue ...string) *string {
+	return CommandLine.Enum(name, values, helpvalue...)
+}
+
+func (s *Set) Enum(name rune, values []string, helpvalue ...string) *string {
+	var p string
+	s.EnumVarLong(&p, "", name, values, helpvalue...)
+	return &p
+}
+
+func EnumLong(name string, short rune, values []string, helpvalue ...string) *string {
+	return CommandLine.EnumLong(name, short, values, helpvalue...)
+}
+
+func (s *Set) EnumLong(name string, short rune, values []string, helpvalue ...string) *string {
+	var p string
+	s.EnumVarLong(&p, name, short, values, helpvalue...)
+	return &p
+}
+
+// EnumVar creates an enum option that defaults to the starting value of *p.
+// If *p is not found in values then a reset of this option will fail.
+func EnumVar(p *string, name rune, values []string, helpvalue ...string) Option {
+	return CommandLine.EnumVar(p, name, values, helpvalue...)
+}
+
+func (s *Set) EnumVar(p *string, name rune, values []string, helpvalue ...string) Option {
+	return s.EnumVarLong(p, "", name, values, helpvalue...)
+}
+
+func EnumVarLong(p *string, name string, short rune, values []string, helpvalue ...string) Option {
+	return CommandLine.EnumVarLong(p, name, short, values, helpvalue...)
+}
+
+func (s *Set) EnumVarLong(p *string, name string, short rune, values []string, helpvalue ...string) Option {
+	m := make(map[string]struct{})
+	for _, v := range values {
+		m[v] = struct{}{}
+	}
+	enumValues[(*enumValue)(p)] = m
+	return s.VarLong((*enumValue)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/enum_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/enum_test.go
@@ -1,0 +1,66 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var enumTests = []struct {
+	where  string
+	in     []string
+	values []string
+	out    string
+	err    string
+}{
+	{
+		loc(),
+		nil,
+		[]string{},
+		"",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-e", "val1"},
+		[]string{"val1", "val2"},
+		"val1",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-e", "val1", "-e", "val2"},
+		[]string{"val1", "val2"},
+		"val2",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-e", "val3"},
+		[]string{"val1", "val2"},
+		"",
+		"test: invalid value: val3\n",
+	},
+}
+
+func TestEnum(t *testing.T) {
+	for x, tt := range enumTests {
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		reset()
+		e := Enum('e', tt.values)
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if *e != tt.out {
+			t.Errorf("%s: got %v, want %v", tt.where, *e, tt.out)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/error.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/error.go
@@ -1,0 +1,93 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "fmt"
+
+// An Error is returned by Getopt when it encounters an error.
+type Error struct {
+	ErrorCode        // General reason of failure.
+	Err       error  // The actual error.
+	Parameter string // Parameter passed to option, if any
+	Name      string // Option that cause error, if any
+}
+
+// Error returns the error message, implementing the error interface.
+func (i *Error) Error() string { return i.Err.Error() }
+
+// An ErrorCode indicates what sort of error was encountered.
+type ErrorCode int
+
+const (
+	NoError          = ErrorCode(iota)
+	UnknownOption    // an invalid option was encountered
+	MissingParameter // the options parameter is missing
+	ExtraParameter   // a value was set to a long flag
+	Invalid          // attempt to set an invalid value
+)
+
+func (e ErrorCode) String() string {
+	switch e {
+	case UnknownOption:
+		return "unknow option"
+	case MissingParameter:
+		return "missing argument"
+	case ExtraParameter:
+		return "unxpected value"
+	case Invalid:
+		return "error setting value"
+	}
+	return "unknown error"
+}
+
+// unknownOption returns an Error indicating an unknown option was
+// encountered.
+func unknownOption(name interface{}) *Error {
+	i := &Error{ErrorCode: UnknownOption}
+	switch n := name.(type) {
+	case rune:
+		if n == '-' {
+			i.Name = "-"
+		} else {
+			i.Name = "-" + string(n)
+		}
+	case string:
+		i.Name = "--" + n
+	}
+	i.Err = fmt.Errorf("unknown option: %s", i.Name)
+	return i
+}
+
+// missingArg returns an Error inidicating option o was not passed
+// a required paramter.
+func missingArg(o Option) *Error {
+	return &Error{
+		ErrorCode: MissingParameter,
+		Name:      o.Name(),
+		Err:       fmt.Errorf("missing parameter for %s", o.Name()),
+	}
+}
+
+// extraArg returns an Error inidicating option o was passed the
+// unexpected paramter value.
+func extraArg(o Option, value string) *Error {
+	return &Error{
+		ErrorCode: ExtraParameter,
+		Name:      o.Name(),
+		Parameter: value,
+		Err:       fmt.Errorf("unexpected parameter passed to %s: %q", o.Name(), value),
+	}
+}
+
+// setError returns an Error inidicating option o and the specified
+// error while setting it to value.
+func setError(o Option, value string, err error) *Error {
+	return &Error{
+		ErrorCode: Invalid,
+		Name:      o.Name(),
+		Parameter: value,
+		Err:       err,
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/getopt.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/getopt.go
@@ -1,0 +1,536 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package getopt (v1) provides traditional getopt processing for implementing
+// commands that use traditional command lines.  The standard Go flag package
+// cannot be used to write a program that parses flags the way ls or ssh does,
+// for example.
+//
+// A new version of this package (v2) (whose package name is also getopt) is
+// available as:
+//
+//	"github.com/pborman/getopt/v2"
+//
+// Getopt supports functionality found in both the standard BSD getopt as well
+// as (one of the many versions of) the GNU getopt_long.  Being a Go package,
+// this package makes common usage easy, but still enables more controlled usage
+// if needed.
+//
+// Typical usage:
+//
+//	// Declare the flags to be used
+//	helpFlag := getopt.Bool('?', "display help")
+//	cmdFlag := getopt.StringLong("command", 'c', "", "the command")
+//
+//	func main() {
+//		// Parse the program arguments
+//		getopt.Parse()
+//		// Get the remaining positional parameters
+//		args := getopt.Args()
+//
+// If you don't want the program to exit on error, use getopt.Getopt:
+//
+//		err := getopt.Getopt(nil)
+//		if err != nil {
+//			// code to handle error
+//			fmt.Fprintln(os.Stderr, err)
+//		}
+//
+// Support is provided for both short (-f) and long (--flag) options.  A single
+// option may have both a short and a long name.  Each option may be a flag or a
+// value.  A value takes an argument.
+//
+// Declaring no long names causes this package to process arguments like the
+// traditional BSD getopt.
+//
+// Short flags may be combined into a single parameter.  For example, "-a -b -c"
+// may also be expressed "-abc".  Long flags must stand on their own "--alpha
+// --beta"
+//
+// Values require an argument.  For short options the argument may either be
+// immediately following the short name or as the next argument.  Only one short
+// value may be combined with short flags in a single argument; the short value
+// must be after all short flags.  For example, if f is a flag and v is a value,
+// then:
+//
+//  -vvalue    (sets v to "value")
+//  -v value   (sets v to "value")
+//  -fvvalue   (sets f, and sets v to "value")
+//  -fv value  (sets f, and sets v to "value")
+//  -vf value  (set v to "f" and value is the first parameter)
+//
+// For the long value option val:
+//
+//  --val value (sets val to "value")
+//  --val=value (sets val to "value")
+//  --valvalue  (invalid option "valvalue")
+//
+// Values with an optional value only set the value if the value is part of the
+// same argument.  In any event, the option count is increased and the option is
+// marked as seen.
+//
+//  -v -f          (sets v and f as being seen)
+//  -vvalue -f     (sets v to "value" and sets f)
+//  --val -f       (sets v and f as being seen)
+//  --val=value -f (sets v to "value" and sets f)
+//
+// There is no convience function defined for making the value optional.  The
+// SetOptional method must be called on the actual Option.
+//
+//  v := String("val", 'v', "", "the optional v")
+//  Lookup("v").SetOptional()
+//
+//  var s string
+//  StringVar(&s, "val", 'v', "the optional v).SetOptional()
+//
+// Parsing continues until the first non-option or "--" is encountered.
+//
+// The short name "-" can be used, but it either is specified as "-" or as part
+// of a group of options, for example "-f-".  If there are no long options
+// specified then "--f" could also be used.  If "-" is not declared as an option
+// then the single "-" will also terminate the option processing but unlike
+// "--", the "-" will be part of the remaining arguments.
+//
+// Normally the parsing is performed by calling the Parse function.  If it is
+// important to see the order of the options then the Getopt function should be
+// used.  The standard Parse function does the equivalent of:
+//
+// func Parse() {
+//	if err := getopt.Getopt(os.Args, nil); err != nil {
+//		fmt.Fprintln(os.Stderr, err)
+//		s.usage()
+//		os.Exit(1)
+//	}
+//
+// When calling Getopt it is the responsibility of the caller to print any
+// errors.
+//
+// Normally the default option set, CommandLine, is used.  Other option sets may
+// be created with New.
+//
+// After parsing, the sets Args will contain the non-option arguments.  If an
+// error is encountered then Args will begin with argument that caused the
+// error.
+//
+// It is valid to call a set's Parse a second time to amend the current set of
+// flags or values.  As an example:
+//
+//  var a = getopt.Bool('a', "", "The a flag")
+//  var b = getopt.Bool('b', "", "The a flag")
+//  var cmd = ""
+//
+//  var opts = getopt.CommandLine
+//
+//  opts.Parse(os.Args)
+//  if opts.NArgs() > 0 {
+//      cmd = opts.Arg(0)
+//      opts.Parse(opts.Args())
+//  }
+//
+// If called with set to { "prog", "-a", "cmd", "-b", "arg" } then both and and
+// b would be set, cmd would be set to "cmd", and opts.Args() would return {
+// "arg" }.
+//
+// Unless an option type explicitly prohibits it, an option may appear more than
+// once in the arguments.  The last value provided to the option is the value.
+//
+// SYNTAX
+//
+// For each option type there are an unfortunately large number of ways, 8, to
+// initialize the option.  This number is derived from three attributes:
+//
+//  1)  Short or Long name
+//  2)  Normal vs Var
+//  3)  Command Line vs Option Set
+//
+// The first two variations provide 4 signature:
+//
+//  Option(name rune, [value type,]  helpvalue... string)
+//  OptionLong(name string, short rune, [value type,]  helpvalue... string)
+//  OptionVar(p *type, name rune, helpvalue... string)
+//  OptionVarLong(p *type, name string, short rune, helpvalue... string)
+//
+// Foo can actually be expressed in terms of FooLong:
+//
+//  func Foo(name rune, value type, helpvalue... string) *type {
+//      return FooLong("", name, value, helpvalue...)
+//  }
+//
+// Normally Foo is used, unless long options are needed.  Setting short to 0
+// creates only a long option.
+//
+// The difference bentween Foo and FooVar is that you pass a pointer, p, to the
+// location of the value to FooVar.  The default value is simply *p.  The
+// initial value of *p is the defaut value of the option.
+//
+// Foo is actually a wrapper around FooVar:
+//
+//  func Foo(name rune, value type, helpvalue... string) *type {
+//      p := value
+//      FooVar(&p, name, helpvalue... string)
+//      return &p
+//  }
+//
+//
+// The third variation provides a top-level function and a method on a Set:
+//
+//  func Option(...)
+//  func (s *Set) Option(...)
+//
+// The top-level function is simply:
+//
+//  func Option(...) *type {
+//      return CommandLine.Option(...) {
+//  }
+//
+// To simplfy documentation, typically only the main top-level function is fully
+// documented.  The others will have documentation when there is something
+// special about them.
+//
+// VALUEHELP
+//
+// All non-flag options are created with a "valuehelp" as the last parameter.
+// Valuehelp should be 0, 1, or 2 strings.  The first string, if provided, is
+// the usage message for the option.  If the second string, if provided, is the
+// name to use for the value when displaying the usage.  If not provided the
+// term "value" is assumed.
+//
+// The usage message for the option created with
+//
+//  StringLong("option", 'o', "defval", "a string of letters")
+//
+// is
+//
+//  -o, -option=value
+//
+//  StringLong("option", 'o', "defval", "a string of letters", "string")
+//
+// is
+//
+//  -o, -option=string
+package getopt
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strings"
+)
+
+// stderr allows tests to capture output to standard error.
+var stderr io.Writer = os.Stderr
+
+// exit allows tests to capture an os.Exit call
+var exit = os.Exit
+
+// DisplayWidth is used to determine where to split usage long lines.
+var DisplayWidth = 80
+
+// HelpColumn is the maximum column position that help strings start to display
+// at.  If the option usage is too long then the help string will be displayed
+// on the next line.  For example:
+//
+//   -a   this is the a flag
+//   -u, --under=location
+//        the u flag's usage is quite long
+var HelpColumn = 20
+
+// PrintUsage prints the usage of the program to w.
+func (s *Set) PrintUsage(w io.Writer) {
+	sort.Sort(s.options)
+	flags := ""
+
+	// Build up the list of short flag names and also compute
+	// how to display the option in the longer help listing.
+	// We also keep track of the longest option usage string
+	// that is no more than HelpColumn-3 bytes (at which point
+	// we use two lines to display the help).  The three
+	// is for the leading space and the two spaces before the
+	// help string.
+	for _, opt := range s.options {
+		if opt.name == "" {
+			opt.name = "value"
+		}
+		if opt.uname == "" {
+			opt.uname = opt.usageName()
+		}
+		if opt.flag && opt.short != 0 && opt.short != '-' {
+			flags += string(opt.short)
+		}
+	}
+
+	var opts []string
+
+	// The short option - is special
+	if s.shortOptions['-'] != nil {
+		opts = append(opts, "-")
+	}
+
+	// If we have a bundle of flags, add them to the list
+	if flags != "" {
+		opts = append(opts, "-"+flags)
+	}
+
+	// Now append all the long options and options that require
+	// values.
+	for _, opt := range s.options {
+		if opt.flag {
+			if opt.short != 0 {
+				continue
+			}
+			flags = "--" + opt.long
+		} else if opt.short != 0 {
+			flags = "-" + string(opt.short) + " " + opt.name
+		} else {
+			flags = "--" + string(opt.long) + " " + opt.name
+		}
+		opts = append(opts, flags)
+	}
+	flags = strings.Join(opts, "] [")
+	if flags != "" {
+		flags = " [" + flags + "]"
+	}
+	if s.parameters != "" {
+		flags += " " + s.parameters
+	}
+	fmt.Fprintf(w, "Usage: %s%s\n", s.program, flags)
+	s.PrintOptions(w)
+}
+
+// PrintOptions prints the list of options in s to w.
+func (s *Set) PrintOptions(w io.Writer) {
+	sort.Sort(s.options)
+	max := 4
+	for _, opt := range s.options {
+		if opt.name == "" {
+			opt.name = "value"
+		}
+		if opt.uname == "" {
+			opt.uname = opt.usageName()
+		}
+		if max < len(opt.uname) && len(opt.uname) <= HelpColumn-3 {
+			max = len(opt.uname)
+		}
+	}
+	// Now print one or more usage lines per option.
+	for _, opt := range s.options {
+		if opt.uname != "" {
+			opt.help = strings.TrimSpace(opt.help)
+			if len(opt.help) == 0 {
+				fmt.Fprintf(w, " %s\n", opt.uname)
+				continue
+			}
+			help := strings.Split(opt.help, "\n")
+			// If they did not put in newlines then we will insert
+			// them to keep the help messages from wrapping.
+			if len(help) == 1 {
+				help = breakup(help[0], DisplayWidth-HelpColumn)
+			}
+			if len(opt.uname) <= max {
+				fmt.Fprintf(w, " %-*s  %s\n", max, opt.uname, help[0])
+				help = help[1:]
+			} else {
+				fmt.Fprintf(w, " %s\n", opt.uname)
+			}
+			for _, s := range help {
+				fmt.Fprintf(w, " %-*s  %s\n", max, " ", s)
+			}
+		}
+	}
+}
+
+// breakup breaks s up into strings no longer than max bytes.
+func breakup(s string, max int) []string {
+	var a []string
+
+	for {
+		// strip leading spaces
+		for len(s) > 0 && s[0] == ' ' {
+			s = s[1:]
+		}
+		// If the option is no longer than the max just return it
+		if len(s) <= max {
+			if len(s) != 0 {
+				a = append(a, s)
+			}
+			return a
+		}
+		x := max
+		for s[x] != ' ' {
+			// the first word is too long?!
+			if x == 0 {
+				x = max
+				for x < len(s) && s[x] != ' ' {
+					x++
+				}
+				if x == len(s) {
+					x--
+				}
+				break
+			}
+			x--
+		}
+		for s[x] == ' ' {
+			x--
+		}
+		a = append(a, s[:x+1])
+		s = s[x+1:]
+	}
+}
+
+// Parse uses Getopt to parse args using the options set for s.  The first
+// element of args is used to assign the program for s if it is not yet set.  On
+// error, Parse displays the error message as well as a usage message on
+// standard error and then exits the program.
+func (s *Set) Parse(args []string) {
+	if err := s.Getopt(args, nil); err != nil {
+		fmt.Fprintln(stderr, err)
+		s.usage()
+		exit(1)
+	}
+}
+
+// Parse uses Getopt to parse args using the options set for s.  The first
+// element of args is used to assign the program for s if it is not yet set.
+// Getop calls fn, if not nil, for each option parsed.
+//
+// Getopt returns nil when all options have been processed (a non-option
+// argument was encountered, "--" was encountered, or fn returned false).
+//
+// On error getopt returns a refernce to an InvalidOption (which implements
+// the error interface).
+func (s *Set) Getopt(args []string, fn func(Option) bool) (err error) {
+	s.State = InProgress
+	defer func() {
+		if s.State == InProgress {
+			switch {
+			case err != nil:
+				s.State = Failure
+			case len(s.args) == 0:
+				s.State = EndOfArguments
+			default:
+				s.State = Unknown
+			}
+		}
+	}()
+	if fn == nil {
+		fn = func(Option) bool { return true }
+	}
+	if len(args) == 0 {
+		return nil
+	}
+
+	if s.program == "" {
+		s.program = path.Base(args[0])
+	}
+	args = args[1:]
+Parsing:
+	for len(args) > 0 {
+		arg := args[0]
+		s.args = args
+		args = args[1:]
+
+		// end of options?
+		if arg == "" || arg[0] != '-' {
+			s.State = EndOfOptions
+			return nil
+		}
+
+		if arg == "-" {
+			goto ShortParsing
+		}
+
+		// explicitly request end of options?
+		if arg == "--" {
+			s.args = args
+			s.State = DashDash
+			return nil
+		}
+
+		// Long option processing
+		if len(s.longOptions) > 0 && arg[1] == '-' {
+			e := strings.IndexRune(arg, '=')
+			var value string
+			if e > 0 {
+				value = arg[e+1:]
+				arg = arg[:e]
+			}
+			opt := s.longOptions[arg[2:]]
+			// If we are processing long options then --f is -f
+			// if f is not defined as a long option.
+			// This lets you say --f=false
+			if opt == nil && len(arg[2:]) == 1 {
+				opt = s.shortOptions[rune(arg[2])]
+			}
+			if opt == nil {
+				return unknownOption(arg[2:])
+			}
+			opt.isLong = true
+			// If we require an option and did not have an =
+			// then use the next argument as an option.
+			if !opt.flag && e < 0 && !opt.optional {
+				if len(args) == 0 {
+					return missingArg(opt)
+				}
+				value = args[0]
+				args = args[1:]
+			}
+			opt.count++
+
+			if err := opt.value.Set(value, opt); err != nil {
+				return setError(opt, value, err)
+			}
+
+			if !fn(opt) {
+				s.State = Terminated
+				return nil
+			}
+			continue Parsing
+		}
+
+		// Short option processing
+		arg = arg[1:] // strip -
+	ShortParsing:
+		for i, c := range arg {
+			opt := s.shortOptions[c]
+			if opt == nil {
+				// In traditional getopt, if - is not registered
+				// as an option, a lone - is treated as
+				// if there were a -- in front of it.
+				if arg == "-" {
+					s.State = Dash
+					return nil
+				}
+				return unknownOption(c)
+			}
+			opt.isLong = false
+			opt.count++
+			var value string
+			if !opt.flag {
+				value = arg[1+i:]
+				if value == "" && !opt.optional {
+					if len(args) == 0 {
+						return missingArg(opt)
+					}
+					value = args[0]
+					args = args[1:]
+				}
+			}
+			if err := opt.value.Set(value, opt); err != nil {
+				return setError(opt, value, err)
+			}
+			if !fn(opt) {
+				s.State = Terminated
+				return nil
+			}
+			if !opt.flag {
+				continue Parsing
+			}
+		}
+	}
+	s.args = []string{}
+	return nil
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/int.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/int.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type intValue int
+
+func (i *intValue) Set(value string, opt Option) error {
+	v, err := strconv.ParseInt(value, 0, strconv.IntSize)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	*i = intValue(v)
+	return nil
+}
+
+func (i *intValue) String() string {
+	return strconv.FormatInt(int64(*i), 10)
+}
+
+// Int creates an option that parses its value as an integer.
+func Int(name rune, value int, helpvalue ...string) *int {
+	return CommandLine.Int(name, value, helpvalue...)
+}
+
+func (s *Set) Int(name rune, value int, helpvalue ...string) *int {
+	return s.IntLong("", name, value, helpvalue...)
+}
+
+func IntLong(name string, short rune, value int, helpvalue ...string) *int {
+	return CommandLine.IntLong(name, short, value, helpvalue...)
+}
+
+func (s *Set) IntLong(name string, short rune, value int, helpvalue ...string) *int {
+	s.IntVarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func IntVar(p *int, name rune, helpvalue ...string) Option {
+	return CommandLine.IntVar(p, name, helpvalue...)
+}
+
+func (s *Set) IntVar(p *int, name rune, helpvalue ...string) Option {
+	return s.IntVarLong(p, "", name, helpvalue...)
+}
+
+func IntVarLong(p *int, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.IntVarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) IntVarLong(p *int, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*intValue)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/int16.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/int16.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type int16Value int16
+
+func (i *int16Value) Set(value string, opt Option) error {
+	v, err := strconv.ParseInt(value, 0, 16)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	*i = int16Value(v)
+	return nil
+}
+
+func (i *int16Value) String() string {
+	return strconv.FormatInt(int64(*i), 10)
+}
+
+// Int16 creates an option that parses its value as an int16.
+func Int16(name rune, value int16, helpvalue ...string) *int16 {
+	return CommandLine.Int16(name, value, helpvalue...)
+}
+
+func (s *Set) Int16(name rune, value int16, helpvalue ...string) *int16 {
+	return s.Int16Long("", name, value, helpvalue...)
+}
+
+func Int16Long(name string, short rune, value int16, helpvalue ...string) *int16 {
+	return CommandLine.Int16Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Int16Long(name string, short rune, value int16, helpvalue ...string) *int16 {
+	s.Int16VarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func Int16Var(p *int16, name rune, helpvalue ...string) Option {
+	return CommandLine.Int16Var(p, name, helpvalue...)
+}
+
+func (s *Set) Int16Var(p *int16, name rune, helpvalue ...string) Option {
+	return s.Int16VarLong(p, "", name, helpvalue...)
+}
+
+func Int16VarLong(p *int16, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.Int16VarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) Int16VarLong(p *int16, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*int16Value)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/int16_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/int16_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var int16Tests = []struct {
+	where string
+	in    []string
+	i     int16
+	int16 int16
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--int16", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--int16=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestInt16(t *testing.T) {
+	for x, tt := range int16Tests {
+		reset()
+		i := Int16('i', 17)
+		opt := Int16Long("int16", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.int16; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/int32.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/int32.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type int32Value int32
+
+func (i *int32Value) Set(value string, opt Option) error {
+	v, err := strconv.ParseInt(value, 0, 32)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	*i = int32Value(v)
+	return nil
+}
+
+func (i *int32Value) String() string {
+	return strconv.FormatInt(int64(*i), 10)
+}
+
+// Int32 creates an option that parses its value as an int32.
+func Int32(name rune, value int32, helpvalue ...string) *int32 {
+	return CommandLine.Int32(name, value, helpvalue...)
+}
+
+func (s *Set) Int32(name rune, value int32, helpvalue ...string) *int32 {
+	return s.Int32Long("", name, value, helpvalue...)
+}
+
+func Int32Long(name string, short rune, value int32, helpvalue ...string) *int32 {
+	return CommandLine.Int32Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Int32Long(name string, short rune, value int32, helpvalue ...string) *int32 {
+	s.Int32VarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func Int32Var(p *int32, name rune, helpvalue ...string) Option {
+	return CommandLine.Int32Var(p, name, helpvalue...)
+}
+
+func (s *Set) Int32Var(p *int32, name rune, helpvalue ...string) Option {
+	return s.Int32VarLong(p, "", name, helpvalue...)
+}
+
+func Int32VarLong(p *int32, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.Int32VarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) Int32VarLong(p *int32, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*int32Value)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/int32_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/int32_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var int32Tests = []struct {
+	where string
+	in    []string
+	i     int32
+	int32 int32
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--int32", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--int32=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestInt32(t *testing.T) {
+	for x, tt := range int32Tests {
+		reset()
+		i := Int32('i', 17)
+		opt := Int32Long("int32", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.int32; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/int64.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/int64.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type int64Value int64
+
+func (i *int64Value) Set(value string, opt Option) error {
+	v, err := strconv.ParseInt(value, 0, 64)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	*i = int64Value(v)
+	return nil
+}
+
+func (i *int64Value) String() string {
+	return strconv.FormatInt(int64(*i), 10)
+}
+
+// Int64 creates an option that parses its value as an int64.
+func Int64(name rune, value int64, helpvalue ...string) *int64 {
+	return CommandLine.Int64(name, value, helpvalue...)
+}
+
+func (s *Set) Int64(name rune, value int64, helpvalue ...string) *int64 {
+	return s.Int64Long("", name, value, helpvalue...)
+}
+
+func Int64Long(name string, short rune, value int64, helpvalue ...string) *int64 {
+	return CommandLine.Int64Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Int64Long(name string, short rune, value int64, helpvalue ...string) *int64 {
+	s.Int64VarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func Int64Var(p *int64, name rune, helpvalue ...string) Option {
+	return CommandLine.Int64Var(p, name, helpvalue...)
+}
+
+func (s *Set) Int64Var(p *int64, name rune, helpvalue ...string) Option {
+	return s.Int64VarLong(p, "", name, helpvalue...)
+}
+
+func Int64VarLong(p *int64, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.Int64VarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) Int64VarLong(p *int64, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*int64Value)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/int64_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/int64_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var int64Tests = []struct {
+	where string
+	in    []string
+	i     int64
+	int64 int64
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--int64", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--int64=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestInt64(t *testing.T) {
+	for x, tt := range int64Tests {
+		reset()
+		i := Int64('i', 17)
+		opt := Int64Long("int64", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.int64; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/int_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/int_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var intTests = []struct {
+	where string
+	in    []string
+	i     int
+	int   int
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--int", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--int=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestInt(t *testing.T) {
+	for x, tt := range intTests {
+		reset()
+		i := Int('i', 17)
+		opt := IntLong("int", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.int; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/list.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/list.go
@@ -1,0 +1,69 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "strings"
+
+type listValue []string
+
+func (s *listValue) Set(value string, opt Option) error {
+	a := strings.Split(value, ",")
+	// If this is the first time we are seen then nil out the
+	// default value.
+	if opt.Count() <= 1 {
+		*s = nil
+	}
+	*s = append(*s, a...)
+	return nil
+}
+
+func (s *listValue) String() string {
+	return strings.Join([]string(*s), ",")
+}
+
+// List creates an option that returns a slice of strings.  The parameters
+// passed are converted from a comma seperated value list into a slice.
+// Subsequent occurrences append to the list.
+func List(name rune, helpvalue ...string) *[]string {
+	return CommandLine.List(name, helpvalue...)
+}
+
+func (s *Set) List(name rune, helpvalue ...string) *[]string {
+	p := []string{}
+	s.ListVar(&p, name, helpvalue...)
+	return &p
+}
+
+func ListLong(name string, short rune, helpvalue ...string) *[]string {
+	return CommandLine.ListLong(name, short, helpvalue...)
+}
+
+func (s *Set) ListLong(name string, short rune, helpvalue ...string) *[]string {
+	p := []string{}
+	s.ListVarLong(&p, name, short, helpvalue...)
+	return &p
+}
+
+// ListVar creats a list option and places the values in p.  If p is pointing
+// to a list of values then those are considered the default values.  The first
+// time name is seen in the options the list will be set to list specified by
+// the parameter to the option.  Subsequent instances of the option will append
+// to the list.
+func ListVar(p *[]string, name rune, helpvalue ...string) Option {
+	return CommandLine.ListVar(p, name, helpvalue...)
+}
+
+func (s *Set) ListVar(p *[]string, name rune, helpvalue ...string) Option {
+	return s.ListVarLong(p, "", name, helpvalue...)
+}
+
+func ListVarLong(p *[]string, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.ListVarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) ListVarLong(p *[]string, name string, short rune, helpvalue ...string) Option {
+	opt := s.VarLong((*listValue)(p), name, short, helpvalue...)
+	return opt
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/list_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/list_test.go
@@ -1,0 +1,99 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "testing"
+
+var listTests = []struct {
+	where   string
+	in      []string
+	l, list []string
+	err     string
+}{
+	{
+		loc(),
+		[]string{},
+		nil, nil,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-l", "one"},
+		[]string{"one"}, nil,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-lone", "-ltwo"},
+		[]string{"one", "two"}, nil,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--list", "one"},
+		nil, []string{"one"},
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--list=one", "--list=two"},
+		nil, []string{"one", "two"},
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--list=one,two"},
+		nil, []string{"one", "two"},
+		"",
+	},
+}
+
+func TestList(t *testing.T) {
+	for _, tt := range listTests {
+		reset()
+		l := List('l')
+		list := ListLong("list", 0)
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if badSlice(*l, tt.l) {
+			t.Errorf("%s: got s = %q, want %q", tt.where, *l, tt.l)
+		}
+		if badSlice(*list, tt.list) {
+			t.Errorf("%s: got s = %q, want %q", tt.where, *list, tt.list)
+		}
+	}
+}
+
+func TestDefaultList(t *testing.T) {
+	reset()
+	list := []string{"d1", "d2", "d3"}
+	ListVar(&list, 'l')
+	parse([]string{"test"})
+
+	want := []string{"d1", "d2", "d3"}
+	if badSlice(list, want) {
+		t.Errorf("got s = %q, want %q", list, want)
+	}
+
+	parse([]string{"test", "-l", "one"})
+	want = []string{"one"}
+	if badSlice(list, want) {
+		t.Errorf("got s = %q, want %q", list, want)
+	}
+
+	parse([]string{"test", "-l", "two"})
+	want = []string{"one", "two"}
+	if badSlice(list, want) {
+		t.Errorf("got s = %q, want %q", list, want)
+	}
+	Lookup('l').Reset()
+	want = []string{"d1", "d2", "d3"}
+	if badSlice(list, want) {
+		t.Errorf("got s = %q, want %q", list, want)
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/option.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/option.go
@@ -1,0 +1,193 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// An Option can be either a Flag or a Value
+type Option interface {
+	// Name returns the name of the option.  If the option has been seen
+	// then the last way it was referenced (short or long) is returned
+	// otherwise if there is a short name then this will be the short name
+	// as a string, else it will be the long name.
+	Name() string
+
+	// IsFlag returns true if Option is a flag.
+	IsFlag() bool
+
+	// Seen returns true if the flag was seen.
+	Seen() bool
+
+	// Count returns the number of times the flag was seen.
+	Count() int
+
+	// String returns the last value the option was set to.
+	String() string
+
+	// Value returns the Value of the option.
+	Value() Value
+
+	// SetOptional makes the value optional.  The option and value are
+	// always a single argument.  Either --option or --option=value.  In
+	// the former case the value of the option does not change but the Set()
+	// will return true and the value returned by Count() is incremented.
+	// The short form is either -o or -ovalue.  SetOptional returns
+	// the Option
+	SetOptional() Option
+
+	// SetFlag makes the value a flag.  Flags are boolean values and
+	// normally do not taken a value.  They are set to true when seen.
+	// If a value is passed in the long form then it must be on, case
+	// insenstive, one of "true", "false", "t", "f", "on", "off", "1", "0".
+	// SetFlag returns the Option
+	SetFlag() Option
+
+	// Reset resets the state of the option so it appears it has not
+	// yet been seen, including resetting the value of the option
+	// to its original default state.
+	Reset()
+}
+
+type option struct {
+	short    rune   // 0 means no short name
+	long     string // "" means no long name
+	isLong   bool   // True if they used the long name
+	flag     bool   // true if a boolean flag
+	defval   string // default value
+	optional bool   // true if we take an optional value
+	help     string // help message
+	where    string // file where the option was defined
+	value    Value  // current value of option
+	count    int    // number of times we have seen this option
+	name     string // name of the value (for usage)
+	uname    string // name of the option (for usage)
+}
+
+// usageName returns the name of the option for printing usage lines in one
+// of the following forms:
+//
+//  -f
+//      --flag
+//  -f, --flag
+//  -s value
+//      --set=value
+//  -s, --set=value
+func (o *option) usageName() string {
+	// Don't print help messages if we have none and there is only one
+	// way to specify the option.
+	if o.help == "" && (o.short == 0 || o.long == "") {
+		return ""
+	}
+	n := ""
+
+	switch {
+	case o.short != 0 && o.long == "":
+		n = "-" + string(o.short)
+	case o.short == 0 && o.long != "":
+		n = "    --" + o.long
+	case o.short != 0 && o.long != "":
+		n = "-" + string(o.short) + ", --" + o.long
+	}
+
+	switch {
+	case o.flag:
+		return n
+	case o.optional:
+		return n + "[=" + o.name + "]"
+	case o.long != "":
+		return n + "=" + o.name
+	}
+	return n + " " + o.name
+}
+
+// sortName returns the name to sort the option on.
+func (o *option) sortName() string {
+	if o.short != 0 {
+		return string(o.short) + o.long
+	}
+	return o.long[:1] + o.long
+}
+
+func (o *option) Seen() bool          { return o.count > 0 }
+func (o *option) Count() int          { return o.count }
+func (o *option) IsFlag() bool        { return o.flag }
+func (o *option) String() string      { return o.value.String() }
+func (o *option) SetOptional() Option { o.optional = true; return o }
+func (o *option) SetFlag() Option     { o.flag = true; return o }
+
+func (o *option) Value() Value {
+	if o == nil {
+		return nil
+	}
+	return o.value
+}
+
+func (o *option) Name() string {
+	if !o.isLong && o.short != 0 {
+		return "-" + string(o.short)
+	}
+	return "--" + o.long
+}
+
+// Reset rests an option so that it appears it has not yet been seen.
+func (o *option) Reset() {
+	o.isLong = false
+	o.count = 0
+	o.value.Set(o.defval, o)
+}
+
+type optionList []*option
+
+func (ol optionList) Len() int      { return len(ol) }
+func (ol optionList) Swap(i, j int) { ol[i], ol[j] = ol[j], ol[i] }
+func (ol optionList) Less(i, j int) bool {
+	// first check the short names (or the first letter of the long name)
+	// If they are not equal (case insensitive) then we have our answer
+	n1 := ol[i].sortName()
+	n2 := ol[j].sortName()
+	l1 := strings.ToLower(n1)
+	l2 := strings.ToLower(n2)
+	if l1 < l2 {
+		return true
+	}
+	if l2 < l1 {
+		return false
+	}
+	return n1 < n2
+}
+
+// AddOption add the option o to set CommandLine if o is not already in set
+// CommandLine.
+func AddOption(o Option) {
+	CommandLine.AddOption(o)
+}
+
+// AddOption add the option o to set s if o is not already in set s.
+func (s *Set) AddOption(o Option) {
+	opt := o.(*option)
+	for _, eopt := range s.options {
+		if opt == eopt {
+			return
+		}
+	}
+	if opt.short != 0 {
+		if oo, ok := s.shortOptions[opt.short]; ok {
+			fmt.Fprintf(stderr, "%s: -%c already declared at %s\n", opt.where, opt.short, oo.where)
+			exit(1)
+		}
+		s.shortOptions[opt.short] = opt
+	}
+	if opt.long != "" {
+		if oo, ok := s.longOptions[opt.long]; ok {
+			fmt.Fprintf(stderr, "%s: --%s already declared at %s\n", opt.where, opt.long, oo.where)
+			exit(1)
+		}
+		s.longOptions[opt.long] = opt
+	}
+	s.options = append(s.options, opt)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/set.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/set.go
@@ -1,0 +1,268 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"io"
+	"os"
+	"sort"
+)
+
+// A Termination says why Getopt returned.
+type State int
+
+const (
+	InProgress     = State(iota) // Getopt is still running
+	Dash                         // Returned on "-"
+	DashDash                     // Returned on "--"
+	EndOfOptions                 // End of options reached
+	EndOfArguments               // No more arguments
+	Terminated                   // Terminated by callback function
+	Failure                      // Terminated due to error
+	Unknown                      // Indicates internal error
+)
+
+type Set struct {
+	State // State of getopt
+
+	// args are the parameters remaining after parsing the optoins.
+	args []string
+
+	// program is the name of the program for usage and error messages.
+	// If not set it will automatically be set to the base name of the
+	// first argument passed to parse.
+	program string
+
+	// parameters is what is displayed on the usage line after displaying
+	// the various options.
+	parameters string
+
+	usage func() // usage should print the programs usage and exit.
+
+	shortOptions map[rune]*option
+	longOptions  map[string]*option
+	options      optionList
+}
+
+// New returns a newly created option set.
+func New() *Set {
+	s := &Set{
+		shortOptions: make(map[rune]*option),
+		longOptions:  make(map[string]*option),
+		parameters:   "[parameters ...]",
+	}
+
+	s.usage = func() {
+		s.PrintUsage(stderr)
+	}
+	return s
+}
+
+// The default set of command-line options.
+var CommandLine = New()
+
+// PrintUsage calls PrintUsage in the default option set.
+func PrintUsage(w io.Writer) { CommandLine.PrintUsage(w) }
+
+// Usage calls the usage function in the default option set.
+func Usage() { CommandLine.usage() }
+
+// Parse calls Parse in the default option set with the command line arguments
+// found in os.Args.
+func Parse() { CommandLine.Parse(os.Args) }
+
+// Getops returns the result of calling Getop in the default option set with the
+// command line arguments found in os.Args.  The fn function, which may be nil,
+// is passed to Getopt.
+func Getopt(fn func(Option) bool) error { return CommandLine.Getopt(os.Args, fn) }
+
+// Arg returns the n'th command-line argument. Arg(0) is the first remaining
+// argument after options have been processed.
+func Arg(n int) string {
+	if n >= 0 && n < len(CommandLine.args) {
+		return CommandLine.args[n]
+	}
+	return ""
+}
+
+// Arg returns the n'th argument. Arg(0) is the first remaining
+// argument after options have been processed.
+func (s *Set) Arg(n int) string {
+	if n >= 0 && n < len(s.args) {
+		return s.args[n]
+	}
+	return ""
+}
+
+// Args returns the non-option command line arguments.
+func Args() []string {
+	return CommandLine.args
+}
+
+// Args returns the non-option arguments.
+func (s *Set) Args() []string {
+	return s.args
+}
+
+// NArgs returns the number of non-option command line arguments.
+func NArgs() int {
+	return len(CommandLine.args)
+}
+
+// NArgs returns the number of non-option arguments.
+func (s *Set) NArgs() int {
+	return len(s.args)
+}
+
+// SetParameters sets the parameters string for printing the command line
+// usage.  It defaults to "[parameters ...]"
+func SetParameters(parameters string) {
+	CommandLine.parameters = parameters
+}
+
+// SetParameters sets the parameters string for printing the s's usage.
+// It defaults to "[parameters ...]"
+func (s *Set) SetParameters(parameters string) {
+	s.parameters = parameters
+}
+
+// SetProgram sets the program name to program.  Nomrally it is determined
+// from the zeroth command line argument (see os.Args).
+func SetProgram(program string) {
+	CommandLine.program = program
+}
+
+// SetProgram sets s's program name to program.  Nomrally it is determined
+// from the zeroth argument passed to Getopt or Parse.
+func (s *Set) SetProgram(program string) {
+	s.program = program
+}
+
+// SetUsage sets the function used by Parse to display the commands usage
+// on error.  It defaults to calling PrintUsage(os.Stderr).
+func SetUsage(usage func()) {
+	CommandLine.usage = usage
+}
+
+// SetUsage sets the function used by Parse to display usage on error.  It
+// defaults to calling f.PrintUsage(os.Stderr).
+func (s *Set) SetUsage(usage func()) {
+	s.usage = usage
+}
+
+// Lookup returns the Option associated with name.  Name should either be
+// a rune (the short name) or a string (the long name).
+func Lookup(name interface{}) Option {
+	return CommandLine.Lookup(name)
+}
+
+// Lookup returns the Option associated with name in s.  Name should either be
+// a rune (the short name) or a string (the long name).
+func (s *Set) Lookup(name interface{}) Option {
+	switch v := name.(type) {
+	case rune:
+		return s.shortOptions[v]
+	case int:
+		return s.shortOptions[rune(v)]
+	case string:
+		return s.longOptions[v]
+	}
+	return nil
+}
+
+// IsSet returns true if the Option associated with name was seen while
+// parsing the command line arguments.  Name should either be a rune (the
+// short name) or a string (the long name).
+func IsSet(name interface{}) bool {
+	return CommandLine.IsSet(name)
+}
+
+// IsSet returns true if the Option associated with name was seen while
+// parsing s.  Name should either be a rune (the short name) or a string (the
+// long name).
+func (s *Set) IsSet(name interface{}) bool {
+	if opt := s.Lookup(name); opt != nil {
+		return opt.Seen()
+	}
+	return false
+}
+
+// GetCount returns the number of times the Option associated with name has been
+// seen while parsing the command line arguments.  Name should either be a rune
+// (the short name) or a string (the long name).
+func GetCount(name interface{}) int {
+	return CommandLine.GetCount(name)
+}
+
+// GetCount returns the number of times the Option associated with name has been
+// seen while parsing s's arguments.  Name should either be a rune (the short
+// name) or a string (the long name).
+func (s *Set) GetCount(name interface{}) int {
+	if opt := s.Lookup(name); opt != nil {
+		return opt.Count()
+	}
+	return 0
+}
+
+// GetValue returns the final value set to the command-line Option with name.
+// If the option has not been seen while parsing s then the default value is
+// returned.  Name should either be a rune (the short name) or a string (the
+// long name).
+func GetValue(name interface{}) string {
+	return CommandLine.GetValue(name)
+}
+
+// GetValue returns the final value set to the Option in s associated with name.
+// If the option has not been seen while parsing s then the default value is
+// returned.  Name should either be a rune (the short name) or a string (the
+// long name).
+func (s *Set) GetValue(name interface{}) string {
+	if opt := s.Lookup(name); opt != nil {
+		return opt.String()
+	}
+	return ""
+}
+
+// Visit visits the command-line options in lexicographical order, calling fn
+// for each. It visits only those options that have been set.
+func Visit(fn func(Option)) { CommandLine.Visit(fn) }
+
+// Visit visits the options in s in lexicographical order, calling fn
+// for each. It visits only those options that have been set.
+func (s *Set) Visit(fn func(Option)) {
+	sort.Sort(s.options)
+	for _, opt := range s.options {
+		if opt.count > 0 {
+			fn(opt)
+		}
+	}
+}
+
+// VisitAll visits the options in s in lexicographical order, calling fn
+// for each. It visits all options, even those not set.
+func VisitAll(fn func(Option)) { CommandLine.VisitAll(fn) }
+
+// VisitAll visits the command-line flags in lexicographical order, calling fn
+// for each. It visits all flags, even those not set.
+func (s *Set) VisitAll(fn func(Option)) {
+	sort.Sort(s.options)
+	for _, opt := range s.options {
+		fn(opt)
+	}
+}
+
+// Reset resets all the command line options to the initial state so it
+// appears none of them have been seen.
+func Reset() {
+	CommandLine.Reset()
+}
+
+// Reset resets all the options in s to the initial state so it
+// appears none of them have been seen.
+func (s *Set) Reset() {
+	for _, opt := range s.options {
+		opt.Reset()
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/signed.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/signed.go
@@ -1,0 +1,110 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type signed int64
+
+type SignedLimit struct {
+	Base int   // Base for conversion as per strconv.ParseInt
+	Bits int   // Number of bits as per strconv.ParseInt
+	Min  int64 // Minimum allowed value if both Min and Max are not 0
+	Max  int64 // Maximum allowed value if both Min and Max are not 0
+}
+
+var signedLimits = make(map[*signed]*SignedLimit)
+
+func (n *signed) Set(value string, opt Option) error {
+	l := signedLimits[n]
+	if l == nil {
+		return fmt.Errorf("no limits defined for %s", opt.Name())
+	}
+	v, err := strconv.ParseInt(value, l.Base, l.Bits)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	if l.Min != 0 || l.Max != 0 {
+		if v < l.Min {
+			return fmt.Errorf("value out of range (<%v): %s", l.Min, value)
+		}
+		if v > l.Max {
+			return fmt.Errorf("value out of range (>%v): %s", l.Max, value)
+		}
+	}
+	*n = signed(v)
+	return nil
+}
+
+func (n *signed) String() string {
+	l := signedLimits[n]
+	if l != nil && l.Base != 0 {
+		return strconv.FormatInt(int64(*n), l.Base)
+	}
+	return strconv.FormatInt(int64(*n), 10)
+}
+
+// Signed creates an option that is stored in an int64 and is constrained
+// by the limits pointed to by l.  The Max and Min values are only used if
+// at least one of the values are not 0.   If Base is 0, the base is implied by
+// the string's prefix: base 16 for "0x", base 8 for "0", and base 10 otherwise.
+func Signed(name rune, value int64, l *SignedLimit, helpvalue ...string) *int64 {
+	return CommandLine.Signed(name, value, l, helpvalue...)
+}
+
+func (s *Set) Signed(name rune, value int64, l *SignedLimit, helpvalue ...string) *int64 {
+	return s.SignedLong("", name, value, l, helpvalue...)
+}
+
+func SignedLong(name string, short rune, value int64, l *SignedLimit, helpvalue ...string) *int64 {
+	return CommandLine.SignedLong(name, short, value, l, helpvalue...)
+}
+
+func (s *Set) SignedLong(name string, short rune, value int64, l *SignedLimit, helpvalue ...string) *int64 {
+	s.SignedVarLong(&value, name, short, l, helpvalue...)
+	return &value
+}
+
+func SignedVar(p *int64, name rune, l *SignedLimit, helpvalue ...string) Option {
+	return CommandLine.SignedVar(p, name, l, helpvalue...)
+}
+
+func (s *Set) SignedVar(p *int64, name rune, l *SignedLimit, helpvalue ...string) Option {
+	return s.SignedVarLong(p, "", name, l, helpvalue...)
+}
+
+func SignedVarLong(p *int64, name string, short rune, l *SignedLimit, helpvalue ...string) Option {
+	return CommandLine.SignedVarLong(p, name, short, l, helpvalue...)
+}
+
+func (s *Set) SignedVarLong(p *int64, name string, short rune, l *SignedLimit, helpvalue ...string) Option {
+	opt := s.VarLong((*signed)(p), name, short, helpvalue...)
+	if l.Base > 36 || l.Base == 1 || l.Base < 0 {
+		fmt.Fprintf(stderr, "invalid base for %s: %d\n", opt.Name(), l.Base)
+		exit(1)
+	}
+	if l.Bits < 0 || l.Bits > 64 {
+		fmt.Fprintf(stderr, "invalid bit size for %s: %d\n", opt.Name(), l.Bits)
+		exit(1)
+	}
+	if l.Min > l.Max {
+		fmt.Fprintf(stderr, "min greater than max for %s\n", opt.Name())
+		exit(1)
+	}
+	lim := *l
+	signedLimits[(*signed)(p)] = &lim
+	return opt
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/signed_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/signed_test.go
@@ -1,0 +1,97 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var signedNumberTests = []struct {
+	where string
+	in    []string
+	l     SignedLimit
+	out   int64
+	err   string
+}{
+	{
+		where: loc(),
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		SignedLimit{Base: 2, Bits: 5},
+		10,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		SignedLimit{Base: 2, Bits: 4},
+		0,
+		"test: value out of range: 1010\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "-1000"},
+		SignedLimit{Base: 2, Bits: 4},
+		-8,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "3"},
+		SignedLimit{Min: 4, Max: 6},
+		0,
+		"test: value out of range (<4): 3\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "4"},
+		SignedLimit{Min: 4, Max: 6},
+		4,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "5"},
+		SignedLimit{Min: 4, Max: 6},
+		5,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "6"},
+		SignedLimit{Min: 4, Max: 6},
+		6,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "7"},
+		SignedLimit{Min: 4, Max: 6},
+		0,
+		"test: value out of range (>6): 7\n",
+	},
+}
+
+func TestSigneds(t *testing.T) {
+	for x, tt := range signedNumberTests {
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		reset()
+		n := Signed('n', 0, &tt.l)
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if *n != tt.out {
+			t.Errorf("%s: got %v, want %v", tt.where, *n, tt.out)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/string.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/string.go
@@ -1,0 +1,53 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+type stringValue string
+
+func (s *stringValue) Set(value string, opt Option) error {
+	*s = stringValue(value)
+	return nil
+}
+
+func (s *stringValue) String() string {
+	return string(*s)
+}
+
+// String returns a value option that stores is value as a string.  The
+// initial value of the string is passed in value.
+func String(name rune, value string, helpvalue ...string) *string {
+	return CommandLine.String(name, value, helpvalue...)
+}
+
+func (s *Set) String(name rune, value string, helpvalue ...string) *string {
+	p := value
+	s.StringVarLong(&p, "", name, helpvalue...)
+	return &p
+}
+
+func StringLong(name string, short rune, value string, helpvalue ...string) *string {
+	return CommandLine.StringLong(name, short, value, helpvalue...)
+}
+
+func (s *Set) StringLong(name string, short rune, value string, helpvalue ...string) *string {
+	s.StringVarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func StringVar(p *string, name rune, helpvalue ...string) Option {
+	return CommandLine.StringVar(p, name, helpvalue...)
+}
+
+func (s *Set) StringVar(p *string, name rune, helpvalue ...string) Option {
+	return s.VarLong((*stringValue)(p), "", name, helpvalue...)
+}
+
+func StringVarLong(p *string, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.StringVarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) StringVarLong(p *string, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*stringValue)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/string_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/string_test.go
@@ -1,0 +1,77 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "testing"
+
+var stringTests = []struct {
+	where  string
+	in     []string
+	sout   string
+	optout string
+	err    string
+}{
+	{
+		loc(),
+		[]string{},
+		"one",
+		"two",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-s"},
+		"one",
+		"two",
+		"test: missing parameter for -s\n",
+	},
+	{
+		loc(),
+		[]string{"test", "--opt"},
+		"one",
+		"two",
+		"test: missing parameter for --opt\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-svalue", "--opt=option"},
+		"value",
+		"option",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-s", "value", "--opt", "option"},
+		"value",
+		"option",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-swrong", "--opt=wrong", "-s", "value", "--opt", "option"},
+		"value",
+		"option",
+		"",
+	},
+}
+
+func TestString(t *testing.T) {
+	for _, tt := range stringTests {
+		reset()
+		s := String('s', "one")
+		opt := StringLong("opt", 0, "two")
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if *s != tt.sout {
+			t.Errorf("%s: got s = %q, want %q", tt.where, *s, tt.sout)
+		}
+		if *opt != tt.optout {
+			t.Errorf("%s: got opt = %q, want %q", tt.where, *opt, tt.optout)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/uint.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/uint.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type uintValue uint
+
+func (i *uintValue) Set(value string, opt Option) error {
+	v, err := strconv.ParseUint(value, 0, strconv.IntSize)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	*i = uintValue(v)
+	return nil
+}
+
+func (i *uintValue) String() string {
+	return strconv.FormatUint(uint64(*i), 10)
+}
+
+// Uint creates an option that parses its value as an unsigned integer.
+func Uint(name rune, value uint, helpvalue ...string) *uint {
+	return CommandLine.Uint(name, value, helpvalue...)
+}
+
+func (s *Set) Uint(name rune, value uint, helpvalue ...string) *uint {
+	return s.UintLong("", name, value, helpvalue...)
+}
+
+func UintLong(name string, short rune, value uint, helpvalue ...string) *uint {
+	return CommandLine.UintLong(name, short, value, helpvalue...)
+}
+
+func (s *Set) UintLong(name string, short rune, value uint, helpvalue ...string) *uint {
+	s.UintVarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func UintVar(p *uint, name rune, helpvalue ...string) Option {
+	return CommandLine.UintVar(p, name, helpvalue...)
+}
+
+func (s *Set) UintVar(p *uint, name rune, helpvalue ...string) Option {
+	return s.UintVarLong(p, "", name, helpvalue...)
+}
+
+func UintVarLong(p *uint, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.UintVarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) UintVarLong(p *uint, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*uintValue)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/uint16.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/uint16.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type uint16Value uint16
+
+func (i *uint16Value) Set(value string, opt Option) error {
+	v, err := strconv.ParseUint(value, 0, 16)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	*i = uint16Value(v)
+	return nil
+}
+
+func (i *uint16Value) String() string {
+	return strconv.FormatUint(uint64(*i), 10)
+}
+
+// Uint16 creates an option that parses its value as an uint16.
+func Uint16(name rune, value uint16, helpvalue ...string) *uint16 {
+	return CommandLine.Uint16(name, value, helpvalue...)
+}
+
+func (s *Set) Uint16(name rune, value uint16, helpvalue ...string) *uint16 {
+	return s.Uint16Long("", name, value, helpvalue...)
+}
+
+func Uint16Long(name string, short rune, value uint16, helpvalue ...string) *uint16 {
+	return CommandLine.Uint16Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Uint16Long(name string, short rune, value uint16, helpvalue ...string) *uint16 {
+	s.Uint16VarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func Uint16Var(p *uint16, name rune, helpvalue ...string) Option {
+	return CommandLine.Uint16Var(p, name, helpvalue...)
+}
+
+func (s *Set) Uint16Var(p *uint16, name rune, helpvalue ...string) Option {
+	return s.Uint16VarLong(p, "", name, helpvalue...)
+}
+
+func Uint16VarLong(p *uint16, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.Uint16VarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) Uint16VarLong(p *uint16, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*uint16Value)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/uint16_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/uint16_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var uint16Tests = []struct {
+	where  string
+	in     []string
+	i      uint16
+	uint16 uint16
+	err    string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--uint16", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--uint16=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestUint16(t *testing.T) {
+	for x, tt := range uint16Tests {
+		reset()
+		i := Uint16('i', 17)
+		opt := Uint16Long("uint16", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.uint16; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/uint32.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/uint32.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type uint32Value uint32
+
+func (i *uint32Value) Set(value string, opt Option) error {
+	v, err := strconv.ParseUint(value, 0, 32)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	*i = uint32Value(v)
+	return nil
+}
+
+func (i *uint32Value) String() string {
+	return strconv.FormatUint(uint64(*i), 10)
+}
+
+// Uint32 creates an option that parses its value as an uint32.
+func Uint32(name rune, value uint32, helpvalue ...string) *uint32 {
+	return CommandLine.Uint32(name, value, helpvalue...)
+}
+
+func (s *Set) Uint32(name rune, value uint32, helpvalue ...string) *uint32 {
+	return s.Uint32Long("", name, value, helpvalue...)
+}
+
+func Uint32Long(name string, short rune, value uint32, helpvalue ...string) *uint32 {
+	return CommandLine.Uint32Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Uint32Long(name string, short rune, value uint32, helpvalue ...string) *uint32 {
+	s.Uint32VarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func Uint32Var(p *uint32, name rune, helpvalue ...string) Option {
+	return CommandLine.Uint32Var(p, name, helpvalue...)
+}
+
+func (s *Set) Uint32Var(p *uint32, name rune, helpvalue ...string) Option {
+	return s.Uint32VarLong(p, "", name, helpvalue...)
+}
+
+func Uint32VarLong(p *uint32, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.Uint32VarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) Uint32VarLong(p *uint32, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*uint32Value)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/uint32_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/uint32_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var uint32Tests = []struct {
+	where  string
+	in     []string
+	i      uint32
+	uint32 uint32
+	err    string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--uint32", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--uint32=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestUint32(t *testing.T) {
+	for x, tt := range uint32Tests {
+		reset()
+		i := Uint32('i', 17)
+		opt := Uint32Long("uint32", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.uint32; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/uint64.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/uint64.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type uint64Value uint64
+
+func (i *uint64Value) Set(value string, opt Option) error {
+	v, err := strconv.ParseUint(value, 0, 64)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	*i = uint64Value(v)
+	return nil
+}
+
+func (i *uint64Value) String() string {
+	return strconv.FormatUint(uint64(*i), 10)
+}
+
+// Uint64 creates an option that parses its value as a uint64.
+func Uint64(name rune, value uint64, helpvalue ...string) *uint64 {
+	return CommandLine.Uint64(name, value, helpvalue...)
+}
+
+func (s *Set) Uint64(name rune, value uint64, helpvalue ...string) *uint64 {
+	return s.Uint64Long("", name, value, helpvalue...)
+}
+
+func Uint64Long(name string, short rune, value uint64, helpvalue ...string) *uint64 {
+	return CommandLine.Uint64Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Uint64Long(name string, short rune, value uint64, helpvalue ...string) *uint64 {
+	s.Uint64VarLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func Uint64Var(p *uint64, name rune, helpvalue ...string) Option {
+	return CommandLine.Uint64Var(p, name, helpvalue...)
+}
+
+func (s *Set) Uint64Var(p *uint64, name rune, helpvalue ...string) Option {
+	return s.Uint64VarLong(p, "", name, helpvalue...)
+}
+
+func Uint64VarLong(p *uint64, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.Uint64VarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) Uint64VarLong(p *uint64, name string, short rune, helpvalue ...string) Option {
+	return s.VarLong((*uint64Value)(p), name, short, helpvalue...)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/uint64_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/uint64_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var uint64Tests = []struct {
+	where  string
+	in     []string
+	i      uint64
+	uint64 uint64
+	err    string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--uint64", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--uint64=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestUint64(t *testing.T) {
+	for x, tt := range uint64Tests {
+		reset()
+		i := Uint64('i', 17)
+		opt := Uint64Long("uint64", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.uint64; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/uint_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/uint_test.go
@@ -1,0 +1,84 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var uintTests = []struct {
+	where string
+	in    []string
+	i     uint
+	uint  uint
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--uint", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--uint=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestUint(t *testing.T) {
+	for x, tt := range uintTests {
+		reset()
+		i := Uint('i', 17)
+		opt := UintLong("uint", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.uint; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/unsigned.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/unsigned.go
@@ -1,0 +1,111 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type unsigned uint64
+
+type UnsignedLimit struct {
+	Base int    // Base for conversion as per strconv.ParseInt
+	Bits int    // Number of bits as per strconv.ParseInt
+	Min  uint64 // Minimum allowed value if both Min and Max are not 0
+	Max  uint64 // Maximum allowed value if both Min and Max are not 0
+}
+
+var unsignedLimits = make(map[*unsigned]*UnsignedLimit)
+
+func (n *unsigned) Set(value string, opt Option) error {
+	l := unsignedLimits[n]
+	if l == nil {
+		return fmt.Errorf("no limits defined for %s", opt.Name())
+	}
+	v, err := strconv.ParseUint(value, l.Base, l.Bits)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	if l.Min != 0 || l.Max != 0 {
+		if v < l.Min {
+			return fmt.Errorf("value out of range (<%v): %s", l.Min, value)
+		}
+		if v > l.Max {
+			return fmt.Errorf("value out of range (>%v): %s", l.Max, value)
+		}
+	}
+	*n = unsigned(v)
+	return nil
+}
+
+func (n *unsigned) String() string {
+	l := unsignedLimits[n]
+	if l != nil && l.Base != 0 {
+		return strconv.FormatUint(uint64(*n), l.Base)
+	}
+	return strconv.FormatUint(uint64(*n), 10)
+}
+
+// Unsigned creates an option that is stored in a uint64 and is
+// constrained by the limits pointed to by l.  The Max and Min values are only
+// used if at least one of the values are not 0.   If Base is 0, the base is
+// implied by the string's prefix: base 16 for "0x", base 8 for "0", and base
+// 10 otherwise.
+func Unsigned(name rune, value uint64, l *UnsignedLimit, helpvalue ...string) *uint64 {
+	return CommandLine.Unsigned(name, value, l, helpvalue...)
+}
+
+func (s *Set) Unsigned(name rune, value uint64, l *UnsignedLimit, helpvalue ...string) *uint64 {
+	return s.UnsignedLong("", name, value, l, helpvalue...)
+}
+
+func UnsignedLong(name string, short rune, value uint64, l *UnsignedLimit, helpvalue ...string) *uint64 {
+	return CommandLine.UnsignedLong(name, short, value, l, helpvalue...)
+}
+
+func (s *Set) UnsignedLong(name string, short rune, value uint64, l *UnsignedLimit, helpvalue ...string) *uint64 {
+	s.UnsignedVarLong(&value, name, short, l, helpvalue...)
+	return &value
+}
+
+func UnsignedVar(p *uint64, name rune, l *UnsignedLimit, helpvalue ...string) Option {
+	return CommandLine.UnsignedVar(p, name, l, helpvalue...)
+}
+
+func (s *Set) UnsignedVar(p *uint64, name rune, l *UnsignedLimit, helpvalue ...string) Option {
+	return s.UnsignedVarLong(p, "", name, l, helpvalue...)
+}
+
+func UnsignedVarLong(p *uint64, name string, short rune, l *UnsignedLimit, helpvalue ...string) Option {
+	return CommandLine.UnsignedVarLong(p, name, short, l, helpvalue...)
+}
+
+func (s *Set) UnsignedVarLong(p *uint64, name string, short rune, l *UnsignedLimit, helpvalue ...string) Option {
+	opt := s.VarLong((*unsigned)(p), name, short, helpvalue...)
+	if l.Base > 36 || l.Base == 1 || l.Base < 0 {
+		fmt.Fprintf(stderr, "invalid base for %s: %d\n", opt.Name(), l.Base)
+		exit(1)
+	}
+	if l.Bits < 0 || l.Bits > 64 {
+		fmt.Fprintf(stderr, "invalid bit size for %s: %d\n", opt.Name(), l.Bits)
+		exit(1)
+	}
+	if l.Min > l.Max {
+		fmt.Fprintf(stderr, "min greater than max for %s\n", opt.Name())
+		exit(1)
+	}
+	lim := *l
+	unsignedLimits[(*unsigned)(p)] = &lim
+	return opt
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/unsigned_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/unsigned_test.go
@@ -1,0 +1,97 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var unsignedTests = []struct {
+	where string
+	in    []string
+	l     UnsignedLimit
+	out   uint64
+	err   string
+}{
+	{
+		where: loc(),
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		UnsignedLimit{Base: 2, Bits: 5},
+		10,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		UnsignedLimit{Base: 2, Bits: 4},
+		10,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		UnsignedLimit{Base: 2, Bits: 3},
+		0,
+		"test: value out of range: 1010\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "3"},
+		UnsignedLimit{Min: 4, Max: 6},
+		0,
+		"test: value out of range (<4): 3\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "4"},
+		UnsignedLimit{Min: 4, Max: 6},
+		4,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "5"},
+		UnsignedLimit{Min: 4, Max: 6},
+		5,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "6"},
+		UnsignedLimit{Min: 4, Max: 6},
+		6,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "7"},
+		UnsignedLimit{Min: 4, Max: 6},
+		0,
+		"test: value out of range (>6): 7\n",
+	},
+}
+
+func TestUnsigneds(t *testing.T) {
+	for x, tt := range unsignedTests {
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		reset()
+		n := Unsigned('n', 0, &tt.l)
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if *n != tt.out {
+			t.Errorf("%s: got %v, want %v", tt.where, *n, tt.out)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/util_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/util_test.go
@@ -1,0 +1,87 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"reflect"
+	"runtime"
+	"strings"
+)
+
+var errorString string
+
+func reset() {
+	CommandLine.shortOptions = make(map[rune]*option)
+	CommandLine.longOptions = make(map[string]*option)
+	CommandLine.options = nil
+	CommandLine.args = nil
+	CommandLine.program = ""
+	errorString = ""
+}
+
+func parse(args []string) {
+	err := CommandLine.Getopt(args, nil)
+	if err != nil {
+		b := &bytes.Buffer{}
+
+		fmt.Fprintln(b, CommandLine.program+": "+err.Error())
+		CommandLine.PrintUsage(b)
+		errorString = b.String()
+	}
+}
+
+func badSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return true
+	}
+	for x, v := range a {
+		if b[x] != v {
+			return true
+		}
+	}
+	return false
+}
+
+func loc() string {
+	_, file, line, _ := runtime.Caller(1)
+	return fmt.Sprintf("%s:%d", path.Base(file), line)
+}
+
+func (o *option) Equal(opt *option) bool {
+	if o.value != nil && opt.value == nil {
+		return false
+	}
+	if o.value == nil && opt.value != nil {
+		return false
+	}
+	if o.value != nil && o.value.String() != opt.value.String() {
+		return false
+	}
+
+	oc := *o
+	optc := *opt
+	oc.value = nil
+	optc.value = nil
+	return reflect.DeepEqual(&oc, &optc)
+}
+
+func newStringValue(s string) *stringValue { return (*stringValue)(&s) }
+
+func checkError(err string) string {
+	switch {
+	case err == errorString:
+		return ""
+	case err == "":
+		return fmt.Sprintf("unexpected error %q", errorString)
+	case errorString == "":
+		return fmt.Sprintf("did not get expected error %q", err)
+	case !strings.HasPrefix(errorString, err):
+		return fmt.Sprintf("got error %q, want %q", errorString, err)
+	}
+	return ""
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/bool.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/bool.go
@@ -1,0 +1,36 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+// Bool creates a flag option that is a bool.  Bools normally do not take a
+// value however one can be assigned by using the long form of the option:
+//
+//  --option=true
+//  --o=false
+//
+// The value is case insensitive and one of true, false, t, f, on, off, t and 0.
+func Bool(name rune, helpvalue ...string) *bool {
+	var b bool
+	CommandLine.Flag(&b, name, helpvalue...)
+	return &b
+}
+
+func BoolLong(name string, short rune, helpvalue ...string) *bool {
+	var p bool
+	CommandLine.FlagLong(&p, name, short, helpvalue...)
+	return &p
+}
+
+func (s *Set) Bool(name rune, helpvalue ...string) *bool {
+	var b bool
+	s.Flag(&b, name, helpvalue...)
+	return &b
+}
+
+func (s *Set) BoolLong(name string, short rune, helpvalue ...string) *bool {
+	var p bool
+	s.FlagLong(&p, name, short, helpvalue...)
+	return &p
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/bool_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/bool_test.go
@@ -1,0 +1,106 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var boolTests = []struct {
+	where string
+	in    []string
+	f     bool
+	fc    int
+	opt   bool
+	optc  int
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		false, 0,
+		false, 0,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-f", "--opt"},
+		true, 1,
+		true, 1,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--f", "--opt"},
+		true, 1,
+		true, 1,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-ff", "-f", "--opt", "--opt"},
+		true, 3,
+		true, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--opt", "--opt=false"},
+		false, 0,
+		false, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-f", "false"},
+		true, 1,
+		false, 0,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-f=false"},
+		true, 1,
+		false, 0,
+		"test: unknown option: -=\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-f", "false"},
+		true, 1,
+		false, 0,
+		"",
+	},
+}
+
+func TestBool(t *testing.T) {
+	for x, tt := range boolTests {
+		reset()
+		f := Bool('f')
+		opt := BoolLong("opt", 0)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *f, tt.f; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.opt; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := GetCount('f'), tt.fc; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := GetCount("opt"), tt.optc; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/breakup_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/breakup_test.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"testing"
+)
+
+var breakupTests = []struct {
+	in  string
+	max int
+	out []string
+}{
+	{"", 8, []string{}},
+	{"a fox", 8, []string{"a fox"}},
+	{"a foxhound is sly", 2, []string{"a", "foxhound", "is", "sly"}},
+	{"a foxhound is sly", 5, []string{"a", "foxhound", "is", "sly"}},
+	{"a foxhound is sly", 6, []string{"a", "foxhound", "is sly"}},
+	{"a foxhound is sly", 7, []string{"a", "foxhound", "is sly"}},
+	{"a foxhound is sly", 8, []string{"a", "foxhound", "is sly"}},
+	{"a foxhound is sly", 9, []string{"a", "foxhound", "is sly"}},
+	{"a foxhound is sly", 10, []string{"a foxhound", "is sly"}},
+}
+
+func TestBreakup(t *testing.T) {
+	for x, tt := range breakupTests {
+		out := breakup(tt.in, tt.max)
+		if badSlice(out, tt.out) {
+			t.Errorf("#%d: got %v, want %v", x, out, tt.out)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/counter.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/counter.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type counterValue int
+
+func (b *counterValue) Set(value string, opt Option) error {
+	if value == "" {
+		*b++
+	} else {
+		v, err := strconv.ParseInt(value, 0, strconv.IntSize)
+		if err != nil {
+			if e, ok := err.(*strconv.NumError); ok {
+				switch e.Err {
+				case strconv.ErrRange:
+					err = fmt.Errorf("value out of range: %s", value)
+				case strconv.ErrSyntax:
+					err = fmt.Errorf("not a valid number: %s", value)
+				}
+			}
+			return err
+		}
+		*b = counterValue(v)
+	}
+	return nil
+}
+
+func (b *counterValue) String() string {
+	return strconv.Itoa(int(*b))
+}
+
+// Counter creates a counting flag stored as an int.  Each time the option
+// is seen while parsing the value is incremented.  The value of the counter
+// may be explicitly set by using the long form:
+//
+//  --counter=5
+//  --c=5
+//
+// Further instances of the option will increment from the set value.
+func Counter(name rune, helpvalue ...string) *int {
+	var p int
+	CommandLine.FlagLong((*counterValue)(&p), "", name, helpvalue...).SetFlag()
+	return &p
+}
+
+func (s *Set) Counter(name rune, helpvalue ...string) *int {
+	var p int
+	s.FlagLong((*counterValue)(&p), "", name, helpvalue...).SetFlag()
+	return &p
+}
+
+func CounterLong(name string, short rune, helpvalue ...string) *int {
+	var p int
+	CommandLine.FlagLong((*counterValue)(&p), name, short, helpvalue...).SetFlag()
+	return &p
+}
+
+func (s *Set) CounterLong(name string, short rune, helpvalue ...string) *int {
+	var p int
+	s.FlagLong((*counterValue)(&p), name, short, helpvalue...).SetFlag()
+	return &p
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/counter_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/counter_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var counterTests = []struct {
+	where string
+	in    []string
+	c     int
+	cnt   int
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		0,
+		0,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-c", "--cnt"},
+		1,
+		1,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-cc", "-c", "--cnt", "--cnt"},
+		3,
+		2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--c=17", "--cnt=42"},
+		17,
+		42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--cnt=false"},
+		0, 0,
+		"test: not a valid number: false\n",
+	},
+}
+
+func TestCounter(t *testing.T) {
+	for x, tt := range counterTests {
+		reset()
+		c := Counter('c')
+		cnt := CounterLong("cnt", 0)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *c, tt.c; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *cnt, tt.cnt; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/duration.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/duration.go
@@ -1,0 +1,28 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "time"
+
+// Duration creates an option that parses its value as a time.Duration.
+func Duration(name rune, value time.Duration, helpvalue ...string) *time.Duration {
+	CommandLine.FlagLong(&value, "", name, helpvalue...)
+	return &value
+}
+
+func (s *Set) Duration(name rune, value time.Duration, helpvalue ...string) *time.Duration {
+	s.FlagLong(&value, "", name, helpvalue...)
+	return &value
+}
+
+func DurationLong(name string, short rune, value time.Duration, helpvalue ...string) *time.Duration {
+	CommandLine.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func (s *Set) DurationLong(name string, short rune, value time.Duration, helpvalue ...string) *time.Duration {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/duration_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/duration_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+var durationTests = []struct {
+	where string
+	in    []string
+	d     time.Duration
+	dur   time.Duration
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-d", "1s", "--duration", "2s"},
+		time.Second, 2 * time.Second,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-d1s", "-d2s"},
+		2 * time.Second, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-d1"},
+		17, 42,
+		"test: time: missing unit in duration 1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "--duration", "foo"},
+		17, 42,
+		"test: time: invalid duration foo\n",
+	},
+}
+
+func TestDuration(t *testing.T) {
+	for x, tt := range durationTests {
+		reset()
+		d := Duration('d', 17)
+		opt := DurationLong("duration", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *d, tt.d; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.dur; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/enum.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/enum.go
@@ -1,0 +1,79 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+type enumValue string
+
+var (
+	enumValuesMu sync.Mutex
+	enumValues   = make(map[*enumValue]map[string]struct{})
+)
+
+func (s *enumValue) Set(value string, opt Option) error {
+	enumValuesMu.Lock()
+	es, ok := enumValues[s]
+	enumValuesMu.Unlock()
+	if !ok || es == nil {
+		return errors.New("this option has no values")
+	}
+	if _, ok := es[value]; !ok {
+		return errors.New("invalid value: " + value)
+	}
+	*s = enumValue(value)
+	return nil
+}
+
+func (s *enumValue) String() string {
+	return string(*s)
+}
+
+// Enum creates an option that can only be set to one of the enumerated strings
+// passed in values.  Passing nil or an empty slice results in an option that
+// will always fail.  If not "", value is the default value of the enum.  If
+// value is not listed in values then Enum will produce an error on standard
+// error and then exit the program with a status of 1.
+func Enum(name rune, values []string, value string, helpvalue ...string) *string {
+	return CommandLine.Enum(name, values, value, helpvalue...)
+}
+
+func (s *Set) Enum(name rune, values []string, value string, helpvalue ...string) *string {
+	var p enumValue
+	p.define(values, value, &option{short: name})
+	s.FlagLong(&p, "", name, helpvalue...)
+	return (*string)(&p)
+}
+
+func EnumLong(name string, short rune, values []string, value string, helpvalue ...string) *string {
+	return CommandLine.EnumLong(name, short, values, value, helpvalue...)
+}
+
+func (s *Set) EnumLong(name string, short rune, values []string, value string, helpvalue ...string) *string {
+	var p enumValue
+	p.define(values, value, &option{short: short, long: name})
+	s.FlagLong(&p, name, short, helpvalue...)
+	return (*string)(&p)
+}
+
+func (e *enumValue) define(values []string, def string, opt Option) {
+	m := make(map[string]struct{})
+	for _, v := range values {
+		m[v] = struct{}{}
+	}
+	enumValuesMu.Lock()
+	enumValues[e] = m
+	enumValuesMu.Unlock()
+	if def != "" {
+		if err := e.Set(def, nil); err != nil {
+			fmt.Fprintf(stderr, "setting default for %s: %v\n", opt.Name(), err)
+			exit(1)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/enum_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/enum_test.go
@@ -1,0 +1,79 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var enumTests = []struct {
+	where  string
+	in     []string
+	values []string
+	def    string
+	out    string
+	err    string
+}{
+	{
+		loc(),
+		nil,
+		[]string{},
+		"",
+		"",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-e", "val1"},
+		[]string{"val1", "val2"},
+		"",
+		"val1",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-e", "val1", "-e", "val2"},
+		[]string{"val1", "val2"},
+		"",
+		"val2",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test"},
+		[]string{"val1", "val2"},
+		"val2",
+		"val2",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-e", "val3"},
+		[]string{"val1", "val2"},
+		"",
+		"",
+		"test: invalid value: val3\n",
+	},
+}
+
+func TestEnum(t *testing.T) {
+	for x, tt := range enumTests {
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		reset()
+		e := Enum('e', tt.values, tt.def)
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if *e != tt.out {
+			t.Errorf("%s: got %v, want %v", tt.where, *e, tt.out)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/error.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/error.go
@@ -1,0 +1,93 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "fmt"
+
+// An Error is returned by Getopt when it encounters an error.
+type Error struct {
+	ErrorCode        // General reason of failure.
+	Err       error  // The actual error.
+	Parameter string // Parameter passed to option, if any
+	Name      string // Option that cause error, if any
+}
+
+// Error returns the error message, implementing the error interface.
+func (i *Error) Error() string { return i.Err.Error() }
+
+// An ErrorCode indicates what sort of error was encountered.
+type ErrorCode int
+
+const (
+	NoError          = ErrorCode(iota)
+	UnknownOption    // an invalid option was encountered
+	MissingParameter // the options parameter is missing
+	ExtraParameter   // a value was set to a long flag
+	Invalid          // attempt to set an invalid value
+)
+
+func (e ErrorCode) String() string {
+	switch e {
+	case UnknownOption:
+		return "unknow option"
+	case MissingParameter:
+		return "missing argument"
+	case ExtraParameter:
+		return "unxpected value"
+	case Invalid:
+		return "error setting value"
+	}
+	return "unknown error"
+}
+
+// unknownOption returns an Error indicating an unknown option was
+// encountered.
+func unknownOption(name interface{}) *Error {
+	i := &Error{ErrorCode: UnknownOption}
+	switch n := name.(type) {
+	case rune:
+		if n == '-' {
+			i.Name = "-"
+		} else {
+			i.Name = "-" + string(n)
+		}
+	case string:
+		i.Name = "--" + n
+	}
+	i.Err = fmt.Errorf("unknown option: %s", i.Name)
+	return i
+}
+
+// missingArg returns an Error inidicating option o was not passed
+// a required paramter.
+func missingArg(o Option) *Error {
+	return &Error{
+		ErrorCode: MissingParameter,
+		Name:      o.Name(),
+		Err:       fmt.Errorf("missing parameter for %s", o.Name()),
+	}
+}
+
+// extraArg returns an Error inidicating option o was passed the
+// unexpected paramter value.
+func extraArg(o Option, value string) *Error {
+	return &Error{
+		ErrorCode: ExtraParameter,
+		Name:      o.Name(),
+		Parameter: value,
+		Err:       fmt.Errorf("unexpected parameter passed to %s: %q", o.Name(), value),
+	}
+}
+
+// setError returns an Error inidicating option o and the specified
+// error while setting it to value.
+func setError(o Option, value string, err error) *Error {
+	return &Error{
+		ErrorCode: Invalid,
+		Name:      o.Name(),
+		Parameter: value,
+		Err:       err,
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/generic.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/generic.go
@@ -1,0 +1,247 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type generic struct {
+	p interface{}
+}
+
+// Flag is shorthand for CommandLine.Flag.
+func Flag(v interface{}, short rune, helpvalue ...string) Option {
+	return CommandLine.long(v, "", short, helpvalue...)
+}
+
+// FlagLong is shorthand for CommandLine.LongFlag.
+func FlagLong(v interface{}, long string, short rune, helpvalue ...string) Option {
+	return CommandLine.long(v, long, short, helpvalue...)
+}
+
+// Flag calls FlagLong with only a short flag name.
+func (s *Set) Flag(v interface{}, short rune, helpvalue ...string) Option {
+	return s.long(v, "", short, helpvalue...)
+}
+
+// FlagLong returns an Option in Set s for setting v.  If long is not "" then
+// the option has a long name, and if short is not 0, the option has a short
+// name.  v must either be of type getopt.Value or a pointer to one of the
+// supported builtin types:
+//
+//	bool, string, []string
+//	int, int8, int16, int32, int64
+//	uint, uint8, uint16, uint32, uint64
+//	float32, float64
+//	time.Duration
+//
+// FlagLong will panic if v is not a getopt.Value or one of the supported
+// builtin types.
+//
+// The default value of the flag is the value of v at the time FlagLong is
+// called.
+func (s *Set) FlagLong(v interface{}, long string, short rune, helpvalue ...string) Option {
+	return s.long(v, long, short, helpvalue...)
+}
+
+func (s *Set) long(v interface{}, long string, short rune, helpvalue ...string) (opt Option) {
+	// Fix up our location when we return.
+	if where := calledFrom(); where != "" {
+		defer func() {
+			if opt, ok := opt.(*option); ok {
+				opt.where = where
+			}
+		}()
+	}
+	switch p := v.(type) {
+	case Value:
+		return s.addFlag(p, long, short, helpvalue...)
+	case *bool:
+		return s.addFlag(&generic{v}, long, short, helpvalue...).SetFlag()
+	case *string, *[]string:
+		return s.addFlag(&generic{v}, long, short, helpvalue...)
+	case *int, *int8, *int16, *int32, *int64:
+		return s.addFlag(&generic{v}, long, short, helpvalue...)
+	case *uint, *uint8, *uint16, *uint32, *uint64:
+		return s.addFlag(&generic{v}, long, short, helpvalue...)
+	case *float32, *float64:
+		return s.addFlag(&generic{v}, long, short, helpvalue...)
+	case *time.Duration:
+		return s.addFlag(&generic{v}, long, short, helpvalue...)
+	default:
+		panic(fmt.Sprintf("unsupported flag type: %T", v))
+	}
+}
+
+// genericValue returns the object underlying the generic Value v, or nil if v
+// is not a generic Value.
+func genericValue(v Value) interface{} {
+	if g, ok := v.(*generic); ok {
+		return g.p
+	}
+	return nil
+}
+
+func (g *generic) Set(value string, opt Option) error {
+	strconvErr := func(err error) error {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	switch p := g.p.(type) {
+	case *bool:
+		switch strings.ToLower(value) {
+		case "", "1", "true", "on", "t":
+			*p = true
+		case "0", "false", "off", "f":
+			*p = false
+		default:
+			return fmt.Errorf("invalid value for bool %s: %q", opt.Name(), value)
+		}
+		return nil
+	case *string:
+		*p = value
+		return nil
+	case *[]string:
+		a := strings.Split(value, ",")
+		// If this is the first time we are seen then nil out the
+		// default value.
+		if opt.Count() <= 1 {
+			*p = nil
+		}
+		*p = append(*p, a...)
+		return nil
+	case *int:
+		i64, err := strconv.ParseInt(value, 0, strconv.IntSize)
+		if err == nil {
+			*p = int(i64)
+		}
+		return strconvErr(err)
+	case *int8:
+		i64, err := strconv.ParseInt(value, 0, 8)
+		if err == nil {
+			*p = int8(i64)
+		}
+		return strconvErr(err)
+	case *int16:
+		i64, err := strconv.ParseInt(value, 0, 16)
+		if err == nil {
+			*p = int16(i64)
+		}
+		return strconvErr(err)
+	case *int32:
+		i64, err := strconv.ParseInt(value, 0, 32)
+		if err == nil {
+			*p = int32(i64)
+		}
+		return strconvErr(err)
+	case *int64:
+		i64, err := strconv.ParseInt(value, 0, 64)
+		if err == nil {
+			*p = i64
+		}
+		return strconvErr(err)
+	case *uint:
+		u64, err := strconv.ParseUint(value, 0, strconv.IntSize)
+		if err == nil {
+			*p = uint(u64)
+		}
+		return strconvErr(err)
+	case *uint8:
+		u64, err := strconv.ParseUint(value, 0, 8)
+		if err == nil {
+			*p = uint8(u64)
+		}
+		return strconvErr(err)
+	case *uint16:
+		u64, err := strconv.ParseUint(value, 0, 16)
+		if err == nil {
+			*p = uint16(u64)
+		}
+		return strconvErr(err)
+	case *uint32:
+		u64, err := strconv.ParseUint(value, 0, 32)
+		if err == nil {
+			*p = uint32(u64)
+		}
+		return strconvErr(err)
+	case *uint64:
+		u64, err := strconv.ParseUint(value, 0, 64)
+		if err == nil {
+			*p = u64
+		}
+		return strconvErr(err)
+	case *float32:
+		f64, err := strconv.ParseFloat(value, 32)
+		if err == nil {
+			*p = float32(f64)
+		}
+		return strconvErr(err)
+	case *float64:
+		f64, err := strconv.ParseFloat(value, 64)
+		if err == nil {
+			*p = f64
+		}
+		return strconvErr(err)
+	case *time.Duration:
+		v, err := time.ParseDuration(value)
+		if err == nil {
+			*p = v
+		}
+		return err
+	}
+	panic("internal error")
+}
+
+func (g *generic) String() string {
+	switch p := g.p.(type) {
+	case *bool:
+		if *p {
+			return "true"
+		}
+		return "false"
+	case *string:
+		return *p
+	case *[]string:
+		return strings.Join([]string(*p), ",")
+	case *int:
+		return strconv.FormatInt(int64(*p), 10)
+	case *int8:
+		return strconv.FormatInt(int64(*p), 10)
+	case *int16:
+		return strconv.FormatInt(int64(*p), 10)
+	case *int32:
+		return strconv.FormatInt(int64(*p), 10)
+	case *int64:
+		return strconv.FormatInt(*p, 10)
+	case *uint:
+		return strconv.FormatUint(uint64(*p), 10)
+	case *uint8:
+		return strconv.FormatUint(uint64(*p), 10)
+	case *uint16:
+		return strconv.FormatUint(uint64(*p), 10)
+	case *uint32:
+		return strconv.FormatUint(uint64(*p), 10)
+	case *uint64:
+		return strconv.FormatUint(*p, 10)
+	case *float32:
+		return strconv.FormatFloat(float64(*p), 'g', -1, 32)
+	case *float64:
+		return strconv.FormatFloat(*p, 'g', -1, 64)
+	case *time.Duration:
+		return p.String()
+	}
+	panic("internal error")
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/generic_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/generic_test.go
@@ -1,0 +1,319 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGeneric(t *testing.T) {
+	const (
+		shortTest = iota
+		longTest
+		bothTest
+	)
+	for _, tt := range []struct {
+		where string
+		kind  int
+		val   interface{}
+		str   string
+		def   interface{}
+		in    []string
+		err   string
+	}{
+		// Do all four tests for string, the rest can mostly just use
+		// shortTest (the 0 value).
+		{
+			where: loc(),
+			kind:  shortTest,
+			val:   "42",
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			kind:  longTest,
+			val:   "42",
+			str:   "42",
+			in:    []string{"test", "--long", "42"},
+		},
+		{
+			where: loc(),
+			kind:  bothTest,
+			val:   "42",
+			str:   "42",
+			in:    []string{"test", "--both", "42"},
+		},
+		{
+			where: loc(),
+			kind:  bothTest,
+			val:   "42",
+			str:   "42",
+			in:    []string{"test", "-b", "42"},
+		},
+		{
+			where: loc(),
+			val:   "42",
+			def:   "42",
+			str:   "42",
+			in:    []string{"test"},
+		},
+		{
+			where: loc(),
+			val:   "42",
+			def:   "43",
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+
+		{
+			where: loc(),
+			val:   true,
+			str:   "true",
+			in:    []string{"test", "-s"},
+		},
+		{
+			where: loc(),
+			val:   true,
+			def:   true,
+			str:   "true",
+			in:    []string{"test"},
+		},
+		{
+			where: loc(),
+			kind:  longTest,
+			val:   false,
+			str:   "false",
+			in:    []string{"test", "--long=false"},
+		},
+		{
+			where: loc(),
+			kind:  longTest,
+			val:   false,
+			def:   true,
+			str:   "false",
+			in:    []string{"test", "--long=false"},
+		},
+
+		{
+			where: loc(),
+			val:   int(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			val:   int8(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			val:   int16(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			val:   int32(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			val:   int64(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+
+		{
+			where: loc(),
+			val:   uint(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			val:   uint8(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			val:   uint16(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			val:   uint32(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+		{
+			where: loc(),
+			val:   uint64(42),
+			str:   "42",
+			in:    []string{"test", "-s", "42"},
+		},
+
+		{
+			where: loc(),
+			val:   float32(4.2),
+			str:   "4.2",
+			in:    []string{"test", "-s", "4.2"},
+		},
+		{
+			where: loc(),
+			val:   float64(4.2),
+			str:   "4.2",
+			in:    []string{"test", "-s", "4.2"},
+		},
+
+		{
+			where: loc(),
+			val:   time.Duration(time.Second * 42),
+			def:   time.Second * 2,
+			str:   "42s",
+			in:    []string{"test", "-s", "42s"},
+		},
+		{
+			where: loc(),
+			val:   time.Duration(time.Second * 42),
+			def:   time.Second * 2,
+			str:   "42s",
+			in:    []string{"test", "-s42s"},
+		},
+		{
+			where: loc(),
+			val:   time.Duration(time.Second * 2),
+			def:   time.Second * 2,
+			in:    []string{"test", "-s42"},
+			str:   "2s",
+			err:   "test: time: missing unit in duration 42",
+		},
+
+		{
+			where: loc(),
+			val:   []string{"42", "."},
+			str:   "42,.",
+			def:   []string{"one", "two", "three"},
+			in:    []string{"test", "-s42", "-s."},
+		},
+		{
+			where: loc(),
+			val:   []string{"42", "."},
+			str:   "42,.",
+			def:   []string{"one", "two", "three"},
+			in:    []string{"test", "-s42,."},
+		},
+		{
+			where: loc(),
+			val:   []string{"one", "two", "three"},
+			def:   []string{"one", "two", "three"},
+			str:   "one,two,three",
+			in:    []string{"test"},
+		},
+	} {
+		reset()
+		var opt Option
+		val := reflect.New(reflect.TypeOf(tt.val)).Interface()
+		if tt.def != nil {
+			reflect.ValueOf(val).Elem().Set(reflect.ValueOf(tt.def))
+		}
+		switch tt.kind {
+		case shortTest:
+			opt = Flag(val, 's')
+		case longTest:
+			opt = FlagLong(val, "long", 0)
+		case bothTest:
+			opt = FlagLong(val, "both", 'b')
+		}
+		_ = opt
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+			continue
+		}
+		got := reflect.ValueOf(val).Elem().Interface()
+		want := reflect.ValueOf(tt.val).Interface()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if str := opt.String(); str != tt.str {
+			t.Errorf("%s: got string %q, want %q", tt.where, str, tt.str)
+		}
+	}
+}
+
+func TestGenericDup(t *testing.T) {
+	defer func() {
+		stderr = os.Stderr
+		exit = os.Exit
+	}()
+
+	reset()
+	var v1, v2 string
+	type myPanic struct{}
+	var errbuf bytes.Buffer
+	stderr = &errbuf
+	_, file, line, _ := runtime.Caller(0)
+	Flag(&v1, 's')
+	line++ // line is now the line number of the first call to Flag.
+
+	exit = func(i int) { panic(myPanic{}) }
+	defer func() {
+		p := recover()
+		if _, ok := p.(myPanic); ok {
+			err := errbuf.String()
+			if !strings.Contains(err, "-s already declared") || !strings.Contains(err, fmt.Sprintf("%s:%d", file, line)) {
+				t.Errorf("unexpected error: %q\nshould contain \"-s already declared\" and \"%s:%d\"", err, file, line)
+			}
+		} else if p == nil {
+			t.Errorf("Second call to Flag did not fail")
+		} else {
+			t.Errorf("panic %v", p)
+		}
+	}()
+	Flag(&v2, 's')
+}
+
+func TestGenericDupNested(t *testing.T) {
+	defer func() {
+		stderr = os.Stderr
+		exit = os.Exit
+	}()
+
+	reset()
+	type myPanic struct{}
+	var errbuf bytes.Buffer
+	stderr = &errbuf
+	_, file, line, _ := runtime.Caller(0)
+	String('s', "default")
+	line++ // line is now the line number of the first call to Flag.
+
+	exit = func(i int) { panic(myPanic{}) }
+	defer func() {
+		p := recover()
+		if _, ok := p.(myPanic); ok {
+			err := errbuf.String()
+			if !strings.Contains(err, "-s already declared") || !strings.Contains(err, fmt.Sprintf("%s:%d", file, line)) {
+				t.Errorf("unexpected error: %q\nshould contain \"-s already declared\" and \"%s:%d\"", err, file, line)
+			}
+		} else if p == nil {
+			t.Errorf("Second call to Flag did not fail")
+		} else {
+			t.Errorf("panic %v", p)
+		}
+	}()
+	String('s', "default")
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/getopt.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/getopt.go
@@ -1,0 +1,564 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package getopt (v2) provides traditional getopt processing for implementing
+// commands that use traditional command lines.  The standard Go flag package
+// cannot be used to write a program that parses flags the way ls or ssh does,
+// for example.  Version 2 of this package has a simplified API.
+//
+// See the github.com/pborman/options package for a simple structure based
+// interface to this package.
+//
+// USAGE
+//
+// Getopt supports functionality found in both the standard BSD getopt as well
+// as (one of the many versions of) the GNU getopt_long.  Being a Go package,
+// this package makes common usage easy, but still enables more controlled usage
+// if needed.
+//
+// Typical usage:
+//
+//	// Declare flags and have getopt return pointers to the values.
+//	helpFlag := getopt.Bool('?', "display help")
+//	cmdFlag := getopt.StringLong("command", 'c', "default", "the command")
+//
+//	// Declare flags against existing variables.
+//	var {
+//		fileName = "/the/default/path"
+//		timeout = time.Second * 5
+//		verbose bool
+//	}
+//	func init() {
+//		getopt.Flag(&verbose, 'v', "be verbose")
+//		getopt.FlagLong(&fileName, "path", 0, "the path")
+//		getopt.FlagLong(&timeout, "timeout", 't', "some timeout")
+//	}
+//
+//	func main() {
+//		// Parse the program arguments
+//		getopt.Parse()
+//		// Get the remaining positional parameters
+//		args := getopt.Args()
+//		...
+//
+// If you don't want the program to exit on error, use getopt.Getopt:
+//
+//		err := getopt.Getopt(nil)
+//		if err != nil {
+//			// code to handle error
+//			fmt.Fprintln(os.Stderr, err)
+//		}
+//
+// FLAG SYNTAX
+//
+// Support is provided for both short (-f) and long (--flag) options.  A single
+// option may have both a short and a long name.  Each option may be a flag or a
+// value.  A value takes an argument.
+//
+// Declaring no long names causes this package to process arguments like the
+// traditional BSD getopt.
+//
+// Short flags may be combined into a single parameter.  For example, "-a -b -c"
+// may also be expressed "-abc".  Long flags must stand on their own "--alpha
+// --beta"
+//
+// Values require an argument.  For short options the argument may either be
+// immediately following the short name or as the next argument.  Only one short
+// value may be combined with short flags in a single argument; the short value
+// must be after all short flags.  For example, if f is a flag and v is a value,
+// then:
+//
+//  -vvalue    (sets v to "value")
+//  -v value   (sets v to "value")
+//  -fvvalue   (sets f, and sets v to "value")
+//  -fv value  (sets f, and sets v to "value")
+//  -vf value  (set v to "f" and value is the first parameter)
+//
+// For the long value option val:
+//
+//  --val value (sets val to "value")
+//  --val=value (sets val to "value")
+//  --valvalue  (invalid option "valvalue")
+//
+// Values with an optional value only set the value if the value is part of the
+// same argument.  In any event, the option count is increased and the option is
+// marked as seen.
+//
+//  -v -f          (sets v and f as being seen)
+//  -vvalue -f     (sets v to "value" and sets f)
+//  --val -f       (sets v and f as being seen)
+//  --val=value -f (sets v to "value" and sets f)
+//
+// There is no convenience function defined for making the value optional.  The
+// SetOptional method must be called on the actual Option.
+//
+//  v := String("val", 'v', "", "the optional v")
+//  Lookup("v").SetOptional()
+//
+//  var s string
+//  FlagLong(&s, "val", 'v', "the optional v).SetOptional()
+//
+// Parsing continues until the first non-option or "--" is encountered.
+//
+// The short name "-" can be used, but it either is specified as "-" or as part
+// of a group of options, for example "-f-".  If there are no long options
+// specified then "--f" could also be used.  If "-" is not declared as an option
+// then the single "-" will also terminate the option processing but unlike
+// "--", the "-" will be part of the remaining arguments.
+//
+// ADVANCED USAGE
+//
+// Normally the parsing is performed by calling the Parse function.  If it is
+// important to see the order of the options then the Getopt function should be
+// used.  The standard Parse function does the equivalent of:
+//
+// func Parse() {
+//	if err := getopt.Getopt(os.Args, nil); err != nil {
+//		fmt.Fprintln(os.Stderr, err)
+//		s.usage()
+//		os.Exit(1)
+//	}
+//
+// When calling Getopt it is the responsibility of the caller to print any
+// errors.
+//
+// Normally the default option set, CommandLine, is used.  Other option sets may
+// be created with New.
+//
+// After parsing, the sets Args will contain the non-option arguments.  If an
+// error is encountered then Args will begin with argument that caused the
+// error.
+//
+// It is valid to call a set's Parse a second time to amen flags or values.  As
+// an example:
+//
+//  var a = getopt.Bool('a', "", "The a flag")
+//  var b = getopt.Bool('b', "", "The a flag")
+//  var cmd = ""
+//
+//  var opts = getopt.CommandLine
+//
+//  opts.Parse(os.Args)
+//  if opts.NArgs() > 0 {
+//      cmd = opts.Arg(0)
+//      opts.Parse(opts.Args())
+//  }
+//
+// If called with set to { "prog", "-a", "cmd", "-b", "arg" } then both and and
+// b would be set, cmd would be set to "cmd", and opts.Args() would return {
+// "arg" }.
+//
+// Unless an option type explicitly prohibits it, an option may appear more than
+// once in the arguments.  The last value provided to the option is the value.
+//
+// BUILTIN TYPES
+//
+// The Flag and FlagLong functions support most standard Go types.  For the
+// list, see the description of FlagLong below for a list of supported types.
+//
+// There are also helper routines to allow single line flag declarations.  These
+// types are: Bool, Counter, Duration, Enum, Int16, Int32, Int64, Int, List,
+// Signed, String, Uint16, Uint32, Uint64, Uint, and Unsigned.
+//
+// Each comes in a short and long flavor, e.g., Bool and BoolLong and include
+// functions to set the flags on the standard command line or for a specific Set
+// of flags.
+//
+// Except for the Counter, Enum, Signed and Unsigned types, all of these types
+// can be declared using Flag and FlagLong by passing in a pointer to the
+// appropriate type.
+//
+// DECLARING NEW FLAG TYPES
+//
+// A pointer to any type that implements the Value interface may be passed to
+// Flag or FlagLong.
+//
+// VALUEHELP
+//
+// All non-flag options are created with a "valuehelp" as the last parameter.
+// Valuehelp should be 0, 1, or 2 strings.  The first string, if provided, is
+// the usage message for the option.  If the second string, if provided, is the
+// name to use for the value when displaying the usage.  If not provided the
+// term "value" is assumed.
+//
+// The usage message for the option created with
+//
+//  StringLong("option", 'o', "defval", "a string of letters")
+//
+// is
+//
+//  -o, -option=value
+//
+//  StringLong("option", 'o', "defval", "a string of letters", "string")
+//
+// is
+//
+//  -o, -option=string
+package getopt
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+// stderr allows tests to capture output to standard error.
+var stderr io.Writer = os.Stderr
+
+// exit allows tests to capture an os.Exit call
+var exit = os.Exit
+
+// DisplayWidth is used to determine where to split usage long lines.
+var DisplayWidth = 80
+
+// HelpColumn is the maximum column position that help strings start to display
+// at.  If the option usage is too long then the help string will be displayed
+// on the next line.  For example:
+//
+//   -a   this is the a flag
+//   -u, --under=location
+//        the u flag's usage is quite long
+var HelpColumn = 20
+
+// PrintUsage prints the usage line and set of options of set S to w.
+func (s *Set) PrintUsage(w io.Writer) {
+	parts := make([]string, 2, 4)
+	parts[0] = "Usage:"
+	parts[1] = s.program
+	if usage := s.UsageLine(); usage != "" {
+		parts = append(parts, usage)
+	}
+	if s.parameters != "" {
+		parts = append(parts, s.parameters)
+	}
+	fmt.Fprintln(w, strings.Join(parts, " "))
+	s.PrintOptions(w)
+}
+
+// UsageLine returns the usage line for the set s.  The set's program name and
+// parameters, if any, are not included.
+func (s *Set) UsageLine() string {
+	sort.Sort(s.options)
+	flags := ""
+
+	// Build up the list of short flag names and also compute
+	// how to display the option in the longer help listing.
+	// We also keep track of the longest option usage string
+	// that is no more than HelpColumn-3 bytes (at which point
+	// we use two lines to display the help).  The three
+	// is for the leading space and the two spaces before the
+	// help string.
+	for _, opt := range s.options {
+		if opt.name == "" {
+			opt.name = "value"
+		}
+		if opt.uname == "" {
+			opt.uname = opt.usageName()
+		}
+		if opt.flag && opt.short != 0 && opt.short != '-' {
+			flags += string(opt.short)
+		}
+	}
+
+	var opts []string
+
+	// The short option - is special
+	if s.shortOptions['-'] != nil {
+		opts = append(opts, "-")
+	}
+
+	// If we have a bundle of flags, add them to the list
+	if flags != "" {
+		opts = append(opts, "-"+flags)
+	}
+
+	// Now append all the long options and options that require
+	// values.
+	for _, opt := range s.options {
+		if opt.flag {
+			if opt.short != 0 {
+				continue
+			}
+			flags = "--" + opt.long
+		} else if opt.short != 0 {
+			flags = "-" + string(opt.short) + " " + opt.name
+		} else {
+			flags = "--" + string(opt.long) + " " + opt.name
+		}
+		opts = append(opts, flags)
+	}
+	flags = strings.Join(opts, "] [")
+	if flags != "" {
+		flags = "[" + flags + "]"
+	}
+	return flags
+}
+
+// PrintOptions prints the list of options in s to w.
+func (s *Set) PrintOptions(w io.Writer) {
+	sort.Sort(s.options)
+	max := 4
+	for _, opt := range s.options {
+		if opt.name == "" {
+			opt.name = "value"
+		}
+		if opt.uname == "" {
+			opt.uname = opt.usageName()
+		}
+		if max < len(opt.uname) && len(opt.uname) <= HelpColumn-3 {
+			max = len(opt.uname)
+		}
+	}
+	// Now print one or more usage lines per option.
+	for _, opt := range s.options {
+		if opt.uname != "" {
+			opt.help = strings.TrimSpace(opt.help)
+			if len(opt.help) == 0 {
+				fmt.Fprintf(w, " %s\n", opt.uname)
+				continue
+			}
+			helpMsg := opt.help
+
+			// If the default value is the known zero value
+			// then don't display it.
+			def := opt.defval
+			switch genericValue(opt.value).(type) {
+			case *bool:
+				if def == "false" {
+					def = ""
+				}
+			case *int, *int8, *int16, *int32, *int64,
+				*uint, *uint8, *uint16, *uint32, *uint64,
+				*float32, *float64:
+				if def == "0" {
+					def = ""
+				}
+			case *time.Duration:
+				if def == "0s" {
+					def = ""
+				}
+			default:
+				if opt.flag && def == "false" {
+					def = ""
+				}
+			}
+			if def != "" {
+				helpMsg += " [" + def + "]"
+			}
+
+			help := strings.Split(helpMsg, "\n")
+			// If they did not put in newlines then we will insert
+			// them to keep the help messages from wrapping.
+			if len(help) == 1 {
+				help = breakup(help[0], DisplayWidth-HelpColumn)
+			}
+			if len(opt.uname) <= max {
+				fmt.Fprintf(w, " %-*s  %s\n", max, opt.uname, help[0])
+				help = help[1:]
+			} else {
+				fmt.Fprintf(w, " %s\n", opt.uname)
+			}
+			for _, s := range help {
+				fmt.Fprintf(w, " %-*s  %s\n", max, " ", s)
+			}
+		}
+	}
+}
+
+// breakup breaks s up into strings no longer than max bytes.
+func breakup(s string, max int) []string {
+	var a []string
+
+	for {
+		// strip leading spaces
+		for len(s) > 0 && s[0] == ' ' {
+			s = s[1:]
+		}
+		// If the option is no longer than the max just return it
+		if len(s) <= max {
+			if len(s) != 0 {
+				a = append(a, s)
+			}
+			return a
+		}
+		x := max
+		for s[x] != ' ' {
+			// the first word is too long?!
+			if x == 0 {
+				x = max
+				for x < len(s) && s[x] != ' ' {
+					x++
+				}
+				if x == len(s) {
+					x--
+				}
+				break
+			}
+			x--
+		}
+		for s[x] == ' ' {
+			x--
+		}
+		a = append(a, s[:x+1])
+		s = s[x+1:]
+	}
+}
+
+// Parse uses Getopt to parse args using the options set for s.  The first
+// element of args is used to assign the program for s if it is not yet set.  On
+// error, Parse displays the error message as well as a usage message on
+// standard error and then exits the program.
+func (s *Set) Parse(args []string) {
+	if err := s.Getopt(args, nil); err != nil {
+		fmt.Fprintln(stderr, err)
+		s.usage()
+		exit(1)
+	}
+}
+
+// Parse uses Getopt to parse args using the options set for s.  The first
+// element of args is used to assign the program for s if it is not yet set.
+// Getop calls fn, if not nil, for each option parsed.
+//
+// Getopt returns nil when all options have been processed (a non-option
+// argument was encountered, "--" was encountered, or fn returned false).
+//
+// On error getopt returns a reference to an InvalidOption (which implements the
+// error interface).
+func (s *Set) Getopt(args []string, fn func(Option) bool) (err error) {
+	s.setState(InProgress)
+	defer func() {
+		if s.State() == InProgress {
+			switch {
+			case err != nil:
+				s.setState(Failure)
+			case len(s.args) == 0:
+				s.setState(EndOfArguments)
+			default:
+				s.setState(Unknown)
+			}
+		}
+	}()
+	if fn == nil {
+		fn = func(Option) bool { return true }
+	}
+	if len(args) == 0 {
+		return nil
+	}
+
+	if s.program == "" {
+		s.program = path.Base(args[0])
+	}
+	args = args[1:]
+Parsing:
+	for len(args) > 0 {
+		arg := args[0]
+		s.args = args
+		args = args[1:]
+
+		// end of options?
+		if arg == "" || arg[0] != '-' {
+			s.setState(EndOfOptions)
+			return nil
+		}
+
+		if arg == "-" {
+			goto ShortParsing
+		}
+
+		// explicitly request end of options?
+		if arg == "--" {
+			s.args = args
+			s.setState(DashDash)
+			return nil
+		}
+
+		// Long option processing
+		if len(s.longOptions) > 0 && arg[1] == '-' {
+			e := strings.IndexRune(arg, '=')
+			var value string
+			if e > 0 {
+				value = arg[e+1:]
+				arg = arg[:e]
+			}
+			opt := s.longOptions[arg[2:]]
+			// If we are processing long options then --f is -f
+			// if f is not defined as a long option.
+			// This lets you say --f=false
+			if opt == nil && len(arg[2:]) == 1 {
+				opt = s.shortOptions[rune(arg[2])]
+			}
+			if opt == nil {
+				return unknownOption(arg[2:])
+			}
+			opt.isLong = true
+			// If we require an option and did not have an =
+			// then use the next argument as an option.
+			if !opt.flag && e < 0 && !opt.optional {
+				if len(args) == 0 {
+					return missingArg(opt)
+				}
+				value = args[0]
+				args = args[1:]
+			}
+			opt.count++
+
+			if err := opt.value.Set(value, opt); err != nil {
+				return setError(opt, value, err)
+			}
+
+			if !fn(opt) {
+				s.setState(Terminated)
+				return nil
+			}
+			continue Parsing
+		}
+
+		// Short option processing
+		arg = arg[1:] // strip -
+	ShortParsing:
+		for i, c := range arg {
+			opt := s.shortOptions[c]
+			if opt == nil {
+				// In traditional getopt, if - is not registered
+				// as an option, a lone - is treated as
+				// if there were a -- in front of it.
+				if arg == "-" {
+					s.setState(Dash)
+					return nil
+				}
+				return unknownOption(c)
+			}
+			opt.isLong = false
+			opt.count++
+			var value string
+			if !opt.flag {
+				value = arg[1+i:]
+				if value == "" && !opt.optional {
+					if len(args) == 0 {
+						return missingArg(opt)
+					}
+					value = args[0]
+					args = args[1:]
+				}
+			}
+			if err := opt.value.Set(value, opt); err != nil {
+				return setError(opt, value, err)
+			}
+			if !fn(opt) {
+				s.setState(Terminated)
+				return nil
+			}
+			if !opt.flag {
+				continue Parsing
+			}
+		}
+	}
+	s.args = []string{}
+	return nil
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/help_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/help_test.go
@@ -1,0 +1,145 @@
+package getopt
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+type flagValue bool
+
+func (f *flagValue) Set(value string, opt Option) error {
+	switch strings.ToLower(value) {
+	case "true", "t", "on", "1":
+		*f = true
+	case "false", "f", "off", "0":
+		*f = false
+	default:
+		return fmt.Errorf("invalid flagValue %q", value)
+	}
+	return nil
+}
+func (f *flagValue) String() string {
+	return fmt.Sprint(bool(*f))
+}
+
+func TestHelpDefaults(t *testing.T) {
+	HelpColumn = 40
+	set := New()
+	bf := false
+	bt := true
+	set.FlagLong(&bf, "bool_false", 'f', "false bool value")
+	set.FlagLong(&bt, "bool_true", 't', "true bool value")
+	i := int(0)
+	i8 := int8(0)
+	i16 := int16(0)
+	i32 := int32(0)
+	i64 := int64(0)
+	si := int(1)
+	si8 := int8(8)
+	si16 := int16(16)
+	si32 := int32(32)
+	si64 := int64(64)
+	ui := uint(0)
+	ui8 := uint8(0)
+	ui16 := uint16(0)
+	ui32 := uint32(0)
+	ui64 := uint64(0)
+	sui := uint(1)
+	sui8 := uint8(8)
+	sui16 := uint16(16)
+	sui32 := uint32(32)
+	sui64 := uint64(64)
+
+	set.FlagLong(&i, "int", 0, "int value")
+	set.FlagLong(&si, "int_set", 0, "set int value")
+	set.FlagLong(&i8, "int8", 0, "int8 value")
+	set.FlagLong(&si8, "int8_set", 0, "set int8 value")
+	set.FlagLong(&i16, "int16", 0, "int16 value")
+	set.FlagLong(&si16, "int16_set", 0, "set int16 value")
+	set.FlagLong(&i32, "int32", 0, "int32 value")
+	set.FlagLong(&si32, "int32_set", 0, "set int32 value")
+	set.FlagLong(&i64, "int64", 0, "int64 value")
+	set.FlagLong(&si64, "int64_set", 0, "set int64 value")
+
+	set.FlagLong(&ui, "uint", 0, "uint value")
+	set.FlagLong(&sui, "uint_set", 0, "set uint value")
+	set.FlagLong(&ui8, "uint8", 0, "uint8 value")
+	set.FlagLong(&sui8, "uint8_set", 0, "set uint8 value")
+	set.FlagLong(&ui16, "uint16", 0, "uint16 value")
+	set.FlagLong(&sui16, "uint16_set", 0, "set uint16 value")
+	set.FlagLong(&ui32, "uint32", 0, "uint32 value")
+	set.FlagLong(&sui32, "uint32_set", 0, "set uint32 value")
+	set.FlagLong(&ui64, "uint64", 0, "uint64 value")
+	set.FlagLong(&sui64, "uint64_set", 0, "set uint64 value")
+
+	f32 := float32(0)
+	f64 := float64(0)
+	sf32 := float32(3.2)
+	sf64 := float64(6.4)
+
+	set.FlagLong(&f32, "float32", 0, "float32 value")
+	set.FlagLong(&sf32, "float32_set", 0, "set float32 value")
+	set.FlagLong(&f64, "float64", 0, "float64 value")
+	set.FlagLong(&sf64, "float64_set", 0, "set float64 value")
+
+	d := time.Duration(0)
+	sd := time.Duration(time.Second)
+
+	set.FlagLong(&d, "duration", 0, "duration value")
+	set.FlagLong(&sd, "duration_set", 0, "set duration value")
+
+	str := ""
+	sstr := "string"
+	set.FlagLong(&str, "string", 0, "string value")
+	set.FlagLong(&sstr, "string_set", 0, "set string value")
+
+	var fv flagValue
+	set.FlagLong(&fv, "vbool", 0, "value bool").SetFlag()
+
+	var fvo flagValue = true
+	set.FlagLong(&fvo, "vbool_on", 0, "value bool").SetFlag()
+
+	want := `
+     --duration=value      duration value
+     --duration_set=value  set duration value [1s]
+ -f, --bool_false          false bool value
+     --float32=value       float32 value
+     --float32_set=value   set float32 value [3.2]
+     --float64=value       float64 value
+     --float64_set=value   set float64 value [6.4]
+     --int=value           int value
+     --int16=value         int16 value
+     --int16_set=value     set int16 value [16]
+     --int32=value         int32 value
+     --int32_set=value     set int32 value [32]
+     --int64=value         int64 value
+     --int64_set=value     set int64 value [64]
+     --int8=value          int8 value
+     --int8_set=value      set int8 value [8]
+     --int_set=value       set int value [1]
+     --string=value        string value
+     --string_set=value    set string value [string]
+ -t, --bool_true           true bool value [true]
+     --uint=value          uint value
+     --uint16=value        uint16 value
+     --uint16_set=value    set uint16 value [16]
+     --uint32=value        uint32 value
+     --uint32_set=value    set uint32 value [32]
+     --uint64=value        uint64 value
+     --uint64_set=value    set uint64 value [64]
+     --uint8=value         uint8 value
+     --uint8_set=value     set uint8 value [8]
+     --uint_set=value      set uint value [1]
+     --vbool               value bool
+     --vbool_on            value bool [true]
+`[1:]
+
+	var buf bytes.Buffer
+	set.PrintOptions(&buf)
+	if got := buf.String(); got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/int.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/int.go
@@ -1,0 +1,157 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+// Int creates an option that parses its value as an integer.
+func Int(name rune, value int, helpvalue ...string) *int {
+	return CommandLine.Int(name, value, helpvalue...)
+}
+
+func (s *Set) Int(name rune, value int, helpvalue ...string) *int {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func IntLong(name string, short rune, value int, helpvalue ...string) *int {
+	return CommandLine.IntLong(name, short, value, helpvalue...)
+}
+
+func (s *Set) IntLong(name string, short rune, value int, helpvalue ...string) *int {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+// Int16 creates an option that parses its value as a 16 bit integer.
+func Int16(name rune, value int16, helpvalue ...string) *int16 {
+	return CommandLine.Int16(name, value, helpvalue...)
+}
+
+func (s *Set) Int16(name rune, value int16, helpvalue ...string) *int16 {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func Int16Long(name string, short rune, value int16, helpvalue ...string) *int16 {
+	return CommandLine.Int16Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Int16Long(name string, short rune, value int16, helpvalue ...string) *int16 {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+// Int32 creates an option that parses its value as a 32 bit integer.
+func Int32(name rune, value int32, helpvalue ...string) *int32 {
+	return CommandLine.Int32(name, value, helpvalue...)
+}
+
+func (s *Set) Int32(name rune, value int32, helpvalue ...string) *int32 {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func Int32Long(name string, short rune, value int32, helpvalue ...string) *int32 {
+	return CommandLine.Int32Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Int32Long(name string, short rune, value int32, helpvalue ...string) *int32 {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+// Int64 creates an option that parses its value as a 64 bit integer.
+func Int64(name rune, value int64, helpvalue ...string) *int64 {
+	return CommandLine.Int64(name, value, helpvalue...)
+}
+
+func (s *Set) Int64(name rune, value int64, helpvalue ...string) *int64 {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func Int64Long(name string, short rune, value int64, helpvalue ...string) *int64 {
+	return CommandLine.Int64Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Int64Long(name string, short rune, value int64, helpvalue ...string) *int64 {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+// Uint creates an option that parses its value as an unsigned integer.
+func Uint(name rune, value uint, helpvalue ...string) *uint {
+	return CommandLine.Uint(name, value, helpvalue...)
+}
+
+func (s *Set) Uint(name rune, value uint, helpvalue ...string) *uint {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func UintLong(name string, short rune, value uint, helpvalue ...string) *uint {
+	return CommandLine.UintLong(name, short, value, helpvalue...)
+}
+
+func (s *Set) UintLong(name string, short rune, value uint, helpvalue ...string) *uint {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+// Uint16 creates an option that parses its value as a 16 bit unsigned integer.
+func Uint16(name rune, value uint16, helpvalue ...string) *uint16 {
+	return CommandLine.Uint16(name, value, helpvalue...)
+}
+
+func (s *Set) Uint16(name rune, value uint16, helpvalue ...string) *uint16 {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func Uint16Long(name string, short rune, value uint16, helpvalue ...string) *uint16 {
+	return CommandLine.Uint16Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Uint16Long(name string, short rune, value uint16, helpvalue ...string) *uint16 {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+// Uint32 creates an option that parses its value as a 32 bit unsigned integer.
+func Uint32(name rune, value uint32, helpvalue ...string) *uint32 {
+	return CommandLine.Uint32(name, value, helpvalue...)
+}
+
+func (s *Set) Uint32(name rune, value uint32, helpvalue ...string) *uint32 {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func Uint32Long(name string, short rune, value uint32, helpvalue ...string) *uint32 {
+	return CommandLine.Uint32Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Uint32Long(name string, short rune, value uint32, helpvalue ...string) *uint32 {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+// Uint64 creates an option that parses its value as a 64 bit unsigned integer.
+func Uint64(name rune, value uint64, helpvalue ...string) *uint64 {
+	return CommandLine.Uint64(name, value, helpvalue...)
+}
+
+func (s *Set) Uint64(name rune, value uint64, helpvalue ...string) *uint64 {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func Uint64Long(name string, short rune, value uint64, helpvalue ...string) *uint64 {
+	return CommandLine.Uint64Long(name, short, value, helpvalue...)
+}
+
+func (s *Set) Uint64Long(name string, short rune, value uint64, helpvalue ...string) *uint64 {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/int_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/int_test.go
@@ -1,0 +1,595 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var intTests = []struct {
+	where string
+	in    []string
+	i     int
+	int   int
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--int", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--int=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestInt(t *testing.T) {
+	for x, tt := range intTests {
+		reset()
+		i := Int('i', 17)
+		opt := IntLong("int", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.int; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}
+
+var int16Tests = []struct {
+	where string
+	in    []string
+	i     int16
+	int16 int16
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--int16", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--int16=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestInt16(t *testing.T) {
+	for x, tt := range int16Tests {
+		reset()
+		i := Int16('i', 17)
+		opt := Int16Long("int16", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.int16; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}
+
+var int32Tests = []struct {
+	where string
+	in    []string
+	i     int32
+	int32 int32
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--int32", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--int32=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestInt32(t *testing.T) {
+	for x, tt := range int32Tests {
+		reset()
+		i := Int32('i', 17)
+		opt := Int32Long("int32", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.int32; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}
+
+var int64Tests = []struct {
+	where string
+	in    []string
+	i     int64
+	int64 int64
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--int64", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--int64=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestInt64(t *testing.T) {
+	for x, tt := range int64Tests {
+		reset()
+		i := Int64('i', 17)
+		opt := Int64Long("int64", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.int64; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}
+
+var uintTests = []struct {
+	where string
+	in    []string
+	i     uint
+	uint  uint
+	err   string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--uint", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--uint=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestUint(t *testing.T) {
+	for x, tt := range uintTests {
+		reset()
+		i := Uint('i', 17)
+		opt := UintLong("uint", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.uint; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}
+
+var uint16Tests = []struct {
+	where  string
+	in     []string
+	i      uint16
+	uint16 uint16
+	err    string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--uint16", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--uint16=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestUint16(t *testing.T) {
+	for x, tt := range uint16Tests {
+		reset()
+		i := Uint16('i', 17)
+		opt := Uint16Long("uint16", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.uint16; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}
+
+var uint32Tests = []struct {
+	where  string
+	in     []string
+	i      uint32
+	uint32 uint32
+	err    string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--uint32", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--uint32=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestUint32(t *testing.T) {
+	for x, tt := range uint32Tests {
+		reset()
+		i := Uint32('i', 17)
+		opt := Uint32Long("uint32", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.uint32; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}
+
+var uint64Tests = []struct {
+	where  string
+	in     []string
+	i      uint64
+	uint64 uint64
+	err    string
+}{
+	{
+		loc(),
+		[]string{},
+		17, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i", "1", "--uint64", "2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "--uint64=2"},
+		1, 2,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i1", "-i2"},
+		2, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i=1"},
+		17, 42,
+		"test: not a valid number: =1\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-i0x20"},
+		0x20, 42,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-i010"},
+		8, 42,
+		"",
+	},
+}
+
+func TestUint64(t *testing.T) {
+	for x, tt := range uint64Tests {
+		reset()
+		i := Uint64('i', 17)
+		opt := Uint64Long("uint64", 0, 42)
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if got, want := *i, tt.i; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+		if got, want := *opt, tt.uint64; got != want {
+			t.Errorf("%s: got %v, want %v", tt.where, got, want)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/list.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/list.go
@@ -1,0 +1,32 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+// List creates an option that returns a slice of strings.  The parameters
+// passed are converted from a comma separated value list into a slice.
+// Subsequent occurrences append to the list.
+func List(name rune, helpvalue ...string) *[]string {
+	p := []string{}
+	CommandLine.Flag(&p, name, helpvalue...)
+	return &p
+}
+
+func (s *Set) List(name rune, helpvalue ...string) *[]string {
+	p := []string{}
+	s.Flag(&p, name, helpvalue...)
+	return &p
+}
+
+func ListLong(name string, short rune, helpvalue ...string) *[]string {
+	p := []string{}
+	CommandLine.FlagLong(&p, name, short, helpvalue...)
+	return &p
+}
+
+func (s *Set) ListLong(name string, short rune, helpvalue ...string) *[]string {
+	p := []string{}
+	s.FlagLong(&p, name, short, helpvalue...)
+	return &p
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/list_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/list_test.go
@@ -1,0 +1,99 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "testing"
+
+var listTests = []struct {
+	where   string
+	in      []string
+	l, list []string
+	err     string
+}{
+	{
+		loc(),
+		[]string{},
+		nil, nil,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-l", "one"},
+		[]string{"one"}, nil,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-lone", "-ltwo"},
+		[]string{"one", "two"}, nil,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--list", "one"},
+		nil, []string{"one"},
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--list=one", "--list=two"},
+		nil, []string{"one", "two"},
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "--list=one,two"},
+		nil, []string{"one", "two"},
+		"",
+	},
+}
+
+func TestList(t *testing.T) {
+	for _, tt := range listTests {
+		reset()
+		l := List('l')
+		list := ListLong("list", 0)
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if badSlice(*l, tt.l) {
+			t.Errorf("%s: got s = %q, want %q", tt.where, *l, tt.l)
+		}
+		if badSlice(*list, tt.list) {
+			t.Errorf("%s: got s = %q, want %q", tt.where, *list, tt.list)
+		}
+	}
+}
+
+func TestDefaultList(t *testing.T) {
+	reset()
+	list := []string{"d1", "d2", "d3"}
+	Flag(&list, 'l')
+	parse([]string{"test"})
+
+	want := []string{"d1", "d2", "d3"}
+	if badSlice(list, want) {
+		t.Errorf("got s = %q, want %q", list, want)
+	}
+
+	parse([]string{"test", "-l", "one"})
+	want = []string{"one"}
+	if badSlice(list, want) {
+		t.Errorf("got s = %q, want %q", list, want)
+	}
+
+	parse([]string{"test", "-l", "two"})
+	want = []string{"one", "two"}
+	if badSlice(list, want) {
+		t.Errorf("got s = %q, want %q", list, want)
+	}
+	Lookup('l').Reset()
+	want = []string{"d1", "d2", "d3"}
+	if badSlice(list, want) {
+		t.Errorf("got s = %q, want %q", list, want)
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/option.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/option.go
@@ -1,0 +1,212 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// An Option can be either a Flag or a Value
+type Option interface {
+	// Name returns the name of the option.  If the option has been seen
+	// then the last way it was referenced (short or long) is returned
+	// otherwise if there is a short name then this will be the short name
+	// as a string, else it will be the long name.
+	Name() string
+
+	// ShortName always returns the short name of the option, or "" if there
+	// is no short name.  The name does not include the "-".
+	ShortName() string
+
+	// LongName always returns the long name of the option, or "" if there
+	// is no long name.  The name does not include the "--".
+	LongName() string
+
+	// IsFlag returns true if Option is a flag.
+	IsFlag() bool
+
+	// Seen returns true if the flag was seen.
+	Seen() bool
+
+	// Count returns the number of times the flag was seen.
+	Count() int
+
+	// String returns the last value the option was set to.
+	String() string
+
+	// Value returns the Value of the option.
+	Value() Value
+
+	// SetOptional makes the value optional.  The option and value are
+	// always a single argument.  Either --option or --option=value.  In
+	// the former case the value of the option does not change but the Set()
+	// will return true and the value returned by Count() is incremented.
+	// The short form is either -o or -ovalue.  SetOptional returns
+	// the Option
+	SetOptional() Option
+
+	// SetFlag makes the value a flag.  Flags are boolean values and
+	// normally do not taken a value.  They are set to true when seen.
+	// If a value is passed in the long form then it must be on, case
+	// insensitivinsensitive, one of "true", "false", "t", "f", "on", "off", "1", "0".
+	// SetFlag returns the Option
+	SetFlag() Option
+
+	// Reset resets the state of the option so it appears it has not
+	// yet been seen, including resetting the value of the option
+	// to its original default state.
+	Reset()
+}
+
+type option struct {
+	short    rune   // 0 means no short name
+	long     string // "" means no long name
+	isLong   bool   // True if they used the long name
+	flag     bool   // true if a boolean flag
+	defval   string // default value
+	optional bool   // true if we take an optional value
+	help     string // help message
+	where    string // file where the option was defined
+	value    Value  // current value of option
+	count    int    // number of times we have seen this option
+	name     string // name of the value (for usage)
+	uname    string // name of the option (for usage)
+}
+
+// usageName returns the name of the option for printing usage lines in one
+// of the following forms:
+//
+//  -f
+//      --flag
+//  -f, --flag
+//  -s value
+//      --set=value
+//  -s, --set=value
+func (o *option) usageName() string {
+	// Don't print help messages if we have none and there is only one
+	// way to specify the option.
+	if o.help == "" && (o.short == 0 || o.long == "") {
+		return ""
+	}
+	n := ""
+
+	switch {
+	case o.short != 0 && o.long == "":
+		n = "-" + string(o.short)
+	case o.short == 0 && o.long != "":
+		n = "    --" + o.long
+	case o.short != 0 && o.long != "":
+		n = "-" + string(o.short) + ", --" + o.long
+	}
+
+	switch {
+	case o.flag:
+		return n
+	case o.optional:
+		return n + "[=" + o.name + "]"
+	case o.long != "":
+		return n + "=" + o.name
+	}
+	return n + " " + o.name
+}
+
+// sortName returns the name to sort the option on.
+func (o *option) sortName() string {
+	if o.short != 0 {
+		return string(o.short) + o.long
+	}
+	return o.long[:1] + o.long
+}
+
+func (o *option) Seen() bool          { return o.count > 0 }
+func (o *option) Count() int          { return o.count }
+func (o *option) IsFlag() bool        { return o.flag }
+func (o *option) String() string      { return o.value.String() }
+func (o *option) SetOptional() Option { o.optional = true; return o }
+func (o *option) SetFlag() Option     { o.flag = true; return o }
+
+func (o *option) Value() Value {
+	if o == nil {
+		return nil
+	}
+	return o.value
+}
+
+func (o *option) Name() string {
+	if !o.isLong && o.short != 0 {
+		return "-" + string(o.short)
+	}
+	return "--" + o.long
+}
+
+func (o *option) ShortName() string {
+	if o.short != 0 {
+		return string(o.short)
+	}
+	return ""
+}
+
+func (o *option) LongName() string {
+	return o.long
+}
+
+// Reset rests an option so that it appears it has not yet been seen.
+func (o *option) Reset() {
+	o.isLong = false
+	o.count = 0
+	o.value.Set(o.defval, o)
+}
+
+type optionList []*option
+
+func (ol optionList) Len() int      { return len(ol) }
+func (ol optionList) Swap(i, j int) { ol[i], ol[j] = ol[j], ol[i] }
+func (ol optionList) Less(i, j int) bool {
+	// first check the short names (or the first letter of the long name)
+	// If they are not equal (case insensitive) then we have our answer
+	n1 := ol[i].sortName()
+	n2 := ol[j].sortName()
+	l1 := strings.ToLower(n1)
+	l2 := strings.ToLower(n2)
+	if l1 < l2 {
+		return true
+	}
+	if l2 < l1 {
+		return false
+	}
+	return n1 < n2
+}
+
+// AddOption add the option o to set CommandLine if o is not already in set
+// CommandLine.
+func AddOption(o Option) {
+	CommandLine.AddOption(o)
+}
+
+// AddOption add the option o to set s if o is not already in set s.
+func (s *Set) AddOption(o Option) {
+	opt := o.(*option)
+	for _, eopt := range s.options {
+		if opt == eopt {
+			return
+		}
+	}
+	if opt.short != 0 {
+		if oo, ok := s.shortOptions[opt.short]; ok {
+			fmt.Fprintf(stderr, "%s: -%c already declared at %s\n", opt.where, opt.short, oo.where)
+			exit(1)
+		}
+		s.shortOptions[opt.short] = opt
+	}
+	if opt.long != "" {
+		if oo, ok := s.longOptions[opt.long]; ok {
+			fmt.Fprintf(stderr, "%s: --%s already declared at %s\n", opt.where, opt.long, oo.where)
+			exit(1)
+		}
+		s.longOptions[opt.long] = opt
+	}
+	s.options = append(s.options, opt)
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/set.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/set.go
@@ -1,0 +1,293 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"io"
+	"os"
+	"sort"
+	"sync"
+)
+
+// A State is why the Getopt returned.
+type State int
+
+const (
+	InProgress     = State(iota) // Getopt is still running
+	Dash                         // Returned on "-"
+	DashDash                     // Returned on "--"
+	EndOfOptions                 // End of options reached
+	EndOfArguments               // No more arguments
+	Terminated                   // Terminated by callback function
+	Failure                      // Terminated due to error
+	Unknown                      // Indicates internal error
+)
+
+type Set struct {
+	stateMu sync.Mutex
+	state   State
+
+	// args are the parameters remaining after parsing the optoins.
+	args []string
+
+	// program is the name of the program for usage and error messages.
+	// If not set it will automatically be set to the base name of the
+	// first argument passed to parse.
+	program string
+
+	// parameters is what is displayed on the usage line after displaying
+	// the various options.
+	parameters string
+
+	usage func() // usage should print the programs usage and exit.
+
+	shortOptions map[rune]*option
+	longOptions  map[string]*option
+	options      optionList
+}
+
+// New returns a newly created option set.
+func New() *Set {
+	s := &Set{
+		shortOptions: make(map[rune]*option),
+		longOptions:  make(map[string]*option),
+		parameters:   "[parameters ...]",
+	}
+
+	s.usage = func() {
+		s.PrintUsage(stderr)
+	}
+	return s
+}
+
+func (s *Set) setState(state State) {
+	s.stateMu.Lock()
+	s.state = state
+	s.stateMu.Unlock()
+}
+
+// State returns the current state of the Set s.  The state is normally the
+// reason the most recent call to Getopt returned.
+func (s *Set) State() State {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	return s.state
+}
+
+// The default set of command-line options.
+var CommandLine = New()
+
+// PrintUsage calls PrintUsage in the default option set.
+func PrintUsage(w io.Writer) { CommandLine.PrintUsage(w) }
+
+// Usage calls the usage function in the default option set.
+func Usage() { CommandLine.usage() }
+
+// Parse calls Parse in the default option set with the command line arguments
+// found in os.Args.
+func Parse() { CommandLine.Parse(os.Args) }
+
+// Same as parse but not found in version 1 of getopt.
+func ParseV2() { CommandLine.Parse(os.Args) }
+
+// Getops returns the result of calling Getop in the default option set with the
+// command line arguments found in os.Args.  The fn function, which may be nil,
+// is passed to Getopt.
+func Getopt(fn func(Option) bool) error { return CommandLine.Getopt(os.Args, fn) }
+
+// Arg returns the n'th command-line argument. Arg(0) is the first remaining
+// argument after options have been processed.
+func Arg(n int) string {
+	if n >= 0 && n < len(CommandLine.args) {
+		return CommandLine.args[n]
+	}
+	return ""
+}
+
+// Arg returns the n'th argument. Arg(0) is the first remaining
+// argument after options have been processed.
+func (s *Set) Arg(n int) string {
+	if n >= 0 && n < len(s.args) {
+		return s.args[n]
+	}
+	return ""
+}
+
+// Args returns the non-option command line arguments.
+func Args() []string {
+	return CommandLine.args
+}
+
+// Args returns the non-option arguments.
+func (s *Set) Args() []string {
+	return s.args
+}
+
+// NArgs returns the number of non-option command line arguments.
+func NArgs() int {
+	return len(CommandLine.args)
+}
+
+// NArgs returns the number of non-option arguments.
+func (s *Set) NArgs() int {
+	return len(s.args)
+}
+
+// SetParameters sets the parameters string for printing the command line
+// usage.  It defaults to "[parameters ...]"
+func SetParameters(parameters string) {
+	CommandLine.parameters = parameters
+}
+
+// SetParameters sets the parameters string for printing the s's usage.
+// It defaults to "[parameters ...]"
+func (s *Set) SetParameters(parameters string) {
+	s.parameters = parameters
+}
+
+// Parameters returns the parameters set by SetParameters on s.
+func (s *Set) Parameters() string { return s.parameters }
+
+// SetProgram sets the program name to program.  Normally it is determined
+// from the zeroth command line argument (see os.Args).
+func SetProgram(program string) {
+	CommandLine.program = program
+}
+
+// SetProgram sets s's program name to program.  Normally it is determined
+// from the zeroth argument passed to Getopt or Parse.
+func (s *Set) SetProgram(program string) {
+	s.program = program
+}
+
+// Program returns the program name associated with Set s.
+func (s *Set) Program() string { return s.program }
+
+// SetUsage sets the function used by Parse to display the commands usage
+// on error.  It defaults to calling PrintUsage(os.Stderr).
+func SetUsage(usage func()) {
+	CommandLine.usage = usage
+}
+
+// SetUsage sets the function used by Parse to display usage on error.  It
+// defaults to calling f.PrintUsage(os.Stderr).
+func (s *Set) SetUsage(usage func()) {
+	s.usage = usage
+}
+
+// Lookup returns the Option associated with name.  Name should either be
+// a rune (the short name) or a string (the long name).
+func Lookup(name interface{}) Option {
+	return CommandLine.Lookup(name)
+}
+
+// Lookup returns the Option associated with name in s.  Name should either be
+// a rune (the short name) or a string (the long name).
+func (s *Set) Lookup(name interface{}) Option {
+	switch v := name.(type) {
+	case rune:
+		return s.shortOptions[v]
+	case int:
+		return s.shortOptions[rune(v)]
+	case string:
+		return s.longOptions[v]
+	}
+	return nil
+}
+
+// IsSet returns true if the Option associated with name was seen while
+// parsing the command line arguments.  Name should either be a rune (the
+// short name) or a string (the long name).
+func IsSet(name interface{}) bool {
+	return CommandLine.IsSet(name)
+}
+
+// IsSet returns true if the Option associated with name was seen while
+// parsing s.  Name should either be a rune (the short name) or a string (the
+// long name).
+func (s *Set) IsSet(name interface{}) bool {
+	if opt := s.Lookup(name); opt != nil {
+		return opt.Seen()
+	}
+	return false
+}
+
+// GetCount returns the number of times the Option associated with name has been
+// seen while parsing the command line arguments.  Name should either be a rune
+// (the short name) or a string (the long name).
+func GetCount(name interface{}) int {
+	return CommandLine.GetCount(name)
+}
+
+// GetCount returns the number of times the Option associated with name has been
+// seen while parsing s's arguments.  Name should either be a rune (the short
+// name) or a string (the long name).
+func (s *Set) GetCount(name interface{}) int {
+	if opt := s.Lookup(name); opt != nil {
+		return opt.Count()
+	}
+	return 0
+}
+
+// GetValue returns the final value set to the command-line Option with name.
+// If the option has not been seen while parsing s then the default value is
+// returned.  Name should either be a rune (the short name) or a string (the
+// long name).
+func GetValue(name interface{}) string {
+	return CommandLine.GetValue(name)
+}
+
+// GetValue returns the final value set to the Option in s associated with name.
+// If the option has not been seen while parsing s then the default value is
+// returned.  Name should either be a rune (the short name) or a string (the
+// long name).
+func (s *Set) GetValue(name interface{}) string {
+	if opt := s.Lookup(name); opt != nil {
+		return opt.String()
+	}
+	return ""
+}
+
+// Visit visits the command-line options in lexicographical order, calling fn
+// for each. It visits only those options that have been set.
+func Visit(fn func(Option)) { CommandLine.Visit(fn) }
+
+// Visit visits the options in s in lexicographical order, calling fn
+// for each. It visits only those options that have been set.
+func (s *Set) Visit(fn func(Option)) {
+	sort.Sort(s.options)
+	for _, opt := range s.options {
+		if opt.count > 0 {
+			fn(opt)
+		}
+	}
+}
+
+// VisitAll visits the options in s in lexicographical order, calling fn
+// for each. It visits all options, even those not set.
+func VisitAll(fn func(Option)) { CommandLine.VisitAll(fn) }
+
+// VisitAll visits the command-line flags in lexicographical order, calling fn
+// for each. It visits all flags, even those not set.
+func (s *Set) VisitAll(fn func(Option)) {
+	sort.Sort(s.options)
+	for _, opt := range s.options {
+		fn(opt)
+	}
+}
+
+// Reset resets all the command line options to the initial state so it
+// appears none of them have been seen.
+func Reset() {
+	CommandLine.Reset()
+}
+
+// Reset resets all the options in s to the initial state so it
+// appears none of them have been seen.
+func (s *Set) Reset() {
+	for _, opt := range s.options {
+		opt.Reset()
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/signed.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/signed.go
@@ -1,0 +1,110 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+type signed int64
+
+type SignedLimit struct {
+	Base int   // Base for conversion as per strconv.ParseInt
+	Bits int   // Number of bits as per strconv.ParseInt
+	Min  int64 // Minimum allowed value if both Min and Max are not 0
+	Max  int64 // Maximum allowed value if both Min and Max are not 0
+}
+
+var (
+	signedLimitsMu sync.Mutex
+	signedLimits   = make(map[*signed]*SignedLimit)
+)
+
+func (n *signed) Set(value string, opt Option) error {
+	signedLimitsMu.Lock()
+	l := signedLimits[n]
+	signedLimitsMu.Unlock()
+	if l == nil {
+		return fmt.Errorf("no limits defined for %s", opt.Name())
+	}
+	v, err := strconv.ParseInt(value, l.Base, l.Bits)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	if l.Min != 0 || l.Max != 0 {
+		if v < l.Min {
+			return fmt.Errorf("value out of range (<%v): %s", l.Min, value)
+		}
+		if v > l.Max {
+			return fmt.Errorf("value out of range (>%v): %s", l.Max, value)
+		}
+	}
+	*n = signed(v)
+	return nil
+}
+
+func (n *signed) String() string {
+	signedLimitsMu.Lock()
+	l := signedLimits[n]
+	signedLimitsMu.Unlock()
+	if l != nil && l.Base != 0 {
+		return strconv.FormatInt(int64(*n), l.Base)
+	}
+	return strconv.FormatInt(int64(*n), 10)
+}
+
+// Signed creates an option that is stored in an int64 and is constrained
+// by the limits pointed to by l.  The Max and Min values are only used if
+// at least one of the values are not 0.   If Base is 0, the base is implied by
+// the string's prefix: base 16 for "0x", base 8 for "0", and base 10 otherwise.
+func Signed(name rune, value int64, l *SignedLimit, helpvalue ...string) *int64 {
+	CommandLine.signedOption(&value, "", name, l, helpvalue...)
+	return &value
+}
+
+func (s *Set) Signed(name rune, value int64, l *SignedLimit, helpvalue ...string) *int64 {
+	s.signedOption(&value, "", name, l, helpvalue...)
+	return &value
+}
+
+func SignedLong(name string, short rune, value int64, l *SignedLimit, helpvalue ...string) *int64 {
+	CommandLine.signedOption(&value, name, short, l, helpvalue...)
+	return &value
+}
+
+func (s *Set) SignedLong(name string, short rune, value int64, l *SignedLimit, helpvalue ...string) *int64 {
+	s.signedOption(&value, name, short, l, helpvalue...)
+	return &value
+}
+
+func (s *Set) signedOption(p *int64, name string, short rune, l *SignedLimit, helpvalue ...string) {
+	opt := s.FlagLong((*signed)(p), name, short, helpvalue...)
+	if l.Base > 36 || l.Base == 1 || l.Base < 0 {
+		fmt.Fprintf(stderr, "invalid base for %s: %d\n", opt.Name(), l.Base)
+		exit(1)
+	}
+	if l.Bits < 0 || l.Bits > 64 {
+		fmt.Fprintf(stderr, "invalid bit size for %s: %d\n", opt.Name(), l.Bits)
+		exit(1)
+	}
+	if l.Min > l.Max {
+		fmt.Fprintf(stderr, "min greater than max for %s\n", opt.Name())
+		exit(1)
+	}
+	lim := *l
+	signedLimitsMu.Lock()
+	signedLimits[(*signed)(p)] = &lim
+	signedLimitsMu.Unlock()
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/signed_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/signed_test.go
@@ -1,0 +1,97 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var signedNumberTests = []struct {
+	where string
+	in    []string
+	l     SignedLimit
+	out   int64
+	err   string
+}{
+	{
+		where: loc(),
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		SignedLimit{Base: 2, Bits: 5},
+		10,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		SignedLimit{Base: 2, Bits: 4},
+		0,
+		"test: value out of range: 1010\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "-1000"},
+		SignedLimit{Base: 2, Bits: 4},
+		-8,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "3"},
+		SignedLimit{Min: 4, Max: 6},
+		0,
+		"test: value out of range (<4): 3\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "4"},
+		SignedLimit{Min: 4, Max: 6},
+		4,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "5"},
+		SignedLimit{Min: 4, Max: 6},
+		5,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "6"},
+		SignedLimit{Min: 4, Max: 6},
+		6,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "7"},
+		SignedLimit{Min: 4, Max: 6},
+		0,
+		"test: value out of range (>6): 7\n",
+	},
+}
+
+func TestSigneds(t *testing.T) {
+	for x, tt := range signedNumberTests {
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		reset()
+		n := Signed('n', 0, &tt.l)
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if *n != tt.out {
+			t.Errorf("%s: got %v, want %v", tt.where, *n, tt.out)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/string.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/string.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+// String returns a value option that stores is value as a string.  The
+// initial value of the string is passed in value.
+func String(name rune, value string, helpvalue ...string) *string {
+	CommandLine.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func (s *Set) String(name rune, value string, helpvalue ...string) *string {
+	s.Flag(&value, name, helpvalue...)
+	return &value
+}
+
+func StringLong(name string, short rune, value string, helpvalue ...string) *string {
+	CommandLine.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}
+
+func (s *Set) StringLong(name string, short rune, value string, helpvalue ...string) *string {
+	s.FlagLong(&value, name, short, helpvalue...)
+	return &value
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/string_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/string_test.go
@@ -1,0 +1,77 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import "testing"
+
+var stringTests = []struct {
+	where  string
+	in     []string
+	sout   string
+	optout string
+	err    string
+}{
+	{
+		loc(),
+		[]string{},
+		"one",
+		"two",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-s"},
+		"one",
+		"two",
+		"test: missing parameter for -s\n",
+	},
+	{
+		loc(),
+		[]string{"test", "--opt"},
+		"one",
+		"two",
+		"test: missing parameter for --opt\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-svalue", "--opt=option"},
+		"value",
+		"option",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-s", "value", "--opt", "option"},
+		"value",
+		"option",
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-swrong", "--opt=wrong", "-s", "value", "--opt", "option"},
+		"value",
+		"option",
+		"",
+	},
+}
+
+func TestString(t *testing.T) {
+	for _, tt := range stringTests {
+		reset()
+		s := String('s', "one")
+		opt := StringLong("opt", 0, "two")
+
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if *s != tt.sout {
+			t.Errorf("%s: got s = %q, want %q", tt.where, *s, tt.sout)
+		}
+		if *opt != tt.optout {
+			t.Errorf("%s: got opt = %q, want %q", tt.where, *opt, tt.optout)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/unsigned.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/unsigned.go
@@ -1,0 +1,111 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+type unsigned uint64
+
+type UnsignedLimit struct {
+	Base int    // Base for conversion as per strconv.ParseInt
+	Bits int    // Number of bits as per strconv.ParseInt
+	Min  uint64 // Minimum allowed value if both Min and Max are not 0
+	Max  uint64 // Maximum allowed value if both Min and Max are not 0
+}
+
+var (
+	unsignedLimitsMu sync.Mutex
+	unsignedLimits   = make(map[*unsigned]*UnsignedLimit)
+)
+
+func (n *unsigned) Set(value string, opt Option) error {
+	unsignedLimitsMu.Lock()
+	l := unsignedLimits[n]
+	unsignedLimitsMu.Unlock()
+	if l == nil {
+		return fmt.Errorf("no limits defined for %s", opt.Name())
+	}
+	v, err := strconv.ParseUint(value, l.Base, l.Bits)
+	if err != nil {
+		if e, ok := err.(*strconv.NumError); ok {
+			switch e.Err {
+			case strconv.ErrRange:
+				err = fmt.Errorf("value out of range: %s", value)
+			case strconv.ErrSyntax:
+				err = fmt.Errorf("not a valid number: %s", value)
+			}
+		}
+		return err
+	}
+	if l.Min != 0 || l.Max != 0 {
+		if v < l.Min {
+			return fmt.Errorf("value out of range (<%v): %s", l.Min, value)
+		}
+		if v > l.Max {
+			return fmt.Errorf("value out of range (>%v): %s", l.Max, value)
+		}
+	}
+	*n = unsigned(v)
+	return nil
+}
+
+func (n *unsigned) String() string {
+	unsignedLimitsMu.Lock()
+	l := unsignedLimits[n]
+	unsignedLimitsMu.Unlock()
+	if l != nil && l.Base != 0 {
+		return strconv.FormatUint(uint64(*n), l.Base)
+	}
+	return strconv.FormatUint(uint64(*n), 10)
+}
+
+// Unsigned creates an option that is stored in a uint64 and is
+// constrained by the limits pointed to by l.  The Max and Min values are only
+// used if at least one of the values are not 0.   If Base is 0, the base is
+// implied by the string's prefix: base 16 for "0x", base 8 for "0", and base
+// 10 otherwise.
+func Unsigned(name rune, value uint64, l *UnsignedLimit, helpvalue ...string) *uint64 {
+	CommandLine.unsignedOption(&value, "", name, l, helpvalue...)
+	return &value
+}
+
+func (s *Set) Unsigned(name rune, value uint64, l *UnsignedLimit, helpvalue ...string) *uint64 {
+	s.unsignedOption(&value, "", name, l, helpvalue...)
+	return &value
+}
+
+func UnsignedLong(name string, short rune, value uint64, l *UnsignedLimit, helpvalue ...string) *uint64 {
+	CommandLine.unsignedOption(&value, name, short, l, helpvalue...)
+	return &value
+}
+
+func (s *Set) UnsignedLong(name string, short rune, value uint64, l *UnsignedLimit, helpvalue ...string) *uint64 {
+	s.unsignedOption(&value, name, short, l, helpvalue...)
+	return &value
+}
+
+func (s *Set) unsignedOption(p *uint64, name string, short rune, l *UnsignedLimit, helpvalue ...string) {
+	opt := s.FlagLong((*unsigned)(p), name, short, helpvalue...)
+	if l.Base > 36 || l.Base == 1 || l.Base < 0 {
+		fmt.Fprintf(stderr, "invalid base for %s: %d\n", opt.Name(), l.Base)
+		exit(1)
+	}
+	if l.Bits < 0 || l.Bits > 64 {
+		fmt.Fprintf(stderr, "invalid bit size for %s: %d\n", opt.Name(), l.Bits)
+		exit(1)
+	}
+	if l.Min > l.Max {
+		fmt.Fprintf(stderr, "min greater than max for %s\n", opt.Name())
+		exit(1)
+	}
+	lim := *l
+	unsignedLimitsMu.Lock()
+	unsignedLimits[(*unsigned)(p)] = &lim
+	unsignedLimitsMu.Unlock()
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/unsigned_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/unsigned_test.go
@@ -1,0 +1,97 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var unsignedTests = []struct {
+	where string
+	in    []string
+	l     UnsignedLimit
+	out   uint64
+	err   string
+}{
+	{
+		where: loc(),
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		UnsignedLimit{Base: 2, Bits: 5},
+		10,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		UnsignedLimit{Base: 2, Bits: 4},
+		10,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "1010"},
+		UnsignedLimit{Base: 2, Bits: 3},
+		0,
+		"test: value out of range: 1010\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "3"},
+		UnsignedLimit{Min: 4, Max: 6},
+		0,
+		"test: value out of range (<4): 3\n",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "4"},
+		UnsignedLimit{Min: 4, Max: 6},
+		4,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "5"},
+		UnsignedLimit{Min: 4, Max: 6},
+		5,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "6"},
+		UnsignedLimit{Min: 4, Max: 6},
+		6,
+		"",
+	},
+	{
+		loc(),
+		[]string{"test", "-n", "7"},
+		UnsignedLimit{Min: 4, Max: 6},
+		0,
+		"test: value out of range (>6): 7\n",
+	},
+}
+
+func TestUnsigneds(t *testing.T) {
+	for x, tt := range unsignedTests {
+		if strings.Index(tt.where, ":-") > 0 {
+			tt.where = fmt.Sprintf("#%d", x)
+		}
+
+		reset()
+		n := Unsigned('n', 0, &tt.l)
+		parse(tt.in)
+		if s := checkError(tt.err); s != "" {
+			t.Errorf("%s: %s", tt.where, s)
+		}
+		if *n != tt.out {
+			t.Errorf("%s: got %v, want %v", tt.where, *n, tt.out)
+		}
+	}
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/util_test.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/util_test.go
@@ -1,0 +1,85 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"reflect"
+	"runtime"
+	"strings"
+)
+
+var errorString string
+
+func reset() {
+	CommandLine.shortOptions = make(map[rune]*option)
+	CommandLine.longOptions = make(map[string]*option)
+	CommandLine.options = nil
+	CommandLine.args = nil
+	CommandLine.program = ""
+	errorString = ""
+}
+
+func parse(args []string) {
+	err := CommandLine.Getopt(args, nil)
+	if err != nil {
+		b := &bytes.Buffer{}
+
+		fmt.Fprintln(b, CommandLine.program+": "+err.Error())
+		CommandLine.PrintUsage(b)
+		errorString = b.String()
+	}
+}
+
+func badSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return true
+	}
+	for x, v := range a {
+		if b[x] != v {
+			return true
+		}
+	}
+	return false
+}
+
+func loc() string {
+	_, file, line, _ := runtime.Caller(1)
+	return fmt.Sprintf("%s:%d", path.Base(file), line)
+}
+
+func (o *option) Equal(opt *option) bool {
+	if o.value != nil && opt.value == nil {
+		return false
+	}
+	if o.value == nil && opt.value != nil {
+		return false
+	}
+	if o.value != nil && o.value.String() != opt.value.String() {
+		return false
+	}
+
+	oc := *o
+	optc := *opt
+	oc.value = nil
+	optc.value = nil
+	return reflect.DeepEqual(&oc, &optc)
+}
+
+func checkError(err string) string {
+	switch {
+	case err == errorString:
+		return ""
+	case err == "":
+		return fmt.Sprintf("unexpected error %q", errorString)
+	case errorString == "":
+		return fmt.Sprintf("did not get expected error %q", err)
+	case !strings.HasPrefix(errorString, err):
+		return fmt.Sprintf("got error %q, want %q", errorString, err)
+	}
+	return ""
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/var.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/v2/var.go
@@ -1,0 +1,100 @@
+// Copyright 2017 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// Value is the interface to the dynamic value stored in a flag.  Flags of type
+// Value are declared using the Flag and FlagLong functions.
+type Value interface {
+	// Set converts value into the appropriate type and assigns it to the
+	// receiver value.  Option details are provided via opt (such as the
+	// flags name).
+	//
+	// Set is used to reset the value of an option to its default value
+	// (which is stored in string form internally).
+	Set(value string, opt Option) error
+
+	// String returns the value of the flag as a string.
+	String() string
+}
+
+var thisPackage string
+
+// init initializes thisPackage to our full package with the trailing .
+// included.
+func init() {
+	pc, _, _, ok := runtime.Caller(0)
+	if !ok {
+		return
+	}
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return
+	}
+	thisPackage = f.Name()
+	x := strings.LastIndex(thisPackage, "/")
+	if x < 0 {
+		return
+	}
+	y := strings.Index(thisPackage[x:], ".")
+	if y < 0 {
+		return
+	}
+	// thisPackage includes the trailing . after the package name.
+	thisPackage = thisPackage[:x+y+1]
+}
+
+// calledFrom returns a string containing the file and linenumber of the first
+// stack frame above us that is not part of this package and is not a test.
+// This is used to determine where a flag was initialized.
+func calledFrom() string {
+	for i := 2; ; i++ {
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			return ""
+		}
+		if !strings.HasSuffix(file, "_test.go") {
+			f := runtime.FuncForPC(pc)
+			if f != nil && strings.HasPrefix(f.Name(), thisPackage) {
+				continue
+			}
+		}
+		return fmt.Sprintf("%s:%d", file, line)
+	}
+}
+
+func (s *Set) addFlag(p Value, name string, short rune, helpvalue ...string) Option {
+	opt := &option{
+		short:  short,
+		long:   name,
+		value:  p,
+		defval: p.String(),
+	}
+
+	switch len(helpvalue) {
+	case 2:
+		opt.name = helpvalue[1]
+		fallthrough
+	case 1:
+		opt.help = helpvalue[0]
+	case 0:
+	default:
+		panic("Too many strings for String helpvalue")
+	}
+	if where := calledFrom(); where != "" {
+		opt.where = where
+	}
+	if opt.short == 0 && opt.long == "" {
+		fmt.Fprintf(stderr, opt.where+": no short or long option given")
+		exit(1)
+	}
+	s.AddOption(opt)
+	return opt
+}

--- a/traffic_ops_ort/vendor/github.com/pborman/getopt/var.go
+++ b/traffic_ops_ort/vendor/github.com/pborman/getopt/var.go
@@ -1,0 +1,63 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package getopt
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Value is the interface to the dynamic value stored in a flag. (The default
+// value is represented as a string.)  Set is passed the string to set the
+// value to as well as the Option that is being processed.
+type Value interface {
+	Set(string, Option) error
+	String() string
+}
+
+// Var creates an option of the specified name. The type and value of the option
+// are represented by the first argument, of type Value, which typically holds a
+// user-defined implementation of Value.  All options are ultimately created
+// as a Var.
+func Var(p Value, name rune, helpvalue ...string) Option {
+	return CommandLine.VarLong(p, "", name, helpvalue...)
+}
+
+func VarLong(p Value, name string, short rune, helpvalue ...string) Option {
+	return CommandLine.VarLong(p, name, short, helpvalue...)
+}
+
+func (s *Set) Var(p Value, name rune, helpvalue ...string) Option {
+	return s.VarLong(p, "", name, helpvalue...)
+}
+
+func (s *Set) VarLong(p Value, name string, short rune, helpvalue ...string) Option {
+	opt := &option{
+		short:  short,
+		long:   name,
+		value:  p,
+		defval: p.String(),
+	}
+
+	switch len(helpvalue) {
+	case 2:
+		opt.name = helpvalue[1]
+		fallthrough
+	case 1:
+		opt.help = helpvalue[0]
+	case 0:
+	default:
+		panic("Too many strings for String helpvalue")
+	}
+	if _, file, line, ok := runtime.Caller(1); ok {
+		opt.where = fmt.Sprintf("%s:%d", file, line)
+	}
+	if opt.short == 0 && opt.long == "" {
+		fmt.Fprintf(stderr, opt.where+": no short or long option given")
+		exit(1)
+	}
+	s.AddOption(opt)
+	return opt
+}


### PR DESCRIPTION
This PR is a transliteration of the traffic_ops_ort.pl perl script to go.  It built command is 'traffic_ops_t3c' and is designed to replace the perl script entirely.  'traffic_ops_t3c' depends on and uses 'atstccfg'.  The go version here implements all the functionality in the perl version.  unit and integration tests will be added.  Looking for feedback from the community on this Draft PR.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->
- Traffic Ops ORT


## What is the best way to verify this PR?
Using a test environment, compare the run results from traffic_ops_ort.pl to the run results from 'traffic_ops_t3c'
## The following criteria are ALL met by this PR


- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

command usage:
`./traffic_ops_t3c --help
Usage: traffic_ops_t3c [options] <Traffic_Ops_URL> <Traffic_Ops_Login>
	<Traffic_Ops_URL> = URL to Traffic Ops host. Example: https://trafficops.company.net
	<Traffic_Ops_Login>  Example: 'username:password'

	[options]:
	  --dispersion=[time in seconds] | -D, [time in seconds] wait a random number between 0 and <time in seconds> before starting, default = 300s
	  --login-dispersion=[time in seconds] | -l, [time in seconds] wait a random number between 0 and <time in seconds> befor login, default = 0
	  --log-location-debug=[value] | -d [value], Where to log debugs. May be a file path, stdout, stderr, or null, default stdout
	  --log-location-error=[value] | -e [value], Where to log errors. May be a file path, stdout, stderr, or null, default stdout
	  --log-location-info=[value] | -i [value], Where to log info. May be a file path, stdout, stderr, or null, default stdout
	  --log-location-warning=[value] | -w [value], Where to log warnings. May be a file path, stdout, stderr, or null, default stdout
	  --run-mode=[mode] | -m [mode] where mode is one of [interactive | report | badass | syncds | revalidate ], default = report
	  --cache-hostname=[hostname] | -H [hostname], Host name of the cache to generate config for. Must be the server host name in Traffic Ops, not a URL, and not the FQDN
	  --num-retries=[number] | -r [number], retry connection to Traffic Ops URL [number] times, default is 3
	  --reval-wait-time=[seconds] | -T [seconds] wait a random number of seconds between 0 and [seconds] before revlidation, default is 60
	  --rev-proxy-disable=[true|false] | -P [true|false] bypass the reverse proxy even if one has been configured, default = false
	  --skip-os-check=[true|false] | -s [true | false] bypass the check for a supported CentOS version. default = false
	  --traffic-ops-timeout-milliseconds=[milliseconds] | -t [milliseconds] the Traffic Ops request timeout in milliseconds. Default = 30000 (30 seconds)
	  --traffic-ops-url=[url] | -u [url], Traffic Ops URL. Must be the full URL, including the scheme. Required. May also be set with the environment variable TO_URL
	  --traffic-ops-user=[username] | -U [username], Traffic Ops username. Required. May also be set with the environment variable TO_USER
	  --traffic-ops-password=[password] | -P [password], Traffic Ops password. Required. May also be set with the environment variable TO_PASS
	  --wait-for-parents | -w [true | false] do not update if parent_pending = 1 in the update json. default = true, wait for parents

	  --help | -h, Print usage information and exit`

