### PR TITLE
Update status: Support more than 1 server for a given hostname

### DIFF
--- a/docs/source/api/v3/servers_hostname_update_status.rst
+++ b/docs/source/api/v3/servers_hostname_update_status.rst
@@ -92,4 +92,4 @@ Each object in the returned array\ [1]_ will contain the following fields:
 		"parent_reval_pending": false
 	}]
 
-.. [1] Despite that the returned object is an array, exactly one server's information is requested and thus returned. That is to say, the array should always have a length of exactly one.
+.. [1] The returned object is an array, and there is no guarantee that one server exists for a given hostname. However, for each server in the array, that server's update status will be accurate for the server with that particular server ID.

--- a/traffic_ops/testing/api/v3/serverupdatestatus_test.go
+++ b/traffic_ops/testing/api/v3/serverupdatestatus_test.go
@@ -482,5 +482,23 @@ func TestSetTopologiesServerUpdateStatuses(t *testing.T) {
 		if updateStatusByCacheGroup[otherEdgeCacheGroup].ParentPending {
 			t.Fatalf("expected UpdPending: %t, actual: %t", false, updateStatusByCacheGroup[otherEdgeCacheGroup].ParentPending)
 		}
+
+		edgeHostName := *cachesByCacheGroup[edgeCacheGroup].HostName
+		*cachesByCacheGroup[edgeCacheGroup].HostName = *cachesByCacheGroup[midCacheGroup].HostName
+		_, _, err = TOSession.UpdateServerByID(*cachesByCacheGroup[edgeCacheGroup].ID, cachesByCacheGroup[edgeCacheGroup])
+		if err != nil {
+			t.Fatalf("unable to update %s's hostname to %s: %s", edgeHostName, *cachesByCacheGroup[midCacheGroup].HostName, err)
+		}
+
+		_, _, err = TOSession.GetServerUpdateStatus(*cachesByCacheGroup[midCacheGroup].HostName, nil)
+		if err != nil {
+			t.Fatalf("expected no error getting server updates for a non-unique hostname %s, got %s", *cachesByCacheGroup[midCacheGroup].HostName, err)
+		}
+
+		*cachesByCacheGroup[edgeCacheGroup].HostName = edgeHostName
+		_, _, err = TOSession.UpdateServerByID(*cachesByCacheGroup[edgeCacheGroup].ID, cachesByCacheGroup[edgeCacheGroup])
+		if err != nil {
+			t.Fatalf("unable to revert %s's hostname back to %s: %s", edgeHostName, edgeHostName, err)
+		}
 	})
 }

--- a/traffic_ops/traffic_ops_golang/server/put_status.go
+++ b/traffic_ops/traffic_ops_golang/server/put_status.go
@@ -115,7 +115,7 @@ WITH RECURSIVE topology_descendants AS (
 /* This is the base case of the recursive CTE, the topology node for the
  * cachegroup containing cachegroup $2.
  */
-	SELECT tcp.parent child, tc.cachegroup
+	SELECT tcp.parent child, NULL cachegroup
 	FROM cachegroup c
 	JOIN topology_cachegroup tc ON c."name" = tc.cachegroup
 	JOIN topology_cachegroup_parents tcp ON tc.id = tcp.parent
@@ -133,8 +133,6 @@ UNION ALL
 SELECT c.id
 FROM cachegroup c
 JOIN topology_descendants td ON c."name" = td.cachegroup
-/* Filter out cachegroup id $2 */
-WHERE c.id != $2
 )
 UPDATE server
 SET upd_pending = TRUE

