### PR TITLE
Fixes the inability to clone ds assignments across servers when 1+ ds is assigned a topology

### DIFF
--- a/traffic_ops/testing/api/v3/servers_to_deliveryservice_assignment_test.go
+++ b/traffic_ops/testing/api/v3/servers_to_deliveryservice_assignment_test.go
@@ -192,11 +192,11 @@ func AssignTopologyBasedDeliveryService(t *testing.T) {
 		t.Fatal("Fetch DS information returned unknown ID")
 	}
 	alerts, reqInf, err := TOSession.AssignDeliveryServiceIDsToServerID(*server.ID, []int{*firstDS.ID}, false)
-	if err == nil {
-		t.Errorf("Expected bad assignment to fail, but it didn't! (alerts: %v)", alerts)
+	if err != nil {
+		t.Errorf("Expected assignment to succeed, but it didn't! (alerts: %v)", alerts)
 	}
-	if reqInf.StatusCode < http.StatusBadRequest || reqInf.StatusCode >= http.StatusInternalServerError {
-		t.Fatalf("assigning Topology-based delivery service to server - expected: 400-level status code, actual: %d", reqInf.StatusCode)
+	if reqInf.StatusCode >= http.StatusBadRequest {
+		t.Fatalf("assigning Topology-based delivery service to server - expected: non-error status code, actual: %d", reqInf.StatusCode)
 	}
 
 	response, _, err := TOSession.GetServerIDDeliveryServices(*server.ID, nil)
@@ -214,7 +214,7 @@ func AssignTopologyBasedDeliveryService(t *testing.T) {
 		}
 	}
 
-	if found {
-		t.Errorf(`Invalid Server/DS assignment was created!`)
+	if !found {
+		t.Errorf(`Valid Server/DS assignment was not created!`)
 	}
 }

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -96,15 +96,6 @@ func AssignDeliveryServicesToServerHandler(w http.ResponseWriter, r *http.Reques
 			api.HandleErr(w, r, inf.Tx.Tx, status, usrErr, sysErr)
 			return
 		}
-		dses, sysErr := dbhelpers.GetDeliveryServicesWithTopologies(inf.Tx.Tx, dsList)
-		if sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, sysErr)
-			return
-		}
-		if len(dses) > 0 {
-			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, fmt.Errorf("delivery services %v are already assigned to a topology", dses), nil)
-			return
-		}
 	}
 
 	// We already know the CDN exists because that's part of the serverInfo query above

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/TableAssignDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/TableAssignDeliveryServicesController.js
@@ -35,6 +35,9 @@ var TableAssignDeliveryServicesController = function(server, deliveryServices, a
 				return parseInt($(this).attr('id'));
 			}).get();
 		$scope.selectedDeliveryServices = _.map(deliveryServices, function(ds) {
+			if (ds.topology) {
+				return ds;
+			}
 			if (visibleDSIds.includes(ds.id)) {
 				ds['selected'] = selected;
 			}

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.assignDeliveryServices.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/table.assignDeliveryServices.tpl.html
@@ -33,7 +33,7 @@ under the License.
         </thead>
         <tbody>
         <tr id="{{::ds.id}}" class="ds-row" ng-class="::{'active': ds.selected}" ng-repeat="ds in ::selectedDeliveryServices" ng-click="ds.selected = !ds.selected; onChange()">
-            <td><input type="checkbox" ng-model="ds.selected"></td>
+            <td><input type="checkbox" ng-model="ds.selected" ng-disabled="ds.topology"></td>
             <td data-search="^{{::ds.xmlId}}$">{{::ds.xmlId}}</td>
             <td data-search="^{{::ds.displayName}}$">{{::ds.displayName}}</td>
             <td data-search="^{{::ds.type}}$">{{::ds.type}}</td>


### PR DESCRIPTION
## What does this PR (Pull Request) do?
With the introduction of topologies, it no longer makes sense to assign caches _directly_ to a delivery service if that ds utilizes a topology. Therefore, a constraint was added to the following api in #4702 to prevent delivery services from being assigned directly to a server if that delivery service utilizes a topology:

`POST api/version/servers/{server-id}/deliveryservices`

However, a common practice when provisioning new caches is to clone the ds assignments (or bulk assign) from an existing cache to the newly provisioned cache using the aforementioned endpoint. However, due to the new constraint added in #4702, this activity will inevitably fail as more delivery services start to use topologies but were never directly unassigned from the servers in which they were previously assigned. Confused yet? 

Anyhow, removing this constraint will ease the transition from delivery services that utilize a topology and other delivery services that choose to assign servers directly. 

In addition, when assigning ds's directly to a server, it makes no sense to directly assign topology-based ds's to a server, therefore, those ds's have been disabled (or are unselectable) in TP.

TLDR; this PR allows bulk assignment of ds's to a server even if one of those ds's utilizes a topology but prevents individual assignment of a ds with a topology to a server (in TP). Because bulk assignment is part of the new server provisioning playbook and cannot be broken.

- [x] This PR fixes #4860 

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
- Run the API and UI tests and/or
- `curl -X POST --data '[dsId]' https://trafficops.domain.com/api/3.x/servers/{server-id}/deliveryservices?replace=true` where dsId is the id of a delivery service that utilizes a topology. The POST should succeed. 
- in TP:
-- edit a delivery service to use a topology. create a topology first if you have to.
-- view the delivery services of a server in the same cdn - https://tp.domain.com/#!/servers/{server-id}/delivery-services
-- click on the `Link Delivery Services to Server` button
-- notice that the delivery service with the topology assigned cannot be selected for direct assignment to the server.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR does NOT include documentation
- [x] This PR does NOT include an update to CHANGELOG.md as the bug was introduced between releases
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
