### PR TITLE
Allow '0' as a valid value for TTL field in DNS static entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added debugging functionality to CDN-in-a-Box for Traffic Stats.
 
 ### Fixed
+- Fixed #3400 - Allow "0" as a TTL value for Static DNS entries
 - Fixed #4743 - Validate absolute DNS name requirement on Static DNS entry for CNAME type [Related github issue](https://github.com/apache/trafficcontrol/issues/4743)
 - Fixed #4848 - `GET /api/x/cdns/capacity` gives back 500, with the message `capacity was zero`
 - Fixed #2156 - Renaming a host in TC, does not impact xmpp_id and thereby hashid [Related github issue](https://github.com/apache/trafficcontrol/issues/2156)

--- a/traffic_ops/testing/api/v2/tc-fixtures.json
+++ b/traffic_ops/testing/api/v2/tc-fixtures.json
@@ -2160,7 +2160,7 @@
             "deliveryservice": "ds1",
             "host": "host1",
             "type": "CNAME_RECORD",
-            "ttl": 10
+            "ttl": 0
         },
         {
             "address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -2687,7 +2687,7 @@
             "deliveryservice": "ds1",
             "host": "host1",
             "type": "CNAME_RECORD",
-            "ttl": 10
+            "ttl": 0
         },
         {
             "address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
@@ -96,7 +96,7 @@ func (staticDNSEntry TOStaticDNSEntry) Validate() error {
 		return err
 	}
 
-	var addressErr error
+	var addressErr, ttlErr error
 	switch typeStr {
 	case "A_RECORD":
 		addressErr = validation.Validate(staticDNSEntry.Address, validation.Required, is.IPv4)
@@ -115,11 +115,18 @@ func (staticDNSEntry TOStaticDNSEntry) Validate() error {
 		addressErr = validation.Validate(staticDNSEntry.Address, validation.Required)
 	}
 
+	ttl := *staticDNSEntry.TTL
+	if ttl == 0 {
+		ttlErr = validation.Validate(staticDNSEntry.TTL, is.Digit)
+	} else {
+		ttlErr = validation.Validate(staticDNSEntry.TTL, validation.Required)
+	}
+
 	errs := validation.Errors{
 		"host":              validation.Validate(staticDNSEntry.Host, validation.Required, is.DNSName),
 		"address":           addressErr,
 		"deliveryserviceId": validation.Validate(staticDNSEntry.DeliveryServiceID, validation.Required),
-		"ttl":               validation.Validate(staticDNSEntry.TTL, validation.Required),
+		"ttl":               ttlErr,
 		"typeId":            validation.Validate(staticDNSEntry.TypeID, validation.Required),
 	}
 	return util.JoinErrs(tovalidate.ToErrors(errs))

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
@@ -115,9 +115,10 @@ func (staticDNSEntry TOStaticDNSEntry) Validate() error {
 		addressErr = validation.Validate(staticDNSEntry.Address, validation.Required)
 	}
 
-	ttl := *staticDNSEntry.TTL
-	if ttl == 0 {
-		ttlErr = validation.Validate(staticDNSEntry.TTL, is.Digit)
+	if staticDNSEntry.TTL != nil {
+		if *staticDNSEntry.TTL == 0 {
+			ttlErr = validation.Validate(staticDNSEntry.TTL, is.Digit)
+		}
 	} else {
 		ttlErr = validation.Validate(staticDNSEntry.TTL, validation.Required)
 	}

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceStaticDnsEntry/form.deliveryServiceStaticDnsEntry.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceStaticDnsEntry/form.deliveryServiceStaticDnsEntry.tpl.html
@@ -50,9 +50,9 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(dsStaticDnsEntryForm.ttl), 'has-feedback': hasError(dsStaticDnsEntryForm.ttl)}">
                 <label for="ttl" class="control-label col-md-2 col-sm-2 col-xs-12">TTL *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="ttl" name="ttl" type="number" class="form-control" ng-model="staticDnsEntry.ttl" min="0" step="1" required>
+                    <input id="ttl" name="ttl" type="number" class="form-control" ng-model="staticDnsEntry.ttl" min="0" step="1" ng-pattern="/^\d+$/" required>
                     <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'required')">Required</small>
-                    <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'step') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'min')">Whole Number</small>
+                    <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'step') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'min') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'pattern')">Whole Number</small>
                     <span ng-show="hasError(dsStaticDnsEntryForm.ttl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceStaticDnsEntry/form.deliveryServiceStaticDnsEntry.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceStaticDnsEntry/form.deliveryServiceStaticDnsEntry.tpl.html