--- a/traffic_ops/traffic_ops_golang/server/servers_update_status.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_update_status.go
@@ -57,7 +57,7 @@ WITH RECURSIVE topology_ancestors AS (
 /* This is the base case of the recursive CTE, the topology node for the
  * cachegroup containing server $4.
  */
-	SELECT tcp.child parent, tc.cachegroup
+	SELECT tcp.child parent, NULL cachegroup
 	FROM "server" s
 	JOIN cachegroup c ON s.cachegroup = c.id
 	JOIN topology_cachegroup tc ON c."name" = tc.cachegroup
@@ -77,8 +77,6 @@ SELECT s.id, s.cachegroup, s.cdn_id, s.upd_pending, s.reval_pending, s.status
 FROM server s
 JOIN cachegroup c ON s.cachegroup = c.id
 JOIN topology_ancestors ta ON c."name" = ta.cachegroup
-/* Filter out cachegroup of host_name $4 */
-WHERE s.cachegroup != (SELECT s.cachegroup FROM server s WHERE s.host_name = $4)
 ), parentservers AS (
 	SELECT ps.id, ps.cachegroup, ps.cdn_id, ps.upd_pending, ps.reval_pending, ps.status
 		FROM server ps
@@ -206,7 +204,7 @@ ORDER BY s.id
 	var rows *sql.Rows
 	var err error
 	if hostName == "all" {
-		rows, err = tx.Query(baseSelectStatement + groupBy, tc.CacheStatusOffline, tc.UseRevalPendingParameterName, tc.GlobalConfigFileName)
+		rows, err = tx.Query(baseSelectStatement+groupBy, tc.CacheStatusOffline, tc.UseRevalPendingParameterName, tc.GlobalConfigFileName)
 		if err != nil {
 			log.Errorf("could not execute select server update status query: %s\n", err)
 			return nil, tc.DBError

--- a/traffic_ops/traffic_ops_golang/server/servers_update_status.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_update_status.go
@@ -57,7 +57,7 @@ WITH RECURSIVE topology_ancestors AS (
 /* This is the base case of the recursive CTE, the topology node for the
  * cachegroup containing server $4.
  */
-	SELECT tcp.child parent, NULL cachegroup
+	SELECT tcp.child parent, NULL cachegroup, s.id base_server_id
 	FROM "server" s
 	JOIN cachegroup c ON s.cachegroup = c.id
 	JOIN topology_cachegroup tc ON c."name" = tc.cachegroup
@@ -65,7 +65,7 @@ WITH RECURSIVE topology_ancestors AS (
 	WHERE s.host_name = $4
 UNION ALL
 /* Find all direct topology parent nodes tc of a given topology ancestor ta. */
-	SELECT tcp.parent, tc.cachegroup
+	SELECT tcp.parent, tc.cachegroup, ta.base_server_id
 	FROM topology_ancestors ta, topology_cachegroup_parents tcp
 	JOIN topology_cachegroup tc ON tcp.parent = tc.id
 	WHERE ta.parent = tcp.child
@@ -73,7 +73,7 @@ UNION ALL
  * ancestor topology node found by topology_ancestors.
  */
 ), server_topology_ancestors AS (
-SELECT s.id, s.cachegroup, s.cdn_id, s.upd_pending, s.reval_pending, s.status
+SELECT s.id, s.cachegroup, s.cdn_id, s.upd_pending, s.reval_pending, s.status, ta.base_server_id
 FROM server s
 JOIN cachegroup c ON s.cachegroup = c.id
 JOIN topology_ancestors ta ON c."name" = ta.cachegroup
@@ -99,12 +99,12 @@ SELECT
 	status.name AS status,
 		/* True if the cachegroup parent or any ancestor topology node has pending updates. */
 		TRUE IN (
-			SELECT sta.upd_pending FROM server_topology_ancestors sta
+			SELECT sta.upd_pending FROM server_topology_ancestors sta WHERE sta.base_server_id = s.id
 			UNION SELECT COALESCE(BOOL_OR(ps.upd_pending), FALSE)
 		) AS parent_upd_pending,
 		/* True if the cachegroup parent or any ancestor topology node has pending revalidation. */
 		TRUE IN (
-			SELECT sta.reval_pending FROM server_topology_ancestors sta
+			SELECT sta.reval_pending FROM server_topology_ancestors sta WHERE sta.base_server_id = s.id
 			UNION SELECT COALESCE(BOOL_OR(ps.reval_pending), FALSE)
 		) AS parent_reval_pending
 	FROM use_reval_pending,


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4935 by excluding the original cachegroup's name from the recursive CTE base result for both the query used in `GET /api/3.0/servers/{host_name}/update_status` and the query used in `PUT /api/1-3/servers/{id}/status`. <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
- This PR makes server update statuses accurate when given a hostname by keeping track of the original server's ID for a given set of update statuses.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run the TO API tests for API versions 1-3, ensure they pass
```shell
docker-compose up -d;
docker-compose -f docker-compose.traffic-ops-test.yml up integration;
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (732c3f8e1c)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
