### PR TITLE
Fix TO to generate monitoring if no snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an option for `coordinateRange` in the RGB configuration file, so that in case a client doesn't have a postal code, we can still determine if it should be allowed or not, based on whether or not the latitude/ longitude of the client falls within the supplied ranges. [Related github issue](https://github.com/apache/trafficcontrol/issues/4372)
 - Fixed #3548 - Prevents DS regexes with non-consecutive order from generating invalid CRconfig/snapshot.
 - Fixed #5020, #5021 - Creating an ASN with the same number and same cache group should not be allowed.
+- Fixed #5006 - Traffic Ops now generates the Monitoring on-the-fly if the snapshot doesn't exist, and logs an error. This fixes upgrading to 4.x to not break the CDN until a Snapshot is done.
 - Fixed #4680 - Change Content-Type to application/json for TR auth calls
 
 ### Changed

--- a/traffic_ops/testing/api/v2/monitoring_test.go
+++ b/traffic_ops/testing/api/v2/monitoring_test.go
@@ -23,8 +23,33 @@ import (
 
 func TestMonitoring(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
+		GetTestMonitoringConfigNoSnapshotOnTheFly(t) // MUST run first
 		AllCDNsCanSnapshot(t)
 	})
+}
+
+// GetTestMonitoringConfigNoSnapshotOnTheFly verifies that Traffic Ops generates a monitoring.json on-the-fly rather than returning "" or "{}" if no snapshot exists.
+// This MUST NOT be run after a different function in the same Test creates a Snapshot, or the test will be invalid.
+// This prevents a critical bug of upgrading to 4.x bringing a CDN down until a Snapshot is performed.
+func GetTestMonitoringConfigNoSnapshotOnTheFly(t *testing.T) {
+	server := tc.Server{}
+	for _, sv := range testData.Servers {
+		if sv.Type != "EDGE" {
+			continue
+		}
+		server = sv
+		break
+	}
+	if server.CDNName == "" {
+		t.Fatal("No edge server found in test data, cannot test")
+	}
+
+	tmConfig, _, err := TOSession.GetTrafficMonitorConfigMap(server.CDNName)
+	if err != nil {
+		t.Error("getting monitoring: " + err.Error())
+	} else if len(tmConfig.TrafficServer) == 0 {
+		t.Error("Expected Monitoring without a snapshot to generate on-the-fly, actual: empty monitoring object for cdn '" + server.CDNName + "'")
+	}
 }
 
 func AllCDNsCanSnapshot(t *testing.T) {

--- a/traffic_ops/testing/api/v2/tc-fixtures.json
+++ b/traffic_ops/testing/api/v2/tc-fixtures.json
@@ -1450,7 +1450,35 @@
             "lastUpdated": "2018-03-02T17:27:11.813052+00:00",
             "name": "RASCAL1",
             "routing_disabled": false,
-            "type": "TM_PROFILE"
+            "type": "TM_PROFILE",
+            "params": [
+                {
+                    "configFile": "rascal.properties",
+                    "name": "health.threshold.queryTime",
+                    "secure": false,
+                    "value": "1000"
+                },
+                {
+                    "configFile": "rascal.properties",
+                    "name": "health.polling.url",
+                    "secure": false,
+                    "value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
+                },
+                {
+                    "configFile": "rascal-config.txt",
+                    "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
+                    "name": "peers.polling.interval",
+                    "secure": false,
+                    "value": "60"
+                },
+                {
+                    "configFile": "rascal-config.txt",
+                    "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
+                    "name": "health.polling.interval",
+                    "secure": false,
+                    "value": "30"
+                }
+            ]
         },
         {
             "cdnName": "cdn1",
@@ -1938,7 +1966,7 @@
             "mgmtIpNetmask": "",
             "offlineReason": null,
             "physLocation": "Denver",
-            "profile": "EDGE1",
+            "profile": "RASCAL1",
             "rack": "RR 119.02",
             "revalPending": false,
             "routerHostName": "",

--- a/traffic_ops/testing/api/v3/monitoring_test.go
+++ b/traffic_ops/testing/api/v3/monitoring_test.go
@@ -23,8 +23,33 @@ import (
 
 func TestMonitoring(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, Topologies, DeliveryServices}, func() {
+		GetTestMonitoringConfigNoSnapshotOnTheFly(t) // MUST run first
 		AllCDNsCanSnapshot(t)
 	})
+}
+
+// GetTestMonitoringConfigNoSnapshotOnTheFly verifies that Traffic Ops generates a monitoring.json on-the-fly rather than returning "" or "{}" if no snapshot exists.
+// This MUST NOT be run after a different function in the same Test creates a Snapshot, or the test will be invalid.
+// This prevents a critical bug of upgrading to 4.x bringing a CDN down until a Snapshot is performed.
+func GetTestMonitoringConfigNoSnapshotOnTheFly(t *testing.T) {
+	server := tc.ServerNullable{}
+	for _, sv := range testData.Servers {
+		if sv.Type != "EDGE" {
+			continue
+		}
+		server = sv
+		break
+	}
+	if server.CDNName == nil || *server.CDNName == "" {
+		t.Fatal("No edge server found in test data, cannot test")
+	}
+
+	tmConfig, _, err := TOSession.GetTrafficMonitorConfigMap(*server.CDNName)
+	if err != nil {
+		t.Error("getting monitoring: " + err.Error())
+	} else if len(tmConfig.TrafficServer) == 0 {
+		t.Error("Expected Monitoring without a snapshot to generate on-the-fly, actual: empty monitoring object for cdn '" + *server.CDNName + "'")
+	}
 }
 
 func AllCDNsCanSnapshot(t *testing.T) {

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -1828,7 +1828,35 @@
             "lastUpdated": "2018-03-02T17:27:11.813052+00:00",
             "name": "RASCAL1",
             "routing_disabled": false,
-            "type": "TM_PROFILE"
+            "type": "TM_PROFILE",
+            "params": [
+                {
+                    "configFile": "rascal.properties",
+                    "name": "health.threshold.queryTime",
+                    "secure": false,
+                    "value": "1000"
+                },
+                {
+                    "configFile": "rascal.properties",
+                    "name": "health.polling.url",
+                    "secure": false,
+                    "value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
+                },
+                {
+                    "configFile": "rascal-config.txt",
+                    "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
+                    "name": "peers.polling.interval",
+                    "secure": false,
+                    "value": "60"
+                },
+                {
+                    "configFile": "rascal-config.txt",
+                    "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
+                    "name": "health.polling.interval",
+                    "secure": false,
+                    "value": "30"
+                }
+            ]
         },
         {
             "cdnName": "cdn1",
@@ -2463,7 +2491,7 @@
             "mgmtIpNetmask": "",
             "offlineReason": null,
             "physLocation": "Denver",
-            "profile": "EDGE1",
+            "profile": "RASCAL1",
             "rack": "RR 119.02",
             "revalPending": false,
             "routerHostName": "",


### PR DESCRIPTION
Fixes TO to generate monitoring if no snapshot.
This fixes a critical issue of upgrading to 4.x breaking production CDNs until a Snapshot is done.

Includes tests.
Includes changelog.
No docs, no interface change.

- [x] This PR does part of #5006 but that issue requires the 4.x Backport as well

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Request the /monitoring endpoint on a TO CDN with no CRConfig/Monitoring Snapshot, verify endpoint returns full monitoring not `""` or `{}`. Verify TO logs an Error that a snapshot needs to be performed.


## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information