### PR TITLE
Revert Delivery Service type alias

### DIFF
--- a/lib/go-atscfg/cacheurldotconfig.go
+++ b/lib/go-atscfg/cacheurldotconfig.go
@@ -35,7 +35,7 @@ type CacheURLDS struct {
 	CacheURL      string
 }
 
-func DeliveryServicesToCacheURLDSes(dses []tc.DeliveryServiceNullable) map[tc.DeliveryServiceName]CacheURLDS {
+func DeliveryServicesToCacheURLDSes(dses []tc.DeliveryServiceNullableV30) map[tc.DeliveryServiceName]CacheURLDS {
 	sDSes := map[tc.DeliveryServiceName]CacheURLDS{}
 	for _, ds := range dses {
 		if ds.OrgServerFQDN == nil || ds.QStringIgnore == nil || ds.XMLID == nil || ds.Active == nil {

--- a/lib/go-atscfg/headerrewritedotconfig.go
+++ b/lib/go-atscfg/headerrewritedotconfig.go
@@ -104,7 +104,7 @@ func HeaderRewriteServerFromServerNotNullable(sv tc.Server) (HeaderRewriteServer
 	return HeaderRewriteServer{Status: status, HostName: sv.HostName, DomainName: sv.DomainName, Port: sv.TCPPort}, nil
 }
 
-func HeaderRewriteDSFromDS(ds *tc.DeliveryServiceNullable) (HeaderRewriteDS, error) {
+func HeaderRewriteDSFromDS(ds *tc.DeliveryServiceNullableV30) (HeaderRewriteDS, error) {
 	errs := []error{}
 	if ds.ID == nil {
 		errs = append(errs, errors.New("ID cannot be nil"))

--- a/lib/go-atscfg/hostingdotconfig.go
+++ b/lib/go-atscfg/hostingdotconfig.go
@@ -43,7 +43,7 @@ func MakeHostingDotConfig(
 	toToolName string, // tm.toolname global parameter (TODO: cache itself?)
 	toURL string, // tm.url global parameter (TODO: cache itself?)
 	params map[string]string, // map[name]value - config file should always be storage.config
-	dses []tc.DeliveryServiceNullable,
+	dses []tc.DeliveryServiceNullableV30,
 	topologies []tc.Topology,
 ) string {
 	text := GenericHeaderComment(server.HostName, toToolName, toURL)

--- a/lib/go-atscfg/hostingdotconfig_test.go
+++ b/lib/go-atscfg/hostingdotconfig_test.go
@@ -44,9 +44,9 @@ func TestMakeHostingDotConfig(t *testing.T) {
 		"https://origin4.example.net/",
 		"http://origin5.example.net/",
 	}
-	dses := []tc.DeliveryServiceNullable{}
+	dses := []tc.DeliveryServiceNullableV30{}
 	for _, origin := range origins {
-		ds := tc.DeliveryServiceNullable{}
+		ds := tc.DeliveryServiceNullableV30{}
 		ds.OrgServerFQDN = util.StrPtr(origin)
 		dses = append(dses, ds)
 	}
@@ -101,19 +101,19 @@ func TestMakeHostingDotConfigTopologiesIgnoreDSS(t *testing.T) {
 		"somethingelse":     "somethingelse-shouldnotappearinconfig",
 	}
 
-	dsTopology := tc.DeliveryServiceNullable{}
+	dsTopology := tc.DeliveryServiceNullableV30{}
 	dsTopology.OrgServerFQDN = util.StrPtr("https://origin0.example.net")
 	dsTopology.XMLID = util.StrPtr("ds-topology")
 	dsTopology.Topology = util.StrPtr("t0")
 	dsTopology.Active = util.BoolPtr(true)
 
-	dsTopologyWithoutServer := tc.DeliveryServiceNullable{}
+	dsTopologyWithoutServer := tc.DeliveryServiceNullableV30{}
 	dsTopologyWithoutServer.OrgServerFQDN = util.StrPtr("https://origin1.example.net")
 	dsTopologyWithoutServer.XMLID = util.StrPtr("ds-topology-without-server")
 	dsTopologyWithoutServer.Topology = util.StrPtr("t1")
 	dsTopologyWithoutServer.Active = util.BoolPtr(true)
 
-	dses := []tc.DeliveryServiceNullable{dsTopology, dsTopologyWithoutServer}
+	dses := []tc.DeliveryServiceNullableV30{dsTopology, dsTopologyWithoutServer}
 
 	topologies := []tc.Topology{
 		tc.Topology{

--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -66,7 +66,7 @@ func MakeMetaConfig(
 	locationParams map[string]ConfigProfileParams, // map[configFile]params; 'location' and 'URL' Parameters on serverHostName's Profile
 	uriSignedDSes []tc.DeliveryServiceName,
 	scopeParams map[string]string, // map[configFileName]scopeParam
-	dses map[tc.DeliveryServiceName]tc.DeliveryServiceNullable,
+	dses map[tc.DeliveryServiceName]tc.DeliveryServiceNullableV30,
 	cacheGroupArr []tc.CacheGroupNullable,
 	topologies []tc.Topology,
 ) string {
@@ -101,7 +101,7 @@ func AddMetaObjConfigDir(
 	locationParams map[string]ConfigProfileParams, // map[configFile]params; 'location' and 'URL' Parameters on serverHostName's Profile
 	uriSignedDSes []tc.DeliveryServiceName,
 	scopeParams map[string]string, // map[configFileName]scopeParam
-	dses map[tc.DeliveryServiceName]tc.DeliveryServiceNullable,
+	dses map[tc.DeliveryServiceName]tc.DeliveryServiceNullableV30,
 	cacheGroupArr []tc.CacheGroupNullable,
 	topologies []tc.Topology,
 ) (tc.ATSConfigMetaData, error) {
@@ -273,7 +273,7 @@ func MakeMetaObj(
 	locationParams map[string]ConfigProfileParams, // map[configFile]params; 'location' and 'URL' Parameters on serverHostName's Profile
 	uriSignedDSes []tc.DeliveryServiceName,
 	scopeParams map[string]string, // map[configFileName]scopeParam
-	dses map[tc.DeliveryServiceName]tc.DeliveryServiceNullable,
+	dses map[tc.DeliveryServiceName]tc.DeliveryServiceNullableV30,
 	cacheGroupArr []tc.CacheGroupNullable,
 	topologies []tc.Topology,
 	configDir string,

--- a/lib/go-atscfg/meta_test.go
+++ b/lib/go-atscfg/meta_test.go
@@ -110,7 +110,7 @@ func TestMakeMetaConfig(t *testing.T) {
 		},
 	}
 	uriSignedDSes := []tc.DeliveryServiceName{"mydsname"}
-	dses := map[tc.DeliveryServiceName]tc.DeliveryServiceNullable{"mydsname": {}}
+	dses := map[tc.DeliveryServiceName]tc.DeliveryServiceNullableV30{"mydsname": {}}
 
 	scopeParams := map[string]string{"custom.config": string(tc.ATSConfigMetaDataConfigFileScopeProfiles)}
 

--- a/lib/go-atscfg/regexremapdotconfig.go
+++ b/lib/go-atscfg/regexremapdotconfig.go
@@ -36,7 +36,7 @@ type CDNDS struct {
 	RegexRemap    string
 }
 
-func DeliveryServicesToCDNDSes(dses []tc.DeliveryServiceNullable) map[tc.DeliveryServiceName]CDNDS {
+func DeliveryServicesToCDNDSes(dses []tc.DeliveryServiceNullableV30) map[tc.DeliveryServiceName]CDNDS {
 	sDSes := map[tc.DeliveryServiceName]CDNDS{}
 	for _, ds := range dses {
 		if ds.OrgServerFQDN == nil || ds.QStringIgnore == nil || ds.XMLID == nil {

--- a/lib/go-atscfg/sslmulticertdotconfig.go
+++ b/lib/go-atscfg/sslmulticertdotconfig.go
@@ -38,7 +38,7 @@ type SSLMultiCertDS struct {
 	ExampleURLs []string
 }
 
-func DeliveryServicesToSSLMultiCertDSes(dses []tc.DeliveryServiceNullable) map[tc.DeliveryServiceName]SSLMultiCertDS {
+func DeliveryServicesToSSLMultiCertDSes(dses []tc.DeliveryServiceNullableV30) map[tc.DeliveryServiceName]SSLMultiCertDS {
 	sDSes := map[tc.DeliveryServiceName]SSLMultiCertDS{}
 	for _, ds := range dses {
 		if ds.Type == nil || ds.Protocol == nil || ds.XMLID == nil {

--- a/lib/go-atscfg/topologyheaderrewritedotconfig.go
+++ b/lib/go-atscfg/topologyheaderrewritedotconfig.go
@@ -47,7 +47,7 @@ func MakeTopologyHeaderRewriteDotConfig(
 	server tc.Server,
 	toToolName string, // tm.toolname global parameter (TODO: cache itself?)
 	toURL string, // tm.url global parameter (TODO: cache itself?)
-	ds tc.DeliveryServiceNullable,
+	ds tc.DeliveryServiceNullableV30,
 	topologies []tc.Topology,
 	cacheGroupArr []tc.CacheGroupNullable,
 	servers []tc.Server,

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -469,7 +469,7 @@ func (ds *DeliveryServiceNullableV30) validateTypeFields(tx *sql.Tx) error {
 	errs := validation.Errors{
 		"consistentHashQueryParams": validation.Validate(ds,
 			validation.By(func(dsi interface{}) error {
-				ds := dsi.(*DeliveryServiceNullable)
+				ds := dsi.(*DeliveryServiceNullableV30)
 				if len(ds.ConsistentHashQueryParams) == 0 || DSType(typeName).IsHTTP() {
 					return nil
 				}
@@ -495,7 +495,7 @@ func (ds *DeliveryServiceNullableV30) validateTypeFields(tx *sql.Tx) error {
 			validation.NewStringRule(validateOrgServerFQDN, "must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)")),
 		"rangeSliceBlockSize": validation.Validate(ds,
 			validation.By(func(dsi interface{}) error {
-				ds := dsi.(*DeliveryServiceNullable)
+				ds := dsi.(*DeliveryServiceNullableV30)
 				if ds.RangeRequestHandling != nil {
 					if *ds.RangeRequestHandling == 3 {
 						return validation.Validate(ds.RangeSliceBlockSize, validation.Required,

--- a/traffic_ops/testing/api/v3/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/cachegroupsdeliveryservices_test.go
@@ -40,7 +40,7 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 		t.Fatalf("cannot test cachegroups delivery services: expected no initial delivery service servers, actual %v", len(dss.Response))
 	}
 
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Fatalf("cannot GET DeliveryServices: %v - %v", err, dses)
 	}

--- a/traffic_ops/testing/api/v3/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
 	"testing"
@@ -28,7 +29,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
-	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/v3-client"
 )
 
 func TestDeliveryServices(t *testing.T) {
@@ -55,7 +56,7 @@ func TestDeliveryServices(t *testing.T) {
 }
 
 func GetTestDeliveryServicesIMSAfterChange(t *testing.T, header http.Header) {
-	_, reqInf, err := TOSession.GetDeliveryServicesNullable(header)
+	_, reqInf, err := TOSession.GetDeliveryServicesV30(header, nil)
 	if err != nil {
 		t.Fatalf("could not GET Delivery Services: %v", err)
 	}
@@ -66,7 +67,7 @@ func GetTestDeliveryServicesIMSAfterChange(t *testing.T, header http.Header) {
 	currentTime = currentTime.Add(1 * time.Second)
 	timeStr := currentTime.Format(time.RFC1123)
 	header.Set(rfc.IfModifiedSince, timeStr)
-	_, reqInf, err = TOSession.GetDeliveryServicesNullable(header)
+	_, reqInf, err = TOSession.GetDeliveryServicesV30(header, nil)
 	if err != nil {
 		t.Fatalf("could not GET Delivery Services: %v", err)
 	}
@@ -78,12 +79,12 @@ func GetTestDeliveryServicesIMSAfterChange(t *testing.T, header http.Header) {
 func PostDeliveryServiceTest(t *testing.T) {
 	ds := testData.DeliveryServices[0]
 	ds.XMLID = util.StrPtr("")
-	_, err := TOSession.CreateDeliveryServiceNullable(&ds)
+	_, _, err := TOSession.CreateDeliveryServiceV30(ds)
 	if err == nil {
 		t.Fatal("Expected error with empty xmlid")
 	}
 	ds.XMLID = nil
-	_, err = TOSession.CreateDeliveryServiceNullable(&ds)
+	_, _, err = TOSession.CreateDeliveryServiceV30(ds)
 	if err == nil {
 		t.Fatal("Expected error with nil xmlid")
 	}
@@ -100,7 +101,7 @@ func CreateTestDeliveryServices(t *testing.T) {
 		t.Errorf("cannot create parameter: %v", err)
 	}
 	for _, ds := range testData.DeliveryServices {
-		_, err = TOSession.CreateDeliveryServiceNullable(&ds)
+		_, _, err = TOSession.CreateDeliveryServiceV30(ds)
 		if err != nil {
 			t.Errorf("could not CREATE delivery service '%s': %v", *ds.XMLID, err)
 		}
@@ -113,7 +114,7 @@ func GetTestDeliveryServicesIMS(t *testing.T) {
 	futureTime := time.Now().AddDate(0, 0, 1)
 	time := futureTime.Format(time.RFC1123)
 	header.Set(rfc.IfModifiedSince, time)
-	_, reqInf, err := TOSession.GetDeliveryServicesNullable(header)
+	_, reqInf, err := TOSession.GetDeliveryServicesV30(header, nil)
 	if err != nil {
 		t.Fatalf("could not GET Delivery Services: %v", err)
 	}
@@ -123,11 +124,11 @@ func GetTestDeliveryServicesIMS(t *testing.T) {
 }
 
 func GetTestDeliveryServices(t *testing.T) {
-	actualDSes, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	actualDSes, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServices: %v - %v", err, actualDSes)
 	}
-	actualDSMap := map[string]tc.DeliveryServiceNullable{}
+	actualDSMap := make(map[string]tc.DeliveryServiceNullableV30, len(actualDSes))
 	for _, ds := range actualDSes {
 		actualDSMap[*ds.XMLID] = ds
 	}
@@ -152,12 +153,12 @@ func GetTestDeliveryServices(t *testing.T) {
 func UpdateTestDeliveryServices(t *testing.T) {
 	firstDS := testData.DeliveryServices[0]
 
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Errorf("cannot GET Delivery Services: %v", err)
 	}
 
-	remoteDS := tc.DeliveryServiceNullable{}
+	remoteDS := tc.DeliveryServiceNullableV30{}
 	found := false
 	for _, ds := range dses {
 		if *ds.XMLID == *firstDS.XMLID {
@@ -178,18 +179,21 @@ func UpdateTestDeliveryServices(t *testing.T) {
 	remoteDS.MaxOriginConnections = &updatedMaxOriginConnections
 	remoteDS.MatchList = nil // verify that this field is optional in a PUT request, doesn't cause nil dereference panic
 
-	if updateResp, err := TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*remoteDS.ID), &remoteDS); err != nil {
+	if updateResp, _, err := TOSession.UpdateDeliveryServiceV30(*remoteDS.ID, remoteDS); err != nil {
 		t.Errorf("cannot UPDATE DeliveryService by ID: %v - %v", err, updateResp)
 	}
 
 	// Retrieve the server to check rack and interfaceName values were updated
-	resp, _, err := TOSession.GetDeliveryServiceNullable(strconv.Itoa(*remoteDS.ID), nil)
+	params := url.Values{}
+	params.Set("id", strconv.Itoa(*remoteDS.ID))
+	apiResp, _, err := TOSession.GetDeliveryServicesV30(nil, params)
 	if err != nil {
-		t.Errorf("cannot GET Delivery Service by ID: %v - %v", remoteDS.XMLID, err)
+		t.Fatalf("cannot GET Delivery Service by ID: %v - %v", remoteDS.XMLID, err)
 	}
-	if resp == nil {
-		t.Errorf("cannot GET Delivery Service by ID: %v - nil", remoteDS.XMLID)
+	if len(apiResp) < 1 {
+		t.Fatalf("cannot GET Delivery Service by ID: %v - nil", remoteDS.XMLID)
 	}
+	resp := apiResp[0]
 
 	if *resp.LongDesc != updatedLongDesc || *resp.MaxDNSAnswers != updatedMaxDNSAnswers || *resp.MaxOriginConnections != updatedMaxOriginConnections {
 		t.Errorf("results do not match actual: %s, expected: %s", *resp.LongDesc, updatedLongDesc)
@@ -201,12 +205,12 @@ func UpdateTestDeliveryServices(t *testing.T) {
 func UpdateNullableTestDeliveryServices(t *testing.T) {
 	firstDS := testData.DeliveryServices[0]
 
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Fatalf("cannot GET Delivery Services: %v", err)
 	}
 
-	remoteDS := tc.DeliveryServiceNullable{}
+	var remoteDS tc.DeliveryServiceNullableV30
 	found := false
 	for _, ds := range dses {
 		if ds.XMLID == nil || ds.ID == nil {
@@ -227,18 +231,20 @@ func UpdateNullableTestDeliveryServices(t *testing.T) {
 	remoteDS.LongDesc = &updatedLongDesc
 	remoteDS.MaxDNSAnswers = &updatedMaxDNSAnswers
 
-	if updateResp, err := TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*remoteDS.ID), &remoteDS); err != nil {
+	if updateResp, _, err := TOSession.UpdateDeliveryServiceV30(*remoteDS.ID, remoteDS); err != nil {
 		t.Fatalf("cannot UPDATE DeliveryService by ID: %v - %v", err, updateResp)
 	}
 
-	// Retrieve the server to check rack and interfaceName values were updated
-	resp, _, err := TOSession.GetDeliveryServiceNullable(strconv.Itoa(*remoteDS.ID), nil)
+	params := url.Values{}
+	params.Set("id", strconv.Itoa(*remoteDS.ID))
+	apiResp, _, err := TOSession.GetDeliveryServicesV30(nil, params)
 	if err != nil {
 		t.Fatalf("cannot GET Delivery Service by ID: %v - %v", remoteDS.XMLID, err)
 	}
-	if resp == nil {
+	if apiResp == nil {
 		t.Fatalf("cannot GET Delivery Service by ID: %v - nil", remoteDS.XMLID)
 	}
+	resp := apiResp[0]
 
 	if resp.LongDesc == nil || resp.MaxDNSAnswers == nil {
 		t.Errorf("results do not match actual: %v, expected: %s", resp.LongDesc, updatedLongDesc)
@@ -253,7 +259,7 @@ func UpdateNullableTestDeliveryServices(t *testing.T) {
 
 // UpdateDeliveryServiceWithInvalidTopology ensures that a topology cannot be assigned to (CLIENT_)STEERING delivery services.
 func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Fatalf("cannot GET Delivery Services: %v", err)
 	}
@@ -263,7 +269,7 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 		if *ds.Type == tc.DSTypeClientSteering {
 			found = true
 			ds.Topology = util.StrPtr("my-topology")
-			if _, err := TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*ds.ID), &ds); err == nil {
+			if _, _, err := TOSession.UpdateDeliveryServiceV30(*ds.ID, ds); err == nil {
 				t.Errorf("assigning topology to CLIENT_STEERING delivery service - expected: error, actual: no error")
 			}
 		}
@@ -276,7 +282,7 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 // UpdateDeliveryServiceTopologyHeaderRewriteFields ensures that a delivery service can only use firstHeaderRewrite,
 // innerHeaderRewrite, or lastHeadeRewrite if a topology is assigned.
 func UpdateDeliveryServiceTopologyHeaderRewriteFields(t *testing.T) {
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Fatalf("cannot GET Delivery Services: %v", err)
 	}
@@ -288,7 +294,7 @@ func UpdateDeliveryServiceTopologyHeaderRewriteFields(t *testing.T) {
 		ds.FirstHeaderRewrite = util.StrPtr("foo")
 		ds.InnerHeaderRewrite = util.StrPtr("bar")
 		ds.LastHeaderRewrite = util.StrPtr("baz")
-		_, err := TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*ds.ID), &ds)
+		_, _, err := TOSession.UpdateDeliveryServiceV30(*ds.ID, ds)
 		if ds.Topology != nil && err != nil {
 			t.Errorf("expected: no error updating topology-based header rewrite fields for topology-based DS, actual: %v", err)
 		}
@@ -300,7 +306,7 @@ func UpdateDeliveryServiceTopologyHeaderRewriteFields(t *testing.T) {
 		ds.LastHeaderRewrite = nil
 		ds.EdgeHeaderRewrite = util.StrPtr("foo")
 		ds.MidHeaderRewrite = util.StrPtr("bar")
-		_, err = TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*ds.ID), &ds)
+		_, _, err = TOSession.UpdateDeliveryServiceV30(*ds.ID, ds)
 		if ds.Topology != nil && err == nil {
 			t.Errorf("expected: error updating legacy header rewrite fields for topology-based DS, actual: nil")
 		}
@@ -317,12 +323,12 @@ func UpdateDeliveryServiceTopologyHeaderRewriteFields(t *testing.T) {
 func UpdateDeliveryServiceWithInvalidRemapText(t *testing.T) {
 	firstDS := testData.DeliveryServices[0]
 
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Fatalf("cannot GET Delivery Services: %v", err)
 	}
 
-	remoteDS := tc.DeliveryServiceNullable{}
+	var remoteDS tc.DeliveryServiceNullableV30
 	found := false
 	for _, ds := range dses {
 		if ds.XMLID == nil || ds.ID == nil {
@@ -341,7 +347,7 @@ func UpdateDeliveryServiceWithInvalidRemapText(t *testing.T) {
 	updatedRemapText := "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua\nline2"
 	remoteDS.RemapText = &updatedRemapText
 
-	if _, err := TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*remoteDS.ID), &remoteDS); err == nil {
+	if _, _, err := TOSession.UpdateDeliveryServiceV30(*remoteDS.ID, remoteDS); err == nil {
 		t.Errorf("Delivery service updated with invalid remap text: %v", updatedRemapText)
 	}
 }
@@ -360,12 +366,12 @@ func UpdateDeliveryServiceWithInvalidSliceRangeRequest(t *testing.T) {
 		t.Fatal("no HTTP or DNS Delivery Services to test with")
 	}
 
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Fatalf("cannot GET Delivery Services: %v", err)
 	}
 
-	remoteDS := tc.DeliveryServiceNullable{}
+	var remoteDS tc.DeliveryServiceNullableV30
 	found := false
 	for _, ds := range dses {
 		if ds.XMLID == nil || ds.ID == nil {
@@ -411,7 +417,7 @@ func UpdateDeliveryServiceWithInvalidSliceRangeRequest(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			remoteDS.RangeSliceBlockSize = tc.slicePluginSize
 			remoteDS.RangeRequestHandling = tc.rangeRequestSetting
-			if _, err := TOSession.UpdateDeliveryServiceNullable(strconv.Itoa(*remoteDS.ID), &remoteDS); err == nil {
+			if _, _, err := TOSession.UpdateDeliveryServiceV30(*remoteDS.ID, remoteDS); err == nil {
 				t.Error("Delivery service updated with invalid slice plugin configuration")
 			}
 		})
@@ -465,7 +471,9 @@ func GetAccessibleToTest(t *testing.T) {
 }
 
 func getByTenants(tenantID int, expectedCount int) error {
-	deliveryServices, _, err := TOSession.GetAccessibleDeliveryServicesByTenant(tenantID)
+	params := url.Values{}
+	params.Set("accessibleTo", strconv.Itoa(tenantID))
+	deliveryServices, _, err := TOSession.GetDeliveryServicesV30(nil, params)
 	if err != nil {
 		return err
 	}
@@ -476,33 +484,40 @@ func getByTenants(tenantID int, expectedCount int) error {
 }
 
 func DeleteTestDeliveryServices(t *testing.T) {
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Errorf("cannot GET deliveryservices: %v", err)
 	}
 	for _, testDS := range testData.DeliveryServices {
-		ds := tc.DeliveryServiceNullable{}
+		var ds tc.DeliveryServiceNullableV30
 		found := false
 		for _, realDS := range dses {
-			if *realDS.XMLID == *testDS.XMLID {
+			if realDS.XMLID != nil && *realDS.XMLID == *testDS.XMLID {
 				ds = realDS
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("DeliveryService not found in Traffic Ops: %v", ds.XMLID)
+			t.Errorf("DeliveryService not found in Traffic Ops: %v", *ds.XMLID)
+			continue
 		}
 
 		delResp, err := TOSession.DeleteDeliveryService(strconv.Itoa(*ds.ID))
 		if err != nil {
 			t.Errorf("cannot DELETE DeliveryService by ID: %v - %v", err, delResp)
+			continue
 		}
 
 		// Retrieve the Server to see if it got deleted
-		foundDS, _, err := TOSession.GetDeliveryServiceNullable(strconv.Itoa(*ds.ID), nil)
-		if err == nil && foundDS != nil {
-			t.Errorf("expected Delivery Service: %s to be deleted", *ds.XMLID)
+		params := url.Values{}
+		params.Set("id", strconv.Itoa(*ds.ID))
+		foundDS, _, err := TOSession.GetDeliveryServicesV30(nil, params)
+		if err != nil {
+			t.Errorf("Unexpected error deleting Delivery Service '%s': %v", *ds.XMLID, err)
+		}
+		if len(foundDS) > 0 {
+			t.Errorf("expected Delivery Service: %s to be deleted, but %d exist with same ID (#%d)", *ds.XMLID, len(foundDS), *ds.ID)
 		}
 	}
 
@@ -517,22 +532,35 @@ func DeleteTestDeliveryServices(t *testing.T) {
 }
 
 func DeliveryServiceMinorVersionsTest(t *testing.T) {
+	if len(testData.DeliveryServices) < 5 {
+		t.Fatalf("Need at least 5 DSes to test minor versions; got: %d", len(testData.DeliveryServices))
+	}
 	testDS := testData.DeliveryServices[4]
+	if testDS.XMLID == nil {
+		t.Fatal("expected XMLID: ds-test-minor-versions, actual: <nil>")
+	}
 	if *testDS.XMLID != "ds-test-minor-versions" {
 		t.Errorf("expected XMLID: ds-test-minor-versions, actual: %s", *testDS.XMLID)
 	}
 
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Errorf("cannot GET DeliveryServices: %v - %v", err, dses)
 	}
-	ds := tc.DeliveryServiceNullable{}
+
+	var ds tc.DeliveryServiceNullableV30
+	found := false
 	for _, d := range dses {
-		if *d.XMLID == *testDS.XMLID {
+		if d.XMLID != nil && *d.XMLID == *testDS.XMLID {
 			ds = d
+			found = true
 			break
 		}
 	}
+	if !found {
+		t.Fatalf("Delivery Service '%s' not found in Traffic Ops", *testDS.XMLID)
+	}
+
 	// GET latest, verify expected values for 1.3 and 1.4 fields
 	if ds.DeepCachingType == nil {
 		t.Errorf("expected DeepCachingType: %s, actual: nil", testDS.DeepCachingType.String())
@@ -585,15 +613,14 @@ func DeliveryServiceMinorVersionsTest(t *testing.T) {
 	if err != nil {
 		t.Errorf("cannot POST deliveryservice, failed to marshal JSON: %s", err.Error())
 	}
-
 }
 
 func DeliveryServiceTenancyTest(t *testing.T) {
-	dses, _, err := TOSession.GetDeliveryServicesNullable(nil)
+	dses, _, err := TOSession.GetDeliveryServicesV30(nil, nil)
 	if err != nil {
 		t.Errorf("cannot GET deliveryservices: %v", err)
 	}
-	tenant3DS := tc.DeliveryServiceNullable{}
+	var tenant3DS tc.DeliveryServiceNullableV30
 	foundTenant3DS := false
 	for _, d := range dses {
 		if *d.XMLID == "ds3" {
@@ -624,7 +651,7 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 	}
 
 	// assert that tenant4user cannot update tenant3user's deliveryservice
-	if _, err = tenant4TOClient.UpdateDeliveryServiceNullable(string(*tenant3DS.ID), &tenant3DS); err == nil {
+	if _, _, err = tenant4TOClient.UpdateDeliveryServiceV30(*tenant3DS.ID, tenant3DS); err == nil {
 		t.Errorf("expected tenant4user to be unable to update tenant3's deliveryservice (%s)", *tenant3DS.XMLID)
 	}
 
@@ -636,8 +663,7 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 	// assert that tenant4user cannot create a deliveryservice outside of its tenant
 	tenant3DS.XMLID = util.StrPtr("deliveryservicetenancytest")
 	tenant3DS.DisplayName = util.StrPtr("deliveryservicetenancytest")
-	if _, err = tenant4TOClient.CreateDeliveryServiceNullable(&tenant3DS); err == nil {
+	if _, _, err = tenant4TOClient.CreateDeliveryServiceV30(tenant3DS); err == nil {
 		t.Error("expected tenant4user to be unable to create a deliveryservice outside of its tenant")
 	}
-
 }

--- a/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
@@ -41,12 +41,14 @@ func TestDeliveryServiceServersWithRequiredCapabilities(t *testing.T) {
 }
 
 func AssignServersToTopologyBasedDeliveryService(t *testing.T) {
-	ds, _, err := TOSession.GetDeliveryServiceByXMLIDNullable("ds-top", nil)
+	params := url.Values{}
+	params.Set("xmlId", "ds-top")
+	ds, _, err := TOSession.GetDeliveryServicesV30(nil, params)
 	if err != nil {
 		t.Fatalf("cannot GET delivery service 'ds-top': %s", err.Error())
 	}
 	if len(ds) != 1 {
-		t.Fatalf("expected one delivery service: 'ds-top', actual: %v", ds)
+		t.Fatalf("expected one delivery service: 'ds-top', actual: %v", len(ds))
 	}
 	if ds[0].Topology == nil {
 		t.Fatal("expected delivery service: 'ds-top' to have a non-nil Topology, actual: nil")

--- a/traffic_ops/testing/api/v3/session_test.go
+++ b/traffic_ops/testing/api/v3/session_test.go
@@ -18,7 +18,8 @@ package v3
 import (
 	"time"
 
-	"github.com/apache/trafficcontrol/traffic_ops/client"
+	"github.com/apache/trafficcontrol/traffic_ops/v3-client"
+
 	_ "github.com/lib/pq"
 )
 

--- a/traffic_ops/testing/api/v3/traffic_control_test.go
+++ b/traffic_ops/testing/api/v3/traffic_control_test.go
@@ -30,7 +30,7 @@ type TrafficControl struct {
 	DeliveryServicesRegexes              []tc.DeliveryServiceRegexesTest         `json:"deliveryServicesRegexes"`
 	DeliveryServiceRequests              []tc.DeliveryServiceRequest             `json:"deliveryServiceRequests"`
 	DeliveryServiceRequestComments       []tc.DeliveryServiceRequestComment      `json:"deliveryServiceRequestComments"`
-	DeliveryServices                     []tc.DeliveryServiceNullable            `json:"deliveryservices"`
+	DeliveryServices                     []tc.DeliveryServiceNullableV30         `json:"deliveryservices"`
 	DeliveryServicesRequiredCapabilities []tc.DeliveryServicesRequiredCapability `json:"deliveryservicesRequiredCapabilities"`
 	Divisions                            []tc.Division                           `json:"divisions"`
 	Federations                          []tc.CDNFederation                      `json:"federations"`

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -48,15 +48,15 @@ import (
 
 type TODeliveryService struct {
 	api.APIInfoImpl
-	tc.DeliveryServiceNullable
+	tc.DeliveryServiceNullableV30
 }
 
 func (ds TODeliveryService) MarshalJSON() ([]byte, error) {
-	return json.Marshal(ds.DeliveryServiceNullable)
+	return json.Marshal(ds.DeliveryServiceNullableV30)
 }
 
 func (ds *TODeliveryService) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, ds.DeliveryServiceNullable)
+	return json.Unmarshal(data, ds.DeliveryServiceNullableV30)
 }
 
 func (ds *TODeliveryService) APIInfo() *api.APIInfo { return ds.ReqInfo }
@@ -90,11 +90,11 @@ func (ds *TODeliveryService) GetType() string {
 
 // IsTenantAuthorized checks that the user is authorized for both the delivery service's existing tenant, and the new tenant they're changing it to (if different).
 func (ds *TODeliveryService) IsTenantAuthorized(user *auth.CurrentUser) (bool, error) {
-	return isTenantAuthorized(ds.ReqInfo, &ds.DeliveryServiceNullable)
+	return isTenantAuthorized(ds.ReqInfo, &ds.DeliveryServiceNullableV30)
 }
 
 func (ds *TODeliveryService) Validate() error {
-	return ds.DeliveryServiceNullable.Validate(ds.APIInfo().Tx.Tx)
+	return ds.DeliveryServiceNullableV30.Validate(ds.APIInfo().Tx.Tx)
 }
 
 func CreateV12(w http.ResponseWriter, r *http.Request) {
@@ -245,8 +245,7 @@ func createV15(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, reqDS t
 }
 
 // create creates the given ds in the database, and returns the DS with its id and other fields created on insert set. On error, the HTTP status code, user error, and system error are returned. The status code SHOULD NOT be used, if both errors are nil.
-func createV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, reqDS tc.DeliveryServiceNullableV30) (*tc.DeliveryServiceNullableV30, int, error, error) {
-	ds := tc.DeliveryServiceNullable(reqDS)
+func createV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, ds tc.DeliveryServiceNullableV30) (*tc.DeliveryServiceNullableV30, int, error, error) {
 	user := inf.User
 	tx := inf.Tx.Tx
 	cfg := inf.Config
@@ -735,9 +734,7 @@ WHERE
 	return nil, status, userErr, sysErr
 }
 
-func updateV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, reqDS *tc.DeliveryServiceNullableV30) (*tc.DeliveryServiceNullableV30, int, error, error) {
-	converted := tc.DeliveryServiceNullable(*reqDS)
-	ds := &converted
+func updateV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, ds *tc.DeliveryServiceNullableV30) (*tc.DeliveryServiceNullableV30, int, error, error) {
 	tx := inf.Tx.Tx
 	cfg := inf.Config
 	user := inf.User
@@ -990,7 +987,7 @@ func (v *TODeliveryService) DeleteQuery() string {
 	return `DELETE FROM deliveryservice WHERE id = :id`
 }
 
-func readGetDeliveryServices(h http.Header, params map[string]string, tx *sqlx.Tx, user *auth.CurrentUser, useIMS bool) ([]tc.DeliveryServiceNullable, error, error, int, *time.Time) {
+func readGetDeliveryServices(h http.Header, params map[string]string, tx *sqlx.Tx, user *auth.CurrentUser, useIMS bool) ([]tc.DeliveryServiceNullableV30, error, error, int, *time.Time) {
 	var maxTime time.Time
 	var runSecond bool
 	if strings.HasSuffix(params["id"], ".json") {
@@ -1024,7 +1021,7 @@ func readGetDeliveryServices(h http.Header, params map[string]string, tx *sqlx.T
 		runSecond, maxTime = ims.TryIfModifiedSinceQuery(tx, h, queryValues, selectMaxLastUpdatedQuery(where))
 		if !runSecond {
 			log.Debugln("IMS HIT")
-			return []tc.DeliveryServiceNullable{}, nil, nil, http.StatusNotModified, &maxTime
+			return []tc.DeliveryServiceNullableV30{}, nil, nil, http.StatusNotModified, &maxTime
 		}
 		log.Debugln("IMS MISS")
 	} else {
@@ -1117,7 +1114,7 @@ func getTypeFromID(id int, tx *sql.Tx) (tc.DSType, error) {
 	return tc.DSTypeFromString(name), nil
 }
 
-func updatePrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServiceNullable) error {
+func updatePrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServiceNullableV30) error {
 	count := 0
 	q := `SELECT count(*) FROM origin WHERE deliveryservice = $1 AND is_primary`
 	if err := tx.QueryRow(q, *ds.ID).Scan(&count); err != nil {
@@ -1157,7 +1154,7 @@ func updatePrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServi
 	return nil
 }
 
-func createPrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServiceNullable) error {
+func createPrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServiceNullableV30) error {
 	if ds.OrgServerFQDN == nil {
 		return nil
 	}
@@ -1189,21 +1186,21 @@ func getDSType(tx *sql.Tx, xmlid string) (tc.DSType, bool, error) {
 	return tc.DSTypeFromString(name), true, nil
 }
 
-func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *sqlx.Tx) ([]tc.DeliveryServiceNullable, error, error, int) {
+func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *sqlx.Tx) ([]tc.DeliveryServiceNullableV30, error, error, int) {
 	rows, err := tx.NamedQuery(query, queryValues)
 	if err != nil {
 		return nil, nil, fmt.Errorf("querying: %v", err), http.StatusInternalServerError
 	}
 	defer rows.Close()
 
-	dses := []tc.DeliveryServiceNullable{}
+	dses := []tc.DeliveryServiceNullableV30{}
 	dsCDNDomains := map[string]string{}
 
 	// ensure json generated from this slice won't come out as `null` if empty
 	dsQueryParams := []string{}
 
 	for rows.Next() {
-		ds := tc.DeliveryServiceNullable{}
+		ds := tc.DeliveryServiceNullableV30{}
 		cdnDomain := ""
 		err := rows.Scan(&ds.Active,
 			&ds.AnonymousBlockingEnabled,
@@ -1323,7 +1320,7 @@ func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *s
 	return dses, nil, nil, http.StatusOK
 }
 
-func updateSSLKeys(ds *tc.DeliveryServiceNullable, hostName string, tx *sql.Tx, cfg *config.Config) error {
+func updateSSLKeys(ds *tc.DeliveryServiceNullableV30, hostName string, tx *sql.Tx, cfg *config.Config) error {
 	if ds.XMLID == nil {
 		return errors.New("delivery services has no XMLID!")
 	}
@@ -1642,7 +1639,7 @@ func GetDSSelectQuery() string {
 }
 
 // getTenantID returns the tenant Id of the given delivery service. Note it may return a nil id and nil error, if the tenant ID in the database is nil.
-func getTenantID(tx *sql.Tx, ds *tc.DeliveryServiceNullable) (*int, error) {
+func getTenantID(tx *sql.Tx, ds *tc.DeliveryServiceNullableV30) (*int, error) {
 	if ds.ID == nil && ds.XMLID == nil {
 		return nil, errors.New("delivery service has no ID or XMLID")
 	}
@@ -1654,7 +1651,7 @@ func getTenantID(tx *sql.Tx, ds *tc.DeliveryServiceNullable) (*int, error) {
 	return existingID, err
 }
 
-func isTenantAuthorized(inf *api.APIInfo, ds *tc.DeliveryServiceNullable) (bool, error) {
+func isTenantAuthorized(inf *api.APIInfo, ds *tc.DeliveryServiceNullableV30) (bool, error) {
 	tx := inf.Tx.Tx
 	user := inf.User
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -105,7 +105,7 @@ func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 			api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullableV12{ds.DeliveryServiceNullableV12})
 		}
 	} else {
-		api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullable{ds})
+		api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullableV30{ds})
 	}
 
 	api.CreateChangeLogRawTx(api.ApiChange, fmt.Sprintf("DS: %s, ID: %d, ACTION: Updated safe fields", *ds.XMLID, *ds.ID), inf.User, tx)

--- a/traffic_ops/v3-client/deliveryservice.go
+++ b/traffic_ops/v3-client/deliveryservice.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -111,8 +112,23 @@ const (
 	API_DELIVERY_SERVICES_SERVERS = apiBase + "/deliveryservices/%s/servers"
 )
 
+// GetDeliveryServicesByServerV30 returns all of the (tenant-visible) Delivery
+// Services to which the server identified by the integral, unique identifier
+// 'id' is assigned.
+func (to *Session) GetDeliveryServicesByServerV30(id int) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
+	var data tc.DeliveryServicesResponseV30
+	reqInf, err := get(to, fmt.Sprintf(API_SERVER_DELIVERY_SERVICES, id), &data, nil)
+	return data.Response, reqInf, err
+}
+
 // GetDeliveryServicesByServer returns all of the (tenant-visible) Delivery Services assigned to
 // the server identified by the integral, unique identifier 'id'.
+//
+// Warning: This method coerces its returned data into an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// GetDeliveryServicesByServerV30.
 func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
 	var data tc.DeliveryServicesNullableResponse
 
@@ -124,7 +140,28 @@ func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryServiceNull
 	return data.Response, reqInf, nil
 }
 
+// GetDeliveryServicesV30 returns all (tenant-visible) Delivery Services that
+// satisfy the passed query string parameters. See the API documentation for
+// information on the available parameters.
+func (to *Session) GetDeliveryServicesV30(header http.Header, params url.Values) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
+	uri := API_DELIVERY_SERVICES
+	if params != nil {
+		uri += "?" + params.Encode()
+	}
+
+	var data tc.DeliveryServicesResponseV30
+
+	reqInf, err := get(to, API_DELIVERY_SERVICES, &data, header)
+	return data.Response, reqInf, err
+}
+
 // GetDeliveryServicesNullable returns a slice of Delivery Services.
+//
+// Warning: This method coerces its returned data into an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// GetDeliveryServicesV30.
 func (to *Session) GetDeliveryServicesNullable(header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
@@ -138,6 +175,12 @@ func (to *Session) GetDeliveryServicesNullable(header http.Header) ([]tc.Deliver
 
 // GetDeliveryServicesByCDNID returns the (tenant-visible) Delivery Services within the CDN identified
 // by the integral, unique identifier 'cdnID'.
+//
+// Warning: This method coerces its returned data into an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// GetDeliveryServicesV30.
 func (to *Session) GetDeliveryServicesByCDNID(cdnID int, header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
@@ -151,6 +194,12 @@ func (to *Session) GetDeliveryServicesByCDNID(cdnID int, header http.Header) ([]
 
 // GetDeliveryServiceNullable returns the Delivery Service identified by the integral, unique identifier
 // 'id' (which must be passed as a string).
+//
+// Warning: This method coerces its returned data into an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// GetDeliveryServicesV30.
 func (to *Session) GetDeliveryServiceNullable(id string, header http.Header) (*tc.DeliveryServiceNullable, ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
@@ -168,6 +217,12 @@ func (to *Session) GetDeliveryServiceNullable(id string, header http.Header) (*t
 // GetDeliveryServiceByXMLIDNullable returns the Delivery Service identified by the passed XMLID.
 // The length of the returned slice should always be 1 when the request is succesful - if it isn't
 // something very wicked has happened to Traffic Ops.
+//
+// Warning: This method coerces its returned data into an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// GetDeliveryServicesV30.
 func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string, header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
 	var data tc.DeliveryServicesNullableResponse
 	reqInf, err := get(to, API_DELIVERY_SERVICES+"?xmlId="+XMLID, &data, header)
@@ -178,7 +233,37 @@ func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string, header http.H
 	return data.Response, reqInf, nil
 }
 
+// CreateDeliveryServiceV30 creates the Delivery Service it's passed.
+// Note that unlike the deprecated, legacy function, this does not make multiple
+// requests to try to fill in information for the caller; the passed 'ds' must
+// be valid.
+func (to *Session) GetDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (tc.DeliveryServiceNullableV30, ReqInf, error) {
+	var reqInf ReqInf
+	bts, err := json.Marshal(ds)
+	if err != nil {
+		return tc.DeliveryServiceNullableV30{}, reqInf, nil
+	}
+
+	var data tc.DeliveryServicesResponseV30
+	reqInf, err = post(to, API_DELIVERY_SERVICES, bts, &data)
+	if err != nil {
+		return tc.DeliveryServiceNullableV30{}, reqInf, err
+	}
+	if len(data.Response) != 1 {
+		return tc.DeliveryServiceNullableV30{}, reqInf, fmt.Errorf("failed to create Delivery Service, response indicated %d were created", len(data.Response))
+	}
+
+	return data.Response[0], reqInf, nil
+}
+
 // CreateDeliveryServiceNullable creates the DeliveryService it's passed.
+//
+// Warning: This method coerces its returned data into an APIv1.5 format, and
+// only accepts input in an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// CreateDeliveryServiceV30.
 func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable) (*tc.CreateDeliveryServiceNullableResponse, error) {
 	if ds.TypeID == nil && ds.Type != nil {
 		ty, _, err := to.GetTypeByName(ds.Type.String(), nil)
@@ -234,8 +319,36 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 	return &data, nil
 }
 
+// UpdateDeliveryServiceV30 replaces the Delivery Service identified by the
+// integral, unique identifier 'id' with the one it's passed.
+func (to *Session) UpdateDeliveryServiceV30(id int, ds tc.DeliveryServiceNullableV30) (tc.DeliveryServiceNullableV30, ReqInf, error) {
+	var reqInf ReqInf
+	bts, err := json.Marshal(ds)
+	if err != nil {
+		return tc.DeliveryServiceNullableV30{}, reqInf, err
+	}
+
+	var data tc.DeliveryServicesResponseV30
+	reqInf, err = put(to, fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), bts, &data)
+	if err != nil {
+		return tc.DeliveryServiceNullableV30{}, reqInf, err
+	}
+	if len(data.Response) != 1 {
+		return tc.DeliveryServiceNullableV30{}, reqInf, fmt.Errorf("failed to update Delivery Service #%d; response indicated that %d were updated", id, len(data.Response))
+	}
+	return data.Response[0], reqInf, nil
+
+}
+
 // UpdateDeliveryServiceNullable updates the DeliveryService matching the ID it's
 // passed with the DeliveryService it is passed.
+//
+// Warning: This method coerces its returned data into an APIv1.5 format, and
+// only accepts input in an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// UpdateDeliveryServiceV30.
 func (to *Session) UpdateDeliveryServiceNullable(id string, ds *tc.DeliveryServiceNullable) (*tc.UpdateDeliveryServiceNullableResponse, error) {
 	var data tc.UpdateDeliveryServiceNullableResponse
 	jsonReq, err := json.Marshal(ds)
@@ -360,7 +473,33 @@ func (to *Session) GetDeliveryServiceURISigningKeys(dsName string, header http.H
 	return []byte(data), reqInf, nil
 }
 
+// SafeDeliveryServiceUpdateV30 updates the "safe" fields of the Delivery
+// Service identified by the integral, unique identifier 'id'.
+func (to *Session) SafeDeliveryServiceUpdateV30(id int, r tc.DeliveryServiceSafeUpdateRequest) (tc.DeliveryServiceNullableV30, ReqInf, error) {
+	var reqInf ReqInf
+	req, err := json.Marshal(r)
+	if err != nil {
+		return tc.DeliveryServiceNullableV30{}, reqInf, err
+	}
+
+	var data tc.DeliveryServiceSafeUpdateResponseV30
+	reqInf, err = put(to, fmt.Sprintf(API_DELIVERY_SERVICES_SAFE_UPDATE, id), req, &data)
+	if err != nil {
+		return tc.DeliveryServiceNullableV30{}, reqInf, err
+	}
+	if len(data.Response) != 1 {
+		return tc.DeliveryServiceNullableV30{}, reqInf, fmt.Errorf("failed to safe update Delivery Service #%d; response indicated that %d were updated", id, len(data.Response))
+	}
+	return data.Response[0], reqInf, nil
+}
+
 // UpdateDeliveryServiceSafe updates the given Delivery Service identified by 'id' with the given "safe" fields.
+//
+// Warning: This method coerces its returned data into an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// SafeDeliveryServiceUpdateV30.
 func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUpdateRequest) ([]tc.DeliveryServiceNullable, ReqInf, error) {
 	var reqInf ReqInf
 	var resp tc.DeliveryServiceSafeUpdateResponse
@@ -382,6 +521,12 @@ func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUp
 
 // GetAccessibleDeliveryServicesByTenant gets all delivery services associated with the given tenant and all of
 // its children.
+//
+// Warning: This method coerces its returned data into an APIv1.5 format.
+//
+// Deprecated: Please used versioned library imports in the future, and
+// versioned methods, specifically, for API v3.0 - in this case,
+// GetDeliveryServicesV30.
 func (to *Session) GetAccessibleDeliveryServicesByTenant(tenantId int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
 	data := tc.DeliveryServicesNullableResponse{}
 	reqInf, err := get(to, fmt.Sprintf("%v?accessibleTo=%v", API_DELIVERY_SERVICES, tenantId), &data, nil)

--- a/traffic_ops_ort/atstccfg/cfgfile/cacheurldotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/cacheurldotconfig.go
@@ -43,7 +43,7 @@ func GetConfigFileCDNCacheURL(toData *config.TOData, fileName string) (string, s
 		dssMap[*dss.DeliveryService] = append(dssMap[*dss.DeliveryService], *dss.Server)
 	}
 
-	dsesWithServers := []tc.DeliveryServiceNullable{}
+	dsesWithServers := []tc.DeliveryServiceNullableV30{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.ID == nil {
 			continue // TODO warn

--- a/traffic_ops_ort/atstccfg/cfgfile/cfgfile.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/cfgfile.go
@@ -112,7 +112,14 @@ func GetTOData(cfg config.TCCfg) (*config.TOData, error) {
 			dses, unsupported, err := cfg.TOClientNew.GetCDNDeliveryServices(server.CDNID)
 			if err == nil && unsupported {
 				log.Warnln("Traffic Ops newer than ORT, falling back to previous API Delivery Services!")
-				dses, err = cfg.TOClient.GetCDNDeliveryServices(server.CDNID)
+				var legacyDSes []tc.DeliveryServiceNullable
+				legacyDSes, err = cfg.TOClient.GetCDNDeliveryServices(server.CDNID)
+				if err == nil {
+					dses = make([]tc.DeliveryServiceNullableV30, 0, len(legacyDSes))
+					for _, ds := range legacyDSes {
+						dses = append(dses, tc.DeliveryServiceNullableV30{DeliveryServiceNullableV15: tc.DeliveryServiceNullableV15(ds)})
+					}
+				}
 			}
 			if err != nil {
 				return errors.New("getting delivery services: " + err.Error())

--- a/traffic_ops_ort/atstccfg/cfgfile/cfgfile_test.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/cfgfile_test.go
@@ -207,11 +207,11 @@ func randDSS() tc.DeliveryServiceServer {
 	}
 }
 
-func randDS() *tc.DeliveryServiceNullable {
+func randDS() *tc.DeliveryServiceNullableV30 {
 	deepCachingTypeNever := tc.DeepCachingTypeNever
 	dsTypeHTTP := tc.DSTypeHTTP
 	protocol := tc.DSProtocolHTTP
-	ds := tc.DeliveryServiceNullable{}
+	ds := tc.DeliveryServiceNullableV30{}
 	ds.EcsEnabled = *randBool()
 	ds.RangeSliceBlockSize = randInt()
 	ds.ConsistentHashRegex = randStr()
@@ -505,7 +505,7 @@ func MakeFakeTOData() *config.TOData {
 			*randParam(),
 			*randParam(),
 		},
-		DeliveryServices: []tc.DeliveryServiceNullable{
+		DeliveryServices: []tc.DeliveryServiceNullableV30{
 			ds0,
 			ds1,
 		},

--- a/traffic_ops_ort/atstccfg/cfgfile/headerrewritedotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/headerrewritedotconfig.go
@@ -31,7 +31,7 @@ import (
 func GetConfigFileCDNHeaderRewrite(toData *config.TOData, fileName string) (string, string, string, error) {
 	dsName := strings.TrimSuffix(strings.TrimPrefix(fileName, atscfg.HeaderRewritePrefix), atscfg.ConfigSuffix) // TODO verify prefix and suffix? Perl doesn't
 
-	tcDS := tc.DeliveryServiceNullable{}
+	tcDS := tc.DeliveryServiceNullableV30{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.XMLID == nil || *ds.XMLID != dsName {
 			continue

--- a/traffic_ops_ort/atstccfg/cfgfile/headerrewritemiddotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/headerrewritemiddotconfig.go
@@ -32,7 +32,7 @@ import (
 func GetConfigFileCDNHeaderRewriteMid(toData *config.TOData, fileName string) (string, string, string, error) {
 	dsName := strings.TrimSuffix(strings.TrimPrefix(fileName, atscfg.HeaderRewriteMidPrefix), atscfg.ConfigSuffix) // TODO verify prefix and suffix? Perl doesn't
 
-	tcDS := tc.DeliveryServiceNullable{}
+	tcDS := tc.DeliveryServiceNullableV30{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.XMLID == nil || *ds.XMLID != dsName {
 			continue

--- a/traffic_ops_ort/atstccfg/cfgfile/hostingdotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/hostingdotconfig.go
@@ -66,7 +66,7 @@ func GetConfigFileServerHostingDotConfig(toData *config.TOData) (string, string,
 
 	isMid := strings.HasPrefix(toData.Server.Type, tc.MidTypePrefix)
 
-	filteredDSes := []tc.DeliveryServiceNullable{}
+	filteredDSes := []tc.DeliveryServiceNullableV30{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.Active == nil || ds.Type == nil || ds.XMLID == nil || ds.CDNID == nil || ds.ID == nil || ds.OrgServerFQDN == nil {
 			// some DSes have nil origins. I think MSO? TODO: verify

--- a/traffic_ops_ort/atstccfg/cfgfile/meta.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/meta.go
@@ -126,7 +126,7 @@ func GetMeta(toData *config.TOData, dir string) (*tc.ATSConfigMetaData, error) {
 		}
 	}
 
-	dses := map[tc.DeliveryServiceName]tc.DeliveryServiceNullable{}
+	dses := map[tc.DeliveryServiceName]tc.DeliveryServiceNullableV30{}
 	if tc.CacheTypeFromString(toData.Server.Type) != tc.CacheTypeMid {
 		dsIDs := map[int]struct{}{}
 		for _, ds := range toData.DeliveryServices {

--- a/traffic_ops_ort/atstccfg/cfgfile/parentdotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/parentdotconfig.go
@@ -272,7 +272,7 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 		parentConfigServerCacheProfileParams[cgServer.Profile] = profileCache
 	}
 
-	dsIDMap := map[int]tc.DeliveryServiceNullable{}
+	dsIDMap := map[int]tc.DeliveryServiceNullableV30{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.ID == nil {
 			log.Errorln("delivery services got nil ID!")
@@ -286,7 +286,7 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 		dsIDMap[*ds.ID] = ds
 	}
 
-	allDSMap := map[int]tc.DeliveryServiceNullable{} // all DSes for this server, NOT all dses in TO
+	allDSMap := map[int]tc.DeliveryServiceNullableV30{} // all DSes for this server, NOT all dses in TO
 	for _, dsIDs := range parentServerDSes {
 		for dsID, _ := range dsIDs {
 			if _, ok := dsIDMap[dsID]; !ok {
@@ -460,7 +460,7 @@ func GetConfigFileServerParentDotConfig(toData *config.TOData) (string, string, 
 }
 
 // GetDSOrigins takes a map[deliveryServiceID]DeliveryService, and returns a map[DeliveryServiceID]OriginURI.
-func GetDSOrigins(dses map[int]tc.DeliveryServiceNullable) (map[int]*atscfg.OriginURI, error) {
+func GetDSOrigins(dses map[int]tc.DeliveryServiceNullableV30) (map[int]*atscfg.OriginURI, error) {
 	dsOrigins := map[int]*atscfg.OriginURI{}
 	for _, ds := range dses {
 		if ds.ID == nil {

--- a/traffic_ops_ort/atstccfg/cfgfile/regexremapdotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/regexremapdotconfig.go
@@ -39,7 +39,7 @@ func GetConfigFileCDNRegexRemap(toData *config.TOData, fileName string) (string,
 	}
 
 	// only send the requested DS to atscfg. The atscfg.Make will work correctly even if we send it other DSes, but this will prevent atscfg.DeliveryServicesToCDNDSes from logging errors about AnyMap and Steering DSes without origins.
-	ds := tc.DeliveryServiceNullable{}
+	ds := tc.DeliveryServiceNullableV30{}
 	for _, dsesDS := range toData.DeliveryServices {
 		if dsesDS.XMLID == nil {
 			continue // TODO log?
@@ -53,7 +53,7 @@ func GetConfigFileCDNRegexRemap(toData *config.TOData, fileName string) (string,
 		return `{"alerts":[{"level":"error","text":"Error - delivery service '` + dsName + `' not found! Do you have a regex_remap_*.config location Parameter for a delivery service that doesn't exist?"}]}`, "", "", config.ErrNotFound
 	}
 
-	cfgDSes := atscfg.DeliveryServicesToCDNDSes([]tc.DeliveryServiceNullable{ds})
+	cfgDSes := atscfg.DeliveryServicesToCDNDSes([]tc.DeliveryServiceNullableV30{ds})
 
 	return atscfg.MakeRegexRemapDotConfig(tc.CDNName(toData.Server.CDNName), toData.TOToolName, toData.TOURL, fileName, cfgDSes), atscfg.ContentTypeRegexRemapDotConfig, atscfg.LineCommentRegexRemapDotConfig, nil
 }

--- a/traffic_ops_ort/atstccfg/cfgfile/remapdotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/remapdotconfig.go
@@ -88,7 +88,7 @@ func GetConfigFileServerRemapDotConfig(toData *config.TOData) (string, string, s
 		useInactive = true
 	}
 
-	filteredDSes := []tc.DeliveryServiceNullable{}
+	filteredDSes := []tc.DeliveryServiceNullableV30{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.ID == nil {
 			continue // TODO log?

--- a/traffic_ops_ort/atstccfg/cfgfile/topologyheaderrewritedotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/topologyheaderrewritedotconfig.go
@@ -35,7 +35,7 @@ func GetConfigFileServerTopologyHeaderRewrite(toData *config.TOData, fileName st
 	dsName = strings.TrimPrefix(dsName, atscfg.HeaderRewriteInnerPrefix)
 	dsName = strings.TrimPrefix(dsName, atscfg.HeaderRewriteLastPrefix)
 
-	tcDS := tc.DeliveryServiceNullable{}
+	tcDS := tc.DeliveryServiceNullableV30{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.XMLID == nil || *ds.XMLID != dsName {
 			continue

--- a/traffic_ops_ort/atstccfg/config/config.go
+++ b/traffic_ops_ort/atstccfg/config/config.go
@@ -257,7 +257,7 @@ type TOData struct {
 	ParentConfigParams []tc.Parameter
 
 	// DeliveryServices must include all Delivery Services on the current server's cdn, including those not assigned to the server. Must not include delivery services on other cdns.
-	DeliveryServices []tc.DeliveryServiceNullable
+	DeliveryServices []tc.DeliveryServiceNullableV30
 
 	// DeliveryServiceServers must include all delivery service servers in Traffic Ops for all delivery services on the current cdn, including those not assigned to the current server.
 	DeliveryServiceServers []tc.DeliveryServiceServer

--- a/traffic_ops_ort/atstccfg/toreqnew/toreqnew.go
+++ b/traffic_ops_ort/atstccfg/toreqnew/toreqnew.go
@@ -40,7 +40,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 
-	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/v3-client"
 	"github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg/torequtil"
 )
 
@@ -72,8 +72,8 @@ func New(cookies string, url *url.URL, user string, pass string, insecure bool, 
 // GetCDNDeliveryServices returns the deliveryservices, whether this client's version is unsupported by the server, and any error.
 // Note if the server returns a 404 or 503, this returns false and a nil error.
 // Users should check the "not supported" bool, and use the vendored TOClient if it's set, and set proper defaults for the new feature(s).
-func (cl *TOClient) GetCDNDeliveryServices(cdnID int) ([]tc.DeliveryServiceNullable, bool, error) {
-	deliveryServices := []tc.DeliveryServiceNullable{}
+func (cl *TOClient) GetCDNDeliveryServices(cdnID int) ([]tc.DeliveryServiceNullableV30, bool, error) {
+	deliveryServices := []tc.DeliveryServiceNullableV30{}
 	unsupported := false
 	err := torequtil.GetRetry(cl.NumRetries, "cdn_"+strconv.Itoa(cdnID)+"_deliveryservices", &deliveryServices, func(obj interface{}) error {
 		toDSes, reqInf, err := cl.C.GetDeliveryServicesByCDNID(cdnID, nil)

--- a/traffic_ops_ort/atstccfg/toreqnew/toreqnew.go
+++ b/traffic_ops_ort/atstccfg/toreqnew/toreqnew.go
@@ -76,7 +76,9 @@ func (cl *TOClient) GetCDNDeliveryServices(cdnID int) ([]tc.DeliveryServiceNulla
 	deliveryServices := []tc.DeliveryServiceNullableV30{}
 	unsupported := false
 	err := torequtil.GetRetry(cl.NumRetries, "cdn_"+strconv.Itoa(cdnID)+"_deliveryservices", &deliveryServices, func(obj interface{}) error {
-		toDSes, reqInf, err := cl.C.GetDeliveryServicesByCDNID(cdnID, nil)
+		params := url.Values{}
+		params.Set("cdn", strconv.Itoa(cdnID))
+		toDSes, reqInf, err := cl.C.GetDeliveryServicesV30(nil, params)
 		if err != nil {
 			if IsUnsupportedErr(err) {
 				unsupported = true
@@ -84,7 +86,7 @@ func (cl *TOClient) GetCDNDeliveryServices(cdnID int) ([]tc.DeliveryServiceNulla
 			}
 			return errors.New("getting delivery services from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
 		}
-		dses := obj.(*[]tc.DeliveryServiceNullable)
+		dses := obj.(*[]tc.DeliveryServiceNullableV30)
 		*dses = toDSes
 		return nil
 	})


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This reverts the "rolling alias" `github.com/apache/trafficcontrol/lib/go-tc.DeliveryServiceNullable` rolling forward to be an alias for `github.com/apache/trafficcontrol/lib/go-tc.DeliveryServiceNullableV30`. That change was breaking; people who made programs that imported `github.com/apache/trafficcontrols/traffic_ops/client` and used its Delivery Service methods to interact with Delivery Services will suddenly have their returned and passed data interpreted differently. After this change, those symbols will be pinned to `tc.DeliveryServiceNullableV15` as before, and new client methods were added to the v3-client to specifically deal with the version 3.0 structures. Methods that deal with the legacy structures are marked as deprecated, and should be removed at the same time as the un-versioned client package. All v3 tests, atstccfg code, and API code dealing with DeliveryServiceNullable structures have been updated to use DeliveryServiceNullableV30 where appropriate.

## Which Traffic Control components are affected by this PR?
- CDN in a Box
- Documentation
- Traffic Ops Client (Go)
- Traffic Ops
- Traffic Ops ORT

## What is the best way to verify this PR?
Run all unit and client/API integration tests. Which actions now do for you :wink: .

## If this is a bug fix, what versions of Traffic Control are affected?
- master


## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**