### PR TITLE
Updated documentation and TP's server UI related to xmppId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Astats csv support - astats will now respond to `Accept: text/csv` and return a csv formatted stats list
 - Updated /deliveryservices/{{ID}}/servers to use multiple interfaces in API v3
 - Updated /deliveryservices/{{ID}}/servers/eligible to use multiple interfaces in API v3
-- Added the ability to view Hash ID field on Traffic Portals' server summary page
+- Added the ability to view Hash ID field (aka xmppID) on Traffic Portals' server summary page
 
 ### Fixed
 - Fixed #2156 - Renaming a host in TC, does not impact xmpp_id and thereby hashid [Related github issue](https://github.com/apache/trafficcontrol/issues/2156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Astats csv support - astats will now respond to `Accept: text/csv` and return a csv formatted stats list
 - Updated /deliveryservices/{{ID}}/servers to use multiple interfaces in API v3
 - Updated /deliveryservices/{{ID}}/servers/eligible to use multiple interfaces in API v3
+- Added the ability to view Hash ID field on Traffic Portals' server summary page
 
 ### Fixed
 - Fixed #2156 - Renaming a host in TC, does not impact xmpp_id and thereby hashid [Related github issue](https://github.com/apache/trafficcontrol/issues/2156)

--- a/docs/source/api/v2/servers.rst
+++ b/docs/source/api/v2/servers.rst
@@ -125,7 +125,7 @@ Response Structure
 :type:       The name of the :term:`Type` of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http
@@ -349,7 +349,7 @@ Response Structure
 :type:       The name of the 'type' of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http

--- a/docs/source/api/v2/servers_details.rst
+++ b/docs/source/api/v2/servers_details.rst
@@ -99,7 +99,7 @@ Response Structure
 		.. note::       This is typically thought of as synonymous with "HTTP port", as the port specified by ``httpsPort`` may also be used for incoming TCP connections.
 
 	:type:                  The name of the 'type' of this server
-	:xmppId:                An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+	:xmppId:                A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 	:xmppPasswd:            The password used in XMPP communications with the server
 
 :size:          The page number - if pagination was requested in the query parameters, else ``0`` to indicate no pagination - of the results represented by the ``response`` array. This is named "size" for legacy reasons

--- a/docs/source/api/v2/servers_id.rst
+++ b/docs/source/api/v2/servers_id.rst
@@ -78,7 +78,7 @@ Request Structure
 
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An optional identifier to be used in XMPP communications with the server - in nearly all cases this should be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: An optional password used in XMPP communications with the server
 
 .. code-block:: http

--- a/docs/source/api/v3/servers.rst
+++ b/docs/source/api/v3/servers.rst
@@ -144,7 +144,7 @@ Response Structure
 :type:       The name of the :term:`Type` of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http
@@ -429,7 +429,7 @@ Response Structure
 :type:       The name of the 'type' of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http

--- a/docs/source/api/v3/servers_details.rst
+++ b/docs/source/api/v3/servers_details.rst
@@ -108,7 +108,7 @@ Response Structure
 		.. note::       This is typically thought of as synonymous with "HTTP port", as the port specified by ``httpsPort`` may also be used for incoming TCP connections.
 
 	:type:                  The name of the 'type' of this server
-	:xmppId:                An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+	:xmppId:                A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 	:xmppPasswd:            The password used in XMPP communications with the server
 
 :size:          The page number - if pagination was requested in the query parameters, else ``0`` to indicate no pagination - of the results represented by the ``response`` array. This is named "size" for legacy reasons

--- a/docs/source/api/v3/servers_id.rst
+++ b/docs/source/api/v3/servers_id.rst
@@ -236,7 +236,7 @@ Response Structure
 :type:       The name of the 'type' of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http
@@ -426,7 +426,7 @@ Response Structure
 :type:       The name of the :term:`Type` of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server had updates of some kind pending, typically to be acted upon by Traffic Ops :term:`ORT`
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http

--- a/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
+++ b/traffic_portal/app/src/common/modules/table/servers/TableServersController.js
@@ -94,6 +94,11 @@ var TableServersController = function(servers, $scope, $state, $uibModal, $windo
 			filter: "agNumberColumnFilter"
 		},
 		{
+			headerName: "Hash ID",
+			field: "xmppId",
+			hide: false
+		},
+		{
 			headerName: "ID",
 			field: "id",
 			hide: true,


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- This PR updated documentation related to xmppId and adds hashId field on Traffic Portal Server summary page.
![image](https://user-images.githubusercontent.com/22248619/88326655-82a95780-cce3-11ea-97d6-903f6775be03.png)

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Portal

## What is the best way to verify this PR?
1. Log into Traffic Portal UI 
2. Go to configure/server tab.
3. Checkmark Hash ID from drop down list on top right corner, book button next to More.
4. Once checked, the field, Hash ID, should appear on the server summary page

## The following criteria are ALL met by this PR
- [x] I have explained why tests are unnecessary
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
This PR has no tests since it is a documentation and UI refactor PR.