@@ -50,9 +50,9 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(dsStaticDnsEntryForm.ttl), 'has-feedback': hasError(dsStaticDnsEntryForm.ttl)}">
                 <label for="ttl" class="control-label col-md-2 col-sm-2 col-xs-12">TTL *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="ttl" name="ttl" type="number" class="form-control" ng-model="staticDnsEntry.ttl" ng-pattern="/^\d+$/" required>
+                    <input id="ttl" name="ttl" type="number" class="form-control" ng-model="staticDnsEntry.ttl" min="0" step="1" ng-pattern="/^\d+$/" required>
                     <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'required')">Required</small>
-                    <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'pattern')">Whole Number</small>
+                    <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'step') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'min') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'pattern')">Whole Number</small>
                     <span ng-show="hasError(dsStaticDnsEntryForm.ttl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceStaticDnsEntry/form.deliveryServiceStaticDnsEntry.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceStaticDnsEntry/form.deliveryServiceStaticDnsEntry.tpl.html
@@ -50,7 +50,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(dsStaticDnsEntryForm.ttl), 'has-feedback': hasError(dsStaticDnsEntryForm.ttl)}">
                 <label for="ttl" class="control-label col-md-2 col-sm-2 col-xs-12">TTL *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="ttl" name="ttl" type="number" class="form-control" ng-model="staticDnsEntry.ttl" min="0" step="1" ng-pattern="/^\d+$/" required>
+                    <input id="ttl" name="ttl" type="number" class="form-control" ng-model="staticDnsEntry.ttl" min="0" step="1" pattern="\d+" required>
                     <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'required')">Required</small>
                     <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'step') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'min') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'pattern')">Whole Number</small>
                     <span ng-show="hasError(dsStaticDnsEntryForm.ttl)" class="form-control-feedback"><i class="fa fa-times"></i></span>

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceStaticDnsEntry/form.deliveryServiceStaticDnsEntry.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceStaticDnsEntry/form.deliveryServiceStaticDnsEntry.tpl.html
@@ -50,9 +50,9 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(dsStaticDnsEntryForm.ttl), 'has-feedback': hasError(dsStaticDnsEntryForm.ttl)}">
                 <label for="ttl" class="control-label col-md-2 col-sm-2 col-xs-12">TTL *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="ttl" name="ttl" type="number" class="form-control" ng-model="staticDnsEntry.ttl" min="0" step="1" ng-pattern="/^\d+$/" required>
+                    <input id="ttl" name="ttl" type="number" class="form-control" ng-model="staticDnsEntry.ttl" ng-pattern="/^\d+$/" required>
                     <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'required')">Required</small>
-                    <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'step') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'min') || hasPropertyError(dsStaticDnsEntryForm.ttl, 'pattern')">Whole Number</small>
+                    <small class="input-error" ng-show="hasPropertyError(dsStaticDnsEntryForm.ttl, 'pattern')">Whole Number</small>
                     <span ng-show="hasError(dsStaticDnsEntryForm.ttl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>

--- a/traffic_portal/test/end_to_end/deliveryServices/delivery-services-spec.js
+++ b/traffic_portal/test/end_to_end/deliveryServices/delivery-services-spec.js
@@ -52,7 +52,7 @@ describe('Traffic Portal Delivery Services Suite', function() {
 		steeringXmlId: "http-xml-id-" + commonFunctions.shuffle('abcdefghijklmonpqrstuvwxyz'),
 		longDesc: "This is only a test delivery service that should be disposed of by Automated UI Testing.",
 		staticDNShostName: "static-dns-xml-id-" + commonFunctions.shuffle('abcdefghijklmonpqrstuvwxyz'),
-		staticDNSTTL: 50,
+		staticDNSTTL: 0,
 		staticDNSAddress: "cdn.test.com."
 
 	};


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #3400 

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Portal 
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
**Manual Testing** 
1. In Traffic Portal, create a HTTP delivery service
2. Click on `More` and then add Static DNS entry
3. Select a Type and type ttl value as zero (`0`) 
4. You can create a static DNS entry with a successful message.

**Automation Testing**
1. Run CIAB
2. Run Traffic_Portal locally (make sure the Traffic_Ops url point to CIAB traffic ops url)
3. Ensure protractor and webdriver-manage are installed.
4. Run webdriver-manager start
5. Run protractor config.js from traffic_control/traffic_portal/test/end-to-end/ folder
6. All 73 specs should pass. `73 specs, 0 failures`

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master (e313410)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [ ] This PR does not include documentation
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
