### PR TITLE
Fix ORT range directive duplication

### DIFF
--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -213,7 +213,6 @@ const RemapConfigRangeDirective = `__RANGE_DIRECTIVE__`
 // The cacheKeyConfigParams map may be nil, if this ds profile had no cache key config params.
 func BuildRemapLine(cacheURLConfigParams map[string]string, atsMajorVersion int, server *ServerInfo, pData map[string]string, text string, ds RemapConfigDSData, mapFrom string, mapTo string, cacheKeyConfigParams map[string]string) string {
 	// ds = 'remap' in perl
-
 	mapFrom = strings.Replace(mapFrom, `__http__`, server.HostName, -1)
 
 	if _, hasDSCPRemap := pData["dscp_remap"]; hasDSCPRemap {
@@ -298,14 +297,20 @@ func BuildRemapLine(cacheURLConfigParams map[string]string, atsMajorVersion int,
 			rangeReqTxt = ` @plugin=slice.so @pparam=--blockbytes=` + strconv.Itoa(*ds.RangeSliceBlockSize) + ` @plugin=cache_range_requests.so	`
 		}
 	}
-	if ds.RemapText != nil && *ds.RemapText != "" && strings.Contains(*ds.RemapText, RemapConfigRangeDirective) {
-		*ds.RemapText = strings.Replace(*ds.RemapText, `__RANGE_DIRECTIVE__`, rangeReqTxt, 1)
+
+	remapText := ""
+	if ds.RemapText != nil {
+		remapText = *ds.RemapText
+	}
+
+	if strings.Contains(remapText, RemapConfigRangeDirective) {
+		remapText = strings.Replace(remapText, RemapConfigRangeDirective, rangeReqTxt, 1)
 	} else {
 		text += rangeReqTxt
 	}
 
-	if ds.RemapText != nil && *ds.RemapText != "" {
-		text += " " + *ds.RemapText
+	if remapText != "" {
+		text += " " + remapText
 	}
 
 	if ds.FQPacingRate != nil && *ds.FQPacingRate > 0 {

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -4940,7 +4940,7 @@ func TestMakeRemapDotConfigRawRemapRangeDirective(t *testing.T) {
 			RegexSetNumber:           util.StrPtr("myregexsetnum"),
 			OriginShield:             util.StrPtr("myoriginshield"),
 			ProfileID:                util.IntPtr(49),
-			Protocol:                 util.IntPtr(int(tc.DSProtocolHTTPToHTTPS)),
+			Protocol:                 util.IntPtr(int(tc.DSProtocolHTTPAndHTTPS)),
 			AnonymousBlockingEnabled: util.BoolPtr(false),
 			Active:                   true,
 			RangeSliceBlockSize:      util.IntPtr(262144),
@@ -4955,8 +4955,8 @@ func TestMakeRemapDotConfigRawRemapRangeDirective(t *testing.T) {
 
 	txtLines := strings.Split(txt, "\n")
 
-	if len(txtLines) != 2 {
-		t.Fatalf("expected 1 remaps from HTTP_TO_HTTPS DS, actual: '%v' count %v", txt, len(txtLines))
+	if len(txtLines) != 3 { // 2 remaps plus header comment
+		t.Fatalf("expected 2 remaps from HTTP_AND_HTTPS DS, actual: '%v' count %v", txt, len(txtLines))
 	}
 
 	remapLine := txtLines[1]
@@ -4983,8 +4983,11 @@ func TestMakeRemapDotConfigRawRemapRangeDirective(t *testing.T) {
 	if strings.Contains(remapLine, "__RANGE_DIRECTIVE__") {
 		t.Errorf("expected raw remap range directive to be replaced, actual '%v'", txt)
 	}
-	if strings.Count(remapLine, "slice.so") != 1 {
-		t.Errorf("expected raw remap range directive to be replaced not duplicated, actual '%v'", txt)
+	if count := strings.Count(remapLine, "slice.so"); count != 1 { // Individual line should only have 1 slice.so
+		t.Errorf("expected raw remap range directive to be replaced not duplicated, actual count %v '%v'", count, txt)
+	}
+	if count := strings.Count(txt, "slice.so"); count != 2 { // All lines should have 2 slice.so - HTTP and HTTPS lines
+		t.Errorf("expected raw remap range directive to have one slice.so for HTTP and one for HTTPS remap, actual count %v '%v'", count, txt)
 	}
 }
 


### PR DESCRIPTION
Fixes a bug where DSes with multiple remap lines (e.g. HTTP and HTTPS)
result in a double range directive, if there's a `__RANGE_DIRECTIVE__`
override.

Tested manually, observed duplicated remap with directive and HTTP_AND_HTTPS DS without fix, generates correctly with fix.

Includes tests.
No docs, bug fix, no interface change.
Includes changelog.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests.
Configure a DS with a __RANGE_DIRECTIVE__ in the raw remap, and HTTP_AND_HTTPS (which will result in 2 remap lines), run ORT, verify generated remap.config has the range directive where expected and not duplicated, for both remap lines of the DS.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.1.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information