### PR TITLE
Fix ORT Max Origin Connections for Mids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed update procedure of servers, so that if a server is linked to one or more delivery services, you cannot change its "cdn". [Related github issue](https://github.com/apache/trafficcontrol/issues/4116)
 - Fixed `POST /api/x/steering` and `PUT /api/x/steering` so that a steering target with an invalid `type` is no longer accepted. [Related github issue](https://github.com/apache/trafficcontrol/issues/3531)
 - Fixed `cachegroups` READ endpoint, so that if a request is made with the `type` specified as a non integer value, you get back a `400` with error details, instead of a `500`. [Related github issue](https://github.com/apache/trafficcontrol/issues/4703)
+- Fixed ORT bug miscalculating Mid Max Origin Connections as all servers, usually resulting in 1.
 - Added Delivery Service Raw Remap `__RANGE_DIRECTIVE__` directive to allow inserting the Range Directive after the Raw Remap text. This allows Raw Remaps which manipulate the Range.
 - Added an option for `coordinateRange` in the RGB configuration file, so that in case a client doesn't have a postal code, we can still determine if it should be allowed or not, based on whether or not the latitude/ longitude of the client falls within the supplied ranges. [Related github issue](https://github.com/apache/trafficcontrol/issues/4372)
 


### PR DESCRIPTION
It wasn't filtering DeliveryServiceServers, resulting in all servers
with parents being included. Fixed to filter correctly.

- [x] This PR is not related to any other Issue

Manually tested, set DS MaxOriginConns, ran ORT, verified mid calculation matches manual calculation of DS setting divided by assigned Mids.

No tests, logic is in the app side not the library so it can't be reasonably unit tested, and ORT doesn't have integration tests yet.
No docs, no interface change.
Includes changelog.

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Set Max Origin Connections on a Delivery Service that uses Mids. Manually calculate how many Reported Mids are parents of assigned Edges and divide the number you set by that, run ORT, verify hdr_rw_mid_yourds.config has the right number.

## If this is a bug fix, what versions of Traffic Control are affected?
- 4.0.0
- 4.0.1


## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information