### PR TITLE
Unit test checks

### DIFF
--- a/.github/actions/go-test/Dockerfile
+++ b/.github/actions/go-test/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM golang:1.11
+FROM golang:1.14
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod a+x /entrypoint.sh

--- a/.github/actions/go-test/Dockerfile
+++ b/.github/actions/go-test/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM golang:1.14
+FROM golang:1.14.2
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod a+x /entrypoint.sh

--- a/.github/actions/go-test/Dockerfile
+++ b/.github/actions/go-test/Dockerfile
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM golang:1.11
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+
+ENTRYPOINT /entrypoint.sh

--- a/.github/actions/go-test/README.md
+++ b/.github/actions/go-test/README.md
@@ -1,0 +1,45 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# go-test Docker action
+
+This action runs Go unit tests.
+
+## Inputs
+
+### `dir`
+
+**Required** Directory in which to run tests.
+
+## Outputs
+
+### `result`
+
+Test results.
+
+### `exit-code`
+
+Exit code of the test command
+
+## Example usage
+```yaml
+uses: actions/go-test@v1
+with:
+  dir: './lib/...'
+```

--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: 'go-test'
+description: 'Runs go tests'
+inputs:
+  dir:  # id of input
+    description: 'Directory in which to run tests'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.dir }}

--- a/.github/actions/go-test/entrypoint.sh
+++ b/.github/actions/go-test/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh -l
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+if [ -z "$INPUT_DIR" ]; then
+	# There's a bug in "defaults" for inputs
+	INPUT_DIR="./lib/..."
+fi
+
+GOPATH="$(mktemp -d)"
+SRCDIR="$GOPATH/src/github.com/apache"
+mkdir -p "$SRCDIR"
+ln -s "$PWD" "$SRCDIR/trafficcontrol"
+cd "$SRCDIR/trafficcontrol"
+
+# Need to fetch golang.org/x/* dependencies
+/usr/local/go/bin/go get -v $INPUT_DIR
+/usr/local/go/bin/go test -v $INPUT_DIR
+exit $?

--- a/.github/workflows/go.unit.tests.yaml
+++ b/.github/workflows/go.unit.tests.yaml
@@ -17,88 +17,26 @@
 
 name: Go Unit Tests
 
-# on:
-#   push:
-#     paths:
-#       - grove/**.go
-#       - lib/**.go
-#       - traffic_monitor/**.go
-#       - traffic_ops/traffic_ops_golang/**.go
-#       - traffic_ops_ort/atstccfg/**.go
-#   create:
-#   pull_request:
-#     paths:
-#       - grove/**.go
-#       - lib/**.go
-#       - traffic_monitor/**.go
-#       - traffic_ops/traffic_ops_golang/**.go
-#       - traffic_ops_ort/atstccfg/**.go
-#     types: [opened, reopened, edited, synchronize]
-
-# jobs:
-#   grove:
-#     runs-on: ubuntu-latest
-
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@master
-#     - name: Run Grove unit tests
-#       uses: ./.github/actions/go-test
-#       with:
-#         dir: ./grove/...
-
-#   lib:
-#     runs-on: ubuntu-latest
-
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@master
-#     - name: Run lib unit tests
-#       uses: ./.github/actions/go-test
-#       with:
-#         dir: ./lib/...
-
-#   monitor:
-#     runs-on: ubuntu-latest
-
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@master
-#     - name: Run Traffic Monitor unit tests
-#       uses: ./.github/actions/go-test
-#       with:
-#         dir: ./traffic_monitor/...
-
-#   ops:
-#     runs-on: ubuntu-latest
-
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@master
-#     - name: Run Traffic Ops unit tests
-#       uses: ./.github/actions/go-test
-#       with:
-#         dir: ./traffic_ops/traffic_ops_golang/...
-
-#   ort:
-#     runs-on: ubuntu-latest
-
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@master
-#     - name: Run Traffic Ops ORT unit tests
-#       uses: ./.github/actions/go-test
-#       with:
-#         dir: ./traffic_ops_ort/atstccfg/...
-
 on:
   push:
