### PR TITLE
Mark topology-based delivery services as available in Traffic Monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Traffic Portal: Added the ability to define first, inner and last header rewrite values for DNS* and HTTP* delivery services that employ a topology.
     - Traffic Portal: Added topology section to cdn snapshot diff.
     - Traffic Router: Added support for topology-based delivery services
+    - Traffic Monitor: Added the ability to mark topology-based delivery services as available
 - Updated /servers/details to use multiple interfaces in API v3
 - Added [Edge Traffic Routing](https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_router.html#edge-traffic-routing) feature which allows Traffic Router to localize more DNS record types than just the routing name for DNS delivery services
 - Added the ability to speedily build development RPMs from any OS without needing Docker

--- a/docs/source/development/traffic_monitor.rst
+++ b/docs/source/development/traffic_monitor.rst
@@ -53,7 +53,7 @@ Project Tree Overview
 * ``srvhttp/`` - HTTP(S) service. Given a map of endpoint functions, which are lambda closures containing aggregated data objects. If HTTPS, the HTTP service will redirect to HTTPS.
 * ``static/`` - Web interface files (markup, styling and scripting)
 * ``threadsafe/`` - Thread-safe objects for storing aggregated data needed by multiple goroutines (typically the aggregator and HTTP server)
-* ``trafficopsdata/`` - Data structure for fetching and storing Traffic Ops data needed from the CDN :term:`Snapshot`. This is primarily mappings, such as :term:`Delivery Service` servers, and server types.
+* ``todata/`` - Data structure for fetching and storing Traffic Ops data needed from the CDN :term:`Snapshot`. This is primarily mappings, such as :term:`Delivery Service` servers, and server types.
 * ``trafficopswrapper/`` - Thread-safe wrapper around the Traffic Ops client. The client used to not be thread-safe, however, it mostly (possibly entirely) is now. But, the wrapper also serves to overwrite the Traffic Ops :file:`monitoring.json` values, which are live, with values from the CDN :term:`Snapshot`.
 
 Architecture

--- a/lib/go-tc/enum.go
+++ b/lib/go-tc/enum.go
@@ -52,6 +52,9 @@ type CacheGroupName string
 // DeliveryServiceName is the name of a CDN delivery service.
 type DeliveryServiceName string
 
+// TopologyName is the name of a topology of cachegroups.
+type TopologyName string
+
 // CacheType is the type (or tier) of a CDN cache.
 type CacheType string
 

--- a/traffic_monitor/todata/todata_test.go
+++ b/traffic_monitor/todata/todata_test.go
@@ -1,0 +1,144 @@
+package todata
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"github.com/apache/trafficcontrol/lib/go-tc"
+
+	"reflect"
+	"testing"
+)
+
+func TestGetDeliveryServiceServersWithTopologyBasedDeliveryService(t *testing.T) {
+	topologyCrConfig := CRConfig{
+		ContentServers: map[tc.CacheName]struct {
+			DeliveryServices map[tc.DeliveryServiceName][]string `json:"deliveryServices"`
+			CacheGroup       string                              `json:"cacheGroup"`
+			Type             string                              `json:"type"`
+		}{
+			tc.CacheName("edge"): {
+				CacheGroup: "CDN_in_a_Box_Edge",
+				Type:       "EDGE",
+			},
+			tc.CacheName("mid"): {
+				CacheGroup: "CDN_in_a_Box_Mid",
+				Type:       "MID",
+			},
+		},
+		DeliveryServices: map[tc.DeliveryServiceName]struct {
+			Topology  tc.TopologyName `json:"topology"`
+			Matchsets []struct {
+				Protocol  string `json:"protocol"`
+				MatchList []struct {
+					Regex string `json:"regex"`
+				} `json:"matchlist"`
+			} `json:"matchsets"`
+		}{
+			"demo1": {
+				Topology: "demo1-top",
+				Matchsets: []struct {
+					Protocol  string `json:"protocol"`
+					MatchList []struct {
+						Regex string `json:"regex"`
+					} `json:"matchlist"`
+				}{{
+					Protocol: "HTTP",
+					MatchList: []struct {
+						Regex string `json:"regex"`
+					}{{Regex: `.*\.demo1\..*`}},
+				}},
+			}},
+		Topologies: map[tc.TopologyName]struct {
+			Nodes []string `json:"nodes"`
+		}{
+			"demo1-top": {Nodes: []string{"CDN_in_a_Box_Edge"}},
+		}}
+
+	expectedTopologiesTOData := TOData{
+		DeliveryServiceServers: map[tc.DeliveryServiceName][]tc.CacheName{"demo1": {"edge"}},
+		ServerDeliveryServices: map[tc.CacheName][]tc.DeliveryServiceName{"edge": {"demo1"}},
+	}
+
+	topologiesTOData := TOData{}
+	var err error
+	if topologiesTOData.DeliveryServiceServers, topologiesTOData.ServerDeliveryServices, err = getDeliveryServiceServers(topologyCrConfig); err != nil {
+		t.Fatalf("unable to get deliveryservice servers for crconfig with topology-based delivery service: %s", err)
+	}
+	if !reflect.DeepEqual(expectedTopologiesTOData, topologiesTOData) {
+		t.Fatalf("getDeliveryServiceServers with topology-based delivery service expected: %+v actual: %+v", expectedTopologiesTOData, topologiesTOData)
+	}
+}
+
+func TestGetDeliveryServiceServersWithNonTopologyBasedDeliveryService(t *testing.T) {
+	nonTopologyCrConfig := CRConfig{
+		ContentServers: map[tc.CacheName]struct {
+			DeliveryServices map[tc.DeliveryServiceName][]string `json:"deliveryServices"`
+			CacheGroup       string                              `json:"cacheGroup"`
+			Type             string                              `json:"type"`
+		}{
+			"edge": {
+				DeliveryServices: map[tc.DeliveryServiceName][]string{
+					"demo2": {"edge.demo2.mycdn.ciab.test"},
+				},
+				CacheGroup: "CDN_in_a_Box_Edge",
+				Type:       "EDGE",
+			},
+			"mid": {
+				CacheGroup: "CDN_in_a_Box_Mid",
+				Type:       "MID",
+			}},
+		DeliveryServices: map[tc.DeliveryServiceName]struct {
+			Topology  tc.TopologyName `json:"topology"`
+			Matchsets []struct {
+				Protocol  string `json:"protocol"`
+				MatchList []struct {
+					Regex string `json:"regex"`
+				} `json:"matchlist"`
+			} `json:"matchsets"`
+		}{
+			"demo2": {
+				Matchsets: []struct {
+					Protocol  string `json:"protocol"`
+					MatchList []struct {
+						Regex string `json:"regex"`
+					} `json:"matchlist"`
+				}{{
+					Protocol: "HTTP",
+					MatchList: []struct {
+						Regex string `json:"regex"`
+					}{{Regex: `.*\.demo2\..*`}},
+				}},
+			},
+		}}
+
+	expectedNonTopologiesTOData := TOData{
+		DeliveryServiceServers: map[tc.DeliveryServiceName][]tc.CacheName{"demo2": {"edge"}},
+		ServerDeliveryServices: map[tc.CacheName][]tc.DeliveryServiceName{"edge": {"demo2"}},
+	}
+
+	nonTopologiesTOData := TOData{}
+	var err error
+	if nonTopologiesTOData.DeliveryServiceServers, nonTopologiesTOData.ServerDeliveryServices, err = getDeliveryServiceServers(nonTopologyCrConfig); err != nil {
+		t.Fatalf("unable to get deliveryservice servers for crconfig with non-topology-based delivery service: %s", err)
+	}
+	if !reflect.DeepEqual(expectedNonTopologiesTOData, nonTopologiesTOData) {
+		t.Fatalf("getDeliveryServiceServers with non-topology-based delivery service expected: %+v actual: %+v", expectedNonTopologiesTOData, nonTopologiesTOData)
+	}
+}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4921 by adding topologies' cachegroups' servers to the delivery service servers map in `todata.getDeliveryServiceServers()`. <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Documentation
- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Make topology-based delivery service
2. Perform CDN snapshot
3. Look at Traffic Monitor logs. Lines to look for:

```go
trafficmonitor_1            | 1595954995.290 host="demo1", type=Delivery Service, available=true, msg="available caches"
trafficmonitor_1            | 1595954995.290 host="demo1", type=DELIVERYSERVICE, available=true, msg="REPORTED - available"
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (cc6f33971a)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->