### PR TITLE
Perl-less tests

### DIFF
--- a/traffic_ops/testing/api/conf/traffic-ops-test.conf
+++ b/traffic_ops/testing/api/conf/traffic-ops-test.conf
@@ -34,5 +34,6 @@
         "port": "5432",
         "type": "Pg",
         "user": "traffic_ops"
-    }
+    },
+    "noPerl": false
 }

--- a/traffic_ops/testing/api/conf/traffic-ops-test.conf
+++ b/traffic_ops/testing/api/conf/traffic-ops-test.conf
@@ -35,5 +35,6 @@
         "type": "Pg",
         "user": "traffic_ops"
     },
-    "noPerl": false
+    "noPerl": false,
+    "noISO": false
 }

--- a/traffic_ops/testing/api/config/config.go
+++ b/traffic_ops/testing/api/config/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	UseIMS       bool         `json:"use_ims"`
 	// Sets whether or not to perform tests that must proxy to Perl
 	NoPerl bool `json:"noPerl"`
+	// Sets whether or not to perform tests that involve ISO generation
+	NoISO bool `json:"noISO"`
 }
 
 // TrafficOps - config section

--- a/traffic_ops/testing/api/config/config.go
+++ b/traffic_ops/testing/api/config/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	TrafficOpsDB TrafficOpsDB `json:"trafficOpsDB"`
 	Default      Default      `json:"default"`
 	UseIMS       bool         `json:"use_ims"`
+	// Sets whether or not to perform tests that must proxy to Perl
+	NoPerl bool `json:"noPerl"`
 }
 
 // TrafficOps - config section

--- a/traffic_ops/testing/api/v1/iso_test.go
+++ b/traffic_ops/testing/api/v1/iso_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestGetOSVersions(t *testing.T) {
+	if Config.NoISO {
+		t.Skip("No ISO generation available")
+	}
 	// Default value per ./traffic_ops/install/data/json/osversions.json file.
 	// This should be the data returned in the CiaB environment.
 	expected := map[string]string{

--- a/traffic_ops/testing/api/v1/userdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v1/userdeliveryservices_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestUserDeliveryServices(t *testing.T) {
+	if Config.NoPerl {
+		t.Skip("No Perl instance for proxying")
+	}
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, DeliveryServices, UsersDeliveryServices}, func() {
 		GetTestUsersDeliveryServices(t)
 	})

--- a/traffic_ops/testing/api/v2/iso_test.go
+++ b/traffic_ops/testing/api/v2/iso_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestGetOSVersions(t *testing.T) {
+	if Config.NoISO {
+		t.Skip("No ISO generation available")
+	}
 	// Default value per ./traffic_ops/install/data/json/osversions.json file.
 	// This should be the data returned in the CiaB environment.
 	expected := map[string]string{

--- a/traffic_ops/testing/api/v3/iso_test.go
+++ b/traffic_ops/testing/api/v3/iso_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestGetOSVersions(t *testing.T) {
+	if Config.NoISO {
+		t.Skip("No ISO generation available")
+	}
 	// Default value per ./traffic_ops/install/data/json/osversions.json file.
 	// This should be the data returned in the CiaB environment.
 	expected := map[string]string{


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR removes the API tests' dependency on a running Perl instance - and also skips running ISO generation tests in unsupported environments. This is done with two new configuration options:
```json
{
	"noPerl": true,
	"noISO": true
}
```
which are exactly what they sound like

## Which Traffic Control components are affected by this PR?
- Traffic Ops Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Run the API tests, both with and without `noPerl` and `noISO` set to true, ensure they all pass in any case, but especially that ISO generation tests are skipped when `noISO` is `true` and that endpoints that don't exist in Go are skipped when `noPerl` is `true`.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**