### PR TITLE
Remove false sub-tasks from issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,35 +3,33 @@
 If this issue identifies a security vulnerability, DO NOT submit it! Instead, contact
 the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
 guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
--->
 
-<!--
 - For *SUPPORT QUESTIONS*, use the
 [Traffic Control slack channels](https://traffic-control-cdn.slack.com) or [Traffic Control mailing lists](http://trafficcontrol.apache.org/mailing_lists/).
 - Before submitting, please **SEARCH GITHUB** for a similar issue or PR. -->
 
 ## I'm submitting a ...
-<!-- (check all that apply with "[x]") -->
+<!-- delete all those that don't apply -->
 <!--- security vulnerability (STOP!! - see above)-->
-- [ ] bug report
-- [ ] new feature / enhancement request
-- [ ] improvement request (usability, performance, tech debt, etc.)
-- [ ] other <!--(Please do not submit support requests here - see above)-->
+-  bug report
+-  new feature / enhancement request
+-  improvement request (usability, performance, tech debt, etc.)
+-  other <!--(Please do not submit support requests here - see above)-->
 
 ## Traffic Control components affected ...
-<!-- (check all that apply with "[x]") -->
-- [ ] CDN in a Box
-- [ ] Documentation
-- [ ] Grove
-- [ ] Traffic Control Client
-- [ ] Traffic Monitor
-- [ ] Traffic Ops
-- [ ] Traffic Ops ORT
-- [ ] Traffic Portal
-- [ ] Traffic Router
-- [ ] Traffic Stats
-- [ ] Traffic Vault
-- [ ] unknown
+<!-- delete all those that don't apply -->
+-  CDN in a Box
+-  Documentation
+-  Grove
+-  Traffic Control Client
+-  Traffic Monitor
+-  Traffic Ops
+-  Traffic Ops ORT
+-  Traffic Portal
+-  Traffic Router
+-  Traffic Stats
+-  Traffic Vault
+-  unknown
 
 ## Current behavior:
 <!-- Describe how the bug manifests / how the current features are insufficient. -->


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

The current system in the issue template for e.g. selecting which components are affected uses "check the boxes of all that apply". On GitHub, a checkbox on an issue represents a sub-task - which is not what we're using them for. This PR switches the method for indicating such things to "delete all items that don't apply". This should have the bonus effect of being less likely to cause rendering errors when people don't format it correctly (`[ X]` etc).

## Which Traffic Control components are affected by this PR?
None.

## What is the best way to verify this PR?
View the rendered template.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**