+    paths:
+      - grove/**.go
+      - lib/**.go
+      - traffic_monitor/**.go
+      - traffic_ops/traffic_ops_golang/**.go
+      - traffic_ops_ort/atstccfg/**.go
   create:
   pull_request:
+    paths:
+      - grove/**.go
+      - lib/**.go
+      - traffic_monitor/**.go
+      - traffic_ops/traffic_ops_golang/**.go
+      - traffic_ops_ort/atstccfg/**.go
     types: [opened, reopened, edited, synchronize]
 
 jobs:
-  grove:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/go.unit.tests.yaml
+++ b/.github/workflows/go.unit.tests.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Run Traffic Ops unit tests
+    - name: Run Grove unit tests
       uses: ./.github/actions/go-test
       with:
         dir: ./grove/...
@@ -53,7 +53,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Run Traffic Ops unit tests
+    - name: Run lib unit tests
       uses: ./.github/actions/go-test
       with:
         dir: ./lib/...
@@ -64,7 +64,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Run Traffic Ops unit tests
+    - name: Run Traffic Monitor unit tests
       uses: ./.github/actions/go-test
       with:
         dir: ./traffic_monitor/...
@@ -86,7 +86,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Run Traffic Ops unit tests
+    - name: Run Traffic Ops ORT unit tests
       uses: ./.github/actions/go-test
       with:
         dir: ./traffic_ops_ort/atstccfg/...

--- a/.github/workflows/go.unit.tests.yaml
+++ b/.github/workflows/go.unit.tests.yaml
@@ -25,6 +25,7 @@ on:
       - traffic_monitor/**.go
       - traffic_ops/traffic_ops_golang/**.go
       - traffic_ops_ort/atstccfg/**.go
+      - traffic_stats/**.go
   create:
   pull_request:
     paths:
@@ -33,6 +34,7 @@ on:
       - traffic_monitor/**.go
       - traffic_ops/traffic_ops_golang/**.go
       - traffic_ops_ort/atstccfg/**.go
+      - traffic_stats/**.go
     types: [opened, reopened, edited, synchronize]
 
 jobs:
@@ -45,4 +47,4 @@ jobs:
     - name: Run unit tests
       uses: ./.github/actions/go-test
       with:
-        dir: ./grove/... ./lib/... ./traffic_monitor/... ./traffic_ops/traffic_ops_golang/... ./traffic_ops_ort/atstccfg/...
+        dir: ./grove/... ./lib/... ./traffic_monitor/... ./traffic_ops/traffic_ops_golang/... ./traffic_ops_ort/atstccfg/... ./traffic_stats/...

--- a/.github/workflows/go.unit.tests.yaml
+++ b/.github/workflows/go.unit.tests.yaml
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Go Unit Tests
+
+on:
+  push:
+    paths:
+      - grove/**.go
+      - lib/**.go
+      - traffic_monitor/**.go
+      - traffic_ops/traffic_ops_golang/**.go
+      - traffic_ops_ort/atstccfg/**.go
+  create:
+  pull_request:
+    paths:
+      - grove/**.go
+      - lib/**.go
+      - traffic_monitor/**.go
+      - traffic_ops/traffic_ops_golang/**.go
+      - traffic_ops_ort/atstccfg/**.go
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  grove:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Run Traffic Ops unit tests
+      uses: ./.github/actions/go-test
+      with:
+        dir: ./grove/...
+
+  lib:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Run Traffic Ops unit tests
+      uses: ./.github/actions/go-test
+      with:
+        dir: ./lib/...
+
+  monitor:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Run Traffic Ops unit tests
+      uses: ./.github/actions/go-test
+      with:
+        dir: ./traffic_monitor/...
+
+  ops:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Run Traffic Ops unit tests
+      uses: ./.github/actions/go-test
+      with:
+        dir: ./traffic_ops/traffic_ops_golang/...
+
+  ort:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Run Traffic Ops unit tests
+      uses: ./.github/actions/go-test
+      with:
+        dir: ./traffic_ops_ort/atstccfg/...

--- a/.github/workflows/go.unit.tests.yaml
+++ b/.github/workflows/go.unit.tests.yaml
@@ -17,22 +17,84 @@
 
 name: Go Unit Tests
 
+# on:
+#   push:
+#     paths:
+#       - grove/**.go
+#       - lib/**.go
+#       - traffic_monitor/**.go
+#       - traffic_ops/traffic_ops_golang/**.go
+#       - traffic_ops_ort/atstccfg/**.go
+#   create:
+#   pull_request:
+#     paths:
+#       - grove/**.go
+#       - lib/**.go
+#       - traffic_monitor/**.go
+#       - traffic_ops/traffic_ops_golang/**.go
+#       - traffic_ops_ort/atstccfg/**.go
+#     types: [opened, reopened, edited, synchronize]
+
+# jobs:
+#   grove:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@master
+#     - name: Run Grove unit tests
+#       uses: ./.github/actions/go-test
+#       with:
+#         dir: ./grove/...
+
+#   lib:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@master
+#     - name: Run lib unit tests
+#       uses: ./.github/actions/go-test
+#       with:
+#         dir: ./lib/...
+
+#   monitor:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@master
+#     - name: Run Traffic Monitor unit tests
+#       uses: ./.github/actions/go-test
+#       with:
+#         dir: ./traffic_monitor/...
+
+#   ops:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@master
+#     - name: Run Traffic Ops unit tests
+#       uses: ./.github/actions/go-test
+#       with:
+#         dir: ./traffic_ops/traffic_ops_golang/...
+
+#   ort:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@master
+#     - name: Run Traffic Ops ORT unit tests
+#       uses: ./.github/actions/go-test
+#       with:
+#         dir: ./traffic_ops_ort/atstccfg/...
+
 on:
   push:
-    paths:
-      - grove/**.go
-      - lib/**.go
-      - traffic_monitor/**.go
-      - traffic_ops/traffic_ops_golang/**.go
-      - traffic_ops_ort/atstccfg/**.go
   create:
   pull_request:
-    paths:
-      - grove/**.go
-      - lib/**.go
-      - traffic_monitor/**.go
-      - traffic_ops/traffic_ops_golang/**.go
-      - traffic_ops_ort/atstccfg/**.go
     types: [opened, reopened, edited, synchronize]
 
 jobs:
@@ -42,51 +104,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Run Grove unit tests
+    - name: Run unit tests
       uses: ./.github/actions/go-test
       with:
-        dir: ./grove/...
-
-  lib:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Run lib unit tests
-      uses: ./.github/actions/go-test
-      with:
-        dir: ./lib/...
-
-  monitor:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Run Traffic Monitor unit tests
-      uses: ./.github/actions/go-test
-      with:
-        dir: ./traffic_monitor/...
-
-  ops:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Run Traffic Ops unit tests
-      uses: ./.github/actions/go-test
-      with:
-        dir: ./traffic_ops/traffic_ops_golang/...
-
-  ort:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Run Traffic Ops ORT unit tests
-      uses: ./.github/actions/go-test
-      with:
-        dir: ./traffic_ops_ort/atstccfg/...
+        dir: ./grove/... ./lib/... ./traffic_monitor/... ./traffic_ops/traffic_ops_golang/... ./traffic_ops_ort/atstccfg/...

--- a/lib/go-util/join_test.go
+++ b/lib/go-util/join_test.go
@@ -1,0 +1,35 @@
+package util
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "errors"
+import "fmt"
+
+func ExampleJoinErrsSep() {
+	errs := []error{
+		errors.New("test"),
+		errors.New("quest"),
+	}
+
+	fmt.Println(JoinErrsSep(errs, "\n"))
+
+	// Output: test
+	// quest
+}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR not related to any Issue

This PR will run Go unit tests on all PRs that modify go code, as well as all pushes to any branch that modifies go code. Specifically, it checks modification in paths that match:
```gitignore
grove/**.go
lib/**.go
traffic_monitor/**.go
traffic_ops/traffic_ops_golang/**.go
traffic_ops_ort/atstccfg/**.go
traffic_stats/**.go
```
and runs the unit tests in those same paths when modifications are found.

In order to show the tests at work, this also adds an example/test for `github.com/apache/trafficcontrol/lib/go-util.JoinErrsSep`.

I know that this sort of got shut down on the mailing list, but [that discussion](https://lists.apache.org/thread.html/ec503661975dc9eb0c3719bcaab3b758b5b7489ebec93f95f7f9416b%40%3Cdev.trafficcontrol.apache.org%3E)  was about a year ago now, and we still don't have unit tests running on our PRs. So this PR adds them. If we want to merge it.

## Which Traffic Control components are affected by this PR?
none

## What is the best way to verify this PR?
Look at the "Checks" tab.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
