### PR TITLE
Fix API tests missing required location params

### DIFF
--- a/traffic_ops/testing/api/v1/atsconfig_meta_test.go
+++ b/traffic_ops/testing/api/v1/atsconfig_meta_test.go
@@ -16,7 +16,6 @@ package v1
 */
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -35,6 +34,9 @@ func GetTestATSConfigMeta(t *testing.T) {
 	if len(testData.Servers) < 1 {
 		t.Fatal("cannot GET Server: no test data")
 	}
+
+	MakeConfigLocationParams(t)
+
 	testServer := testData.Servers[0]
 
 	serverList, _, err := TOSession.GetServerByHostName(testServer.HostName)

--- a/traffic_ops/testing/api/v1/tc-fixtures.json
+++ b/traffic_ops/testing/api/v1/tc-fixtures.json
@@ -924,6 +924,20 @@
             "name": "use_tenancy",
             "secure": false,
             "value": "1"
+        },
+        {
+            "configFile": "cache.config",
+            "lastUpdated": "2018-01-19T19:01:21.501151+00:00",
+            "name": "location",
+            "secure": false,
+            "value": "/opt/trafficserver/etc/trafficserver"
+        },
+        {
+            "configFile": "hosting.config",
+            "lastUpdated": "2018-01-19T19:01:21.501151+00:00",
+            "name": "location",
+            "secure": false,
+            "value": "/opt/trafficserver/etc/trafficserver"
         }
     ],
     "physLocations": [


### PR DESCRIPTION
Fixes the TO API Tests failing because they lack required Location Parameters now enforced by the config generation.

Is a test.
No docs, it's a test.
No changelog, it's a test.

- [x] This PR is not related to any other Issue 

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Run API tests.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix, it's a test.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information