### PR TITLE
Set content-type json on TR auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added Delivery Service Raw Remap `__RANGE_DIRECTIVE__` directive to allow inserting the Range Directive after the Raw Remap text. This allows Raw Remaps which manipulate the Range.
 - Added an option for `coordinateRange` in the RGB configuration file, so that in case a client doesn't have a postal code, we can still determine if it should be allowed or not, based on whether or not the latitude/ longitude of the client falls within the supplied ranges. [Related github issue](https://github.com/apache/trafficcontrol/issues/4372)
 - Fixed #3548 - Prevents DS regexes with non-consecutive order from generating invalid CRconfig/snapshot.
+- Fixed #4680 - Change Content-Type to application/json for TR auth calls
 
 ### Changed
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/Fetcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/Fetcher.java
@@ -47,8 +47,11 @@ public class Fetcher {
 	protected static final String UTF8_STR = "UTF-8";
 	protected static final int DEFAULT_TIMEOUT = 10000;
 	private static final String GZIP_ENCODING_STRING = "gzip";
+	private static final String CONTENT_TYPE_STRING = "Content-Type";
+	protected static final String CONTENT_TYPE_JSON = "application/json";
 	protected int timeout = DEFAULT_TIMEOUT; // override if you want something different
 	protected final Map<String, String> requestProps = new HashMap<String, String>();
+
 
 	static {
 		try {
@@ -72,6 +75,11 @@ public class Fetcher {
 	}
 
 	protected HttpURLConnection getConnection(final String url, final String data, final String requestMethod, final long lastFetchTime) throws IOException {
+		return getConnection(url, data, requestMethod, lastFetchTime, null);
+	}
+
+	@SuppressWarnings("PMD.CyclomaticComplexity")
+	protected HttpURLConnection getConnection(final String url, final String data, final String requestMethod, final long lastFetchTime, final String contentType) throws IOException {
 		HttpURLConnection http = null;
 		try {
 			String method = GET_STR;
@@ -110,6 +118,10 @@ public class Fetcher {
 
 			for (final String key : requestProps.keySet()) {
 				http.addRequestProperty(key, requestProps.get(key));
+			}
+
+			if (contentType != null) {
+				http.addRequestProperty(CONTENT_TYPE_STRING, contentType);
 			}
 
 			if (method.equals(POST_STR) && data != null) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/ProtectedFetcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/ProtectedFetcher.java
@@ -33,7 +33,7 @@ public class ProtectedFetcher extends Fetcher {
 	@Override
 	protected HttpURLConnection getConnection(final String url, final String data, final String method, final long lastFetchedTime) throws IOException {
 		if (!isCookieValid()) {
-			extractCookie(super.getConnection(getAuthorizationEndpoint(), getData(), POST_STR, 0L));
+			extractCookie(super.getConnection(getAuthorizationEndpoint(), getData(), POST_STR, 0L, CONTENT_TYPE_JSON));
 		}
 
 		return extractCookie(super.getConnection(url, data, method, lastFetchedTime));


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Changes Content-Type in TR auth request from `x-www-form-urlencoded` to `application/json` to properly reflect the contents of the request 

- [x] This PR fixes #4680 


## Which Traffic Control components are affected by this PR?
- Traffic Router

## What is the best way to verify this PR?
Confirm TR can fetch files from TO. There's no great way to see the content type as the request itself goes over https. 

## The following criteria are ALL met by this PR
- [x] I have explained why tests are unnecessary (fix is not worth a test)
- [x] I have explained why documentation is unnecessary (small bug fix)
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
