### PR TITLE
TP: On server create, expands the first interface which is required

### DIFF
--- a/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
@@ -244,8 +244,9 @@ under the License.
             <fieldset>
                 <legend>Interfaces<button name="addInterfaceBtn" class="btn btn-primary right-button btn-xs" type="button" title="add a new interface" ng-click="addInterface()"><i class="fa fa-plus"></i></button></legend>
                 <fieldset ng-repeat="inf in server.interfaces">
-                    <legend>
-                        <input type="text" ng-model="inf.name" required aria-label="Interface name" id="{{inf.name}}-name" name="{{inf.name}}-name" class="interface-name-input" ng-class="{'has-error': hasError(serverForm[inf.name+'-name'])}" placeholder="interface-name"/>
+                    <legend ng-class="{'has-error': hasError(serverForm[inf.name+'-name'])}">
+                        <label for="{{inf.name}}-name" ng-class="{'has-error': hasError(serverForm[inf.name+'-name'])}">Name</label>
+                        <input type="text" ng-model="inf.name" required aria-label="Interface name" id="{{inf.name}}-name" name="{{inf.name}}-name" class="interface-name-input"/>
                         <button class="btn btn-danger right-button btn-xs" type="button" title="delete this interface" ng-click="deleteInterface(inf)"><i class="fa fa-minus"></i></button>
                     </legend>
 

--- a/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
@@ -271,7 +271,7 @@ under the License.
                                 <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-'+ip.address], 'required')">Required</small>
                                 <label for="{{inf.name}}-{{ip.address}}-gateway">Gateway</label>
                                 <input type="text" id="{{inf.name}}-{{ip.address}}-gateway" name="{{inf.name}}-{{ip.address}}-gateway" ng-model="ip.gateway" ng-pattern="IPPattern"/>
-                                <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-'+ip.address-gateway], 'pattern')">Invalid gateway</small>
+                                <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-'+ip.address+'-gateway'], 'pattern')">Invalid gateway</small>
                                 <label for="{{inf.name}}-{{ip.address}}-serviceAddress">Is a Service Address</label>
                                 <input type="checkbox" name="{{inf.name}}-{{ip.address}}-serviceAddress" id="{{inf.name}}-{{ip.address}}-serviceAddress" class="service-addr-cb" ng-model="ip.serviceAddress"/>
                                 <button type="button" title="delete this IP address" class="btn btn-danger btn-xs" style="justify-self: start;" ng-click="deleteIP(inf, ip)"><i class="fa fa-minus"></i></button>

--- a/traffic_portal/app/src/modules/private/servers/new/index.js
+++ b/traffic_portal/app/src/modules/private/servers/new/index.js
@@ -33,7 +33,17 @@ module.exports = angular.module('trafficPortal.private.servers.new', [])
                                     tcpPort: 80,
                                     httpsPort: 443,
                                     ipIsService: false,
-                                    ip6IsService: false
+                                    ip6IsService: false,
+                                    interfaces: [
+                                        {
+                                            ipAddresses: [
+                                                {
+                                                    serviceAddress: true
+                                                }
+                                            ],
+                                            monitor: true
+                                        }
+                                    ]
                                 };
                             }
                         }

--- a/traffic_portal/test/end_to_end/servers/servers-spec.js
+++ b/traffic_portal/test/end_to_end/servers/servers-spec.js
@@ -57,11 +57,8 @@ describe('Traffic Portal Servers Test Suite', function() {
 		element(by.css("#type [label='EDGE']")).click();
 		commonFunctions.selectDropdownbyNum(pageData.profile, 1);
 		commonFunctions.selectDropdownbyNum(pageData.physLocation, 1);
-		pageData.addInterfaceBtn.click();
 		pageData.interfaceName.sendKeys(mockVals.interfaceName);
-		pageData.addIPBtn.click();
 		pageData.ipAddress.sendKeys(mockVals.ipAddress);
-		pageData.ipIsService.click();
 		expect(pageData.createButton.isEnabled()).toBe(true);
 		pageData.createButton.click();
 		expect(browser.getCurrentUrl().then(commonFunctions.urlPath)).toEqual(commonFunctions.urlPath(browser.baseUrl)+"#!/servers");


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4895 

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
- Run UI tests and ensure they pass.
Manual:
- Create a new server at https://tp.domain.com/#!/servers/new
- Notice that one interface is expanded for the user with 2 required fields (name and ip address)
- The Create button will only enable once all required fields are complete.
- also notice that entering an invalid gateway (i.e. 1.1.1.1/32) will show an error message as it did not before.

## If this is a bug fix, what versions of Traffic Control are affected?
-  master


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR has NO CHANGELOG.md update as it is a bug in an unreleased feature.
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
