### PR TITLE
Ciab remove location params

### DIFF
--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -25,6 +25,7 @@ import logging
 import re
 import subprocess
 import typing
+from os import path
 
 from munch import Munch
 from requests.compat import urljoin
@@ -80,7 +81,8 @@ class API(TOSession):
 			"--traffic-ops-password={}".format(conf.password),
 			"--log-location-error=stderr",
 			"--log-location-warning=stderr",
-			"--log-location-info=stderr"
+			"--log-location-info=stderr",
+			"--dir={}".format(path.join(conf.tsroot, "etc/trafficserver"))
 		]
 
 		if conf.timeout is not None and conf.timeout >= 0:

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/010-ATS_EDGE_TIER_CACHE.json
@@ -126,54 +126,6 @@
 			"value": "INT 2"
 		},
 		{
-			"configFile": "cache.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "hosting.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "parent.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "plugin.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "records.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "remap.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "storage.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "volume.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
 			"configFile": "records.config",
 			"name": "CONFIG proxy.config.url_remap.remap_required",
 			"secure": false,

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/020-ATS_MID_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/020-ATS_MID_TIER_CACHE.json
@@ -126,54 +126,6 @@
 			"value": "INT 2"
 		},
 		{
-			"configFile": "cache.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "hosting.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "parent.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "plugin.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "records.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "remap.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "storage.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
-			"configFile": "volume.config",
-			"name": "location",
-			"secure": false,
-			"value": "/etc/trafficserver/"
-		},
-		{
 			"configFile": "records.config",
 			"name": "CONFIG proxy.config.url_remap.remap_required",
 			"secure": false,


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4890 

This PR removes all location parameters for required files:

- cache.config
- hosting.config
- parent.config
- plugin.config
- records.config
- remap.config
- storage.config
- volume.config

and adds support for the new `--dir` option-argument of `atstccfg` to ORT.py.

## Which Traffic Control components are affected by this PR?
- CDN in a Box

## What is the best way to verify this PR?
Build and run CDN-in-a-Box, ensure the readiness container exits successfully.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**