### PR TITLE
Ds active flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The format of the `/servers/{{host name}}/update_status` Traffic Ops API endpoint has been changed to use a top-level `response` property, in keeping with (most of) the rest of the API.
 - The API v4 Traffic Ops Go client has been overhauled compared to its predecessors to have a consistent call signature that allows passing query string parameters and HTTP headers to any client method.
 - Updated BouncyCastle libraries in Traffic Router to v1.68.
+- Delivery Service 'Active' properties are now a trinary "ACTIVE"/"PRIMED"/"INACTIVE" field rather than a strict boolean (as of Traffic Ops APIv4).
 
 ### Deprecated
 - The Riak Traffic Vault backend is now deprecated and its support may be removed in a future release. It is highly recommended to use the new PostgreSQL backend instead.

--- a/docs/source/admin/environment_creation.rst
+++ b/docs/source/admin/environment_creation.rst
@@ -51,4 +51,4 @@ Audience for Ansible-based Lab Deployment
 	:caption: Read more
 	:glob:
 
- 	ansible-labs/*
+	ansible-labs/*

--- a/docs/source/admin/traffic_portal/usingtrafficportal.rst
+++ b/docs/source/admin/traffic_portal/usingtrafficportal.rst
@@ -370,7 +370,7 @@ Use the `Quick Search` to search across all table columns or the column filter t
 :Cache Group:       [Visible by default] The :ref:`Name of the Cache Group <cache-group-name>` to which this server belongs
 :CDN:               [Visible by default] The name of the CDN to which the server belongs
 :Domain:            [Visible by default] The domain part of the server's :abbr:`FQDN (Fully Qualified Domain Name)`
-:Hash ID:			The identifier of the server used in Traffic Router's consistent hashing algorithm.
+:Hash ID:           The identifier of the server used in Traffic Router's consistent hashing algorithm.
 :Host:              [Visible by default] The (short) hostname of the server
 :HTTPS Port:        The port on which the server listens for incoming HTTPS connections/requests
 :ID:                An integral, unique identifier for this server

--- a/docs/source/api/v1/api_capabilities.rst
+++ b/docs/source/api/v1/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -150,7 +150,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -182,4 +182,3 @@ Response Structure
 		"id": 273,
 		"capability": "types-write"
 	}}
-

--- a/docs/source/api/v1/api_capabilities_id.rst
+++ b/docs/source/api/v1/api_capabilities_id.rst
@@ -161,7 +161,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v1/cachegroupparameters.rst
+++ b/docs/source/api/v1/cachegroupparameters.rst
@@ -156,7 +156,7 @@ Response Structure
 :parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
@@ -184,4 +184,3 @@ Response Structure
 			"parameterId": 124
 		}
 	]}
-

--- a/docs/source/api/v1/capabilities_name.rst
+++ b/docs/source/api/v1/capabilities_name.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :description: Describes the APIs covered by the capability
-:lastUpdated: Date and time of the last update made to this capability, in ISO format
+:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
 :name:        Name of the capability
 
 .. code-block:: http
@@ -129,7 +129,7 @@ Request Structure
 Response Structure
 ------------------
 :description: Describes the APIs covered by the capability.
-:lastUpdated: Date and time of the last update made to this capability, in ISO format
+:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
 :name:        The name of the capability
 
 .. code-block:: http

--- a/docs/source/api/v1/cdns.rst
+++ b/docs/source/api/v1/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v1/cdns_id.rst
+++ b/docs/source/api/v1/cdns_id.rst
@@ -45,7 +45,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http
@@ -193,4 +193,3 @@ Response Structure
 			"level": "success"
 		}
 	]}
-

--- a/docs/source/api/v1/cdns_name_federations.rst
+++ b/docs/source/api/v1/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v1/cdns_name_federations_id.rst
+++ b/docs/source/api/v1/cdns_name_federations_id.rst
@@ -82,7 +82,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of the :ref:`to-api-v1-cdns-name-federations` endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -172,7 +172,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v1/cdns_name_name.rst
+++ b/docs/source/api/v1/cdns_name_name.rst
@@ -45,7 +45,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http
@@ -120,4 +120,3 @@ Response Structure
 			"level": "success"
 		}
 	]}
-

--- a/docs/source/api/v1/deliveryservices.rst
+++ b/docs/source/api/v1/deliveryservices.rst
@@ -63,7 +63,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -113,7 +113,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -279,7 +279,7 @@ Allows users to create :term:`Delivery Service`.
 
 Request Structure
 -----------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -419,7 +419,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -469,7 +469,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:         A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/deliveryservices_id.rst
+++ b/docs/source/api/v1/deliveryservices_id.rst
@@ -71,7 +71,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -121,7 +121,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -291,7 +291,7 @@ Allows users to edit an existing :term:`Delivery Service`.
 
 Request Structure
 -----------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 

--- a/docs/source/api/v1/deliveryservices_id_safe.rst
+++ b/docs/source/api/v1/deliveryservices_id_safe.rst
@@ -61,7 +61,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -111,7 +111,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/divisions.rst
+++ b/docs/source/api/v1/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v1/divisions_id.rst
+++ b/docs/source/api/v1/divisions_id.rst
@@ -71,7 +71,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -137,7 +137,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v1/keys_ping.rst
+++ b/docs/source/api/v1/keys_ping.rst
@@ -43,8 +43,8 @@ No parameters available.
 
 Response Structure
 ------------------
-:server:	The hostname and port of :ref:`tv-overview`.
-:status:	The `reason phrase <https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1.1>`_ of the response that :ref:`to-overview` received from :ref:`tv-overview`.
+:server: The hostname and port of :ref:`tv-overview`.
+:status: The `reason phrase <https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1.1>`_ of the response that :ref:`to-overview` received from :ref:`tv-overview`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v1/logs.rst
+++ b/docs/source/api/v1/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v1/logs_days_days.rst
+++ b/docs/source/api/v1/logs_days_days.rst
@@ -60,7 +60,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v1/phys_locations.rst
+++ b/docs/source/api/v1/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v1/phys_locations_id.rst
+++ b/docs/source/api/v1/phys_locations_id.rst
@@ -75,7 +75,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -190,7 +190,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v1/profiles_id_unassigned_parameters.rst
+++ b/docs/source/api/v1/profiles_id_unassigned_parameters.rst
@@ -74,7 +74,7 @@ Response Structure
 	Date: Wed, 05 Dec 2018 21:37:50 GMT
 	Transfer-Encoding: chunked
 
-	{	"alerts": [{
+	{ "alerts": [{
 			"level": "warning",
 			"text": "This endpoint is deprecated, and will be removed in the future"
 		}],

--- a/docs/source/api/v1/profiles_trimmed.rst
+++ b/docs/source/api/v1/profiles_trimmed.rst
@@ -36,7 +36,7 @@ Response Structure
 :name: The :ref:`profile-name` of the :term:`Profile`
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true

--- a/docs/source/api/v1/regions.rst
+++ b/docs/source/api/v1/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v1/regions_id.rst
+++ b/docs/source/api/v1/regions_id.rst
@@ -143,7 +143,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v1/servers_id_deliveryservices.rst
+++ b/docs/source/api/v1/servers_id_deliveryservices.rst
@@ -67,7 +67,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -117,7 +117,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/servers_totals.rst
+++ b/docs/source/api/v1/servers_totals.rst
@@ -54,7 +54,7 @@ Response Structure
 	Whole-Content-Sha512: J4wy8zf+LX44/qWIbvziWHCcDZpUJ9GOpOVUVqPbVHUCh1V19o8FnE7T+V0639n9Xyw9k10NcaGIqASA+O9Rzg==
 	Content-Length: 305
 
-	{	"alerts": [
+	{ "alerts": [
 		{
 			"level": "warning",
 			"text": "This endpoint is deprecated"

--- a/docs/source/api/v1/stats_summary.rst
+++ b/docs/source/api/v1/stats_summary.rst
@@ -110,7 +110,7 @@ Summary Stats
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
+:summaryTime: Timestamp of the last updated summary, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -202,7 +202,7 @@ Request Structure
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v1/types.rst
+++ b/docs/source/api/v1/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v1/types_id.rst
+++ b/docs/source/api/v1/types_id.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -129,7 +129,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v1/users.rst
+++ b/docs/source/api/v1/users.rst
@@ -81,7 +81,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -210,7 +210,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v1/users_id.rst
+++ b/docs/source/api/v1/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -194,7 +194,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v1/users_id_deliveryservices.rst
+++ b/docs/source/api/v1/users_id_deliveryservices.rst
@@ -52,7 +52,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -104,7 +104,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/api_capabilities.rst
+++ b/docs/source/api/v2/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/cachegroupparameters.rst
+++ b/docs/source/api/v2/cachegroupparameters.rst
@@ -156,7 +156,7 @@ Response Structure
 :parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
@@ -184,4 +184,3 @@ Response Structure
 			"parameterId": 124
 		}
 	]}
-

--- a/docs/source/api/v2/cdns.rst
+++ b/docs/source/api/v2/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v2/cdns_name_federations.rst
+++ b/docs/source/api/v2/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v2/cdns_name_federations_id.rst
+++ b/docs/source/api/v2/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v2/deliveryservice_request_comments.rst
+++ b/docs/source/api/v2/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v2/deliveryservice_requests.rst
+++ b/docs/source/api/v2/deliveryservice_requests.rst
@@ -84,7 +84,7 @@ Response Structure
 :author:                The username of the user who created the Delivery Service Request.
 :authorId:              The integral, unique identifier assigned to the author
 :changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -165,7 +165,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
@@ -478,7 +478,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -559,7 +559,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
@@ -693,7 +693,7 @@ Request Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -894,7 +894,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -975,7 +975,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v2/deliveryservice_requests.rst
+++ b/docs/source/api/v2/deliveryservice_requests.rst
@@ -87,86 +87,86 @@ Response Structure
 :createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
 :deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:              A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                              A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example
@@ -296,84 +296,84 @@ Creates a new :term:`Delivery Service Request`.
 
 Request Structure
 -----------------
-:changeType:            The action that you want to perform on the delivery service. It can be "create", "update", or "delete".
-:status:                        The status of your request. Can be "draft", "submitted", "rejected", "pending", or "complete".
-:deliveryService:       The :term:`Delivery Service` that you have submitted for review as part of this request.
+:changeType:      The action that you want to perform on the delivery service. It can be "create", "update", or "delete".
+:status:          The status of your request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:deliveryService: The :term:`Delivery Service` that you have submitted for review as part of this request.
 
-	:active:                                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                       A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                     An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                          The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
 .. code-block:: http
 	:caption: Request Example
@@ -475,92 +475,92 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:              A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                              A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                        The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example
@@ -690,91 +690,91 @@ Updates an existing :ref:`Delivery Service Request <ds_requests>`.
 
 Request Structure
 -----------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                       A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                     An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                          The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. table:: Request Query Parameters
 
@@ -891,92 +891,92 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                        The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v2/deliveryservice_requests_id_assign.rst
@@ -53,7 +53,7 @@ Response Structure
 :author:          The author of the :term:`Delivery Service Request`
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -134,7 +134,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v2/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v2/deliveryservice_requests_id_assign.rst
@@ -49,93 +49,93 @@ Request Structure
 
 Response Structure
 ------------------
-:assignee:              The username of the user to whom the :term:`Delivery Service Request` is assigned.
-:author:                The author of the :term:`Delivery Service Request`
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:assignee:        The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:author:          The author of the :term:`Delivery Service Request`
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v2/deliveryservice_requests_id_status.rst
@@ -28,8 +28,8 @@ Sets the status of a :term:`Delivery Service Request`.
 
 Request Structure
 -----------------
-:id:            The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:status:        The status of the `DSR <Delivery Service Request>`. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:     The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:status: The status of the :term:`DSR <Delivery Service Request>`. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Request Example
@@ -49,94 +49,94 @@ Request Structure
 
 Response Structure
 ------------------
-:assignee:              The username of the user to whom the :term:`Delivery Service Request` is assigned.
-:assigneeId:            The integral, unique identifier of the user to whom the :term:`Delivery Service Request` is assigned.
-:author:                The author of the :term:`Delivery Service Request`
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:assignee:        The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:assigneeId:      The integral, unique identifier of the user to whom the :term:`Delivery Service Request` is assigned.
+:author:          The author of the :term:`Delivery Service Request`
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v2/deliveryservice_requests_id_status.rst
@@ -54,7 +54,7 @@ Response Structure
 :author:          The author of the :term:`Delivery Service Request`
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -135,7 +135,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v2/deliveryservices.rst
+++ b/docs/source/api/v2/deliveryservices.rst
@@ -65,7 +65,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -100,7 +100,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -248,7 +248,7 @@ Allows users to create :term:`Delivery Service`.
 
 Request Structure
 -----------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -355,7 +355,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -390,7 +390,7 @@ Response Structure
 :infoUrl:             		An :ref:`ds-info-url`
 :initialDispersion:   		The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           		The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/deliveryservices.rst
+++ b/docs/source/api/v2/deliveryservices.rst
@@ -368,34 +368,34 @@ Response Structure
 :checkPath:                 A :ref:`ds-check-path`
 :consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
 :consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
-:deepCachingType:     		The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-:displayName:       		The :ref:`ds-display-name`
-:dnsBypassCname:    		A :ref:`ds-dns-bypass-cname`
-:dnsBypassIp:       		A :ref:`ds-dns-bypass-ip`
-:dnsBypassIp6:      		A :ref:`ds-dns-bypass-ipv6`
-:dnsBypassTtl:      		The :ref:`ds-dns-bypass-ttl`
-:dscp:              		A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-:ecsEnabled:        		A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-:edgeHeaderRewrite: 		A set of :ref:`ds-edge-header-rw-rules`
-:exampleURLs:       		An array of :ref:`ds-example-urls`
-:fqPacingRate:      		The :ref:`ds-fqpr`
-:geoLimit:            		An integer that defines the :ref:`ds-geo-limit`
-:geoLimitCountries:  		A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
-:geoLimitRedirectUrl: 		A :ref:`ds-geo-limit-redirect-url`
-:geoProvider:         		The :ref:`ds-geo-provider`
-:globalMaxMbps:       		The :ref:`ds-global-max-mbps`
-:globalMaxTps:        		The :ref:`ds-global-max-tps`
-:httpBypassFqdn:      		A :ref:`ds-http-bypass-fqdn`
-:id:                  		An integral, unique identifier for this :term:`Delivery Service`
-:infoUrl:             		An :ref:`ds-info-url`
-:initialDispersion:   		The :ref:`ds-initial-dispersion`
-:ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
-:logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:           		The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:           		The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:          		The :term:`Delivery Service`'s :ref:`ds-matchlist`
+:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+:displayName:               The :ref:`ds-display-name`
+:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+:exampleURLs:               An array of :ref:`ds-example-urls`
+:fqPacingRate:              The :ref:`ds-fqpr`
+:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
+:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`
+:geoProvider:               The :ref:`ds-geo-provider`
+:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+:globalMaxTps:              The :ref:`ds-global-max-tps`
+:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+:id:                        An integral, unique identifier for this :term:`Delivery Service`
+:infoUrl:                   An :ref:`ds-info-url`
+:initialDispersion:         The :ref:`ds-initial-dispersion`
+:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:                 The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -420,8 +420,8 @@ Response Structure
 :remapText:            :ref:`ds-raw-remap`
 :signed:               ``true`` if  and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
 :signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-:rangeSliceBlockSize: An integer that defines the byte block size for the ATS Slice Plugin. It can only and must be set if ``rangeRequestHandling`` is set to 3.
-:sslKeyVersion: 	   This integer indicates the :ref:`ds-ssl-key-version`
+:rangeSliceBlockSize:  An integer that defines the byte block size for the ATS Slice Plugin. It can only and must be set if ``rangeRequestHandling`` is set to 3.
+:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
 :tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
 :trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 :trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`

--- a/docs/source/api/v2/deliveryservices_id.rst
+++ b/docs/source/api/v2/deliveryservices_id.rst
@@ -29,7 +29,7 @@ Allows users to edit an existing :term:`Delivery Service`.
 
 Request Structure
 -----------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 

--- a/docs/source/api/v2/deliveryservices_id_safe.rst
+++ b/docs/source/api/v2/deliveryservices_id_safe.rst
@@ -61,7 +61,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -96,7 +96,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/divisions.rst
+++ b/docs/source/api/v2/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v2/divisions_id.rst
+++ b/docs/source/api/v2/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v2/logs.rst
+++ b/docs/source/api/v2/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v2/phys_locations.rst
+++ b/docs/source/api/v2/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v2/phys_locations_id.rst
+++ b/docs/source/api/v2/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v2/regions.rst
+++ b/docs/source/api/v2/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v2/regions_id.rst
+++ b/docs/source/api/v2/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v2/servers_id_deliveryservices.rst
+++ b/docs/source/api/v2/servers_id_deliveryservices.rst
@@ -67,7 +67,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -102,7 +102,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/stats_summary.rst
+++ b/docs/source/api/v2/stats_summary.rst
@@ -110,7 +110,7 @@ Summary Stats
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
+:summaryTime: Timestamp of the last updated summary, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -200,7 +200,7 @@ Request Structure
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v2/types.rst
+++ b/docs/source/api/v2/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -156,5 +156,3 @@ Response Structure
 			"useInTable": "server"
 		}]
 	}
-
-

--- a/docs/source/api/v2/types_id.rst
+++ b/docs/source/api/v2/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v2/users.rst
+++ b/docs/source/api/v2/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v2/users_id.rst
+++ b/docs/source/api/v2/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v3/api_capabilities.rst
+++ b/docs/source/api/v3/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/cachegroupparameters.rst
+++ b/docs/source/api/v3/cachegroupparameters.rst
@@ -156,7 +156,7 @@ Response Structure
 :parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
@@ -184,4 +184,3 @@ Response Structure
 			"parameterId": 124
 		}
 	]}
-

--- a/docs/source/api/v3/cdns.rst
+++ b/docs/source/api/v3/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v3/cdns_name_configs_monitoring.rst
+++ b/docs/source/api/v3/cdns_name_configs_monitoring.rst
@@ -98,15 +98,15 @@ Response Structure
 
 :trafficServers: An array of objects that represent the :term:`cache servers` being monitored within this CDN
 
-	:cacheGroup:    The :term:`Cache Group` to which this :term:`cache server` belongs
-	:fqdn:          An :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the :term:`cache server`'s IPv4 (or IPv6) address
-	:hashId:        The (short) hostname for the :term:`cache server` - named "hashId" for legacy reasons
-	:hostName:      The (short) hostname of the :term:`cache server`
-	:port:          The port on which the :term:`cache server` listens for incoming connections
-	:profile:       A string that is the :ref:`profile-name` of the :term:`Profile` assigned to this :term:`cache server`
-	:status:        The status of the :term:`cache server`
-	:type:          A string that names the :term:`Type` of the :term:`cache server` - should (ideally) be either ``EDGE`` or ``MID``
-	:interfaces:		A set of the network interfaces in use by the server. In most scenarios, only one will be present, but it is illegal for this set to be an empty collection.
+	:cacheGroup: The :term:`Cache Group` to which this :term:`cache server` belongs
+	:fqdn:       An :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the :term:`cache server`'s IPv4 (or IPv6) address
+	:hashId:     The (short) hostname for the :term:`cache server` - named "hashId" for legacy reasons
+	:hostName:   The (short) hostname of the :term:`cache server`
+	:port:       The port on which the :term:`cache server` listens for incoming connections
+	:profile:    A string that is the :ref:`profile-name` of the :term:`Profile` assigned to this :term:`cache server`
+	:status:     The status of the :term:`cache server`
+	:type:       A string that names the :term:`Type` of the :term:`cache server` - should (ideally) be either ``EDGE`` or ``MID``
+	:interfaces: A set of the network interfaces in use by the server. In most scenarios, only one will be present, but it is illegal for this set to be an empty collection.
 
 		:ipAddresses: A set of objects representing IP Addresses assigned to this network interface. In most scenarios, only one or two (usually one IPv4 address and one IPv6 address) will be present, but it is illegal for this set to be an empty collection.
 

--- a/docs/source/api/v3/cdns_name_federations.rst
+++ b/docs/source/api/v3/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v3/cdns_name_federations_id.rst
+++ b/docs/source/api/v3/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v3/cdns_name_snapshot.rst
+++ b/docs/source/api/v3/cdns_name_snapshot.rst
@@ -326,7 +326,7 @@ Response Structure
 	:tm_user:    The username of the currently logged-in user
 	:tm_version: The full version number of the Traffic Ops server, including release number, git commit hash, and supported Enterprise Linux version
 
-:topologies:	An array of :term:`Topologies` where each key is the name of that Topology.
+:topologies: An array of :term:`Topologies` where each key is the name of that Topology.
 
 	:nodes: An array of the names of the :term:`Edge-Tier` :term:`Cache Groups` in this :term:`Topology`. :term:`Mid-Tier` Cache Groups in the topology are not included.
 

--- a/docs/source/api/v3/cdns_name_snapshot_new.rst
+++ b/docs/source/api/v3/cdns_name_snapshot_new.rst
@@ -326,7 +326,7 @@ Response Structure
 	:tm_user:    The username of the currently logged-in user
 	:tm_version: The full version number of the Traffic Ops server, including release number, git commit hash, and supported Enterprise Linux version
 
-:topologies:	An array of :term:`Topologies` where each key is the name of that Topology.
+:topologies: An array of :term:`Topologies` where each key is the name of that Topology.
 
 	:nodes: An array of the names of the :term:`Edge-Tier` :term:`Cache Groups` in this :term:`Topology`. :term:`Mid-Tier` Cache Groups in the topology are not included.
 

--- a/docs/source/api/v3/deliveryservice_request_comments.rst
+++ b/docs/source/api/v3/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v3/deliveryservice_requests.rst
+++ b/docs/source/api/v3/deliveryservice_requests.rst
@@ -81,96 +81,96 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:              A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                              A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example
@@ -304,88 +304,88 @@ Creates a new :term:`Delivery Service Request`.
 
 Request Structure
 -----------------
-:changeType:            The action that you want to perform on the delivery service. It can be "create", "update", or "delete".
-:status:                        The status of your request. Can be "draft", "submitted", "rejected", "pending", or "complete".
-:deliveryService:       The :term:`Delivery Service` that you have submitted for review as part of this request.
+:changeType:      The action that you want to perform on the delivery service. It can be "create", "update", or "delete".
+:status:          The status of your request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:deliveryService: The :term:`Delivery Service` that you have submitted for review as part of this request.
 
-	:active:                                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                       A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                     An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                          The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
 .. code-block:: http
 	:caption: Request Example
@@ -491,96 +491,96 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:              A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                              A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                        The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example
@@ -714,95 +714,95 @@ Updates an existing :ref:`Delivery Service Request <ds_requests>`.
 
 Request Structure
 -----------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                       A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                     An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                          The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. table:: Request Query Parameters
 
@@ -923,96 +923,96 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                        The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/deliveryservice_requests.rst
+++ b/docs/source/api/v3/deliveryservice_requests.rst
@@ -84,7 +84,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -169,7 +169,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
@@ -494,7 +494,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -717,7 +717,7 @@ Request Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -926,7 +926,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -1011,7 +1011,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v3/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_assign.rst
@@ -28,8 +28,8 @@ Assign a :term:`Delivery Service Request` to a user.
 
 Request Structure
 -----------------
-:id:            The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:assignee:      The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:id:       The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:assignee: The username of the user to whom the :term:`Delivery Service Request` is assigned.
 
 .. code-block:: http
 	:caption: Request Example
@@ -49,97 +49,97 @@ Request Structure
 
 Response Structure
 ------------------
-:assignee:              The username of the user to whom the :term:`Delivery Service Request` is assigned.
-:author:                The author of the :term:`Delivery Service Request`
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:assignee:        The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:author:          The author of the :term:`Delivery Service Request`
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_assign.rst
@@ -53,7 +53,7 @@ Response Structure
 :author:          The author of the :term:`Delivery Service Request`
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -138,7 +138,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v3/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_status.rst
@@ -28,8 +28,8 @@ Sets the status of a :term:`Delivery Service Request`.
 
 Request Structure
 -----------------
-:id:            The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:status:        The status of the `DSR <Delivery Service Request>`. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:     The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:status: The status of the `DSR <Delivery Service Request>`. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Request Example
@@ -49,98 +49,98 @@ Request Structure
 
 Response Structure
 ------------------
-:assignee:              The username of the user to whom the :term:`Delivery Service Request` is assigned.
-:assigneeId:            The integral, unique identifier of the user to whom the :term:`Delivery Service Request` is assigned.
-:author:                The author of the :term:`Delivery Service Request`
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:assignee:        The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:assigneeId:      The integral, unique identifier of the user to whom the :term:`Delivery Service Request` is assigned.
+:author:          The author of the :term:`Delivery Service Request`
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_status.rst
@@ -54,7 +54,7 @@ Response Structure
 :author:          The author of the :term:`Delivery Service Request`
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
@@ -139,7 +139,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v3/deliveryservices.rst
+++ b/docs/source/api/v3/deliveryservices.rst
@@ -71,7 +71,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -109,7 +109,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -266,7 +266,7 @@ Allows users to create :term:`Delivery Service`.
 
 Request Structure
 -----------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -381,7 +381,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -419,7 +419,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           		The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/deliveryservices.rst
+++ b/docs/source/api/v3/deliveryservices.rst
@@ -394,37 +394,37 @@ Response Structure
 :checkPath:                 A :ref:`ds-check-path`
 :consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
 :consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
-:deepCachingType:     		The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-:displayName:       		The :ref:`ds-display-name`
-:dnsBypassCname:    		A :ref:`ds-dns-bypass-cname`
-:dnsBypassIp:       		A :ref:`ds-dns-bypass-ip`
-:dnsBypassIp6:      		A :ref:`ds-dns-bypass-ipv6`
-:dnsBypassTtl:      		The :ref:`ds-dns-bypass-ttl`
-:dscp:              		A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-:ecsEnabled:        		A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-:edgeHeaderRewrite: 		A set of :ref:`ds-edge-header-rw-rules`
-:exampleURLs:       		An array of :ref:`ds-example-urls`
+:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+:displayName:               The :ref:`ds-display-name`
+:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+:exampleURLs:               An array of :ref:`ds-example-urls`
 :firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
-:fqPacingRate:      		The :ref:`ds-fqpr`
-:geoLimit:            		An integer that defines the :ref:`ds-geo-limit`
-:geoLimitCountries:  		A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
-:geoLimitRedirectUrl: 		A :ref:`ds-geo-limit-redirect-url`
-:geoProvider:         		The :ref:`ds-geo-provider`
-:globalMaxMbps:       		The :ref:`ds-global-max-mbps`
-:globalMaxTps:        		The :ref:`ds-global-max-tps`
-:httpBypassFqdn:      		A :ref:`ds-http-bypass-fqdn`
-:id:                  		An integral, unique identifier for this :term:`Delivery Service`
-:infoUrl:             		An :ref:`ds-info-url`
-:initialDispersion:   		The :ref:`ds-initial-dispersion`
+:fqPacingRate:              The :ref:`ds-fqpr`
+:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
+:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`
+:geoProvider:               The :ref:`ds-geo-provider`
+:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+:globalMaxTps:              The :ref:`ds-global-max-tps`
+:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+:id:                        An integral, unique identifier for this :term:`Delivery Service`
+:infoUrl:                   An :ref:`ds-info-url`
+:initialDispersion:         The :ref:`ds-initial-dispersion`
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
-:ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
-:logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:           		The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:           		The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:          		The :term:`Delivery Service`'s :ref:`ds-matchlist`
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:                 The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -452,7 +452,7 @@ Response Structure
 :signed:                ``true`` if  and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
 :signingAlgorithm:      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
 :rangeSliceBlockSize:   An integer that defines the byte block size for the ATS Slice Plugin. It can only and must be set if ``rangeRequestHandling`` is set to 3.
-:sslKeyVersion: 	    This integer indicates the :ref:`ds-ssl-key-version`
+:sslKeyVersion:         This integer indicates the :ref:`ds-ssl-key-version`
 :tenantId:              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
 :topology:              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 :trRequestHeaders:      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`

--- a/docs/source/api/v3/deliveryservices_id.rst
+++ b/docs/source/api/v3/deliveryservices_id.rst
@@ -29,7 +29,7 @@ Allows users to edit an existing :term:`Delivery Service`.
 
 Request Structure
 -----------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 

--- a/docs/source/api/v3/deliveryservices_id_safe.rst
+++ b/docs/source/api/v3/deliveryservices_id_safe.rst
@@ -61,7 +61,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -99,7 +99,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/divisions.rst
+++ b/docs/source/api/v3/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v3/divisions_id.rst
+++ b/docs/source/api/v3/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v3/logs.rst
+++ b/docs/source/api/v3/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v3/phys_locations.rst
+++ b/docs/source/api/v3/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v3/phys_locations_id.rst
+++ b/docs/source/api/v3/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v3/regions.rst
+++ b/docs/source/api/v3/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v3/regions_id.rst
+++ b/docs/source/api/v3/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v3/servers_id_deliveryservices.rst
+++ b/docs/source/api/v3/servers_id_deliveryservices.rst
@@ -67,7 +67,7 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
+:active:                   A boolean that defines :ref:`ds-active`. ``true`` means that the Delivery Service is ACTIVE, while ``false`` means that it is either PRIMED or INACTIVE (API versions earlier than 4 are incapable of distinguishing between the two).
 :anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
 :cacheurl:                 A :ref:`ds-cacheurl`
 
@@ -105,7 +105,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/servicecategories.rst
+++ b/docs/source/api/v3/servicecategories.rst
@@ -63,7 +63,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
 
 .. code-block:: http
     :caption: Response Example
@@ -119,7 +119,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
 
 .. code-block:: http
     :caption: Response Example

--- a/docs/source/api/v3/stats_summary.rst
+++ b/docs/source/api/v3/stats_summary.rst
@@ -110,7 +110,7 @@ Summary Stats
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
+:summaryTime: Timestamp of the last updated summary, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -200,7 +200,7 @@ Request Structure
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v3/types.rst
+++ b/docs/source/api/v3/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -156,5 +156,3 @@ Response Structure
 			"useInTable": "server"
 		}]
 	}
-
-

--- a/docs/source/api/v3/types_id.rst
+++ b/docs/source/api/v3/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v3/users.rst
+++ b/docs/source/api/v3/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v3/users_id.rst
+++ b/docs/source/api/v3/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v4/api_capabilities.rst
+++ b/docs/source/api/v4/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/cachegroupparameters.rst
+++ b/docs/source/api/v4/cachegroupparameters.rst
@@ -156,7 +156,7 @@ Response Structure
 :parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
@@ -184,4 +184,3 @@ Response Structure
 			"parameterId": 124
 		}
 	]}
-

--- a/docs/source/api/v4/cdn_notifications.rst
+++ b/docs/source/api/v4/cdn_notifications.rst
@@ -54,11 +54,11 @@ Request Structure
 
 Response Structure
 ------------------
-:id:			The integral, unique identifier of the notification
-:cdn:			The name of the CDN to which the notification belongs to
-:lastUpdated:	The time and date this server entry was last updated in an ISO-like format
-:notification:	The content of the notification
-:user:			The user responsible for creating the notification
+:id:           The integral, unique identifier of the notification
+:cdn:          The name of the CDN to which the notification belongs to
+:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:notification: The content of the notification
+:user:         The user responsible for creating the notification
 
 .. code-block:: http
 	:caption: Response Example
@@ -98,8 +98,8 @@ Creates a notification for a specific CDN.
 
 Request Structure
 -----------------
-:cdn:			The name of the CDN to which the notification shall belong
-:notification:	The content of the notification
+:cdn:          The name of the CDN to which the notification shall belong
+:notification: The content of the notification
 
 .. code-block:: http
 	:caption: Request Example
@@ -117,11 +117,11 @@ Request Structure
 
 Response Structure
 ------------------
-:id:			The integral, unique identifier of the notification
-:cdn:			The name of the CDN to which the notification belongs to
-:lastUpdated:	The time and date this server entry was last updated in an ISO-like format
-:notification:	The content of the notification
-:user:			The user responsible for creating the notification
+:id:           The integral, unique identifier of the notification
+:cdn:          The name of the CDN to which the notification belongs to
+:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:notification: The content of the notification
+:user:         The user responsible for creating the notification
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/cdns.rst
+++ b/docs/source/api/v4/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v4/cdns_name_configs_monitoring.rst
+++ b/docs/source/api/v4/cdns_name_configs_monitoring.rst
@@ -98,15 +98,15 @@ Response Structure
 
 :trafficServers: An array of objects that represent the :term:`cache servers` being monitored within this CDN
 
-	:cacheGroup:    The :term:`Cache Group` to which this :term:`cache server` belongs
-	:fqdn:          An :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the :term:`cache server`'s IPv4 (or IPv6) address
-	:hashId:        The (short) hostname for the :term:`cache server` - named "hashId" for legacy reasons
-	:hostName:      The (short) hostname of the :term:`cache server`
-	:port:          The port on which the :term:`cache server` listens for incoming connections
-	:profile:       A string that is the :ref:`profile-name` of the :term:`Profile` assigned to this :term:`cache server`
-	:status:        The status of the :term:`cache server`
-	:type:          A string that names the :term:`Type` of the :term:`cache server` - should (ideally) be either ``EDGE`` or ``MID``
-	:interfaces:		A set of the network interfaces in use by the server. In most scenarios, only one will be present, but it is illegal for this set to be an empty collection.
+	:cacheGroup: The :term:`Cache Group` to which this :term:`cache server` belongs
+	:fqdn:       An :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the :term:`cache server`'s IPv4 (or IPv6) address
+	:hashId:     The (short) hostname for the :term:`cache server` - named "hashId" for legacy reasons
+	:hostName:   The (short) hostname of the :term:`cache server`
+	:port:       The port on which the :term:`cache server` listens for incoming connections
+	:profile:    A string that is the :ref:`profile-name` of the :term:`Profile` assigned to this :term:`cache server`
+	:status:     The status of the :term:`cache server`
+	:type:       A string that names the :term:`Type` of the :term:`cache server` - should (ideally) be either ``EDGE`` or ``MID``
+	:interfaces: A set of the network interfaces in use by the server. In most scenarios, only one will be present, but it is illegal for this set to be an empty collection.
 
 		:ipAddresses: A set of objects representing IP Addresses assigned to this network interface. In most scenarios, only one or two (usually one IPv4 address and one IPv6 address) will be present, but it is illegal for this set to be an empty collection.
 

--- a/docs/source/api/v4/cdns_name_federations.rst
+++ b/docs/source/api/v4/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v4/cdns_name_federations_id.rst
+++ b/docs/source/api/v4/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v4/cdns_name_snapshot.rst
+++ b/docs/source/api/v4/cdns_name_snapshot.rst
@@ -320,7 +320,7 @@ Response Structure
 	:tm_user:    The username of the currently logged-in user
 	:tm_version: The full version number of the Traffic Ops server, including release number, git commit hash, and supported Enterprise Linux version
 
-:topologies:	An array of :term:`Topologies` where each key is the name of that Topology.
+:topologies: An array of :term:`Topologies` where each key is the name of that Topology.
 
 	:nodes: An array of the names of the :term:`Edge-Tier` :term:`Cache Groups` in this :term:`Topology`. :term:`Mid-Tier` Cache Groups in the topology are not included.
 

--- a/docs/source/api/v4/cdns_name_snapshot_new.rst
+++ b/docs/source/api/v4/cdns_name_snapshot_new.rst
@@ -320,7 +320,7 @@ Response Structure
 	:tm_user:    The username of the currently logged-in user
 	:tm_version: The full version number of the Traffic Ops server, including release number, git commit hash, and supported Enterprise Linux version
 
-:topologies:	An array of :term:`Topologies` where each key is the name of that Topology.
+:topologies: An array of :term:`Topologies` where each key is the name of that Topology.
 
 	:nodes: An array of the names of the :term:`Edge-Tier` :term:`Cache Groups` in this :term:`Topology`. :term:`Mid-Tier` Cache Groups in the topology are not included.
 

--- a/docs/source/api/v4/deliveryservice_request_comments.rst
+++ b/docs/source/api/v4/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v4/deliveryservice_requests.rst
+++ b/docs/source/api/v4/deliveryservice_requests.rst
@@ -107,7 +107,7 @@ The response is an array of representations of :term:`Delivery Service Requests`
 		"lastEditedById": 2,
 		"lastUpdated": "2020-02-24 19:11:12+00",
 		"requested": {
-			"active": false,
+			"active": "INACTIVE",
 			"anonymousBlockingEnabled": false,
 			"cacheurl": null,
 			"ccrDnsTtl": null,
@@ -135,7 +135,7 @@ The response is an array of representations of :term:`Delivery Service Requests`
 			"innerHeaderRewrite": null,
 			"ipv6RoutingEnabled": true,
 			"lastHeaderRewrite": null,
-			"lastUpdated": "0001-01-01 00:00:00+00",
+			"lastUpdated": "0001-01-01T00:00:00Z",
 			"logsEnabled": true,
 			"longDesc": "Apachecon North America 2018",
 			"longDesc1": null,
@@ -225,7 +225,7 @@ The request must be a well-formed representation of a :term:`Delivery Service Re
 		"changeType": "update",
 		"status": "draft",
 		"requested": {
-			"active": false,
+			"active": "INACTIVE",
 			"anonymousBlockingEnabled": false,
 			"cacheurl": null,
 			"ccrDnsTtl": null,
@@ -253,7 +253,7 @@ The request must be a well-formed representation of a :term:`Delivery Service Re
 			"innerHeaderRewrite": null,
 			"ipv6RoutingEnabled": true,
 			"lastHeaderRewrite": null,
-			"lastUpdated": "2020-02-13 16:43:54+00",
+			"lastUpdated": "2020-09-25T07:13:08.753352Z",
 			"logsEnabled": true,
 			"longDesc": "Apachecon North America 2018",
 			"longDesc1": null,
@@ -350,7 +350,7 @@ The response will be a representation of the created :term:`Delivery Service Req
 			"lastEditedById": 2,
 			"lastUpdated": "2020-02-24 19:11:12+00",
 			"requested": {
-				"active": false,
+				"active": "INACTIVE",
 				"anonymousBlockingEnabled": false,
 				"cacheurl": null,
 				"ccrDnsTtl": null,
@@ -378,7 +378,7 @@ The response will be a representation of the created :term:`Delivery Service Req
 				"innerHeaderRewrite": null,
 				"ipv6RoutingEnabled": true,
 				"lastHeaderRewrite": null,
-				"lastUpdated": "0001-01-01 00:00:00+00",
+				"lastUpdated": "0001-01-01T00:00:00Z",
 				"logsEnabled": true,
 				"longDesc": "Apachecon North America 2018",
 				"longDesc1": null,
@@ -435,7 +435,7 @@ The response will be a representation of the created :term:`Delivery Service Req
 				"ecsEnabled": false
 			},
 			"original": {
-				"active": true,
+				"active": "ACTIVE",
 				"anonymousBlockingEnabled": false,
 				"cacheurl": null,
 				"ccrDnsTtl": null,
@@ -463,7 +463,7 @@ The response will be a representation of the created :term:`Delivery Service Req
 				"innerHeaderRewrite": null,
 				"ipv6RoutingEnabled": true,
 				"lastHeaderRewrite": null,
-				"lastUpdated": "2020-02-13 16:43:54+00",
+				"lastUpdated": "2020-09-25T07:13:08.753352Z",
 				"logsEnabled": true,
 				"longDesc": "Apachecon North America 2018",
 				"longDesc1": null,
@@ -560,7 +560,7 @@ The request body must be a representation of a :term:`Delivery Service Request` 
 	{
 		"changeType": "update",
 		"requested": {
-			"active": true,
+			"active": "ACTIVE",
 			"cdnId": 2,
 			"ccrDnsTtl": 30,
 			"deepCachingType": "NEVER",
@@ -613,7 +613,7 @@ The response is a full representation of the edited :term:`Delivery Service Requ
 		"lastEditedBy": "admin",
 		"lastUpdated": "2020-09-25T02:38:04.180237Z",
 		"original": {
-			"active": true,
+			"active": "ACTIVE",
 			"anonymousBlockingEnabled": false,
 			"cacheurl": null,
 			"ccrDnsTtl": null,
@@ -638,7 +638,7 @@ The response is a full representation of the edited :term:`Delivery Service Requ
 			"infoUrl": null,
 			"initialDispersion": 1,
 			"ipv6RoutingEnabled": true,
-			"lastUpdated": "2020-09-25 02:09:54+00",
+			"lastUpdated": "2020-09-25T07:13:08.753352Z",
 			"logsEnabled": true,
 			"longDesc": "Apachecon North America 2018",
 			"longDesc1": null,
@@ -700,7 +700,7 @@ The response is a full representation of the edited :term:`Delivery Service Requ
 			"serviceCategory": null
 		},
 		"requested": {
-			"active": true,
+			"active": "ACTIVE",
 			"anonymousBlockingEnabled": false,
 			"cacheurl": null,
 			"ccrDnsTtl": 30,

--- a/docs/source/api/v4/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v4/deliveryservice_requests_id_assign.rst
@@ -96,7 +96,7 @@ Request Structure
 	.. versionchanged:: 4.0
 		Prior to APIv4.0, this was the only property that could be used to change a :term:`Delivery Service Request`'s Assignee - and thus was a required field.
 
-		It is not required to send both of these; either property is sufficient to determine an :ref:`dsr-assignee`. In most cases, it's easier to use just `assignee`. If both *are* given, then `assigneeId` will take precedence in the event that the two properties do not refer to the same user. Sending a request that sets the assignee to ``null`` un-assigns the :term:`DSR` from any assignees it previously had\ [#implicit-null]_.
+It is not required to send both of these; either property is sufficient to determine an :ref:`dsr-assignee`. In most cases, it's easier to use just `assignee`. If both *are* given, then `assigneeId` will take precedence in the event that the two properties do not refer to the same user. Sending a request that sets the assignee to ``null`` un-assigns the :term:`DSR` from any assignees it previously had\ [#implicit-null]_.
 
 .. code-block:: http
 	:caption: Request Example
@@ -144,7 +144,7 @@ The response contains a full representation of the newly assigned :term:`Deliver
 		"lastEditedBy": "admin",
 		"lastUpdated": "2020-09-25T07:01:24.600029Z",
 		"original": {
-			"active": true,
+			"active": "ACTIVE",
 			"anonymousBlockingEnabled": false,
 			"cacheurl": null,
 			"ccrDnsTtl": null,
@@ -169,7 +169,7 @@ The response contains a full representation of the newly assigned :term:`Deliver
 			"infoUrl": null,
 			"initialDispersion": 1,
 			"ipv6RoutingEnabled": true,
-			"lastUpdated": "2020-09-25 02:09:54+00",
+			"lastUpdated": "2020-09-25T07:13:08.753352Z",
 			"logsEnabled": true,
 			"longDesc": "Apachecon North America 2018",
 			"longDesc1": null,
@@ -231,7 +231,7 @@ The response contains a full representation of the newly assigned :term:`Deliver
 			"serviceCategory": null
 		},
 		"requested": {
-			"active": true,
+			"active": "ACTIVE",
 			"anonymousBlockingEnabled": false,
 			"cacheurl": null,
 			"ccrDnsTtl": 30,

--- a/docs/source/api/v4/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v4/deliveryservice_requests_id_status.rst
@@ -141,7 +141,7 @@ The response is a full representation of the modified :term:`DSR`.
 		"lastEditedBy": "admin",
 		"lastUpdated": "2020-09-25T07:13:28.753352Z",
 		"original": {
-			"active": true,
+			"active": "ACTIVE",
 			"anonymousBlockingEnabled": false,
 			"cacheurl": null,
 			"ccrDnsTtl": null,
@@ -166,7 +166,7 @@ The response is a full representation of the modified :term:`DSR`.
 			"infoUrl": null,
 			"initialDispersion": 1,
 			"ipv6RoutingEnabled": true,
-			"lastUpdated": "2020-09-25 02:09:54+00",
+			"lastUpdated": "2020-09-25T07:13:08Z",
 			"logsEnabled": true,
 			"longDesc": "Apachecon North America 2018",
 			"longDesc1": null,
@@ -228,7 +228,7 @@ The response is a full representation of the modified :term:`DSR`.
 			"serviceCategory": null
 		},
 		"requested": {
-			"active": true,
+			"active": "ACTIVE",
 			"anonymousBlockingEnabled": false,
 			"cacheurl": null,
 			"ccrDnsTtl": 30,

--- a/docs/source/api/v4/deliveryservices.rst
+++ b/docs/source/api/v4/deliveryservices.rst
@@ -71,8 +71,12 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
-:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+:active: A string that defines :ref:`ds-active`.
+
+	.. versionchanged:: 4.0
+		Prior to API version 4.0, this was a boolean field.
+
+:anonymousBlockingEnabled:  A boolean that defines :ref:`ds-anonymous-blocking`
 :ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
 :cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
 :cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
@@ -105,11 +109,15 @@ Response Structure
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:                 The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
+
+	.. versionchanged:: 4.0
+		In API versions earlier than 4.0, this string is in a legacy format - ``YYYY-MM-DD hh:mm:ss+ZZ`` (no sub-second precision) - instead of :rfc:`3339` format.
+
+:logsEnabled: A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:    The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:   The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:   The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:   The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -261,8 +269,12 @@ Allows users to create :term:`Delivery Service`.
 
 Request Structure
 -----------------
-:active:                   A boolean that defines :ref:`ds-active`.
-:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+:active: A string that defines :ref:`ds-active`.
+
+	.. versionchanged:: 4.0
+		Prior to API version 4.0, this was a boolean field.
+
+:anonymousBlockingEnabled:  A boolean that defines :ref:`ds-anonymous-blocking`
 :ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
 :cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
 :checkPath:                 A :ref:`ds-check-path`
@@ -371,45 +383,53 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
-:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+:active: A string that defines :ref:`ds-active`.
+
+	.. versionchanged:: 4.0
+		Prior to API version 4.0, this was a boolean field.
+
+:anonymousBlockingEnabled:  A boolean that defines :ref:`ds-anonymous-blocking`
 :ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
 :cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
 :cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
 :checkPath:                 A :ref:`ds-check-path`
 :consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
 :consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
-:deepCachingType:     		The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-:displayName:       		The :ref:`ds-display-name`
-:dnsBypassCname:    		A :ref:`ds-dns-bypass-cname`
-:dnsBypassIp:       		A :ref:`ds-dns-bypass-ip`
-:dnsBypassIp6:      		A :ref:`ds-dns-bypass-ipv6`
-:dnsBypassTtl:      		The :ref:`ds-dns-bypass-ttl`
-:dscp:              		A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-:ecsEnabled:        		A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-:edgeHeaderRewrite: 		A set of :ref:`ds-edge-header-rw-rules`
-:exampleURLs:       		An array of :ref:`ds-example-urls`
+:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+:displayName:               The :ref:`ds-display-name`
+:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+:exampleURLs:               An array of :ref:`ds-example-urls`
 :firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
-:fqPacingRate:      		The :ref:`ds-fqpr`
-:geoLimit:            		An integer that defines the :ref:`ds-geo-limit`
-:geoLimitCountries:  		A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
-:geoLimitRedirectUrl: 		A :ref:`ds-geo-limit-redirect-url`
-:geoProvider:         		The :ref:`ds-geo-provider`
-:globalMaxMbps:       		The :ref:`ds-global-max-mbps`
-:globalMaxTps:        		The :ref:`ds-global-max-tps`
-:httpBypassFqdn:      		A :ref:`ds-http-bypass-fqdn`
-:id:                  		An integral, unique identifier for this :term:`Delivery Service`
-:infoUrl:             		An :ref:`ds-info-url`
-:initialDispersion:   		The :ref:`ds-initial-dispersion`
+:fqPacingRate:              The :ref:`ds-fqpr`
+:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
+:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`
+:geoProvider:               The :ref:`ds-geo-provider`
+:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+:globalMaxTps:              The :ref:`ds-global-max-tps`
+:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+:id:                        An integral, unique identifier for this :term:`Delivery Service`
+:infoUrl:                   An :ref:`ds-info-url`
+:initialDispersion:         The :ref:`ds-initial-dispersion`
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
-:ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-:logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:           		The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:           		The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:          		The :term:`Delivery Service`'s :ref:`ds-matchlist`
+:lastUpdated:              The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 4.0
+		In API versions earlier than 4.0, this string is in a legacy format - ``YYYY-MM-DD hh:mm:ss+ZZ`` (no sub-second precision) - instead of :rfc:`3339` format.
+
+:logsEnabled: A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:    The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:   The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:   The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:   The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -437,7 +457,7 @@ Response Structure
 :signed:                ``true`` if  and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
 :signingAlgorithm:      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
 :rangeSliceBlockSize:   An integer that defines the byte block size for the ATS Slice Plugin. It can only and must be set if ``rangeRequestHandling`` is set to 3.
-:sslKeyVersion: 	    This integer indicates the :ref:`ds-ssl-key-version`
+:sslKeyVersion:         This integer indicates the :ref:`ds-ssl-key-version`
 :tenantId:              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
 :topology:              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 :trRequestHeaders:      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`

--- a/docs/source/api/v4/deliveryservices_id.rst
+++ b/docs/source/api/v4/deliveryservices_id.rst
@@ -29,8 +29,12 @@ Allows users to edit an existing :term:`Delivery Service`.
 
 Request Structure
 -----------------
-:active:                   A boolean that defines :ref:`ds-active`.
-:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+:active: A string that defines :ref:`ds-active`.
+
+	.. versionchanged:: 4.0
+		Prior to API version 4.0, this was a boolean field.
+
+:anonymousBlockingEnabled:  A boolean that defines :ref:`ds-anonymous-blocking`
 :ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
 :cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
 

--- a/docs/source/api/v4/deliveryservices_id_safe.rst
+++ b/docs/source/api/v4/deliveryservices_id_safe.rst
@@ -61,8 +61,12 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
-:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+:active: A string that defines :ref:`ds-active`.
+
+	.. versionchanged:: 4.0
+		Prior to API version 4.0, this was a boolean field.
+
+:anonymousBlockingEnabled:  A boolean that defines :ref:`ds-anonymous-blocking`
 :ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
 :cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
 :cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
@@ -95,11 +99,15 @@ Response Structure
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:                 The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
+
+	.. versionchanged:: 4.0
+		In API versions earlier than 4.0, this string is in a legacy format - ``YYYY-MM-DD hh:mm:ss+ZZ`` (no sub-second precision) - instead of :rfc:`3339` format.
+
+:logsEnabled: A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:    The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:   The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:   The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:   The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.

--- a/docs/source/api/v4/divisions.rst
+++ b/docs/source/api/v4/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v4/divisions_id.rst
+++ b/docs/source/api/v4/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v4/logs.rst
+++ b/docs/source/api/v4/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v4/phys_locations.rst
+++ b/docs/source/api/v4/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v4/phys_locations_id.rst
+++ b/docs/source/api/v4/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v4/regions.rst
+++ b/docs/source/api/v4/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v4/regions_id.rst
+++ b/docs/source/api/v4/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v4/servers_id_deliveryservices.rst
+++ b/docs/source/api/v4/servers_id_deliveryservices.rst
@@ -67,8 +67,12 @@ Request Structure
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
-:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+:active: A string that defines :ref:`ds-active`.
+
+	.. versionchanged:: 4.0
+		Prior to API version 4.0, this was a boolean field.
+
+:anonymousBlockingEnabled:  A boolean that defines :ref:`ds-anonymous-blocking`
 :ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
 :cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
 :cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
@@ -101,11 +105,15 @@ Response Structure
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
 :lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:                 The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
+
+	.. versionchanged:: 4.0
+		In API versions earlier than 4.0, this string is in a legacy format - ``YYYY-MM-DD hh:mm:ss+ZZ`` (no sub-second precision) - instead of :rfc:`3339` format.
+
+:logsEnabled: A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:    The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:   The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:   The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:   The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -148,29 +156,44 @@ Response Structure
 	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
 	Content-Type: application/json
-	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-	Whole-Content-Sha512: CFmtW41aoDezCYxtAXnS54dfFOD6jdxDJ2/LMpbBqnndy5kac7JQhdFAWF109sl95XVSUV85JHFzXZTw/mJabQ==
+	Permissions-Policy: interest-cohort=()
+	Set-Cookie: mojolicious=...; Path=/; Expires=Wed, 19 May 2021 15:51:04 GMT; Max-Age=3600; HttpOnly
+	Vary: Accept-Encoding
 	X-Server-Name: traffic_ops_golang/
-	Date: Mon, 10 Jun 2019 17:01:30 GMT
-	Content-Length: 1500
+	Date: Wed, 19 May 2021 14:51:04 GMT
+	Content-Length: 839
 
-	{ "response": [ {
-		"active": true,
+	{ "response": [{
+		"active": "ACTIVE",
 		"anonymousBlockingEnabled": false,
-		"cacheurl": null,
 		"ccrDnsTtl": null,
 		"cdnId": 2,
 		"cdnName": "CDN-in-a-Box",
 		"checkPath": null,
+		"consistentHashQueryParams": [
+			"abc",
+			"pdq",
+			"xxx",
+			"zyx"
+		],
+		"consistentHashRegex": null,
+		"deepCachingType": "NEVER",
 		"displayName": "Demo 1",
 		"dnsBypassCname": null,
 		"dnsBypassIp": null,
 		"dnsBypassIp6": null,
 		"dnsBypassTtl": null,
 		"dscp": 0,
+		"ecsEnabled": false,
 		"edgeHeaderRewrite": null,
+		"exampleURLs": [
+			"http://video.demo1.mycdn.ciab.test",
+			"https://video.demo1.mycdn.ciab.test"
+		],
 		"firstHeaderRewrite": null,
+		"fqPacingRate": null,
 		"geoLimit": 0,
 		"geoLimitCountries": null,
 		"geoLimitRedirectURL": null,
@@ -178,13 +201,13 @@ Response Structure
 		"globalMaxMbps": null,
 		"globalMaxTps": null,
 		"httpBypassFqdn": null,
-		"id": 1,
+		"id": 2,
 		"infoUrl": null,
 		"initialDispersion": 1,
 		"innerHeaderRewrite": null,
 		"ipv6RoutingEnabled": true,
 		"lastHeaderRewrite": null,
-		"lastUpdated": "2019-06-10 15:14:29+00",
+		"lastUpdated": "2021-05-19T14:49:04.279784Z",
 		"logsEnabled": true,
 		"longDesc": "Apachecon North America 2018",
 		"longDesc1": null,
@@ -197,6 +220,8 @@ Response Structure
 			}
 		],
 		"maxDnsAnswers": null,
+		"maxOriginConnections": 0,
+		"maxRequestHeaderBytes": 0,
 		"midHeaderRewrite": null,
 		"missLat": 42,
 		"missLong": -88,
@@ -209,41 +234,25 @@ Response Structure
 		"protocol": 2,
 		"qstringIgnore": 0,
 		"rangeRequestHandling": 0,
+		"rangeSliceBlockSize": null,
 		"regexRemap": null,
 		"regionalGeoBlocking": false,
 		"remapText": null,
 		"routingName": "video",
+		"serviceCategory": null,
 		"signed": false,
-		"sslKeyVersion": 1,
-		"tenantId": 1,
-		"type": "HTTP",
-		"typeId": 1,
-		"xmlId": "demo1",
-		"exampleURLs": [
-			"http://video.demo1.mycdn.ciab.test",
-			"https://video.demo1.mycdn.ciab.test"
-		],
-		"deepCachingType": "NEVER",
-		"fqPacingRate": null,
 		"signingAlgorithm": null,
+		"sslKeyVersion": 1,
 		"tenant": "root",
+		"tenantId": 1,
+		"topology": null,
 		"trResponseHeaders": null,
 		"trRequestHeaders": null,
-		"consistentHashRegex": null,
-		"consistentHashQueryParams": [
-			"abc",
-			"pdq",
-			"xxx",
-			"zyx"
-		],
-		"maxOriginConnections": 0,
-		"ecsEnabled": false,
-		"rangeSliceBlockSize": null,
-		"topology": null
+		"type": "HTTP",
+		"typeId": 1,
+		"xmlId": "demo1"
 	}]}
 
-
-.. [#tenancy] Only the :term:`Delivery Services` visible to the requesting user's :term:`Tenant` will appear, regardless of their :term:`Role` or the :term:`Delivery Services`' actual 'server assignment' status.
 
 ``POST``
 ========
@@ -291,7 +300,7 @@ The request body is an array of IDs of :term:`Delivery Services` that you want t
 Response Structure
 ------------------
 :dsIds:         An array of integral, unique identifiers for :term:`Delivery Services` which the request added to server. If ``:replace:`` is ``false``, :term:`Delivery Services` that are already assigned will remain, though they are not listed by ``:dsIds:``.
-:replace:       The ``:replace:`` value you provided in the body of the request, or ``null`` if none was provided.
+:replace:       The ``replace`` value you provided in the body of the request, or ``null`` if none was provided.
 :serverId:      The server's integral, unique identifier
 
 .. code-block:: http
@@ -325,3 +334,6 @@ Response Structure
 			"replace": true
 		}
 	}
+
+
+.. [#tenancy] Only the :term:`Delivery Services` visible to the requesting user's :term:`Tenant` will appear, regardless of their :term:`Role` or the :term:`Delivery Services`' actual 'server assignment' status.

--- a/docs/source/api/v4/servicecategories.rst
+++ b/docs/source/api/v4/servicecategories.rst
@@ -63,7 +63,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
 
 .. code-block:: http
     :caption: Response Example
@@ -119,7 +119,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
 
 .. code-block:: http
     :caption: Response Example

--- a/docs/source/api/v4/stats_summary.rst
+++ b/docs/source/api/v4/stats_summary.rst
@@ -110,7 +110,7 @@ Summary Stats
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
+:summaryTime: Timestamp of the last updated summary, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -200,7 +200,7 @@ Request Structure
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v4/types.rst
+++ b/docs/source/api/v4/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -156,5 +156,3 @@ Response Structure
 			"useInTable": "server"
 		}]
 	}
-
-

--- a/docs/source/api/v4/types_id.rst
+++ b/docs/source/api/v4/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v4/users.rst
+++ b/docs/source/api/v4/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v4/users_id.rst
+++ b/docs/source/api/v4/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/development/traffic_router.rst
+++ b/docs/source/development/traffic_router.rst
@@ -115,9 +115,9 @@ To install the Traffic Router Developer environment:
   * copy :file:`core/src/main/conf/traffic_ops.properties` to :file:`core/src/test/conf/` and then edit the credentials as appropriate for the Traffic Ops instance you will be using.
   * Default configuration values now reside in :file:`core/src/main/webapp/WEB-INF/applicationContext.xml`
 
-  	.. note:: These values may be overridden by creating and/or modifying the property files listed in :file:`core/src/main/resources/applicationProperties.xml`
+	.. note:: These values may be overridden by creating and/or modifying the property files listed in :file:`core/src/main/resources/applicationProperties.xml`
 
-  	.. note:: Pre-existing properties files are still honored by Traffic Router. For example :file:`traffic_monitor.properties` may contain the :abbr:`FQDN (Fully Qualified Domain Name)` and port of the Traffic Monitor instance(s), separated by semicolons as necessary (do not include scheme e.g. ``http://``)
+	.. note:: Pre-existing properties files are still honored by Traffic Router. For example :file:`traffic_monitor.properties` may contain the :abbr:`FQDN (Fully Qualified Domain Name)` and port of the Traffic Monitor instance(s), separated by semicolons as necessary (do not include scheme e.g. ``http://``)
 
 
 #. Import the existing git repository as projects into your IDE (Eclipse):

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -44,7 +44,7 @@ Glossary
 	Cache Groups
 		A group of caching HTTP proxy servers that together create a combined larger cache using consistent hashing. Traffic Router treats all servers in a :dfn:`Cache Group` as though they are in the  same geographic location, though they are in fact only in the same general area. A :dfn:`Cache Group` has one single set of geographical coordinates even if the :term:`cache servers` that make up the :dfn:`Cache Group` are actually in :term:`Physical Locations`. The :term:`cache servers` in a :dfn:`Cache Group` are not aware of the other :term:`cache servers` in the group - there is no clustering software or communications between :term:`cache servers` in a :dfn:`Cache Group`.
 
-  		There are two basic types of :dfn:`Cache Groups`: EDGE_LOC and MID_LOC ("LOC" being short for "location" - a holdover from when :dfn:`Cache Groups` were called "Cache Locations). Traffic Control is a two-tiered system, where the clients get directed to the Edge-tier (EDGE_LOC) :dfn:`Cache Group`. On cache miss, the :term:`cache server` in the Edge-tier :dfn:`Cache Group` obtains content from a Mid-tier (MID_LOC) :dfn:`Cache Group`, rather than the origin, which is shared with multiple Edge-tier :dfn:`Cache Groups`. Edge-tier :dfn:`Cache Groups` are usually configured to have a single "parent" :dfn:`Cache Group`, but in general Mid-tier :dfn:`Cache Groups` have many "children".
+		There are two basic types of :dfn:`Cache Groups`: EDGE_LOC and MID_LOC ("LOC" being short for "location" - a holdover from when :dfn:`Cache Groups` were called "Cache Locations). Traffic Control is a two-tiered system, where the clients get directed to the Edge-tier (EDGE_LOC) :dfn:`Cache Group`. On cache miss, the :term:`cache server` in the Edge-tier :dfn:`Cache Group` obtains content from a Mid-tier (MID_LOC) :dfn:`Cache Group`, rather than the origin, which is shared with multiple Edge-tier :dfn:`Cache Groups`. Edge-tier :dfn:`Cache Groups` are usually configured to have a single "parent" :dfn:`Cache Group`, but in general Mid-tier :dfn:`Cache Groups` have many "children".
 
 		..  Note:: Often the Edge-tier to Mid-tier relationship is based on network distance, and does not necessarily match the geographic distance.
 
@@ -238,8 +238,8 @@ Glossary
 	geo localization or geo routing
 		Localizing clients to the nearest caches using a geo database like the one from Maxmind.
 
- 	Health Protocol
- 		The protocol to monitor the health of all the caches. See :ref:`health-proto`.
+	Health Protocol
+		The protocol to monitor the health of all the caches. See :ref:`health-proto`.
 
 	Inner-tier
 	Inner-tier cache
@@ -255,8 +255,8 @@ Glossary
 	Last-tier cache servers
 		The tier above the First and Inner tiers. The last tier in a :term:`Topology` is the tier that forwards requests from other caches to :term:`Origins`.
 
- 	localization
- 		Finding location on the network, or on planet earth
+	localization
+		Finding location on the network, or on planet earth
 
 	Mid
 	Mid-tier

--- a/docs/source/overview/delivery_service_requests.rst
+++ b/docs/source/overview/delivery_service_requests.rst
@@ -99,7 +99,7 @@ update
 
 Created At
 ----------
-This is the date and time at which the :abbr:`DSR (Delivery Service Request)` was created. In the context of the :ref:`to-api`, it is formatted as an :rfc:`3339` date string.
+This is the date and time at which the :abbr:`DSR (Delivery Service Request)` was created. In the context of the :ref:`to-api`, it is formatted as an :rfc:`3339` date string except where otherwise noted.
 
 ID
 --

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -20,7 +20,7 @@ Delivery Services
 *****************
 "Delivery Services" are a very important construct in :abbr:`ATC (Apache Traffic Control)`. At their most basic, they are a source of content and a set of :term:`cache servers` and configuration options used to distribute that content.
 
-Delivery Services are modeled several times over, in the Traffic Ops database, in Traffic Portal forms and tables, and several times for various :ref:`to-api` versions in the new Go Traffic Ops codebase. Go-specific data structures can be found in `the project's GoDoc documentation <https://pkg.go.dev/github.com/apache/trafficcontrol/lib/go-tc#DeliveryServiceNullableV11>`_. Rather than application-specific definitions, what follows is an attempt at consolidating all of the different properties and names of properties of Delivery Service objects throughout the :abbr:`ATC (Apache Traffic Control)` suite. The names of these fields are typically chosen as the most human-readable and/or most commonly-used names for the fields, and when reading please note that in many cases these names will appear camelCased or snake_cased to be machine-readable. Any aliases of these fields that are not merely case transformations of the indicated, canonical names will be noted in a table of aliases.
+Delivery Services are modeled several times over, in the Traffic Ops database, in Traffic Portal forms and tables, and several times for various :ref:`to-api` versions in the new Go Traffic Ops codebase. Go-specific data structures can be found in `the project's GoDoc documentation <https://pkg.go.dev/github.com/apache/trafficcontrol/lib/go-tc#DeliveryServiceV4>`_. Rather than application-specific definitions, what follows is an attempt at consolidating all of the different properties and names of properties of Delivery Service objects throughout the :abbr:`ATC (Apache Traffic Control)` suite. The names of these fields are typically chosen as the most human-readable and/or most commonly-used names for the fields, and when reading please note that in many cases these names will appear camelCased or snake_cased to be machine-readable. Any aliases of these fields that are not merely case transformations of the indicated, canonical names will be noted in a table of aliases.
 
 .. seealso:: The API reference for Delivery Service-related endpoints such as :ref:`to-api-deliveryservices` contains definitions of the Delivery Service object(s) returned and/or accepted by those endpoints.
 .. seealso:: :ref:`delivery-service-requests`
@@ -29,7 +29,19 @@ Delivery Services are modeled several times over, in the Traffic Ops database, i
 
 Active
 ------
-Whether or not this Delivery Service is active on the CDN and can be served. When a Delivery Service is not "active", Traffic Router will not be made aware of its existence - i.e. it will not appear in CDN :term:`Snapshots`. Setting a Delivery Service to be "active" (or "inactive") will require that a new :term:`Snapshot` be taken.
+"Active" defines whether or not this Delivery Service is routed by Traffic Router and whether or not :term:`cache servers` have the necessary configuration to serve its content. In nearly every case, this is a string which may have one of the following values with the associated meanings:
+
+ACTIVE
+	This Delivery Service is both routed (appears in CDN :term:`Snapshots`) and served by :term:`cache servers`.
+PRIMED
+	This Delivery Service is not routed (doesn't appear in CDN :term:`Snapshots`), but is still served by :term:`cache servers`.
+INACTIVE
+	This Delivery Service is neither routed (doesn't appear in CDN :term:`Snapshots`), nor is its content served by :term:`cache servers`.
+
+Setting a Delivery Service's Active property in a way that changes whether or not it is routed will require that a new :term:`Snapshot` be taken, while setting it in a way that changes whether or not its content is served by :term:`cache servers` will require that a :term:`Queue Server Updates` is performed on the affected :term:`cache servers`.
+
+.. versionchanged:: ATCv6/APIv4
+	Changed from a strict boolean to an enumeration of the herein listed values. In versions of :abbr:`ATC (Apache Traffic Control)` later than 6.0, :ref:`to-api` versions earlier than 4.0 will report ACTIVE Delivery Services with Active properties set to ``true``, and PRIMED or INACTIVE Delivery Services with Active properties set to ``false``.
 
 .. _ds-anonymous-blocking:
 

--- a/infrastructure/cdn-in-a-box/enroller/enroller.go
+++ b/infrastructure/cdn-in-a-box/enroller/enroller.go
@@ -227,7 +227,7 @@ func enrollDeliveryService(toSession *session, r io.Reader) error {
 	if err != nil {
 		for _, alert := range alerts.Alerts.Alerts {
 			if strings.Contains(alert.Text, "already exists") {
-				log.Infof("Delivery Service '%s' already exists", *s.XMLID)
+				log.Infof("Delivery Service '%s' already exists", s.XMLID)
 				return nil
 			}
 		}
@@ -827,7 +827,7 @@ func enrollFederation(toSession *session, r io.Reader) error {
 				return err
 			}
 			deliveryService := deliveryServices.Response[0]
-			if deliveryService.CDNName == nil || deliveryService.ID == nil || deliveryService.XMLID == nil {
+			if deliveryService.CDNName == nil || deliveryService.ID == nil {
 				err = fmt.Errorf("Delivery Service '%s' as returned from Traffic Ops had null or undefined CDN name and/or ID", xmlID)
 				log.Infoln(err)
 				return err

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/010-demo1.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/010-demo1.json
@@ -7,7 +7,7 @@
     "orgServerFqdn": "http://origin.infra.ciab.test",
     "cdnName": "$CDN_NAME",
     "type": "HTTP",
-    "active": true,
+    "active": "ACTIVE",
     "dscp": 0,
     "geoLimit": 0,
     "geoProvider": 0,

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/020-demo2.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/020-demo2.json
@@ -7,7 +7,7 @@
     "orgServerFqdn": "http://origin.infra.ciab.test",
     "cdnName": "$CDN_NAME",
     "type": "DNS",
-    "active": true,
+    "active": "ACTIVE",
     "dscp": 0,
     "geoLimit": 0,
     "geoProvider": 0,

--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -798,12 +798,12 @@ func (dsr DeliveryServiceRequestV40) Downgrade() DeliveryServiceRequestNullable 
 	if dsr.XMLID != "" {
 		downgraded.XMLID = new(string)
 		*downgraded.XMLID = dsr.XMLID
-	} else if dsr.Original != nil && dsr.Original.XMLID != nil {
+	} else if dsr.Original != nil {
 		downgraded.XMLID = new(string)
-		*downgraded.XMLID = *dsr.Original.XMLID
-	} else if dsr.Requested.XMLID != nil {
+		*downgraded.XMLID = dsr.Original.XMLID
+	} else {
 		downgraded.XMLID = new(string)
-		*downgraded.XMLID = *dsr.Requested.XMLID
+		*downgraded.XMLID = dsr.Requested.XMLID
 	}
 	return downgraded
 }
@@ -870,13 +870,13 @@ func (dsr *DeliveryServiceRequestV40) SetXMLID() {
 		return
 	}
 
-	if dsr.ChangeType == DSRChangeTypeDelete && dsr.Original != nil && dsr.Original.XMLID != nil {
-		dsr.XMLID = *dsr.Original.XMLID
+	if dsr.ChangeType == DSRChangeTypeDelete && dsr.Original != nil {
+		dsr.XMLID = dsr.Original.XMLID
 		return
 	}
 
-	if dsr.Requested != nil && dsr.Requested.XMLID != nil {
-		dsr.XMLID = *dsr.Requested.XMLID
+	if dsr.Requested != nil {
+		dsr.XMLID = dsr.Requested.XMLID
 	}
 }
 

--- a/lib/go-tc/deliveryservice_requests_test.go
+++ b/lib/go-tc/deliveryservice_requests_test.go
@@ -151,7 +151,7 @@ func TestDeliveryServiceRequestV40_Downgrade(t *testing.T) {
 		Requested:      &DeliveryServiceV4{},
 		Status:         RequestStatusComplete,
 	}
-	dsr.Requested.XMLID = &xmlid
+	dsr.Requested.XMLID = xmlid
 
 	downgraded := dsr.Downgrade()
 	if downgraded.Assignee != nil {
@@ -214,8 +214,7 @@ func ExampleDeliveryServiceRequestV40_SetXMLID() {
 	fmt.Println(dsr.XMLID == "")
 
 	dsr.Requested = new(DeliveryServiceV4)
-	dsr.Requested.XMLID = new(string)
-	*dsr.Requested.XMLID = "test"
+	dsr.Requested.XMLID = "test"
 	dsr.SetXMLID()
 
 	fmt.Println(dsr.XMLID)

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -635,7 +635,7 @@ type DeliveryServiceRemovedFieldsV11 struct {
 	CacheURL *string `json:"cacheurl" db:"cacheurl"`
 }
 
-// DowngradeToV3 converts the 4.x DS to a 3.x DS
+// DowngradeToV3 converts the 4.x DS to a 3.x DS.
 func (ds *DeliveryServiceV4) DowngradeToV3() DeliveryServiceNullableV30 {
 	var ret DeliveryServiceNullableV30
 	ret.Active = new(bool)
@@ -692,9 +692,13 @@ func (ds *DeliveryServiceV4) DowngradeToV3() DeliveryServiceNullableV30 {
 	ret.LongDesc = ds.LongDesc
 	ret.LongDesc1 = ds.LongDesc1
 	ret.LongDesc2 = ds.LongDesc2
-	ret.MatchList = new([]DeliveryServiceMatch)
-	*ret.MatchList = make([]DeliveryServiceMatch, len(ds.MatchList))
-	copy(*ret.MatchList, ds.MatchList)
+	if ds.MatchList != nil {
+		ret.MatchList = new([]DeliveryServiceMatch)
+		*ret.MatchList = make([]DeliveryServiceMatch, len(ds.MatchList))
+		copy(*ret.MatchList, ds.MatchList)
+	} else {
+		ret.MatchList = nil
+	}
 	ret.MaxDNSAnswers = ds.MaxDNSAnswers
 	ret.MaxOriginConnections = ds.MaxOriginConnections
 	ret.MaxRequestHeaderBytes = ds.MaxRequestHeaderBytes
@@ -736,7 +740,7 @@ func (ds *DeliveryServiceV4) DowngradeToV3() DeliveryServiceNullableV30 {
 	return ret
 }
 
-// UpgradeToV4 converts the 3.x DS to a 4.x DS
+// UpgradeToV4 converts the 3.x DS to a 4.x DS.
 func (ds *DeliveryServiceNullableV30) UpgradeToV4() DeliveryServiceV4 {
 	var ret DeliveryServiceV4
 	if ds.Active != nil && *ds.Active {
@@ -818,6 +822,8 @@ func (ds *DeliveryServiceNullableV30) UpgradeToV4() DeliveryServiceV4 {
 	if ds.MatchList != nil {
 		ret.MatchList = make([]DeliveryServiceMatch, len(*ds.MatchList))
 		copy(ret.MatchList, *ds.MatchList)
+	} else {
+		ret.MatchList = nil
 	}
 	ret.MaxDNSAnswers = ds.MaxDNSAnswers
 	ret.MaxOriginConnections = ds.MaxOriginConnections

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-util"
 )
@@ -189,15 +190,310 @@ type DeliveryServiceFieldsV31 struct {
 	MaxRequestHeaderBytes *int `json:"maxRequestHeaderBytes" db:"max_request_header_bytes"`
 }
 
+// DeliveryServiceActiveState is an "enumerated" type which encodes the valid
+// values of a Delivery Service's 'Active' property (v3.0+).
+type DeliveryServiceActiveState string
+
+// A DeliveryServiceActiveState describes the availability of Delivery Service
+// content from the perspective of caching servers and Traffic Routers.
+const (
+	// Traffic Router routes clients for this Delivery Service and cache
+	// servers are configured to serve its content.
+	DS_ACTIVE = DeliveryServiceActiveState("ACTIVE")
+	// Traffic Router does not route for this Delivery Service and cache
+	// servers cannot serve its content.
+	DS_INACTIVE = DeliveryServiceActiveState("INACTIVE")
+	// Traffic Router does not route for this Delivery Service, but cache
+	// servers are configured to serve its content.
+	DS_PRIMED = DeliveryServiceActiveState("PRIMED")
+)
+
 // DeliveryServiceV40 is a Delivery Service as it appears in version 4.0 of the
 // Traffic Ops API.
 type DeliveryServiceV40 struct {
-	DeliveryServiceFieldsV31
-	DeliveryServiceFieldsV30
-	DeliveryServiceFieldsV15
-	DeliveryServiceFieldsV14
-	DeliveryServiceFieldsV13
-	DeliveryServiceNullableFieldsV11
+	// Active dictates whether the Delivery Service is routed by Traffic Router,
+	// as well as whether or not cache servers have the correct configuration to
+	// serve its content.
+	Active DeliveryServiceActiveState `json:"active" db:"active"`
+	// AnonymousBlockingEnabled sets whether or not anonymized IP addresses
+	// (e.g. Tor exit nodes) should be restricted from accessing the Delivery
+	// Service's content.
+	AnonymousBlockingEnabled bool `json:"anonymousBlockingEnabled" db:"anonymous_blocking_enabled"`
+	// CCRDNSTTL sets the Time-to-Live - in seconds - for DNS responses for this
+	// Delivery Service from Traffic Router.
+	CCRDNSTTL *int `json:"ccrDnsTtl" db:"ccr_dns_ttl"`
+	// CDNID is the integral, unique identifier for the CDN to which the
+	// Delivery Service belongs.
+	CDNID int `json:"cdnId" db:"cdn_id"`
+	// CDNName is the name of the CDN to which the Delivery Service belongs.
+	CDNName *string `json:"cdnName"`
+	// CheckPath is a path which may be requested of the Delivery Service's
+	// origin to ensure it's working properly.
+	CheckPath *string `json:"checkPath" db:"check_path"`
+	// ConsistentHashQueryParams is a list of al of the query string parameters
+	// which ought to be considered by Traffic Router in client request URIs for
+	// HTTP-routed Delivery Services in the hashing process.
+	ConsistentHashQueryParams []string `json:"consistentHashQueryParams"`
+	// ConsistentHashRegex is used by Traffic Router to extract meaningful parts
+	// of a client's request URI for HTTP-routed Delivery Services before
+	// hashing the request to find a cache server to which to direct the client.
+	ConsistentHashRegex *string `json:"consistentHashRegex"`
+	// DeepCachingType may only legally point to 'ALWAYS' or 'NEVER', which
+	// define whether "deep caching" may or may not be used for this Delivery
+	// Service, respectively.
+	DeepCachingType DeepCachingType `json:"deepCachingType" db:"deep_caching_type"`
+	// DisplayName is a human-friendly name that might be used in some UIs
+	// somewhere.
+	DisplayName string `json:"displayName" db:"display_name"`
+	// DNSBypassCNAME is a fully qualified domain name to be used in a CNAME
+	// record presented to clients in bypass scenarios.
+	DNSBypassCNAME *string `json:"dnsBypassCname" db:"dns_bypass_cname"`
+	// DNSBypassIP is an IPv4 address to be used in an A record presented to
+	// clients in bypass scenarios.
+	DNSBypassIP *string `json:"dnsBypassIp" db:"dns_bypass_ip"`
+	// DNSBypassIP6 is an IPv6 address to be used in an AAAA record presented to
+	// clients in bypass scenarios.
+	DNSBypassIP6 *string `json:"dnsBypassIp6" db:"dns_bypass_ip6"`
+	// DNSBypassTTL sets the Time-to-Live - in seconds - of DNS responses from
+	// the Traffic Router that contain records for bypass destinations.
+	DNSBypassTTL *int `json:"dnsBypassTtl" db:"dns_bypass_ttl"`
+	// DSCP sets the Differentiated Services Code Point for IP packets
+	// transferred between clients, origins, and cache servers when obtaining
+	// and serving content for this Delivery Service.
+	// See Also: https://en.wikipedia.org/wiki/Differentiated_services
+	DSCP int `json:"dscp" db:"dscp"`
+	// EcsEnabled describes whether or not the Traffic Router's EDNS0 Client
+	// Subnet extensions should be enabled when serving DNS responses for this
+	// Delivery Service. Even if this is true, the Traffic Router may still
+	// have the extensions unilaterally disabled in its own configuration.
+	EcsEnabled bool `json:"ecsEnabled" db:"ecs_enabled"`
+	// EdgeHeaderRewrite is a "header rewrite rule" used by ATS at the Edge-tier
+	// of caching. This has no effect on Delivery Services that don't use a
+	// Topology.
+	EdgeHeaderRewrite *string `json:"edgeHeaderRewrite" db:"edge_header_rewrite"`
+	// ExampleURLs is a list of all of the URLs from which content may be
+	// requested from the Delivery Service.
+	ExampleURLs []string `json:"exampleURLs"`
+	// FirstHeaderRewrite is a "header rewrite rule" used by ATS at the first
+	// caching layer encountered in the Delivery Service's Topology, or nil if
+	// there is no such rule. This has no effect on Delivery Services that don't
+	// employ Topologies.
+	FirstHeaderRewrite *string `json:"firstHeaderRewrite" db:"first_header_rewrite"`
+	// FQPacingRate sets the maximum bytes per second a cache server will deliver
+	// on any single TCP connection for this Delivery Service. This may never
+	// legally point to a value less than zero.
+	FQPacingRate *int `json:"fqPacingRate" db:"fq_pacing_rate"`
+	// GeoLimit defines whether or not access to a Delivery Service's content
+	// should be limited based on the requesting client's geographic location.
+	// Despite that this is a pointer to an arbitrary integer, the only valid
+	// values are 0 (which indicates that content should not be limited
+	// geographically), 1 (which indicates that content should only be served to
+	// clients whose IP addresses can be found within a Coverage Zone File), and
+	// 2 (which indicates that content should be served to clients whose IP
+	// addresses can be found within a Coverage Zone File OR are allowed access
+	// according to the "array" in GeoLimitCountries).
+	GeoLimit int `json:"geoLimit" db:"geo_limit"`
+	// GeoLimitCountries is an "array" of "country codes" that itemizes the
+	// countries within which the Delivery Service's content ought to be made
+	// available. This has no effect if GeoLimit is not a pointer to exactly the
+	// value 2.
+	GeoLimitCountries *string `json:"geoLimitCountries" db:"geo_limit_countries"`
+	// GeoLimitRedirectURL is a URL to which clients will be redirected if their
+	// access to the Delivery Service's content is blocked by GeoLimit rules.
+	GeoLimitRedirectURL *string `json:"geoLimitRedirectURL" db:"geolimit_redirect_url"`
+	// GeoProvider names the type of database to be used for providing IP
+	// address-to-geographic-location mapping for this Delivery Service. The
+	// only valid values to which it may point are 0 (which indicates the use of
+	// a MaxMind GeoIP2 database) and 1 (which indicates the use of a Neustar
+	// GeoPoint IP address database).
+	GeoProvider int `json:"geoProvider" db:"geo_provider"`
+	// GlobalMaxMBPS defines a maximum number of MegaBytes Per Second which may
+	// be served for the Delivery Service before redirecting clients to bypass
+	// locations.
+	GlobalMaxMBPS *int `json:"globalMaxMbps" db:"global_max_mbps"`
+	// GlobalMaxTPS defines a maximum number of Transactions Per Second which
+	// may be served for the Delivery Service before redirecting clients to
+	// bypass locations.
+	GlobalMaxTPS *int `json:"globalMaxTps" db:"global_max_tps"`
+	// HTTPBypassFQDN is a network location to which clients will be redirected
+	// in bypass scenarios using HTTP "Location" headers and appropriate
+	// redirection response codes.
+	HTTPBypassFQDN *string `json:"httpBypassFqdn" db:"http_bypass_fqdn"`
+	// ID is an integral, unique identifier for the Delivery Service.
+	ID *int `json:"id" db:"id"`
+	// InfoURL is a URL to which operators or clients may be directed to obtain
+	// further information about a Delivery Service.
+	InfoURL *string `json:"infoUrl" db:"info_url"`
+	// InitialDispersion sets the number of cache servers within the first
+	// caching layer ("Edge-tier" in a non-Topology context) across which
+	// content will be dispersed per Cache Group.
+	InitialDispersion *int `json:"initialDispersion" db:"initial_dispersion"`
+	// InnerHeaderRewrite is a "header rewrite rule" used by ATS at all caching
+	// layers encountered in the Delivery Service's Topology except the first
+	// and last, or nil if there is no such rule. This has no effect on Delivery
+	// Services that don't employ Topologies.
+	InnerHeaderRewrite *string `json:"innerHeaderRewrite" db:"inner_header_rewrite"`
+	// IPV6RoutingEnabled controls whether or not routing over IPv6 should be
+	// done for this Delivery Service.
+	IPV6RoutingEnabled bool `json:"ipv6RoutingEnabled" db:"ipv6_routing_enabled"`
+	// LastHeaderRewrite is a "header rewrite rule" used by ATS at the first
+	// caching layer encountered in the Delivery Service's Topology, or nil if
+	// there is no such rule. This has no effect on Delivery Services that don't
+	// employ Topologies.
+	LastHeaderRewrite *string `json:"lastHeaderRewrite" db:"last_header_rewrite"`
+	// LastUpdated is the time and date at which the Delivery Service was last
+	// updated.
+	LastUpdated time.Time `json:"lastUpdated" db:"last_updated"`
+	// LogsEnabled controls nothing. It is kept only for legacy compatibility.
+	LogsEnabled bool `json:"logsEnabled" db:"logs_enabled"`
+	// LongDesc is a description of the Delivery Service, having arbitrary
+	// length.
+	LongDesc *string `json:"longDesc" db:"long_desc"`
+	// LongDesc1 is a description of the Delivery Service, having arbitrary
+	// length.
+	LongDesc1 *string `json:"longDesc1" db:"long_desc_1"`
+	// LongDesc2 is a description of the Delivery Service, having arbitrary
+	// length.
+	LongDesc2 *string `json:"longDesc2" db:"long_desc_2"`
+	// MatchList is a list of Regular Expressions used for routing the Delivery
+	// Service. Order matters, and the array is not allowed to be sparse.
+	MatchList []DeliveryServiceMatch `json:"matchList"`
+	// MaxDNSAnswers sets the maximum number of records which should be returned
+	// by Traffic Router in DNS responses to requests for resolving names for
+	// this Delivery Service.
+	MaxDNSAnswers *int `json:"maxDnsAnswers" db:"max_dns_answers"`
+	// MaxOriginConnections defines the total maximum  number of connections
+	// that the highest caching layer ("Mid-tier" in a non-Topology context) is
+	// allowed to have concurrently open to the Delivery Service's Origin. This
+	// may never legally point to a value less than 0.
+	MaxOriginConnections *int `json:"maxOriginConnections" db:"max_origin_connections"`
+	// MaxRequestHeaderBytes is the maximum size (in bytes) of the request
+	// header that is allowed for this Delivery Service.
+	MaxRequestHeaderBytes *int `json:"maxRequestHeaderBytes" db:"max_request_header_bytes"`
+	// MidHeaderRewrite is a "header rewrite rule" used by ATS at the Mid-tier
+	// of caching. This has no effect on Delivery Services that don't use a
+	// Topology.
+	MidHeaderRewrite *string `json:"midHeaderRewrite" db:"mid_header_rewrite"`
+	// MissLat is a latitude to default to for clients of this Delivery Service
+	// when geolocation attempts fail.
+	MissLat *float64 `json:"missLat" db:"miss_lat"`
+	// MissLong is a longitude to default to for clients of this Delivery
+	// Service when geolocation attempts fail.
+	MissLong *float64 `json:"missLong" db:"miss_long"`
+	// MultiSiteOrigin determines whether or not the Delivery Service makes use
+	// of "Multi-Site Origin".
+	MultiSiteOrigin *bool `json:"multiSiteOrigin" db:"multi_site_origin"`
+	// OriginShield is a field that does nothing. It is kept only for legacy
+	// compatibility reasons.
+	OriginShield *string `json:"originShield" db:"origin_shield"`
+	// OrgServerFQDN is the URL - NOT Fully Qualified Domain Name - of the
+	// origin of the Delivery Service's content.
+	OrgServerFQDN *string `json:"orgServerFqdn" db:"org_server_fqdn"`
+	// ProfileDesc is the Description of the Profile used by the Delivery
+	// Service, if any.
+	ProfileDesc *string `json:"profileDescription"`
+	// ProfileID is the integral, unique identifier of the Profile used by the
+	// Delivery Service, if any.
+	ProfileID *int `json:"profileId" db:"profile"`
+	// ProfileName is the Name of the Profile used by the Delivery Service, if
+	// any.
+	ProfileName *string `json:"profileName"`
+	// Protocol defines the protocols by which caching servers may communicate
+	// with clients. The valid values to which it may point are 0 (which implies
+	// that only HTTP may be used), 1 (which implies that only HTTPS may be
+	// used), 2 (which implies that either HTTP or HTTPS may be used), and 3
+	// (which implies that clients using HTTP must be redirected to use HTTPS,
+	// while communications over HTTPS may proceed as normal).
+	Protocol *int `json:"protocol" db:"protocol"`
+	// QStringIgnore sets how query strings in HTTP requests to cache servers
+	// from clients are treated. The only valid values to which it may point are
+	// 0 (which implies that all caching layers will pass query strings in
+	// upstream requests and use them in the cache key), 1 (which implies that
+	// all caching layers will pass query strings in upstream requests, but not
+	// use them in cache keys), and 2 (which implies that the first encountered
+	// caching layer - "Edge-tier" in a non-Topology context - will strip query
+	// strings, effectively preventing them from being passed in upstream
+	// requests, and not use them in the cache key).
+	QStringIgnore *int `json:"qstringIgnore" db:"qstring_ignore"`
+	// RangeRequestHandling defines how HTTP GET requests with a Range header
+	// will be handled by cache servers serving the Delivery Service's content.
+	// The only valid values to which it may point are 0 (which implies that
+	// Range requests will not be cached at all), 1 (which implies that the
+	// background_fetch plugin will be used to service the range request while
+	// caching the whole object), 2 (which implies that the cache_range_requests
+	// plugin will be used to cache ranges as unique objects), and 3 (which
+	// implies that the slice plugin will be used to slice range based requests
+	// into deterministic chunks.)
+	RangeRequestHandling *int `json:"rangeRequestHandling" db:"range_request_handling"`
+	// RangeSliceBlockSize defines the size of range request blocks - or
+	// "slices" - used by the "slice" plugin. This has no effect if
+	// RangeRequestHandling does not point to exactly 3. This may never legally
+	// point to a value less than zero.
+	RangeSliceBlockSize *int `json:"rangeSliceBlockSize" db:"range_slice_block_size"`
+	// Regex Remap is a raw line to be inserted into "regex_remap.config" on the
+	// cache server. Care is necessitated in its use, because the input is in no
+	// way restricted, validated, or limited in scope to the Delivery Service.
+	RegexRemap *string `json:"regexRemap" db:"regex_remap"`
+	// RegionalGeoBlocking defines whether or not whatever Regional Geo Blocking
+	// rules are configured on the Traffic Router serving content for this
+	// Delivery Service will have an effect on the traffic of this Delivery
+	// Service.
+	RegionalGeoBlocking bool `json:"regionalGeoBlocking" db:"regional_geo_blocking"`
+	// RemapText is raw text to insert in "remap.config" on the cache servers
+	// serving content for this Delivery Service. Care is necessitated in its
+	// use, because the input is in no way restricted, validated, or limited in
+	// scope to the Delivery Service.
+	RemapText *string `json:"remapText" db:"remap_text"`
+	// RoutingName defines the lowest-level DNS label used by the Delivery
+	// Service, e.g. if trafficcontrol.apache.org were a Delivery Service, it
+	// would have a RoutingName of "trafficcontrol".
+	RoutingName string `json:"routingName" db:"routing_name"`
+	// ServiceCategory defines a category to which a Delivery Service may
+	// belong, which will cause HTTP Responses containing content for the
+	// Delivery Service to have the "X-CDN-SVC" header with a value that is the
+	// XMLID of the Delivery Service.
+	ServiceCategory *string `json:"serviceCategory" db:"service_category"`
+	// Signed is a legacy field. It is allowed to be `true` if and only if
+	// SigningAlgorithm is not nil.
+	Signed bool `json:"signed"`
+	// SigningAlgorithm is the name of the algorithm used to sign CDN URIs for
+	// this Delivery Service's content, or nil if no URI signing is done for the
+	// Delivery Service. This may only point to the values "url_sig" or
+	// "uri_signing".
+	SigningAlgorithm *string `json:"signingAlgorithm" db:"signing_algorithm"`
+	// SSLKeyVersion incremented whenever Traffic Portal generates new SSL keys
+	// for the Delivery Service, effectively making it a "generational" marker.
+	SSLKeyVersion *int `json:"sslKeyVersion" db:"ssl_key_version"`
+	// Tenant is the Tenant to which the Delivery Service belongs.
+	Tenant *string `json:"tenant"`
+	// TenantID is the integral, unique identifier for the Tenant to which the
+	// Delivery Service belongs.
+	TenantID int `json:"tenantId" db:"tenant_id"`
+	// Topology is the name of the Topology used by the Delivery Service, or nil
+	// if no Topology is used.
+	Topology *string `json:"topology" db:"topology"`
+	// TRResponseHeaders is a set of headers (separated by CRLF pairs as per the
+	// HTTP spec) and their values (separated by a colon as per the HTTP spec)
+	// which will be sent by Traffic Router in HTTP responses to client requests
+	// for this Delivery Service's content. This has no effect on DNS-routed or
+	// un-routed Delivery Service Types.
+	TRResponseHeaders *string `json:"trResponseHeaders"`
+	// TRRequestHeaders is an "array" of HTTP headers which should be logged
+	// from client HTTP requests for this Delivery Service's content by Traffic
+	// Router, separated by newlines. This has no effect on DNS-routed or
+	// un-routed Delivery Service Types.
+	TRRequestHeaders *string `json:"trRequestHeaders"`
+	// Type describes how content is routed and cached for this Delivery Service
+	// as well as what other properties have any meaning.
+	Type *DSType `json:"type"`
+	// TypeID is an integral, unique identifier for the Tenant to which the
+	// Delivery Service belongs.
+	TypeID int `json:"typeId" db:"type"`
+	// XMLID is a unique identifier that is also the second lowest-level DNS
+	// label used by the Delivery Service. For example, if a Delivery Service's
+	// content may be requested from video.demo1.mycdn.ciab.test, it may be
+	// inferred that the Delivery Service's XMLID is demo1.
+	XMLID string `json:"xmlId" db:"xml_id"`
 }
 
 // DeliveryServiceV4 is a Delivery Service as it appears in version 4 of the
@@ -341,38 +637,233 @@ type DeliveryServiceRemovedFieldsV11 struct {
 
 // DowngradeToV3 converts the 4.x DS to a 3.x DS
 func (ds *DeliveryServiceV4) DowngradeToV3() DeliveryServiceNullableV30 {
-	return DeliveryServiceNullableV30{
-		DeliveryServiceV30: DeliveryServiceV30{
-			DeliveryServiceNullableV15: DeliveryServiceNullableV15{
-				DeliveryServiceNullableV14: DeliveryServiceNullableV14{
-					DeliveryServiceNullableV13: DeliveryServiceNullableV13{
-						DeliveryServiceNullableV12: DeliveryServiceNullableV12{
-							DeliveryServiceNullableV11: DeliveryServiceNullableV11{
-								DeliveryServiceNullableFieldsV11: ds.DeliveryServiceNullableFieldsV11,
-							},
-						},
-						DeliveryServiceFieldsV13: ds.DeliveryServiceFieldsV13,
-					},
-					DeliveryServiceFieldsV14: ds.DeliveryServiceFieldsV14,
-				},
-				DeliveryServiceFieldsV15: ds.DeliveryServiceFieldsV15,
-			},
-			DeliveryServiceFieldsV30: ds.DeliveryServiceFieldsV30,
-		},
-		DeliveryServiceFieldsV31: ds.DeliveryServiceFieldsV31,
+	var ret DeliveryServiceNullableV30
+	ret.Active = new(bool)
+	if ds.Active == DS_ACTIVE {
+		*ret.Active = true
+	} else {
+		*ret.Active = false
 	}
+	ret.AnonymousBlockingEnabled = new(bool)
+	*ret.AnonymousBlockingEnabled = ds.AnonymousBlockingEnabled
+	ret.CCRDNSTTL = ds.CCRDNSTTL
+	ret.CDNID = new(int)
+	*ret.CDNID = ds.CDNID
+	ret.CDNName = ds.CDNName
+	ret.CheckPath = ds.CheckPath
+	ret.ConsistentHashRegex = ds.ConsistentHashRegex
+	ret.ConsistentHashQueryParams = make([]string, len(ds.ConsistentHashQueryParams))
+	copy(ret.ConsistentHashQueryParams, ds.ConsistentHashQueryParams)
+	ret.DeepCachingType = new(DeepCachingType)
+	*ret.DeepCachingType = ds.DeepCachingType
+	ret.DisplayName = new(string)
+	*ret.DisplayName = ds.DisplayName
+	ret.DNSBypassCNAME = ds.DNSBypassCNAME
+	ret.DNSBypassIP = ds.DNSBypassIP
+	ret.DNSBypassIP6 = ds.DNSBypassIP6
+	ret.DNSBypassTTL = ds.DNSBypassTTL
+	ret.DSCP = new(int)
+	*ret.DSCP = ds.DSCP
+	ret.EcsEnabled = ds.EcsEnabled
+	ret.EdgeHeaderRewrite = ds.EdgeHeaderRewrite
+	ret.ExampleURLs = make([]string, len(ds.ExampleURLs))
+	copy(ret.ExampleURLs, ds.ExampleURLs)
+	ret.FirstHeaderRewrite = ds.FirstHeaderRewrite
+	ret.FQPacingRate = ds.FQPacingRate
+	ret.GeoLimit = new(int)
+	*ret.GeoLimit = ds.GeoLimit
+	ret.GeoLimitCountries = ds.GeoLimitCountries
+	ret.GeoLimitRedirectURL = ds.GeoLimitRedirectURL
+	ret.GeoProvider = new(int)
+	*ret.GeoProvider = ds.GeoProvider
+	ret.GlobalMaxMBPS = ds.GlobalMaxMBPS
+	ret.GlobalMaxTPS = ds.GlobalMaxTPS
+	ret.HTTPBypassFQDN = ds.HTTPBypassFQDN
+	ret.ID = ds.ID
+	ret.InfoURL = ds.InfoURL
+	ret.InitialDispersion = ds.InitialDispersion
+	ret.InnerHeaderRewrite = ds.InnerHeaderRewrite
+	ret.IPV6RoutingEnabled = new(bool)
+	*ret.IPV6RoutingEnabled = ds.IPV6RoutingEnabled
+	ret.LastHeaderRewrite = ds.LastHeaderRewrite
+	ret.LastUpdated = TimeNoModFromTime(ds.LastUpdated)
+	ret.LogsEnabled = new(bool)
+	*ret.LogsEnabled = ds.LogsEnabled
+	ret.LongDesc = ds.LongDesc
+	ret.LongDesc1 = ds.LongDesc1
+	ret.LongDesc2 = ds.LongDesc2
+	ret.MatchList = new([]DeliveryServiceMatch)
+	*ret.MatchList = make([]DeliveryServiceMatch, len(ds.MatchList))
+	copy(*ret.MatchList, ds.MatchList)
+	ret.MaxDNSAnswers = ds.MaxDNSAnswers
+	ret.MaxOriginConnections = ds.MaxOriginConnections
+	ret.MaxRequestHeaderBytes = ds.MaxRequestHeaderBytes
+	ret.MidHeaderRewrite = ds.MidHeaderRewrite
+	ret.MissLat = ds.MissLat
+	ret.MissLong = ds.MissLong
+	ret.MultiSiteOrigin = ds.MultiSiteOrigin
+	ret.OriginShield = ds.OriginShield
+	ret.OrgServerFQDN = ds.OrgServerFQDN
+	ret.ProfileDesc = ds.ProfileDesc
+	ret.ProfileID = ds.ProfileID
+	ret.ProfileName = ds.ProfileName
+	ret.Protocol = ds.Protocol
+	ret.QStringIgnore = ds.QStringIgnore
+	ret.RangeRequestHandling = ds.RangeRequestHandling
+	ret.RangeSliceBlockSize = ds.RangeSliceBlockSize
+	ret.RegexRemap = ds.RegexRemap
+	ret.RegionalGeoBlocking = new(bool)
+	*ret.RegionalGeoBlocking = ds.RegionalGeoBlocking
+	ret.RemapText = ds.RemapText
+	ret.RoutingName = new(string)
+	*ret.RoutingName = ds.RoutingName
+	ret.ServiceCategory = ds.ServiceCategory
+	ret.Signed = ds.Signed
+	ret.SigningAlgorithm = ds.SigningAlgorithm
+	ret.SSLKeyVersion = ds.SSLKeyVersion
+	ret.Tenant = ds.Tenant
+	ret.TenantID = new(int)
+	*ret.TenantID = ds.TenantID
+	ret.Topology = ds.Topology
+	ret.TRResponseHeaders = ds.TRResponseHeaders
+	ret.TRRequestHeaders = ds.TRRequestHeaders
+	ret.Type = ds.Type
+	ret.TypeID = new(int)
+	*ret.TypeID = ds.TypeID
+	ret.XMLID = new(string)
+	*ret.XMLID = ds.XMLID
+
+	return ret
 }
 
 // UpgradeToV4 converts the 3.x DS to a 4.x DS
 func (ds *DeliveryServiceNullableV30) UpgradeToV4() DeliveryServiceV4 {
-	return DeliveryServiceV4{
-		DeliveryServiceFieldsV31:         ds.DeliveryServiceFieldsV31,
-		DeliveryServiceFieldsV30:         ds.DeliveryServiceFieldsV30,
-		DeliveryServiceFieldsV15:         ds.DeliveryServiceFieldsV15,
-		DeliveryServiceFieldsV14:         ds.DeliveryServiceFieldsV14,
-		DeliveryServiceFieldsV13:         ds.DeliveryServiceFieldsV13,
-		DeliveryServiceNullableFieldsV11: ds.DeliveryServiceNullableFieldsV11,
+	var ret DeliveryServiceV4
+	if ds.Active != nil && *ds.Active {
+		ret.Active = DS_ACTIVE
+	} else {
+		ret.Active = DS_PRIMED
 	}
+	if ds.AnonymousBlockingEnabled != nil && *ds.AnonymousBlockingEnabled {
+		ret.AnonymousBlockingEnabled = true
+	} else {
+		ret.AnonymousBlockingEnabled = false
+	}
+	ret.CCRDNSTTL = ds.CCRDNSTTL
+	if ds.CDNID != nil {
+		ret.CDNID = *ds.CDNID
+	}
+	ret.CDNName = ds.CDNName
+	ret.CheckPath = ds.CheckPath
+	ret.ConsistentHashRegex = ds.ConsistentHashRegex
+	ret.ConsistentHashQueryParams = make([]string, len(ds.ConsistentHashQueryParams))
+	copy(ret.ConsistentHashQueryParams, ds.ConsistentHashQueryParams)
+	if ds.DeepCachingType != nil && *ds.DeepCachingType == DeepCachingTypeAlways {
+		ret.DeepCachingType = DeepCachingTypeAlways
+	} else {
+		ret.DeepCachingType = DeepCachingTypeNever
+	}
+	if ds.DisplayName != nil {
+		ret.DisplayName = *ds.DisplayName
+	}
+	ret.DNSBypassCNAME = ds.DNSBypassCNAME
+	ret.DNSBypassIP = ds.DNSBypassIP
+	ret.DNSBypassIP6 = ds.DNSBypassIP6
+	ret.DNSBypassTTL = ds.DNSBypassTTL
+	if ds.DSCP != nil {
+		ret.DSCP = *ds.DSCP
+	}
+	ret.EcsEnabled = ds.EcsEnabled
+	ret.EdgeHeaderRewrite = ds.EdgeHeaderRewrite
+	ret.ExampleURLs = make([]string, len(ds.ExampleURLs))
+	copy(ret.ExampleURLs, ds.ExampleURLs)
+	ret.FirstHeaderRewrite = ds.FirstHeaderRewrite
+	ret.FQPacingRate = ds.FQPacingRate
+	if ds.GeoLimit != nil && (*ds.GeoLimit == 1 || *ds.GeoLimit == 2) {
+		ret.GeoLimit = *ds.GeoLimit
+	} else {
+		ret.GeoLimit = 0
+	}
+	ret.GeoLimitCountries = ds.GeoLimitCountries
+	ret.GeoLimitRedirectURL = ds.GeoLimitRedirectURL
+	if ds.GeoProvider != nil && *ds.GeoProvider == 1 {
+		ret.GeoProvider = 1
+	} else {
+		ret.GeoProvider = 0
+	}
+	ret.GlobalMaxMBPS = ds.GlobalMaxMBPS
+	ret.GlobalMaxTPS = ds.GlobalMaxTPS
+	ret.HTTPBypassFQDN = ds.HTTPBypassFQDN
+	ret.ID = ds.ID
+	ret.InfoURL = ds.InfoURL
+	ret.InitialDispersion = ds.InitialDispersion
+	ret.InnerHeaderRewrite = ds.InnerHeaderRewrite
+	if ds.IPV6RoutingEnabled != nil && *ds.IPV6RoutingEnabled {
+		ret.IPV6RoutingEnabled = true
+	} else {
+		ret.IPV6RoutingEnabled = false
+	}
+	ret.LastHeaderRewrite = ds.LastHeaderRewrite
+	if ds.LastUpdated != nil {
+		ret.LastUpdated = ds.LastUpdated.Time
+	}
+	if ds.LogsEnabled != nil && *ds.LogsEnabled {
+		ret.LogsEnabled = true
+	} else {
+		ret.LogsEnabled = false
+	}
+	ret.LongDesc = ds.LongDesc
+	ret.LongDesc1 = ds.LongDesc1
+	ret.LongDesc2 = ds.LongDesc2
+	if ds.MatchList != nil {
+		ret.MatchList = make([]DeliveryServiceMatch, len(*ds.MatchList))
+		copy(ret.MatchList, *ds.MatchList)
+	}
+	ret.MaxDNSAnswers = ds.MaxDNSAnswers
+	ret.MaxOriginConnections = ds.MaxOriginConnections
+	ret.MaxRequestHeaderBytes = ds.MaxRequestHeaderBytes
+	ret.MidHeaderRewrite = ds.MidHeaderRewrite
+	ret.MissLat = ds.MissLat
+	ret.MissLong = ds.MissLong
+	ret.MultiSiteOrigin = ds.MultiSiteOrigin
+	ret.OriginShield = ds.OriginShield
+	ret.OrgServerFQDN = ds.OrgServerFQDN
+	ret.ProfileDesc = ds.ProfileDesc
+	ret.ProfileID = ds.ProfileID
+	ret.ProfileName = ds.ProfileName
+	ret.Protocol = ds.Protocol
+	ret.QStringIgnore = ds.QStringIgnore
+	ret.RangeRequestHandling = ds.RangeRequestHandling
+	ret.RangeSliceBlockSize = ds.RangeSliceBlockSize
+	ret.RegexRemap = ds.RegexRemap
+	if ds.RegionalGeoBlocking != nil && *ds.RegionalGeoBlocking {
+		ret.RegionalGeoBlocking = true
+	} else {
+		ret.RegionalGeoBlocking = false
+	}
+	ret.RemapText = ds.RemapText
+	if ds.RoutingName != nil {
+		ret.RoutingName = *ds.RoutingName
+	}
+	ret.ServiceCategory = ds.ServiceCategory
+	ret.Signed = ds.Signed
+	ret.SigningAlgorithm = ds.SigningAlgorithm
+	ret.SSLKeyVersion = ds.SSLKeyVersion
+	ret.Tenant = ds.Tenant
+	if ds.TenantID != nil {
+		ret.TenantID = *ds.TenantID
+	}
+	ret.Topology = ds.Topology
+	ret.TRResponseHeaders = ds.TRResponseHeaders
+	ret.TRRequestHeaders = ds.TRRequestHeaders
+	ret.Type = ds.Type
+	if ds.TypeID != nil {
+		ret.TypeID = *ds.TypeID
+	}
+	if ds.XMLID != nil {
+		ret.XMLID = *ds.XMLID
+	}
+	return ret
 }
 
 func jsonValue(v interface{}) (driver.Value, error) {

--- a/lib/go-tc/deliveryservices_test.go
+++ b/lib/go-tc/deliveryservices_test.go
@@ -1,0 +1,696 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tc
+
+import "testing"
+
+func compareV31DSes(a, b DeliveryServiceNullableV30, t *testing.T) {
+	if (a.Active == nil && b.Active != nil) || (a.Active != nil && b.Active == nil) {
+		t.Error("Mismatched 'Active' property; one was nil but the other was not.")
+	} else if a.Active != nil && *a.Active != *b.Active {
+		t.Errorf("Mismatched 'Active' property; one was '%v', the other was '%v'", *a.Active, *b.Active)
+	}
+	if (a.AnonymousBlockingEnabled == nil && b.AnonymousBlockingEnabled != nil) || (a.AnonymousBlockingEnabled != nil && b.AnonymousBlockingEnabled == nil) {
+		t.Error("Mismatched 'AnonymousBlockingEnabled' property; one was nil but the other was not.")
+	} else if a.AnonymousBlockingEnabled != nil && *a.AnonymousBlockingEnabled != *b.AnonymousBlockingEnabled {
+		t.Errorf("Mismatched 'AnonymousBlockingEnabled' property; one was '%v', the other was '%v'", *a.AnonymousBlockingEnabled, *b.AnonymousBlockingEnabled)
+	}
+	if (a.CCRDNSTTL == nil && b.CCRDNSTTL != nil) || (a.CCRDNSTTL != nil && b.CCRDNSTTL == nil) {
+		t.Error("Mismatched 'CCRDNSTTL' property; one was nil but the other was not.")
+	} else if a.CCRDNSTTL != nil && *a.CCRDNSTTL != *b.CCRDNSTTL {
+		t.Errorf("Mismatched 'CCRDNSTTL' property; one was '%v', the other was '%v'", *a.CCRDNSTTL, *b.CCRDNSTTL)
+	}
+	if (a.CDNID == nil && b.CDNID != nil) || (a.CDNID != nil && b.CDNID == nil) {
+		t.Error("Mismatched 'CDNID' property; one was nil but the other was not.")
+	} else if a.CDNID != nil && *a.CDNID != *b.CDNID {
+		t.Errorf("Mismatched 'CDNID' property; one was '%v', the other was '%v'", *a.CDNID, *b.CDNID)
+	}
+	if (a.CDNName == nil && b.CDNName != nil) || (a.CDNName != nil && b.CDNName == nil) {
+		t.Error("Mismatched 'CDNName' property; one was nil but the other was not.")
+	} else if a.CDNName != nil && *a.CDNName != *b.CDNName {
+		t.Errorf("Mismatched 'CDNName' property; one was '%v', the other was '%v'", *a.CDNName, *b.CDNName)
+	}
+	if (a.CheckPath == nil && b.CheckPath != nil) || (a.CheckPath != nil && b.CheckPath == nil) {
+		t.Error("Mismatched 'CheckPath' property; one was nil but the other was not.")
+	} else if a.CheckPath != nil && *a.CheckPath != *b.CheckPath {
+		t.Errorf("Mismatched 'CheckPath' property; one was '%v', the other was '%v'", *a.CheckPath, *b.CheckPath)
+	}
+	if len(a.ConsistentHashQueryParams) != len(b.ConsistentHashQueryParams) {
+		t.Errorf("Mismatched 'ConsistentHashQueryParams' property; one contained %d but the other contained %d.", len(a.ConsistentHashQueryParams), len(b.ConsistentHashQueryParams))
+	} else {
+		for i, qp := range a.ConsistentHashQueryParams {
+			if qp != b.ConsistentHashQueryParams[i] {
+				t.Errorf("Mismatched 'ConsistentHashQueryParams[%d]'; one was %s, but the other was %s", i, qp, b.ConsistentHashQueryParams[i])
+			}
+		}
+	}
+	if (a.ConsistentHashRegex == nil && b.ConsistentHashRegex != nil) || (a.ConsistentHashRegex != nil && b.ConsistentHashRegex == nil) {
+		t.Error("Mismatched 'ConsistentHashRegex' property; one was nil but the other was not.")
+	} else if a.ConsistentHashRegex != nil && *a.ConsistentHashRegex != *b.ConsistentHashRegex {
+		t.Errorf("Mismatched 'ConsistentHashRegex' property; one was '%v', the other was '%v'", *a.ConsistentHashRegex, *b.ConsistentHashRegex)
+	}
+	if (a.DeepCachingType == nil && b.DeepCachingType != nil) || (a.DeepCachingType != nil && b.DeepCachingType == nil) {
+		t.Error("Mismatched 'DeepCachingType' property; one was nil but the other was not.")
+	} else if a.DeepCachingType != nil && *a.DeepCachingType != *b.DeepCachingType {
+		t.Errorf("Mismatched 'DeepCachingType' property; one was '%v', the other was '%v'", *a.DeepCachingType, *b.DeepCachingType)
+	}
+	if (a.DisplayName == nil && b.DisplayName != nil) || (a.DisplayName != nil && b.DisplayName == nil) {
+		t.Error("Mismatched 'DisplayName' property; one was nil but the other was not.")
+	} else if a.DisplayName != nil && *a.DisplayName != *b.DisplayName {
+		t.Errorf("Mismatched 'DisplayName' property; one was '%v', the other was '%v'", *a.DisplayName, *b.DisplayName)
+	}
+	if (a.DNSBypassCNAME == nil && b.DNSBypassCNAME != nil) || (a.DNSBypassCNAME != nil && b.DNSBypassCNAME == nil) {
+		t.Error("Mismatched 'DNSBypassCNAME' property; one was nil but the other was not.")
+	} else if a.DNSBypassCNAME != nil && *a.DNSBypassCNAME != *b.DNSBypassCNAME {
+		t.Errorf("Mismatched 'DNSBypassCNAME' property; one was '%v', the other was '%v'", *a.DNSBypassCNAME, *b.DNSBypassCNAME)
+	}
+	if (a.DNSBypassIP6 == nil && b.DNSBypassIP6 != nil) || (a.DNSBypassIP6 != nil && b.DNSBypassIP6 == nil) {
+		t.Error("Mismatched 'DNSBypassIP6' property; one was nil but the other was not.")
+	} else if a.DNSBypassIP6 != nil && *a.DNSBypassIP6 != *b.DNSBypassIP6 {
+		t.Errorf("Mismatched 'DNSBypassIP6' property; one was '%v', the other was '%v'", *a.DNSBypassIP6, *b.DNSBypassIP6)
+	}
+	if (a.DNSBypassIP == nil && b.DNSBypassIP != nil) || (a.DNSBypassIP != nil && b.DNSBypassIP == nil) {
+		t.Error("Mismatched 'DNSBypassIP' property; one was nil but the other was not.")
+	} else if a.DNSBypassIP != nil && *a.DNSBypassIP != *b.DNSBypassIP {
+		t.Errorf("Mismatched 'DNSBypassIP' property; one was '%v', the other was '%v'", *a.DNSBypassIP, *b.DNSBypassIP)
+	}
+	if (a.DNSBypassTTL == nil && b.DNSBypassTTL != nil) || (a.DNSBypassTTL != nil && b.DNSBypassTTL == nil) {
+		t.Error("Mismatched 'DNSBypassTTL' property; one was nil but the other was not.")
+	} else if a.DNSBypassTTL != nil && *a.DNSBypassTTL != *b.DNSBypassTTL {
+		t.Errorf("Mismatched 'DNSBypassTTL' property; one was '%v', the other was '%v'", *a.DNSBypassTTL, *b.DNSBypassTTL)
+	}
+	if (a.DSCP == nil && b.DSCP != nil) || (a.DSCP != nil && b.DSCP == nil) {
+		t.Error("Mismatched 'DSCP' property; one was nil but the other was not.")
+	} else if a.DSCP != nil && *a.DSCP != *b.DSCP {
+		t.Errorf("Mismatched 'DSCP' property; one was '%v', the other was '%v'", *a.DSCP, *b.DSCP)
+	}
+	if a.EcsEnabled != b.EcsEnabled {
+		t.Errorf("Mismatched 'EcsEnabled' property; one was '%v', the other was '%v'", a.EcsEnabled, b.EcsEnabled)
+	}
+	if (a.EdgeHeaderRewrite == nil && b.EdgeHeaderRewrite != nil) || (a.EdgeHeaderRewrite != nil && b.EdgeHeaderRewrite == nil) {
+		t.Error("Mismatched 'EdgeHeaderRewrite' property; one was nil but the other was not.")
+	} else if a.EdgeHeaderRewrite != nil && *a.EdgeHeaderRewrite != *b.EdgeHeaderRewrite {
+		t.Errorf("Mismatched 'EdgeHeaderRewrite' property; one was '%v', the other was '%v'", *a.EdgeHeaderRewrite, *b.EdgeHeaderRewrite)
+	}
+	if len(a.ExampleURLs) != len(b.ExampleURLs) {
+		t.Errorf("Mismatched 'ExampleURLs' property; one contained %d but the other contained %d", len(a.ExampleURLs), len(b.ExampleURLs))
+	} else {
+		for i, eu := range a.ExampleURLs {
+			if eu != b.ExampleURLs[i] {
+				t.Errorf("Mismatched 'ExampleURLs[%d]' property; one was '%v', the other was '%v'", i, eu, b.ExampleURLs[i])
+			}
+		}
+	}
+	if (a.FirstHeaderRewrite == nil && b.FirstHeaderRewrite != nil) || (a.FirstHeaderRewrite != nil && b.FirstHeaderRewrite == nil) {
+		t.Error("Mismatched 'FirstHeaderRewrite' property; one was nil but the other was not.")
+	} else if a.FirstHeaderRewrite != nil && *a.FirstHeaderRewrite != *b.FirstHeaderRewrite {
+		t.Errorf("Mismatched 'FirstHeaderRewrite' property; one was '%v', the other was '%v'", *a.FirstHeaderRewrite, *b.FirstHeaderRewrite)
+	}
+	if (a.FQPacingRate == nil && b.FQPacingRate != nil) || (a.FQPacingRate != nil && b.FQPacingRate == nil) {
+		t.Error("Mismatched 'FQPacingRate' property; one was nil but the other was not.")
+	} else if a.FQPacingRate != nil && *a.FQPacingRate != *b.FQPacingRate {
+		t.Errorf("Mismatched 'FQPacingRate' property; one was '%v', the other was '%v'", *a.FQPacingRate, *b.FQPacingRate)
+	}
+	if (a.GeoLimit == nil && b.GeoLimit != nil) || (a.GeoLimit != nil && b.GeoLimit == nil) {
+		t.Error("Mismatched 'GeoLimit' property; one was nil but the other was not.")
+	} else if a.GeoLimit != nil && *a.GeoLimit != *b.GeoLimit {
+		t.Errorf("Mismatched 'GeoLimit' property; one was '%v', the other was '%v'", *a.GeoLimit, *b.GeoLimit)
+	}
+	if (a.GeoLimitCountries == nil && b.GeoLimitCountries != nil) || (a.GeoLimitCountries != nil && b.GeoLimitCountries == nil) {
+		t.Error("Mismatched 'GeoLimitCountries' property; one was nil but the other was not.")
+	} else if a.GeoLimitCountries != nil && *a.GeoLimitCountries != *b.GeoLimitCountries {
+		t.Errorf("Mismatched 'GeoLimitCountries' property; one was '%v', the other was '%v'", *a.GeoLimitCountries, *b.GeoLimitCountries)
+	}
+	if (a.GeoLimitRedirectURL == nil && b.GeoLimitRedirectURL != nil) || (a.GeoLimitRedirectURL != nil && b.GeoLimitRedirectURL == nil) {
+		t.Error("Mismatched 'GeoLimitRedirectURL' property; one was nil but the other was not.")
+	} else if a.GeoLimitRedirectURL != nil && *a.GeoLimitRedirectURL != *b.GeoLimitRedirectURL {
+		t.Errorf("Mismatched 'GeoLimitRedirectURL' property; one was '%v', the other was '%v'", *a.GeoLimitRedirectURL, *b.GeoLimitRedirectURL)
+	}
+	if (a.GeoProvider == nil && b.GeoProvider != nil) || (a.GeoProvider != nil && b.GeoProvider == nil) {
+		t.Error("Mismatched 'GeoProvider' property; one was nil but the other was not.")
+	} else if a.GeoProvider != nil && *a.GeoProvider != *b.GeoProvider {
+		t.Errorf("Mismatched 'GeoProvider' property; one was '%v', the other was '%v'", *a.GeoProvider, *b.GeoProvider)
+	}
+	if (a.GlobalMaxMBPS == nil && b.GlobalMaxMBPS != nil) || (a.GlobalMaxMBPS != nil && b.GlobalMaxMBPS == nil) {
+		t.Error("Mismatched 'GlobalMaxMBPS' property; one was nil but the other was not.")
+	} else if a.GlobalMaxMBPS != nil && *a.GlobalMaxMBPS != *b.GlobalMaxMBPS {
+		t.Errorf("Mismatched 'GlobalMaxMBPS' property; one was '%v', the other was '%v'", *a.GlobalMaxMBPS, *b.GlobalMaxMBPS)
+	}
+	if (a.GlobalMaxTPS == nil && b.GlobalMaxTPS != nil) || (a.GlobalMaxTPS != nil && b.GlobalMaxTPS == nil) {
+		t.Error("Mismatched 'GlobalMaxTPS' property; one was nil but the other was not.")
+	} else if a.GlobalMaxTPS != nil && *a.GlobalMaxTPS != *b.GlobalMaxTPS {
+		t.Errorf("Mismatched 'GlobalMaxTPS' property; one was '%v', the other was '%v'", *a.GlobalMaxTPS, *b.GlobalMaxTPS)
+	}
+	if (a.HTTPBypassFQDN == nil && b.HTTPBypassFQDN != nil) || (a.HTTPBypassFQDN != nil && b.HTTPBypassFQDN == nil) {
+		t.Error("Mismatched 'HTTPBypassFQDN' property; one was nil but the other was not.")
+	} else if a.HTTPBypassFQDN != nil && *a.HTTPBypassFQDN != *b.HTTPBypassFQDN {
+		t.Errorf("Mismatched 'HTTPBypassFQDN' property; one was '%v', the other was '%v'", *a.HTTPBypassFQDN, *b.HTTPBypassFQDN)
+	}
+	if (a.ID == nil && b.ID != nil) || (a.ID != nil && b.ID == nil) {
+		t.Error("Mismatched 'ID' property; one was nil but the other was not.")
+	} else if a.ID != nil && *a.ID != *b.ID {
+		t.Errorf("Mismatched 'ID' property; one was '%v', the other was '%v'", *a.ID, *b.ID)
+	}
+	if (a.InfoURL == nil && b.InfoURL != nil) || (a.InfoURL != nil && b.InfoURL == nil) {
+		t.Error("Mismatched 'InfoURL' property; one was nil but the other was not.")
+	} else if a.InfoURL != nil && *a.InfoURL != *b.InfoURL {
+		t.Errorf("Mismatched 'InfoURL' property; one was '%v', the other was '%v'", *a.InfoURL, *b.InfoURL)
+	}
+	if (a.InitialDispersion == nil && b.InitialDispersion != nil) || (a.InitialDispersion != nil && b.InitialDispersion == nil) {
+		t.Error("Mismatched 'InitialDispersion' property; one was nil but the other was not.")
+	} else if a.InitialDispersion != nil && *a.InitialDispersion != *b.InitialDispersion {
+		t.Errorf("Mismatched 'InitialDispersion' property; one was '%v', the other was '%v'", *a.InitialDispersion, *b.InitialDispersion)
+	}
+	if (a.InnerHeaderRewrite == nil && b.InnerHeaderRewrite != nil) || (a.InnerHeaderRewrite != nil && b.InnerHeaderRewrite == nil) {
+		t.Error("Mismatched 'InnerHeaderRewrite' property; one was nil but the other was not.")
+	} else if a.InnerHeaderRewrite != nil && *a.InnerHeaderRewrite != *b.InnerHeaderRewrite {
+		t.Errorf("Mismatched 'InnerHeaderRewrite' property; one was '%v', the other was '%v'", *a.InnerHeaderRewrite, *b.InnerHeaderRewrite)
+	}
+	if (a.IPV6RoutingEnabled == nil && b.IPV6RoutingEnabled != nil) || (a.IPV6RoutingEnabled != nil && b.IPV6RoutingEnabled == nil) {
+		t.Error("Mismatched 'IPV6RoutingEnabled' property; one was nil but the other was not.")
+	} else if a.IPV6RoutingEnabled != nil && *a.IPV6RoutingEnabled != *b.IPV6RoutingEnabled {
+		t.Errorf("Mismatched 'IPV6RoutingEnabled' property; one was '%v', the other was '%v'", *a.IPV6RoutingEnabled, *b.IPV6RoutingEnabled)
+	}
+	if (a.LastHeaderRewrite == nil && b.LastHeaderRewrite != nil) || (a.LastHeaderRewrite != nil && b.LastHeaderRewrite == nil) {
+		t.Error("Mismatched 'LastHeaderRewrite' property; one was nil but the other was not.")
+	} else if a.LastHeaderRewrite != nil && *a.LastHeaderRewrite != *b.LastHeaderRewrite {
+		t.Errorf("Mismatched 'LastHeaderRewrite' property; one was '%v', the other was '%v'", *a.LastHeaderRewrite, *b.LastHeaderRewrite)
+	}
+	if (a.LastUpdated == nil && b.LastUpdated != nil) || (a.LastUpdated != nil && b.LastUpdated == nil) {
+		t.Error("Mismatched 'LastUpdated' property; one was nil but the other was not.")
+	} else if a.LastUpdated != nil && *a.LastUpdated != *b.LastUpdated {
+		t.Errorf("Mismatched 'LastUpdated' property; one was '%v', the other was '%v'", *a.LastUpdated, *b.LastUpdated)
+	}
+	if (a.LogsEnabled == nil && b.LogsEnabled != nil) || (a.LogsEnabled != nil && b.LogsEnabled == nil) {
+		t.Error("Mismatched 'LogsEnabled' property; one was nil but the other was not.")
+	} else if a.LogsEnabled != nil && *a.LogsEnabled != *b.LogsEnabled {
+		t.Errorf("Mismatched 'LogsEnabled' property; one was '%v', the other was '%v'", *a.LogsEnabled, *b.LogsEnabled)
+	}
+	if (a.LongDesc1 == nil && b.LongDesc1 != nil) || (a.LongDesc1 != nil && b.LongDesc1 == nil) {
+		t.Error("Mismatched 'LongDesc1' property; one was nil but the other was not.")
+	} else if a.LongDesc1 != nil && *a.LongDesc1 != *b.LongDesc1 {
+		t.Errorf("Mismatched 'LongDesc1' property; one was '%v', the other was '%v'", *a.LongDesc1, *b.LongDesc1)
+	}
+	if (a.LongDesc2 == nil && b.LongDesc2 != nil) || (a.LongDesc2 != nil && b.LongDesc2 == nil) {
+		t.Error("Mismatched 'LongDesc2' property; one was nil but the other was not.")
+	} else if a.LongDesc2 != nil && *a.LongDesc2 != *b.LongDesc2 {
+		t.Errorf("Mismatched 'LongDesc2' property; one was '%v', the other was '%v'", *a.LongDesc2, *b.LongDesc2)
+	}
+	if (a.LongDesc == nil && b.LongDesc != nil) || (a.LongDesc != nil && b.LongDesc == nil) {
+		t.Error("Mismatched 'LongDesc' property; one was nil but the other was not.")
+	} else if a.LongDesc != nil && *a.LongDesc != *b.LongDesc {
+		t.Errorf("Mismatched 'LongDesc' property; one was '%v', the other was '%v'", *a.LongDesc, *b.LongDesc)
+	}
+	if (a.MatchList != nil && b.MatchList == nil) || (a.MatchList == nil && b.MatchList != nil) {
+		t.Error("Mismatched 'MatchList' property; one was nil but the other was not")
+	} else if a.MatchList != nil {
+		if len(*a.MatchList) != len(*b.MatchList) {
+			t.Errorf("Mismatched 'MatchList' property; one contained %d but the other contained %d", len(*a.MatchList), len(*b.MatchList))
+		} else {
+			for i, m := range *a.MatchList {
+				if m != (*b.MatchList)[i] {
+					t.Errorf("Mismatched 'MatchList[%d]' property; one was '%v', the other was '%v'", i, m, (*b.MatchList)[i])
+				}
+			}
+		}
+	}
+	if (a.MaxDNSAnswers == nil && b.MaxDNSAnswers != nil) || (a.MaxDNSAnswers != nil && b.MaxDNSAnswers == nil) {
+		t.Error("Mismatched 'MaxDNSAnswers' property; one was nil but the other was not.")
+	} else if a.MaxDNSAnswers != nil && *a.MaxDNSAnswers != *b.MaxDNSAnswers {
+		t.Errorf("Mismatched 'MaxDNSAnswers' property; one was '%v', the other was '%v'", *a.MaxDNSAnswers, *b.MaxDNSAnswers)
+	}
+	if (a.MaxOriginConnections == nil && b.MaxOriginConnections != nil) || (a.MaxOriginConnections != nil && b.MaxOriginConnections == nil) {
+		t.Error("Mismatched 'MaxOriginConnections' property; one was nil but the other was not.")
+	} else if a.MaxOriginConnections != nil && *a.MaxOriginConnections != *b.MaxOriginConnections {
+		t.Errorf("Mismatched 'MaxOriginConnections' property; one was '%v', the other was '%v'", *a.MaxOriginConnections, *b.MaxOriginConnections)
+	}
+	if (a.MaxRequestHeaderBytes == nil && b.MaxRequestHeaderBytes != nil) || (a.MaxRequestHeaderBytes != nil && b.MaxRequestHeaderBytes == nil) {
+		t.Error("Mismatched 'MaxRequestHeaderBytes' property; one was nil but the other was not.")
+	} else if a.MaxRequestHeaderBytes != nil && *a.MaxRequestHeaderBytes != *b.MaxRequestHeaderBytes {
+		t.Errorf("Mismatched 'MaxRequestHeaderBytes' property; one was '%v', the other was '%v'", *a.MaxRequestHeaderBytes, *b.MaxRequestHeaderBytes)
+	}
+	if (a.MidHeaderRewrite == nil && b.MidHeaderRewrite != nil) || (a.MidHeaderRewrite != nil && b.MidHeaderRewrite == nil) {
+		t.Error("Mismatched 'MidHeaderRewrite' property; one was nil but the other was not.")
+	} else if a.MidHeaderRewrite != nil && *a.MidHeaderRewrite != *b.MidHeaderRewrite {
+		t.Errorf("Mismatched 'MidHeaderRewrite' property; one was '%v', the other was '%v'", *a.MidHeaderRewrite, *b.MidHeaderRewrite)
+	}
+	if (a.MissLat == nil && b.MissLat != nil) || (a.MissLat != nil && b.MissLat == nil) {
+		t.Error("Mismatched 'MissLat' property; one was nil but the other was not.")
+	} else if a.MissLat != nil && *a.MissLat != *b.MissLat {
+		t.Errorf("Mismatched 'MissLat' property; one was '%v', the other was '%v'", *a.MissLat, *b.MissLat)
+	}
+	if (a.MissLong == nil && b.MissLong != nil) || (a.MissLong != nil && b.MissLong == nil) {
+		t.Error("Mismatched 'MissLong' property; one was nil but the other was not.")
+	} else if a.MissLong != nil && *a.MissLong != *b.MissLong {
+		t.Errorf("Mismatched 'MissLong' property; one was '%v', the other was '%v'", *a.MissLong, *b.MissLong)
+	}
+	if (a.MultiSiteOrigin == nil && b.MultiSiteOrigin != nil) || (a.MultiSiteOrigin != nil && b.MultiSiteOrigin == nil) {
+		t.Error("Mismatched 'MultiSiteOrigin' property; one was nil but the other was not.")
+	} else if a.MultiSiteOrigin != nil && *a.MultiSiteOrigin != *b.MultiSiteOrigin {
+		t.Errorf("Mismatched 'MultiSiteOrigin' property; one was '%v', the other was '%v'", *a.MultiSiteOrigin, *b.MultiSiteOrigin)
+	}
+	if (a.OrgServerFQDN == nil && b.OrgServerFQDN != nil) || (a.OrgServerFQDN != nil && b.OrgServerFQDN == nil) {
+		t.Error("Mismatched 'OrgServerFQDN' property; one was nil but the other was not.")
+	} else if a.OrgServerFQDN != nil && *a.OrgServerFQDN != *b.OrgServerFQDN {
+		t.Errorf("Mismatched 'OrgServerFQDN' property; one was '%v', the other was '%v'", *a.OrgServerFQDN, *b.OrgServerFQDN)
+	}
+	if (a.OriginShield == nil && b.OriginShield != nil) || (a.OriginShield != nil && b.OriginShield == nil) {
+		t.Error("Mismatched 'OriginShield' property; one was nil but the other was not.")
+	} else if a.OriginShield != nil && *a.OriginShield != *b.OriginShield {
+		t.Errorf("Mismatched 'OriginShield' property; one was '%v', the other was '%v'", *a.OriginShield, *b.OriginShield)
+	}
+	if (a.ProfileDesc == nil && b.ProfileDesc != nil) || (a.ProfileDesc != nil && b.ProfileDesc == nil) {
+		t.Error("Mismatched 'ProfileDesc' property; one was nil but the other was not.")
+	} else if a.ProfileDesc != nil && *a.ProfileDesc != *b.ProfileDesc {
+		t.Errorf("Mismatched 'ProfileDesc' property; one was '%v', the other was '%v'", *a.ProfileDesc, *b.ProfileDesc)
+	}
+	if (a.ProfileID == nil && b.ProfileID != nil) || (a.ProfileID != nil && b.ProfileID == nil) {
+		t.Error("Mismatched 'ProfileID' property; one was nil but the other was not.")
+	} else if a.ProfileID != nil && *a.ProfileID != *b.ProfileID {
+		t.Errorf("Mismatched 'ProfileID' property; one was '%v', the other was '%v'", *a.ProfileID, *b.ProfileID)
+	}
+	if (a.ProfileName == nil && b.ProfileName != nil) || (a.ProfileName != nil && b.ProfileName == nil) {
+		t.Error("Mismatched 'ProfileName' property; one was nil but the other was not.")
+	} else if a.ProfileName != nil && *a.ProfileName != *b.ProfileName {
+		t.Errorf("Mismatched 'ProfileName' property; one was '%v', the other was '%v'", *a.ProfileName, *b.ProfileName)
+	}
+	if (a.Protocol == nil && b.Protocol != nil) || (a.Protocol != nil && b.Protocol == nil) {
+		t.Error("Mismatched 'Protocol' property; one was nil but the other was not.")
+	} else if a.Protocol != nil && *a.Protocol != *b.Protocol {
+		t.Errorf("Mismatched 'Protocol' property; one was '%v', the other was '%v'", *a.Protocol, *b.Protocol)
+	}
+	if (a.QStringIgnore == nil && b.QStringIgnore != nil) || (a.QStringIgnore != nil && b.QStringIgnore == nil) {
+		t.Error("Mismatched 'QStringIgnore' property; one was nil but the other was not.")
+	} else if a.QStringIgnore != nil && *a.QStringIgnore != *b.QStringIgnore {
+		t.Errorf("Mismatched 'QStringIgnore' property; one was '%v', the other was '%v'", *a.QStringIgnore, *b.QStringIgnore)
+	}
+	if (a.RangeRequestHandling == nil && b.RangeRequestHandling != nil) || (a.RangeRequestHandling != nil && b.RangeRequestHandling == nil) {
+		t.Error("Mismatched 'RangeRequestHandling' property; one was nil but the other was not.")
+	} else if a.RangeRequestHandling != nil && *a.RangeRequestHandling != *b.RangeRequestHandling {
+		t.Errorf("Mismatched 'RangeRequestHandling' property; one was '%v', the other was '%v'", *a.RangeRequestHandling, *b.RangeRequestHandling)
+	}
+	if (a.RangeSliceBlockSize == nil && b.RangeSliceBlockSize != nil) || (a.RangeSliceBlockSize != nil && b.RangeSliceBlockSize == nil) {
+		t.Error("Mismatched 'RangeSliceBlockSize' property; one was nil but the other was not.")
+	} else if a.RangeSliceBlockSize != nil && *a.RangeSliceBlockSize != *b.RangeSliceBlockSize {
+		t.Errorf("Mismatched 'RangeSliceBlockSize' property; one was '%v', the other was '%v'", *a.RangeSliceBlockSize, *b.RangeSliceBlockSize)
+	}
+	if (a.RegexRemap == nil && b.RegexRemap != nil) || (a.RegexRemap != nil && b.RegexRemap == nil) {
+		t.Error("Mismatched 'RegexRemap' property; one was nil but the other was not.")
+	} else if a.RegexRemap != nil && *a.RegexRemap != *b.RegexRemap {
+		t.Errorf("Mismatched 'RegexRemap' property; one was '%v', the other was '%v'", *a.RegexRemap, *b.RegexRemap)
+	}
+	if (a.RegionalGeoBlocking == nil && b.RegionalGeoBlocking != nil) || (a.RegionalGeoBlocking != nil && b.RegionalGeoBlocking == nil) {
+		t.Error("Mismatched 'RegionalGeoBlocking' property; one was nil but the other was not.")
+	} else if a.RegionalGeoBlocking != nil && *a.RegionalGeoBlocking != *b.RegionalGeoBlocking {
+		t.Errorf("Mismatched 'RegionalGeoBlocking' property; one was '%v', the other was '%v'", *a.RegionalGeoBlocking, *b.RegionalGeoBlocking)
+	}
+	if (a.RemapText == nil && b.RemapText != nil) || (a.RemapText != nil && b.RemapText == nil) {
+		t.Error("Mismatched 'RemapText' property; one was nil but the other was not.")
+	} else if a.RemapText != nil && *a.RemapText != *b.RemapText {
+		t.Errorf("Mismatched 'RemapText' property; one was '%v', the other was '%v'", *a.RemapText, *b.RemapText)
+	}
+	if (a.RoutingName == nil && b.RoutingName != nil) || (a.RoutingName != nil && b.RoutingName == nil) {
+		t.Error("Mismatched 'RoutingName' property; one was nil but the other was not.")
+	} else if a.RoutingName != nil && *a.RoutingName != *b.RoutingName {
+		t.Errorf("Mismatched 'RoutingName' property; one was '%v', the other was '%v'", *a.RoutingName, *b.RoutingName)
+	}
+	if (a.ServiceCategory == nil && b.ServiceCategory != nil) || (a.ServiceCategory != nil && b.ServiceCategory == nil) {
+		t.Error("Mismatched 'ServiceCategory' property; one was nil but the other was not.")
+	} else if a.ServiceCategory != nil && *a.ServiceCategory != *b.ServiceCategory {
+		t.Errorf("Mismatched 'ServiceCategory' property; one was '%v', the other was '%v'", *a.ServiceCategory, *b.ServiceCategory)
+	}
+	if a.Signed != b.Signed {
+		t.Errorf("Mismatched 'Signed' property; one was '%v', the other was '%v'", a.Signed, b.Signed)
+	}
+	if (a.SigningAlgorithm == nil && b.SigningAlgorithm != nil) || (a.SigningAlgorithm != nil && b.SigningAlgorithm == nil) {
+		t.Error("Mismatched 'SigningAlgorithm' property; one was nil but the other was not.")
+	} else if a.SigningAlgorithm != nil && *a.SigningAlgorithm != *b.SigningAlgorithm {
+		t.Errorf("Mismatched 'SigningAlgorithm' property; one was '%v', the other was '%v'", *a.SigningAlgorithm, *b.SigningAlgorithm)
+	}
+	if (a.SSLKeyVersion == nil && b.SSLKeyVersion != nil) || (a.SSLKeyVersion != nil && b.SSLKeyVersion == nil) {
+		t.Error("Mismatched 'SSLKeyVersion' property; one was nil but the other was not.")
+	} else if a.SSLKeyVersion != nil && *a.SSLKeyVersion != *b.SSLKeyVersion {
+		t.Errorf("Mismatched 'SSLKeyVersion' property; one was '%v', the other was '%v'", *a.SSLKeyVersion, *b.SSLKeyVersion)
+	}
+	if (a.Tenant == nil && b.Tenant != nil) || (a.Tenant != nil && b.Tenant == nil) {
+		t.Error("Mismatched 'Tenant' property; one was nil but the other was not.")
+	} else if a.Tenant != nil && *a.Tenant != *b.Tenant {
+		t.Errorf("Mismatched 'Tenant' property; one was '%v', the other was '%v'", *a.Tenant, *b.Tenant)
+	}
+	if (a.TenantID == nil && b.TenantID != nil) || (a.TenantID != nil && b.TenantID == nil) {
+		t.Error("Mismatched 'TenantID' property; one was nil but the other was not.")
+	} else if a.TenantID != nil && *a.TenantID != *b.TenantID {
+		t.Errorf("Mismatched 'TenantID' property; one was '%v', the other was '%v'", *a.TenantID, *b.TenantID)
+	}
+	if (a.Topology == nil && b.Topology != nil) || (a.Topology != nil && b.Topology == nil) {
+		t.Error("Mismatched 'Topology' property; one was nil but the other was not.")
+	} else if a.Topology != nil && *a.Topology != *b.Topology {
+		t.Errorf("Mismatched 'Topology' property; one was '%v', the other was '%v'", *a.Topology, *b.Topology)
+	}
+	if (a.TRRequestHeaders == nil && b.TRRequestHeaders != nil) || (a.TRRequestHeaders != nil && b.TRRequestHeaders == nil) {
+		t.Error("Mismatched 'TRRequestHeaders' property; one was nil but the other was not.")
+	} else if a.TRRequestHeaders != nil && *a.TRRequestHeaders != *b.TRRequestHeaders {
+		t.Errorf("Mismatched 'TRRequestHeaders' property; one was '%v', the other was '%v'", *a.TRRequestHeaders, *b.TRRequestHeaders)
+	}
+	if (a.TRResponseHeaders == nil && b.TRResponseHeaders != nil) || (a.TRResponseHeaders != nil && b.TRResponseHeaders == nil) {
+		t.Error("Mismatched 'TRResponseHeaders' property; one was nil but the other was not.")
+	} else if a.TRResponseHeaders != nil && *a.TRResponseHeaders != *b.TRResponseHeaders {
+		t.Errorf("Mismatched 'TRResponseHeaders' property; one was '%v', the other was '%v'", *a.TRResponseHeaders, *b.TRResponseHeaders)
+	}
+	if (a.Type == nil && b.Type != nil) || (a.Type != nil && b.Type == nil) {
+		t.Error("Mismatched 'Type' property; one was nil but the other was not.")
+	} else if a.Type != nil && *a.Type != *b.Type {
+		t.Errorf("Mismatched 'Type' property; one was '%v', the other was '%v'", *a.Type, *b.Type)
+	}
+	if (a.TypeID == nil && b.TypeID != nil) || (a.TypeID != nil && b.TypeID == nil) {
+		t.Error("Mismatched 'TypeID' property; one was nil but the other was not.")
+	} else if a.TypeID != nil && *a.TypeID != *b.TypeID {
+		t.Errorf("Mismatched 'TypeID' property; one was '%v', the other was '%v'", *a.TypeID, *b.TypeID)
+	}
+	if (a.XMLID == nil && b.XMLID != nil) || (a.XMLID != nil && b.XMLID == nil) {
+		t.Error("Mismatched 'XMLID' property; one was nil but the other was not.")
+	} else if a.XMLID != nil && *a.XMLID != *b.XMLID {
+		t.Errorf("Mismatched 'XMLID' property; one was '%v', the other was '%v'", *a.XMLID, *b.XMLID)
+	}
+}
+
+// This gets equivalent legacy and new Delivery Services, for testing comparisons.
+func dsUpgradeAndDowngradeTestingPair() (DeliveryServiceNullableV30, DeliveryServiceV4) {
+	anonymousBlockingEnabled := false
+	cacheURL := "testquest"
+	cCRDNSTTL := 42
+	cdnID := -12
+	cdnName := "cdnName"
+	checkPath := "checkPath"
+	consistentHashQueryParams := []string{"consistent", "hash", "query", "params"}
+	consistentHashRegex := "consistentHashRegex"
+	deepCachingType := DeepCachingTypeNever
+	displayName := "displayName"
+	dnsBypassCNAME := "dnsBypassCNAME"
+	dnsBypassIP := "dnsBypassIP"
+	dnsBypassIP6 := "dnsBypassIP6"
+	dnsBypassTTL := 100
+	dscp := -69
+	ecsEnabled := true
+	edgeHeaderRewrite := "edgeHeaderRewrite"
+	exampleURLs := []string{"http://example", "https://URLs"}
+	firstHeaderRewrite := "firstHeaderRewrite"
+	fqPacingRate := 1337
+	geoLimit := 2
+	geoLimitCountries := "geo,Limit,Countries"
+	geoLimitRedirectURL := "wss://geoLimitRedirectURL"
+	geoProvider := 1
+	globalMaxMBPS := -72485
+	globalMaxTPS := 867
+	hTTPBypassFQDN := "hTTPBypassFQDN"
+	id := -1551
+	infoURL := "infoURL"
+	initialDispersion := 65154
+	innerHeaderRewrite := "innerHeaderRewrite"
+	ipv6RoutingEnabled := false
+	lastHeaderRewrite := "lastHeaderRewrite"
+	lastUpdated := NewTimeNoMod()
+	logsEnabled := true
+	longDesc := "longDesc"
+	longDesc1 := "longDesc1"
+	longDesc2 := "longDesc2"
+	maxDNSAnswers := -76675
+	maxOriginConnections := 6514684
+	maxRequestHeaderBytes := 555
+	midHeaderRewrite := "midHeaderRewrite"
+	missLat := -98.171455
+	missLong := 42.122167
+	multiSiteOrigin := false
+	originShield := "originShield"
+	orgServerFQDN := "orgServerFQDN"
+	profileDesc := "profileDesc"
+	profileID := -4657
+	profileName := "profileName"
+	protocol := 87487
+	qstringIgnore := -474
+	rangeRequestHandling := 16716
+	rangeSliceBlockSize := -92559
+	regexRemap := "regexRemap"
+	regionalGeoBlocking := true
+	remapText := "remapText"
+	routingName := "routingName"
+	serviceCategory := "serviceCategory"
+	signed := false
+	signingAlgorithm := "signingAlgorithm"
+	sSLKeyVersion := 721574
+	tenant := "tenant"
+	tenantID := -6551
+	topology := "topology"
+	trResponseHeaders := "trResponseHeaders"
+	trRequestHeaders := "trRequestHeaders"
+	typ := DSTypeDNS
+	typeID := 22
+	xmlid := "xmlid"
+
+	newDS := DeliveryServiceV4{
+		Active:                    DS_PRIMED,
+		AnonymousBlockingEnabled:  anonymousBlockingEnabled,
+		CCRDNSTTL:                 &cCRDNSTTL,
+		CDNID:                     cdnID,
+		CDNName:                   &cdnName,
+		CheckPath:                 &checkPath,
+		ConsistentHashQueryParams: consistentHashQueryParams,
+		ConsistentHashRegex:       &consistentHashRegex,
+		DeepCachingType:           deepCachingType,
+		DisplayName:               displayName,
+		DNSBypassCNAME:            &dnsBypassCNAME,
+		DNSBypassIP:               &dnsBypassIP,
+		DNSBypassIP6:              &dnsBypassIP6,
+		DNSBypassTTL:              &dnsBypassTTL,
+		DSCP:                      dscp,
+		EcsEnabled:                ecsEnabled,
+		EdgeHeaderRewrite:         &edgeHeaderRewrite,
+		ExampleURLs:               exampleURLs,
+		FirstHeaderRewrite:        &firstHeaderRewrite,
+		FQPacingRate:              &fqPacingRate,
+		GeoLimit:                  geoLimit,
+		GeoLimitCountries:         &geoLimitCountries,
+		GeoLimitRedirectURL:       &geoLimitRedirectURL,
+		GeoProvider:               geoProvider,
+		GlobalMaxMBPS:             &globalMaxMBPS,
+		GlobalMaxTPS:              &globalMaxTPS,
+		HTTPBypassFQDN:            &hTTPBypassFQDN,
+		ID:                        &id,
+		InfoURL:                   &infoURL,
+		InitialDispersion:         &initialDispersion,
+		InnerHeaderRewrite:        &innerHeaderRewrite,
+		IPV6RoutingEnabled:        ipv6RoutingEnabled,
+		LastHeaderRewrite:         &lastHeaderRewrite,
+		LastUpdated:               lastUpdated.Time,
+		LogsEnabled:               logsEnabled,
+		LongDesc:                  &longDesc,
+		LongDesc1:                 &longDesc1,
+		LongDesc2:                 &longDesc2,
+		MatchList:                 nil,
+		MaxDNSAnswers:             &maxDNSAnswers,
+		MaxOriginConnections:      &maxOriginConnections,
+		MaxRequestHeaderBytes:     &maxRequestHeaderBytes,
+		MidHeaderRewrite:          &midHeaderRewrite,
+		MissLat:                   &missLat,
+		MissLong:                  &missLong,
+		MultiSiteOrigin:           &multiSiteOrigin,
+		OriginShield:              &originShield,
+		OrgServerFQDN:             &orgServerFQDN,
+		ProfileDesc:               &profileDesc,
+		ProfileID:                 &profileID,
+		ProfileName:               &profileName,
+		Protocol:                  &protocol,
+		QStringIgnore:             &qstringIgnore,
+		RangeRequestHandling:      &rangeRequestHandling,
+		RangeSliceBlockSize:       &rangeSliceBlockSize,
+		RegexRemap:                &regexRemap,
+		RegionalGeoBlocking:       regionalGeoBlocking,
+		RemapText:                 &remapText,
+		RoutingName:               routingName,
+		ServiceCategory:           &serviceCategory,
+		Signed:                    signed,
+		SigningAlgorithm:          &signingAlgorithm,
+		SSLKeyVersion:             &sSLKeyVersion,
+		Tenant:                    &tenant,
+		TenantID:                  tenantID,
+		Topology:                  &topology,
+		TRResponseHeaders:         &trResponseHeaders,
+		TRRequestHeaders:          &trRequestHeaders,
+		Type:                      &typ,
+		TypeID:                    typeID,
+		XMLID:                     xmlid,
+	}
+
+	active := false
+	oldDS := DeliveryServiceNullableV30{
+		DeliveryServiceV30: DeliveryServiceV30{
+			DeliveryServiceNullableV15: DeliveryServiceNullableV15{
+				DeliveryServiceNullableV14: DeliveryServiceNullableV14{
+					DeliveryServiceNullableV13: DeliveryServiceNullableV13{
+						DeliveryServiceNullableV12: DeliveryServiceNullableV12{
+							DeliveryServiceNullableV11: DeliveryServiceNullableV11{
+								DeliveryServiceNullableFieldsV11: DeliveryServiceNullableFieldsV11{
+									Active:                   &active,
+									AnonymousBlockingEnabled: &anonymousBlockingEnabled,
+									CCRDNSTTL:                &cCRDNSTTL,
+									CDNID:                    &cdnID,
+									CDNName:                  &cdnName,
+									CheckPath:                &checkPath,
+									DisplayName:              &displayName,
+									DNSBypassCNAME:           &dnsBypassCNAME,
+									DNSBypassIP:              &dnsBypassIP,
+									DNSBypassIP6:             &dnsBypassIP6,
+									DNSBypassTTL:             &dnsBypassTTL,
+									DSCP:                     &dscp,
+									EdgeHeaderRewrite:        &edgeHeaderRewrite,
+									ExampleURLs:              exampleURLs,
+									GeoLimit:                 &geoLimit,
+									GeoLimitCountries:        &geoLimitCountries,
+									GeoLimitRedirectURL:      &geoLimitRedirectURL,
+									GeoProvider:              &geoProvider,
+									GlobalMaxMBPS:            &globalMaxMBPS,
+									GlobalMaxTPS:             &globalMaxTPS,
+									HTTPBypassFQDN:           &hTTPBypassFQDN,
+									ID:                       &id,
+									InfoURL:                  &infoURL,
+									InitialDispersion:        &initialDispersion,
+									IPV6RoutingEnabled:       &ipv6RoutingEnabled,
+									LastUpdated:              lastUpdated,
+									LogsEnabled:              &logsEnabled,
+									LongDesc:                 &longDesc,
+									LongDesc1:                &longDesc1,
+									LongDesc2:                &longDesc2,
+									MatchList:                nil,
+									MaxDNSAnswers:            &maxDNSAnswers,
+									MidHeaderRewrite:         &midHeaderRewrite,
+									MissLat:                  &missLat,
+									MissLong:                 &missLong,
+									MultiSiteOrigin:          &multiSiteOrigin,
+									OriginShield:             &originShield,
+									OrgServerFQDN:            &orgServerFQDN,
+									ProfileDesc:              &profileDesc,
+									ProfileID:                &profileID,
+									ProfileName:              &profileName,
+									Protocol:                 &protocol,
+									QStringIgnore:            &qstringIgnore,
+									RangeRequestHandling:     &rangeRequestHandling,
+									RegexRemap:               &regexRemap,
+									RegionalGeoBlocking:      &regionalGeoBlocking,
+									RemapText:                &remapText,
+									RoutingName:              &routingName,
+									Signed:                   signed,
+									SSLKeyVersion:            &sSLKeyVersion,
+									TenantID:                 &tenantID,
+									Type:                     &typ,
+									TypeID:                   &typeID,
+									XMLID:                    &xmlid,
+								},
+								DeliveryServiceRemovedFieldsV11: DeliveryServiceRemovedFieldsV11{
+									CacheURL: &cacheURL,
+								},
+							},
+						},
+						DeliveryServiceFieldsV13: DeliveryServiceFieldsV13{
+							DeepCachingType:   &deepCachingType,
+							FQPacingRate:      &fqPacingRate,
+							SigningAlgorithm:  &signingAlgorithm,
+							Tenant:            &tenant,
+							TRResponseHeaders: &trResponseHeaders,
+							TRRequestHeaders:  &trRequestHeaders,
+						},
+					},
+					DeliveryServiceFieldsV14: DeliveryServiceFieldsV14{
+						ConsistentHashQueryParams: consistentHashQueryParams,
+						ConsistentHashRegex:       &consistentHashRegex,
+						MaxOriginConnections:      &maxOriginConnections,
+					},
+				},
+				DeliveryServiceFieldsV15: DeliveryServiceFieldsV15{
+					EcsEnabled:          ecsEnabled,
+					RangeSliceBlockSize: &rangeSliceBlockSize,
+				},
+			},
+			DeliveryServiceFieldsV30: DeliveryServiceFieldsV30{
+				FirstHeaderRewrite: &firstHeaderRewrite,
+				InnerHeaderRewrite: &innerHeaderRewrite,
+				LastHeaderRewrite:  &lastHeaderRewrite,
+				ServiceCategory:    &serviceCategory,
+				Topology:           &topology,
+			},
+		},
+		DeliveryServiceFieldsV31: DeliveryServiceFieldsV31{
+			MaxRequestHeaderBytes: &maxRequestHeaderBytes,
+		},
+	}
+
+	return oldDS, newDS
+}
+
+func TestDeliveryServiceUpgradeAndDowngrade(t *testing.T) {
+	oldDS, newDS := dsUpgradeAndDowngradeTestingPair()
+	compareV31DSes(oldDS, newDS.DowngradeToV3(), t)
+
+	nullableOldDS := DeliveryServiceNullableV30(oldDS)
+	upgraded := nullableOldDS.UpgradeToV4()
+	compareV31DSes(upgraded.DowngradeToV3(), newDS.DowngradeToV3(), t)
+
+	downgraded := newDS.DowngradeToV3()
+	upgraded = downgraded.UpgradeToV4()
+	downgraded = upgraded.DowngradeToV3()
+	compareV31DSes(oldDS, downgraded, t)
+
+	upgraded = nullableOldDS.UpgradeToV4()
+	downgraded = newDS.DowngradeToV3()
+	tmp := downgraded.UpgradeToV4()
+	downgraded = tmp.DowngradeToV3()
+	compareV31DSes(upgraded.DowngradeToV3(), downgraded, t)
+
+	if oldDS.CacheURL == nil {
+		oldDS.CacheURL = new(string)
+		*oldDS.CacheURL = "testquest"
+	}
+
+	upgraded = oldDS.UpgradeToV4()
+	downgraded = upgraded.DowngradeToV3()
+	if downgraded.CacheURL != nil {
+		t.Error("Expected 'cacheurl' to be null after upgrade then downgrade because it doesn't exist in APIv4, but it wasn't")
+	}
+
+	newDS.Active = "ACTIVE"
+	downgraded = newDS.DowngradeToV3()
+	if downgraded.Active == nil {
+		t.Error("'active' was nil after downgrade")
+	} else if !*downgraded.Active {
+		t.Error("Expected 'active' to be true after downgrading an 'ACTIVE' Delivery Service, but it was false")
+	}
+
+	active := true
+	oldDS.Active = &active
+	newDS = oldDS.UpgradeToV4()
+	if newDS.Active != DS_ACTIVE {
+		t.Errorf("Incorrect 'Active' property after upgrade; want: 'ACTIVE', got: '%s'", newDS.Active)
+	}
+
+	active = false
+	newDS = oldDS.UpgradeToV4()
+	if newDS.Active != DS_PRIMED {
+		t.Errorf("Incorrect 'Active' property after upgrade; want: 'PRIMED', got: '%s'", newDS.Active)
+	}
+
+	oldDS.Active = nil
+	newDS = oldDS.UpgradeToV4()
+	if newDS.Active != DS_PRIMED {
+		t.Errorf("Incorrect 'Active' property after upgrade; want: 'PRIMED', got: '%s'", newDS.Active)
+	}
+}

--- a/traffic_ops/app/db/migrations/2021051800000000_ds_active_flag.sql
+++ b/traffic_ops/app/db/migrations/2021051800000000_ds_active_flag.sql
@@ -26,6 +26,43 @@ UPDATE public.deliveryservice SET active_state = 'PRIMED' WHERE active IS FALSE;
 ALTER TABLE public.deliveryservice DROP COLUMN active;
 ALTER TABLE public.deliveryservice RENAME COLUMN active_state TO active;
 
+UPDATE public.deliveryservice_request
+SET
+	deliveryservice = jsonb_set(deliveryservice, '{active}', '"ACTIVE"')
+WHERE
+	deliveryservice IS NOT NULL
+	AND
+	deliveryservice ? 'active'
+	AND
+	(deliveryservice -> 'active')::boolean IS TRUE;
+UPDATE public.deliveryservice_request
+SET
+	deliveryservice = jsonb_set(deliveryservice, '{active}', '"PRIMED"')
+WHERE
+	deliveryservice IS NOT NULL
+	AND
+	deliveryservice ? 'active'
+	AND
+	(deliveryservice -> 'active')::boolean IS FALSE;
+UPDATE public.deliveryservice_request
+SET
+	original = jsonb_set(original, '{active}', '"ACTIVE"')
+WHERE
+	original IS NOT NULL
+	AND
+	original ? 'active'
+	AND
+	(original -> 'active')::boolean IS TRUE;
+UPDATE public.deliveryservice_request
+SET
+	original = jsonb_set(original, '{active}', '"PRIMED"')
+WHERE
+	original IS NOT NULL
+	AND
+	original ? 'active'
+	AND
+	(original -> 'active')::boolean IS FALSE;
+
 -- +goose Down
 ALTER TABLE public.deliveryservice
 ADD COLUMN active_flag boolean DEFAULT FALSE NOT NULL;
@@ -41,3 +78,46 @@ WHERE active IS 'ACTIVE';
 ALTER TABLE public.deliveryservice DROP COLUMN active;
 ALTER TABLE public.deliveryservice RENAME COLUMN active_flag TO active;
 DROP TYPE public.ds_active_state;
+
+UPDATE public.deliveryservice_request
+SET
+	deliveryservice = jsonb_set(deliveryservice, '{active}', 'true')
+WHERE
+	deliveryservice IS NOT NULL
+	AND
+	deliveryservice ? 'active'
+	AND
+	deliveryservice ->> 'active' = 'ACTIVE';
+UPDATE public.deliveryservice_request
+SET
+	deliveryservice = jsonb_set(deliveryservice, '{active}', 'false')
+WHERE
+	deliveryservice IS NOT NULL
+	AND
+	deliveryservice ? 'active'
+	AND (
+		deliveryservice ->> 'active' = 'PRIMED'
+		OR
+		deliveryservice ->> 'active' = 'INACTIVE'
+	);
+UPDATE public.deliveryservice_request
+SET
+	original = jsonb_set(original, '{active}', 'true')
+WHERE
+	original IS NOT NULL
+	AND
+	original ? 'active'
+	AND
+	original ->> 'active' = 'ACTIVE';
+UPDATE public.deliveryservice_request
+SET
+	original = jsonb_set(original, '{active}', 'false')
+WHERE
+	original IS NOT NULL
+	AND
+	original ? 'active'
+	AND (
+		original ->> 'active' = 'PRIMED'
+		OR
+		original ->> 'active' = 'INACTIVE'
+	);

--- a/traffic_ops/app/db/migrations/2021051800000000_ds_active_flag.sql
+++ b/traffic_ops/app/db/migrations/2021051800000000_ds_active_flag.sql
@@ -1,0 +1,43 @@
+-- syntax:postgresql
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+-- +goose Up
+CREATE TYPE public.ds_active_state AS ENUM (
+	'ACTIVE',
+	'INACTIVE',
+	'PRIMED'
+);
+ALTER TABLE public.deliveryservice
+ADD COLUMN active_state ds_active_state NOT NULL DEFAULT 'INACTIVE';
+
+UPDATE public.deliveryservice SET active_state = 'ACTIVE' WHERE active IS TRUE;
+UPDATE public.deliveryservice SET active_state = 'PRIMED' WHERE active IS FALSE;
+
+ALTER TABLE public.deliveryservice DROP COLUMN active;
+ALTER TABLE public.deliveryservice RENAME COLUMN active_state TO active;
+
+-- +goose Down
+ALTER TABLE public.deliveryservice
+ADD COLUMN active_flag boolean DEFAULT FALSE NOT NULL;
+
+UPDATE public.deliveryservice
+SET active_flag = FALSE
+WHERE active IS 'PRIMED' OR active IS 'INACTIVE';
+
+UPDATE public.deliveryservice
+SET active_flag = TRUE
+WHERE active IS 'ACTIVE';
+
+ALTER TABLE public.deliveryservice DROP COLUMN active;
+ALTER TABLE public.deliveryservice RENAME COLUMN active_flag TO active;
+DROP TYPE public.ds_active_state;

--- a/traffic_ops/testing/api/v4/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/cachegroupsdeliveryservices_test.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/apache/trafficcontrol/lib/go-tc"
 	client "github.com/apache/trafficcontrol/traffic_ops/v4-client"
 )
 
@@ -159,12 +160,8 @@ func setInactive(t *testing.T, dsID int) {
 	}
 
 	ds := resp.Response[0]
-	if ds.Active == nil {
-		t.Errorf("Deliver Service #%d had null or undefined 'active'", dsID)
-		ds.Active = new(bool)
-	}
-	if *ds.Active {
-		*ds.Active = false
+	if ds.Active != tc.DS_INACTIVE {
+		ds.Active = tc.DS_INACTIVE
 		_, _, err = TOSession.UpdateDeliveryService(dsID, ds, client.RequestOptions{})
 		if err != nil {
 			t.Errorf("Failed to set Delivery Service #%d to inactive: %v", dsID, err)

--- a/traffic_ops/testing/api/v4/deliveryservice_request_comments_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservice_request_comments_test.go
@@ -105,22 +105,22 @@ func CreateTestDeliveryServiceRequestComments(t *testing.T) {
 		ds = dsr.Requested
 	}
 	resetDS(ds)
-	if ds == nil || ds.XMLID == nil {
-		t.Fatal("first DSR in the test data had a nil DeliveryService or one with no XMLID")
+	if ds == nil {
+		t.Fatal("first DSR in the test data had a nil Delivery Service")
 	}
 
 	opts := client.NewRequestOptions()
-	opts.QueryParameters.Set("xmlId", *ds.XMLID)
+	opts.QueryParameters.Set("xmlId", ds.XMLID)
 	resp, _, err := TOSession.GetDeliveryServiceRequests(opts)
 	if err != nil {
-		t.Fatalf("cannot get Delivery Service Request by XMLID '%s': %v - alerts: %+v", *ds.XMLID, err, resp.Alerts)
+		t.Fatalf("cannot get Delivery Service Request by XMLID '%s': %v - alerts: %+v", ds.XMLID, err, resp.Alerts)
 	}
 	if len(resp.Response) != 1 {
-		t.Fatalf("found %d Delivery Service request by XMLID '%s, expected exactly one", len(resp.Response), *ds.XMLID)
+		t.Fatalf("found %d Delivery Service request by XMLID '%s, expected exactly one", len(resp.Response), ds.XMLID)
 	}
 	respDSR := resp.Response[0]
 	if respDSR.ID == nil {
-		t.Fatalf("got Delivery Service Request with xml_id '%s' that had a null ID", *ds.XMLID)
+		t.Fatalf("got Delivery Service Request with xml_id '%s' that had a null ID", ds.XMLID)
 	}
 
 	for _, comment := range testData.DeliveryServiceRequestComments {

--- a/traffic_ops/testing/api/v4/deliveryservice_requests_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservice_requests_test.go
@@ -48,11 +48,11 @@ func resetDS(ds *tc.DeliveryServiceV4) {
 	if ds == nil {
 		return
 	}
-	ds.CDNID = nil
+	ds.CDNID = 0
 	ds.ID = nil
 	ds.ProfileID = nil
-	ds.TenantID = nil
-	ds.TypeID = nil
+	ds.TenantID = 0
+	ds.TypeID = 0
 }
 
 func TestDeliveryServiceRequests(t *testing.T) {
@@ -90,25 +90,25 @@ func UpdateTestDeliveryServiceRequestsWithHeaders(t *testing.T, header http.Head
 		ds = dsr.Requested
 	}
 	resetDS(ds)
-	if ds == nil || ds.XMLID == nil {
-		t.Fatalf("the %dth DSR in the test data had no DeliveryService - or that DeliveryService had no XMLID", dsrGood)
+	if ds == nil {
+		t.Fatalf("the %dth DSR in the test data had no Delivery Service", dsrGood)
 	}
 	opts := client.NewRequestOptions()
 	opts.Header = header
-	opts.QueryParameters.Set("xmlId", *ds.XMLID)
+	opts.QueryParameters.Set("xmlId", ds.XMLID)
 	resp, _, err := TOSession.GetDeliveryServiceRequests(opts)
 	if err != nil {
-		t.Errorf("cannot get Delivery Service Request by XMLID '%s': %v - alerts: %+v", *ds.XMLID, err, resp.Alerts)
+		t.Errorf("cannot get Delivery Service Request by XMLID '%s': %v - alerts: %+v", ds.XMLID, err, resp.Alerts)
 	}
 	if len(resp.Response) == 0 {
 		t.Fatal("Length of GET DeliveryServiceRequest is 0")
 	}
 	respDSR := resp.Response[0]
 	if respDSR.ID == nil {
-		t.Fatalf("Got a DSR for XML ID '%s' that had a nil ID", *ds.XMLID)
+		t.Fatalf("Got a DSR for XML ID '%s' that had a nil ID", ds.XMLID)
 	}
 	if respDSR.ChangeType != dsr.ChangeType {
-		t.Fatalf("remote representation of DSR with XMLID '%s' differed from stored data", *ds.XMLID)
+		t.Fatalf("remote representation of DSR with XMLID '%s' differed from stored data", ds.XMLID)
 	}
 	var respDS *tc.DeliveryServiceV4
 	if respDSR.ChangeType == tc.DSRChangeTypeDelete {
@@ -117,8 +117,7 @@ func UpdateTestDeliveryServiceRequestsWithHeaders(t *testing.T, header http.Head
 		respDS = respDSR.Requested
 	}
 
-	respDS.DisplayName = new(string)
-	*respDS.DisplayName = "new display name"
+	respDS.DisplayName = "new display name"
 	opts.QueryParameters.Del("xmlId")
 	_, reqInf, err := TOSession.UpdateDeliveryServiceRequest(*respDSR.ID, respDSR, opts)
 	if err == nil {
@@ -144,13 +143,13 @@ func GetTestDeliveryServiceRequestsIMSAfterChange(t *testing.T, header http.Head
 	}
 
 	resetDS(ds)
-	if ds == nil || ds.XMLID == nil {
-		t.Fatalf("the %dth DSR in the test data had no DeliveryService - or that DeliveryService had no XMLID", dsrGood)
+	if ds == nil {
+		t.Fatalf("the %dth DSR in the test data had no Delivery Service", dsrGood)
 	}
 
 	opts := client.NewRequestOptions()
 	opts.Header = header
-	opts.QueryParameters.Set("xmlId", *ds.XMLID)
+	opts.QueryParameters.Set("xmlId", ds.XMLID)
 	resp, reqInf, err := TOSession.GetDeliveryServiceRequests(opts)
 	if err != nil {
 		t.Fatalf("Expected no error, but got: %v - alerts: %+v", err, resp.Alerts)
@@ -227,9 +226,9 @@ func TestDeliveryServiceRequestRules(t *testing.T) {
 		if ds == nil {
 			t.Fatalf("the %dth DSR in the test data had no DeliveryService", dsrGood)
 		}
-		ds.DisplayName = &displayName
-		ds.RoutingName = &routingName
-		ds.XMLID = &XMLID
+		ds.DisplayName = displayName
+		ds.RoutingName = routingName
+		ds.XMLID = XMLID
 
 		_, _, err := TOSession.CreateDeliveryServiceRequest(dsr, client.RequestOptions{})
 		if err == nil {
@@ -254,8 +253,8 @@ func TestDeliveryServiceRequestTypeFields(t *testing.T) {
 			ds = dsr.Requested
 		}
 		resetDS(ds)
-		if ds == nil || ds.XMLID == nil {
-			t.Fatalf("the %dth DSR in the test data had no DeliveryService - or that DeliveryService had no XMLID", dsrBadTenant)
+		if ds == nil {
+			t.Fatalf("the %dth DSR in the test data had no DeliveryService", dsrBadTenant)
 		}
 
 		resp, _, err := TOSession.CreateDeliveryServiceRequest(dsr, client.RequestOptions{})
@@ -278,16 +277,16 @@ func TestDeliveryServiceRequestTypeFields(t *testing.T) {
 		}
 
 		opts := client.NewRequestOptions()
-		opts.QueryParameters.Set("xmlId", *ds.XMLID)
+		opts.QueryParameters.Set("xmlId", ds.XMLID)
 		dsrs, _, err := TOSession.GetDeliveryServiceRequests(opts)
 		if err != nil {
-			t.Errorf("Unexpected error retriving Delivery Service Requests with XMLID '%s': %v - alerts: %+v", *ds.XMLID, err, dsrs.Alerts)
+			t.Errorf("Unexpected error retriving Delivery Service Requests with XMLID '%s': %v - alerts: %+v", ds.XMLID, err, dsrs.Alerts)
 		}
 		if len(dsrs.Response) != 1 {
-			t.Fatalf("expected exactly one Deliveryservice Request with XMLID '%s'; got %d", *ds.XMLID, len(dsrs.Response))
+			t.Fatalf("expected exactly one Deliveryservice Request with XMLID '%s'; got %d", ds.XMLID, len(dsrs.Response))
 		}
 		if dsrs.Response[0].ID == nil {
-			t.Fatalf("got a DSR with a null ID by XMLID '%s'", *ds.XMLID)
+			t.Fatalf("got a DSR with a null ID by XMLID '%s'", ds.XMLID)
 		}
 
 		alert, _, err := TOSession.DeleteDeliveryServiceRequest(*dsrs.Response[0].ID, client.RequestOptions{})
@@ -464,14 +463,14 @@ func GetTestDeliveryServiceRequestsIMS(t *testing.T) {
 		ds = dsr.Requested
 	}
 	resetDS(ds)
-	if ds == nil || ds.XMLID == nil {
+	if ds == nil {
 		t.Fatalf("the %dth DSR in the test data had no DeliveryService - or that DeliveryService had no XMLID", dsrGood)
 	}
 
-	opts.QueryParameters.Set("xmlId", *ds.XMLID)
+	opts.QueryParameters.Set("xmlId", ds.XMLID)
 	resp, reqInf, err := TOSession.GetDeliveryServiceRequests(opts)
 	if err != nil {
-		t.Fatalf("Unexpected error getting Delivery Service Requests with XMLID '%s': %v - alerts: %+v", *ds.XMLID, err, resp.Alerts)
+		t.Fatalf("Unexpected error getting Delivery Service Requests with XMLID '%s': %v - alerts: %+v", ds.XMLID, err, resp.Alerts)
 	}
 	if reqInf.StatusCode != http.StatusNotModified {
 		t.Fatalf("Expected 304 status code, got %v", reqInf.StatusCode)
@@ -493,15 +492,15 @@ func GetTestDeliveryServiceRequests(t *testing.T) {
 	}
 	resetDS(ds)
 
-	if ds == nil || ds.XMLID == nil {
-		t.Fatalf("the %dth DSR in the test data had no DeliveryService - or that DeliveryService had no XMLID", dsrGood)
+	if ds == nil {
+		t.Fatalf("the %dth DSR in the test data had no Delivery Service", dsrGood)
 	}
 
 	opts := client.NewRequestOptions()
-	opts.QueryParameters.Set("xmlId", *ds.XMLID)
+	opts.QueryParameters.Set("xmlId", ds.XMLID)
 	resp, _, err := TOSession.GetDeliveryServiceRequests(opts)
 	if err != nil {
-		t.Errorf("cannot get Delivery Service Requests with XMLID '%s': %v - alerts: %+v", *ds.XMLID, err, resp.Alerts)
+		t.Errorf("cannot get Delivery Service Requests with XMLID '%s': %v - alerts: %+v", ds.XMLID, err, resp.Alerts)
 	}
 }
 
@@ -522,22 +521,22 @@ func UpdateTestDeliveryServiceRequests(t *testing.T) {
 	}
 
 	resetDS(ds)
-	if ds == nil || ds.XMLID == nil {
-		t.Fatalf("the %dth DSR in the test data had no DeliveryService - or that DeliveryService had no XMLID", dsrGood)
+	if ds == nil {
+		t.Fatalf("the %dth DSR in the test data had no Delivery Service", dsrGood)
 	}
 
 	opts := client.NewRequestOptions()
-	opts.QueryParameters.Set("xmlId", *ds.XMLID)
+	opts.QueryParameters.Set("xmlId", ds.XMLID)
 	resp, _, err := TOSession.GetDeliveryServiceRequests(opts)
 	if err != nil {
-		t.Errorf("cannot get Delivery Service Request with XMLID '%s': %v - alerts: %+v", *ds.XMLID, err, resp.Alerts)
+		t.Errorf("cannot get Delivery Service Request with XMLID '%s': %v - alerts: %+v", ds.XMLID, err, resp.Alerts)
 	}
 	if len(resp.Response) == 0 {
-		t.Fatalf("Expected at least one Deliver Service Request to exist with XMLID '%s', but none were found in Traffic Ops", *ds.XMLID)
+		t.Fatalf("Expected at least one Deliver Service Request to exist with XMLID '%s', but none were found in Traffic Ops", ds.XMLID)
 	}
 	respDSR := resp.Response[0]
 	if respDSR.ID == nil {
-		t.Fatalf("got a DSR by XMLID '%s' with a null or undefined ID", *ds.XMLID)
+		t.Fatalf("got a DSR by XMLID '%s' with a null or undefined ID", ds.XMLID)
 	}
 	var respDS *tc.DeliveryServiceV4
 	if dsr.ChangeType == tc.DSRChangeTypeDelete {
@@ -546,7 +545,7 @@ func UpdateTestDeliveryServiceRequests(t *testing.T) {
 		respDS = dsr.Requested
 	}
 	expDisplayName := "new display name"
-	respDS.DisplayName = &expDisplayName
+	respDS.DisplayName = expDisplayName
 	id := *respDSR.ID
 	alerts, _, err := TOSession.UpdateDeliveryServiceRequest(id, respDSR, client.RequestOptions{})
 	if err != nil {
@@ -572,11 +571,11 @@ func UpdateTestDeliveryServiceRequests(t *testing.T) {
 		respDS = dsr.Requested
 	}
 
-	if respDS == nil || respDS.DisplayName == nil {
-		t.Fatalf("Got DSR by ID '%d' that had no DeliveryService - or said DeliveryService had no DisplayName", id)
+	if respDS == nil {
+		t.Fatalf("Got DSR by ID '%d' that had no Delivery Service", id)
 	}
-	if *respDS.DisplayName != expDisplayName {
-		t.Errorf("results do not match actual: %s, expected: %s", *respDS.DisplayName, expDisplayName)
+	if respDS.DisplayName != expDisplayName {
+		t.Errorf("results do not match actual: %s, expected: %s", respDS.DisplayName, expDisplayName)
 	}
 }
 
@@ -597,22 +596,22 @@ func DeleteTestDeliveryServiceRequests(t *testing.T) {
 	}
 
 	resetDS(ds)
-	if ds == nil || ds.XMLID == nil {
-		t.Fatalf("the %dth DSR in the test data had no DeliveryService - or that DeliveryService had no XMLID", dsrGood)
+	if ds == nil {
+		t.Fatalf("the %dth DSR in the test data had no Delivery Service", dsrGood)
 	}
 
 	opts := client.NewRequestOptions()
-	opts.QueryParameters.Set("xmlId", *ds.XMLID)
+	opts.QueryParameters.Set("xmlId", ds.XMLID)
 	resp, _, err := TOSession.GetDeliveryServiceRequests(opts)
 	if err != nil {
-		t.Fatalf("cannot get Delivery Service Requests with XMLID '%s': %v - alerts: %+v", *ds.XMLID, err, resp.Alerts)
+		t.Fatalf("cannot get Delivery Service Requests with XMLID '%s': %v - alerts: %+v", ds.XMLID, err, resp.Alerts)
 	}
 	if len(resp.Response) < 1 {
-		t.Fatalf("expected at least one Delivery Service Request to have XMLID '%s', got none", *ds.XMLID)
+		t.Fatalf("expected at least one Delivery Service Request to have XMLID '%s', got none", ds.XMLID)
 	}
 	respDSR := resp.Response[0]
 	if respDSR.ID == nil {
-		t.Fatalf("Got a DSR by XMLID '%s' that had no ID", *ds.XMLID)
+		t.Fatalf("Got a DSR by XMLID '%s' that had no ID", ds.XMLID)
 	}
 	alert, _, err := TOSession.DeleteDeliveryServiceRequest(*respDSR.ID, client.RequestOptions{})
 	if err != nil {

--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -98,9 +98,6 @@ func UpdateTestDeliveryServicesWithHeaders(t *testing.T, header http.Header) {
 		t.Fatal("Need at least one Delivery Service to test updating Delivery Services with HTTP Headers")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatalf("couldn't get the xml ID of test DS")
-	}
 
 	opts := client.RequestOptions{Header: header}
 	dses, _, err := TOSession.GetDeliveryServices(opts)
@@ -111,17 +108,17 @@ func UpdateTestDeliveryServicesWithHeaders(t *testing.T, header http.Header) {
 	var remoteDS tc.DeliveryServiceV4
 	found := false
 	for _, ds := range dses.Response {
-		if ds.XMLID != nil && *ds.XMLID == *firstDS.XMLID {
+		if ds.XMLID == firstDS.XMLID {
 			found = true
 			remoteDS = ds
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("GET Delivery Services missing: %v", *firstDS.XMLID)
+		t.Fatalf("GET Delivery Services missing: %v", firstDS.XMLID)
 	}
 	if remoteDS.ID == nil {
-		t.Fatalf("Traffic Ops returned a representation for Delivery Service '%s' that had a null or undefined ID", *firstDS.XMLID)
+		t.Fatalf("Traffic Ops returned a representation for Delivery Service '%s' that had a null or undefined ID", firstDS.XMLID)
 	}
 
 	updatedLongDesc := "something different"
@@ -176,11 +173,7 @@ func createBlankCDN(cdnName string, t *testing.T) tc.CDN {
 }
 
 func cleanUp(t *testing.T, ds tc.DeliveryServiceV4, oldCDNID int, newCDNID int, sslKeyVersions []string) {
-	if ds.XMLID == nil {
-		t.Error("Cannot clean up Delivery Service with nil XMLID")
-		return
-	}
-	xmlid := *ds.XMLID
+	xmlid := ds.XMLID
 	if ds.ID == nil {
 		t.Error("Cannot clean up Delivery Service with nil ID")
 		return
@@ -215,16 +208,7 @@ func cleanUp(t *testing.T, ds tc.DeliveryServiceV4, oldCDNID int, newCDNID int, 
 
 // getCustomDS returns a DS that is guaranteed to have non-nil:
 //
-//    Active
-//    CDNID
-//    DSCP
-//    DisplayName
-//    RoutingName
-//    GeoLimit
-//    GeoProvider
-//    IPV6RoutingEnabled
 //    InitialDispersion
-//    LogsEnabled
 //    MissLat
 //    MissLong
 //    MultiSiteOrigin
@@ -232,24 +216,20 @@ func cleanUp(t *testing.T, ds tc.DeliveryServiceV4, oldCDNID int, newCDNID int, 
 //    Protocol
 //    QStringIgnore
 //    RangeRequestHandling
-//    RegionalGeoBlocking
-//    TenantID
-//    TypeID
-//    XMLID
 //
 // BUT, will ALWAYS have nil MaxRequestHeaderBytes.
-func getCustomDS(cdnID, typeID int, displayName, routingName, orgFQDN, dsID string) tc.DeliveryServiceV4 {
+func getCustomDS(cdnID, typeID int, displayName, routingName, orgFQDN, xmlID string) tc.DeliveryServiceV4 {
 	customDS := tc.DeliveryServiceV4{}
-	customDS.Active = util.BoolPtr(true)
-	customDS.CDNID = util.IntPtr(cdnID)
-	customDS.DSCP = util.IntPtr(0)
-	customDS.DisplayName = util.StrPtr(displayName)
-	customDS.RoutingName = util.StrPtr(routingName)
-	customDS.GeoLimit = util.IntPtr(0)
-	customDS.GeoProvider = util.IntPtr(0)
-	customDS.IPV6RoutingEnabled = util.BoolPtr(false)
+	customDS.Active = tc.DS_ACTIVE
+	customDS.CDNID = cdnID
+	customDS.DSCP = 0
+	customDS.DisplayName = displayName
+	customDS.RoutingName = routingName
+	customDS.GeoLimit = 0
+	customDS.GeoProvider = 0
+	customDS.IPV6RoutingEnabled = false
 	customDS.InitialDispersion = util.IntPtr(1)
-	customDS.LogsEnabled = util.BoolPtr(true)
+	customDS.LogsEnabled = true
 	customDS.MissLat = util.FloatPtr(0)
 	customDS.MissLong = util.FloatPtr(0)
 	customDS.MultiSiteOrigin = util.BoolPtr(false)
@@ -257,10 +237,10 @@ func getCustomDS(cdnID, typeID int, displayName, routingName, orgFQDN, dsID stri
 	customDS.Protocol = util.IntPtr(2)
 	customDS.QStringIgnore = util.IntPtr(0)
 	customDS.RangeRequestHandling = util.IntPtr(0)
-	customDS.RegionalGeoBlocking = util.BoolPtr(false)
-	customDS.TenantID = util.IntPtr(1)
-	customDS.TypeID = util.IntPtr(typeID)
-	customDS.XMLID = util.StrPtr(dsID)
+	customDS.RegionalGeoBlocking = false
+	customDS.TenantID = 1
+	customDS.TypeID = typeID
+	customDS.XMLID = xmlID
 	customDS.MaxRequestHeaderBytes = nil
 	return customDS
 }
@@ -289,9 +269,6 @@ func DeleteCDNOldSSLKeys(t *testing.T) {
 		t.Fatalf("Expected Delivery Service creation to return exactly one Delivery Service, got: %d", len(resp.Response))
 	}
 	ds := resp.Response[0]
-	if ds.XMLID == nil {
-		t.Fatal("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID")
-	}
 
 	ds.CDNName = &cdn.Name
 	sslKeyRequestFields := tc.SSLKeyRequestFields{
@@ -302,9 +279,9 @@ func DeleteCDNOldSSLKeys(t *testing.T) {
 		Country:      util.StrPtr("CO"),
 		State:        util.StrPtr("ST"),
 	}
-	genResp, _, err := TOSession.GenerateSSLKeysForDS(*ds.XMLID, *ds.CDNName, sslKeyRequestFields, client.RequestOptions{})
+	genResp, _, err := TOSession.GenerateSSLKeysForDS(ds.XMLID, *ds.CDNName, sslKeyRequestFields, client.RequestOptions{})
 	if err != nil {
-		t.Fatalf("Unexpected error generaing SSL Keys for Delivery Service '%s': %v - alerts: %+v", *ds.XMLID, err, genResp.Alerts)
+		t.Fatalf("Unexpected error generaing SSL Keys for Delivery Service '%s': %v - alerts: %+v", ds.XMLID, err, genResp.Alerts)
 	}
 	defer cleanUp(t, ds, cdn.ID, -1, []string{"1"})
 
@@ -319,15 +296,15 @@ func DeleteCDNOldSSLKeys(t *testing.T) {
 		t.Fatalf("Expected Delivery Service creation to return exactly one Delivery Service, got: %d", len(resp.Response))
 	}
 	ds2 := resp.Response[0]
-	if ds2.XMLID == nil || ds2.ID == nil {
-		t.Fatal("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID and/or ID")
+	if ds2.ID == nil {
+		t.Fatal("Traffic Ops returned a representation for a Delivery Service with null or undefined ID")
 	}
 
 	ds2.CDNName = &cdn.Name
 	sslKeyRequestFields.HostName = util.StrPtr("*.test2.com")
-	genResp, _, err = TOSession.GenerateSSLKeysForDS(*ds2.XMLID, *ds2.CDNName, sslKeyRequestFields, client.RequestOptions{})
+	genResp, _, err = TOSession.GenerateSSLKeysForDS(ds2.XMLID, *ds2.CDNName, sslKeyRequestFields, client.RequestOptions{})
 	if err != nil {
-		t.Fatalf("Unexpected error generaing SSL Keys for Delivery Service '%s': %v - alerts: %+v", *ds2.XMLID, err, genResp.Alerts)
+		t.Fatalf("Unexpected error generaing SSL Keys for Delivery Service '%s': %v - alerts: %+v", ds2.XMLID, err, genResp.Alerts)
 	}
 
 	var cdnKeys []tc.CDNSSLKeys
@@ -404,12 +381,9 @@ func DeliveryServiceSSLKeys(t *testing.T) {
 		t.Fatalf("Expected Delivery Service creation to return exactly one Delivery Service, got: %d", len(resp.Response))
 	}
 	ds := resp.Response[0]
-	if ds.XMLID == nil {
-		t.Fatal("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID")
-	}
 
 	ds.CDNName = &cdn.Name
-	genResp, _, err := TOSession.GenerateSSLKeysForDS(*ds.XMLID, *ds.CDNName, tc.SSLKeyRequestFields{
+	genResp, _, err := TOSession.GenerateSSLKeysForDS(ds.XMLID, *ds.CDNName, tc.SSLKeyRequestFields{
 		BusinessUnit: util.StrPtr("BU"),
 		City:         util.StrPtr("CI"),
 		Organization: util.StrPtr("OR"),
@@ -418,7 +392,7 @@ func DeliveryServiceSSLKeys(t *testing.T) {
 		State:        util.StrPtr("ST"),
 	}, client.RequestOptions{})
 	if err != nil {
-		t.Fatalf("Unexpected error generating SSL Keys for Delivery Service '%s': %v - alerts: %+v", *ds.XMLID, err, genResp.Alerts)
+		t.Fatalf("Unexpected error generating SSL Keys for Delivery Service '%s': %v - alerts: %+v", ds.XMLID, err, genResp.Alerts)
 	}
 	defer cleanUp(t, ds, cdn.ID, -1, []string{"1"})
 
@@ -426,7 +400,7 @@ func DeliveryServiceSSLKeys(t *testing.T) {
 	for tries := 0; tries < 5; tries++ {
 		time.Sleep(time.Second)
 		var sslKeysResp tc.DeliveryServiceSSLKeysResponse
-		sslKeysResp, _, err = TOSession.GetDeliveryServiceSSLKeys(*ds.XMLID, client.RequestOptions{})
+		sslKeysResp, _, err = TOSession.GetDeliveryServiceSSLKeys(ds.XMLID, client.RequestOptions{})
 		*dsSSLKey = sslKeysResp.Response
 		if err == nil && dsSSLKey != nil {
 			break
@@ -434,7 +408,7 @@ func DeliveryServiceSSLKeys(t *testing.T) {
 	}
 
 	if err != nil || dsSSLKey == nil {
-		t.Fatalf("unable to get DS %v SSL key: %v", *ds.XMLID, err)
+		t.Fatalf("unable to get DS %v SSL key: %v", ds.XMLID, err)
 	}
 	if dsSSLKey.Certificate.Key == "" {
 		t.Errorf("expected a valid key but got nothing")
@@ -474,7 +448,7 @@ func DeliveryServiceSSLKeys(t *testing.T) {
 	for tries := 0; tries < 5; tries++ {
 		time.Sleep(time.Second)
 		var sslKeysResp tc.DeliveryServiceSSLKeysResponse
-		sslKeysResp, _, err = TOSession.GetDeliveryServiceSSLKeys(*ds.XMLID, client.RequestOptions{})
+		sslKeysResp, _, err = TOSession.GetDeliveryServiceSSLKeys(ds.XMLID, client.RequestOptions{})
 		*dsSSLKey = sslKeysResp.Response
 		if err == nil && dsSSLKey != nil {
 			break
@@ -482,7 +456,7 @@ func DeliveryServiceSSLKeys(t *testing.T) {
 	}
 
 	if err != nil || dsSSLKey == nil {
-		t.Fatalf("unable to get DS %v SSL key: %v", *ds.XMLID, err)
+		t.Fatalf("unable to get DS %v SSL key: %v", ds.XMLID, err)
 	}
 	if dsSSLKey.Certificate.Key == "" {
 		t.Errorf("expected a valid key but got nothing")
@@ -521,9 +495,6 @@ func SSLDeliveryServiceCDNUpdateTest(t *testing.T) {
 		t.Fatalf("Expected Delivery Service creation to create exactly one Delivery Service, Traffic Ops indicates %d were created", len(resp.Response))
 	}
 	ds := resp.Response[0]
-	if ds.XMLID == nil {
-		t.Fatal("Traffic Ops created a Delivery Service with no XMLID")
-	}
 	if ds.ID == nil {
 		t.Fatal("Traffic Ops created a Delivery Service with no ID")
 	}
@@ -531,7 +502,7 @@ func SSLDeliveryServiceCDNUpdateTest(t *testing.T) {
 
 	defer cleanUp(t, ds, oldCdn.ID, newCdn.ID, []string{"1"})
 
-	_, _, err = TOSession.GenerateSSLKeysForDS(*ds.XMLID, *ds.CDNName, tc.SSLKeyRequestFields{
+	_, _, err = TOSession.GenerateSSLKeysForDS(ds.XMLID, *ds.CDNName, tc.SSLKeyRequestFields{
 		BusinessUnit: util.StrPtr("BU"),
 		City:         util.StrPtr("CI"),
 		Organization: util.StrPtr("OR"),
@@ -564,14 +535,14 @@ func SSLDeliveryServiceCDNUpdateTest(t *testing.T) {
 		t.Fatalf("unable to get cdn %v keys: %v", newCdn.Name, err)
 	}
 
-	ds.RoutingName = util.StrPtr("anothername")
+	ds.RoutingName = "anothername"
 	_, _, err = TOSession.UpdateDeliveryService(*ds.ID, ds, client.RequestOptions{})
 	if err == nil {
 		t.Fatal("should not be able to update delivery service (routing name) as it has ssl keys")
 	}
-	ds.RoutingName = util.StrPtr("routingName")
+	ds.RoutingName = "routingName"
 
-	ds.CDNID = &newCdn.ID
+	ds.CDNID = newCdn.ID
 	ds.CDNName = &newCdn.Name
 	_, _, err = TOSession.UpdateDeliveryService(*ds.ID, ds, client.RequestOptions{})
 	if err == nil {
@@ -626,24 +597,16 @@ func PostDeliveryServiceTest(t *testing.T) {
 		t.Fatal("Need at least one testing Delivery Service to test creating Delivery Services")
 	}
 	ds := testData.DeliveryServices[0]
-	if ds.XMLID == nil {
-		t.Fatal("Testing Delivery Service had no XMLID")
-	}
-	xmlid := *ds.XMLID + "-topology-test"
+	xmlid := ds.XMLID + "-topology-test"
 
-	ds.XMLID = new(string)
+	ds.XMLID = ""
 	_, _, err := TOSession.CreateDeliveryService(ds, client.RequestOptions{})
 	if err == nil {
 		t.Error("Expected error with empty xmlid")
 	}
-	ds.XMLID = nil
-	_, _, err = TOSession.CreateDeliveryService(ds, client.RequestOptions{})
-	if err == nil {
-		t.Error("Expected error with nil xmlid")
-	}
 
 	ds.Topology = new(string)
-	ds.XMLID = &xmlid
+	ds.XMLID = xmlid
 
 	_, reqInf, err := TOSession.CreateDeliveryService(ds, client.RequestOptions{})
 	if err == nil {
@@ -667,7 +630,7 @@ func CreateTestDeliveryServices(t *testing.T) {
 	for _, ds := range testData.DeliveryServices {
 		resp, _, err := TOSession.CreateDeliveryService(ds, client.RequestOptions{})
 		if err != nil {
-			t.Errorf("could not create Delivery Service '%s': %v - alerts: %+v", *ds.XMLID, err, resp.Alerts)
+			t.Errorf("could not create Delivery Service '%s': %v - alerts: %+v", ds.XMLID, err, resp.Alerts)
 		}
 	}
 }
@@ -699,25 +662,17 @@ func GetTestDeliveryServices(t *testing.T) {
 	}
 	actualDSMap := make(map[string]tc.DeliveryServiceV4, len(actualDSes.Response))
 	for _, ds := range actualDSes.Response {
-		if ds.XMLID == nil {
-			t.Error("Traffic Ops returned representation of a Delivery Service with null or undefined XMLID")
-			continue
-		}
-		actualDSMap[*ds.XMLID] = ds
+		actualDSMap[ds.XMLID] = ds
 	}
 	cnt := 0
 	for _, ds := range testData.DeliveryServices {
-		if ds.XMLID == nil {
-			t.Error("Delivery Service found in test data with null or undefined XMLID")
-			continue
-		}
-		if _, ok := actualDSMap[*ds.XMLID]; !ok {
-			t.Errorf("GET DeliveryService missing: %s", *ds.XMLID)
+		if _, ok := actualDSMap[ds.XMLID]; !ok {
+			t.Errorf("GET DeliveryService missing: %s", ds.XMLID)
 		}
 		// exactly one ds should have exactly 3 query params. the rest should have none
 		if c := len(ds.ConsistentHashQueryParams); c > 0 {
 			if c != 3 {
-				t.Errorf("deliveryservice %s has %d query params; expected 3 or 0", *ds.XMLID, c)
+				t.Errorf("deliveryservice %s has %d query params; expected 3 or 0", ds.XMLID, c)
 			}
 			cnt++
 		}
@@ -729,32 +684,24 @@ func GetTestDeliveryServices(t *testing.T) {
 
 func GetInactiveTestDeliveryServices(t *testing.T) {
 	opts := client.NewRequestOptions()
-	opts.QueryParameters.Set("active", strconv.FormatBool(false))
+	opts.QueryParameters.Set("active", string(tc.DS_INACTIVE))
 	inactiveDSes, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Errorf("cannot get inactive Delivery Services: %v - alerts: %+v", err, inactiveDSes.Alerts)
 	}
 	for _, ds := range inactiveDSes.Response {
-		if ds.Active == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined 'active'")
-			continue
-		}
-		if *ds.Active != false {
-			t.Errorf("expected all delivery services to be inactive, but got atleast one active DS")
+		if ds.Active != tc.DS_INACTIVE {
+			t.Errorf("expected all delivery services to be inactive, but got at least one active DS")
 		}
 	}
 
-	opts.QueryParameters.Set("active", strconv.FormatBool(true))
+	opts.QueryParameters.Set("active", string(tc.DS_ACTIVE))
 	activeDSes, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Errorf("cannot get active Delivery Services: %v - alerts: %+v", err, activeDSes.Alerts)
 	}
 	for _, ds := range activeDSes.Response {
-		if ds.Active == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined 'active'")
-			continue
-		}
-		if *ds.Active != true {
+		if ds.Active != tc.DS_ACTIVE {
 			t.Errorf("expected all delivery services to be active, but got atleast one inactive DS")
 		}
 	}
@@ -767,18 +714,14 @@ func GetTestDeliveryServicesCapacity(t *testing.T) {
 	}
 	actualDSMap := map[string]tc.DeliveryServiceV4{}
 	for _, ds := range actualDSes.Response {
-		if ds.XMLID == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID")
-			continue
-		}
 		if ds.ID == nil {
 			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined ID")
 			continue
 		}
-		actualDSMap[*ds.XMLID] = ds
+		actualDSMap[ds.XMLID] = ds
 		capDS, _, err := TOSession.GetDeliveryServiceCapacity(*ds.ID, client.RequestOptions{})
 		if err != nil {
-			t.Errorf(`cannot get Delivery Service "%s"'s (#%d) Capacity: %v - alerts: %+v`, *ds.XMLID, *ds.ID, err, capDS.Alerts)
+			t.Errorf(`cannot get Delivery Service "%s"'s (#%d) Capacity: %v - alerts: %+v`, ds.XMLID, *ds.ID, err, capDS.Alerts)
 		}
 	}
 
@@ -789,9 +732,6 @@ func UpdateTestDeliveryServices(t *testing.T) {
 		t.Fatal("Need at least one Delivery Service to test updating a Delivery Service")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("Found a Delivery Service in the test data with a null or undefined XMLID")
-	}
 
 	dses, _, err := TOSession.GetDeliveryServices(client.RequestOptions{})
 	if err != nil {
@@ -801,11 +741,7 @@ func UpdateTestDeliveryServices(t *testing.T) {
 	var remoteDS tc.DeliveryServiceV4
 	found := false
 	for _, ds := range dses.Response {
-		if ds.XMLID == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID")
-			continue
-		}
-		if *ds.XMLID == *firstDS.XMLID {
+		if ds.XMLID == firstDS.XMLID {
 			found = true
 			remoteDS = ds
 			break
@@ -873,9 +809,6 @@ func UpdateNullableTestDeliveryServices(t *testing.T) {
 		t.Fatal("Need at least one Delivery Service to test updating nullable fields of a Delivery Service")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("Found a Delivery Service in the test data with a null or undefined XMLID")
-	}
 
 	dses, _, err := TOSession.GetDeliveryServices(client.RequestOptions{})
 	if err != nil {
@@ -885,11 +818,11 @@ func UpdateNullableTestDeliveryServices(t *testing.T) {
 	var remoteDS tc.DeliveryServiceV4
 	found := false
 	for _, ds := range dses.Response {
-		if ds.XMLID == nil || ds.ID == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID and/or ID")
+		if ds.ID == nil {
+			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined ID")
 			continue
 		}
-		if *ds.XMLID == *firstDS.XMLID {
+		if ds.XMLID == firstDS.XMLID {
 			found = true
 			remoteDS = ds
 			break
@@ -982,8 +915,8 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 		t.Fatalf("expected: 1 DS, actual: %d", len(dses.Response))
 	}
 	ds := dses.Response[0]
-	if ds.Topology == nil || ds.ID == nil || ds.XMLID == nil {
-		t.Fatal("Traffic Ops returned a representation for a Delivery Service that had null or undefined Topology and/or XMLID and/or ID")
+	if ds.Topology == nil || ds.ID == nil {
+		t.Fatal("Traffic Ops returned a representation for a Delivery Service that had null or undefined Topology and/or ID")
 	}
 	// unassign its topology, add a required capability that its topology
 	// can't satisfy, then attempt to reassign its topology
@@ -999,7 +932,7 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 	}
 	dsrcResp, _, err := TOSession.CreateDeliveryServicesRequiredCapability(reqCap, client.RequestOptions{})
 	if err != nil {
-		t.Fatalf("adding 'asdf' required capability to '%s', expected: no error, actual: %v - alerts: %+v", *ds.XMLID, err, dsrcResp.Alerts)
+		t.Fatalf("adding 'asdf' required capability to '%s', expected: no error, actual: %v - alerts: %+v", ds.XMLID, err, dsrcResp.Alerts)
 	}
 	ds.Topology = &top
 	_, reqInf, err := TOSession.UpdateDeliveryService(*ds.ID, ds, client.RequestOptions{})
@@ -1011,7 +944,7 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 	}
 	dsrcResp, _, err = TOSession.DeleteDeliveryServicesRequiredCapability(*ds.ID, "asdf", client.RequestOptions{})
 	if err != nil {
-		t.Fatalf("removing 'asdf' required capability from '%s', expected: no error, actual: %v - alerts: %+v", *ds.XMLID, err, dsrcResp.Alerts)
+		t.Fatalf("removing 'asdf' required capability from '%s', expected: no error, actual: %v - alerts: %+v", ds.XMLID, err, dsrcResp.Alerts)
 	}
 	_, _, err = TOSession.UpdateDeliveryService(*ds.ID, ds, client.RequestOptions{})
 	if err != nil {
@@ -1041,9 +974,6 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 		t.Fatalf("Expected exactly one Delivery Service to have ID %d, found: %d", *ds.ID, len(resp.Response))
 	}
 	ds = resp.Response[0]
-	if ds.CDNID == nil {
-		t.Fatal("Traffic Ops returned a representation for a Delivery Service that had null or undefined CDN ID")
-	}
 
 	const cdn1Name = "cdn1"
 	opts = client.NewRequestOptions()
@@ -1073,7 +1003,7 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 	if cachegroup.ID == nil {
 		t.Fatalf("Traffic Ops returned a representation for Cache Group '%s' that had null or undefined ID", cacheGroupName)
 	}
-	opts.QueryParameters = url.Values{"cdn": {strconv.Itoa(*ds.CDNID)}, "cachegroup": {strconv.Itoa(*cachegroup.ID)}}
+	opts.QueryParameters = url.Values{"cdn": {strconv.Itoa(ds.CDNID)}, "cachegroup": {strconv.Itoa(*cachegroup.ID)}}
 	servers, _, err := TOSession.GetServers(opts)
 	if err != nil {
 		t.Fatalf("getting Server with params %v: %v - alerts: %+v", opts.QueryParameters, err, servers.Alerts)
@@ -1128,12 +1058,12 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 	ds.Topology = dsTopology
 	_, reqInf, err = TOSession.UpdateDeliveryService(*ds.ID, ds, client.RequestOptions{})
 	if err == nil {
-		t.Fatalf("expected 400-level error assigning Topology %s to Delivery Service %s because Cache Group %s has no Servers in it in CDN %d, no error received", *dsTopology, xmlID, cacheGroupName, *ds.CDNID)
+		t.Fatalf("expected 400-level error assigning Topology %s to Delivery Service %s because Cache Group %s has no Servers in it in CDN %d, no error received", *dsTopology, xmlID, cacheGroupName, ds.CDNID)
 	}
 	if reqInf.StatusCode < http.StatusBadRequest || reqInf.StatusCode >= http.StatusInternalServerError {
 		t.Fatalf("expected %d-level status code but received status code %d", http.StatusBadRequest, reqInf.StatusCode)
 	}
-	*server.CDNID = *ds.CDNID
+	*server.CDNID = ds.CDNID
 	*server.ProfileID = profileCopy.ExistingID
 
 	// Put things back the way they were
@@ -1203,9 +1133,6 @@ func UpdateDeliveryServiceWithInvalidRemapText(t *testing.T) {
 		t.Fatal("Need at least one Delivery Service to test updating Delivery Service with invalid remap text")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("Found a Delivery Service in the test data that has null or undefined XMLID")
-	}
 
 	dses, _, err := TOSession.GetDeliveryServices(client.RequestOptions{})
 	if err != nil {
@@ -1215,18 +1142,18 @@ func UpdateDeliveryServiceWithInvalidRemapText(t *testing.T) {
 	var remoteDS tc.DeliveryServiceV4
 	found := false
 	for _, ds := range dses.Response {
-		if ds.XMLID == nil || ds.ID == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service that had null or undefined XMLID and/or ID")
+		if ds.ID == nil {
+			t.Error("Traffic Ops returned a representation for a Delivery Service that had null or undefined ID")
 			continue
 		}
-		if *ds.XMLID == *firstDS.XMLID {
+		if ds.XMLID == firstDS.XMLID {
 			found = true
 			remoteDS = ds
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("GET Delivery Services missing: %s", *firstDS.XMLID)
+		t.Fatalf("GET Delivery Services missing: %s", firstDS.XMLID)
 	}
 
 	updatedRemapText := "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua\nline2"
@@ -1247,7 +1174,8 @@ func UpdateDeliveryServiceWithInvalidSliceRangeRequest(t *testing.T) {
 			continue
 		}
 		if ds.Type.IsDNS() || ds.Type.IsHTTP() {
-			dsXML = ds.XMLID
+			dsXML = new(string)
+			*dsXML = ds.XMLID
 			break
 		}
 	}
@@ -1263,11 +1191,11 @@ func UpdateDeliveryServiceWithInvalidSliceRangeRequest(t *testing.T) {
 	var remoteDS tc.DeliveryServiceV4
 	found := false
 	for _, ds := range dses.Response {
-		if ds.XMLID == nil || ds.ID == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service that had null or undefined XMLID and/or ID")
+		if ds.ID == nil {
+			t.Error("Traffic Ops returned a representation for a Delivery Service that had null or undefined ID")
 			continue
 		}
-		if *ds.XMLID == *dsXML {
+		if ds.XMLID == *dsXML {
 			found = true
 			remoteDS = ds
 			break
@@ -1330,13 +1258,13 @@ func UpdateValidateORGServerCacheGroup(t *testing.T) {
 		t.Fatalf("Expected exactly one Delivery Service with the XMLID 'ds-top', found: %d", len(resp.Response))
 	}
 	remoteDS := resp.Response[0]
-	if remoteDS.XMLID == nil || remoteDS.ID == nil || remoteDS.Topology == nil {
-		t.Fatal("Traffic Ops returned a representation for a Delivery Service that had null or undefined XMLID and/or ID and/or Topology")
+	if remoteDS.ID == nil || remoteDS.Topology == nil {
+		t.Fatal("Traffic Ops returned a representation for a Delivery Service that had null or undefined ID and/or Topology")
 	}
 
 	//Assign ORG server to DS
 	assignServer := []string{"denver-mso-org-01"}
-	alerts, _, err := TOSession.AssignServersToDeliveryService(assignServer, *remoteDS.XMLID, client.RequestOptions{})
+	alerts, _, err := TOSession.AssignServersToDeliveryService(assignServer, remoteDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Errorf("cannot assign server to Delivery Services: %v - alerts: %+v", err, alerts)
 	}
@@ -1452,25 +1380,21 @@ func DeleteTestDeliveryServices(t *testing.T) {
 		t.Errorf("cannot get Delivery Services: %v - alerts: %+v", err, dses.Alerts)
 	}
 	for _, testDS := range testData.DeliveryServices {
-		if testDS.XMLID == nil {
-			t.Errorf("testing Delivery Service has no XMLID")
-			continue
-		}
 		var ds tc.DeliveryServiceV4
 		found := false
 		for _, realDS := range dses.Response {
-			if realDS.XMLID == nil || realDS.ID == nil {
-				t.Errorf("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID and/or ID")
+			if realDS.ID == nil {
+				t.Errorf("Traffic Ops returned a representation for a Delivery Service with null or undefined ID")
 				continue
 			}
-			if *realDS.XMLID == *testDS.XMLID {
+			if realDS.XMLID == testDS.XMLID {
 				ds = realDS
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("DeliveryService not found in Traffic Ops: %v", *testDS.XMLID)
+			t.Errorf("DeliveryService not found in Traffic Ops: %v", testDS.XMLID)
 			continue
 		}
 
@@ -1485,10 +1409,10 @@ func DeleteTestDeliveryServices(t *testing.T) {
 		opts.QueryParameters.Set("id", strconv.Itoa(*ds.ID))
 		foundDS, _, err := TOSession.GetDeliveryServices(opts)
 		if err != nil {
-			t.Errorf("Unexpected error deleting Delivery Service '%s': %v - alelts: %+v", *ds.XMLID, err, foundDS.Alerts)
+			t.Errorf("Unexpected error deleting Delivery Service '%s': %v - alelts: %+v", ds.XMLID, err, foundDS.Alerts)
 		}
 		if len(foundDS.Response) > 0 {
-			t.Errorf("expected Delivery Service: %s to be deleted, but %d exist with same ID (#%d)", *ds.XMLID, len(foundDS.Response), *ds.ID)
+			t.Errorf("expected Delivery Service: %s to be deleted, but %d exist with same ID (#%d)", ds.XMLID, len(foundDS.Response), *ds.ID)
 		}
 	}
 
@@ -1512,11 +1436,8 @@ func DeliveryServiceMinorVersionsTest(t *testing.T) {
 		t.Fatalf("Need at least 5 DSes to test minor versions; got: %d", len(testData.DeliveryServices))
 	}
 	testDS := testData.DeliveryServices[4]
-	if testDS.XMLID == nil {
-		t.Fatal("expected XMLID: ds-test-minor-versions, actual: <nil>")
-	}
-	if *testDS.XMLID != "ds-test-minor-versions" {
-		t.Errorf("expected XMLID: ds-test-minor-versions, actual: %s", *testDS.XMLID)
+	if testDS.XMLID != "ds-test-minor-versions" {
+		t.Errorf("expected XMLID: ds-test-minor-versions, actual: %s", testDS.XMLID)
 	}
 
 	dses, _, err := TOSession.GetDeliveryServices(client.RequestOptions{})
@@ -1527,21 +1448,19 @@ func DeliveryServiceMinorVersionsTest(t *testing.T) {
 	var ds tc.DeliveryServiceV4
 	found := false
 	for _, d := range dses.Response {
-		if d.XMLID != nil && *d.XMLID == *testDS.XMLID {
+		if d.XMLID == testDS.XMLID {
 			ds = d
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("Delivery Service '%s' not found in Traffic Ops", *testDS.XMLID)
+		t.Fatalf("Delivery Service '%s' not found in Traffic Ops", testDS.XMLID)
 	}
 
 	// GET latest, verify expected values for 1.3 and 1.4 fields
-	if ds.DeepCachingType == nil {
-		t.Errorf("expected DeepCachingType: %s, actual: nil", testDS.DeepCachingType.String())
-	} else if *ds.DeepCachingType != *testDS.DeepCachingType {
-		t.Errorf("expected DeepCachingType: %s, actual: %s", testDS.DeepCachingType.String(), ds.DeepCachingType.String())
+	if ds.DeepCachingType != testDS.DeepCachingType {
+		t.Errorf("expected DeepCachingType: %s, actual: %s", testDS.DeepCachingType, ds.DeepCachingType)
 	}
 	if ds.FQPacingRate == nil {
 		t.Errorf("expected FQPacingRate: %d, actual: nil", testDS.FQPacingRate)
@@ -1588,7 +1507,7 @@ func DeliveryServiceMinorVersionsTest(t *testing.T) {
 	_, err = json.Marshal(ds)
 	if err != nil {
 		// TODO: should this actually be doing a POST?
-		t.Errorf("cannot POST deliveryservice, failed to marshal JSON: %s", err.Error())
+		t.Errorf("cannot POST deliveryservice, failed to marshal JSON: %v", err)
 	}
 }
 
@@ -1600,11 +1519,11 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 	var tenant3DS tc.DeliveryServiceV4
 	foundTenant3DS := false
 	for _, d := range dses.Response {
-		if d.XMLID == nil || d.ID == nil || d.Tenant == nil {
-			t.Error("Traffic Ops returned a representation of a Delivery Service that had null or undefined XMLID and/or ID and/or Tenant")
+		if d.ID == nil || d.Tenant == nil {
+			t.Error("Traffic Ops returned a representation of a Delivery Service that had null or undefined ID and/or Tenant")
 			continue
 		}
-		if *d.XMLID == "ds3" {
+		if d.XMLID == "ds3" {
 			tenant3DS = d
 			foundTenant3DS = true
 		}
@@ -1626,28 +1545,24 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 
 	// assert that tenant4user cannot read deliveryservices outside of its tenant
 	for _, ds := range dsesReadableByTenant4.Response {
-		if ds.XMLID == nil {
-			t.Error("Traffic Ops returned a representation of a Delivery Service that had null or undefined XMLID")
-			continue
-		}
-		if *ds.XMLID == "ds3" {
+		if ds.XMLID == "ds3" {
 			t.Error("expected tenant4 to be unable to read delivery services from tenant 3")
 		}
 	}
 
 	// assert that tenant4user cannot update tenant3user's deliveryservice
 	if _, _, err = tenant4TOClient.UpdateDeliveryService(*tenant3DS.ID, tenant3DS, client.RequestOptions{}); err == nil {
-		t.Errorf("expected tenant4user to be unable to update tenant3's deliveryservice (%s)", *tenant3DS.XMLID)
+		t.Errorf("expected tenant4user to be unable to update tenant3's deliveryservice (%s)", tenant3DS.XMLID)
 	}
 
 	// assert that tenant4user cannot delete tenant3user's deliveryservice
 	if _, _, err = tenant4TOClient.DeleteDeliveryService(*tenant3DS.ID, client.RequestOptions{}); err == nil {
-		t.Errorf("expected tenant4user to be unable to delete tenant3's deliveryservice (%s)", *tenant3DS.XMLID)
+		t.Errorf("expected tenant4user to be unable to delete tenant3's deliveryservice (%s)", tenant3DS.XMLID)
 	}
 
 	// assert that tenant4user cannot create a deliveryservice outside of its tenant
-	tenant3DS.XMLID = util.StrPtr("deliveryservicetenancytest")
-	tenant3DS.DisplayName = util.StrPtr("deliveryservicetenancytest")
+	tenant3DS.XMLID = "deliveryservicetenancytest"
+	tenant3DS.DisplayName = "deliveryservicetenancytest"
 	if _, _, err = tenant4TOClient.CreateDeliveryService(tenant3DS, client.RequestOptions{}); err == nil {
 		t.Error("expected tenant4user to be unable to create a deliveryservice outside of its tenant")
 	}
@@ -1730,27 +1645,25 @@ func GetDeliveryServiceByCdn(t *testing.T) {
 	}
 
 	opts := client.NewRequestOptions()
-	if firstDS.CDNID == nil {
-		opts.QueryParameters.Set("name", *firstDS.CDNName)
-		cdns, _, err := TOSession.GetCDNs(opts)
-		if err != nil {
-			t.Errorf("Unexpected error getting CDN '%s' by name: %v - alerts: %+v", *firstDS.CDNName, err, cdns.Alerts)
-		}
-		if len(cdns.Response) != 1 {
-			t.Fatalf("Expected exactly one CDN named '%s' to exist, found: %d", *firstDS.CDNName, len(cdns.Response))
-		}
-		firstDS.CDNID = new(int)
-		*firstDS.CDNID = cdns.Response[0].ID
-		opts.QueryParameters.Del("name")
-	}
 
-	opts.QueryParameters.Set("cdn", strconv.Itoa(*firstDS.CDNID))
+	opts.QueryParameters.Set("name", *firstDS.CDNName)
+	cdns, _, err := TOSession.GetCDNs(opts)
+	if err != nil {
+		t.Errorf("Unexpected error getting CDN '%s' by name: %v - alerts: %+v", *firstDS.CDNName, err, cdns.Alerts)
+	}
+	if len(cdns.Response) != 1 {
+		t.Fatalf("Expected exactly one CDN named '%s' to exist, found: %d", *firstDS.CDNName, len(cdns.Response))
+	}
+	firstDS.CDNID = cdns.Response[0].ID
+	opts.QueryParameters.Del("name")
+
+	opts.QueryParameters.Set("cdn", strconv.Itoa(firstDS.CDNID))
 	resp, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Errorf("Unexpected error getting Delivery Services filtered by CDN ID: %v - alerts: %+v", err, resp.Alerts)
 	}
 	if len(resp.Response) == 0 {
-		t.Fatalf("Expected at least one Delivery Service to exist in CDN '%s' (#%d)", *firstDS.CDNName, *firstDS.CDNID)
+		t.Fatalf("Expected at least one Delivery Service to exist in CDN '%s' (#%d)", *firstDS.CDNName, firstDS.CDNID)
 	}
 	if resp.Response[0].CDNName == nil {
 		t.Fatal("Traffic Ops returned a representation for a Delivery Service with null or undefined CDN Name")
@@ -1837,11 +1750,8 @@ func GetTestDeliveryServicesURLSignatureKeys(t *testing.T) {
 		t.Fatal("couldn't get the xml ID of test DS")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("couldn't get the xml ID of test DS")
-	}
 
-	_, _, err := TOSession.GetDeliveryServiceURLSignatureKeys(*firstDS.XMLID, client.RequestOptions{})
+	_, _, err := TOSession.GetDeliveryServiceURLSignatureKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Error("failed to get url sig keys: " + err.Error())
 	}
@@ -1852,15 +1762,12 @@ func CreateTestDeliveryServicesURLSignatureKeys(t *testing.T) {
 		t.Fatal("couldn't get the xml ID of test DS")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("couldn't get the xml ID of test DS")
-	}
 
-	resp, _, err := TOSession.CreateDeliveryServiceURLSignatureKeys(*firstDS.XMLID, client.RequestOptions{})
+	resp, _, err := TOSession.CreateDeliveryServiceURLSignatureKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error creaetting URL signing keys: %v - alerts: %+v", err, resp.Alerts)
 	}
-	firstKeys, _, err := TOSession.GetDeliveryServiceURLSignatureKeys(*firstDS.XMLID, client.RequestOptions{})
+	firstKeys, _, err := TOSession.GetDeliveryServiceURLSignatureKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error getting URL signing keys: %v - alerts: %+v", err, firstKeys.Alerts)
 	}
@@ -1873,11 +1780,11 @@ func CreateTestDeliveryServicesURLSignatureKeys(t *testing.T) {
 	}
 
 	// Create new keys again and check that they are different
-	resp, _, err = TOSession.CreateDeliveryServiceURLSignatureKeys(*firstDS.XMLID, client.RequestOptions{})
+	resp, _, err = TOSession.CreateDeliveryServiceURLSignatureKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error creating URL signing keys: %v - alerts: %+v", err, resp.Alerts)
 	}
-	secondKeys, _, err := TOSession.GetDeliveryServiceURLSignatureKeys(*firstDS.XMLID, client.RequestOptions{})
+	secondKeys, _, err := TOSession.GetDeliveryServiceURLSignatureKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error getting URL signing keys: %v - alerts: %+v", err, secondKeys.Alerts)
 	}
@@ -1899,11 +1806,8 @@ func DeleteTestDeliveryServicesURLSignatureKeys(t *testing.T) {
 		t.Fatal("couldn't get the xml ID of test DS")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("couldn't get the xml ID of test DS")
-	}
 
-	resp, _, err := TOSession.DeleteDeliveryServiceURLSignatureKeys(*firstDS.XMLID, client.RequestOptions{})
+	resp, _, err := TOSession.DeleteDeliveryServiceURLSignatureKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error deletining URL signing keys: %v - alerts: %+v", err, resp.Alerts)
 	}
@@ -1915,13 +1819,10 @@ func GetTestDeliveryServicesURISigningKeys(t *testing.T) {
 		t.Fatal("couldn't get the xml ID of test DS")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("couldn't get the xml ID of test DS")
-	}
 
-	_, _, err := TOSession.GetDeliveryServiceURISigningKeys(*firstDS.XMLID, client.RequestOptions{})
+	_, _, err := TOSession.GetDeliveryServiceURISigningKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
-		t.Errorf("Unexpected error getting URI signing keys for Delivery Service '%s': %v", *firstDS.XMLID, err)
+		t.Errorf("Unexpected error getting URI signing keys for Delivery Service '%s': %v", firstDS.XMLID, err)
 	}
 }
 
@@ -1961,9 +1862,6 @@ func CreateTestDeliveryServicesURISigningKeys(t *testing.T) {
 		t.Fatal("couldn't get the xml ID of test DS")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("couldn't get the xml ID of test DS")
-	}
 
 	var keyset map[string]tc.URISignerKeyset
 
@@ -1971,12 +1869,12 @@ func CreateTestDeliveryServicesURISigningKeys(t *testing.T) {
 		t.Errorf("json.UnMarshal(): expected nil error, actual: %v", err)
 	}
 
-	_, _, err := TOSession.CreateDeliveryServiceURISigningKeys(*firstDS.XMLID, keyset, client.RequestOptions{})
+	_, _, err := TOSession.CreateDeliveryServiceURISigningKeys(firstDS.XMLID, keyset, client.RequestOptions{})
 	if err != nil {
 		t.Error("failed to create uri sig keys: " + err.Error())
 	}
 
-	firstKeysBytes, _, err := TOSession.GetDeliveryServiceURISigningKeys(*firstDS.XMLID, client.RequestOptions{})
+	firstKeysBytes, _, err := TOSession.GetDeliveryServiceURISigningKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Error("failed to get uri sig keys: " + err.Error())
 	}
@@ -1997,12 +1895,12 @@ func CreateTestDeliveryServicesURISigningKeys(t *testing.T) {
 		t.Errorf("json.UnMarshal(): expected nil error, actual: %v", err)
 	}
 
-	alerts, _, err := TOSession.CreateDeliveryServiceURISigningKeys(*firstDS.XMLID, keyset2, client.RequestOptions{})
+	alerts, _, err := TOSession.CreateDeliveryServiceURISigningKeys(firstDS.XMLID, keyset2, client.RequestOptions{})
 	if err != nil {
-		t.Errorf("Unexpected error creating URI Signature Keys for Delivery Service '%s': %v - alerts: %+v", *firstDS.XMLID, err, alerts.Alerts)
+		t.Errorf("Unexpected error creating URI Signature Keys for Delivery Service '%s': %v - alerts: %+v", firstDS.XMLID, err, alerts.Alerts)
 	}
 
-	secondKeysBytes, _, err := TOSession.GetDeliveryServiceURISigningKeys(*firstDS.XMLID, client.RequestOptions{})
+	secondKeysBytes, _, err := TOSession.GetDeliveryServiceURISigningKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
 		t.Error("failed to get uri sig keys: " + err.Error())
 	}
@@ -2026,13 +1924,10 @@ func DeleteTestDeliveryServicesURISigningKeys(t *testing.T) {
 		t.Fatal("couldn't get the xml ID of test DS")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Fatal("couldn't get the xml ID of test DS")
-	}
 
-	resp, _, err := TOSession.DeleteDeliveryServiceURISigningKeys(*firstDS.XMLID, client.RequestOptions{})
+	resp, _, err := TOSession.DeleteDeliveryServiceURISigningKeys(firstDS.XMLID, client.RequestOptions{})
 	if err != nil {
-		t.Errorf("Unexpected error deleting URI Signing keys for Delivery Service '%s': %v - alerts: %+v", *firstDS.XMLID, err, resp.Alerts)
+		t.Errorf("Unexpected error deleting URI Signing keys for Delivery Service '%s': %v - alerts: %+v", firstDS.XMLID, err, resp.Alerts)
 	}
 
 }
@@ -2042,24 +1937,18 @@ func GetDeliveryServiceByLogsEnabled(t *testing.T) {
 		t.Fatal("Need at least one Delivery Service to test getting Delivery Services filtered by their Logs Enabled property")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.LogsEnabled == nil {
-		t.Fatal("Logs Enabled is nil in the pre-requisites ")
-	}
 
 	opts := client.NewRequestOptions()
-	opts.QueryParameters.Set("logsEnabled", strconv.FormatBool(*firstDS.LogsEnabled))
+	opts.QueryParameters.Set("logsEnabled", strconv.FormatBool(firstDS.LogsEnabled))
 	resp, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Errorf("Unexpected error getting Delivery Services filtered by 'logsEnabled': %v - alerts: %+v", err, resp.Alerts)
 	}
 	if len(resp.Response) == 0 {
-		t.Fatalf("Expected at least one Delivery Service to exist with Logs Enabled set to %t", *firstDS.LogsEnabled)
+		t.Fatalf("Expected at least one Delivery Service to exist with Logs Enabled set to %t", firstDS.LogsEnabled)
 	}
-	if resp.Response[0].LogsEnabled == nil {
-		t.Fatal("Traffic Ops returned a representation for a Delivery Service with null or undefined Logs Enabled property")
-	}
-	if *resp.Response[0].LogsEnabled != *firstDS.LogsEnabled {
-		t.Errorf("Logs enabled status expected: %t, actual: %t", *firstDS.LogsEnabled, *resp.Response[0].LogsEnabled)
+	if resp.Response[0].LogsEnabled != firstDS.LogsEnabled {
+		t.Errorf("Logs enabled status expected: %t, actual: %t", firstDS.LogsEnabled, resp.Response[0].LogsEnabled)
 	}
 }
 
@@ -2115,21 +2004,18 @@ func GetDeliveryServiceByValidTenant(t *testing.T) {
 	}
 
 	opts := client.NewRequestOptions()
-	if firstDS.TenantID == nil {
-		opts.QueryParameters.Set("name", *firstDS.Tenant)
-		tenants, _, err := TOSession.GetTenants(opts)
-		if err != nil {
-			t.Errorf("Unexpected error getting Tenants filtered by name: %v - alerts: %+v", err, tenants.Alerts)
-		}
-		if len(tenants.Response) != 1 {
-			t.Fatalf("Expected exactly one Tenant to exist with name '%s', found %d:", *firstDS.Tenant, len(tenants.Response))
-		}
-		firstDS.TenantID = new(int)
-		*firstDS.TenantID = tenants.Response[0].ID
-		opts.QueryParameters.Del("name")
+	opts.QueryParameters.Set("name", *firstDS.Tenant)
+	tenants, _, err := TOSession.GetTenants(opts)
+	if err != nil {
+		t.Errorf("Unexpected error getting Tenants filtered by name: %v - alerts: %+v", err, tenants.Alerts)
 	}
+	if len(tenants.Response) != 1 {
+		t.Fatalf("Expected exactly one Tenant to exist with name '%s', found %d:", *firstDS.Tenant, len(tenants.Response))
+	}
+	firstDS.TenantID = tenants.Response[0].ID
+	opts.QueryParameters.Del("name")
 
-	opts.QueryParameters.Set("tenant", strconv.Itoa(*firstDS.TenantID))
+	opts.QueryParameters.Set("tenant", strconv.Itoa(firstDS.TenantID))
 	resp, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Errorf("Unexpected error getting Delivery Services filtered by Tenant ID: %v - alerts: %+v", err, resp.Alerts)
@@ -2155,27 +2041,24 @@ func GetDeliveryServiceByValidType(t *testing.T) {
 	}
 
 	opts := client.NewRequestOptions()
-	if firstDS.TypeID == nil {
-		opts.QueryParameters.Set("name", firstDS.Type.String())
-		types, _, err := TOSession.GetTypes(opts)
-		if err != nil {
-			t.Errorf("Unexpected error getting Types filtered by name: %v - alerts: %+v", err, types.Alerts)
-		}
-		if len(types.Response) != 1 {
-			t.Fatalf("Expected exactly one Type to exist with name '%s', found %d:", *firstDS.Type, len(types.Response))
-		}
-		firstDS.TypeID = new(int)
-		*firstDS.TypeID = types.Response[0].ID
-		opts.QueryParameters.Del("name")
+	opts.QueryParameters.Set("name", firstDS.Type.String())
+	types, _, err := TOSession.GetTypes(opts)
+	if err != nil {
+		t.Errorf("Unexpected error getting Types filtered by name: %v - alerts: %+v", err, types.Alerts)
 	}
+	if len(types.Response) != 1 {
+		t.Fatalf("Expected exactly one Type to exist with name '%s', found %d:", *firstDS.Type, len(types.Response))
+	}
+	firstDS.TypeID = types.Response[0].ID
+	opts.QueryParameters.Del("name")
 
-	opts.QueryParameters.Set("type", strconv.Itoa(*firstDS.TypeID))
+	opts.QueryParameters.Set("type", strconv.Itoa(firstDS.TypeID))
 	resp, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Errorf("Unexpected error getting Delivery Services filtered by Type ID: %v - alerts: %+v", err, resp.Alerts)
 	}
 	if len(resp.Response) == 0 {
-		t.Fatalf("Expected at least one Delivery Service to exist with Type '%s' (#%d)", *firstDS.Type, *firstDS.TypeID)
+		t.Fatalf("Expected at least one Delivery Service to exist with Type '%s' (#%d)", *firstDS.Type, firstDS.TypeID)
 	}
 	if resp.Response[0].Type == nil {
 		t.Fatal("Traffic Ops returned a representation of a Delivery Service with null or undefined Type Name")
@@ -2190,24 +2073,18 @@ func GetDeliveryServiceByValidXmlId(t *testing.T) {
 		t.Fatal("Need at least one Delivery Service to test getting Delivery Services filtered by XMLID")
 	}
 	firstDS := testData.DeliveryServices[0]
-	if firstDS.XMLID == nil {
-		t.Errorf("XML ID is nil in the Pre-requisites")
-	}
 
 	opts := client.NewRequestOptions()
-	opts.QueryParameters.Set("xmlId", *firstDS.XMLID)
+	opts.QueryParameters.Set("xmlId", firstDS.XMLID)
 	resp, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Errorf("Unexpected error getting Delivery Services filtered by XMLID: %v - alerts: %+v", err, resp.Alerts)
 	}
 	if len(resp.Response) != 1 {
-		t.Fatalf("Expected exactly one Delivery Service to exist with XMLID '%s', found: %d", *firstDS.XMLID, len(resp.Response))
+		t.Fatalf("Expected exactly one Delivery Service to exist with XMLID '%s', found: %d", firstDS.XMLID, len(resp.Response))
 	}
-	if resp.Response[0].XMLID == nil {
-		t.Fatal("Traffic Ops returned a representation of a Delivery Service with null or undefined XMLID")
-	}
-	if *resp.Response[0].XMLID != *firstDS.XMLID {
-		t.Errorf("Delivery Service XMLID expected: %s, actual: %s", *firstDS.XMLID, *resp.Response[0].XMLID)
+	if resp.Response[0].XMLID != firstDS.XMLID {
+		t.Errorf("Delivery Service XMLID expected: %s, actual: %s", firstDS.XMLID, resp.Response[0].XMLID)
 	}
 }
 
@@ -2239,10 +2116,8 @@ func SortTestDeliveryServicesDesc(t *testing.T) {
 	for start, end := 0, len(respDesc)-1; start < end; start, end = start+1, end-1 {
 		respDesc[start], respDesc[end] = respDesc[end], respDesc[start]
 	}
-	if respDesc[0].XMLID != nil && respAsc[0].XMLID != nil {
-		if !reflect.DeepEqual(respDesc[0].XMLID, respAsc[0].XMLID) {
-			t.Errorf("Delivery Service responses are not equal after reversal: %v - %v", *respDesc[0].XMLID, *respAsc[0].XMLID)
-		}
+	if !reflect.DeepEqual(respDesc[0].XMLID, respAsc[0].XMLID) {
+		t.Errorf("Delivery Service responses are not equal after reversal: %v - %v", respDesc[0].XMLID, respAsc[0].XMLID)
 	}
 }
 
@@ -2254,11 +2129,7 @@ func SortTestDeliveryServices(t *testing.T) {
 
 	sortedList := make([]string, 0, len(resp.Response))
 	for _, ds := range resp.Response {
-		if ds.XMLID == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID")
-			continue
-		}
-		sortedList = append(sortedList, *ds.XMLID)
+		sortedList = append(sortedList, ds.XMLID)
 	}
 
 	if !sort.StringsAreSorted(sortedList) {

--- a/traffic_ops/testing/api/v4/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v4/deliveryserviceservers_test.go
@@ -204,13 +204,13 @@ func AssignServersToTopologyBasedDeliveryService(t *testing.T) {
 		t.Fatalf("expected one delivery service: 'ds-top', actual: %v", len(ds.Response))
 	}
 	d := ds.Response[0]
-	if d.Topology == nil || d.ID == nil || d.CDNID == nil || d.CDNName == nil {
-		t.Fatal("Traffic Ops returned a representation of a Delivery Service that had null or undefined Topology and/or CDN ID and/or CDN Name and/or ID")
+	if d.Topology == nil || d.ID == nil || d.CDNName == nil {
+		t.Fatal("Traffic Ops returned a representation of a Delivery Service that had null or undefined Topology and/or CDN Name and/or ID")
 	}
 	serversResp, _, err := TOSession.GetServers(client.RequestOptions{})
 	servers := []tc.ServerV4{}
 	for _, s := range serversResp.Response {
-		if s.CDNID != nil && *s.CDNID == *d.CDNID && s.Type == tc.CacheTypeEdge.String() {
+		if s.CDNID != nil && *s.CDNID == d.CDNID && s.Type == tc.CacheTypeEdge.String() {
 			servers = append(servers, s)
 		}
 	}
@@ -222,7 +222,7 @@ func AssignServersToTopologyBasedDeliveryService(t *testing.T) {
 	}
 	serverNames := []string{}
 	for _, s := range servers {
-		if s.CDNID != nil && s.HostName != nil && *s.CDNID == *d.CDNID && s.Type == tc.CacheTypeEdge.String() {
+		if s.CDNID != nil && s.HostName != nil && *s.CDNID == d.CDNID && s.Type == tc.CacheTypeEdge.String() {
 			serverNames = append(serverNames, *s.HostName)
 		} else {
 			t.Fatalf("expected only EDGE servers in cdn '%s', actual: %v", *d.CDNName, servers)
@@ -328,8 +328,8 @@ func AssignServersToNonTopologyBasedDeliveryServiceThatUsesMidTier(t *testing.T)
 	if dsWithMid.Topology != nil {
 		t.Fatal("expected delivery service: 'ds1' to have a nil Topology, actual: non-nil")
 	}
-	if dsWithMid.CDNID == nil || dsWithMid.CDNName == nil || dsWithMid.ID == nil {
-		t.Fatal("Traffic Ops returned a representation of a Delivery Service that had null or undefined CDN ID and/or CDN Name and/or ID")
+	if dsWithMid.CDNName == nil || dsWithMid.ID == nil {
+		t.Fatal("Traffic Ops returned a representation of a Delivery Service that had null or undefined CDN Name and/or ID")
 	}
 	serversResp, _, err := TOSession.GetServers(client.RequestOptions{})
 	if err != nil {
@@ -337,7 +337,7 @@ func AssignServersToNonTopologyBasedDeliveryServiceThatUsesMidTier(t *testing.T)
 	}
 	serversIds := []int{}
 	for _, s := range serversResp.Response {
-		if s.CDNID != nil && *s.CDNID == *dsWithMid.CDNID && s.Type == tc.CacheTypeEdge.String() {
+		if s.CDNID != nil && *s.CDNID == dsWithMid.CDNID && s.Type == tc.CacheTypeEdge.String() {
 			serversIds = append(serversIds, *s.ID)
 		}
 	}
@@ -364,8 +364,12 @@ func AssignServersToNonTopologyBasedDeliveryServiceThatUsesMidTier(t *testing.T)
 	}
 
 	for _, dss := range dsServersResp.Response {
-		if dss.CDNID != nil && *dss.CDNID != *dsWithMid.CDNID {
-			t.Fatalf("a server for another cdn was returned for this delivery service")
+		if dss.CDNID == nil {
+			t.Error("Traffic Ops returned a representation for a server with null or undefined CDN ID")
+			continue
+		}
+		if *dss.CDNID != dsWithMid.CDNID {
+			t.Error("a server for another cdn was returned for this delivery service")
 		}
 	}
 }
@@ -555,9 +559,6 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 	if ds.ID == nil {
 		t.Fatalf("Got a delivery service with a nil ID %+v", ds)
 	}
-	if ds.Active == nil {
-		t.Fatalf("Got a Delivery Service with nil 'Active': %+v", ds)
-	}
 
 	resp, _, err := TOSession.CreateDeliveryServiceServers(*ds.ID, []int{*server.ID}, true, client.RequestOptions{})
 	if err != nil {
@@ -580,8 +581,8 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 		t.Error("POST delivery service servers returned success, but ds-server not in GET")
 	}
 
-	if *ds.Active {
-		*ds.Active = false
+	if ds.Active == tc.DS_ACTIVE {
+		ds.Active = tc.DS_INACTIVE
 		_, _, err = TOSession.UpdateDeliveryService(*ds.ID, ds, client.RequestOptions{})
 		if err != nil {
 			t.Errorf("Setting Delivery Service #%d to inactive", *ds.ID)

--- a/traffic_ops/testing/api/v4/federations_test.go
+++ b/traffic_ops/testing/api/v4/federations_test.go
@@ -223,14 +223,14 @@ func AddFederationResolversForCurrentUserTest(t *testing.T) {
 
 	mappings := tc.DeliveryServiceFederationResolverMappingRequest{
 		tc.DeliveryServiceFederationResolverMapping{
-			DeliveryService: *ds.XMLID,
+			DeliveryService: ds.XMLID,
 			Mappings: tc.ResolverMapping{
 				Resolve4: []string{"0.0.0.0"},
 				Resolve6: []string{"::1"},
 			},
 		},
 		tc.DeliveryServiceFederationResolverMapping{
-			DeliveryService: *ds1.XMLID,
+			DeliveryService: ds1.XMLID,
 			Mappings: tc.ResolverMapping{
 				Resolve4: []string{"1.2.3.4/28"},
 				Resolve6: []string{"1234::/110"},

--- a/traffic_ops/testing/api/v4/jobs_test.go
+++ b/traffic_ops/testing/api/v4/jobs_test.go
@@ -71,10 +71,7 @@ func JobCollisionWarningTest(t *testing.T) {
 	if len(testData.DeliveryServices) < 1 {
 		t.Fatal("Need at least one Delivery Service to test Invalidation Job collisions")
 	}
-	if testData.DeliveryServices[0].XMLID == nil {
-		t.Fatal("Found a Delivery Service in the testing data with null or undefined XMLID")
-	}
-	xmlID := *testData.DeliveryServices[0].XMLID
+	xmlID := testData.DeliveryServices[0].XMLID
 
 	startTime := tc.Time{
 		Time:  time.Now().Add(time.Hour),
@@ -175,11 +172,11 @@ func CreateTestInvalidationJobs(t *testing.T) {
 	}
 	dsNameIDs := make(map[string]int64, len(toDSes.Response))
 	for _, ds := range toDSes.Response {
-		if ds.XMLID == nil || ds.ID == nil {
-			t.Error("Traffic Ops returned a representation of a Delivery Service that had null or undefined XMLID and/or ID")
+		if ds.ID == nil {
+			t.Error("Traffic Ops returned a representation of a Delivery Service that had null or undefined ID")
 			continue
 		}
-		dsNameIDs[*ds.XMLID] = int64(*ds.ID)
+		dsNameIDs[ds.XMLID] = int64(*ds.ID)
 	}
 
 	for _, job := range testData.InvalidationJobs {
@@ -203,11 +200,11 @@ func CreateTestInvalidJob(t *testing.T) {
 	}
 	dsNameIDs := make(map[string]int64, len(toDSes.Response))
 	for _, ds := range toDSes.Response {
-		if ds.XMLID == nil || ds.ID == nil {
-			t.Error("Traffic Ops returned a representation of a Delivery Service that had null or undefined XMLID and/or ID")
+		if ds.ID == nil {
+			t.Error("Traffic Ops returned a representation of a Delivery Service that had null or undefined ID")
 			continue
 		}
-		dsNameIDs[*ds.XMLID] = int64(*ds.ID)
+		dsNameIDs[ds.XMLID] = int64(*ds.ID)
 	}
 
 	if len(testData.InvalidationJobs) < 1 {

--- a/traffic_ops/testing/api/v4/servers_test.go
+++ b/traffic_ops/testing/api/v4/servers_test.go
@@ -593,11 +593,11 @@ func GetTestServersQueryParameters(t *testing.T) {
 		topology   = "mso-topology"
 	)
 	for _, ds = range dses.Response {
-		if ds.XMLID == nil || ds.ID == nil {
-			t.Error("Traffic Ops returned a representation of a Delivery Service that had a null or undefined XMLID and/or ID")
+		if ds.ID == nil {
+			t.Error("Traffic Ops returned a representation of a Delivery Service that had a null or undefined ID")
 			continue
 		}
-		if *ds.XMLID != topDSXmlID {
+		if ds.XMLID != topDSXmlID {
 			continue
 		}
 		if ds.Topology == nil || ds.FirstHeaderRewrite == nil || ds.InnerHeaderRewrite == nil || ds.LastHeaderRewrite == nil {

--- a/traffic_ops/testing/api/v4/servers_to_deliveryservice_assignment_test.go
+++ b/traffic_ops/testing/api/v4/servers_to_deliveryservice_assignment_test.go
@@ -56,12 +56,8 @@ func AssignTestDeliveryService(t *testing.T) {
 		t.Fatalf("Server '%s' had nil ID", *server.HostName)
 	}
 
-	if testData.DeliveryServices[0].XMLID == nil {
-		t.Fatal("Found Delivery Service in testing data with null or undefined XMLID")
-	}
-
 	opts.QueryParameters.Del("hostName")
-	opts.QueryParameters.Set("xmlId", *testData.DeliveryServices[0].XMLID)
+	opts.QueryParameters.Set("xmlId", testData.DeliveryServices[0].XMLID)
 	rd, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Fatalf("Failed to fetch DS information: %v - alerts: %+v", err, rd.Alerts)
@@ -138,12 +134,9 @@ func AssignIncorrectTestDeliveryService(t *testing.T) {
 	if len(testData.DeliveryServices) < 1 {
 		t.Fatal("Need at least one Delivery Service to test assignment of servers to Delivery Services")
 	}
-	if testData.DeliveryServices[0].XMLID == nil {
-		t.Fatal("Delivery Service selected for testing had null or undefined XMLID")
-	}
 
 	opts = client.NewRequestOptions()
-	opts.QueryParameters.Set("xmlId", *testData.DeliveryServices[0].XMLID)
+	opts.QueryParameters.Set("xmlId", testData.DeliveryServices[0].XMLID)
 	rd, _, err := TOSession.GetDeliveryServices(opts)
 	if err != nil {
 		t.Fatalf("Failed to fetch DS information: %v - alerts: %+v", err, rd.Alerts)

--- a/traffic_ops/testing/api/v4/tc-fixtures.json
+++ b/traffic_ops/testing/api/v4/tc-fixtures.json
@@ -296,7 +296,7 @@
         {
             "changeType": "create",
             "requested": {
-                "active": true,
+                "active": "ACTIVE",
                 "cdnName": "cdn1",
                 "ccrDnsTtl": 30,
                 "deepCachingType": "NEVER",
@@ -326,7 +326,7 @@
         {
             "changeType": "create",
             "requested": {
-                "active": true,
+                "active": "ACTIVE",
                 "cdnName": "cdn1",
                 "ccrDnsTtl": 30,
                 "deepCachingType": "NEVER",
@@ -384,7 +384,7 @@
         {
             "changeType": "create",
             "requested": {
-                "active": false,
+                "active": "PRIMED",
                 "cdnName": "cdn1",
                 "ccrDnsTtl": 30,
                 "deepCachingType": "NEVER",
@@ -414,7 +414,7 @@
     ],
     "deliveryServices": [
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -442,7 +442,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "d s 1",
             "longDesc1": "ds1",
@@ -481,7 +480,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -509,7 +508,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "d s 1",
             "longDesc1": "ds2",
@@ -549,7 +547,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -577,7 +575,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "d s 3",
             "longDesc1": "ds3",
@@ -617,7 +614,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -641,7 +638,6 @@
             "infoUrl": "",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "",
             "longDesc1": "",
@@ -675,7 +671,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -734,7 +730,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -762,7 +758,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "mso DS 1",
             "longDesc1": "msods1",
@@ -801,7 +796,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -829,7 +824,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "d s 1",
             "longDesc1": "ds1nat",
@@ -868,7 +862,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -892,7 +886,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "d s top",
             "longDesc1": "ds top",
@@ -935,7 +928,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -959,7 +952,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "",
             "longDesc1": "",
@@ -999,7 +991,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -1023,7 +1015,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "",
             "longDesc1": "",
@@ -1063,7 +1054,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -1087,7 +1078,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "d s client-steering",
             "longDesc1": "ds client-steering",
@@ -1126,7 +1116,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn2",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -1150,7 +1140,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "",
             "longDesc1": "",
@@ -1190,7 +1179,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -1214,7 +1203,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "",
             "longDesc1": "",
@@ -1254,7 +1242,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -1278,7 +1266,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "",
             "longDesc1": "",
@@ -1318,7 +1305,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "cdnName": "cdn2",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -1342,7 +1329,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "",
             "longDesc1": "",
@@ -1382,7 +1368,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": false,
+            "active": "PRIMED",
             "cdnName": "cdn1",
             "ccrDnsTtl": 3600,
             "checkPath": "",
@@ -1410,7 +1396,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 15:48:51+00",
             "logsEnabled": false,
             "longDesc": "d s inactive",
             "longDesc1": "dsinactive",
@@ -1449,7 +1434,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": true,
+            "active": "ACTIVE",
             "anonymousBlockingEnabled": false,
             "cdnName": "cdn1",
             "displayName": "test",
@@ -1473,7 +1458,7 @@
             "maxRequestHeaderBytes": 131072
         },
         {
-            "active": false,
+            "active": "PRIMED",
             "cdnName": "cdn1",
             "cacheurl": "cacheUrl3",
             "ccrDnsTtl": 3600,
@@ -1502,7 +1487,6 @@
             "infoUrl": "TBD",
             "initialDispersion": 1,
             "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
             "logsEnabled": false,
             "longDesc": "d s 4",
             "longDesc1": "ds4",
@@ -1682,126 +1666,108 @@
     "parameters": [
         {
             "configFile": "rascal.properties",
-            "lastUpdated": "2018-01-19T19:01:21.489534+00:00",
             "name": "history.count",
             "secure": false,
             "value": "30"
         },
         {
             "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.434425+00:00",
             "name": "CONFIG proxy.config.allocator.enable_reclaim",
             "secure": false,
             "value": "INT 0"
         },
         {
             "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.435957+00:00",
             "name": "CONFIG proxy.config.allocator.max_overage",
             "secure": false,
             "value": "INT 3"
         },
         {
             "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.437496+00:00",
             "name": "CONFIG proxy.config.diags.show_location",
             "secure": false,
             "value": "INT 0"
         },
         {
             "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.439033+00:00",
             "name": "CONFIG proxy.config.http.cache.allow_empty_doc",
             "secure": false,
             "value": "INT 0"
         },
         {
             "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.440502+00:00",
             "name": "LOCAL proxy.config.cache.interim.storage",
             "secure": false,
             "value": "STRING NULL"
         },
         {
             "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.441933+00:00",
             "name": "CONFIG proxy.config.http.parent_proxy.file",
             "secure": false,
             "value": "STRING parent.config"
         },
         {
             "configFile": "plugin.config",
-            "lastUpdated": "2018-01-19T19:01:21.447837+00:00",
             "name": "astats_over_http.so",
             "secure": false,
             "value": "_astats 33.101.99.100,172.39.19.39,172.39.19.49,172.39.19.49,172.39.29.49"
         },
         {
             "configFile": "logs_xml.config",
-            "lastUpdated": "2018-01-19T19:01:21.461206+00:00",
             "name": "LogFormat.Name",
             "secure": false,
             "value": "custom_ats_2"
         },
         {
             "configFile": "logs_xml.config",
-            "lastUpdated": "2018-01-19T19:01:21.462772+00:00",
             "name": "LogObject.Format",
             "secure": false,
             "value": "custom_ats_2"
         },
         {
             "configFile": "logs_xml.config",
-            "lastUpdated": "2018-01-19T19:01:21.464259+00:00",
             "name": "LogObject.Filename",
             "secure": false,
             "value": "custom_ats_2"
         },
         {
             "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.467349+00:00",
             "name": "CONFIG proxy.config.cache.control.filename",
             "secure": false,
             "value": "STRING cache.config"
         },
         {
             "configFile": "plugin.config",
-            "lastUpdated": "2018-01-19T19:01:21.469075+00:00",
             "name": "regex_revalidate.so",
             "secure": false,
             "value": "--config regex_revalidate.config"
         },
         {
             "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.49285+00:00",
             "name": "CONFIG proxy.config.hostdb.storage_size",
             "secure": false,
             "value": "INT 33554432"
         },
         {
             "configFile": "regex_revalidate.config",
-            "lastUpdated": "2018-01-19T19:01:21.496195+00:00",
             "name": "maxRevalDurationDays",
             "secure": false,
             "value": "90"
         },
         {
             "configFile": "package",
-            "lastUpdated": "2018-01-19T19:01:21.499423+00:00",
             "name": "trafficserver",
             "secure": false,
             "value": "5.3.2-765.f4354b9.el7.centos.x86_64"
         },
         {
             "configFile": "global",
-            "lastUpdated": "2018-01-19T19:01:21.501151+00:00",
             "name": "use_tenancy",
             "secure": false,
             "value": "1"
         },
         {
             "configFile": "global",
-            "lastUpdated": "2020-04-21T05:19:43.853831+00:00",
             "name": "tm.instance_name",
             "secure": false,
             "value": "Traffic Ops API Tests"
@@ -1813,7 +1779,6 @@
             "city": "Denver",
             "comments": null,
             "email": null,
-            "lastUpdated": "2018-01-19T21:19:32.081465+00:00",
             "name": "Denver",
             "phone": "303-111-1111",
             "poc": null,
@@ -1827,7 +1792,6 @@
             "city": "Boulder",
             "comments": null,
             "email": null,
-            "lastUpdated": "2018-01-19T21:19:32.086195+00:00",
             "name": "Boulder",
             "phone": "303-222-2222",
             "poc": null,
@@ -1841,7 +1805,6 @@
             "city": "Atlanta",
             "comments": null,
             "email": null,
-            "lastUpdated": "2018-01-19T21:19:32.089538+00:00",
             "name": "HotAtlanta",
             "phone": "404-222-2222",
             "poc": null,
@@ -2227,7 +2190,6 @@
         {
             "cdnName": "cdn1",
             "description": "edge1 description",
-            "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
             "name": "EDGE1",
             "routing_disabled": false,
             "type": "ATS_PROFILE",
@@ -2255,7 +2217,6 @@
         {
             "cdnName": "cdn2",
             "description": "edge2 description",
-            "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
             "name": "EDGEInCDN2",
             "routing_disabled": false,
             "type": "ATS_PROFILE"
@@ -2263,7 +2224,6 @@
         {
             "cdnName": "cdn4",
             "description": "edge2 description",
-            "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
             "name": "EDGE2",
             "routing_disabled": false,
             "type": "ATS_PROFILE"
@@ -2278,7 +2238,6 @@
         {
             "cdnName": "cdn1",
             "description": "mid description",
-            "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
             "name": "MID1",
             "routing_disabled": false,
             "type": "ATS_PROFILE"
@@ -2286,7 +2245,6 @@
         {
             "cdnName": "cdn2",
             "description": "mid description",
-            "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
             "name": "MID2",
             "routing_disabled": false,
             "type": "ATS_PROFILE"
@@ -2294,7 +2252,6 @@
         {
             "cdnName": "cdn1",
             "description": "origin description",
-            "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
             "name": "ORIGIN1",
             "routing_disabled": false,
             "type": "ORG_PROFILE"
@@ -2302,7 +2259,6 @@
         {
             "cdnName": "cdn1",
             "description": "cdn1 description",
-            "lastUpdated": "2018-03-02T17:27:11.80452+00:00",
             "name": "CCR1",
             "routing_disabled": false,
             "type": "TR_PROFILE"
@@ -2310,7 +2266,6 @@
         {
             "cdnName": "cdn2",
             "description": "cdn2 description",
-            "lastUpdated": "2018-03-02T17:27:11.807948+00:00",
             "name": "CCR2",
             "routing_disabled": false,
             "type": "TR_PROFILE"
@@ -2318,7 +2273,6 @@
         {
             "cdnName": "cdn1",
             "description": "rascal description",
-            "lastUpdated": "2018-03-02T17:27:11.813052+00:00",
             "name": "RASCAL1",
             "routing_disabled": false,
             "type": "TM_PROFILE",
@@ -2337,14 +2291,12 @@
                 },
                 {
                     "configFile": "rascal-config.txt",
-                    "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
                     "name": "peers.polling.interval",
                     "secure": false,
                     "value": "60"
                 },
                 {
                     "configFile": "rascal-config.txt",
-                    "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
                     "name": "health.polling.interval",
                     "secure": false,
                     "value": "30"
@@ -2354,7 +2306,6 @@
         {
             "cdnName": "cdn1",
             "description": "mso origin description",
-            "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
             "name": "MSO",
             "routing_disabled": false,
             "type": "ORG_PROFILE"
@@ -2441,7 +2392,6 @@
                     "routerPort": "9000"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2486,7 +2436,6 @@
                     "routerPort": "9001"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2536,7 +2485,6 @@
                     "routerPort": "9002"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2586,7 +2534,6 @@
                     "routerPort": "9003"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2636,7 +2583,6 @@
                     "routerPort": "9004"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2686,7 +2632,6 @@
                     "routerPort": "9005"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2737,7 +2682,6 @@
                 }
             ],
             "ipNetmask": "255.255.255.252",
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2787,7 +2731,6 @@
                     "routerPort": "9007"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2837,7 +2780,6 @@
                     "routerPort": "9008"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2887,7 +2829,6 @@
                     "routerPort": "9009"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2937,7 +2878,6 @@
                     "routerPort": "9010"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -2987,7 +2927,6 @@
                     "routerPort": "9011"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -3037,7 +2976,6 @@
                     "routerPort": "9012"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -3136,7 +3074,6 @@
                     "routerPort": "9014"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -3186,7 +3123,6 @@
                     "routerPort": "9015"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -4067,7 +4003,6 @@
                     "routerPort": "9038"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -4613,7 +4548,6 @@
                     "routerPort": "9000"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -4663,7 +4597,6 @@
                     "routerPort": "9011"
                 }
             ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
             "mgmtIpAddress": "",
             "mgmtIpGateway": "",
             "mgmtIpNetmask": "",
@@ -5122,193 +5055,161 @@
     "types": [
         {
             "description": "Host header regular expression",
-            "lastUpdated": "2018-03-02T19:13:46.788583+00:00",
             "name": "HOST_REGEXP",
             "useInTable": "regex"
         },
         {
             "description": "DNS Content routing, RAM cache, National",
-            "lastUpdated": "2018-03-02T19:13:46.792319+00:00",
             "name": "DNS_LIVE_NATNL",
             "useInTable": "deliveryservice"
         },
         {
             "description": "Other CDN (CDS-IS, Akamai, etc)",
-            "lastUpdated": "2018-03-02T19:13:46.793921+00:00",
             "name": "OTHER_CDN",
             "useInTable": "server"
         },
         {
             "description": "Client-Controlled Steering Delivery Service",
-            "lastUpdated": "2018-03-02T19:13:46.795291+00:00",
             "name": "CLIENT_STEERING",
             "useInTable": "deliveryservice"
         },
         {
             "description": "influxdb type",
-            "lastUpdated": "2018-03-02T19:13:46.796707+00:00",
             "name": "INFLUXDB",
             "useInTable": "server"
         },
         {
             "description": "riak type",
-            "lastUpdated": "2018-03-02T19:13:46.798008+00:00",
             "name": "RIAK",
             "useInTable": "server"
         },
         {
             "description": "Origin",
-            "lastUpdated": "2018-03-02T19:13:46.799404+00:00",
             "name": "ORG",
             "useInTable": "server"
         },
         {
             "description": "HTTP Content routing cache in RAM ",
-            "lastUpdated": "2018-03-02T19:13:46.800738+00:00",
             "name": "HTTP_LIVE",
             "useInTable": "deliveryservice"
         },
         {
             "description": "Active Directory User",
-            "lastUpdated": "2018-03-02T19:13:46.802044+00:00",
             "name": "ACTIVE_DIRECTORY",
             "useInTable": "tm_user"
         },
         {
             "description": "federation type resolve4",
-            "lastUpdated": "2018-03-02T19:13:46.803471+00:00",
             "name": "RESOLVE4",
             "useInTable": "federation"
         },
         {
             "description": "Static DNS A entry",
-            "lastUpdated": "2018-03-02T19:13:46.804776+00:00",
             "name": "A_RECORD",
             "useInTable": "staticdnsentry"
         },
         {
             "description": "Local User",
-            "lastUpdated": "2018-03-02T19:13:46.806035+00:00",
             "name": "LOCAL",
             "useInTable": "tm_user"
         },
         {
             "description": "Weighted steering target",
-            "lastUpdated": "2018-03-02T19:13:46.80748+00:00",
             "name": "STEERING_WEIGHT",
             "useInTable": "steering_target"
         },
         {
             "description": "HTTP Content routing, RAM cache, National",
-            "lastUpdated": "2018-03-02T19:13:46.808911+00:00",
             "name": "HTTP_LIVE_NATNL",
             "useInTable": "deliveryservice"
         },
         {
             "description": "Ops hosts for management",
-            "lastUpdated": "2018-03-02T19:13:46.810576+00:00",
             "name": "TOOLS_SERVER",
             "useInTable": "server"
         },
         {
             "description": "Path regular expression",
-            "lastUpdated": "2018-03-02T19:13:46.812049+00:00",
             "name": "PATH_REGEXP",
             "useInTable": "regex"
         },
         {
             "description": "Static DNS CNAME entry",
-            "lastUpdated": "2018-03-02T19:13:46.813461+00:00",
             "name": "CNAME_RECORD",
             "useInTable": "staticdnsentry"
         },
         {
             "description": "Kabletown Content Router",
-            "lastUpdated": "2018-03-02T19:13:46.814833+00:00",
             "name": "CCR",
             "useInTable": "server"
         },
         {
             "description": "Origin Cachegroup",
-            "lastUpdated": "2018-03-02T19:13:46.816199+00:00",
             "name": "ORG_LOC",
             "useInTable": "cachegroup"
         },
         {
             "description": "Mid Cachegroup",
-            "lastUpdated": "2018-03-02T19:13:46.816199+00:00",
             "name": "MID_LOC",
             "useInTable": "cachegroup"
         },
         {
             "description": "Edge Cache",
-            "lastUpdated": "2018-03-02T19:13:46.817689+00:00",
             "name": "EDGE",
             "useInTable": "server"
         },
         {
             "description": "Ordered steering target",
-            "lastUpdated": "2018-03-02T19:13:46.81913+00:00",
             "name": "STEERING_ORDER",
             "useInTable": "steering_target"
         },
         {
             "description": "DNS Content Routing",
-            "lastUpdated": "2018-03-02T19:13:46.820528+00:00",
             "name": "DNS",
             "useInTable": "deliveryservice"
         },
         {
             "description": "federation type resolve6",
-            "lastUpdated": "2018-03-02T19:13:46.822161+00:00",
             "name": "RESOLVE6",
             "useInTable": "federation"
         },
         {
             "description": "Static DNS AAAA entry",
-            "lastUpdated": "2018-03-02T19:13:46.823506+00:00",
             "name": "AAAA_RECORD",
             "useInTable": "staticdnsentry"
         },
         {
             "description": "HTTP Content Routing, no caching",
-            "lastUpdated": "2018-03-02T19:13:46.824798+00:00",
             "name": "HTTP_NO_CACHE",
             "useInTable": "deliveryservice"
         },
         {
             "description": "any_map type",
-            "lastUpdated": "2018-03-02T19:13:46.826411+00:00",
             "name": "ANY_MAP",
             "useInTable": "deliveryservice"
         },
         {
             "description": "Steering Delivery Service",
-            "lastUpdated": "2018-03-02T19:13:46.827779+00:00",
             "name": "STEERING",
             "useInTable": "deliveryservice"
         },
         {
             "description": "Edge Cachegroup",
-            "lastUpdated": "2018-03-02T19:13:46.829249+00:00",
             "name": "EDGE_LOC",
             "useInTable": "cachegroup"
         },
         {
             "description": "HTTP Content routing cache ",
-            "lastUpdated": "2018-03-02T19:13:46.830862+00:00",
             "name": "HTTP",
             "useInTable": "deliveryservice"
         },
         {
             "description": "Mid Tier Cache",
-            "lastUpdated": "2018-03-02T19:13:46.832327+00:00",
             "name": "MID",
             "useInTable": "server"
         },
         {
             "description": "Traffic Monitor (Rascal)",
-            "lastUpdated": "2018-03-02T19:13:46.832327+00:00",
             "name": "RASCAL",
             "useInTable": "server"
         }

--- a/traffic_ops/testing/api/v4/tenants_test.go
+++ b/traffic_ops/testing/api/v4/tenants_test.go
@@ -286,13 +286,6 @@ func DeleteTestTenants(t *testing.T) {
 	}
 }
 
-func ExtractXMLID(ds *tc.DeliveryServiceV4) string {
-	if ds.XMLID != nil {
-		return *ds.XMLID
-	}
-	return "nil"
-}
-
 func UpdateTestTenantsActive(t *testing.T) {
 	originalTenants, _, err := TOSession.GetTenants(client.RequestOptions{})
 	if err != nil {
@@ -340,7 +333,7 @@ func UpdateTestTenantsActive(t *testing.T) {
 		t.Errorf("Unexpected error fetching Delivery Services filtered by XMLID 'ds3': %v - alerts: %+v", err, resp.Alerts)
 	}
 	for _, ds := range resp.Response {
-		t.Errorf("tenant3user got delivery service %s with tenant3 but tenant3 parent tenant2 is inactive, expected: no ds", ExtractXMLID(&ds))
+		t.Errorf("tenant3user got delivery service %s with tenant3 but tenant3 parent tenant2 is inactive, expected: no ds", ds.XMLID)
 	}
 
 	setTenantActive(t, "tenant1", true)
@@ -353,7 +346,7 @@ func UpdateTestTenantsActive(t *testing.T) {
 		t.Errorf("Unexpected error fetching Delivery Services filtered by XMLID 'ds3': %v - alerts: %+v", err, resp.Alerts)
 	}
 	for _, ds := range resp.Response {
-		t.Errorf("tenant3user got delivery service %s with tenant3 but tenant3 is inactive, expected: no ds", ExtractXMLID(&ds))
+		t.Errorf("tenant3user got delivery service %s with tenant3 but tenant3 is inactive, expected: no ds", ds.XMLID)
 	}
 
 	setTenantActive(t, "tenant1", true)
@@ -378,7 +371,7 @@ func UpdateTestTenantsActive(t *testing.T) {
 		t.Errorf("Unexpected error fetching Delivery Services filtered by XMLID 'ds2': %v - alerts: %+v", err, resp.Alerts)
 	}
 	for _, ds := range resp.Response {
-		t.Errorf("tenant3user got delivery service %s with tenant2, expected: no ds", ExtractXMLID(&ds))
+		t.Errorf("tenant3user got delivery service %s with tenant2, expected: no ds", ds.XMLID)
 	}
 
 	// 1. ds1 has tenant1.
@@ -391,7 +384,7 @@ func UpdateTestTenantsActive(t *testing.T) {
 		t.Errorf("Unexpected error fetching Delivery Services filtered by XMLID 'ds1': %v - alerts: %+v", err, resp.Alerts)
 	}
 	for _, ds := range resp.Response {
-		t.Errorf("tenant4user got delivery service %s with tenant1, expected: no ds", ExtractXMLID(&ds))
+		t.Errorf("tenant4user got delivery service %s with tenant1, expected: no ds", ds.XMLID)
 	}
 
 	setTenantActive(t, "tenant3", false)
@@ -401,7 +394,7 @@ func UpdateTestTenantsActive(t *testing.T) {
 		t.Errorf("Unexpected error fetching Delivery Services filtered by XMLID 'ds3': %v - alerts: %+v", err, resp.Alerts)
 	}
 	for _, ds := range resp.Response {
-		t.Errorf("tenant3user was inactive, but got delivery service %s with tenant3, expected: no ds", ExtractXMLID(&ds))
+		t.Errorf("tenant3user was inactive, but got delivery service %s with tenant3, expected: no ds", ds.XMLID)
 	}
 
 	for _, tn := range originalTenants.Response {

--- a/traffic_ops/testing/api/v4/topologies_queue_update_test.go
+++ b/traffic_ops/testing/api/v4/topologies_queue_update_test.go
@@ -56,10 +56,10 @@ func getCDNIDAndDSID(t *testing.T) (int64, int) {
 		t.Fatalf("deliveryservice with xmlId '%s' not found!", xmlID)
 	}
 	ds := dses.Response[0]
-	if ds.CDNID == nil || ds.ID == nil {
-		t.Fatalf("Traffic Ops returned a representation of a Delivery Service that had null or undefined CDN ID and/or ID")
+	if ds.ID == nil {
+		t.Fatalf("Traffic Ops returned a representation of a Delivery Service that had null or undefined ID")
 	}
-	return int64(*ds.CDNID), *ds.ID
+	return int64(ds.CDNID), *ds.ID
 }
 
 func InvalidCDNIDIsRejected(t *testing.T, topologyName string) {

--- a/traffic_ops/testing/api/v4/topologies_test.go
+++ b/traffic_ops/testing/api/v4/topologies_test.go
@@ -353,15 +353,15 @@ func UpdateValidateTopologyORGServerCacheGroup(t *testing.T) {
 		t.Fatalf("Expected exactly one Delivery Service to exist with XMLID 'ds-top', found: %d", len(resp.Response))
 	}
 	remoteDS := resp.Response[0]
-	if remoteDS.XMLID == nil || remoteDS.Topology == nil || remoteDS.ID == nil {
-		t.Fatal("Traffic Ops returned a representation of a Delivery Service that had null or undefined Topology and/or XMLID and/or ID")
+	if remoteDS.Topology == nil || remoteDS.ID == nil {
+		t.Fatal("Traffic Ops returned a representation of a Delivery Service that had null or undefined Topology and/or ID")
 	}
 
 	//Assign ORG server to DS
 	assignServer := []string{"denver-mso-org-01"}
-	assignResponse, _, err := TOSession.AssignServersToDeliveryService(assignServer, *remoteDS.XMLID, toclient.RequestOptions{})
+	assignResponse, _, err := TOSession.AssignServersToDeliveryService(assignServer, remoteDS.XMLID, toclient.RequestOptions{})
 	if err != nil {
-		t.Errorf("Unexpected error assigning server 'denver-mso-org-01' to Delivery Service '%s': %v - alerts: %+v", *remoteDS.XMLID, err, assignResponse.Alerts)
+		t.Errorf("Unexpected error assigning server 'denver-mso-org-01' to Delivery Service '%s': %v - alerts: %+v", remoteDS.XMLID, err, assignResponse.Alerts)
 	}
 
 	//Get Topology node to update and remove ORG server nodes

--- a/traffic_ops/traffic_ops_golang/crconfig/deliveryservice.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/deliveryservice.go
@@ -131,7 +131,7 @@ FROM deliveryservice AS d
 INNER JOIN type AS t ON t.id = d.type
 LEFT OUTER JOIN profile AS p ON p.id = d.profile
 WHERE d.cdn_id = (select id FROM cdn WHERE name = $1)
-AND d.active = true
+AND d.active = 'ACTIVE'
 `
 	q += fmt.Sprintf(" and t.name != '%s'", tc.DSTypeAnyMap)
 	rows, err := tx.Query(q, cdn)
@@ -431,7 +431,7 @@ from staticdnsentry as e
 inner join deliveryservice as d on d.id = e.deliveryservice
 inner join type as t on t.id = e.type
 where d.cdn_id = (select id from cdn where name = $1)
-and d.active = true
+and d.active = 'ACTIVE'
 `
 	rows, err := tx.Query(q, cdn)
 	if err != nil {
@@ -473,7 +473,7 @@ inner join deliveryservice as d on d.id = dr.deliveryservice
 inner join type as t on t.id = r.type
 inner join type as dt on dt.id = d.type
 where d.cdn_id = (select id from cdn where name = $1)
-and d.active = true
+and d.active = 'ACTIVE'
 order by dr.set_number asc
 `
 	rows, err := tx.Query(q, cdn)

--- a/traffic_ops/traffic_ops_golang/crconfig/servers.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/servers.go
@@ -269,7 +269,7 @@ inner join type as dt on dt.id = ds.type
 inner join profile as p on p.id = s.profile
 inner join status as st ON st.id = s.status
 where ds.cdn_id = (select id from cdn where name = $1)
-and ds.active = true` +
+and ds.active = 'ACTIVE'` +
 		fmt.Sprintf(" and dt.name != '%s' ", tc.DSTypeAnyMap) + `
 and p.routing_disabled = false
 and (st.name = 'REPORTED' or st.name = 'ONLINE' or st.name = 'ADMIN_DOWN')
@@ -313,7 +313,7 @@ inner join deliveryservice_regex as dsr on dsr.regex = r.id
 inner join deliveryservice as ds on ds.id = dsr.deliveryservice
 inner join type as dt on dt.id = ds.type
 where ds.cdn_id = (select id from cdn where name = $1)
-and ds.active = true` +
+and ds.active = 'ACTIVE'` +
 		fmt.Sprintf(" and dt.name != '%s' ", tc.DSTypeAnyMap) + `
 and rt.name = 'HOST_REGEXP'
 order by dsr.set_number asc

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -885,14 +885,14 @@ func CheckTopology(tx *sqlx.Tx, ds tc.DeliveryServiceV4) (int, error, error) {
 
 	cacheGroupIDs, _, err := GetTopologyCachegroups(tx.Tx, *ds.Topology)
 	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Errorf("getting topology cachegroups: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Errorf("getting topology cachegroups: %w", err)
 	}
 	if len(cacheGroupIDs) == 0 {
 		return http.StatusBadRequest, fmt.Errorf("no such Topology '%s'", *ds.Topology), nil
 	}
 
-	if err = topology_validation.CheckForEmptyCacheGroups(tx, cacheGroupIDs, []int{*ds.CDNID}, true, []int{}); err != nil {
-		return http.StatusBadRequest, fmt.Errorf("empty cachegroups in Topology %s found for CDN %d: %s", *ds.Topology, *ds.CDNID, err.Error()), nil
+	if err = topology_validation.CheckForEmptyCacheGroups(tx, cacheGroupIDs, []int{ds.CDNID}, true, []int{}); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("empty cachegroups in Topology %s found for CDN %d: %w", *ds.Topology, ds.CDNID, err), nil
 	}
 
 	return statusCode, userErr, sysErr

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -1372,7 +1372,7 @@ func validateTypeFields(tx *sql.Tx, ds *tc.DeliveryServiceV4) error {
 		"initialDispersion": validation.Validate(ds.InitialDispersion,
 			validation.By(requiredIfMatchesTypeName([]string{HTTPRegexType}, typeName)),
 			validation.By(tovalidate.IsGreaterThanZero)),
-		"ipv6RoutingEnabled": validation.Validate(ds.IPV6RoutingEnabled,
+		"ipv6RoutingEnabled": validation.Validate(&ds.IPV6RoutingEnabled,
 			validation.By(requiredIfMatchesTypeName([]string{SteeringRegexType, DNSRegexType, HTTPRegexType}, typeName))),
 		"missLat": validation.Validate(ds.MissLat,
 			validation.By(requiredIfMatchesTypeName([]string{DNSRegexType, HTTPRegexType}, typeName)),
@@ -1943,9 +1943,6 @@ func deleteLocationParam(tx *sql.Tx, configFile string) error {
 
 // getTenantID returns the tenant Id of the given delivery service. Note it may return a nil id and nil error, if the tenant ID in the database is nil.
 func getTenantID(tx *sql.Tx, ds *tc.DeliveryServiceV4) (*int, error) {
-	if ds.ID == nil {
-		return nil, errors.New("delivery service has no ID or XMLID")
-	}
 	if ds.ID != nil {
 		existingID, _, err := getDSTenantIDByID(tx, *ds.ID) // ignore exists return - if the DS is new, we only need to check the user input tenant
 		return existingID, err

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -1165,6 +1165,18 @@ func (v *TODeliveryService) DeleteQuery() string {
 	return `DELETE FROM deliveryservice WHERE id = :id`
 }
 
+func isActiveState(s string) error {
+	switch tc.DeliveryServiceActiveState(s) {
+	case tc.DS_ACTIVE:
+		fallthrough
+	case tc.DS_INACTIVE:
+		fallthrough
+	case tc.DS_PRIMED:
+		return nil
+	}
+	return fmt.Errorf("'%s' is not a known Delivery Service Active State", s)
+}
+
 func readGetDeliveryServices(h http.Header, params map[string]string, tx *sqlx.Tx, user *auth.CurrentUser, useIMS bool) ([]tc.DeliveryServiceV4, error, error, int, *time.Time) {
 	var maxTime time.Time
 	var runSecond bool
@@ -1189,7 +1201,7 @@ func readGetDeliveryServices(h http.Header, params map[string]string, tx *sqlx.T
 		"signingAlgorithm": {Column: "ds.signing_algorithm"},
 		"topology":         {Column: "ds.topology"},
 		"serviceCategory":  {Column: "ds.service_category"},
-		"active":           {Column: "ds.active", Checker: api.IsBool},
+		"active":           {Column: "ds.active", Checker: isActiveState},
 	}
 
 	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -95,10 +95,7 @@ func (ds TODeliveryService) GetKeyFieldsInfo() []api.KeyFieldInfo {
 }
 
 func (ds *TODeliveryService) GetAuditName() string {
-	if ds.XMLID != nil {
-		return *ds.XMLID
-	}
-	return ""
+	return ds.XMLID
 }
 
 func (ds *TODeliveryService) GetType() string {
@@ -320,7 +317,7 @@ func createV31(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV31 t
 		}
 	}
 
-	if err := EnsureCacheURLParams(tx, *ds.ID, *ds.XMLID, dsV31.CacheURL); err != nil {
+	if err := EnsureCacheURLParams(tx, *ds.ID, ds.XMLID, dsV31.CacheURL); err != nil {
 		return nil, http.StatusInternalServerError, nil, err
 	}
 
@@ -344,10 +341,7 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 	}
 
 	// TODO change DeepCachingType to implement sql.Valuer and sql.Scanner, so sqlx struct scan can be used.
-	deepCachingType := tc.DeepCachingType("").String()
-	if ds.DeepCachingType != nil {
-		deepCachingType = ds.DeepCachingType.String() // necessary, because DeepCachingType's default needs to insert the string, not "", and Query doesn't call .String().
-	}
+	deepCachingType := ds.DeepCachingType.String() // necessary, because DeepCachingType's default needs to insert the string, not "", and Query doesn't call .String().
 
 	if errCode, userErr, sysErr := dbhelpers.CheckTopology(inf.Tx, ds); userErr != nil || sysErr != nil {
 		return nil, errCode, userErr, sysErr
@@ -421,7 +415,7 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 	defer resultRows.Close()
 
 	id := 0
-	lastUpdated := tc.TimeNoMod{}
+	var lastUpdated time.Time
 	if !resultRows.Next() {
 		return nil, http.StatusInternalServerError, nil, errors.New("no deliveryservice request inserted, no id was returned")
 	}
@@ -436,19 +430,13 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 	if ds.ID == nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("missing id after insert")
 	}
-	if ds.XMLID == nil {
-		return nil, http.StatusInternalServerError, nil, errors.New("missing xml_id after insert")
-	}
-	if ds.TypeID == nil {
-		return nil, http.StatusInternalServerError, nil, errors.New("missing type after insert")
-	}
-	dsType, err := getTypeFromID(*ds.TypeID, tx)
+	dsType, err := getTypeFromID(ds.TypeID, tx)
 	if err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("getting delivery service type: " + err.Error())
 	}
 	ds.Type = &dsType
 
-	if err := createDefaultRegex(tx, *ds.ID, *ds.XMLID); err != nil {
+	if err := createDefaultRegex(tx, *ds.ID, ds.XMLID); err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("creating default regex: " + err.Error())
 	}
 
@@ -457,14 +445,14 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 		return nil, code, usrErr, sysErr
 	}
 
-	matchlists, err := GetDeliveryServicesMatchLists([]string{*ds.XMLID}, tx)
+	matchlists, err := GetDeliveryServicesMatchLists([]string{ds.XMLID}, tx)
 	if err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("creating DS: reading matchlists: " + err.Error())
 	}
-	if matchlist, ok := matchlists[*ds.XMLID]; !ok {
+	if matchlist, ok := matchlists[ds.XMLID]; !ok {
 		return nil, http.StatusInternalServerError, nil, errors.New("creating DS: reading matchlists: not found")
 	} else {
-		ds.MatchList = &matchlist
+		ds.MatchList = matchlist
 	}
 
 	cdnName, cdnDomain, dnssecEnabled, err := getCDNNameDomainDNSSecEnabled(*ds.ID, tx)
@@ -472,9 +460,9 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 		return nil, http.StatusInternalServerError, nil, errors.New("creating DS: getting CDN info: " + err.Error())
 	}
 
-	ds.ExampleURLs = MakeExampleURLs(ds.Protocol, *ds.Type, *ds.RoutingName, *ds.MatchList, cdnDomain)
+	ds.ExampleURLs = MakeExampleURLs(ds.Protocol, *ds.Type, ds.RoutingName, ds.MatchList, cdnDomain)
 
-	if err := EnsureParams(tx, *ds.ID, *ds.XMLID, ds.EdgeHeaderRewrite, ds.MidHeaderRewrite, ds.RegexRemap, ds.SigningAlgorithm, dsType, ds.MaxOriginConnections); err != nil {
+	if err := EnsureParams(tx, *ds.ID, ds.XMLID, ds.EdgeHeaderRewrite, ds.MidHeaderRewrite, ds.RegexRemap, ds.SigningAlgorithm, dsType, ds.MaxOriginConnections); err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("ensuring ds parameters:: " + err.Error())
 	}
 
@@ -482,7 +470,7 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 		if !inf.Config.TrafficVaultEnabled {
 			return nil, http.StatusInternalServerError, nil, errors.New("cannot create DNSSEC keys for delivery service: Traffic Vault is not configured")
 		}
-		if userErr, sysErr, statusCode := PutDNSSecKeys(tx, *ds.XMLID, cdnName, ds.ExampleURLs, inf.Vault, r.Context()); userErr != nil || sysErr != nil {
+		if userErr, sysErr, statusCode := PutDNSSecKeys(tx, ds.XMLID, cdnName, ds.ExampleURLs, inf.Vault, r.Context()); userErr != nil || sysErr != nil {
 			return nil, statusCode, userErr, sysErr
 		}
 	}
@@ -491,8 +479,8 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 		return nil, http.StatusInternalServerError, nil, errors.New("creating delivery service: " + err.Error())
 	}
 
-	ds.LastUpdated = &lastUpdated
-	if err := api.CreateChangeLogRawErr(api.ApiChange, "DS: "+*ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Created delivery service", user, tx); err != nil {
+	ds.LastUpdated = lastUpdated
+	if err := api.CreateChangeLogRawErr(api.ApiChange, "DS: "+ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Created delivery service", user, tx); err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("error writing to audit log: " + err.Error())
 	}
 
@@ -905,7 +893,7 @@ func updateV31(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV31 *
 		}
 	}
 
-	if err := EnsureCacheURLParams(tx, *ds.ID, *ds.XMLID, dsV31.CacheURL); err != nil {
+	if err := EnsureCacheURLParams(tx, *ds.ID, ds.XMLID, dsV31.CacheURL); err != nil {
 		return nil, http.StatusInternalServerError, nil, err
 	}
 
@@ -926,16 +914,13 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 		return nil, http.StatusForbidden, errors.New("not authorized on this tenant"), nil
 	}
 
-	if ds.XMLID == nil {
-		return nil, http.StatusBadRequest, errors.New("missing xml_id"), nil
-	}
 	if ds.ID == nil {
 		return nil, http.StatusBadRequest, errors.New("missing id"), nil
 	}
 
-	dsType, ok, err := getDSType(tx, *ds.XMLID)
+	dsType, ok, err := getDSType(tx, ds.XMLID)
 	if !ok {
-		return nil, http.StatusNotFound, errors.New("delivery service '" + *ds.XMLID + "' not found"), nil
+		return nil, http.StatusNotFound, errors.New("delivery service '" + ds.XMLID + "' not found"), nil
 	}
 	if err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("getting delivery service type during update: " + err.Error())
@@ -951,20 +936,17 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 		if userErr != nil || sysErr != nil {
 			return nil, errCode, userErr, sysErr
 		}
-		if sslKeysExist, err = getSSLVersion(*ds.XMLID, tx); err != nil {
+		if sslKeysExist, err = getSSLVersion(ds.XMLID, tx); err != nil {
 			return nil, http.StatusInternalServerError, nil, fmt.Errorf("querying delivery service with sslKeyVersion failed: %s", err)
 		}
-		if ds.CDNID == nil {
-			return nil, http.StatusBadRequest, errors.New("invalid request: 'cdnId' cannot be blank"), nil
-		}
 		if sslKeysExist {
-			if oldDetails.OldCdnId != *ds.CDNID {
+			if oldDetails.OldCdnId != ds.CDNID {
 				cdnRoutingDetailDiff = true
 			}
 			if ds.CDNName != nil && oldDetails.OldCdnName != *ds.CDNName {
 				cdnRoutingDetailDiff = true
 			}
-			if ds.RoutingName != nil && oldDetails.OldRoutingName != *ds.RoutingName {
+			if oldDetails.OldRoutingName != ds.RoutingName {
 				cdnRoutingDetailDiff = true
 			}
 			if cdnRoutingDetailDiff {
@@ -975,10 +957,7 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 	}
 
 	// TODO change DeepCachingType to implement sql.Valuer and sql.Scanner, so sqlx struct scan can be used.
-	deepCachingType := tc.DeepCachingType("").String()
-	if ds.DeepCachingType != nil {
-		deepCachingType = ds.DeepCachingType.String() // necessary, because DeepCachingType's default needs to insert the string, not "", and Query doesn't call .String().
-	}
+	deepCachingType := ds.DeepCachingType.String() // necessary, because DeepCachingType's default needs to insert the string, not "", and Query doesn't call .String().
 
 	userErr, sysErr, errCode = api.CheckIfUnModified(r.Header, inf.Tx, *ds.ID, "deliveryservice")
 	if userErr != nil || sysErr != nil {
@@ -1076,31 +1055,18 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 	if !resultRows.Next() {
 		return nil, http.StatusNotFound, errors.New("no delivery service found with this id"), nil
 	}
-	lastUpdated := tc.TimeNoMod{}
+	var lastUpdated time.Time
 	if err := resultRows.Scan(&lastUpdated); err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("scan updating delivery service: " + err.Error())
 	}
 	if resultRows.Next() {
-		xmlID := ""
-		if ds.XMLID != nil {
-			xmlID = *ds.XMLID
-		}
-		return nil, http.StatusInternalServerError, nil, errors.New("updating delivery service " + xmlID + ": " + "this update affected too many rows: > 1")
+		return nil, http.StatusInternalServerError, nil, errors.New("updating delivery service " + ds.XMLID + ": " + "this update affected too many rows: > 1")
 	}
 
 	if ds.ID == nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("missing id after update")
 	}
-	if ds.XMLID == nil {
-		return nil, http.StatusInternalServerError, nil, errors.New("missing xml_id after update")
-	}
-	if ds.TypeID == nil {
-		return nil, http.StatusInternalServerError, nil, errors.New("missing type after update")
-	}
-	if ds.RoutingName == nil {
-		return nil, http.StatusInternalServerError, nil, errors.New("missing routing name after update")
-	}
-	newDSType, err := getTypeFromID(*ds.TypeID, tx)
+	newDSType, err := getTypeFromID(ds.TypeID, tx)
 	if err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("getting delivery service type after update: " + err.Error())
 	}
@@ -1111,17 +1077,17 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 		return nil, http.StatusInternalServerError, nil, errors.New("getting CDN domain: (" + cdnDomain + ") after update: " + err.Error())
 	}
 
-	matchLists, err := GetDeliveryServicesMatchLists([]string{*ds.XMLID}, tx)
+	matchLists, err := GetDeliveryServicesMatchLists([]string{ds.XMLID}, tx)
 	if err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("getting matchlists after update: " + err.Error())
 	}
-	if ml, ok := matchLists[*ds.XMLID]; !ok {
+	if ml, ok := matchLists[ds.XMLID]; !ok {
 		return nil, http.StatusInternalServerError, nil, errors.New("no matchlists after update")
 	} else {
-		ds.MatchList = &ml
+		ds.MatchList = ml
 	}
 
-	if err := EnsureParams(tx, *ds.ID, *ds.XMLID, ds.EdgeHeaderRewrite, ds.MidHeaderRewrite, ds.RegexRemap, ds.SigningAlgorithm, newDSType, ds.MaxOriginConnections); err != nil {
+	if err := EnsureParams(tx, *ds.ID, ds.XMLID, ds.EdgeHeaderRewrite, ds.MidHeaderRewrite, ds.RegexRemap, ds.SigningAlgorithm, newDSType, ds.MaxOriginConnections); err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("ensuring ds parameters:: " + err.Error())
 	}
 
@@ -1131,14 +1097,14 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 		}
 	}
 
-	ds.LastUpdated = &lastUpdated
+	ds.LastUpdated = lastUpdated
 
 	// the update may change or delete the query params -- delete existing and re-add if any provided
 	q := `DELETE FROM deliveryservice_consistent_hash_query_param WHERE deliveryservice_id = $1`
 	if res, err := tx.Exec(q, *ds.ID); err != nil {
-		return nil, http.StatusInternalServerError, nil, fmt.Errorf("deleting consistent hash query params for ds %s: %s", *ds.XMLID, err.Error())
+		return nil, http.StatusInternalServerError, nil, fmt.Errorf("deleting consistent hash query params for ds %s: %w", ds.XMLID, err)
 	} else if c, _ := res.RowsAffected(); c > 0 {
-		api.CreateChangeLogRawTx(api.ApiChange, "DS: "+*ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Deleted "+strconv.FormatInt(c, 10)+" consistent hash query params", user, tx)
+		api.CreateChangeLogRawTx(api.ApiChange, "DS: "+ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Deleted "+strconv.FormatInt(c, 10)+" consistent hash query params", user, tx)
 	}
 
 	if _, err = createConsistentHashQueryParams(tx, *ds.ID, ds.ConsistentHashQueryParams); err != nil {
@@ -1146,7 +1112,7 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 		return nil, code, usrErr, sysErr
 	}
 
-	if err := api.CreateChangeLogRawErr(api.ApiChange, "Updated ds: "+*ds.XMLID+" id: "+strconv.Itoa(*ds.ID), user, tx); err != nil {
+	if err := api.CreateChangeLogRawErr(api.ApiChange, "Updated ds: "+ds.XMLID+" id: "+strconv.Itoa(*ds.ID), user, tx); err != nil {
 		return nil, http.StatusInternalServerError, nil, errors.New("writing change log entry: " + err.Error())
 	}
 	dsV40 = (*tc.DeliveryServiceV40)(&ds)
@@ -1165,7 +1131,7 @@ func (ds *TODeliveryService) Delete() (error, error, int) {
 	} else if !ok {
 		return errors.New("delivery service not found"), nil, http.StatusNotFound
 	}
-	ds.XMLID = &xmlID
+	ds.XMLID = xmlID
 
 	// Note ds regexes MUST be deleted before the ds, because there's a ON DELETE CASCADE on deliveryservice_regex (but not on regex).
 	// Likewise, it MUST happen in a transaction with the later DS delete, so they aren't deleted if the DS delete fails.
@@ -1185,7 +1151,7 @@ func (ds *TODeliveryService) Delete() (error, error, int) {
 	paramConfigFilePrefixes := []string{"hdr_rw_", "hdr_rw_mid_", "regex_remap_", "cacheurl_"}
 	configFiles := []string{}
 	for _, prefix := range paramConfigFilePrefixes {
-		configFiles = append(configFiles, prefix+*ds.XMLID+".config")
+		configFiles = append(configFiles, prefix+ds.XMLID+".config")
 	}
 
 	if _, err := ds.ReqInfo.Tx.Tx.Exec(`DELETE FROM parameter WHERE name = 'location' AND config_file = ANY($1)`, pq.Array(configFiles)); err != nil {
@@ -1389,7 +1355,7 @@ func validateTypeFields(tx *sql.Tx, ds *tc.DeliveryServiceV4) error {
 	latitudeErr := "Must be a floating point number within the range +-90"
 	longitudeErr := "Must be a floating point number within the range +-180"
 
-	typeName, err := tc.ValidateTypeID(tx, ds.TypeID, "deliveryservice")
+	typeName, err := tc.ValidateTypeID(tx, &ds.TypeID, "deliveryservice")
 	if err != nil {
 		return err
 	}
@@ -1516,7 +1482,7 @@ func updatePrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServi
 	count := 0
 	q := `SELECT count(*) FROM origin WHERE deliveryservice = $1 AND is_primary`
 	if err := tx.QueryRow(q, *ds.ID).Scan(&count); err != nil {
-		return fmt.Errorf("querying existing primary origin for ds %s: %s", *ds.XMLID, err.Error())
+		return fmt.Errorf("querying existing primary origin for ds %s: %w", ds.XMLID, err)
 	}
 
 	if ds.OrgServerFQDN == nil || *ds.OrgServerFQDN == "" {
@@ -1524,9 +1490,9 @@ func updatePrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServi
 			// the update is removing the existing orgServerFQDN, so the existing row needs to be deleted
 			q = `DELETE FROM origin WHERE deliveryservice = $1 AND is_primary`
 			if _, err := tx.Exec(q, *ds.ID); err != nil {
-				return fmt.Errorf("deleting primary origin for ds %s: %s", *ds.XMLID, err.Error())
+				return fmt.Errorf("deleting primary origin for ds %s: %w", ds.XMLID, err)
 			}
-			api.CreateChangeLogRawTx(api.ApiChange, "DS: "+*ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Deleted primary origin", user, tx)
+			api.CreateChangeLogRawTx(api.ApiChange, "DS: "+ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Deleted primary origin", user, tx)
 		}
 		return nil
 	}
@@ -1544,10 +1510,10 @@ func updatePrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServi
 	name := ""
 	q = `UPDATE origin SET protocol = $1, fqdn = $2, port = $3 WHERE is_primary AND deliveryservice = $4 RETURNING name`
 	if err := tx.QueryRow(q, protocol, fqdn, port, *ds.ID).Scan(&name); err != nil {
-		return fmt.Errorf("update primary origin for ds %s from '%s': %s", *ds.XMLID, *ds.OrgServerFQDN, err.Error())
+		return fmt.Errorf("update primary origin for ds %s from '%s': %w", ds.XMLID, *ds.OrgServerFQDN, err)
 	}
 
-	api.CreateChangeLogRawTx(api.ApiChange, "DS: "+*ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Updated primary origin: "+name, user, tx)
+	api.CreateChangeLogRawTx(api.ApiChange, "DS: "+ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Updated primary origin: "+name, user, tx)
 
 	return nil
 }
@@ -1568,7 +1534,7 @@ func createPrimaryOrigin(tx *sql.Tx, user *auth.CurrentUser, ds tc.DeliveryServi
 		return fmt.Errorf("insert origin from '%s': %s", *ds.OrgServerFQDN, err.Error())
 	}
 
-	api.CreateChangeLogRawTx(api.ApiChange, "DS: "+*ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Created primary origin id: "+strconv.Itoa(originID), user, tx)
+	api.CreateChangeLogRawTx(api.ApiChange, "DS: "+ds.XMLID+", ID: "+strconv.Itoa(*ds.ID)+", ACTION: Created primary origin id: "+strconv.Itoa(originID), user, tx)
 
 	return nil
 }
@@ -1687,10 +1653,10 @@ func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *s
 			}
 		}
 
-		dsCDNDomains[*ds.XMLID] = cdnDomain
-		if ds.DeepCachingType != nil {
-			*ds.DeepCachingType = tc.DeepCachingTypeFromString(string(*ds.DeepCachingType))
-		}
+		dsCDNDomains[ds.XMLID] = cdnDomain
+		// TODO: why?
+		ds.DeepCachingType = tc.DeepCachingTypeFromString(string(ds.DeepCachingType))
+
 		ds.Signed = ds.SigningAlgorithm != nil && *ds.SigningAlgorithm == tc.SigningAlgorithmURLSig
 
 		dses = append(dses, ds)
@@ -1698,7 +1664,7 @@ func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *s
 
 	dsNames := make([]string, len(dses), len(dses))
 	for i, ds := range dses {
-		dsNames[i] = *ds.XMLID
+		dsNames[i] = ds.XMLID
 	}
 
 	matchLists, err := GetDeliveryServicesMatchLists(dsNames, tx.Tx)
@@ -1706,12 +1672,12 @@ func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *s
 		return nil, nil, errors.New("getting delivery service matchlists: " + err.Error()), http.StatusInternalServerError
 	}
 	for i, ds := range dses {
-		matchList, ok := matchLists[*ds.XMLID]
+		matchList, ok := matchLists[ds.XMLID]
 		if !ok {
 			continue
 		}
-		ds.MatchList = &matchList
-		ds.ExampleURLs = MakeExampleURLs(ds.Protocol, *ds.Type, *ds.RoutingName, *ds.MatchList, dsCDNDomains[*ds.XMLID])
+		ds.MatchList = matchList
+		ds.ExampleURLs = MakeExampleURLs(ds.Protocol, *ds.Type, ds.RoutingName, ds.MatchList, dsCDNDomains[ds.XMLID])
 		dses[i] = ds
 	}
 
@@ -1977,14 +1943,14 @@ func deleteLocationParam(tx *sql.Tx, configFile string) error {
 
 // getTenantID returns the tenant Id of the given delivery service. Note it may return a nil id and nil error, if the tenant ID in the database is nil.
 func getTenantID(tx *sql.Tx, ds *tc.DeliveryServiceV4) (*int, error) {
-	if ds.ID == nil && ds.XMLID == nil {
+	if ds.ID == nil {
 		return nil, errors.New("delivery service has no ID or XMLID")
 	}
 	if ds.ID != nil {
 		existingID, _, err := getDSTenantIDByID(tx, *ds.ID) // ignore exists return - if the DS is new, we only need to check the user input tenant
 		return existingID, err
 	}
-	existingID, _, err := getDSTenantIDByName(tx, tc.DeliveryServiceName(*ds.XMLID)) // ignore exists return - if the DS is new, we only need to check the user input tenant
+	existingID, _, err := getDSTenantIDByName(tx, tc.DeliveryServiceName(ds.XMLID)) // ignore exists return - if the DS is new, we only need to check the user input tenant
 	return existingID, err
 }
 
@@ -1996,10 +1962,8 @@ func isTenantAuthorized(inf *api.APIInfo, ds *tc.DeliveryServiceV4) (bool, error
 	if err != nil {
 		return false, errors.New("getting tenant ID: " + err.Error())
 	}
-	if ds.TenantID == nil {
-		ds.TenantID = existingID
-	}
-	if existingID != nil && existingID != ds.TenantID {
+	if existingID != nil {
+		ds.TenantID = *existingID
 		userAuthorizedForExistingDSTenant, err := tenant.IsResourceAuthorizedToUserTx(*existingID, user, tx)
 		if err != nil {
 			return false, errors.New("checking authorization for existing DS ID: " + err.Error())
@@ -2008,8 +1972,8 @@ func isTenantAuthorized(inf *api.APIInfo, ds *tc.DeliveryServiceV4) (bool, error
 			return false, nil
 		}
 	}
-	if ds.TenantID != nil {
-		userAuthorizedForNewDSTenant, err := tenant.IsResourceAuthorizedToUserTx(*ds.TenantID, user, tx)
+	if ds.TenantID != 0 {
+		userAuthorizedForNewDSTenant, err := tenant.IsResourceAuthorizedToUserTx(ds.TenantID, user, tx)
 		if err != nil {
 			return false, errors.New("checking authorization for new DS ID: " + err.Error())
 		}
@@ -2086,11 +2050,8 @@ func sanitize(ds *tc.DeliveryServiceV4) {
 		&ds.InnerHeaderRewrite,
 		&ds.LastHeaderRewrite,
 	)
-	if ds.RoutingName == nil || *ds.RoutingName == "" {
-		ds.RoutingName = util.StrPtr(tc.DefaultRoutingName)
-	}
-	if ds.AnonymousBlockingEnabled == nil {
-		ds.AnonymousBlockingEnabled = util.BoolPtr(false)
+	if ds.RoutingName == "" {
+		ds.RoutingName = tc.DefaultRoutingName
 	}
 	signedAlgorithm := tc.SigningAlgorithmURLSig
 	if ds.Signed && (ds.SigningAlgorithm == nil || *ds.SigningAlgorithm == "") {
@@ -2102,11 +2063,7 @@ func sanitize(ds *tc.DeliveryServiceV4) {
 	if ds.MaxOriginConnections == nil || *ds.MaxOriginConnections < 0 {
 		ds.MaxOriginConnections = util.IntPtr(0)
 	}
-	if ds.DeepCachingType == nil {
-		s := tc.DeepCachingType("")
-		ds.DeepCachingType = &s
-	}
-	*ds.DeepCachingType = tc.DeepCachingTypeFromString(string(*ds.DeepCachingType))
+	ds.DeepCachingType = tc.DeepCachingTypeFromString(string(ds.DeepCachingType))
 	if ds.MaxRequestHeaderBytes == nil {
 		ds.MaxRequestHeaderBytes = util.IntPtr(tc.DefaultMaxRequestHeaderBytes)
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/matches.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/matches.go
@@ -60,7 +60,7 @@ SELECT ds.xml_id, ds.remap_text, r.pattern
 FROM deliveryservice as ds
 JOIN deliveryservice_regex as dsr ON dsr.deliveryservice = ds.id
 JOIN regex as r ON r.id = dsr.regex
-WHERE ds.active = true
+WHERE ds.active = 'ACTIVE'
 `
 	qParams := []interface{}{}
 	tenantIDs, err := tenant.GetUserTenantIDListTx(tx, userTenantID)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
@@ -306,11 +306,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 // DeliveryService's Tenant, as appropriate to the change type.
 func isTenantAuthorized(dsr tc.DeliveryServiceRequestV40, inf *api.APIInfo) (bool, error) {
 	if dsr.Requested != nil && (dsr.ChangeType == tc.DSRChangeTypeUpdate || dsr.ChangeType == tc.DSRChangeTypeCreate) {
-		if dsr.Requested.TenantID == nil {
-			log.Debugf("requested.tenantID is nil")
-			return false, errors.New("requested.tenantID is nil")
-		}
-		ok, err := tenant.IsResourceAuthorizedToUserTx(*dsr.Requested.TenantID, inf.User, inf.Tx.Tx)
+		ok, err := tenant.IsResourceAuthorizedToUserTx(dsr.Requested.TenantID, inf.User, inf.Tx.Tx)
 		if err != nil {
 			err = fmt.Errorf("requested: %v", err)
 		}
@@ -325,11 +321,7 @@ func isTenantAuthorized(dsr tc.DeliveryServiceRequestV40, inf *api.APIInfo) (boo
 		return true, nil
 	}
 
-	if ds.TenantID == nil {
-		log.Debugf("original.tenantID is nil")
-		return false, errors.New("original.tenantID is nil")
-	}
-	ok, err := tenant.IsResourceAuthorizedToUserTx(*ds.TenantID, inf.User, inf.Tx.Tx)
+	ok, err := tenant.IsResourceAuthorizedToUserTx(ds.TenantID, inf.User, inf.Tx.Tx)
 	if err != nil {
 		err = fmt.Errorf("original: %v", err)
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/validate.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/validate.go
@@ -121,7 +121,7 @@ func validateV4(dsr tc.DeliveryServiceRequestV40, tx *sql.Tx) (error, error) {
 				}
 				err := deliveryservice.Validate(tx, ds)
 				if err == nil {
-					dsr.XMLID = *ds.XMLID
+					dsr.XMLID = ds.XMLID
 				}
 				return err
 			},

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -80,7 +80,7 @@ func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 	} else {
 		log.Warnf("Couldn't get config %v", e)
 	}
-	dses, userErr, sysErr, errCode, _ := readGetDeliveryServices(r.Header, inf.Params, inf.Tx, inf.User, useIMS)
+	dses, userErr, sysErr, errCode, _ := readGetDeliveryServices(r.Header, inf, useIMS)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -107,7 +107,7 @@ func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 		api.WriteRespAlertObj(w, r, tc.SuccessLevel, alertMsg, []tc.DeliveryServiceNullableV30{ds.DowngradeToV3()})
 	}
 
-	api.CreateChangeLogRawTx(api.ApiChange, fmt.Sprintf("DS: %s, ID: %d, ACTION: Updated safe fields", *ds.XMLID, *ds.ID), inf.User, tx)
+	api.CreateChangeLogRawTx(api.ApiChange, fmt.Sprintf("DS: %s, ID: %d, ACTION: Updated safe fields", ds.XMLID, *ds.ID), inf.User, tx)
 }
 
 // updateDSSafe updates the given delivery service in the database. Returns whether the DS existed, and any error.

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -132,7 +132,7 @@ func delete(w http.ResponseWriter, r *http.Request, deprecated bool) {
 
 	ds := dses[0]
 
-	if ds.Active != tc.DS_INACTIVE {
+	if ds.Active == tc.DS_ACTIVE {
 		errCode, userErr, sysErr = checkLastServer(dsID, serverID, tx)
 		if userErr != nil || sysErr != nil {
 			api.HandleErrOptionalDeprecation(w, r, inf.Tx.Tx, errCode, userErr, sysErr, deprecated, &alt)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -131,27 +131,15 @@ func delete(w http.ResponseWriter, r *http.Request, deprecated bool) {
 	}
 
 	ds := dses[0]
-	if ds.Active == nil {
-		errCode = http.StatusInternalServerError
-		sysErr = fmt.Errorf("Delivery Service #%d had nil Active", dsID)
-		api.HandleErrOptionalDeprecation(w, r, tx, errCode, nil, sysErr, deprecated, &alt)
-		return
-	}
 
-	if *ds.Active {
+	if ds.Active != tc.DS_INACTIVE {
 		errCode, userErr, sysErr = checkLastServer(dsID, serverID, tx)
 		if userErr != nil || sysErr != nil {
 			api.HandleErrOptionalDeprecation(w, r, inf.Tx.Tx, errCode, userErr, sysErr, deprecated, &alt)
 			return
 		}
 	}
-	if ds.XMLID == nil {
-		errCode = http.StatusInternalServerError
-		sysErr = fmt.Errorf("Delivery Service #%d had nil XMLID", dsID)
-		api.HandleErrOptionalDeprecation(w, r, tx, errCode, nil, sysErr, deprecated, &alt)
-		return
-	}
-	dsName := *ds.XMLID
+	dsName := ds.XMLID
 
 	serverName, exists, err := dbhelpers.GetServerNameFromID(tx, serverID)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -571,7 +571,7 @@ func validateDSSAssignments(tx *sql.Tx, ds DSInfo, serverInfos []tc.ServerInfo, 
 		return userErr, sysErr, status
 	}
 
-	if ds.Active && replace {
+	if ds.Active != tc.DS_INACTIVE && replace {
 		ids := make([]int, 0, len(serverInfos))
 		for _, inf := range serverInfos {
 			ids = append(ids, inf.ID)
@@ -996,7 +996,7 @@ func selectMaxLastUpdatedQuery(where string) string {
 }
 
 type DSInfo struct {
-	Active               bool
+	Active               tc.DeliveryServiceActiveState
 	ID                   int
 	Name                 string
 	Type                 tc.DSType

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
@@ -458,7 +458,7 @@ func getDeliveryServices(tx *sql.Tx) ([]DeliveryService, error) {
 	query := `
 	SELECT ds.xml_id, ds.global_max_tps, ds.global_max_mbps
 	FROM deliveryservice ds
-	WHERE ds.active = true
+	WHERE ds.active = 'ACTIVE'
 	`
 	rows, err := tx.Query(query)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -483,9 +483,9 @@ RETURNING
 `
 
 const originServerQuery = `
-JOIN deliveryservice_server dsorg 
-ON dsorg.server = s.id 
-WHERE t.name = '` + tc.OriginTypeName + `' 
+JOIN deliveryservice_server dsorg
+ON dsorg.server = s.id
+WHERE t.name = '` + tc.OriginTypeName + `'
 AND dsorg.deliveryservice=:dsId
 `
 const deleteServerQuery = `DELETE FROM server WHERE id=$1`
@@ -1274,8 +1274,8 @@ func getMidServers(edgeIDs []int, servers map[int]tc.ServerV40, dsID int, cdnID 
 		capabilities.array_agg
 		@>
 		(
-		SELECT ARRAY_AGG(drc.required_capability) 
-		FROM deliveryservices_required_capability drc 
+		SELECT ARRAY_AGG(drc.required_capability)
+		FROM deliveryservices_required_capability drc
 		WHERE drc.deliveryservice_id=:ds_id)
 		)`
 	} else {
@@ -2023,7 +2023,7 @@ WHERE "deliveryservice" IN (
 	INNER JOIN deliveryservice
 	ON deliveryservice_server.deliveryservice = deliveryservice.id
 	WHERE deliveryservice_server."server" = $1
-	AND deliveryservice.active
+	AND deliveryservice.active = 'ACTIVE'
 )
 GROUP BY "deliveryservice"
 HAVING COUNT("server") = 1;

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -72,7 +72,7 @@ WHERE deliveryservice IN (
 	FROM deliveryservice_server
 	INNER JOIN deliveryservice ON deliveryservice.id = deliveryservice_server.deliveryservice
 	WHERE deliveryservice_server.server=$1
-	AND deliveryservice.active IS TRUE
+	AND deliveryservice.active = 'ACTIVE'
 )
 AND NOT (deliveryservice_server.deliveryservice = ANY($2::BIGINT[]))
 AND (status.name = '` + string(tc.CacheStatusOnline) + `' OR status.name = '` + string(tc.CacheStatusReported) + `')

--- a/traffic_ops/traffic_ops_golang/user/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/user/deliveryservices.go
@@ -120,7 +120,7 @@ func filterAvailableAuthorized(tx *sql.Tx, dses []tc.UserAvailableDS, user *auth
 func getUserDSes(tx *sql.Tx, userID int) ([]tc.DeliveryServiceNullable, error) {
 	q := `
 SELECT
-ds.active,
+ds.active = 'ACTIVE' AS active,
 ds.anonymous_blocking_enabled,
 ds.cacheurl,
 ds.ccr_dns_ttl,

--- a/traffic_ops/v4-client/deliveryservice.go
+++ b/traffic_ops/v4-client/deliveryservice.go
@@ -75,7 +75,7 @@ const (
 	// apiDeliveryServiceGenerateSSLKeys is the API path on which Traffic Ops will generate new SSL keys.
 	apiDeliveryServiceGenerateSSLKeys = apiDeliveryServices + "/sslkeys/generate"
 
-	// apiDeliveryServiceAddSSLKeys is the API path on which Traffic Ops will add SSL keys
+	// apiDeliveryServiceAddSSLKeys is the API path on which Traffic Ops will add SSL keys.
 	apiDeliveryServiceAddSSLKeys = apiDeliveryServices + "/sslkeys/add"
 
 	// apiDeliveryServiceURISigningKeys is the API path on which Traffic Ops serves information
@@ -134,7 +134,7 @@ func (to *Session) GetDeliveryServices(opts RequestOptions) (tc.DeliveryServices
 func (to *Session) CreateDeliveryService(ds tc.DeliveryServiceV4, opts RequestOptions) (tc.DeliveryServicesResponseV4, toclientlib.ReqInf, error) {
 	var reqInf toclientlib.ReqInf
 	var resp tc.DeliveryServicesResponseV4
-	if ds.TypeID == nil && ds.Type != nil {
+	if ds.TypeID == 0 && ds.Type != nil {
 		typeOpts := NewRequestOptions()
 		typeOpts.QueryParameters.Set("name", ds.Type.String())
 		ty, _, err := to.GetTypes(typeOpts)
@@ -144,10 +144,10 @@ func (to *Session) CreateDeliveryService(ds tc.DeliveryServiceV4, opts RequestOp
 		if len(ty.Response) == 0 {
 			return resp, reqInf, fmt.Errorf("no Type named '%s'", ds.Type)
 		}
-		ds.TypeID = &ty.Response[0].ID
+		ds.TypeID = ty.Response[0].ID
 	}
 
-	if ds.CDNID == nil && ds.CDNName != nil {
+	if ds.CDNID == 0 && ds.CDNName != nil {
 		cdnOpts := NewRequestOptions()
 		cdnOpts.QueryParameters.Set("name", *ds.CDNName)
 		cdns, _, err := to.GetCDNs(cdnOpts)
@@ -158,7 +158,7 @@ func (to *Session) CreateDeliveryService(ds tc.DeliveryServiceV4, opts RequestOp
 		if len(cdns.Response) == 0 {
 			return resp, reqInf, fmt.Errorf("no CDN named '%s'", *ds.CDNName)
 		}
-		ds.CDNID = &cdns.Response[0].ID
+		ds.CDNID = cdns.Response[0].ID
 	}
 
 	if ds.ProfileID == nil && ds.ProfileName != nil {
@@ -174,7 +174,7 @@ func (to *Session) CreateDeliveryService(ds tc.DeliveryServiceV4, opts RequestOp
 		ds.ProfileID = &profiles.Response[0].ID
 	}
 
-	if ds.TenantID == nil && ds.Tenant != nil {
+	if ds.TenantID == 0 && ds.Tenant != nil {
 		tenantOpts := NewRequestOptions()
 		tenantOpts.QueryParameters.Set("name", *ds.Tenant)
 		ten, _, err := to.GetTenants(tenantOpts)
@@ -184,7 +184,7 @@ func (to *Session) CreateDeliveryService(ds tc.DeliveryServiceV4, opts RequestOp
 		if len(ten.Response) == 0 {
 			return resp, reqInf, fmt.Errorf("no Tenant named '%s'", *ds.Tenant)
 		}
-		ds.TenantID = &ten.Response[0].ID
+		ds.TenantID = ten.Response[0].ID
 	}
 
 	reqInf, err := to.post(apiDeliveryServices, RequestOptions{Header: opts.Header}, ds, &resp)
@@ -254,7 +254,7 @@ func (to *Session) GenerateSSLKeysForDS(
 	return response, reqInf, err
 }
 
-// AddSSLKeysForDS adds SSL Keys for the given DS
+// AddSSLKeysForDS adds SSL Keys for the given Delivery Service.
 func (to *Session) AddSSLKeysForDS(request tc.DeliveryServiceAddSSLKeysReq, opts RequestOptions) (tc.SSLKeysAddResponse, toclientlib.ReqInf, error) {
 	var response tc.SSLKeysAddResponse
 	reqInf, err := to.post(apiDeliveryServiceAddSSLKeys, opts, request, &response)
@@ -319,7 +319,7 @@ func (to *Session) GetDeliveryServiceURISigningKeys(dsName string, opts RequestO
 }
 
 // CreateDeliveryServiceURISigningKeys creates new URI-signing keys used by the Delivery Service
-// identified by the XMLID 'dsXMLID'
+// identified by the XMLID 'dsXMLID'.
 func (to *Session) CreateDeliveryServiceURISigningKeys(dsXMLID string, body map[string]tc.URISignerKeyset, opts RequestOptions) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(fmt.Sprintf(apiDeliveryServicesURISigningKeys, url.PathEscape(dsXMLID)), opts, body, &alerts)
@@ -327,7 +327,7 @@ func (to *Session) CreateDeliveryServiceURISigningKeys(dsXMLID string, body map[
 }
 
 // DeleteDeliveryServiceURISigningKeys deletes the URI-signing keys used by the Delivery Service
-// identified by the XMLID 'dsXMLID'
+// identified by the XMLID 'dsXMLID'.
 func (to *Session) DeleteDeliveryServiceURISigningKeys(dsXMLID string, opts RequestOptions) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.del(fmt.Sprintf(apiDeliveryServicesURISigningKeys, url.PathEscape(dsXMLID)), opts, &alerts)

--- a/traffic_ops/v4-client/deliveryservice_requests.go
+++ b/traffic_ops/v4-client/deliveryservice_requests.go
@@ -65,24 +65,24 @@ func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequestV4,
 		ds = dsr.Requested
 	}
 
-	if ds.TypeID == nil && ds.Type.String() != "" {
+	if ds.TypeID == 0 && ds.Type.String() != "" {
 		typeOpts := NewRequestOptions()
 		typeOpts.QueryParameters.Set("name", ds.Type.String())
 		ty, reqInf, err := to.GetTypes(typeOpts)
 		if err != nil || len(ty.Response) == 0 {
 			return resp, reqInf, errors.New("no type named " + ds.Type.String())
 		}
-		ds.TypeID = &ty.Response[0].ID
+		ds.TypeID = ty.Response[0].ID
 	}
 
-	if ds.CDNID == nil && ds.CDNName != nil {
+	if ds.CDNID == 0 && ds.CDNName != nil {
 		cdnOpts := NewRequestOptions()
 		cdnOpts.QueryParameters.Set("name", *ds.CDNName)
 		cdns, reqInf, err := to.GetCDNs(cdnOpts)
 		if err != nil || len(cdns.Response) == 0 {
 			return resp, reqInf, fmt.Errorf("no CDN named '%s'", *ds.CDNName)
 		}
-		ds.CDNID = &cdns.Response[0].ID
+		ds.CDNID = cdns.Response[0].ID
 	}
 
 	if ds.ProfileID == nil && ds.ProfileName != nil {
@@ -95,14 +95,14 @@ func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequestV4,
 		ds.ProfileID = &profiles.Response[0].ID
 	}
 
-	if ds.TenantID == nil && ds.Tenant != nil {
+	if ds.TenantID == 0 && ds.Tenant != nil {
 		tenantOpts := NewRequestOptions()
 		tenantOpts.QueryParameters.Set("name", *ds.Tenant)
 		ten, reqInf, err := to.GetTenants(tenantOpts)
 		if err != nil || len(ten.Response) == 0 {
 			return resp, reqInf, fmt.Errorf("no Tenant named '%s'", *ds.Tenant)
 		}
-		ds.TenantID = &ten.Response[0].ID
+		ds.TenantID = ten.Response[0].ID
 	}
 
 	reqInf, err := to.post(apiDSRequests, opts, dsr, &resp)

--- a/traffic_ops/v4-client/server.go
+++ b/traffic_ops/v4-client/server.go
@@ -176,9 +176,9 @@ func (to *Session) AssignDeliveryServiceIDsToServerID(server int, dsIDs []int, r
 
 // GetServerIDDeliveryServices returns all of the Delivery Services assigned to the server identified
 // by the integral, unique identifier 'server'.
-func (to *Session) GetServerIDDeliveryServices(server int, opts RequestOptions) (tc.DeliveryServicesNullableResponse, toclientlib.ReqInf, error) {
+func (to *Session) GetServerIDDeliveryServices(server int, opts RequestOptions) (tc.DeliveryServicesResponseV40, toclientlib.ReqInf, error) {
 	endpoint := fmt.Sprintf(apiServerDeliveryServices, server)
-	var data tc.DeliveryServicesNullableResponse
+	var data tc.DeliveryServicesResponseV40
 	reqInf, err := to.get(endpoint, opts, &data)
 	return data, reqInf, err
 }

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -20,7 +20,7 @@
 var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 
     this.getDeliveryServices = function(queryParams) {
-        return $http.get(ENV.api['root'] + 'deliveryservices', {params: queryParams}).then(
+        return $http.get(ENV.api['stable'] + 'deliveryservices', {params: queryParams}).then(
             function(result) {
                 return result.data.response;
             },
@@ -31,7 +31,7 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
     };
 
     this.getDeliveryService = function(id) {
-        return $http.get(ENV.api['root'] + 'deliveryservices', {params: {id: id}}).then(
+        return $http.get(ENV.api['stable'] + 'deliveryservices', {params: {id: id}}).then(
             function(result) {
                 return result.data.response[0];
             },
@@ -45,7 +45,7 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
         // strip out any falsy values or duplicates from consistentHashQueryParams
         ds.consistentHashQueryParams = Array.from(new Set(ds.consistentHashQueryParams)).filter(function(i){return i;});
 
-        return $http.post(ENV.api['root'] + "deliveryservices", ds).then(
+        return $http.post(ENV.api['stable'] + "deliveryservices", ds).then(
             function(response) {
                 return response;
             },
@@ -59,7 +59,7 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
         // strip out any falsy values or duplicates from consistentHashQueryParams
         ds.consistentHashQueryParams = Array.from(new Set(ds.consistentHashQueryParams)).filter(function(i){return i;});
 
-        return $http.put(ENV.api['root'] + "deliveryservices/" + ds.id, ds).then(
+        return $http.put(ENV.api['stable'] + "deliveryservices/" + ds.id, ds).then(
             function(response) {
                 return response;
             },
@@ -71,7 +71,7 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 
     // todo: change to use query param when it is supported
     this.deleteDeliveryService = function(ds) {
-        return $http.delete(ENV.api['root'] + "deliveryservices/" + ds.id).then(
+        return $http.delete(ENV.api['stable'] + "deliveryservices/" + ds.id).then(
             function(response) {
                 return response;
             },
@@ -121,7 +121,7 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
     };
 
     this.getServerDeliveryServices = function(serverId) {
-        return $http.get(ENV.api['root'] + 'servers/' + serverId + '/deliveryservices').then(
+        return $http.get(ENV.api['stable'] + 'servers/' + serverId + '/deliveryservices').then(
             function(result) {
                 return result.data.response;
             },
@@ -190,17 +190,6 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
             },
             function(err) {
                 messageModel.setMessages(err.data.alerts, true);
-                throw err;
-            }
-        );
-    };
-
-    this.getUserDeliveryServices = function(userId) {
-        return $http.get(ENV.api['root'] + 'users/' + userId + '/deliveryservices').then(
-            function(result) {
-                return result.data.response;
-            },
-            function(err) {
                 throw err;
             }
         );

--- a/traffic_portal/test/integration/Data/origins.ts
+++ b/traffic_portal/test/integration/Data/origins.ts
@@ -77,7 +77,7 @@ export const origins = {
 			method: "post",
 			data: [
 				{
-					active: true,
+					active: "ACTIVE",
 					cdnId: 2,
 					displayName: "ds1",
 					dscp: 0,
@@ -107,7 +107,7 @@ export const origins = {
 					]
 				},
 				{
-					active: true,
+					active: "ACTIVE",
 					cdnId: 2,
 					displayName: "ds2",
 					dscp: 0,
@@ -137,7 +137,7 @@ export const origins = {
 					]
 				},
 				{
-					active: true,
+					active: "ACTIVE",
 					cdnId: 2,
 					displayName: "ds3",
 					dscp: 0,
@@ -167,7 +167,7 @@ export const origins = {
 					]
 				},
 				{
-					active: true,
+					active: "ACTIVE",
 					cdnId: 2,
 					displayName: "ds4",
 					dscp: 0,

--- a/traffic_portal/test/integration/Data/servers.ts
+++ b/traffic_portal/test/integration/Data/servers.ts
@@ -614,7 +614,7 @@ export const servers = {
 			method: "post",
 			data: [
 				{
-					active: true,
+					active: "ACTIVE",
 					cdnId: 0,
 					displayName: "servertestds1",
 					dscp: 0,
@@ -650,7 +650,7 @@ export const servers = {
 					]
 				},
 				{
-					active: true,
+					active: "ACTIVE",
 					cdnId: 0,
 					displayName: "servertestdsop1",
 					dscp: 0,


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR implements the Delivery Services Active flag changes described in [the "Delivery Services 'Active' flag" blueprint](https://github.com/apache/trafficcontrol/blob/04b6bb59188be169f22ea575b1e37d3dd67a6fe8/blueprints/ds-active.md) in Traffic Ops. Traffic Portal is changed to use the stable 3.1 version of the Traffic Ops API for Delivery Service-related API calls until the necessary changes are made to support the new typing of the 'active' flag in APIv4.

## Which Traffic Control components are affected by this PR?
- CDN in a Box
- Documentation
- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
Make sure all the tests pass and verify that PRIMED and INACTIVE Delivery Services don't appear in CDN Snapshots or monitoring configuration.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**