### PR TITLE
Updates for traffic_ops_ort.pl for CentOS 8

### DIFF
--- a/traffic_ops_ort/traffic_ops_ort.pl
+++ b/traffic_ops_ort/traffic_ops_ort.pl
@@ -16,6 +16,7 @@
 use strict;
 use warnings;
 use feature qw(switch);
+no if $] >= 5.018, warnings => qw( experimental::smartmatch );
 use JSON;
 use File::Basename;
 use File::Path;
@@ -29,7 +30,7 @@ chomp($date);
 print "$date\n";
 
 # supported redhat/centos releases
-my %supported_el_release = ( "EL6" => 1, "EL7" => 1);
+my %supported_el_release = ( "EL6" => 1, "EL7" => 1, "EL8" => 1);
 
 my $dispersion = 300;
 my $retries = 5;
@@ -310,7 +311,7 @@ sub revalidate_while_sleeping {
 
 sub os_version {
 	my $release = "UNKNOWN";
-	if (`uname -r` =~ m/.+(el\d)(?:\.\w+)*\.x86_64/)  {
+	if (`uname -r` =~ m/.+(el\d)((?:\.\w+)|(?:_\w+))*\.x86_64/)  {
 		$release = uc $1;
 	}
 	if (!exists $supported_el_release{$release} && !$skip_os_check) {
@@ -494,7 +495,7 @@ sub start_service {
 	( $log_level >> $DEBUG ) && print "DEBUG start_service called for $pkg_name.\n";
 
 	my $pkg_running;
-	if ($RELEASE eq "EL7") {
+	if (($RELEASE eq "EL7") || ($RELEASE eq "EL8")) {
 		$pkg_running = &systemd_service_status($pkg_name);
 	} else {
 		$pkg_running  = `/sbin/service $pkg_name status`;
@@ -516,7 +517,7 @@ sub start_service {
 				( $log_level >> $ERROR ) && print "ERROR $pkg_name needs started. Trying to do that now.\n";
 				my $pkg_start_output = `/sbin/service $pkg_name start`;
 				my $pkg_started = 0;
-				if ($RELEASE eq "EL7") {
+				if (($RELEASE eq "EL7") || ($RELEASE eq "EL8")) {
 					my $_st = &systemd_service_status($pkg_name);
 					if ($_st =~ m/\(pid\s+(\d+)\) is running.../) {
 						$pkg_started++;
@@ -549,7 +550,7 @@ sub start_service {
 					( $log_level >> $ERROR ) && print "ERROR $pkg_name needs started. Trying to do that now.\n";
 					my $pkg_start_output = `/sbin/service $pkg_name start`;
 					my $pkg_started = 0;
-					if ($RELEASE eq "EL7") {
+					if (($RELEASE eq "EL7") || ($RELEASE eq "EL8")) {
 						my $_st = &systemd_service_status($pkg_name);
 						if ($_st =~ m/\(pid\s+(\d+)\) is running.../) {
 							$pkg_started++;
@@ -581,6 +582,7 @@ sub start_service {
 	}
 	else {
 		( $log_level >> $FATAL ) && print "FATAL Unrecognized service: $pkg_name. Not starting $pkg_name.\n";
+		$pkg_running = $START_NOT_ATTEMPTED;
 	}
 	return $pkg_running;
 }
@@ -589,7 +591,7 @@ sub restart_service {
 	my $pkg_name = $_[0];
 
 	my $pkg_running;
-	if ($RELEASE eq "EL7") {
+	if (($RELEASE eq "EL7") || ($RELEASE eq "EL8")) {
 		$pkg_running = &systemd_service_status($pkg_name);
 	} else {
 		$pkg_running  = `/sbin/service $pkg_name status`;
@@ -615,11 +617,12 @@ sub restart_service {
 				}
 				if ($pkg_started) {
 					( $log_level >> $ERROR ) && print "ERROR $pkg_name restarted successfully.\n";
-					$pkg_running++;
+					$pkg_running = $START_SUCCESSFUL;
 				}
 				else {
 					$pkg_start_output =~ s/\n/\t/g;
 					( $log_level >> $ERROR ) && print "ERROR $pkg_name failed to restart, error is: $pkg_start_output.\n";
+					$pkg_running = $START_FAILED;
 				}
 			}
 			if ( $script_mode == $INTERACTIVE ) {
@@ -639,22 +642,24 @@ sub restart_service {
 					}
 					if ($pkg_started) {
 						( $log_level >> $DEBUG ) && print "DEBUG $pkg_name restarted successfully.\n";
-						$pkg_running++;
+						$pkg_running = $START_SUCCESSFUL;
 					}
 					else {
 						$pkg_start_output =~ s/\n/\t/g;
 						( $log_level >> $ERROR ) && print "ERROR $pkg_name failed to restart, error is: $pkg_start_output.\n";
+						$pkg_running = $START_FAILED;
 					}
 				}
 			}
 		}
 		else {
 			( $log_level >> $DEBUG ) && print "DEBUG $pkg_name is not running! This shouldn't happnen, $pkg_name must have died recently!\n";
-			$pkg_running++;
+			$pkg_running = $START_FAILED;
 		}
 	}
 	else {
 		( $log_level >> $FATAL ) && print "FATAL Unrecognized service: $pkg_name. Not restarting $pkg_name.\n";
+		$pkg_running = $START_NOT_ATTEMPTED;
 	}
 	return $pkg_running;
 }
@@ -2054,7 +2059,7 @@ sub chkconfig_matches {
 	# This will work for now as  it trys to map from chkconfig run level settings to systemd enabled/disabled state.
 	# I think that a new generic endpoint should be added to traffic opts for chkconfig and systemd state settings and that functions
 	# here in the ort script should abstract the checking of chkconfig/systemd states with traffic ops.
-	if ($RELEASE eq "EL7") {
+	if (($RELEASE eq "EL7") || ($RELEASE eq "EL8")) {
 		my $service_state = systemd_service_chk($service);
 		if ($service_state eq "enabled") {
 			if ($service_settings =~ m/on/) {
@@ -2130,7 +2135,7 @@ sub process_chkconfig {
 
 						if ($fixit) {
 							#use systemd commands by mapping chkconfig runlrvrld to either enable or disable.
-							if ($RELEASE eq "EL7") {
+							if (($RELEASE eq "EL7") || ($RELEASE eq "EL8")) {
 								my $systemd_service_enable = "disable";
 								if ($chkconfig->{"value"} =~ m/on/) {
 									$systemd_service_enable = "enable";


### PR DESCRIPTION
And some minor bug fixes for starting ATS

## What does this PR (Pull Request) do?

This allows trafffic_ops_ort.pl to run on CentOS 8 and fixes some minor bugs with starting ATS.

- [x] This PR is not related to any Issue 

## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT

Documentation not required because there were not functionality updates made to the script.

## What is the best way to verify this PR?

Run it on a cache server

## If this is a bug fix, what versions of Traffic Control are affected?

4.0.0
4.1.0
master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
