### PR TITLE
Remove grunt-usemin

### DIFF
--- a/traffic_portal/package-lock.json
+++ b/traffic_portal/package-lock.json
@@ -3059,57 +3059,6 @@
         }
       }
     },
-    "grunt-usemin": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-3.1.1.tgz",
-      "integrity": "sha1-WrZ5UQ1nLOpWbMcXq+i4oAn2QcI=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.1",
-        "debug": "^2.1.3",
-        "lodash": "^3.6.0",
-        "path-exists": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "grunt-wiredep": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/grunt-wiredep/-/grunt-wiredep-3.0.1.tgz",

--- a/traffic_portal/package.json
+++ b/traffic_portal/package.json
@@ -24,7 +24,6 @@
     "grunt-newer": "1.3.0",
     "grunt-run": "0.8.1",
     "grunt-string-replace": "1.3.1",
-    "grunt-usemin": "3.1.1",
     "grunt-wiredep": "3.0.1",
     "load-grunt-config": "2.0.1",
     "load-grunt-tasks": "5.1.0",


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This removes the unused and unmaintained library `grunt-usemin`

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Portal

## What is the best way to verify this PR?
Run the integration tests.
Ensure production and dev builds work, as well as CiaB.
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

## Additional Information
Diff output from running `grunt dist`:
```
❯ diff -dr dist dist_master
diff --color -dr dist/public/index.html dist_master/public/index.html
34,37c34,37
<         <link rel="stylesheet" media="all" href="resources/styles/theme.css?built=1595342124350">
<         <link rel="stylesheet" media="all" href="resources/styles/loading.css?built=1595342124350">
<         <link rel="stylesheet" media="all" href="resources/styles/main.css?built=1595342124350">
<         <link rel="stylesheet" media="all" href="resources/assets/css/custom.css?built=1595342124350">
---
>         <link rel="stylesheet" media="all" href="resources/styles/theme.css?built=1595342071418">
>         <link rel="stylesheet" media="all" href="resources/styles/loading.css?built=1595342071418">
>         <link rel="stylesheet" media="all" href="resources/styles/main.css?built=1595342071418">
>         <link rel="stylesheet" media="all" href="resources/assets/css/custom.css?built=1595342071418">
51c51
<         <script src="resources/assets/js/shared-libs.js?built=1595342124350"></script>
---
>         <script src="resources/assets/js/shared-libs.js?built=1595342071418"></script>
53,54c53,54
<         <script src="resources/assets/js/app.js?built=1595342124350"></script>
<         <script src="resources/assets/js/config.js?built=1595342124350"></script>
---
>         <script src="resources/assets/js/app.js?built=1595342071418"></script>
>         <script src="resources/assets/js/config.js?built=1595342071418"></script>
```