### PR TITLE
Traffic Ops unit tests: TestGetMonitoringJSON sometimes fails

### DIFF
--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -392,6 +392,20 @@ func TestGetConfig(t *testing.T) {
 	}
 }
 
+func sortByInterfaceName(servers []Cache) {
+	for _, cache := range servers {
+		sort.SliceStable(cache.Interfaces, func(i, j int) bool {
+			interface1, interface2 := cache.Interfaces[i], cache.Interfaces[j]
+			switch {
+			case interface1.Name != interface2.Name:
+				return interface1.Name < interface2.Name
+			default:
+				return interface1.Name < interface2.Name
+			}
+		})
+	}
+}
+
 func TestGetMonitoringJSON(t *testing.T) {
 	resp := MonitoringResponse{}
 	mockDB, mock, err := sqlmock.New()
@@ -528,9 +542,10 @@ func TestGetMonitoringJSON(t *testing.T) {
 	if err != nil {
 		t.Errorf("GetMonitoringJSON expected: nil error, actual: %v", err)
 	}
-
 	resp.Response.TrafficServers = sortCaches(resp.Response.TrafficServers)
 	sqlResp.TrafficServers = sortCaches(sqlResp.TrafficServers)
+	sortByInterfaceName(resp.Response.TrafficServers)
+	sortByInterfaceName(sqlResp.TrafficServers)
 	resp.Response.TrafficMonitors = sortMonitors(resp.Response.TrafficMonitors)
 	sqlResp.TrafficMonitors = sortMonitors(sqlResp.TrafficMonitors)
 	resp.Response.Cachegroups = sortCachegroups(resp.Response.Cachegroups)

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -544,8 +544,6 @@ func TestGetMonitoringJSON(t *testing.T) {
 	}
 	resp.Response.TrafficServers = sortCaches(resp.Response.TrafficServers)
 	sqlResp.TrafficServers = sortCaches(sqlResp.TrafficServers)
-	sortByInterfaceName(resp.Response.TrafficServers)
-	sortByInterfaceName(sqlResp.TrafficServers)
 	resp.Response.TrafficMonitors = sortMonitors(resp.Response.TrafficMonitors)
 	sqlResp.TrafficMonitors = sortMonitors(sqlResp.TrafficMonitors)
 	resp.Response.Cachegroups = sortCachegroups(resp.Response.Cachegroups)
@@ -623,6 +621,7 @@ func (s SortableCaches) Less(i, j int) bool {
 
 func sortCaches(p []Cache) []Cache {
 	sort.Sort(SortableCaches(p))
+	sortByInterfaceName(p)
 	return p
 }
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4919

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Follow the steps in #4919 

```bash
cd traffic_ops/traffic_ops_golang/monitoring
go test -c
failures=0
for ((i = 0; i < 100; i++)); do
  ./monitoring.test || (( ++failures ))
done;
echo "Failed ${failures} times out of ${i}"
```
should result in 0 failures, always.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] I have explained why documentation is unnecessary
- [x] This PR does not include an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**