### PR TITLE
GET /api/3.0/servers?dsId=1 500s when requested with If-Modified-Since header

### DIFF
--- a/traffic_ops/client/deliveryserviceserver.go
+++ b/traffic_ops/client/deliveryserviceserver.go
@@ -88,13 +88,13 @@ func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string
 }
 
 // GetDeliveryServiceServers gets all delivery service servers, with the default API limit.
-func (to *Session) GetDeliveryServiceServers() (tc.DeliveryServiceServerResponse, ReqInf, error) {
-	return to.getDeliveryServiceServers(url.Values{})
+func (to *Session) GetDeliveryServiceServers(h http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+	return to.getDeliveryServiceServers(url.Values{}, h)
 }
 
 // GetDeliveryServiceServersN gets all delivery service servers, with a limit of n.
 func (to *Session) GetDeliveryServiceServersN(n int) (tc.DeliveryServiceServerResponse, ReqInf, error) {
-	return to.getDeliveryServiceServers(url.Values{"limit": []string{strconv.Itoa(n)}})
+	return to.getDeliveryServiceServers(url.Values{"limit": []string{strconv.Itoa(n)}}, nil)
 }
 
 // GetDeliveryServiceServersWithLimits gets all delivery service servers, allowing specifying the limit of mappings to return, the delivery services to return, and the servers to return.
@@ -121,16 +121,19 @@ func (to *Session) GetDeliveryServiceServersWithLimits(limit int, deliveryServic
 		vals.Set("serverids", strings.Join(serverIDStrs, ","))
 	}
 
-	return to.getDeliveryServiceServers(vals)
+	return to.getDeliveryServiceServers(vals, nil)
 }
 
-func (to *Session) getDeliveryServiceServers(urlQuery url.Values) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) getDeliveryServiceServers(urlQuery url.Values, h http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
 	route := apiBase + `/deliveryserviceserver`
 	if qry := urlQuery.Encode(); qry != "" {
 		route += `?` + qry
 	}
-	reqResp, remoteAddr, err := to.request(http.MethodGet, route, nil, nil)
+	reqResp, remoteAddr, err := to.request(http.MethodGet, route, nil, h)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if reqResp != nil {
+		reqInf.StatusCode = reqResp.StatusCode
+	}
 	if err != nil {
 		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
 	}

--- a/traffic_ops/client/server.go
+++ b/traffic_ops/client/server.go
@@ -327,6 +327,9 @@ func (to *Session) GetServerIDDeliveryServices(server int, header http.Header) (
 
 	resp, remoteAddr, err := to.request(http.MethodGet, endpoint, nil, header)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return nil, reqInf, err
 	}

--- a/traffic_ops/testing/api/v3/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/cachegroupsdeliveryservices_test.go
@@ -32,7 +32,7 @@ func TestCacheGroupsDeliveryServices(t *testing.T) {
 const TestEdgeServerCacheGroupName = "cachegroup3"
 
 func CreateTestCachegroupsDeliveryServices(t *testing.T) {
-	dss, _, err := TOSession.GetDeliveryServiceServers()
+	dss, _, err := TOSession.GetDeliveryServiceServers(nil)
 	if err != nil {
 		t.Fatalf("cannot GET DeliveryServiceServers: %v", err)
 	}
@@ -151,7 +151,7 @@ func DeleteTestCachegroupsDeliveryServices(t *testing.T) {
 		}
 	}
 
-	dss, _, err = TOSession.GetDeliveryServiceServers()
+	dss, _, err = TOSession.GetDeliveryServiceServers(nil)
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServiceServers: %v", err)
 	}

--- a/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
@@ -252,7 +252,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 		t.Errorf("POST delivery service servers: %v", err)
 	}
 
-	dsServers, _, err := TOSession.GetDeliveryServiceServers()
+	dsServers, _, err := TOSession.GetDeliveryServiceServers(nil)
 	if err != nil {
 		t.Errorf("GET delivery service servers: %v", err)
 	}
@@ -272,7 +272,7 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 		t.Errorf("DELETE delivery service server: %v", err)
 	}
 
-	dsServers, _, err = TOSession.GetDeliveryServiceServers()
+	dsServers, _, err = TOSession.GetDeliveryServiceServers(nil)
 	if err != nil {
 		t.Errorf("GET delivery service servers: %v", err)
 	}

--- a/traffic_ops/testing/api/v3/servers_test.go
+++ b/traffic_ops/testing/api/v3/servers_test.go
@@ -17,12 +17,13 @@ package v3
 
 import (
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"net/http"
 	"net/url"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 )
 
 func TestServers(t *testing.T) {
@@ -166,6 +167,17 @@ func GetTestServersQueryParameters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get server by Delivery Service ID: %v", err)
 	}
+
+	currentTime := time.Now().UTC().Add(5 * time.Second)
+	time := currentTime.Format(time.RFC1123)
+	var header http.Header
+	header = make(map[string][]string)
+	header.Set(rfc.IfModifiedSince, time)
+	_, reqInf, _ := TOSession.GetServers(&params, header)
+	if reqInf.StatusCode != http.StatusNotModified {
+		t.Errorf("Expected a status code of 304, got %v", reqInf.StatusCode)
+	}
+
 	params.Del("dsId")
 
 	resp, _, err := TOSession.GetServers(nil, nil)

