### PR TITLE
CiaB Enroller: Retry reading empty JSON files

### DIFF
--- a/infrastructure/cdn-in-a-box/enroller/enroller.go
+++ b/infrastructure/cdn-in-a-box/enroller/enroller.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -82,7 +83,7 @@ func enrollType(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.Type
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Type: %s\n", err)
 		return err
 	}
@@ -109,7 +110,7 @@ func enrollCDN(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.CDN
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding CDN: %s\n", err)
 		return err
 	}
@@ -135,7 +136,7 @@ func enrollASN(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.ASN
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding ASN: %s\n", err)
 		return err
 	}
@@ -162,7 +163,7 @@ func enrollCachegroup(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.CacheGroupNullable
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Cachegroup: %s\n", err)
 		return err
 	}
@@ -188,7 +189,7 @@ func enrollDeliveryService(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.DeliveryServiceNullable
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding DeliveryService: %s\n", err)
 		return err
 	}
@@ -216,7 +217,7 @@ func enrollDeliveryServiceServer(toSession *session, r io.Reader) error {
 	// DeliveryServiceServers lists ds xmlid and array of server names.  Use that to create multiple DeliveryServiceServer objects
 	var dss tc.DeliveryServiceServers
 	err := dec.Decode(&dss)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding DeliveryServiceServer: %s\n", err)
 		return err
 	}
@@ -258,7 +259,7 @@ func enrollDivision(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.Division
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Division: %s\n", err)
 		return err
 	}
@@ -284,7 +285,7 @@ func enrollOrigin(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.Origin
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Origin: %s\n", err)
 		return err
 	}
@@ -310,7 +311,7 @@ func enrollParameter(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var params []tc.Parameter
 	err := dec.Decode(&params)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Parameter: %s\n", err)
 		return err
 	}
@@ -375,7 +376,7 @@ func enrollPhysLocation(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.PhysLocation
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding PhysLocation: %s\n", err)
 		return err
 	}
@@ -401,7 +402,7 @@ func enrollRegion(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.Region
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Region: %s\n", err)
 		return err
 	}
@@ -427,7 +428,7 @@ func enrollStatus(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.StatusNullable
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Status: %s\n", err)
 		return err
 	}
@@ -453,7 +454,7 @@ func enrollTenant(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.Tenant
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Tenant: %s\n", err)
 		return err
 	}
@@ -480,7 +481,7 @@ func enrollUser(toSession *session, r io.Reader) error {
 	var s tc.User
 	err := dec.Decode(&s)
 	log.Infof("User is %++v\n", s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding User: %s\n", err)
 		return err
 	}
@@ -508,7 +509,7 @@ func enrollProfile(toSession *session, r io.Reader) error {
 	var profile tc.Profile
 
 	err := dec.Decode(&profile)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Profile: %s\n", err)
 		return err
 	}
@@ -623,7 +624,7 @@ func enrollServer(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
 	var s tc.ServerNullable
 	err := dec.Decode(&s)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		log.Infof("error decoding Server: %s\n", err)
 		return err
 	}
@@ -659,7 +660,12 @@ func newDirWatcher(toSession *session) (*dirWatcher, error) {
 		const (
 			processed = ".processed"
 			rejected  = ".rejected"
+			retry  = ".retry"
 		)
+		originalNameRegex := regexp.MustCompile(`(\.retry)*$`)
+
+		emptyCount := map[string]int{}
+		const maxEmptyTries = 10
 
 		for {
 			select {
@@ -692,10 +698,27 @@ func newDirWatcher(toSession *session) (*dirWatcher, error) {
 				if f, ok := dw.watched[dir]; ok {
 					t := filepath.Base(dir)
 					log.Infoln("creating " + t + " from " + event.Name)
-					// TODO: ensure file content is there before attempting to read.  For now, this does the trick..
+					// Sleep for 100 milliseconds so that the file content is probably there when the directory watcher
+					// sees the file
 					time.Sleep(100 * time.Millisecond)
 
 					err := f(toSession, event.Name)
+					// If a file is empty, try reading from it 10 times before giving up on that file
+					if err == io.EOF {
+						originalName := originalNameRegex.ReplaceAllString(event.Name, "")
+						if _, exists := emptyCount[originalName]; !exists {
+							emptyCount[originalName] = 0
+						}
+						emptyCount[originalName]++
+						log.Infof("empty json object %s: %s\ntried file %d out of %d times", originalName, err.Error(), emptyCount[originalName], maxEmptyTries)
+						if emptyCount[originalName] < maxEmptyTries {
+							newName := event.Name + retry
+							if err := os.Rename(event.Name, newName); err != nil {
+								log.Infof("error renaming %s to %s: %s", event.Name, newName, err)
+							}
+							continue
+						}
+					}
 					if err != nil {
 						log.Infof("error creating %s from %s: %s\n", dir, event.Name, err.Error())
 					} else {


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

 [As noted](https://github.com/apache/trafficcontrol/commit/3347dd9a63#diff-40a48c7520a4509d5bec739008dbbba1R802-R803) in 3347dd9a63, the CDN-in-a-Box Enroller has a bug when working with slow volumes, where, if a file is created but no content is there yet, the Enroller will fail silently, as its only defense against empty files of this type is unconditionally waiting 100ms after detecting the file before attempting to read it, since [the Enroller does not treat `io.EOF` as an error](https://github.com/apache/trafficcontrol/commit/183fcdf741).
 
 This PR extends the hack by 
 - Treating `io.EOF` as an error, and
 - Retrying files for which `json.Decoder.Decode()` reports an `io.EOF` error up to 10 times per file before giving up on that file.
 
This PR 
- fixes the CDN-in-a-Box CI GitHub action, which currently fails 1 out of 8 times due to this race condition
- should fix CDN-in-a-Box for any users who find that sometimes it starts successfully and sometimes it does not.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Push this branch to your own repo fork 10 times
2. Optional: Go to *Actions* => *Weasel License cheks* and cancel all 10 pending/running workflows:
    ```javascript
    timeout = 0;
    document.querySelectorAll('form[method="post"] button.menu-item-danger.dropdown-item[type=submit]').forEach(element => {
      element.parentNode.setAttribute("target", "_blank");
      setTimeout(() => element.click(), timeout++ * 500);
    });
    ```
3. Do something else for 20-30 minutes
4. Go to the *Actions* tab for your own fork and make sure the *CDN-in-a-Box CI* workflow succeeded all 10 of 10 times

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (c93160a93b)
- RELEASE-4.1.0

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR fixes a test
- [x] I don't see anywhere in the docs that mentions this bug, so AFAICT amending the documentation is not necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->