### PR TITLE
Change ORT to not update ip_allow except badass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed Traffic Portal to use the more performant and powerful ag-grid for all server tables.
 - Changed ORT Config Generation to be deterministic, which will prevent spurious diffs when nothing actually changed.
 - Changed ORT to find the local ATS config directory and use it when location Parameters don't exist for many required configs, including all Delivery Service files (Header Rewrites, Regex Remap, URL Sig, URI Signing).
+- Changed ORT to not update ip_allow.config but log an error if it needs updating in syncds mode, and only actually update in badass mode.
+    - ATS has a known bug, where reloading when ip_allow.config has changed blocks arbitrary addresses. This will break things by not allowing any new necessary servers, but prevents breaking the Mid server. There is no solution that doesn't break something, until ATS fixes the bug, and breaking an Edge is better than breaking a Mid.
 - Changed the access logs in Traffic Ops to now show the route ID with every API endpoint call. The Route ID is appended to the end of the access log line.
 - Changed Traffic Monitor's `tmconfig.backup` to store the result of `GET /api/2.0/cdns/{{name}}/configs/monitoring` instead of a transformed map
 - [Multiple Interface Servers](https://github.com/apache/trafficcontrol/blob/master/blueprints/multi-interface-servers.md)

--- a/traffic_ops_ort/traffic_ops_ort.pl
+++ b/traffic_ops_ort/traffic_ops_ort.pl
@@ -42,6 +42,7 @@ my $rev_proxy_disable = 0;
 my $skip_os_check = 0;
 my $override_hostname_short = '';
 my $to_timeout_ms = 30000;
+my $syncds_updates_ipallow = 0;
 
 GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "retries=i"          => \$retries,
@@ -51,6 +52,7 @@ GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "skip_os_check=i" => \$skip_os_check,
             "override_hostname_short=s" => \$override_hostname_short,
             "to_timeout_ms=i" => \$to_timeout_ms,
+            "syncds_updates_ipallow=i" => \$syncds_updates_ipallow,
           );
 
 if ( $#ARGV < 1 ) {
@@ -345,6 +347,7 @@ sub usage {
 	print "\t   skip_os_check=<0|1>            => bypass the check for a supported CentOS version. Default = 0.\n";
 	print "\t   override_hostname_short=<text> => override the short hostname of the OS for config generation. Default = ''.\n";
 	print "\t   to_timeout_ms=<time>           => the Traffic Ops request timeout in milliseconds. Default = 30000 (30 seconds).\n";
+	print "\t   syncds_updates_ipallow=<0|1>   => Update ip_allow.config in syncds mode, which may trigger an ATS bug blocking random addresses on load! Default = 0, only update on badass and restart.\n";
 	print "====-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-====\n";
 	exit 1;
 }
@@ -412,7 +415,7 @@ sub process_cfg_file {
 		}
 	}
 
-	if ($change_needed && $cfg_file eq "ip_allow.config") {
+	if ($change_needed && $cfg_file eq "ip_allow.config" && $syncds_updates_ipallow != 1) {
 		if ($script_mode == $BADASS) {
 			$trafficserver_restart_needed++;
 		} else {

--- a/traffic_ops_ort/traffic_ops_ort.pl
+++ b/traffic_ops_ort/traffic_ops_ort.pl
@@ -412,6 +412,15 @@ sub process_cfg_file {
 		}
 	}
 
+	if ($change_needed && $cfg_file eq "ip_allow.config") {
+		if ($script_mode == $BADASS) {
+			$trafficserver_restart_needed++;
+		} else {
+			( $log_level >> $ERROR ) && print "ERROR Not in badass mode, but ip_allow.config changed! Changing that file will cause ATS to break the next time it Reloads! Ignoring file!! This will cause this server to reject any new servers! ORT must be run in badass mode to get the ip_allow.config change and permit the necessary client!\n";
+			$change_needed = undef;
+		}
+	}
+
 	if ( $change_needed ) {
 		$cfg_file_tracker->{$cfg_file}{'change_needed'}++;
 		( $log_level >> $ERROR ) && print "ERROR $file needs updated.\n";


### PR DESCRIPTION
ATS has a known bug where changing ip_allow.config causes random
blocking on config reload. We changed ORT a while back to not reload
when it changes, but other files can later trigger a reload.

This changes ORT to not update the file at all, and log an error.
This will cause any added servers to not be added to the allow,
likely breaking Edges. But breaking an Edge is better than
breaking a Mid.

Further, the error log will allow users to create alarms, so
they know to go in and manually badass and restart the machine.

I've manually tested, verified server IP changes log the error but don't update the file, changes to other files apply as expected, badass mode updates ip_allow.config as expected.

Includes changelog.
No docs, ORT config file details are not documented.
No tests, ORT itself doesn't have an integration test framework yet. 

- [x] This PR is not related to any other Issue 

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Change or add a Server in Traffic Ops with a new IP, run ORT in syncds mode, verify an Error is logged but the file is not updated. Change something else, like a DS Origin, verify change still applies correctly. Run ORT in badass move, verify ip_allow.config is updated.

## If this is a bug fix, what versions of Traffic Control are affected?
It's behaved this way forever

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information