--- a/traffic_ops/testing/api/v3/servers_to_deliveryservice_assignment_test.go
+++ b/traffic_ops/testing/api/v3/servers_to_deliveryservice_assignment_test.go
@@ -18,7 +18,9 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -87,6 +89,16 @@ func AssignTestDeliveryService(t *testing.T) {
 
 	if !found {
 		t.Errorf(`Server/DS assignment not found after "successful" assignment!`)
+	}
+
+	currentTime := time.Now().UTC().Add(5 * time.Second)
+	time := currentTime.Format(time.RFC1123)
+	var header http.Header
+	header = make(map[string][]string)
+	header.Set(rfc.IfModifiedSince, time)
+	_, reqInf, _ := TOSession.GetServerIDDeliveryServices(*firstServer.ID, header)
+	if reqInf.StatusCode != http.StatusNotModified {
+		t.Errorf("Expected a status code of 304, got %v", reqInf.StatusCode)
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -814,7 +814,7 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 
 func selectMaxLastUpdatedQuery(where string) string {
 	return `SELECT max(t) from (
-		SELECT max(dss.last_updated) as t from deliveryservice_server dss ` + where +
+		SELECT max(dss.last_updated) as t from deliveryservice_server dss JOIN deliveryservice ds ON ds.id = dss.deliveryservice ` + where +
 		` UNION ALL
 	select max(last_updated) as t from last_deleted l where l.table_name='deliveryservice_server') as res`
 }

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -611,7 +611,8 @@ JOIN cdn cdn ON s.cdn_id = cdn.id
 JOIN phys_location pl ON s.phys_location = pl.id
 JOIN profile p ON s.profile = p.id
 JOIN status st ON s.status = st.id
-JOIN type t ON s.type = t.id ` + where +
+JOIN type t ON s.type = t.id 
+FULL OUTER JOIN deliveryservice_server dss ON dss.server = s.id ` + where +
 		` UNION ALL
 	select max(last_updated) as t from last_deleted l where l.table_name='server') as res`
 }

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -648,7 +648,7 @@ JOIN phys_location pl ON s.phys_location = pl.id
 JOIN profile p ON s.profile = p.id
 JOIN status st ON s.status = st.id
 JOIN type t ON s.type = t.id ` +
-queryAddition + where +
+		queryAddition + where +
 		` UNION ALL
 	select max(last_updated) as t from last_deleted l where l.table_name='server') as res`
 }

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -604,15 +604,15 @@ func ReadID(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-func selectMaxLastUpdatedQuery(where string) string {
+func selectMaxLastUpdatedQuery(queryAddition string, where string) string {
 	return `SELECT max(t) from (
 		SELECT max(s.last_updated) as t from server s JOIN cachegroup cg ON s.cachegroup = cg.id
 JOIN cdn cdn ON s.cdn_id = cdn.id
 JOIN phys_location pl ON s.phys_location = pl.id
 JOIN profile p ON s.profile = p.id
 JOIN status st ON s.status = st.id
-JOIN type t ON s.type = t.id 
-FULL OUTER JOIN deliveryservice_server dss ON dss.server = s.id ` + where +
+JOIN type t ON s.type = t.id ` +
+queryAddition + where +
 		` UNION ALL
 	select max(last_updated) as t from last_deleted l where l.table_name='server') as res`
 }
@@ -688,7 +688,7 @@ func getServers(h http.Header, params map[string]string, tx *sqlx.Tx, user *auth
 
 	serversList := []tc.ServerNullable{}
 	if useIMS {
-		runSecond, maxTime = ims.TryIfModifiedSinceQuery(tx, h, queryValues, selectMaxLastUpdatedQuery(where))
+		runSecond, maxTime = ims.TryIfModifiedSinceQuery(tx, h, queryValues, selectMaxLastUpdatedQuery(queryAddition, where))
 		if !runSecond {
 			log.Debugln("IMS HIT")
 			return serversList, 0, nil, nil, http.StatusNotModified, &maxTime

--- a/traffic_ops/traffic_ops_golang/util/ims/ims.go
+++ b/traffic_ops/traffic_ops_golang/util/ims/ims.go
@@ -2,12 +2,13 @@ package ims
 
 import (
 	"database/sql"
+	"net/http"
+	"time"
+
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/jmoiron/sqlx"
-	"net/http"
-	"time"
 )
 
 /*
@@ -60,7 +61,7 @@ func TryIfModifiedSinceQuery(tx *sqlx.Tx, h http.Header, queryValues map[string]
 			defer rows.Close()
 		}
 		if err != nil {
-			log.Warnf("Couldn't get the max last updated time: %v", err)
+			log.Errorf("Couldn't get the max last updated time: %v", err)
 			return runSecond, maxTime
 		}
 		if err == sql.ErrNoRows {


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #4949 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Start TO locally
Make a call to get the servers associated with a ds like:
`curl -X GET -k -H "Accept: application/json" -H "If-Modified-Since: Mon, 13 Jul 2020 21:26:00 GMT" "https://localhost:8443/api/3.0/servers?dsId=3"`
This should not give you a 500 error, instead, you should see the servers associated with this DS.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master
## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR does not include an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
