### PR TITLE
Fixes a bug in the ort t3c command

### DIFF
--- a/traffic_ops_ort/t3c/config/config.go
+++ b/traffic_ops_ort/t3c/config/config.go
@@ -334,7 +334,8 @@ func validateURL(u *url.URL) error {
 }
 
 func isCommandAvailable(name string) bool {
-	cmd := exec.Command("/bin/sh", "-c", name, "--version")
+	command := name + " --version"
+	cmd := exec.Command("/bin/sh", "-c", command)
 	if err := cmd.Run(); err != nil {
 		return false
 	}

--- a/traffic_ops_ort/t3c/torequest/torequest.go
+++ b/traffic_ops_ort/t3c/torequest/torequest.go
@@ -1452,7 +1452,7 @@ func (r *TrafficOpsReq) UpdateTrafficOps(syncdsUpdate *UpdateStatus) (bool, erro
 		updateResult = true
 		log.Errorln("Traffic Ops is signaling that an update is ready to be applied but, none was found! Clearing update state in Traffic Ops anyway.")
 	} else if *syncdsUpdate == UpdateTropsNotNeeded {
-		log.Errorln("Traffic Ops does not require and update at this time")
+		log.Errorln("Traffic Ops does not require an update at this time")
 		return true, nil
 	} else if *syncdsUpdate == UpdateTropsFailed {
 		log.Errorln("Traffic Ops requires an update but, applying the update locally failed.  Traffic Ops is not being updated.")


### PR DESCRIPTION
Fixes a command execution bug in the t3c ORT command and fixes a spelling error in a log message.


## What does this PR (Pull Request) do?
I found an issue while running integration tests with the t3c command.  t3c checks for the
availability of the systemctl command and it was running the systemctl --version command 
incorrectly.  Also there is a mis-spelled word in a log message.



## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT

## What is the best way to verify this PR?

When running 't3c' it correctly identifies that a system has the systemctl command and does 
not error out reporting the absence of the systemctl command.

## If this is a bug fix, what versions of Traffic Control are affected?

- master (bf2f05df)



## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [ ] This PR includes any and all required license headers
- [ ] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [ ] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
