### PR TITLE
ORT t3c command fixes:

### DIFF
--- a/traffic_ops_ort/t3c/torequest/torequest.go
+++ b/traffic_ops_ort/t3c/torequest/torequest.go
@@ -193,6 +193,24 @@ func (r *TrafficOpsReq) atsTcExec(cmdstr string) ([]byte, error) {
 
 // atsTcExecCommand is used to run the atstccfg command.
 func (r *TrafficOpsReq) atsTcExecCommand(cmdstr string, queueState int, revalState int) ([]byte, error) {
+	// adjust log locations used for atstccfg
+	// cannot use stdout as this will cause json parsing errors.
+	errorLocation := r.Cfg.LogLocationErr
+	if errorLocation == "stdout" {
+		errorLocation = "stderr"
+		log.Infoln("atstccfg error logging has been re-directed to 'stderr'")
+	}
+	infoLocation := r.Cfg.LogLocationInfo
+	if infoLocation == "stdout" {
+		infoLocation = "stderr"
+		log.Infoln("atstccfg info logging has been re-directed to 'stderr'")
+	}
+	warningLocation := r.Cfg.LogLocationWarn
+	if warningLocation == "stdout" {
+		warningLocation = "stderr"
+		log.Infoln("atstccfg warning logging has been re-directed to 'stderr'")
+	}
+
 	args := []string{
 		"--traffic-ops-timeout-milliseconds=" + strconv.FormatInt(int64(r.Cfg.TOTimeoutMS), 10),
 		"--traffic-ops-disable-proxy=" + strconv.FormatBool(r.Cfg.ReverseProxyDisable),
@@ -200,9 +218,13 @@ func (r *TrafficOpsReq) atsTcExecCommand(cmdstr string, queueState int, revalSta
 		"--traffic-ops-password=" + r.Cfg.TOPass,
 		"--traffic-ops-url=" + r.Cfg.TOURL,
 		"--cache-host-name=" + r.Cfg.CacheHostName,
-		"--log-location-error=" + r.Cfg.LogLocationErr,
-		"--log-location-info=" + r.Cfg.LogLocationInfo,
-		"--log-location-warning=" + r.Cfg.LogLocationWarn,
+		"--log-location-error=" + errorLocation,
+		"--log-location-info=" + infoLocation,
+		"--log-location-warning=" + warningLocation,
+	}
+
+	if r.Cfg.TOInsecure == true {
+		args = append(args, "--traffic-ops-insecure")
 	}
 
 	switch cmdstr {
@@ -236,10 +258,18 @@ func (r *TrafficOpsReq) atsTcExecCommand(cmdstr string, queueState int, revalSta
 	}
 
 	cmd := exec.Command(config.AtsTcConfig, args...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
+	var outbuf bytes.Buffer
+	var errbuf bytes.Buffer
+
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
+
 	err := cmd.Run()
-	return out.Bytes(), err
+	if err != nil {
+		return nil, errors.New("Error from atstccfg: " + err.Error() + ": " + errbuf.String())
+	}
+
+	return outbuf.Bytes(), nil
 }
 
 // backUpFile makes a backup of a config file.

--- a/traffic_ops_ort/t3c/util/util.go
+++ b/traffic_ops_ort/t3c/util/util.go
@@ -99,11 +99,18 @@ func DirectoryExists(dir string) (bool, os.FileInfo) {
 }
 
 func ExecCommand(fullCommand string, arg ...string) ([]byte, int, error) {
-	var output bytes.Buffer
+	var outbuf bytes.Buffer
+	var errbuf bytes.Buffer
 	cmd := exec.Command(fullCommand, arg...)
-	cmd.Stdout = &output
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
 	err := cmd.Run()
-	return output.Bytes(), cmd.ProcessState.ExitCode(), err
+
+  if err != nil {
+    return outbuf.Bytes(), cmd.ProcessState.ExitCode(), 
+      errors.New("Error executing '" + fullCommand + "': " + errbuf.String())
+  }
+	return outbuf.Bytes(), cmd.ProcessState.ExitCode(), err
 }
 
 func FileExists(fn string) (bool, os.FileInfo) {


### PR DESCRIPTION
Fixes the following problems found while integration testing the ORT t3c command.
  
  - use the atstccfg --traffic-ops-insecure flag to allow for self signed certs.
  - insure that atstccfg logging locations do not use 'stdout' as using 'stdout'
    will cause json parsing errors.
  - corrects the --help output to correctly show the default logging locations for
    t3c is 'stderr'.

<!--

## What does this PR (Pull Request) do?
Fixes bugs found while integration testing the ORT t3c command:

-  use the atstccfg --traffic-ops-insecure flag to allow for self signed certs.
- insure that atstccfg logging locations do not use 'stdout' as using 'stdout'
    will cause json parsing errors.
- corrects the --help output to correctly show the default logging locations for
    t3c is 'stderr'.

- [X] This PR fixe is not related to any Issue 

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run the integration tests.

## If this is a bug fix, what versions of Traffic Control are affected?

- master (f55bb5a5)

## The following criteria are ALL met by this PR

- [X] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [ ] This PR includes any and all required license headers
- [ ] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [ ] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
