### PR TITLE
Do not copy Maven repository for clean builds

### DIFF
--- a/build/clean_build.sh
+++ b/build/clean_build.sh
@@ -49,7 +49,7 @@ fi
  cd "$GOPATH"
  mkdir -p src pkg bin "$(dirname "$tc_dir")"
 )
-rsync -a --exclude=dist "${tc_volume}/" "$tc_dir";
+rsync -a --exclude=^dist --exclude=^.m2 "${tc_volume}/" "$tc_dir";
 if ! [ -d ${tc_dir}/.git ]; then
 	rsync -a "${tc_volume}/.git" $tc_dir; # Docker for Windows compatibility
 fi

--- a/pkg
+++ b/pkg
@@ -134,6 +134,7 @@ while (( "$#" )); do
 		if (( "$verbose" == 0 )); then
 			exec >/dev/null 2>&1
 		fi
+		"${COMPOSECMD[@]}" -f $COMPOSE_FILE pull $1 || exit 1
 		"${COMPOSECMD[@]}" -f $COMPOSE_FILE build --pull $1 || exit 1
 		"${COMPOSECMD[@]}" -f $COMPOSE_FILE run "${RUN_OPTIONS[@]}" --rm $1 || exit 1
 	) || {


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

1.  When building all of the components simultaneously, there is sometimes an rsync error:

    ```shell script
    rsync warning: some files vanished before they could be transferred (code 24) at main.c(1179) [sender=3.1.2]
    ```

    or
    ```shell script
    file has vanished: "/trafficcontrol/.m2/repository/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom.part"
    ```

    This is because Traffic Router mounts the local Maven repository (`.m2/` directory) and adds Maven dependencies in order to build Traffic Router, which makes `jcl-over-slf4j-1.5.6.pom.part` disappear from the `rsync` file list for any other components building at the same time.

    This PR ignores the Maven repository in `rsync` command in `clean_build.sh`, which avoids that error.

2. This PR also fixes an issue in `pkg` where it did not attempt to get the latest builder image before building.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.
Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Build system

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Make sure there is no rsync warning like (`rsync warning: some files vanished before they could be transferred (code 24) at main.c(1179) [sender=3.1.2]`) when building the components simultaneously:
```shell script
cd infrastructure/docker/build 
docker-compose up # (Wait for all of the components to finish building)
docker-compose ps # All should have an exit status of 0
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (357cf5983d)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] Only changes the build environment and building the components is effectively a test, no further tests necessary
- [x] Intended behavior unchanged, no documentation necessary
- [x] Fixes a bug that was not present in a release, no CHANGELOG.md update necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
