### PR TITLE
Add indicator when using a UI backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated /deliveryservices/{{ID}}/servers to use multiple interfaces in API v3
 - Updated /deliveryservices/{{ID}}/servers/eligible to use multiple interfaces in API v3
 - Added the ability to view Hash ID field (aka xmppID) on Traffic Portals' server summary page
+- Added an indiciator to the Traffic Monitor UI when using a disk backup of Traffic ops.
 
 ### Fixed
 - Fixed #4848 - `GET /api/x/cdns/capacity` gives back 500, with the message `capacity was zero`

--- a/traffic_monitor/handler/handler.go
+++ b/traffic_monitor/handler/handler.go
@@ -40,6 +40,7 @@ type OpsConfig struct {
 	HttpsListener string `json:"httpsListener"`
 	CertFile      string `json:"certFile"`
 	KeyFile       string `json:"keyFile"`
+	UsingDummyTO  bool   `json:"usingDummyTO"`
 }
 
 type Handler interface {

--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -193,6 +193,7 @@ func StartOpsConfigManager(
 					toSession.Set(realToSession)
 					// At this point we have a valid 'dummy' session. This will allow us to pull from disk but will also retry when TO comes up
 					log.Errorf("error instantiating Session with traffic_ops, backup disk files exist, creating empty traffic_ops session to read")
+					newOpsConfig.UsingDummyTO = true
 					break
 				}
 
@@ -200,9 +201,11 @@ func StartOpsConfigManager(
 				continue
 			} else {
 				toSession.Set(realToSession)
+				newOpsConfig.UsingDummyTO = false
 				break
 			}
 		}
+		opsConfig.Set(newOpsConfig)
 
 		if cdn, err := getMonitorCDN(realToSession, staticAppData.Hostname); err != nil {
 			handleErr(fmt.Errorf("getting CDN name from Traffic Ops, using config CDN '%s': %s\n", newOpsConfig.CdnName, err))

--- a/traffic_monitor/static/index.html
+++ b/traffic_monitor/static/index.html
@@ -65,10 +65,10 @@ under the License.
 	<!-- TODO: There's no reference to these in the script nor styling; safe to remove? -->
 	<div>Number of updates: <span>0</span></div>
 	<div>Last Val: <span>0</span></div>
-    <div id="icon-disc-holder" class="hidden">
-        <span class="icon-disc-tooltip">Traffic Monitor is using a disk backup of Traffic Ops</span>
-        <i id="icon-disc"></i>
-    </div>
+	<div id="icon-disc-holder" class="hidden">
+		<span class="icon-disc-tooltip">Traffic Monitor is using a disk backup of Traffic Ops</span>
+		<i id="icon-disc"></i>
+	</div>
 
 	<ul class="tabs" role="tablist">
 		<li class="tab" id="cache-states-content-tab">

--- a/traffic_monitor/static/index.html
+++ b/traffic_monitor/static/index.html
@@ -65,7 +65,7 @@ under the License.
 	<!-- TODO: There's no reference to these in the script nor styling; safe to remove? -->
 	<div>Number of updates: <span>0</span></div>
 	<div>Last Val: <span>0</span></div>
-	<div id="icon-disc-holder" class="hidden">
+	<div id="icon-disc-holder" hidden>
 		<span class="icon-disc-tooltip">Traffic Monitor is using a disk backup of Traffic Ops</span>
 		<i id="icon-disc"></i>
 	</div>

--- a/traffic_monitor/static/index.html
+++ b/traffic_monitor/static/index.html
@@ -65,6 +65,10 @@ under the License.
 	<!-- TODO: There's no reference to these in the script nor styling; safe to remove? -->
 	<div>Number of updates: <span>0</span></div>
 	<div>Last Val: <span>0</span></div>
+    <div id="icon-disc-holder" class="hidden">
+        <span class="icon-disc-tooltip">Traffic Monitor is using a disk backup of Traffic Ops</span>
+        <i id="icon-disc"></i>
+    </div>
 
 	<ul class="tabs" role="tablist">
 		<li class="tab" id="cache-states-content-tab">

--- a/traffic_monitor/static/script.js
+++ b/traffic_monitor/static/script.js
@@ -109,7 +109,14 @@ function getTrafficOpsUri() {
 
 function getTrafficOpsCdn() {
 	ajax("/publish/ConfigDoc", function(r) {
-		document.getElementById("cdn-name").textContent = JSON.parse(r).cdnName || "unknown";
+		let opsConfig = JSON.parse(r);
+		document.getElementById("cdn-name").textContent = opsConfig.cdnName || "unknown";
+		var diskIconContainer = document.getElementById("icon-disc-holder");
+		if ((opsConfig.usingDummyTO || true) === false) {
+			diskIconContainer.classList.add("hidden");
+		} else {
+			//diskIconContainer.classList.remove("hidden");
+		}
 	});
 }
 

--- a/traffic_monitor/static/script.js
+++ b/traffic_monitor/static/script.js
@@ -108,14 +108,15 @@ function getTrafficOpsUri() {
 }
 
 function getTrafficOpsCdn() {
+	const cdnName = document.getElementById("cdn-name");
+	const discIconContainer = document.getElementById("icon-disc-holder");
 	ajax("/publish/ConfigDoc", function(r) {
 		let opsConfig = JSON.parse(r);
-		document.getElementById("cdn-name").textContent = opsConfig.cdnName || "unknown";
-		var discIconContainer = document.getElementById("icon-disc-holder");
-		if ((opsConfig.usingDummyTO || true) === false) {
-			discIconContainer.classList.add("hidden");
+		cdnName.textContent = opsConfig.cdnName || "unknown";
+		if (opsConfig.usingDummyTO === false) {
+		    discIconContainer.hidden = true;
 		} else {
-			discIconContainer.classList.remove("hidden");
+			discIconContainer.hidden = false;
 		}
 	});
 }

--- a/traffic_monitor/static/script.js
+++ b/traffic_monitor/static/script.js
@@ -111,11 +111,11 @@ function getTrafficOpsCdn() {
 	ajax("/publish/ConfigDoc", function(r) {
 		let opsConfig = JSON.parse(r);
 		document.getElementById("cdn-name").textContent = opsConfig.cdnName || "unknown";
-		var diskIconContainer = document.getElementById("icon-disc-holder");
+		var discIconContainer = document.getElementById("icon-disc-holder");
 		if ((opsConfig.usingDummyTO || true) === false) {
-			diskIconContainer.classList.add("hidden");
+			discIconContainer.classList.add("hidden");
 		} else {
-			//diskIconContainer.classList.remove("hidden");
+			discIconContainer.classList.remove("hidden");
 		}
 	});
 }

--- a/traffic_monitor/static/style.css
+++ b/traffic_monitor/static/style.css
@@ -80,6 +80,71 @@ th {
 	margin: 15px 0;
 }
 
+#icon-disc-holder.hidden {
+	display: none;
+}
+#icon-disc-holder {
+	display: block;
+    width: 125px;
+	position: relative;
+	margin-top: 5px;
+	cursor: pointer;
+}
+
+#icon-disc,
+#icon-disc::after,
+#icon-disc::before {
+	display: block;
+	box-sizing: border-box;
+	border: 2px solid;
+	border-radius: 50%
+}
+#icon-disc {
+	margin: auto;
+	border-top-color: transparent;
+	border-bottom-color: transparent;
+	transform: rotate(45deg);
+	position: relative;
+	width: 14px;
+	height: 14px;
+}
+#icon-disc-holder .icon-disc-tooltip {
+	visibility: hidden;
+	background-color: black;
+	color: #fff;
+	text-align: center;
+	border-radius: 6px;
+	padding: 5px 0;
+
+	position: absolute;
+	z-index: 1;
+	width: 125px;
+	top: 20px
+}
+
+#icon-disc-holder:hover .icon-disc-tooltip {
+	visibility: visible;
+	opacity: 1;
+    animation: 1s ease-in;
+}
+
+#icon-disc::after,
+#icon-disc::before {
+	content: "";
+	position: absolute;
+	width: 6px;
+	height: 6px;
+	top: 2px;
+	left: 2px
+}
+#icon-disc::after {
+	width: 22px;
+	height: 22px;
+	border-radius: 100%;
+	top: -6px;
+	left: -6px
+}
+
 /*****************/
 /*     Links     */
 /*****************/

