### PR TITLE
Fix license file for bbolt change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -406,9 +406,9 @@ The bytefmt component is used under the Apache 2.0 license:
 @grove/vendor/code.cloudfoundry.org/bytefmt/*
 ./grove/vendor/code.cloudfoundry.org/bytefmt/LICENSE
 
-The bytefmt component is used under the MIT license:
-@grove/vendor/github.com/coreos/bbolt/*
-./grove/vendor/github.com/coreos/bbolt/LICENSE
+The bbolt component is used under the MIT license:
+@grove/vendor/go.etcd.io/bbolt/*
+./grove/vendor/go.etcd.io/bbolt/LICENSE
 
 For the siphash component:
 @grove/vendor/github.com/dchest/siphash/*


### PR DESCRIPTION
Fixes LICENSE for the bbolt dependency move.

No changelog, it's a license file fix.
No docs, it's a license file fix.
No tests, it's a license file fix. Weasel is the test.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?


## What is the best way to verify this PR?
Run weasel.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information

