### PR TITLE
4.1.x Backport: Fix ORT remap.config cachekey to be deterministic

### DIFF
--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -137,7 +137,15 @@ func GetServerConfigRemapDotConfigForMid(
 				log.Errorln("Making remap.config for Delivery Service '" + ds.Name + "': qstring_ignore and cachekey params both add cachekey, but ATS cachekey doesn't work correctly with multiple entries! Adding anyway!")
 			}
 			midRemap += ` @plugin=cachekey.so`
+
+			dsProfileCacheKeyParams := []KeyVal{}
 			for name, val := range profilesCacheKeyConfigParams[*ds.ProfileID] {
+				dsProfileCacheKeyParams = append(dsProfileCacheKeyParams, KeyVal{Key: name, Val: val})
+			}
+			sort.Sort(KeyVals(dsProfileCacheKeyParams))
+			for _, nameVal := range dsProfileCacheKeyParams {
+				name := nameVal.Key
+				val := nameVal.Val
 				midRemap += ` @pparam=--` + name + "=" + val
 			}
 		}
@@ -412,4 +420,20 @@ func GetQStringIgnoreRemap(atsMajorVersion int) (string, bool, bool) {
 		addingCacheKey := false
 		return ` @plugin=cacheurl.so @pparam=cacheurl_qstring.config`, addingCacheURL, addingCacheKey
 	}
+}
+
+type KeyVal struct {
+	Key string
+	Val string
+}
+
+type KeyVals []KeyVal
+
+func (ks KeyVals) Len() int      { return len(ks) }
+func (ks KeyVals) Swap(i, j int) { ks[i], ks[j] = ks[j], ks[i] }
+func (ks KeyVals) Less(i, j int) bool {
+	if ks[i].Key != ks[j].Key {
+		return ks[i].Key < ks[j].Key
+	}
+	return ks[i].Val < ks[j].Val
 }


### PR DESCRIPTION
Backport of https://github.com/apache/trafficcontrol/pull/5045