### PR TITLE
[4.1.x] Make 4.1.x TM backwards compatible with pre-4.0 TO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added the ability to set TLS config provided here: https://golang.org/pkg/crypto/tls/#Config in Traffic Ops
 
+### Fixed
+- Fixed #5005: Traffic Monitor cannot be upgraded independently of Traffic Ops
+
 ### Deprecated
 - Deprecated the `insecure` option in `traffic_ops_golang` in favor of `"tls_config": { "InsecureSkipVerify": <bool> }`
 

--- a/traffic_monitor/datareq/crconfig.go
+++ b/traffic_monitor/datareq/crconfig.go
@@ -27,9 +27,9 @@ import (
 	"github.com/apache/trafficcontrol/traffic_monitor/towrap"
 )
 
-func srvTRConfig(opsConfig threadsafe.OpsConfig, toSession towrap.ITrafficOpsSession) ([]byte, time.Time, error) {
+func srvTRConfig(opsConfig threadsafe.OpsConfig, toSession towrap.TrafficOpsSessionThreadsafe) ([]byte, time.Time, error) {
 	cdnName := opsConfig.Get().CdnName
-	if toSession == nil {
+	if !toSession.Initialized() {
 		return nil, time.Time{}, fmt.Errorf("Unable to connect to Traffic Ops")
 	}
 	if cdnName == "" {

--- a/traffic_monitor/datareq/crconfighist.go
+++ b/traffic_monitor/datareq/crconfighist.go
@@ -25,7 +25,7 @@ import (
 	"github.com/json-iterator/go"
 )
 
-func srvAPICRConfigHist(toc towrap.ITrafficOpsSession) ([]byte, error) {
+func srvAPICRConfigHist(toc towrap.TrafficOpsSessionThreadsafe) ([]byte, error) {
 	json := jsoniter.ConfigFastest
 	return json.Marshal(toc.CRConfigHistory())
 }

--- a/traffic_monitor/datareq/datareq.go
+++ b/traffic_monitor/datareq/datareq.go
@@ -41,7 +41,7 @@ import (
 // MakeDispatchMap returns the map of paths to http.HandlerFuncs for dispatching.
 func MakeDispatchMap(
 	opsConfig threadsafe.OpsConfig,
-	toSession towrap.ITrafficOpsSession,
+	toSession towrap.TrafficOpsSessionThreadsafe,
 	localStates peer.CRStatesThreadsafe,
 	peerStates peer.CRStatesPeersThreadsafe,
 	combinedStates peer.CRStatesThreadsafe,

--- a/traffic_monitor/handler/handler.go
+++ b/traffic_monitor/handler/handler.go
@@ -40,6 +40,7 @@ type OpsConfig struct {
 	HttpsListener string `json:"httpsListener"`
 	CertFile      string `json:"certFile"`
 	KeyFile       string `json:"keyFile"`
+	UsingDummyTO  bool   `json:"usingDummyTO"`
 }
 
 type Handler interface {

--- a/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/manager/manager.go
@@ -44,7 +44,7 @@ import (
 // Start starts the poller and handler goroutines
 //
 func Start(opsConfigFile string, cfg config.Config, appData config.StaticAppData, trafficMonitorConfigFileName string) error {
-	toSession := towrap.ITrafficOpsSession(towrap.NewTrafficOpsSessionThreadsafe(nil, nil, cfg.CRConfigHistoryCount, cfg))
+	toSession := towrap.NewTrafficOpsSessionThreadsafe(nil, nil, cfg.CRConfigHistoryCount, cfg)
 
 	localStates := peer.NewCRStatesThreadsafe() // this is the local state as discoverer by this traffic_monitor
 	fetchCount := threadsafe.NewUint()          // note this is the number of individual caches fetched from, not the number of times all the caches were polled.
@@ -126,7 +126,7 @@ func Start(opsConfigFile string, cfg config.Config, appData config.StaticAppData
 		toSession,
 		toData,
 		[]chan<- handler.OpsConfig{monitorConfigPoller.OpsConfigChannel},
-		[]chan<- towrap.ITrafficOpsSession{monitorConfigPoller.SessionChannel},
+		[]chan<- towrap.TrafficOpsSessionThreadsafe{monitorConfigPoller.SessionChannel},
 		localStates,
 		peerStates,
 		combinedStates,

--- a/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/manager/manager.go
@@ -44,7 +44,7 @@ import (
 // Start starts the poller and handler goroutines
 //
 func Start(opsConfigFile string, cfg config.Config, appData config.StaticAppData, trafficMonitorConfigFileName string) error {
-	toSession := towrap.ITrafficOpsSession(towrap.NewTrafficOpsSessionThreadsafe(nil, cfg.CRConfigHistoryCount, cfg))
+	toSession := towrap.ITrafficOpsSession(towrap.NewTrafficOpsSessionThreadsafe(nil, nil, cfg.CRConfigHistoryCount, cfg))
 
 	localStates := peer.NewCRStatesThreadsafe() // this is the local state as discoverer by this traffic_monitor
 	fetchCount := threadsafe.NewUint()          // note this is the number of individual caches fetched from, not the number of times all the caches were polled.

--- a/traffic_monitor/manager/monitorconfig.go
+++ b/traffic_monitor/manager/monitorconfig.go
@@ -129,7 +129,7 @@ func StartMonitorConfigManager(
 	cachesChangeSubscriber chan<- struct{},
 	cfg config.Config,
 	staticAppData config.StaticAppData,
-	toSession towrap.ITrafficOpsSession,
+	toSession towrap.TrafficOpsSessionThreadsafe,
 	toData todata.TODataThreadsafe,
 ) threadsafe.TrafficMonitorConfigMap {
 	monitorConfig := threadsafe.NewTrafficMonitorConfigMap()
@@ -199,7 +199,7 @@ func monitorConfigListen(
 	cachesChangeSubscriber chan<- struct{},
 	cfg config.Config,
 	staticAppData config.StaticAppData,
-	toSession towrap.ITrafficOpsSession,
+	toSession towrap.TrafficOpsSessionThreadsafe,
 	toData todata.TODataThreadsafe,
 ) {
 	defer func() {

--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -20,12 +20,9 @@ package manager
  */
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
-	"net/http"
-	"net/http/cookiejar"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -41,7 +38,6 @@ import (
 	"github.com/apache/trafficcontrol/traffic_monitor/threadsafe"
 	"github.com/apache/trafficcontrol/traffic_monitor/todata"
 	"github.com/apache/trafficcontrol/traffic_monitor/towrap"
-	to "github.com/apache/trafficcontrol/traffic_ops/client"
 
 	"github.com/json-iterator/go"
 )
@@ -156,7 +152,6 @@ func StartOpsConfigManager(
 		// TODO config? parameter?
 		useCache := false
 		trafficOpsRequestTimeout := time.Second * time.Duration(10)
-		var realToSession *to.Session
 		var toAddr net.Addr
 		var toLoginCount uint64
 
@@ -169,7 +164,7 @@ func StartOpsConfigManager(
 			backoff = util.NewConstantBackoff(util.ConstantBackoffDuration)
 		}
 		for {
-			realToSession, toAddr, err = to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
+			err = toSession.Update(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
 			if err != nil {
 				handleErr(fmt.Errorf("MonitorConfigPoller: error instantiating Session with traffic_ops (%v): %s\n", toAddr, err))
 				duration := backoff.BackoffDuration()
@@ -177,34 +172,22 @@ func StartOpsConfigManager(
 				time.Sleep(duration)
 
 				if toSession.BackupFileExists() && (toLoginCount >= cfg.TrafficOpsDiskRetryMax) {
-					jar, err := cookiejar.New(nil)
-					if err != nil {
-						log.Errorf("Err getting cookiejar")
-						continue
-					}
-
-					realToSession = to.NewSession(newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Url, staticAppData.UserAgent, &http.Client{
-						Timeout: trafficOpsRequestTimeout,
-						Transport: &http.Transport{
-							TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-						},
-						Jar: jar,
-					}, useCache)
-					toSession.Set(realToSession)
 					// At this point we have a valid 'dummy' session. This will allow us to pull from disk but will also retry when TO comes up
 					log.Errorf("error instantiating Session with traffic_ops, backup disk files exist, creating empty traffic_ops session to read")
+					newOpsConfig.UsingDummyTO = true
 					break
 				}
 
 				toLoginCount++
 				continue
 			} else {
-				toSession.Set(realToSession)
+				newOpsConfig.UsingDummyTO = false
 				break
 			}
 		}
+		opsConfig.Set(newOpsConfig)
 
-		if cdn, err := getMonitorCDN(realToSession, staticAppData.Hostname); err != nil {
+		if cdn, err := toSession.MonitorCDN(staticAppData.Hostname); err != nil {
 			handleErr(fmt.Errorf("getting CDN name from Traffic Ops, using config CDN '%s': %s\n", newOpsConfig.CdnName, err))
 		} else {
 			if newOpsConfig.CdnName != "" && newOpsConfig.CdnName != cdn {
@@ -246,21 +229,4 @@ func StartOpsConfigManager(
 	startSignalFileReloader(opsConfigFile, unix.SIGHUP, onChange)
 
 	return opsConfig, nil
-}
-
-// getMonitorCDN returns the CDN of a given Traffic Monitor.
-// TODO change to get by name, when Traffic Ops supports querying a single server.
-func getMonitorCDN(toc *to.Session, monitorHostname string) (string, error) {
-	servers, _, err := toc.GetServers()
-	if err != nil {
-		return "", fmt.Errorf("getting monitor %s CDN: %v", monitorHostname, err)
-	}
-
-	for _, server := range servers {
-		if server.HostName != monitorHostname {
-			continue
-		}
-		return server.CDNName, nil
-	}
-	return "", fmt.Errorf("no monitor named %v found in Traffic Ops", monitorHostname)
 }

--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -46,10 +46,10 @@ import (
 // Note the OpsConfigManager is in charge of the httpServer, because ops config changes trigger server changes. If other things needed to trigger server restarts, the server could be put in its own goroutine with signal channels
 func StartOpsConfigManager(
 	opsConfigFile string,
-	toSession towrap.ITrafficOpsSession,
+	toSession towrap.TrafficOpsSessionThreadsafe,
 	toData todata.TODataThreadsafe,
 	opsConfigChangeSubscribers []chan<- handler.OpsConfig,
-	toChangeSubscribers []chan<- towrap.ITrafficOpsSession,
+	toChangeSubscribers []chan<- towrap.TrafficOpsSessionThreadsafe,
 	localStates peer.CRStatesThreadsafe,
 	peerStates peer.CRStatesPeersThreadsafe,
 	combinedStates peer.CRStatesThreadsafe,
@@ -216,7 +216,7 @@ func StartOpsConfigManager(
 			go func(s chan<- handler.OpsConfig) { s <- newOpsConfig }(subscriber)
 		}
 		for _, subscriber := range toChangeSubscribers {
-			go func(s chan<- towrap.ITrafficOpsSession) { s <- toSession }(subscriber)
+			go func(s chan<- towrap.TrafficOpsSessionThreadsafe) { s <- toSession }(subscriber)
 		}
 	}
 

--- a/traffic_monitor/todata/todata.go
+++ b/traffic_monitor/todata/todata.go
@@ -138,7 +138,7 @@ type CRConfig struct {
 
 // Fetch gets the CRConfig from Traffic Ops, creates the TOData maps, and atomically sets the TOData.
 // TODO since the session is threadsafe, each TOData get func below could be put in a goroutine, if performance mattered
-func (d TODataThreadsafe) Fetch(to towrap.ITrafficOpsSession, cdn string) error {
+func (d TODataThreadsafe) Fetch(to towrap.TrafficOpsSessionThreadsafe, cdn string) error {
 	if _, err := to.CRConfigRaw(cdn); err != nil {
 		return fmt.Errorf("Error getting CRconfig from Traffic Ops: %v", err)
 	}
@@ -146,7 +146,7 @@ func (d TODataThreadsafe) Fetch(to towrap.ITrafficOpsSession, cdn string) error 
 }
 
 // Update updates the TOData data with the last fetched CDN
-func (d TODataThreadsafe) Update(to towrap.ITrafficOpsSession, cdn string) error {
+func (d TODataThreadsafe) Update(to towrap.TrafficOpsSessionThreadsafe, cdn string) error {
 	crConfigBytes, _, err := to.LastCRConfig(cdn)
 	if err != nil {
 		return fmt.Errorf("Error getting last CRConfig: %v", err)

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"strconv"
 	"sync"
@@ -306,6 +307,13 @@ func MonitorConfigValid(cfg *tc.TrafficMonitorConfigMap) error {
 	return nil
 }
 
+func MaybeIPStr(addr net.Addr) string {
+	if addr != nil {
+		return addr.String()
+	}
+	return ""
+}
+
 // CRConfigRaw returns the CRConfig from the Traffic Ops. This is safe for multiple goroutines.
 func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 
@@ -321,7 +329,7 @@ func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 		b, reqInf, e := ss.GetCRConfig(cdn)
 		err = e
 		data = b
-		remoteAddr = reqInf.RemoteAddr.String()
+		remoteAddr = MaybeIPStr(reqInf.RemoteAddr)
 	} else {
 		ss := s.get()
 		if ss == nil {
@@ -331,7 +339,7 @@ func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 		b, reqInf, e := ss.GetCRConfig(cdn)
 		err = e
 		data = b
-		remoteAddr = reqInf.RemoteAddr.String()
+		remoteAddr = MaybeIPStr(reqInf.RemoteAddr)
 	}
 
 	if err == nil {

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_monitor/config"
 	"github.com/apache/trafficcontrol/traffic_ops/client"
+	legacyClient "github.com/apache/trafficcontrol/traffic_ops/v1-3-client"
 
 	"github.com/json-iterator/go"
 )
@@ -41,16 +42,10 @@ type ITrafficOpsSession interface {
 	CRConfigRaw(cdn string) ([]byte, error)
 	LastCRConfig(cdn string) ([]byte, time.Time, error)
 	TrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, error)
-	Set(session *client.Session)
-	URL() (string, error)
-	User() (string, error)
-	Servers() ([]tc.Server, error)
-	Profiles() ([]tc.Profile, error)
-	Parameters(profileName string) ([]tc.Parameter, error)
-	DeliveryServices() ([]tc.DeliveryService, error)
-	CacheGroups() ([]tc.CacheGroupNullable, error)
+	Update(url, username, password string, insecure bool, userAgent string, useCache bool, timeout time.Duration) error
 	CRConfigHistory() []CRConfigStat
 	BackupFileExists() bool
+	MonitorCDN(hostName string) (string, error)
 }
 
 const localHostIP = "127.0.0.1"
@@ -164,23 +159,60 @@ type CRConfigStat struct {
 // TrafficOpsSessionThreadsafe provides access to the Traffic Ops client safe for multiple goroutines. This fulfills the ITrafficOpsSession interface.
 type TrafficOpsSessionThreadsafe struct {
 	session            **client.Session // pointer-to-pointer, because we're given a pointer from the Traffic Ops package, and we don't want to copy it.
+	legacySession      **legacyClient.Session
 	m                  *sync.Mutex
 	lastCRConfig       ByteMapCache
 	crConfigHist       CRConfigHistoryThreadsafe
 	CRConfigBackupFile string
 	TMConfigBackupFile string
+	useLegacy          bool
 }
 
 // NewTrafficOpsSessionThreadsafe returns a new threadsafe TrafficOpsSessionThreadsafe wrapping the given `Session`.
-func NewTrafficOpsSessionThreadsafe(s *client.Session, crConfigHistoryLimit uint64, cfg config.Config) TrafficOpsSessionThreadsafe {
-	return TrafficOpsSessionThreadsafe{session: &s, m: &sync.Mutex{}, lastCRConfig: NewByteMapCache(), crConfigHist: NewCRConfigHistoryThreadsafe(crConfigHistoryLimit), CRConfigBackupFile: cfg.CRConfigBackupFile, TMConfigBackupFile: cfg.TMConfigBackupFile}
+func NewTrafficOpsSessionThreadsafe(s *client.Session, ls *legacyClient.Session, crConfigHistoryLimit uint64, cfg config.Config) TrafficOpsSessionThreadsafe {
+	return TrafficOpsSessionThreadsafe{
+		session:            &s,
+		legacySession:      &ls,
+		m:                  &sync.Mutex{},
+		lastCRConfig:       NewByteMapCache(),
+		crConfigHist:       NewCRConfigHistoryThreadsafe(crConfigHistoryLimit),
+		CRConfigBackupFile: cfg.CRConfigBackupFile,
+		TMConfigBackupFile: cfg.TMConfigBackupFile,
+		useLegacy:          false,
+	}
 }
 
-// Set sets the internal Traffic Ops session. This is safe for multiple goroutines, being aware they will race.
-func (s TrafficOpsSessionThreadsafe) Set(session *client.Session) {
+// Update updates the TrafficOpsSessionThreadsafe's connection information with
+// the provided information. It's safe for calling by multiple goroutines, being
+// aware that they will race.
+func (s TrafficOpsSessionThreadsafe) Update(
+	url string,
+	username string,
+	password string,
+	insecure bool,
+	userAgent string,
+	useCache bool,
+	timeout time.Duration,
+) error {
 	s.m.Lock()
 	defer s.m.Unlock()
-	*s.session = session
+
+	session, _, err := client.LoginWithAgent(url, username, password, insecure, userAgent, useCache, timeout)
+	if err != nil {
+		log.Errorf("Error logging in using up-to-date client: %v", err)
+		legacySession, _, err := legacyClient.LoginWithAgent(url, username, password, insecure, userAgent, useCache, timeout)
+		if err != nil || legacySession == nil {
+			err = fmt.Errorf("logging in using legacy client: %v", err)
+			return err
+		}
+		*s.legacySession = legacySession
+		s.useLegacy = true
+	} else {
+		*s.session = session
+		s.useLegacy = false
+	}
+
+	return nil
 }
 
 // getThreadsafeSession is used internally to get a copy of the session pointer, or nil if it doesn't exist. This should not be used outside TrafficOpsSessionThreadsafe, and never stored, because part of the purpose of TrafficOpsSessionThreadsafe is to store a pointer to the Session pointer, so it can be updated by one goroutine and immediately used by another. This should only be called immediately before using the session, since someone else may update it concurrently.
@@ -193,20 +225,13 @@ func (s TrafficOpsSessionThreadsafe) get() *client.Session {
 	return *s.session
 }
 
-func (s TrafficOpsSessionThreadsafe) URL() (string, error) {
-	ss := s.get()
-	if ss == nil {
-		return "", ErrNilSession
+func (s TrafficOpsSessionThreadsafe) getLegacy() *legacyClient.Session {
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.legacySession == nil || *s.legacySession == nil {
+		return nil
 	}
-	return ss.URL, nil
-}
-
-func (s TrafficOpsSessionThreadsafe) User() (string, error) {
-	ss := s.get()
-	if ss == nil {
-		return "", ErrNilSession
-	}
-	return ss.UserName, nil
+	return *s.legacySession
 }
 
 func (s TrafficOpsSessionThreadsafe) CRConfigHistory() []CRConfigStat {
@@ -284,21 +309,36 @@ func MonitorConfigValid(cfg *tc.TrafficMonitorConfigMap) error {
 // CRConfigRaw returns the CRConfig from the Traffic Ops. This is safe for multiple goroutines.
 func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 
-	ss := s.get()
-
 	var remoteAddr string
+	var err error
+	var data []byte
 
-	if ss == nil {
-		return nil, ErrNilSession
+	if s.useLegacy {
+		ss := s.getLegacy()
+		if ss == nil {
+			return nil, ErrNilSession
+		}
+		b, reqInf, e := ss.GetCRConfig(cdn)
+		err = e
+		data = b
+		remoteAddr = reqInf.RemoteAddr.String()
+	} else {
+		ss := s.get()
+		if ss == nil {
+			return nil, ErrNilSession
+		}
+
+		b, reqInf, e := ss.GetCRConfig(cdn)
+		err = e
+		data = b
+		remoteAddr = reqInf.RemoteAddr.String()
 	}
 
-	b, reqInf, err := ss.GetCRConfig(cdn)
 	if err == nil {
-		remoteAddr = reqInf.RemoteAddr.String()
-		ioutil.WriteFile(s.CRConfigBackupFile, b, 0644)
+		ioutil.WriteFile(s.CRConfigBackupFile, data, 0644)
 	} else {
 		if s.BackupFileExists() {
-			b, err = ioutil.ReadFile(s.CRConfigBackupFile)
+			data, err = ioutil.ReadFile(s.CRConfigBackupFile)
 			if err != nil {
 				err = errors.New("file Read Error: " + err.Error())
 				return nil, err
@@ -307,7 +347,7 @@ func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 			log.Errorln("Error getting CRConfig from traffic_ops, backup file exists, reading from file")
 			err = nil
 		} else {
-			return nil, ErrNilSession
+			return nil, fmt.Errorf("Failed to get CRConfig from Traffic Ops (%v), and there is no backup file", err)
 		}
 	}
 
@@ -315,26 +355,26 @@ func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 	defer s.crConfigHist.Add(hist)
 
 	if err != nil {
-		return b, err
+		return data, err
 	}
 
 	crc := &tc.CRConfig{}
 	json := jsoniter.ConfigFastest
-	if err = json.Unmarshal(b, crc); err != nil {
+	if err = json.Unmarshal(data, crc); err != nil {
 		err = errors.New("invalid JSON: " + err.Error())
 		hist.Err = err
-		return b, err
+		return data, err
 	}
 	hist.Stats = crc.Stats
 
 	if err = s.CRConfigValid(crc, cdn); err != nil {
 		err = errors.New("invalid CRConfig: " + err.Error())
 		hist.Err = err
-		return b, err
+		return data, err
 	}
 
-	s.lastCRConfig.Set(cdn, b, &crc.Stats)
-	return b, nil
+	s.lastCRConfig.Set(cdn, data, &crc.Stats)
+	return data, nil
 }
 
 // LastCRConfig returns the last CRConfig requested from CRConfigRaw, and the time it was returned. This is designed to be used in conjunction with a poller which regularly calls CRConfigRaw. If no last CRConfig exists, because CRConfigRaw has never been called successfully, this calls CRConfigRaw once to try to get the CRConfig from Traffic Ops.
@@ -349,12 +389,22 @@ func (s TrafficOpsSessionThreadsafe) LastCRConfig(cdn string) ([]byte, time.Time
 
 // TrafficMonitorConfigMapRaw returns the Traffic Monitor config map from the Traffic Ops, directly from the monitoring.json endpoint. This is not usually what is needed, rather monitoring needs the snapshotted CRConfig data, which is filled in by `TrafficMonitorConfigMap`. This is safe for multiple goroutines.
 func (s TrafficOpsSessionThreadsafe) trafficMonitorConfigMapRaw(cdn string) (*tc.TrafficMonitorConfigMap, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
+	var configMap *tc.TrafficMonitorConfigMap
+	var err error
 
-	configMap, _, err := ss.GetTrafficMonitorConfigMap(cdn)
+	if s.useLegacy {
+		ss := s.getLegacy()
+		if ss == nil {
+			return nil, ErrNilSession
+		}
+		configMap, _, err = ss.GetTrafficMonitorConfigMap(cdn)
+	} else {
+		ss := s.get()
+		if ss == nil {
+			return nil, ErrNilSession
+		}
+		configMap, _, err = ss.GetTrafficMonitorConfigMap(cdn)
+	}
 
 	if err == nil {
 		err = MonitorConfigValid(configMap)
@@ -412,6 +462,37 @@ func (s TrafficOpsSessionThreadsafe) TrafficMonitorConfigMap(cdn string) (*tc.Tr
 	}
 
 	return mc, nil
+}
+
+// MonitorCDN returns the name of the CDN of a Traffic Monitor with the given
+// hostName.
+func (s TrafficOpsSessionThreadsafe) MonitorCDN(hostName string) (string, error) {
+	var err error
+	var servers []tc.Server
+
+	if s.useLegacy {
+		ss := s.getLegacy()
+		if ss == nil {
+			err = ErrNilSession
+		}
+		servers, _, err = ss.GetServerByHostName(hostName)
+	} else {
+		ss := s.get()
+		if ss == nil {
+			err = ErrNilSession
+		}
+		servers, _, err = ss.GetServerByHostName(hostName)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("getting monitor CDN: %v", err)
+	}
+
+	if len(servers) < 1 {
+		return "", fmt.Errorf("no server '%s' found in Traffic Ops", hostName)
+	}
+
+	return servers[0].CDNName, nil
 }
 
 func CreateMonitorConfig(crConfig tc.CRConfig, mc *tc.TrafficMonitorConfigMap) (*tc.TrafficMonitorConfigMap, error) {
@@ -540,49 +621,4 @@ func CreateMonitorConfig(crConfig tc.CRConfig, mc *tc.TrafficMonitorConfigMap) (
 		}
 	}
 	return mc, nil
-}
-
-func (s TrafficOpsSessionThreadsafe) Servers() ([]tc.Server, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	servers, _, error := ss.GetServers()
-	return servers, error
-}
-
-func (s TrafficOpsSessionThreadsafe) Profiles() ([]tc.Profile, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	profiles, _, error := ss.GetProfiles()
-	return profiles, error
-}
-
-func (s TrafficOpsSessionThreadsafe) Parameters(profileName string) ([]tc.Parameter, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	parameters, _, error := ss.GetParametersByProfileName(profileName)
-	return parameters, error
-}
-
-func (s TrafficOpsSessionThreadsafe) DeliveryServices() ([]tc.DeliveryService, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	deliveryServices, _, error := ss.GetDeliveryServices()
-	return deliveryServices, error
-}
-
-func (s TrafficOpsSessionThreadsafe) CacheGroups() ([]tc.CacheGroupNullable, error) {
-	ss := s.get()
-	if ss == nil {
-		return nil, ErrNilSession
-	}
-	cacheGroups, _, error := ss.GetCacheGroupsNullable()
-	return cacheGroups, error
 }

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -482,14 +482,16 @@ func (s TrafficOpsSessionThreadsafe) MonitorCDN(hostName string) (string, error)
 		ss := s.getLegacy()
 		if ss == nil {
 			err = ErrNilSession
+		} else {
+			servers, _, err = ss.GetServerByHostName(hostName)
 		}
-		servers, _, err = ss.GetServerByHostName(hostName)
 	} else {
 		ss := s.get()
 		if ss == nil {
 			err = ErrNilSession
+		} else {
+			servers, _, err = ss.GetServerByHostName(hostName)
 		}
-		servers, _, err = ss.GetServerByHostName(hostName)
 	}
 
 	if err != nil {

--- a/traffic_ops/v1-3-client/README.md
+++ b/traffic_ops/v1-3-client/README.md
@@ -1,0 +1,53 @@
+# TO Client Library Golang
+
+## Getting Started
+1. Obtain the latest version of the library
+
+`go get github.com/apache/trafficcontrol/traffic_ops/client`
+
+2. Get a basic TO session started and fetch a list of CDNs
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
+)
+
+const TOURL = "http://localhost"
+const TOUser = "user"
+const TOPassword = "password"
+const AllowInsecureConnections = true
+const UserAgent = "MySampleApp"
+const UseClientCache = false
+const TrafficOpsRequestTimeout = time.Second * time.Duration(10)
+
+func main() {
+	session, remoteaddr, err := toclient.LoginWithAgent(
+		TOURL,
+		TOUser,
+		TOPassword,
+		AllowInsecureConnections,
+		UserAgent,
+		UseClientCache,
+		TrafficOpsRequestTimeout)
+	if err != nil {
+		fmt.Printf("An error occurred while logging in:\n\t%v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Connected to: " + remoteaddr.String())
+	var cdns []v13.CDN
+	cdns, _, err = session.GetCDNs()
+	if err != nil {
+		fmt.Printf("An error occurred while getting cdns:\n\t%v\n", err)
+		os.Exit(1)
+	}
+	for _, cdn := range cdns {
+		fmt.Println(cdn.Name)
+	}
+}
+```

--- a/traffic_ops/v1-3-client/about.go
+++ b/traffic_ops/v1-3-client/about.go
@@ -1,0 +1,43 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const (
+	API_v13_ABOUT = "/api/1.3/about"
+)
+
+// GetAbout gets data about the TO instance
+func (to *Session) GetAbout() (map[string]string, ReqInf, error) {
+	route := API_v13_ABOUT
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/asn.go
+++ b/traffic_ops/v1-3-client/asn.go
@@ -1,0 +1,164 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v2_ASNs = "/api/1.3/asns"
+)
+
+// Create a ASN
+func (to *Session) CreateASN(entity tc.ASN) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(entity)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v2_ASNs, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a ASN by ID
+func (to *Session) UpdateASNByID(id int, entity tc.ASN) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(entity)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v2_ASNs, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of ASNs
+func (to *Session) GetASNs() ([]tc.ASN, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v2_ASNs, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ASNsResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a ASN by the id
+func (to *Session) GetASNByID(id int) ([]tc.ASN, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v2_ASNs, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ASNsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET an ASN by the asn number
+func (to *Session) GetASNByASN(asn int) ([]tc.ASN, ReqInf, error) {
+	url := fmt.Sprintf("%s?asn=%d", API_v2_ASNs, asn)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ASNsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE an ASN by asn number
+func (to *Session) DeleteASNByASN(asn int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/asn/%d", API_v2_ASNs, asn)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alerts, ReqInf, error) {
+	route := apiBase + `/deliveryservice_server/` + strconv.Itoa(dsID) + "/" + strconv.Itoa(serverID)
+	reqResp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
+	}
+	defer reqResp.Body.Close()
+	resp := tc.Alerts{}
+	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
+		return tc.Alerts{}, reqInf, errors.New("decoding response: " + err.Error())
+	}
+	return resp, reqInf, nil
+}
+
+func (to *Session) GetDeliveryServiceServers() (tc.DeliveryServiceServerResponse, ReqInf, error) {
+	route := apiBase + `/deliveryserviceserver`
+	reqResp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
+	}
+	defer reqResp.Body.Close()
+	resp := tc.DeliveryServiceServerResponse{}
+	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
+		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("decoding response: " + err.Error())
+	}
+	return resp, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/cachegroup.go
+++ b/traffic_ops/v1-3-client/cachegroup.go
@@ -1,0 +1,242 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_CacheGroups = "/api/1.3/cachegroups"
+)
+
+// Create a CacheGroup
+func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cachegroup)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_CacheGroups, reqBody)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+	var cachegroupResp tc.CacheGroupDetailResponse
+	if err = json.NewDecoder(resp.Body).Decode(&cachegroupResp); err != nil {
+		return nil, reqInf, err
+	}
+	return &cachegroupResp, reqInf, nil
+}
+
+// Create a CacheGroup
+// Deprecated: Use CreateCacheGroupNullable
+func (to *Session) CreateCacheGroup(cachegroup tc.CacheGroup) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cachegroup)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_CacheGroups, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a CacheGroup by ID
+func (to *Session) UpdateCacheGroupNullableByID(id int, cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cachegroup)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_CacheGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+	var cachegroupResp tc.CacheGroupDetailResponse
+	if err = json.NewDecoder(resp.Body).Decode(&cachegroupResp); err != nil {
+		return nil, reqInf, err
+	}
+	return &cachegroupResp, reqInf, nil
+}
+
+// Update a CacheGroup by ID
+// Deprecated: use UpdateCachegroupNullableByID
+func (to *Session) UpdateCacheGroupByID(id int, cachegroup tc.CacheGroup) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cachegroup)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_CacheGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of CacheGroups
+func (to *Session) GetCacheGroupsNullable() ([]tc.CacheGroupNullable, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_CacheGroups, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheGroupsNullableResponse
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+	return data.Response, reqInf, nil
+}
+
+// Returns a list of CacheGroups
+// Deprecated: use GetCacheGroupsNullable
+func (to *Session) GetCacheGroups() ([]tc.CacheGroup, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_CacheGroups, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheGroupsResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// CacheGroups gets the CacheGroups in an array of CacheGroup structs
+// (note CacheGroup used to be called location)
+// Deprecated: use GetCacheGroups.
+func (to *Session) CacheGroups() ([]tc.CacheGroup, error) {
+	cgs, _, err := to.GetCacheGroups()
+	return cgs, err
+}
+
+// GET a CacheGroup by the CacheGroup id
+func (to *Session) GetCacheGroupNullableByID(id int) ([]tc.CacheGroupNullable, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_CacheGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheGroupsNullableResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a CacheGroup by the CacheGroup id
+// Deprecated: use GetCacheGroupNullableByID
+func (to *Session) GetCacheGroupByID(id int) ([]tc.CacheGroup, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_CacheGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheGroupsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a CacheGroup by the CacheGroup name
+func (to *Session) GetCacheGroupNullableByName(name string) ([]tc.CacheGroupNullable, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_CacheGroups, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheGroupsNullableResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a CacheGroup by the CacheGroup name
+// Deprecated: use GetCachegroupNullableByName
+func (to *Session) GetCacheGroupByName(name string) ([]tc.CacheGroup, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_CacheGroups, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CacheGroupsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a CacheGroup by ID
+func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_CacheGroups, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/cdn.go
+++ b/traffic_ops/v1-3-client/cdn.go
@@ -1,0 +1,175 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_CDNs = "/api/1.3/cdns"
+)
+
+// Create a CDN
+func (to *Session) CreateCDN(cdn tc.CDN) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cdn)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_CDNs, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a CDN by ID
+func (to *Session) UpdateCDNByID(id int, cdn tc.CDN) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cdn)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_CDNs, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of CDNs
+func (to *Session) GetCDNs() ([]tc.CDN, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_CDNs, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CDNsResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a CDN by the CDN ID
+func (to *Session) GetCDNByID(id int) ([]tc.CDN, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_CDNs, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CDNsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a CDN by the CDN name
+func (to *Session) GetCDNByName(name string) ([]tc.CDN, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_CDNs, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CDNsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a CDN by ID
+func (to *Session) DeleteCDNByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_CDNs, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+func (to *Session) GetCDNSSLKeys(name string) ([]tc.CDNSSLKeys, ReqInf, error) {
+	url := fmt.Sprintf("%s/name/%s/sslkeys", API_v13_CDNs, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CDNSSLKeysResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// Deprecated: use GetCDNs.
+func (to *Session) CDNs() ([]tc.CDN, error) {
+	cdns, _, err := to.GetCDNs()
+	return cdns, err
+}
+
+// CDNName gets an array of CDNs
+// Deprecated: use GetCDNByName
+func (to *Session) CDNName(name string) ([]tc.CDN, error) {
+	n, _, err := to.GetCDNByName(name)
+	return n, err
+}
+
+// CDNName gets an array of CDNs
+// Deprecated: use GetCDNByName
+func (to *Session) GetCDNName(name string) ([]tc.CDN, error) {
+	n, _, err := to.GetCDNByName(name)
+	return n, err
+}
+
+// Deprecated: use GetCDNSSLKeys
+func (to *Session) CDNSSLKeys(name string) ([]tc.CDNSSLKeys, error) {
+	ks, _, err := to.GetCDNSSLKeys(name)
+	return ks, err
+}

--- a/traffic_ops/v1-3-client/cdn_domains.go
+++ b/traffic_ops/v1-3-client/cdn_domains.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+func (to *Session) GetDomains() ([]tc.Domain, ReqInf, error) {
+	var data tc.DomainsResponse
+	inf, err := get(to, apiBase+"/cdns/domains", &data)
+	if err != nil {
+		return nil, inf, err
+	}
+	return data.Response, inf, nil
+}

--- a/traffic_ops/v1-3-client/cdnfederations.go
+++ b/traffic_ops/v1-3-client/cdnfederations.go
@@ -1,0 +1,73 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+/* Internally, the CDNName is only used in the GET method. The CDNName
+ * seems to primarily be used to differentiate between `/federations` and
+ * `/cdns/:name/federations`. Although the behavior is odd, it is kept to
+ * keep the same behavior from perl. */
+
+func (to *Session) CreateCDNFederationByName(f tc.CDNFederation, CDNName string) (*tc.CreateCDNFederationResponse, ReqInf, error) {
+	jsonReq, err := json.Marshal(f)
+	if err != nil { //There is no remoteAddr for ReqInf at this point
+		return nil, ReqInf{CacheHitStatus: CacheHitStatusMiss}, err
+	}
+
+	data := tc.CreateCDNFederationResponse{}
+	url := fmt.Sprintf("%s/cdns/%s/federations", apiBase, CDNName)
+	inf, err := makeReq(to, "POST", url, jsonReq, &data)
+	return &data, inf, err
+}
+
+func (to *Session) GetCDNFederationsByName(CDNName string) (*tc.CDNFederationResponse, ReqInf, error) {
+	data := tc.CDNFederationResponse{}
+	url := fmt.Sprintf("%s/cdns/%s/federations", apiBase, CDNName)
+	inf, err := get(to, url, &data)
+	return &data, inf, err
+}
+
+func (to *Session) GetCDNFederationsByID(CDNName string, ID int) (*tc.CDNFederationResponse, ReqInf, error) {
+	data := tc.CDNFederationResponse{}
+	url := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, CDNName, ID)
+	inf, err := get(to, url, &data)
+	return &data, inf, err
+}
+
+func (to *Session) UpdateCDNFederationsByID(f tc.CDNFederation, CDNName string, ID int) (*tc.UpdateCDNFederationResponse, ReqInf, error) {
+	jsonReq, err := json.Marshal(f)
+	if err != nil { //There is no remoteAddr for ReqInf at this point
+		return nil, ReqInf{CacheHitStatus: CacheHitStatusMiss}, err
+	}
+
+	data := tc.UpdateCDNFederationResponse{}
+	url := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, CDNName, ID)
+	inf, err := makeReq(to, "PUT", url, jsonReq, &data)
+	return &data, inf, err
+}
+
+func (to *Session) DeleteCDNFederationByID(CDNName string, ID int) (*tc.DeleteCDNFederationResponse, ReqInf, error) {
+	data := tc.DeleteCDNFederationResponse{}
+	url := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, CDNName, ID)
+	inf, err := makeReq(to, "DELETE", url, nil, &data)
+	return &data, inf, err
+}

--- a/traffic_ops/v1-3-client/coordinate.go
+++ b/traffic_ops/v1-3-client/coordinate.go
@@ -1,0 +1,155 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_V13_Coordinates = "/api/1.3/coordinates"
+)
+
+// Create a Coordinate
+func (to *Session) CreateCoordinate(coordinate tc.Coordinate) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(coordinate)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_V13_Coordinates, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a Coordinate by ID
+func (to *Session) UpdateCoordinateByID(id int, coordinate tc.Coordinate) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(coordinate)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s?id=%d", API_V13_Coordinates, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of Coordinates
+func (to *Session) GetCoordinates() ([]tc.Coordinate, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_V13_Coordinates, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CoordinatesResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a Coordinate by the Coordinate id
+func (to *Session) GetCoordinateByID(id int) ([]tc.Coordinate, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_V13_Coordinates, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CoordinatesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Coordinate by the Coordinate name
+func (to *Session) GetCoordinateByName(name string) ([]tc.Coordinate, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_V13_Coordinates, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.CoordinatesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Coordinate by ID
+func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_V13_Coordinates, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int64) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
+	uri := apiBase + `/cachegroups/` + strconv.Itoa(cgID) + `/deliveryservices`
+	req := tc.CachegroupPostDSReq{DeliveryServices: dsIDs}
+	reqBody, err := json.Marshal(req)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+	if err != nil {
+		return tc.CacheGroupPostDSRespResponse{}, reqInf, err
+	}
+	reqResp, _, err := to.request(http.MethodPost, uri, reqBody)
+	if err != nil {
+		return tc.CacheGroupPostDSRespResponse{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
+	}
+	defer reqResp.Body.Close()
+
+	resp := tc.CacheGroupPostDSRespResponse{}
+	if err := json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
+		return tc.CacheGroupPostDSRespResponse{}, reqInf, errors.New("decoding response: " + err.Error())
+	}
+	return resp, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/crconfig.go
+++ b/traffic_ops/v1-3-client/crconfig.go
@@ -1,0 +1,30 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import "fmt"
+
+// CRConfigRaw Deprecated: use GetCRConfig instead
+func (to *Session) CRConfigRaw(cdn string) ([]byte, error) {
+	bytes, _, err := to.GetCRConfig(cdn)
+	return bytes, err
+}
+
+// GetCRConfig returns the raw JSON bytes of the CRConfig from Traffic Ops, and whether the bytes were from the client's internal cache.
+func (to *Session) GetCRConfig(cdn string) ([]byte, ReqInf, error) {
+	url := fmt.Sprintf("/CRConfig-Snapshots/%s/CRConfig.json", cdn)
+	return to.getBytesWithTTL(url, tmPollingInterval)
+}

--- a/traffic_ops/v1-3-client/deliveryservice.go
+++ b/traffic_ops/v1-3-client/deliveryservice.go
@@ -1,0 +1,285 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+// DeliveryServices gets an array of DeliveryServices
+// Deprecated: use GetDeliveryServices
+func (to *Session) DeliveryServices() ([]tc.DeliveryService, error) {
+	dses, _, err := to.GetDeliveryServices()
+	return dses, err
+}
+
+func (to *Session) GetDeliveryServices() ([]tc.DeliveryService, ReqInf, error) {
+	var data tc.DeliveryServicesResponse
+	reqInf, err := get(to, deliveryServicesEp(), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DeliveryServicesByServer gets an array of all DeliveryServices with the given server ID assigend.
+// Deprecated: use GetDeliveryServicesByServer
+func (to *Session) DeliveryServicesByServer(id int) ([]tc.DeliveryService, error) {
+	dses, _, err := to.GetDeliveryServicesByServer(id)
+	return dses, err
+}
+
+func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryService, ReqInf, error) {
+	var data tc.DeliveryServicesResponse
+	reqInf, err := get(to, deliveryServicesByServerEp(strconv.Itoa(id)), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+func (to *Session) GetDeliveryServiceByXMLID(XMLID string) ([]tc.DeliveryService, ReqInf, error) {
+	var data tc.GetDeliveryServiceResponse
+	reqInf, err := get(to, deliveryServicesByXMLID(XMLID), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DeliveryService gets the DeliveryService for the ID it's passed
+// Deprecated: use GetDeliveryService
+func (to *Session) DeliveryService(id string) (*tc.DeliveryService, error) {
+	ds, _, err := to.GetDeliveryService(id)
+	return ds, err
+}
+
+func (to *Session) GetDeliveryService(id string) (*tc.DeliveryService, ReqInf, error) {
+	var data tc.DeliveryServicesResponse
+	reqInf, err := get(to, deliveryServiceEp(id), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	if len(data.Response) == 0 {
+		return nil, reqInf, nil
+	}
+	return &data.Response[0], reqInf, nil
+}
+
+// CreateDeliveryService creates the DeliveryService it's passed
+func (to *Session) CreateDeliveryService(ds *tc.DeliveryService) (*tc.CreateDeliveryServiceResponse, error) {
+	var data tc.CreateDeliveryServiceResponse
+	jsonReq, err := json.Marshal(ds)
+	if err != nil {
+		return nil, err
+	}
+	err = post(to, deliveryServicesEp(), jsonReq, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// UpdateDeliveryService updates the DeliveryService matching the ID it's passed with
+// the DeliveryService it is passed
+func (to *Session) UpdateDeliveryService(id string, ds *tc.DeliveryService) (*tc.UpdateDeliveryServiceResponse, error) {
+	var data tc.UpdateDeliveryServiceResponse
+	jsonReq, err := json.Marshal(ds)
+	if err != nil {
+		return nil, err
+	}
+	err = put(to, deliveryServiceEp(id), jsonReq, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// DeleteDeliveryService deletes the DeliveryService matching the ID it's passed
+func (to *Session) DeleteDeliveryService(id string) (*tc.DeleteDeliveryServiceResponse, error) {
+	var data tc.DeleteDeliveryServiceResponse
+	err := del(to, deliveryServiceEp(id), &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// DeliveryServiceState gets the DeliveryServiceState for the ID it's passed
+// Deprecated: use GetDeliveryServiceState
+func (to *Session) DeliveryServiceState(id string) (*tc.DeliveryServiceState, error) {
+	dss, _, err := to.GetDeliveryServiceState(id)
+	return dss, err
+}
+
+func (to *Session) GetDeliveryServiceState(id string) (*tc.DeliveryServiceState, ReqInf, error) {
+	var data tc.DeliveryServiceStateResponse
+	reqInf, err := get(to, deliveryServiceStateEp(id), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response, reqInf, nil
+}
+
+// DeliveryServiceHealth gets the DeliveryServiceHealth for the ID it's passed
+// Deprecated: use GetDeliveryServiceHealth
+func (to *Session) DeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, error) {
+	dsh, _, err := to.GetDeliveryServiceHealth(id)
+	return dsh, err
+}
+
+func (to *Session) GetDeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, ReqInf, error) {
+	var data tc.DeliveryServiceHealthResponse
+	reqInf, err := get(to, deliveryServiceHealthEp(id), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response, reqInf, nil
+}
+
+// DeliveryServiceCapacity gets the DeliveryServiceCapacity for the ID it's passed
+// Deprecated: use GetDeliveryServiceCapacity
+func (to *Session) DeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, error) {
+	dsc, _, err := to.GetDeliveryServiceCapacity(id)
+	return dsc, err
+}
+
+func (to *Session) GetDeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, ReqInf, error) {
+	var data tc.DeliveryServiceCapacityResponse
+	reqInf, err := get(to, deliveryServiceCapacityEp(id), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response, reqInf, nil
+}
+
+// DeliveryServiceRouting gets the DeliveryServiceRouting for the ID it's passed
+// Deprecated: use GetDeliveryServiceRouting
+func (to *Session) DeliveryServiceRouting(id string) (*tc.DeliveryServiceRouting, error) {
+	dsr, _, err := to.GetDeliveryServiceRouting(id)
+	return dsr, err
+}
+
+func (to *Session) GetDeliveryServiceRouting(id string) (*tc.DeliveryServiceRouting, ReqInf, error) {
+	var data tc.DeliveryServiceRoutingResponse
+	reqInf, err := get(to, deliveryServiceRoutingEp(id), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response, reqInf, nil
+}
+
+// DeliveryServiceServer gets the DeliveryServiceServer
+// Deprecated: use GetDeliveryServiceServer
+func (to *Session) DeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, error) {
+	dss, _, err := to.GetDeliveryServiceServer(page, limit)
+	return dss, err
+}
+
+func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, ReqInf, error) {
+	var data tc.DeliveryServiceServerResponse
+	reqInf, err := get(to, deliveryServiceServerEp(page, limit), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DeliveryServiceRegexes gets the DeliveryService regexes
+// Deprecated: use GetDeliveryServiceRegexes
+func (to *Session) DeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, error) {
+	dsrs, _, err := to.GetDeliveryServiceRegexes()
+	return dsrs, err
+}
+func (to *Session) GetDeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, ReqInf, error) {
+	var data tc.DeliveryServiceRegexResponse
+	reqInf, err := get(to, deliveryServiceRegexesEp(), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DeliveryServiceSSLKeysByID gets the DeliveryServiceSSLKeys by ID
+// Deprecated: use GetDeliveryServiceSSLKeysByID
+func (to *Session) DeliveryServiceSSLKeysByID(id string) (*tc.DeliveryServiceSSLKeys, error) {
+	dsks, _, err := to.GetDeliveryServiceSSLKeysByID(id)
+	return dsks, err
+}
+
+func (to *Session) GetDeliveryServiceSSLKeysByID(id string) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
+	var data tc.DeliveryServiceSSLKeysResponse
+	reqInf, err := get(to, deliveryServiceSSLKeysByIDEp(id), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response, reqInf, nil
+}
+
+// DeliveryServiceSSLKeysByHostname gets the DeliveryServiceSSLKeys by Hostname
+// Deprecated: use GetDeliveryServiceSSLKeysByHostname
+func (to *Session) DeliveryServiceSSLKeysByHostname(hostname string) (*tc.DeliveryServiceSSLKeys, error) {
+	dsks, _, err := to.GetDeliveryServiceSSLKeysByHostname(hostname)
+	return dsks, err
+}
+
+func (to *Session) GetDeliveryServiceSSLKeysByHostname(hostname string) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
+	var data tc.DeliveryServiceSSLKeysResponse
+	reqInf, err := get(to, deliveryServiceSSLKeysByHostnameEp(hostname), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response, reqInf, nil
+}
+
+func (to *Session) GetDeliveryServiceMatches() ([]tc.DeliveryServicePatterns, ReqInf, error) {
+	uri := apiBase + `/deliveryservice_matches`
+	resp := tc.DeliveryServiceMatchesResponse{}
+	reqInf, err := get(to, uri, &resp)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	return resp.Response, reqInf, nil
+}
+
+func (to *Session) GetDeliveryServicesEligible(dsID int) ([]tc.DSServer, ReqInf, error) {
+	resp := struct {
+		Response []tc.DSServer `json:"response"`
+	}{Response: []tc.DSServer{}}
+	uri := apiBase + `/deliveryservices/` + strconv.Itoa(dsID) + `/servers/eligible`
+	reqInf, err := get(to, uri, &resp)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	return resp.Response, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/deliveryservice_endpoints.go
+++ b/traffic_ops/v1-3-client/deliveryservice_endpoints.go
@@ -1,0 +1,70 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+const dsPath = "/deliveryservices"
+
+func deliveryServicesEp() string {
+	return apiBase + dsPath + ".json"
+}
+
+func deliveryServicesByServerEp(id string) string {
+	return apiBase + "/servers/" + id + dsPath + ".json"
+}
+
+func deliveryServiceBaseEp(id string) string {
+	return apiBase + dsPath + "/" + id
+}
+
+func deliveryServiceEp(id string) string {
+	return deliveryServiceBaseEp(id) + ".json"
+}
+
+func deliveryServiceStateEp(id string) string {
+	return deliveryServiceBaseEp(id) + "/state.json"
+}
+
+func deliveryServiceHealthEp(id string) string {
+	return deliveryServiceBaseEp(id) + "/health.json"
+}
+
+func deliveryServiceCapacityEp(id string) string {
+	return deliveryServiceBaseEp(id) + "/capacity.json"
+}
+
+func deliveryServiceRoutingEp(id string) string {
+	return deliveryServiceBaseEp(id) + "/routing.json"
+}
+
+func deliveryServiceServerEp(page, limit string) string {
+	return apiBase + "/deliveryserviceserver.json?page=" + page + "&limit=" + limit
+}
+
+func deliveryServiceRegexesEp() string {
+	return apiBase + "/deliveryservices_regexes.json"
+}
+
+func deliveryServiceSSLKeysByIDEp(id string) string {
+	return apiBase + dsPath + "/xmlId/" + id + "/sslkeys.json"
+}
+
+func deliveryServiceSSLKeysByHostnameEp(hostname string) string {
+	return apiBase + dsPath + "/hostname/" + hostname + "/sslkeys.json"
+}
+
+func deliveryServicesByXMLID(XMLID string) string {
+	return apiBase + dsPath + "?xmlId=" + XMLID
+}

--- a/traffic_ops/v1-3-client/deliveryservice_request_comments.go
+++ b/traffic_ops/v1-3-client/deliveryservice_request_comments.go
@@ -1,0 +1,115 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+
+	"fmt"
+)
+
+const (
+	API_v13_DeliveryServiceRequestComments = "/api/1.3/deliveryservice_request_comments"
+)
+
+// Create a delivery service request comment
+func (to *Session) CreateDeliveryServiceRequestComment(comment tc.DeliveryServiceRequestComment) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(comment)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_DeliveryServiceRequestComments, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a delivery service request by ID
+func (to *Session) UpdateDeliveryServiceRequestCommentByID(id int, comment tc.DeliveryServiceRequestComment) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(comment)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s?id=%d", API_v13_DeliveryServiceRequestComments, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of delivery service request comments
+func (to *Session) GetDeliveryServiceRequestComments() ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_DeliveryServiceRequestComments, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.DeliveryServiceRequestCommentsResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a delivery service request comment by ID
+func (to *Session) GetDeliveryServiceRequestCommentByID(id int) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_v13_DeliveryServiceRequestComments, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.DeliveryServiceRequestCommentsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a delivery service request comment by ID
+func (to *Session) DeleteDeliveryServiceRequestCommentByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_v13_DeliveryServiceRequestComments, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/deliveryservice_requests.go
+++ b/traffic_ops/v1-3-client/deliveryservice_requests.go
@@ -1,0 +1,188 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_DS_REQUESTS = "/api/1.3/deliveryservice_requests"
+)
+
+// Create a Delivery Service Request
+func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequest) (tc.Alerts, ReqInf, error) {
+
+	var alerts tc.Alerts
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(dsr)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return alerts, reqInf, err
+	}
+	resp, remoteAddr, err := to.rawRequest(http.MethodPost, API_DS_REQUESTS, reqBody)
+	defer resp.Body.Close()
+
+	if err == nil {
+		body, readErr := ioutil.ReadAll(resp.Body)
+		if readErr != nil {
+			return alerts, reqInf, readErr
+		}
+		if err = json.Unmarshal(body, &alerts); err != nil {
+			return alerts, reqInf, err
+		}
+	}
+
+	return alerts, reqInf, err
+}
+
+// GetDeliveryServiceRequests retrieves all deliveryservices available to session user.
+func (to *Session) GetDeliveryServiceRequests() ([]tc.DeliveryServiceRequest, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_DS_REQUESTS, nil)
+
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	data := struct {
+		Response []tc.DeliveryServiceRequest `json:"response"`
+	}{}
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a DeliveryServiceRequest by the DeliveryServiceRequest XMLID
+func (to *Session) GetDeliveryServiceRequestByXMLID(XMLID string) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+	route := fmt.Sprintf("%s?xmlId=%s", API_DS_REQUESTS, XMLID)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	data := struct {
+		Response []tc.DeliveryServiceRequest `json:"response"`
+	}{}
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a DeliveryServiceRequest by the DeliveryServiceRequest id
+func (to *Session) GetDeliveryServiceRequestByID(id int) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_DS_REQUESTS, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	data := struct {
+		Response []tc.DeliveryServiceRequest `json:"response"`
+	}{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// Update a DeliveryServiceRequest by ID
+func (to *Session) UpdateDeliveryServiceRequestByID(id int, dsr tc.DeliveryServiceRequest) (tc.Alerts, ReqInf, error) {
+
+	route := fmt.Sprintf("%s?id=%d", API_DS_REQUESTS, id)
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(dsr)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// DELETE a DeliveryServiceRequest by DeliveryServiceRequest assignee
+func (to *Session) DeleteDeliveryServiceRequestByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_DS_REQUESTS, id)
+	resp, remoteAddr, err := to.rawRequest(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+/*
+
+// Returns a list of DeliveryServiceRequests
+func (to *Session) GetDeliveryServiceRequests() ([]tc.DeliveryServiceRequest, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_DS_REQUESTS, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.DeliveryServiceRequestsResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a DeliveryServiceRequest by the DeliveryServiceRequest assignee
+func (to *Session) GetDeliveryServiceRequestByAssignee(assignee string) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+	url := fmt.Sprintf("%s/assignee/%s", API_DS_REQUESTS, assignee)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.DeliveryServiceRequestsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+*/

--- a/traffic_ops/v1-3-client/deliveryserviceserver.go
+++ b/traffic_ops/v1-3-client/deliveryserviceserver.go
@@ -1,0 +1,44 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+// CreateDeliveryServiceServers associates the given servers with the given delivery services. If replace is true, it deletes any existing associations for the given delivery service.
+func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, replace bool) (*tc.DSServerIDs, error) {
+	path := apiBase + `/deliveryserviceserver`
+	req := tc.DSServerIDs{
+		DeliveryServiceID: util.IntPtr(dsID),
+		ServerIDs:         serverIDs,
+		Replace:           util.BoolPtr(replace),
+	}
+	jsonReq, err := json.Marshal(&req)
+	if err != nil {
+		return nil, err
+	}
+	resp := struct {
+		Response tc.DSServerIDs `json:"response"`
+	}{}
+	if err := post(to, path, jsonReq, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Response, nil
+}

--- a/traffic_ops/v1-3-client/division.go
+++ b/traffic_ops/v1-3-client/division.go
@@ -1,0 +1,146 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_Divisions = "/api/1.3/divisions"
+)
+
+// Create a Division
+func (to *Session) CreateDivision(division tc.Division) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(division)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_Divisions, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a Division by ID
+func (to *Session) UpdateDivisionByID(id int, division tc.Division) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(division)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_Divisions, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of Divisions
+func (to *Session) GetDivisions() ([]tc.Division, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_Divisions, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.DivisionsResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a Division by the Division id
+func (to *Session) GetDivisionByID(id int) ([]tc.Division, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_Divisions, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.DivisionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Division by the Division name
+func (to *Session) GetDivisionByName(name string) ([]tc.Division, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_Divisions, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.DivisionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Division by Division id
+func (to *Session) DeleteDivisionByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_Divisions, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// DELETE a Division by Division name
+func (to *Session) DeleteDivisionByName(name string) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/name/%s", API_v13_Divisions, name)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/dsuser.go
+++ b/traffic_ops/v1-3-client/dsuser.go
@@ -1,0 +1,60 @@
+package client
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"encoding/json"
+	"strconv"
+
+	tc "github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+// GetUserDeliveryServices gets the delivery services associated with the given user.
+func (to *Session) GetUserDeliveryServices(userID int) (*tc.UserDeliveryServicesNullableResponse, ReqInf, error) {
+	uri := apiBase + `/users/` + strconv.Itoa(userID) + `/deliveryservices`
+	resp := tc.UserDeliveryServicesNullableResponse{}
+	reqInf, err := get(to, uri, &resp)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	return &resp, reqInf, nil
+}
+
+// SetUserDeliveryService associates the given delivery services with the given user.
+func (to *Session) SetDeliveryServiceUser(userID int, dses []int, replace bool) (*tc.UserDeliveryServicePostResponse, error) {
+	uri := apiBase + `/deliveryservice_user`
+	ds := tc.DeliveryServiceUserPost{UserID: &userID, DeliveryServices: &dses, Replace: &replace}
+	jsonReq, err := json.Marshal(ds)
+	if err != nil {
+		return nil, err
+	}
+	resp := tc.UserDeliveryServicePostResponse{}
+	err = post(to, uri, jsonReq, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeleteDeliveryServiceUser deletes the association between the given delivery service and user
+func (to *Session) DeleteDeliveryServiceUser(userID int, dsID int) (*tc.UserDeliveryServiceDeleteResponse, error) {
+	uri := apiBase + `/deliveryservice_user/` + strconv.Itoa(dsID) + `/` + strconv.Itoa(userID)
+	resp := tc.UserDeliveryServiceDeleteResponse{}
+	if err := del(to, uri, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/traffic_ops/v1-3-client/endpoints.go
+++ b/traffic_ops/v1-3-client/endpoints.go
@@ -1,0 +1,18 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+const apiBase = "/api/1.3"

--- a/traffic_ops/v1-3-client/hardware.go
+++ b/traffic_ops/v1-3-client/hardware.go
@@ -1,0 +1,50 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	tc "github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+// Hardware gets an array of Hardware
+// Deprecated: use GetHardware
+func (to *Session) Hardware(limit int) ([]tc.Hardware, error) {
+	h, _, err := to.GetHardware(limit)
+	return h, err
+}
+
+func (to *Session) GetHardware(limit int) ([]tc.Hardware, ReqInf, error) {
+	url := "/api/1.2/hwinfo.json"
+	if limit > 0 {
+		url += fmt.Sprintf("?limit=%v", limit)
+	}
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.HardwareResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/origin.go
+++ b/traffic_ops/v1-3-client/origin.go
@@ -1,0 +1,126 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_Origins = "/api/1.3/origins"
+)
+
+// Create an Origin
+func (to *Session) CreateOrigin(origin tc.Origin) (*tc.OriginDetailResponse, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(origin)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_Origins, reqBody)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+	var originResp tc.OriginDetailResponse
+	if err = json.NewDecoder(resp.Body).Decode(&originResp); err != nil {
+		return nil, reqInf, err
+	}
+	return &originResp, reqInf, nil
+}
+
+// Update an Origin by ID
+func (to *Session) UpdateOriginByID(id int, origin tc.Origin) (*tc.OriginDetailResponse, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(origin)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	route := fmt.Sprintf("%s?id=%d", API_v13_Origins, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+	var originResp tc.OriginDetailResponse
+	if err = json.NewDecoder(resp.Body).Decode(&originResp); err != nil {
+		return nil, reqInf, err
+	}
+	return &originResp, reqInf, nil
+}
+
+// GET a list of Origins by a query parameter string
+func (to *Session) GetOriginsByQueryParams(queryParams string) ([]tc.Origin, ReqInf, error) {
+	URI := API_v13_Origins + queryParams
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.OriginsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// Returns a list of Origins
+func (to *Session) GetOrigins() ([]tc.Origin, ReqInf, error) {
+	return to.GetOriginsByQueryParams("")
+}
+
+// GET an Origin by the Origin ID
+func (to *Session) GetOriginByID(id int) ([]tc.Origin, ReqInf, error) {
+	return to.GetOriginsByQueryParams(fmt.Sprintf("?id=%d", id))
+}
+
+// GET an Origin by the Origin name
+func (to *Session) GetOriginByName(name string) ([]tc.Origin, ReqInf, error) {
+	return to.GetOriginsByQueryParams(fmt.Sprintf("?name=%s", name))
+}
+
+// GET a list of Origins by Delivery Service ID
+func (to *Session) GetOriginsByDeliveryServiceID(id int) ([]tc.Origin, ReqInf, error) {
+	return to.GetOriginsByQueryParams(fmt.Sprintf("?deliveryservice=%d", id))
+}
+
+// DELETE an Origin by ID
+func (to *Session) DeleteOriginByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_v13_Origins, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/parameter.go
+++ b/traffic_ops/v1-3-client/parameter.go
@@ -1,0 +1,193 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_Parameters = "/api/1.3/parameters"
+)
+
+// Create a Parameter
+func (to *Session) CreateParameter(pl tc.Parameter) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(pl)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_Parameters, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a Parameter by ID
+func (to *Session) UpdateParameterByID(id int, pl tc.Parameter) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(pl)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_Parameters, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of Parameters
+func (to *Session) GetParameters() ([]tc.Parameter, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_Parameters, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ParametersResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// Parameters gets an array of parameter structs for the profile given
+// Deprecated: use GetParameters
+func (to *Session) Parameters(profileName string) ([]tc.Parameter, error) {
+	ps, _, err := to.GetParametersByProfileName(profileName)
+	return ps, err
+}
+
+func (to *Session) GetParametersByProfileName(profileName string) ([]tc.Parameter, ReqInf, error) {
+	url := fmt.Sprintf(API_v13_Parameters+"/profile/%s.json", profileName)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ParametersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Parameter by the Parameter ID
+func (to *Session) GetParameterByID(id int) ([]tc.Parameter, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_Parameters, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ParametersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Parameter by the Parameter name
+func (to *Session) GetParameterByName(name string) ([]tc.Parameter, ReqInf, error) {
+	URI := API_v13_Parameters + "?name=" + url.QueryEscape(name)
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ParametersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Parameter by the Parameter ConfigFile
+func (to *Session) GetParameterByConfigFile(configFile string) ([]tc.Parameter, ReqInf, error) {
+	URI := API_v13_Parameters + "?configFile=" + url.QueryEscape(configFile)
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ParametersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Parameter by the Parameter Name and ConfigFile
+func (to *Session) GetParameterByNameAndConfigFile(name string, configFile string) ([]tc.Parameter, ReqInf, error) {
+	URI := fmt.Sprintf("%s?name=%s&configFile=%s", API_v13_Parameters, url.QueryEscape(name), url.QueryEscape(configFile))
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ParametersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Parameter by ID
+func (to *Session) DeleteParameterByID(id int) (tc.Alerts, ReqInf, error) {
+	URI := fmt.Sprintf("%s/%d", API_v13_Parameters, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/phys_location.go
+++ b/traffic_ops/v1-3-client/phys_location.go
@@ -1,0 +1,132 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_PhysLocations = "/api/1.3/phys_locations"
+)
+
+// Create a PhysLocation
+func (to *Session) CreatePhysLocation(pl tc.PhysLocation) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(pl)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_PhysLocations, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a PhysLocation by ID
+func (to *Session) UpdatePhysLocationByID(id int, pl tc.PhysLocation) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(pl)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_PhysLocations, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of PhysLocations
+func (to *Session) GetPhysLocations() ([]tc.PhysLocation, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_PhysLocations, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.PhysLocationsResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a PhysLocation by the PhysLocation ID
+func (to *Session) GetPhysLocationByID(id int) ([]tc.PhysLocation, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_PhysLocations, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.PhysLocationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a PhysLocation by the PhysLocation name
+func (to *Session) GetPhysLocationByName(name string) ([]tc.PhysLocation, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_PhysLocations, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.PhysLocationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a PhysLocation by ID
+func (to *Session) DeletePhysLocationByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_PhysLocations, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/ping.go
+++ b/traffic_ops/v1-3-client/ping.go
@@ -1,0 +1,39 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const (
+	API_v13_PING = "/api/1.3/ping"
+)
+
+// Ping returns a static json object to show that traffic_ops is responsive
+func (to *Session) Ping() (map[string]string, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_PING, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data map[string]string
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/profile.go
+++ b/traffic_ops/v1-3-client/profile.go
@@ -1,0 +1,177 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_Profiles = "/api/1.3/profiles"
+)
+
+// Create a Profile
+func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(pl)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_Profiles, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a Profile by ID
+func (to *Session) UpdateProfileByID(id int, pl tc.Profile) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(pl)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_Profiles, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Profiles gets an array of Profiles
+// Deprecated: use GetProfiles
+func (to *Session) Profiles() ([]tc.Profile, error) {
+	ps, _, err := to.GetProfiles()
+	return ps, err
+}
+
+// Returns a list of Profiles
+func (to *Session) GetProfiles() ([]tc.Profile, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_Profiles, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ProfilesResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a Profile by the Profile ID
+func (to *Session) GetProfileByID(id int) ([]tc.Profile, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_Profiles, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ProfilesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Profile by the Profile name
+func (to *Session) GetProfileByName(name string) ([]tc.Profile, ReqInf, error) {
+	URI := API_v13_Profiles + "?name=" + url.QueryEscape(name)
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ProfilesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Profile by the Profile "param"
+func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, ReqInf, error) {
+	URI := API_v13_Profiles + "?param=" + url.QueryEscape(param)
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ProfilesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Profile by the Profile cdn id
+func (to *Session) GetProfileByCDNID(cdnID int) ([]tc.Profile, ReqInf, error) {
+	URI := API_v13_Profiles + "?cdn=" + strconv.Itoa(cdnID)
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ProfilesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Profile by ID
+func (to *Session) DeleteProfileByID(id int) (tc.Alerts, ReqInf, error) {
+	URI := fmt.Sprintf("%s/%d", API_v13_Profiles, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/profile_parameter.go
+++ b/traffic_ops/v1-3-client/profile_parameter.go
@@ -1,0 +1,96 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_Profile_Parameters = "/api/1.3/profileparameters"
+	ProfileIdQueryParam        = "profileId"
+	ParameterIdQueryParam      = "parameterId"
+)
+
+// Create a ProfileParameter
+func (to *Session) CreateProfileParameter(pp tc.ProfileParameter) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(pp)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_Profile_Parameters, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of Profile Parameters
+func (to *Session) GetProfileParameters() ([]tc.ProfileParameter, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_Profile_Parameters, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ProfileParametersResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a Profile Parameter by the Parameter
+func (to *Session) GetProfileParameterByQueryParams(queryParams string) ([]tc.ProfileParameter, ReqInf, error) {
+	URI := API_v13_Profile_Parameters + queryParams
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ProfileParametersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Parameter by Parameter
+func (to *Session) DeleteParameterByProfileParameter(profile int, parameter int) (tc.Alerts, ReqInf, error) {
+	URI := fmt.Sprintf("%s/profile/%d/parameter/%d", API_v13_Profile_Parameters, profile, parameter)
+	resp, remoteAddr, err := to.request(http.MethodDelete, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/region.go
+++ b/traffic_ops/v1-3-client/region.go
@@ -1,0 +1,149 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_REGIONS = "/api/1.3/regions"
+)
+
+// Create a Region
+func (to *Session) CreateRegion(region tc.Region) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(region)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_REGIONS, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a Region by ID
+func (to *Session) UpdateRegionByID(id int, region tc.Region) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(region)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_REGIONS, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of regions
+func (to *Session) GetRegions() ([]tc.Region, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_REGIONS, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.RegionsResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a Region by the Region id
+func (to *Session) GetRegionByID(id int) ([]tc.Region, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_REGIONS, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.RegionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Region by the Region name
+func (to *Session) GetRegionByName(name string) ([]tc.Region, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_REGIONS, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.RegionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Region by ID
+func (to *Session) DeleteRegionByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_REGIONS, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// GetRegionByNamePath gets a region by name, using the /api/version/region/name path. This gets the same data as GetRegionByName, but uses a different API path to get the same data, and returns a slightly different format.
+func (to *Session) GetRegionByNamePath(name string) ([]tc.RegionName, ReqInf, error) {
+	url := apiBase + `/regions/name/` + name
+	reqResp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer reqResp.Body.Close()
+
+	resp := tc.RegionNameResponse{}
+	if err := json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
+		return nil, reqInf, err
+	}
+	return resp.Response, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/role.go
+++ b/traffic_ops/v1-3-client/role.go
@@ -1,0 +1,139 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_ROLES = "/api/1.3/roles"
+)
+
+// Create a Role
+func (to *Session) CreateRole(region tc.Role) (tc.Alerts, ReqInf, int, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(region)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, 0, err
+	}
+	resp, remoteAddr, errClient := to.rawRequest(http.MethodPost, API_v13_ROLES, reqBody)
+	if resp != nil {
+		defer resp.Body.Close()
+		var alerts tc.Alerts
+		if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+			return alerts, reqInf, resp.StatusCode, err
+		}
+		return alerts, reqInf, resp.StatusCode, errClient
+	}
+	return tc.Alerts{}, reqInf, 0, errClient
+}
+
+// Update a Role by ID
+func (to *Session) UpdateRoleByID(id int, region tc.Role) (tc.Alerts, ReqInf, int, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(region)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, 0, err
+	}
+	route := fmt.Sprintf("%s/?id=%d", API_v13_ROLES, id)
+	resp, remoteAddr, errClient := to.rawRequest(http.MethodPut, route, reqBody)
+	if resp != nil {
+		defer resp.Body.Close()
+		var alerts tc.Alerts
+		if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+			return alerts, reqInf, resp.StatusCode, err
+		}
+		return alerts, reqInf, resp.StatusCode, errClient
+	}
+	return tc.Alerts{}, reqInf, 0, errClient
+}
+
+// Returns a list of roles
+func (to *Session) GetRoles() ([]tc.Role, ReqInf, int, error) {
+	resp, remoteAddr, errClient := to.rawRequest(http.MethodGet, API_v13_ROLES, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		defer resp.Body.Close()
+
+		var data tc.RolesResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return data.Response, reqInf, resp.StatusCode, err
+		}
+		return data.Response, reqInf, resp.StatusCode, errClient
+	}
+	return []tc.Role{}, reqInf, 0, errClient
+}
+
+// GET a Role by the Role id
+func (to *Session) GetRoleByID(id int) ([]tc.Role, ReqInf, int, error) {
+	route := fmt.Sprintf("%s/?id=%d", API_v13_ROLES, id)
+	resp, remoteAddr, errClient := to.rawRequest(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		defer resp.Body.Close()
+
+		var data tc.RolesResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return data.Response, reqInf, resp.StatusCode, err
+		}
+		return data.Response, reqInf, resp.StatusCode, errClient
+	}
+	return []tc.Role{}, reqInf, 0, errClient
+}
+
+// GET a Role by the Role name
+func (to *Session) GetRoleByName(name string) ([]tc.Role, ReqInf, int, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_ROLES, name)
+	resp, remoteAddr, errClient := to.rawRequest(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		defer resp.Body.Close()
+
+		var data tc.RolesResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return data.Response, reqInf, resp.StatusCode, err
+		}
+		return data.Response, reqInf, resp.StatusCode, errClient
+	}
+	return []tc.Role{}, reqInf, 0, errClient
+}
+
+// DELETE a Role by ID
+func (to *Session) DeleteRoleByID(id int) (tc.Alerts, ReqInf, int, error) {
+	route := fmt.Sprintf("%s/?id=%d", API_v13_ROLES, id)
+	resp, remoteAddr, errClient := to.rawRequest(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		defer resp.Body.Close()
+
+		var alerts tc.Alerts
+		if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+			return alerts, reqInf, resp.StatusCode, err
+		}
+		return alerts, reqInf, resp.StatusCode, errClient
+	}
+	return tc.Alerts{}, reqInf, 0, errClient
+}

--- a/traffic_ops/v1-3-client/server.go
+++ b/traffic_ops/v1-3-client/server.go
@@ -1,0 +1,228 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_Servers = "/api/1.3/servers"
+)
+
+// Create a Server
+func (to *Session) CreateServer(server tc.Server) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(server)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_Servers, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a Server by ID
+func (to *Session) UpdateServerByID(id int, server tc.Server) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(server)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_Servers, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Servers gets an array of servers
+// Deprecated: use GetServers
+func (to *Session) Servers() ([]tc.Server, error) {
+	s, _, err := to.GetServers()
+	return s, err
+}
+
+// Returns a list of Servers
+func (to *Session) GetServers() ([]tc.Server, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_Servers, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ServersResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// Server gets a server by hostname
+// Deprecated: use GetServer
+func (to *Session) Server(name string) (*tc.Server, error) {
+	s, _, err := to.GetServerByHostName(name)
+	if len(s) > 0 {
+		return &s[0], err
+	}
+	return nil, errors.New("not found")
+}
+
+// GET a Server by the Server ID
+func (to *Session) GetServerByID(id int) ([]tc.Server, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_Servers, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ServersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Server by the Server hostname
+func (to *Session) GetServerByHostName(hostName string) ([]tc.Server, ReqInf, error) {
+	url := fmt.Sprintf("%s?hostName=%s", API_v13_Servers, hostName)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ServersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Server by ID
+func (to *Session) DeleteServerByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_Servers, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// ServersByType gets an array of serves of a specified type.
+// Deprecated: use GetServersByType
+func (to *Session) ServersByType(qparams url.Values) ([]tc.Server, error) {
+	ss, _, err := to.GetServersByType(qparams)
+	return ss, err
+}
+
+func (to *Session) GetServersByType(qparams url.Values) ([]tc.Server, ReqInf, error) {
+	url := fmt.Sprintf("%s.json?%s", API_v13_Servers, qparams.Encode())
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.ServersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// ServersFqdn returns a the full domain name for the server short name passed in.
+// Deprecated: use GetServersFQDN
+func (to *Session) ServersFqdn(n string) (string, error) {
+	f, _, err := to.GetServerFQDN(n)
+	return f, err
+}
+
+func (to *Session) GetServerFQDN(n string) (string, ReqInf, error) {
+	// TODO fix to only request one server
+	fdn := ""
+	servers, reqInf, err := to.GetServers()
+	if err != nil {
+		return "Error", reqInf, err
+	}
+
+	for _, server := range servers {
+		if server.HostName == n {
+			fdn = fmt.Sprintf("%s.%s", server.HostName, server.DomainName)
+		}
+	}
+	if fdn == "" {
+		return "Error", reqInf, fmt.Errorf("No Server %s found", n)
+	}
+	return fdn, reqInf, nil
+}
+
+// ServersShortNameSearch returns a slice of short server names that match a greedy match.
+// Deprecated: use GetServersShortNameSearch
+func (to *Session) ServersShortNameSearch(shortname string) ([]string, error) {
+	ss, _, err := to.GetServersShortNameSearch(shortname)
+	return ss, err
+}
+
+func (to *Session) GetServersShortNameSearch(shortname string) ([]string, ReqInf, error) {
+	var serverlst []string
+	servers, reqInf, err := to.GetServers()
+	if err != nil {
+		serverlst = append(serverlst, "N/A")
+		return serverlst, reqInf, err
+	}
+	for _, server := range servers {
+		if strings.Contains(server.HostName, shortname) {
+			serverlst = append(serverlst, server.HostName)
+		}
+	}
+	if len(serverlst) == 0 {
+		serverlst = append(serverlst, "N/A")
+		return serverlst, reqInf, fmt.Errorf("No Servers Found")
+	}
+	return serverlst, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/session.go
+++ b/traffic_ops/v1-3-client/session.go
@@ -1,0 +1,426 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptrace"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	tc "github.com/apache/trafficcontrol/lib/go-tc"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// Session ...
+type Session struct {
+	UserName     string
+	Password     string
+	URL          string
+	Client       *http.Client
+	cache        map[string]CacheEntry
+	cacheMutex   *sync.RWMutex
+	useCache     bool
+	UserAgentStr string
+}
+
+func NewSession(user, password, url, userAgent string, client *http.Client, useCache bool) *Session {
+	return &Session{
+		UserName:     user,
+		Password:     password,
+		URL:          url,
+		Client:       client,
+		cache:        map[string]CacheEntry{},
+		cacheMutex:   &sync.RWMutex{},
+		useCache:     useCache,
+		UserAgentStr: userAgent,
+	}
+}
+
+const DefaultTimeout = time.Second * time.Duration(30)
+
+// HTTPError is returned on Update Session failure.
+type HTTPError struct {
+	HTTPStatusCode int
+	HTTPStatus     string
+	URL            string
+	Body           string
+}
+
+// Error implements the error interface for our customer error type.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("%s[%d] - Error requesting Traffic Ops %s %s", e.HTTPStatus, e.HTTPStatusCode, e.URL, e.Body)
+}
+
+// CacheEntry ...
+type CacheEntry struct {
+	Entered    int64
+	Bytes      []byte
+	RemoteAddr net.Addr
+}
+
+// TODO JvD
+const tmPollingInterval = 60
+
+// loginCreds gathers login credentials for Traffic Ops.
+func loginCreds(toUser string, toPasswd string) ([]byte, error) {
+	credentials := tc.UserCredentials{
+		Username: toUser,
+		Password: toPasswd,
+	}
+
+	js, err := json.Marshal(credentials)
+	if err != nil {
+		err := fmt.Errorf("Error creating login json: %v", err)
+		return nil, err
+	}
+	return js, nil
+}
+
+// Deprecated: Login is deprecated, use LoginWithAgent instead. The `Login` function with its present signature will be removed in the next version and replaced with `Login(toURL string, toUser string, toPasswd string, insecure bool, userAgent string)`. The `LoginWithAgent` function will be removed the version after that.
+func Login(toURL string, toUser string, toPasswd string, insecure bool) (*Session, error) {
+	s, _, err := LoginWithAgent(toURL, toUser, toPasswd, insecure, "traffic-ops-client", false, DefaultTimeout)
+	return s, err
+}
+
+// login tries to log in to Traffic Ops, and set the auth cookie in the Session. Returns the IP address of the remote Traffic Ops.
+func (to *Session) login() (net.Addr, error) {
+	credentials, err := loginCreds(to.UserName, to.Password)
+	if err != nil {
+		return nil, errors.New("creating login credentials: " + err.Error())
+	}
+
+	path := apiBase + "/user/login"
+	resp, remoteAddr, err := to.rawRequest("POST", path, credentials)
+	resp, remoteAddr, err = to.ErrUnlessOK(resp, remoteAddr, err, path)
+	if err != nil {
+		return remoteAddr, errors.New("requesting: " + err.Error())
+	}
+	defer resp.Body.Close()
+
+	var alerts tc.Alerts
+	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+		return remoteAddr, errors.New("decoding response JSON: " + err.Error())
+	}
+
+	success := false
+	for _, alert := range alerts.Alerts {
+		if alert.Level == "success" && alert.Text == "Successfully logged in." {
+			success = true
+			break
+		}
+	}
+
+	if !success {
+		return remoteAddr, fmt.Errorf("Login failed, alerts string: %+v", alerts)
+	}
+
+	return remoteAddr, nil
+}
+
+// logout of Traffic Ops
+func (to *Session) logout() (net.Addr, error) {
+	credentials, err := loginCreds(to.UserName, to.Password)
+	if err != nil {
+		return nil, errors.New("creating login credentials: " + err.Error())
+	}
+
+	path := apiBase + "/user/logout"
+	resp, remoteAddr, err := to.rawRequest("POST", path, credentials)
+	resp, remoteAddr, err = to.ErrUnlessOK(resp, remoteAddr, err, path)
+	if err != nil {
+		return remoteAddr, errors.New("requesting: " + err.Error())
+	}
+	defer resp.Body.Close()
+
+	var alerts tc.Alerts
+	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+		return remoteAddr, errors.New("decoding response JSON: " + err.Error())
+	}
+
+	success := false
+	for _, alert := range alerts.Alerts {
+		if alert.Level == "success" && alert.Text == "Successfully logged in." {
+			success = true
+			break
+		}
+	}
+
+	if !success {
+		return remoteAddr, fmt.Errorf("Logout failed, alerts string: %+v", alerts)
+	}
+
+	return remoteAddr, nil
+}
+
+// Login to traffic_ops, the response should set the cookie for this session
+// automatically. Start with
+//     to := traffic_ops.Login("user", "passwd", true)
+// subsequent calls like to.GetData("datadeliveryservice") will be authenticated.
+// Returns the logged in client, the remote address of Traffic Ops which was translated and used to log in, and any error. If the error is not nil, the remote address may or may not be nil, depending whether the error occurred before the login request.
+func LoginWithAgent(toURL string, toUser string, toPasswd string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) (*Session, net.Addr, error) {
+	options := cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	}
+
+	jar, err := cookiejar.New(&options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	to := NewSession(toUser, toPasswd, toURL, userAgent, &http.Client{
+		Timeout: requestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		},
+		Jar: jar,
+	}, useCache)
+
+	remoteAddr, err := to.login()
+	if err != nil {
+		return nil, remoteAddr, errors.New("logging in: " + err.Error())
+	}
+	return to, remoteAddr, nil
+}
+
+// Logout of traffic_ops
+func LogoutWithAgent(toURL string, toUser string, toPasswd string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) (*Session, net.Addr, error) {
+	options := cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	}
+
+	jar, err := cookiejar.New(&options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	to := NewSession(toUser, toPasswd, toURL, userAgent, &http.Client{
+		Timeout: requestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		},
+		Jar: jar,
+	}, useCache)
+
+	remoteAddr, err := to.logout()
+	if err != nil {
+		return nil, remoteAddr, errors.New("logging out: " + err.Error())
+	}
+	return to, remoteAddr, nil
+}
+
+// NewNoAuthSession returns a new Session without logging in
+// this can be used for querying unauthenticated endpoints without requiring a login
+func NewNoAuthSession(toURL string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) *Session {
+	return NewSession("", "", toURL, userAgent, &http.Client{
+		Timeout: requestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		},
+	}, useCache)
+}
+
+// ErrUnlessOk returns nil and an error if the given Response's status code is anything but 200 OK. This includes reading the Response.Body and Closing it. Otherwise, the given response and error are returned unchanged.
+func (to *Session) ErrUnlessOK(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
+	if err != nil {
+		return resp, remoteAddr, err
+	}
+	if resp.StatusCode == http.StatusOK {
+		return resp, remoteAddr, err
+	}
+
+	defer resp.Body.Close()
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, remoteAddr, readErr
+	}
+	return nil, remoteAddr, errors.New(resp.Status + "[" + strconv.Itoa(resp.StatusCode) + "] - Error requesting Traffic Ops " + to.getURL(path) + " " + string(body))
+}
+
+func (to *Session) getURL(path string) string { return to.URL + path }
+
+// request performs the HTTP request to Traffic Ops, trying to refresh the cookie if an Unauthorized or Forbidden code is received. It only tries once. If the login fails, the original Unauthorized/Forbidden response is returned. If the login succeeds and the subsequent re-request fails, the re-request's response is returned even if it's another Unauthorized/Forbidden.
+func (to *Session) request(method, path string, body []byte) (*http.Response, net.Addr, error) {
+	r, remoteAddr, err := to.rawRequest(method, path, body)
+	if err != nil {
+		return r, remoteAddr, err
+	}
+	if r.StatusCode != http.StatusUnauthorized && r.StatusCode != http.StatusForbidden {
+		return to.ErrUnlessOK(r, remoteAddr, err, path)
+	}
+	if _, lerr := to.login(); lerr != nil {
+		return to.ErrUnlessOK(r, remoteAddr, err, path) // if re-logging-in fails, return the original request's response
+	}
+
+	// return second request, even if it's another Unauthorized or Forbidden.
+	r, remoteAddr, err = to.rawRequest(method, path, body)
+	return to.ErrUnlessOK(r, remoteAddr, err, path)
+}
+
+// rawRequest performs the actual HTTP request to Traffic Ops, simply, without trying to refresh the cookie if an Unauthorized code is returned.
+func (to *Session) rawRequest(method, path string, body []byte) (*http.Response, net.Addr, error) {
+	url := to.getURL(path)
+
+	var req *http.Request
+	var err error
+	remoteAddr := net.Addr(nil)
+
+	if body != nil {
+		req, err = http.NewRequest(method, url, bytes.NewBuffer(body))
+		if err != nil {
+			return nil, remoteAddr, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+		if err != nil {
+			return nil, remoteAddr, err
+		}
+	}
+
+	trace := &httptrace.ClientTrace{
+		GotConn: func(connInfo httptrace.GotConnInfo) {
+			remoteAddr = connInfo.Conn.RemoteAddr()
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	req.Header.Set("User-Agent", to.UserAgentStr)
+
+	resp, err := to.Client.Do(req)
+	if err != nil {
+		return nil, remoteAddr, err
+	}
+
+	return resp, remoteAddr, nil
+}
+
+type ReqInf struct {
+	CacheHitStatus CacheHitStatus
+	RemoteAddr     net.Addr
+}
+
+type CacheHitStatus string
+
+const CacheHitStatusHit = CacheHitStatus("hit")
+const CacheHitStatusExpired = CacheHitStatus("expired")
+const CacheHitStatusMiss = CacheHitStatus("miss")
+const CacheHitStatusInvalid = CacheHitStatus("")
+
+func (s CacheHitStatus) String() string {
+	return string(s)
+}
+
+func StringToCacheHitStatus(s string) CacheHitStatus {
+	s = strings.ToLower(s)
+	switch s {
+	case "hit":
+		return CacheHitStatusHit
+	case "expired":
+		return CacheHitStatusExpired
+	case "miss":
+		return CacheHitStatusMiss
+	default:
+		return CacheHitStatusInvalid
+	}
+}
+
+// setCache Sets the given cache key and value. This is threadsafe for multiple goroutines.
+func (to *Session) setCache(path string, entry CacheEntry) {
+	if !to.useCache {
+		return
+	}
+	to.cacheMutex.Lock()
+	defer to.cacheMutex.Unlock()
+	to.cache[path] = entry
+}
+
+// getCache gets the cache value at the given key, or false if it doesn't exist. This is threadsafe for multiple goroutines.
+func (to *Session) getCache(path string) (CacheEntry, bool) {
+	to.cacheMutex.RLock()
+	defer to.cacheMutex.RUnlock()
+	cacheEntry, ok := to.cache[path]
+	return cacheEntry, ok
+}
+
+//if cacheEntry, ok := to.Cache[path]; ok {
+
+// getBytesWithTTL gets the path, and caches in the session. Returns bytes from the cache, if found and the TTL isn't expired. Otherwise, gets it and store it in cache
+func (to *Session) getBytesWithTTL(path string, ttl int64) ([]byte, ReqInf, error) {
+	var body []byte
+	var err error
+	var cacheHitStatus CacheHitStatus
+	var remoteAddr net.Addr
+
+	getFresh := false
+	if cacheEntry, ok := to.getCache(path); ok {
+		if cacheEntry.Entered > time.Now().Unix()-ttl {
+			cacheHitStatus = CacheHitStatusHit
+			body = cacheEntry.Bytes
+			remoteAddr = cacheEntry.RemoteAddr
+		} else {
+			cacheHitStatus = CacheHitStatusExpired
+			getFresh = true
+		}
+	} else {
+		cacheHitStatus = CacheHitStatusMiss
+		getFresh = true
+	}
+
+	if getFresh {
+		body, remoteAddr, err = to.getBytes(path)
+		if err != nil {
+			return nil, ReqInf{CacheHitStatus: CacheHitStatusInvalid, RemoteAddr: remoteAddr}, err
+		}
+
+		newEntry := CacheEntry{
+			Entered:    time.Now().Unix(),
+			Bytes:      body,
+			RemoteAddr: remoteAddr,
+		}
+		to.setCache(path, newEntry)
+	}
+
+	return body, ReqInf{CacheHitStatus: cacheHitStatus, RemoteAddr: remoteAddr}, nil
+}
+
+// GetBytes - get []bytes array for a certain path on the to session.
+// returns the raw body, the remote address the Traffic Ops URL resolved to, or any error. If the error is not nil, the RemoteAddr may or may not be nil, depending whether the error occurred before the request was executed.
+func (to *Session) getBytes(path string) ([]byte, net.Addr, error) {
+	resp, remoteAddr, err := to.request("GET", path, nil)
+	if err != nil {
+		return nil, remoteAddr, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, remoteAddr, err
+	}
+
+	return body, remoteAddr, nil
+}

--- a/traffic_ops/v1-3-client/staticdnsentry.go
+++ b/traffic_ops/v1-3-client/staticdnsentry.go
@@ -1,0 +1,134 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_StaticDNSEntries = "/api/1.3/staticdnsentries"
+)
+
+// Create a StaticDNSEntry
+func (to *Session) CreateStaticDNSEntry(cdn tc.StaticDNSEntry) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cdn)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_StaticDNSEntries, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a StaticDNSEntry by ID
+func (to *Session) UpdateStaticDNSEntryByID(id int, cdn tc.StaticDNSEntry) (tc.Alerts, ReqInf, int, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(cdn)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, 0, err
+	}
+	route := fmt.Sprintf("%s?id=%d", API_v13_StaticDNSEntries, id)
+	resp, remoteAddr, errClient := to.rawRequest(http.MethodPut, route, reqBody)
+	if resp != nil {
+		defer resp.Body.Close()
+		var alerts tc.Alerts
+		if err = json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+			return alerts, reqInf, resp.StatusCode, err
+		}
+		return alerts, reqInf, resp.StatusCode, errClient
+	}
+	return tc.Alerts{}, reqInf, 0, errClient
+}
+
+// Returns a list of StaticDNSEntrys
+func (to *Session) GetStaticDNSEntries() ([]tc.StaticDNSEntry, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_StaticDNSEntries, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.StaticDNSEntriesResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a StaticDNSEntry by the StaticDNSEntry ID
+func (to *Session) GetStaticDNSEntryByID(id int) ([]tc.StaticDNSEntry, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_v13_StaticDNSEntries, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.StaticDNSEntriesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a StaticDNSEntry by the StaticDNSEntry hsot
+func (to *Session) GetStaticDNSEntriesByHost(host string) ([]tc.StaticDNSEntry, ReqInf, error) {
+	url := fmt.Sprintf("%s?host=%s", API_v13_StaticDNSEntries, host)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.StaticDNSEntriesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a StaticDNSEntry by ID
+func (to *Session) DeleteStaticDNSEntryByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", API_v13_StaticDNSEntries, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/stats_summary.go
+++ b/traffic_ops/v1-3-client/stats_summary.go
@@ -1,0 +1,125 @@
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	tc "github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+// SummaryStats ...
+// Deprecated: use GetSummaryStats
+func (to *Session) SummaryStats(cdn string, deliveryService string, statName string) ([]tc.StatsSummary, error) {
+	ss, _, err := to.GetSummaryStats(cdn, deliveryService, statName)
+	return ss, err
+}
+
+func (to *Session) GetSummaryStats(cdn string, deliveryService string, statName string) ([]tc.StatsSummary, ReqInf, error) {
+	var queryParams []string
+	if len(cdn) > 0 {
+		queryParams = append(queryParams, fmt.Sprintf("cdnName=%s", cdn))
+	}
+	if len(deliveryService) > 0 {
+		queryParams = append(queryParams, fmt.Sprintf("deliveryServiceName=%s", deliveryService))
+	}
+	if len(statName) > 0 {
+		queryParams = append(queryParams, fmt.Sprintf("statName=%s", statName))
+	}
+	queryURL := "/api/1.2/stats_summary.json"
+	queryParamString := "?"
+	if len(queryParams) > 0 {
+		for i, param := range queryParams {
+			if i == 0 {
+				queryParamString += param
+			} else {
+				queryParamString += fmt.Sprintf("&%s", param)
+			}
+		}
+		queryURL += queryParamString
+	}
+
+	resp, remoteAddr, err := to.request("GET", queryURL, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.StatsSummaryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// SummaryStatsLastUpdated ...
+// Deprecated: use GetSummaryStatsLastUpdated
+func (to *Session) SummaryStatsLastUpdated(statName string) (string, error) {
+	s, _, err := to.GetSummaryStatsLastUpdated(statName)
+	return s, err
+}
+
+func (to *Session) GetSummaryStatsLastUpdated(statName string) (string, ReqInf, error) {
+	queryURL := "/api/1.2/stats_summary.json?lastSummaryDate=true"
+	if len(statName) > 0 {
+		queryURL += fmt.Sprintf("?statName=%s", statName)
+	}
+
+	resp, remoteAddr, err := to.request("GET", queryURL, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return "", reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.LastUpdated
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", reqInf, err
+	}
+
+	if len(data.Response.SummaryTime) > 0 {
+		return data.Response.SummaryTime, reqInf, nil
+	}
+	t := "1970-01-01 00:00:00"
+	return t, reqInf, nil
+}
+
+// AddSummaryStats ...
+// Deprecated: use DoAddSummaryStats
+func (to *Session) AddSummaryStats(statsSummary tc.StatsSummary) error {
+	_, err := to.DoAddSummaryStats(statsSummary)
+	return err
+}
+func (to *Session) DoAddSummaryStats(statsSummary tc.StatsSummary) (ReqInf, error) {
+	reqBody, err := json.Marshal(statsSummary)
+	if err != nil {
+		return ReqInf{}, err
+	}
+
+	url := "/api/1.2/stats_summary/create"
+	resp, remoteAddr, err := to.request("POST", url, reqBody)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return reqInf, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		err := fmt.Errorf("Response code = %s and Status = %s", strconv.Itoa(resp.StatusCode), resp.Status)
+		return reqInf, err
+	}
+	return reqInf, nil
+}

--- a/traffic_ops/v1-3-client/status.go
+++ b/traffic_ops/v1-3-client/status.go
@@ -1,0 +1,132 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_STATUSES = "/api/1.3/statuses"
+)
+
+// Create a Status
+func (to *Session) CreateStatus(status tc.Status) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(status)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_STATUSES, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a Status by ID
+func (to *Session) UpdateStatusByID(id int, status tc.Status) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(status)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_STATUSES, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Returns a list of Statuses
+func (to *Session) GetStatuses() ([]tc.Status, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_STATUSES, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.StatusesResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+// GET a Status by the Status id
+func (to *Session) GetStatusByID(id int) ([]tc.Status, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_STATUSES, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.StatusesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Status by the Status name
+func (to *Session) GetStatusByName(name string) ([]tc.Status, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_STATUSES, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.StatusesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Status by id
+func (to *Session) DeleteStatusByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_STATUSES, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/steeringtarget.go
+++ b/traffic_ops/v1-3-client/steeringtarget.go
@@ -1,0 +1,96 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func (to *Session) CreateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, ReqInf, error) {
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+	if st.DeliveryServiceID == nil {
+		return tc.Alerts{}, reqInf, errors.New("missing delivery service id")
+	}
+	reqBody, err := json.Marshal(st)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+
+	resp := (*http.Response)(nil)
+	if resp, reqInf.RemoteAddr, err = to.request(http.MethodPost, apiBase+`/steering/`+strconv.Itoa(int(*st.DeliveryServiceID))+`/targets`, reqBody); err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	alerts := tc.Alerts{}
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+func (to *Session) UpdateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, ReqInf, error) {
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+	if st.DeliveryServiceID == nil {
+		return tc.Alerts{}, reqInf, errors.New("missing delivery service id")
+	}
+	if st.TargetID == nil {
+		return tc.Alerts{}, reqInf, errors.New("missing target id")
+	}
+
+	reqBody, err := json.Marshal(st)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp := (*http.Response)(nil)
+	resp, reqInf.RemoteAddr, err = to.request(http.MethodPut, apiBase+`/steering/`+strconv.Itoa(int(*st.DeliveryServiceID))+`/targets/`+strconv.Itoa(int(*st.TargetID)), reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	alerts := tc.Alerts{}
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+func (to *Session) GetSteeringTargets(dsID int) ([]tc.SteeringTargetNullable, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, apiBase+`/steering/`+strconv.Itoa(dsID)+`/targets`, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	data := struct {
+		Response []tc.SteeringTargetNullable `json:"response"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data.Response, reqInf, nil
+}
+
+func (to *Session) DeleteSteeringTarget(dsID int, targetID int) (tc.Alerts, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodDelete, apiBase+`/steering/`+strconv.Itoa(dsID)+`/targets/`+strconv.Itoa(targetID), nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	alerts := tc.Alerts{}
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/tenant.go
+++ b/traffic_ops/v1-3-client/tenant.go
@@ -1,0 +1,106 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+
+	tc "github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+// Tenants gets an array of Tenants
+func (to *Session) Tenants() ([]tc.Tenant, ReqInf, error) {
+	var data tc.GetTenantsResponse
+	reqInf, err := get(to, tenantsEp(), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// Tenant gets the Tenant for the ID it's passed
+func (to *Session) Tenant(id string) (*tc.Tenant, ReqInf, error) {
+	var data tc.GetTenantsResponse
+	reqInf, err := get(to, tenantEp(id), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response[0], reqInf, nil
+}
+
+// TenantByName gets the Tenant for the name it's passed
+func (to *Session) TenantByName(name string) (*tc.Tenant, ReqInf, error) {
+	var data tc.GetTenantsResponse
+	query := tenantsEp() + "?name=" + url.QueryEscape(name)
+	reqInf, err := get(to, query, &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	var ten *tc.Tenant
+	if len(data.Response) > 0 {
+		ten = &data.Response[0]
+	} else {
+		err = errors.New("no tenant found with name " + name)
+	}
+	return ten, reqInf, err
+}
+
+// CreateTenant creates the Tenant it's passed
+func (to *Session) CreateTenant(t *tc.Tenant) (*tc.TenantResponse, error) {
+	var data tc.TenantResponse
+	jsonReq, err := json.Marshal(t)
+	if err != nil {
+		return nil, err
+	}
+	err = post(to, tenantsEp(), jsonReq, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// UpdateTenant updates the Tenant matching the ID it's passed with
+// the Tenant it is passed
+func (to *Session) UpdateTenant(id string, t *tc.Tenant) (*tc.TenantResponse, error) {
+	var data tc.TenantResponse
+	jsonReq, err := json.Marshal(t)
+	if err != nil {
+		return nil, err
+	}
+	err = put(to, tenantEp(id), jsonReq, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// DeleteTenant deletes the Tenant matching the ID it's passed
+func (to *Session) DeleteTenant(id string) (*tc.DeleteTenantResponse, error) {
+	var data tc.DeleteTenantResponse
+	err := del(to, tenantEp(id), &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}

--- a/traffic_ops/v1-3-client/tenant_endpoints.go
+++ b/traffic_ops/v1-3-client/tenant_endpoints.go
@@ -1,0 +1,25 @@
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+const tenantPath = "/tenants"
+
+func tenantsEp() string {
+	return apiBase + tenantPath
+}
+
+func tenantEp(id string) string {
+	return apiBase + tenantPath + "/" + id
+}

--- a/traffic_ops/v1-3-client/traffic_monitor.go
+++ b/traffic_ops/v1-3-client/traffic_monitor.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// TrafficMonitorConfigMap ...
+// Deprecated: use GetTrafficMonitorConfigMap
+func (to *Session) TrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, error) {
+	m, _, err := to.GetTrafficMonitorConfigMap(cdn)
+	return m, err
+}
+
+func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, ReqInf, error) {
+	tmConfig, reqInf, err := to.GetTrafficMonitorConfig(cdn)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	tmConfigMap, err := tc.TrafficMonitorTransformToMap(tmConfig)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	return tmConfigMap, reqInf, nil
+}
+
+// TrafficMonitorConfig ...
+// Deprecated: use GetTrafficMonitorConfig
+func (to *Session) TrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, error) {
+	c, _, err := to.GetTrafficMonitorConfig(cdn)
+	return c, err
+}
+
+func (to *Session) GetTrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, ReqInf, error) {
+	url := fmt.Sprintf("/api/1.3/cdns/%s/configs/monitoring.json", cdn)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.TMConfigResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/type.go
+++ b/traffic_ops/v1-3-client/type.go
@@ -1,0 +1,159 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+const (
+	API_v13_Types = "/api/1.3/types"
+)
+
+// Create a Type
+func (to *Session) CreateType(typ tc.Type) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(typ)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	resp, remoteAddr, err := to.request(http.MethodPost, API_v13_Types, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Update a Type by ID
+func (to *Session) UpdateTypeByID(id int, typ tc.Type) (tc.Alerts, ReqInf, error) {
+
+	var remoteAddr net.Addr
+	reqBody, err := json.Marshal(typ)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	route := fmt.Sprintf("%s/%d", API_v13_Types, id)
+	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody)
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}
+
+// Types gets an array of Types.
+// optional parameter: userInTable
+// Deprecated: use GetTypes
+func (to *Session) Types(useInTable ...string) ([]tc.Type, error) {
+	t, _, err := to.GetTypes(useInTable...)
+	return t, err
+}
+
+func (to *Session) GetTypes(useInTable ...string) ([]tc.Type, ReqInf, error) {
+	if len(useInTable) > 1 {
+		return nil, ReqInf{}, errors.New("Please pass in a single value for the 'useInTable' parameter")
+	}
+
+	url := apiBase + "/types.json"
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.TypesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	var types []tc.Type
+	for _, d := range data.Response {
+		if useInTable != nil {
+			if d.UseInTable == useInTable[0] {
+				types = append(types, d)
+			}
+		} else {
+			types = append(types, d)
+		}
+	}
+
+	return types, reqInf, nil
+}
+
+// GET a Type by the Type ID
+func (to *Session) GetTypeByID(id int) ([]tc.Type, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_Types, id)
+	resp, remoteAddr, err := to.request(http.MethodGet, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.TypesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GET a Type by the Type name
+func (to *Session) GetTypeByName(name string) ([]tc.Type, ReqInf, error) {
+	url := fmt.Sprintf("%s?name=%s", API_v13_Types, name)
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.TypesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// DELETE a Type by ID
+func (to *Session) DeleteTypeByID(id int) (tc.Alerts, ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", API_v13_Types, id)
+	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return tc.Alerts{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var alerts tc.Alerts
+	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	return alerts, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/update.go
+++ b/traffic_ops/v1-3-client/update.go
@@ -1,0 +1,72 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+)
+
+// UpdateStatusClear is the value received by and posted to the Traffic Ops cache update endpoint, indicating no updates are pending for a cache.
+const UpdateStatusClear = 0
+
+// UpdateStatusPending is the value received by and posted to the Traffic Ops cache update endpoint, indicating an update is pending for a cache. That is, someone has clicked "Queue Updates" in Traffic Ops, and the cache has yet to run ORT, which will fetch updates and clear the update pending flag.
+const UpdateStatusPending = 1
+
+type UpdateResponse []Update
+
+type Update struct {
+	UpdatePending      bool   `json:"upd_pending"`
+	ParentPending      bool   `json:"parent_pending"`
+	RevalPending       bool   `json:"reval_pending"`
+	ParentRevalPending bool   `json:"parent_reval_pending"`
+	Status             string `json:"status"`
+	HostID             int    `json:"host_id"`
+	HostName           string `json:"host_name"`
+}
+
+func (to *Session) GetUpdate(serverName string) (Update, ReqInf, error) {
+	url := "/update/" + serverName
+	resp, remoteAddr, err := to.request(http.MethodGet, url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return Update{}, reqInf, err
+	}
+	defer resp.Body.Close()
+	var data UpdateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return Update{}, reqInf, err
+	}
+	if len(data) < 1 {
+		return Update{}, reqInf, errors.New("empty response")
+	}
+	return data[0], reqInf, nil
+}
+
+// SetUpdate sets the Update Pending and Reval Pending flags for the given cache server in Traffic Ops. This MUST only be called by an app (like ORT) which has fetched new config updates for the cache, generated or downloaded the config files onto the cache, and instructed the cache service to reload its config. This MUST NOT be called unless the cache is running the latest configuration in Traffic Ops, else the Traffic Ops cache update status will be wrong. If only the Reval or Update status has been updated, but not both, the old status should be queried from the update endpoint, and the original status for the unchanged value sent here.
+func (to *Session) SetUpdate(serverName string, updatePending int, revalPending int) (ReqInf, error) {
+	updateURL := "/update/" + serverName + "?" + "host_name=" + serverName + "&updated=" + strconv.Itoa(updatePending) + "&reval_updated=" + strconv.Itoa(revalPending)
+	resp, remoteAddr, err := to.request(http.MethodPost, updateURL, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return reqInf, err
+	}
+	defer resp.Body.Close()
+	// TODO return error if body is not success response
+	return reqInf, nil
+}

--- a/traffic_ops/v1-3-client/user.go
+++ b/traffic_ops/v1-3-client/user.go
@@ -1,0 +1,57 @@
+package client
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"encoding/json"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+// Users gets an array of Users.
+// Deprecated: use GetUsers
+func (to *Session) Users() ([]tc.User, error) {
+	us, _, err := to.GetUsers()
+	return us, err
+}
+
+func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
+	url := apiBase + "/users.json"
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data tc.UsersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
+}
+
+// GetUserCurrent gets information about the current user
+func (to *Session) GetUserCurrent() (*tc.UserCurrent, ReqInf, error) {
+	url := apiBase + `/user/current`
+	resp := tc.UserCurrentResponse{}
+	reqInf, err := get(to, url, &resp)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	return &resp.Response, reqInf, nil
+}

--- a/traffic_ops/v1-3-client/util.go
+++ b/traffic_ops/v1-3-client/util.go
@@ -1,0 +1,61 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+)
+
+func get(to *Session, endpoint string, respStruct interface{}) (ReqInf, error) {
+	return makeReq(to, "GET", endpoint, nil, respStruct)
+}
+
+func post(to *Session, endpoint string, body []byte, respStruct interface{}) error {
+	_, err := makeReq(to, "POST", endpoint, body, respStruct)
+	return err
+}
+
+func put(to *Session, endpoint string, body []byte, respStruct interface{}) error {
+	_, err := makeReq(to, "PUT", endpoint, body, respStruct)
+	return err
+}
+
+func del(to *Session, endpoint string, respStruct interface{}) error {
+	_, err := makeReq(to, "DELETE", endpoint, nil, respStruct)
+	return err
+}
+
+func makeReq(to *Session, method, endpoint string, body []byte, respStruct interface{}) (ReqInf, error) {
+	resp, remoteAddr, err := to.request(method, endpoint, body) // TODO change to getBytesWithTTL
+	reqInf := ReqInf{RemoteAddr: remoteAddr, CacheHitStatus: CacheHitStatusMiss}
+	if err != nil {
+		return reqInf, err
+	}
+	defer resp.Body.Close()
+
+	bts, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return reqInf, errors.New("reading body: " + err.Error())
+	}
+
+	if err := json.Unmarshal(bts, respStruct); err != nil {
+		return reqInf, errors.New("unmarshalling body '" + string(body) + "': " + err.Error())
+	}
+
+	return reqInf, nil
+}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
NOTE: this is not a true backport, but these changes were extracted from
similar changes made to TM in master.

- [x] This PR fixes #5005 


## Which Traffic Control components are affected by this PR?

- Traffic Monitor

## What is the best way to verify this PR?
With a pre-4.0 TO, upgrade TM to this version, verify that TM attempts to use TO API 2.0 before falling back to 1.3.

## If this is a bug fix, what versions of Traffic Control are affected?
- 4.0
- 4.1


## The following criteria are ALL met by this PR

- [x] This PR is a pseudo-backport, but this change had no corresponding tests
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
