### PR TITLE
Fix ORT remap.config cachekey to be deterministic

### DIFF
--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -163,7 +163,15 @@ func GetServerConfigRemapDotConfigForMid(
 				log.Errorln("Making remap.config for Delivery Service '" + *ds.XMLID + "': qstring_ignore and cachekey params both add cachekey, but ATS cachekey doesn't work correctly with multiple entries! Adding anyway!")
 			}
 			midRemap += ` @plugin=cachekey.so`
+
+			dsProfileCacheKeyParams := []KeyVal{}
 			for name, val := range profilesCacheKeyConfigParams[*ds.ProfileID] {
+				dsProfileCacheKeyParams = append(dsProfileCacheKeyParams, KeyVal{Key: name, Val: val})
+			}
+			sort.Sort(KeyVals(dsProfileCacheKeyParams))
+			for _, nameVal := range dsProfileCacheKeyParams {
+				name := nameVal.Key
+				val := nameVal.Val
 				midRemap += ` @pparam=--` + name + "=" + val
 			}
 		}
@@ -709,4 +717,20 @@ func makeDSRegexMap(regexes []tc.DeliveryServiceRegexes) map[tc.DeliveryServiceN
 		dsRegexMap[tc.DeliveryServiceName(dsRegex.DSName)] = dsRegex.Regexes
 	}
 	return dsRegexMap
+}
+
+type KeyVal struct {
+	Key string
+	Val string
+}
+
+type KeyVals []KeyVal
+
+func (ks KeyVals) Len() int      { return len(ks) }
+func (ks KeyVals) Swap(i, j int) { ks[i], ks[j] = ks[j], ks[i] }
+func (ks KeyVals) Less(i, j int) bool {
+	if ks[i].Key != ks[j].Key {
+		return ks[i].Key < ks[j].Key
+	}
+	return ks[i].Val < ks[j].Val
 }


### PR DESCRIPTION
Fixes ORT remap.config generation to be deterministic, with respect to cache key plugin parameters.

No changelog, changelog already exists for ORT deterministic config gen, this was just an oversight.
No new tests, remap.config already has extensive unit tests.
No docs, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests.
Run ORT, verify config is semantically unchanged. Run ORT multiple times with cache key parameters, verify output is always the same.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information