### PR TITLE
Add ORT atstccfg log appending and logrotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `POST /api/x/steering` and `PUT /api/x/steering` so that a steering target with an invalid `type` is no longer accepted. [Related github issue](https://github.com/apache/trafficcontrol/issues/3531)
 - Fixed `cachegroups` READ endpoint, so that if a request is made with the `type` specified as a non integer value, you get back a `400` with error details, instead of a `500`. [Related github issue](https://github.com/apache/trafficcontrol/issues/4703)
 - Fixed ORT bug miscalculating Mid Max Origin Connections as all servers, usually resulting in 1.
+- Fixed ORT atstccfg helper log to append and not overwrite old logs. Also changed to log to /var/log/ort and added a logrotate to the RPM. See the ORT README.md for details.
 - Added Delivery Service Raw Remap `__RANGE_DIRECTIVE__` directive to allow inserting the Range Directive after the Raw Remap text. This allows Raw Remaps which manipulate the Range.
 - Added an option for `coordinateRange` in the RGB configuration file, so that in case a client doesn't have a postal code, we can still determine if it should be allowed or not, based on whether or not the latitude/ longitude of the client falls within the supplied ranges. [Related github issue](https://github.com/apache/trafficcontrol/issues/4372)
 

--- a/traffic_ops_ort/README.md
+++ b/traffic_ops_ort/README.md
@@ -94,6 +94,12 @@ ORT verifies all devices in the file are owned by the owner listed in the file, 
 
 ORT verifies all devices in the file do not have filesystems. If any device has a filesystem, ORT assumes it was a mistake to assign as an ATS storage device, and logs a fatal error.
 
+# Logging
+
+ORT outputs its immediate log to `stdout`, therefore it will log wherever you direct it. The recommended system location is `/var/log/ort/ort.log`.
+
+ORT uses the helper tool `atstccfg` to generate config files. Its log is output at `/var/log/ort/atstccfg.log`.
+
 # Trivia
 
 ORT stands for "Operational Readiness Test." The acronym is a legacy artifact and does not reflect the current purpose, which is to apply configuration from Traffic Ops.

--- a/traffic_ops_ort/atstccfg/atstccfg.go
+++ b/traffic_ops_ort/atstccfg/atstccfg.go
@@ -74,6 +74,17 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Because logs will be appended, we want a "start" message, so individual runs are easily distinguishable.
+	// log the "start" message to each distinct logger.
+	startMsg := "Starting atstccfg"
+	log.Errorln(startMsg)
+	if cfg.WarningLog() != cfg.ErrorLog() {
+		log.Warnln(startMsg)
+	}
+	if cfg.InfoLog() != cfg.WarningLog() && cfg.InfoLog() != cfg.ErrorLog() {
+		log.Infoln(startMsg)
+	}
+
 	plugins := plugin.Get(cfg)
 	plugins.OnStartup(plugin.StartupData{Cfg: cfg})
 

--- a/traffic_ops_ort/build/atstccfg.logrotate
+++ b/traffic_ops_ort/build/atstccfg.logrotate
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+/var/log/ort/atstccfg.log {
+        compress
+        maxage 30
+        missingok
+        nomail
+        size 10M
+        rotate 5
+        copytruncate
+}

--- a/traffic_ops_ort/build/build_rpm.sh
+++ b/traffic_ops_ort/build/build_rpm.sh
@@ -69,10 +69,18 @@ initBuildArea() {
 
 	cp -p traffic_ops_ort.pl "$dest";
 	cp -p supermicro_udev_mapper.pl "$dest";
+	mkdir -p "${dest}/build";
+
+	echo "build_rpm.sh lsing for logrotate";
+	ls -lah .;
+	ls -lah ./build;
+
+	cp -p build/atstccfg.logrotate "$dest"/build;
 	mkdir -p "${dest}/atstccfg";
 	cp -a atstccfg/* "${dest}/atstccfg";
 	tar -czvf "$dest".tgz -C "$RPMBUILD"/SOURCES "$(basename "$dest")";
 	cp build/traffic_ops_ort.spec "$RPMBUILD"/SPECS/.;
+	cp build/atstccfg.logrotate "$RPMBUILD"/.;
 
 	echo "The build area has been initialized.";
 }

--- a/traffic_ops_ort/build/traffic_ops_ort.spec
+++ b/traffic_ops_ort/build/traffic_ops_ort.spec
@@ -55,11 +55,16 @@ got3cdir=src/github.com/apache/trafficcontrol/traffic_ops_ort/t3c
 
 %install
 mkdir -p ${RPM_BUILD_ROOT}/opt/ort
+mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
+mkdir -p "${RPM_BUILD_ROOT}"/var/log/ort
+
 cp -p ${RPM_SOURCE_DIR}/traffic_ops_ort-%{version}/traffic_ops_ort.pl ${RPM_BUILD_ROOT}/opt/ort
 cp -p ${RPM_SOURCE_DIR}/traffic_ops_ort-%{version}/supermicro_udev_mapper.pl ${RPM_BUILD_ROOT}/opt/ort
 
-src=src/github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg
-cp -p "$src"/atstccfg ${RPM_BUILD_ROOT}/opt/ort
+src=src/github.com/apache/trafficcontrol/traffic_ops_ort
+cp -p ${RPM_SOURCE_DIR}/traffic_ops_ort-%{version}/build/atstccfg.logrotate "${RPM_BUILD_ROOT}"/etc/logrotate.d/atstccfg
+touch ${RPM_BUILD_ROOT}/var/log/ort/atstccfg.log
+cp -p "$src"/atstccfg/atstccfg ${RPM_BUILD_ROOT}/opt/ort
 
 t3csrc=src/github.com/apache/trafficcontrol/traffic_ops_ort/t3c
 cp -p "$t3csrc"/t3c ${RPM_BUILD_ROOT}/opt/ort
@@ -75,5 +80,8 @@ rm -rf ${RPM_BUILD_ROOT}
 /opt/ort/supermicro_udev_mapper.pl
 /opt/ort/atstccfg
 /opt/ort/t3c
+
+%config(noreplace) /etc/logrotate.d/atstccfg
+%config(noreplace) /var/log/ort/atstccfg.log
 
 %changelog

--- a/traffic_ops_ort/traffic_ops_ort.pl
+++ b/traffic_ops_ort/traffic_ops_ort.pl
@@ -165,7 +165,9 @@ if ($rev_proxy_disable != 0) {
 }
 
 my $TMP_BASE  = "/tmp/ort";
-my $atstccfg_log_path = $TMP_BASE . '/atstccfg.log';
+
+my $LOG_BASE  = "/var/log/ort"; # TODO add inferring ORT install location, and allowing / vs /opt install
+my $atstccfg_log_path = $LOG_BASE . '/atstccfg.log';
 
 # add any special yum options for your environment here; this variable is used with all yum commands
 my $YUM_OPTS = "";
@@ -773,7 +775,7 @@ sub send_update_to_trops {
 		$reval_str='true';
 	}
 
-	my $response = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --set-queue-status=$upd_str --set-reval-status=$reval_str 2>$atstccfg_log_path`;
+	my $response = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --set-queue-status=$upd_str --set-reval-status=$reval_str 2>>$atstccfg_log_path`;
 	my $atstccfg_exit_code = $?;
 	if ($atstccfg_exit_code != 0) {
 		( $log_level >> $ERROR ) && printf("ERROR sending update status with atstccfg (via Traffic Ops). See $atstccfg_log_path.\n");
@@ -783,7 +785,7 @@ sub send_update_to_trops {
 }
 
 sub get_update_status {
-	my $upd_ref = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=update-status 2>$atstccfg_log_path`;
+	my $upd_ref = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=update-status 2>>$atstccfg_log_path`;
 	my $atstccfg_exit_code = $?;
 	if ($atstccfg_exit_code != 0) {
 		( $log_level >> $ERROR ) && printf("ERROR getting update status from atstccfg (via Traffic Ops). See $atstccfg_log_path.\n");
@@ -794,7 +796,7 @@ sub get_update_status {
 
 	##Some versions of Traffic Ops had the 1.3 API but did not have the use_reval_pending field.  If this field is not present, exit.
 	if ( !defined( $upd_json->{'use_reval_pending'} ) ) {
-		my $info_ref = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=system-info 2>$atstccfg_log_path`;
+		my $info_ref = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=system-info 2>>$atstccfg_log_path`;
 		my $atstccfg_exit_code = $?;
 		if ($atstccfg_exit_code != 0) {
 			( $log_level >> $ERROR ) && printf("ERROR Unable to get status of use_reval_pending parameter.  Stopping.\n");
@@ -849,7 +851,7 @@ sub check_revalidate_state {
 			( $log_level >> $ERROR ) && print "ERROR Traffic Ops is signaling that no revalidations are waiting to be applied.\n";
 		}
 
-		my $stj = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=statuses 2>$atstccfg_log_path`;
+		my $stj = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=statuses 2>>$atstccfg_log_path`;
 		my $atstccfg_exit_code = $?;
 		if ( $atstccfg_exit_code != 0 ) {
 			( $log_level >> $ERROR ) && print "Statuses URL: returned $stj! Skipping creation of status file.\n";
@@ -968,7 +970,7 @@ sub check_syncds_state {
 			( $log_level >> $ERROR ) && print "ERROR Traffic Ops is signaling that no update is waiting to be applied.\n";
 		}
 
-		my $stj = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=statuses 2>$atstccfg_log_path`;
+		my $stj = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=statuses 2>>$atstccfg_log_path`;
 		my $atstccfg_exit_code = $?;
 		if ( $atstccfg_exit_code != 0 ) {
 			( $log_level >> $ERROR ) && print "Statuses URL: returned $stj! Skipping creation of status file.\n";
@@ -1610,7 +1612,7 @@ sub get_cfg_file_list {
 		$atstccfg_reval_arg = '--revalidate-only';
 	}
 
-	my $result = `$atstccfg_cmd --dir='$ats_config_dir' $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$host_name' $atstccfg_reval_arg --log-location-error=stderr --log-location-warning=stderr --log-location-info=null 2>$atstccfg_log_path`;
+	my $result = `$atstccfg_cmd --dir='$ats_config_dir' $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$host_name' $atstccfg_reval_arg --log-location-error=stderr --log-location-warning=stderr --log-location-info=null 2>>$atstccfg_log_path`;
 	my $atstccfg_exit_code = $?;
 	if ($atstccfg_exit_code != 0) {
 		( $log_level >> $ERROR ) && printf("ERROR getting config files from atstccfg via Traffic Ops. See $atstccfg_log_path for details\n");
@@ -1686,7 +1688,7 @@ sub parse_multipart_config_files {
 sub get_header_comment {
 	my $toolname;
 
-	my $result = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=system-info 2>$atstccfg_log_path`;
+	my $result = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=system-info 2>>$atstccfg_log_path`;
 	my $atstccfg_exit_code = $?;
 	if ($atstccfg_exit_code != 0) {
 			( $log_level >> $ERROR ) && printf("ERROR Unable to get system info. Stopping.\n");
@@ -1861,7 +1863,7 @@ sub process_packages {
 
 	my $proceed = 0;
 
-	my $result = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=packages 2>$atstccfg_log_path`;
+	my $result = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=packages 2>>$atstccfg_log_path`;
 	my $atstccfg_exit_code = $?;
 	if ($atstccfg_exit_code != 0) {
 		( $log_level >> $FATAL ) && print "FATAL Error getting package list from Traffic Ops!\n";
@@ -2107,7 +2109,7 @@ sub process_chkconfig {
 
 	my $proceed = 0;
 
-	my $result = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=chkconfig 2>$atstccfg_log_path`;
+	my $result = `$atstccfg_cmd $atstccfg_timeout_arg $atstccfg_arg_disable_proxy --traffic-ops-user='$TO_USER' --traffic-ops-password='$TO_PASS' --traffic-ops-url='$TO_URL' --cache-host-name='$hostname_short' --log-location-error=stderr --log-location-warning=stderr --log-location-info=null --get-data=chkconfig 2>>$atstccfg_log_path`;
 
 	my $atstccfg_exit_code = $?;
 	if ($atstccfg_exit_code != 0) {


### PR DESCRIPTION
Fixes atstccfg to append its log rather than overwrite. 

It also adds logrotate, which is necessary for a continuously-appending log, and moves the log to `/var/log` - `/tmp` was never an appropriate place, and certainly not for a persistent log.

Labeling 'bug' because the overwrite was a bug, and the other changes are ancillary to the bug fix.

## What does this PR (Pull Request) do?
Fixes atstccfg to append its log rather than overwrite. 

I've manually tested, verified install puts logrotate in the right place, ORT logs atstccfg log to /var/log/ort/atstccfg.log, multiple runs append.

No tests, ORT doesn't have an integration test framework yet.
Includes docs.
Includes changelog.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT, verify atstccfg log is output at /var/log/atstccfg.log. Run again, verify log is appended and not overwritten.

## If this is a bug fix, what versions of Traffic Control are affected?
- master 
- 4.0.0
- 4.0.1

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information