### PR TITLE
Add Docker Health Checks to Traffic Ops and Traffic Monitor CiaB images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Ops Ort: Adds a transliteration of the traffic_ops_ort.pl perl script to the go language. See traffic_ops_ort/t3c/README.md.
 - Traffic Ops API v3
 - Added an optional readiness check service to cdn-in-a-box that exits successfully when it is able to get a `200 OK` from all delivery services
+- Added health check to Traffic Ops in cdn-in-a-box
 - [Flexible Topologies (in progress)](https://github.com/apache/trafficcontrol/blob/master/blueprints/flexible-topologies.md)
     - Traffic Ops: Added an API 3.0 endpoint, /api/3.0/topologies, to create, read, update and delete flexible topologies.
     - Traffic Ops: Added new `topology` field to the /api/3.0/deliveryservices APIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Ops Ort: Adds a transliteration of the traffic_ops_ort.pl perl script to the go language. See traffic_ops_ort/t3c/README.md.
 - Traffic Ops API v3
 - Added an optional readiness check service to cdn-in-a-box that exits successfully when it is able to get a `200 OK` from all delivery services
-- Added health check to Traffic Ops in cdn-in-a-box
+- Added health checks to Traffic Ops and Traffic Monitor in cdn-in-a-box
 - [Flexible Topologies (in progress)](https://github.com/apache/trafficcontrol/blob/master/blueprints/flexible-topologies.md)
     - Traffic Ops: Added an API 3.0 endpoint, /api/3.0/topologies, to create, read, update and delete flexible topologies.
     - Traffic Ops: Added new `topology` field to the /api/3.0/deliveryservices APIs

--- a/docs/source/development/debugging.rst
+++ b/docs/source/development/debugging.rst
@@ -45,7 +45,7 @@ Traffic Monitor
 
 * Still in ``infrastructure/cdn-in-a-box``, open ``variables.env`` and set ``TM_DEBUG_ENABLE`` to ``true``.
 
-* Stop CDN-in-a-Box if it is running and remove any existing volumes. Rebuild the ``trafficmonitor`` image without reusing any cached layers to make sure it uses our fresh ``traffic_monitor.rpm``. Then, start CDN-in-a-Box.
+* Stop CDN-in-a-Box if it is running and remove any existing volumes. Rebuild the ``trafficmonitor`` image to make sure it uses our fresh ``traffic_monitor.rpm``. Then, start CDN-in-a-Box.
 
 .. code-block:: shell
 	:caption: docker-compose command for debugging Traffic Monitor
@@ -55,7 +55,7 @@ Traffic Monitor
 	mydc build trafficmonitor-nondebug trafficmonitor
 	mydc up
 
-* Install `an IDE that supports delve <https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code>`_ and create a debugging configuration over port 2344. If you are using VS Code, the configuration should look like this:
+* Install `an IDE that supports delve <https://github.com/go-delve/delve/blob/master/Documentation/EditorIntegration.md>`_ and create a debugging configuration over port 2344. If you are using VS Code, the configuration should look like this:
 
 .. code-block:: json
 	:caption: VS Code launch.json for debugging Traffic Monitor
@@ -94,7 +94,7 @@ Traffic Ops (Go)
 
 * Still in ``infrastructure/cdn-in-a-box``, open ``variables.env`` and set ``TO_DEBUG_ENABLE`` to ``true``.
 
-* Stop CDN-in-a-Box if it is running and remove any existing volumes. Rebuild the ``trafficops-go`` image without reusing any cached layers to make sure it uses our fresh ``traffic_ops.rpm``. Then, start CDN-in-a-Box.
+* Stop CDN-in-a-Box if it is running and remove any existing volumes. Rebuild the ``trafficops-go`` image to make sure it uses our fresh ``traffic_ops.rpm``. Then, start CDN-in-a-Box.
 
 .. code-block:: shell
 	:caption: docker-compose command for debugging Traffic Ops
@@ -104,7 +104,7 @@ Traffic Ops (Go)
 	mydc build trafficops-nondebug trafficops
 	mydc up
 
-* Install `an IDE that supports delve <https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code>`_ and create a debugging configuration over port 2345. If you are using VS Code, the configuration should look like this:
+* Install `an IDE that supports delve <https://github.com/go-delve/delve/blob/master/Documentation/EditorIntegration.md>`_ and create a debugging configuration over port 2345. If you are using VS Code, the configuration should look like this:
 
 .. code-block:: json
 	:caption: VS Code launch.json for debugging Traffic Ops
@@ -314,7 +314,7 @@ Traffic Stats
 
 * Still in ``infrastructure/cdn-in-a-box``, open ``variables.env`` and set ``TS_DEBUG_ENABLE`` to ``true``.
 
-* Stop CDN-in-a-Box if it is running and remove any existing volumes. Rebuild the ``trafficstats`` image without reusing any cached layers to make sure it uses our fresh ``traffic_stats.rpm``. Then, start CDN-in-a-Box.
+* Stop CDN-in-a-Box if it is running and remove any existing volumes. Rebuild the ``trafficstats`` image to make sure it uses our fresh ``traffic_stats.rpm``. Then, start CDN-in-a-Box.
 
 .. code-block:: shell
 	:caption: docker-compose command for debugging Traffic Stats
@@ -324,7 +324,7 @@ Traffic Stats
 	mydc build trafficstats-nondebug trafficstats
 	mydc up
 
-* Install `an IDE that supports delve <https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code>`_ and create a debugging configuration over port 2346. If you are using VS Code, the configuration should look like this:
+* Install `an IDE that supports delve <https://github.com/go-delve/delve/blob/master/Documentation/EditorIntegration.md>`_ and create a debugging configuration over port 2346. If you are using VS Code, the configuration should look like this:
 
 .. code-block:: json
 	:caption: VS Code launch.json for debugging Traffic Stats

--- a/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
@@ -55,4 +55,4 @@ EXPOSE 80
 ADD traffic_monitor/run.sh /
 CMD /run.sh
 HEALTHCHECK --interval=10s --timeout=1s \
-    CMD bash -c 'source /to-access.sh && [[ "$(curl -s http://trafficmonitor.infra.ciab.test/api/traffic-ops-uri)" == "https://${TO_FQDN}:${TO_PORT}" ]]'
+    CMD bash -c 'source /to-access.sh && [[ "$(curl -s http://trafficmonitor.infra.ciab.test/api/traffic-ops-uri)" == "$TO_URL" ]]'

--- a/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
@@ -54,3 +54,5 @@ COPY dns/set-dns.sh \
 EXPOSE 80
 ADD traffic_monitor/run.sh /
 CMD /run.sh
+HEALTHCHECK --interval=10s --timeout=1s \
+    CMD bash -c 'source /to-access.sh && [[ "$(curl -s http://trafficmonitor.infra.ciab.test/api/traffic-ops-uri)" == "https://${TO_FQDN}:${TO_PORT}" ]]'

--- a/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/run.sh
@@ -128,7 +128,7 @@ traffic_monitor_command=(/opt/traffic_monitor/bin/traffic_monitor -opsCfg /opt/t
 if [[ "$TM_DEBUG_ENABLE" == true ]]; then
   dlv '--continue' '--listen=:2344' '--accept-multiclient=true' '--headless=true' '--api-version=2' exec \
     "${traffic_monitor_command[0]}" -- "${traffic_monitor_command[@]:1}" &
-  tail -f /dev/null;
 else
-  "${traffic_monitor_command[@]}"
+  "${traffic_monitor_command[@]}" &
 fi;
+tail -f /dev/null; # Keeps the container running indefinitely. The container health check (see dockerfile) will report whether Traffic Monitor is running.

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
@@ -65,3 +65,5 @@ COPY dns/set-dns.sh \
 WORKDIR /opt/traffic_ops/app
 EXPOSE  443
 CMD     /run-go.sh
+HEALTHCHECK --interval=10s --timeout=1s \
+    CMD bash -c 'source /to-access.sh && [[ "$(curl -s "https://${TO_FQDN}/api/${TO_API_VERSION}/ping" | jq .ping)" == \"pong\" ]]'

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile-go
@@ -66,4 +66,4 @@ WORKDIR /opt/traffic_ops/app
 EXPOSE  443
 CMD     /run-go.sh
 HEALTHCHECK --interval=10s --timeout=1s \
-    CMD bash -c 'source /to-access.sh && [[ "$(curl -s "https://${TO_FQDN}/api/${TO_API_VERSION}/ping" | jq .ping)" == \"pong\" ]]'
+    CMD bash -c 'source /to-access.sh && [[ "$(curl -sk "https://${TO_FQDN}/api/${TO_API_VERSION}/ping" | jq .ping)" == \"pong\" ]]'

--- a/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/run-go.sh
@@ -127,6 +127,4 @@ fi
 fg '"${traffic_ops_golang_command[@]}"'; # Bring traffic_ops_golang to foreground
 fg; # Bring to-enroll to foreground if it is still running
 
-if [[ "$TO_DEBUG_ENABLE" == true ]]; then
-  tail -f /dev/null;
-fi;
+tail -f /dev/null; # Keeps the container running indefinitely. The container health check (see dockerfile) will report whether Traffic Ops is running.


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
- This PR adds health checks to the Traffic Ops (Golang) and Traffic Monitor CDN-in-a-Box images so you can tell if it is working by running `docker-compose ps`.

Example output:

```
                 Name                                Command                  State                                                                               Ports
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
cdn-in-a-box_db_1                         /bin/sh -c /run-db.sh            Up             0.0.0.0:5432->5432/tcp
cdn-in-a-box_dns_1                        /sbin/entrypoint.sh /usr/s ...   Up             0.0.0.0:9353->53/tcp, 0.0.0.0:9353->53/udp
cdn-in-a-box_edge_1                       /bin/sh -c /run.sh               Up             0.0.0.0:9000->80/tcp
cdn-in-a-box_enroller_1                   /bin/sh -c /run.sh               Up
cdn-in-a-box_influxdb_1                   /run-influxdb.sh                 Up             0.0.0.0:8086->8086/tcp
cdn-in-a-box_mid-01_1                     /bin/sh -c /run.sh               Up             0.0.0.0:9100->80/tcp
cdn-in-a-box_mid-02_1                     /bin/sh -c /run.sh               Up             0.0.0.0:9200->80/tcp
cdn-in-a-box_origin_1                     /bin/sh -c /run.sh               Up             0.0.0.0:9300->80/tcp
cdn-in-a-box_smtp_1                       /usr/bin/env run.sh              Up (healthy)   1025/tcp, 1080/tcp, 0.0.0.0:4443->443/tcp
cdn-in-a-box_socksproxy_1                 /run.sh                          Up             0.0.0.0:9080->1080/tcp
cdn-in-a-box_trafficmonitor_1             /bin/sh -c /run.sh               Up (healthy)   0.0.0.0:2344->2344/tcp, 0.0.0.0:80->80/tcp
cdn-in-a-box_trafficops-perl_1            /bin/sh -c /run.sh               Up             0.0.0.0:60443->443/tcp, 0.0.0.0:5000->5000/tcp
cdn-in-a-box_trafficops_1                 /bin/sh -c /run-go.sh            Up (healthy)   0.0.0.0:2345->2345/tcp, 0.0.0.0:6443->443/tcp
cdn-in-a-box_trafficportal_1              /bin/sh -c /run.sh               Up             0.0.0.0:443->443/tcp
cdn-in-a-box_trafficrouter_1              /bin/sh -c /run.sh               Up             0.0.0.0:3333->3333/tcp, 0.0.0.0:2222->3443/tcp, 0.0.0.0:3443->443/tcp, 0.0.0.0:5005->5005/tcp, 0.0.0.0:3053->53/tcp, 0.0.0.0:3053->53/udp,
                                                                                          0.0.0.0:3080->80/tcp
cdn-in-a-box_trafficstats_1               /bin/sh -c /run.sh               Up             0.0.0.0:2346->2346/tcp
cdn-in-a-box_trafficvault_1               /bin/sh -c /run.sh               Up             0.0.0.0:8087->8087/tcp, 0.0.0.0:8088->8088/tcp, 0.0.0.0:8098->8098/tcp
```

Because those containers now have health checks, a user no longer needs to depend on whether the container is Up to know whether Traffic Ops or Traffic Monitor are running. This means that `tail -f /dev/null` can safely be re-added to the end of those services' `run.sh` files, which allows a developer to copy in a new `traffic_ops_golang` or `traffic_monitor` binary into the container and start it without the container ever exiting (or needing to restart or rebuild CDN-in-a-Box).

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->
- CDN in a Box
- Documentation

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Start CDN-in-a-Box
2. For each of Traffic Ops and Traffic Monitor (example written out for Traffic Ops):
    i. Make sure Traffic Ops is healthy with
    ```shell
    docker-compose ps trafficops
    ```
    ii. Kill the `traffic_ops_golang` process:
    ```shell
    docker-compose exec trafficops pkill traffic_ops_golang
    ```
    iii. Wait 10 seconds (the health check runs every 10 seconds)
    iv. Make sure Traffic Ops is still running but reported as unhealthy:
    ```shell
    docker-compose ps trafficops
    ```
   Expected output:
    ```
                     Name                                Command                  State                                                                               Ports
    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    cdn-in-a-box_db_1                         /bin/sh -c /run-db.sh            Up             0.0.0.0:5432->5432/tcp
    cdn-in-a-box_dns_1                        /sbin/entrypoint.sh /usr/s ...   Up             0.0.0.0:9353->53/tcp, 0.0.0.0:9353->53/udp
    cdn-in-a-box_edge_1                       /bin/sh -c /run.sh               Up             0.0.0.0:9000->80/tcp
    cdn-in-a-box_enroller_1                   /bin/sh -c /run.sh               Up
    cdn-in-a-box_influxdb_1                   /run-influxdb.sh                 Up             0.0.0.0:8086->8086/tcp
    cdn-in-a-box_mid-01_1                     /bin/sh -c /run.sh               Up             0.0.0.0:9100->80/tcp
    cdn-in-a-box_mid-02_1                     /bin/sh -c /run.sh               Up             0.0.0.0:9200->80/tcp
    cdn-in-a-box_origin_1                     /bin/sh -c /run.sh               Up             0.0.0.0:9300->80/tcp
    cdn-in-a-box_smtp_1                       /usr/bin/env run.sh              Up (healthy)   1025/tcp, 1080/tcp, 0.0.0.0:4443->443/tcp
    cdn-in-a-box_socksproxy_1                 /run.sh                          Up             0.0.0.0:9080->1080/tcp
    cdn-in-a-box_trafficmonitor_1             /bin/sh -c /run.sh               Up (healthy)   0.0.0.0:2344->2344/tcp, 0.0.0.0:80->80/tcp
    cdn-in-a-box_trafficops-perl_1            /bin/sh -c /run.sh               Up             0.0.0.0:60443->443/tcp, 0.0.0.0:5000->5000/tcp
    cdn-in-a-box_trafficops_1                 /bin/sh -c /run-go.sh            Up (unhealthy)   0.0.0.0:2345->2345/tcp, 0.0.0.0:6443->443/tcp
    cdn-in-a-box_trafficportal_1              /bin/sh -c /run.sh               Up             0.0.0.0:443->443/tcp
    cdn-in-a-box_trafficrouter_1              /bin/sh -c /run.sh               Up             0.0.0.0:3333->3333/tcp, 0.0.0.0:2222->3443/tcp, 0.0.0.0:3443->443/tcp, 0.0.0.0:5005->5005/tcp, 0.0.0.0:3053->53/tcp, 0.0.0.0:3053->53/udp,
                                                                                              0.0.0.0:3080->80/tcp
    cdn-in-a-box_trafficstats_1               /bin/sh -c /run.sh               Up             0.0.0.0:2346->2346/tcp
    cdn-in-a-box_trafficvault_1               /bin/sh -c /run.sh               Up             0.0.0.0:8087->8087/tcp, 0.0.0.0:8088->8088/tcp, 0.0.0.0:8098->8098/tcp
    ```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (3995be21c4)
- RELEASE-4.1.0
This is when Traffic Ops and Traffic Monitor containers in CDN-in-a-Box were made to exit after the `traffic_ops_golang` or `traffic_monitor` process exits.

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