--- a/traffic_monitor/static/style.css
+++ b/traffic_monitor/static/style.css
@@ -85,7 +85,7 @@ th {
 }
 #icon-disc-holder {
 	display: block;
-    width: 125px;
+	width: 125px;
 	position: relative;
 	margin-top: 5px;
 	cursor: pointer;
@@ -124,8 +124,6 @@ th {
 
 #icon-disc-holder:hover .icon-disc-tooltip {
 	visibility: visible;
-	opacity: 1;
-    animation: 1s ease-in;
 }
 
 #icon-disc::after,

--- a/traffic_monitor/static/style.css
+++ b/traffic_monitor/static/style.css
@@ -88,7 +88,6 @@ th {
 	width: 125px;
 	position: relative;
 	margin-top: 5px;
-	cursor: pointer;
 }
 
 #icon-disc,

--- a/traffic_monitor/static/style.css
+++ b/traffic_monitor/static/style.css
@@ -80,11 +80,7 @@ th {
 	margin: 15px 0;
 }
 
-#icon-disc-holder.hidden {
-	display: none;
-}
 #icon-disc-holder {
-	display: block;
 	width: 125px;
 	position: relative;
 	margin-top: 5px;


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #3529 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

It adds an indicator to the traffic monitor UI when it is using a disk backup for Traffic Ops.

## Which Traffic Control components are affected by this PR?

<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Monitor

## What is the best way to verify this PR?
Ensure that running TM as usual there is no UI change.
Run TM with a crconfig.backup and tmconfig.backup file present and TO down. Confirm that the UI has an indicator representing the disk backup usage. 
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
Currently this backup is only loaded once at startup, as can be seen in `opsconfig.go:StartOpsConfigMapper`. CiaB requires TO to start before it will run TM, so you will need to do something tricky if you want to test in CiaB, I used breakpoints + debugger.
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
