### PR TITLE
Use RFC lib and correct Content-Type on TM api

### DIFF
--- a/lib/go-rfc/http.go
+++ b/lib/go-rfc/http.go
@@ -48,6 +48,7 @@ const (
 	ApplicationOctetStream    = "application/octet-stream" // RFC2046§4.5.2
 	ContentTypeMultiPartMixed = "multipart/mixed"          // RFC1341§7.2
 	ContentTypeTextPlain      = "text/plain"               // RFC2046§4.1
+	ContentTypeURIList        = "text/uri-list"            // RFC2483§5
 	Gzip                      = "gzip"                     // RFC7230§4.2.3
 )
 

--- a/traffic_monitor/datareq/datareq.go
+++ b/traffic_monitor/datareq/datareq.go
@@ -113,7 +113,7 @@ func MakeDispatchMap(
 		}, rfc.ContentTypeTextPlain)),
 		"/api/traffic-ops-uri": wrap(WrapBytes(func() []byte {
 			return srvAPITrafficOpsURI(opsConfig)
-		}, rfc.ApplicationJSON)),
+		}, rfc.ContentTypeURIList)),
 		"/api/cache-statuses": wrap(WrapErr(errorCount, func() ([]byte, error) {
 			return srvAPICacheStates(toData, statInfoHistory, statResultHistory, healthHistory, lastHealthDurations, localStates, lastStats, localCacheStatus, statMaxKbpses, monitorConfig)
 		}, rfc.ApplicationJSON)),

--- a/traffic_monitor/datareq/datareq.go
+++ b/traffic_monitor/datareq/datareq.go
@@ -30,6 +30,7 @@ import (
 	"unicode"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/traffic_monitor/config"
 	"github.com/apache/trafficcontrol/traffic_monitor/health"
 	"github.com/apache/trafficcontrol/traffic_monitor/peer"
@@ -72,62 +73,62 @@ func MakeDispatchMap(
 	dispatchMap := map[string]http.HandlerFunc{
 		"/publish/CrConfig": wrap(WrapAgeErr(errorCount, func() ([]byte, time.Time, error) {
 			return srvTRConfig(opsConfig, toSession)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/publish/CrStates": wrap(WrapParams(func(params url.Values, path string) ([]byte, int) {
 			bytes, statusCode, err := srvTRState(params, localStates, combinedStates, peerStates)
 			return WrapErrStatusCode(errorCount, path, bytes, statusCode, err)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/publish/CacheStats": wrap(WrapParams(func(params url.Values, path string) ([]byte, int) {
 			return srvCacheStats(params, errorCount, path, toData, statResultHistory, statInfoHistory, monitorConfig, combinedStates, statMaxKbpses)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/publish/DsStats": wrap(WrapParams(func(params url.Values, path string) ([]byte, int) {
 			return srvDSStats(params, errorCount, path, toData, dsStats)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/publish/EventLog": wrap(WrapErr(errorCount, func() ([]byte, error) {
 			return srvEventLog(events)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/publish/PeerStates": wrap(WrapParams(func(params url.Values, path string) ([]byte, int) {
 			return srvPeerStates(params, errorCount, path, toData, peerStates)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/publish/Stats": wrap(WrapErr(errorCount, func() ([]byte, error) {
 			return srvStats(staticAppData, healthPollInterval, lastHealthDurations, fetchCount, healthIteration, errorCount, peerStates)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/publish/ConfigDoc": wrap(WrapErr(errorCount, func() ([]byte, error) {
 			return srvConfigDoc(opsConfig)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/publish/StatSummary": wrap(WrapParams(func(params url.Values, path string) ([]byte, int) {
 			return srvStatSummary(params, errorCount, path, toData, statResultHistory)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/cache-count": wrap(WrapBytes(func() []byte {
 			return srvAPICacheCount(localStates)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/cache-available-count": wrap(WrapBytes(func() []byte {
 			return srvAPICacheAvailableCount(localStates)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/cache-down-count": wrap(WrapBytes(func() []byte {
 			return srvAPICacheDownCount(localStates, monitorConfig)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/version": wrap(WrapBytes(func() []byte {
 			return srvAPIVersion(staticAppData)
-		}, ContentTypeJSON)),
+		}, rfc.ContentTypeTextPlain)),
 		"/api/traffic-ops-uri": wrap(WrapBytes(func() []byte {
 			return srvAPITrafficOpsURI(opsConfig)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/cache-statuses": wrap(WrapErr(errorCount, func() ([]byte, error) {
 			return srvAPICacheStates(toData, statInfoHistory, statResultHistory, healthHistory, lastHealthDurations, localStates, lastStats, localCacheStatus, statMaxKbpses, monitorConfig)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/bandwidth-kbps": wrap(WrapBytes(func() []byte {
 			return srvAPIBandwidthKbps(toData, lastStats)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/bandwidth-capacity-kbps": wrap(WrapBytes(func() []byte {
 			return srvAPIBandwidthCapacityKbps(statMaxKbpses)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/monitor-config": wrap(WrapErr(errorCount, func() ([]byte, error) {
 			return srvMonitorConfig(monitorConfig)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 		"/api/crconfig-history": wrap(WrapErr(errorCount, func() ([]byte, error) {
 			return srvAPICRConfigHist(toSession)
-		}, ContentTypeJSON)),
+		}, rfc.ApplicationJSON)),
 	}
 	return addTrailingSlashEndpoints(dispatchMap)
 }
@@ -285,8 +286,6 @@ func wrapUnpolledCheck(unpolledCaches threadsafe.UnpolledCaches, errorCount thre
 		f(w, r)
 	}
 }
-
-const ContentTypeJSON = "application/json"
 
 func stripAllWhitespace(s string) string {
 	return strings.Map(func(r rune) rune {


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #2565. <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

It replaces the content-type specification in TM with those found in the go-rfc lib. It also changes the `/api/version` and `/api/traffic-ops-uri` TM endpoints to have a Content-Type of `text/plain`/`text/uri-list` (respectively) in place of `application-json` as it does not return a valid JSON string.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Monitor

## What is the best way to verify this PR?
Ensure TM tests pass
Make a request to `api/version` and `api/traffic-ops-uri` and confirm Content-Type
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

## If this is a bug fix, what versions of Traffic Control are affected?
master (9e69ce1)

<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information|
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be: -->
Before:
```
❯ curl -v http://localhost/api/version
*   Trying ::1:80...
* Connected to localhost (::1) port 80 (#0)
> GET /api/version HTTP/1.1
> Host: localhost
> User-Agent: curl/7.71.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Thu, 13 Aug 2020 17:14:52 GMT
< Content-Length: 28
< 
* Connection #0 to host localhost left intact
traffic_monitor-4.2.0.9e69ce
```

After:   
```
❯ curl -v http://localhost/api/version
*   Trying ::1:80...
* Connected to localhost (::1) port 80 (#0)
> GET /api/version HTTP/1.1
> Host: localhost
> User-Agent: curl/7.71.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: text/plain
< Date: Thu, 13 Aug 2020 17:14:52 GMT
< Content-Length: 28
< 
* Connection #0 to host localhost left intact
traffic_monitor-4.2.0.9e69ce   
```


<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
