### PR TITLE
Specify ChromeDriver version again when starting webdriver-manager

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal_integration_test/run.sh
@@ -52,7 +52,8 @@ if (( time - start_time >= timeout_in_seconds )); then
 	echo "Warning: Traffic Portal did not start after ${timeout_in_seconds} seconds.";
 fi;
 
-nohup webdriver-manager start &
+chrome_version="$(repoquery --installed --qf='%{version}' google-chrome-stable)"
+nohup webdriver-manager start --versions.chrome "$chrome_version" &
 
 selenium_port=4444
 selenium_fqdn="http://localhost:${selenium_port}"


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
PR #4911 ensured that the version of ChromeDriver that we install is compatible with our version of Chrome. However, if you specify a custom ChromeDriver version when running `webdriver-manager update` but not at `webdriver-manager` run-time, you get

```
portal-integration-test_1  | Driver info: driver.version: unknown
portal-integration-test_1  | [04:02:42] E/launcher - SessionNotCreatedError: Unable to create new service: ChromeDriverService
```

This PR specifies the same ChromeDriver version again when starting `webdriver-manager`.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box (Traffic Portal integration test)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run TP tests in CDN-in-a-Box and verify that the result is `72 specs, 1 failure`, which indicates that the tests themselves were executed correctly.

When the TP test starts, you should see a message like this:
```shell script
portal-integration-test_1   | Starting ChromeDriver 84.0.4147.30 (48b3e868b4cc0aa7e8149519690b6f6949e110a8-refs/branch-heads/4147@{#310}) on port 8804
```

```shell script
docker-compose up -d trafficportal trafficops trafficvault && \
docker-compose -f docker-compose.yml -f docker-compose.traffic-portal-test.yml up --build portal-integration-test
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (a3d7d7f140)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR fixes tests
- [x] Bugfix fix, no documentation necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
