### PR TITLE
Add missing TP configuration options to ansible infra code and improve TP configuration safety

### DIFF
--- a/infrastructure/ansible/roles/traffic_portal/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_portal/defaults/main.yml
@@ -42,7 +42,14 @@ tp_default_properties_template:
   _comment: These are the default properties for Traffic Portal. Customize these values
     to fit your needs.
   properties:
+    _comments:
+      name: Customize the name of Traffic Portal if desired.
+      enforceCapabilities: Not currently supported. Must be false.
     name: Traffic Portal
+    environment:
+      _comments: Optionally set the environment name (production, staging, development, etc) and an indicator if the environment is production or not.
+      name: Kabletown2.0
+      isProd: false
     api:
       _comment: This should have the same value found in /etc/traffic_portal/conf/config.js
       baseUrl: "{{ tp_to_base_url }}/api/"

--- a/infrastructure/ansible/roles/traffic_portal/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_portal/defaults/main.yml
@@ -53,6 +53,7 @@ tp_default_properties_template:
     api:
       _comment: This should have the same value found in /etc/traffic_portal/conf/config.js
       baseUrl: "{{ tp_to_base_url }}/api/"
+    # enforceCapabilities is not currently supported and must be false
     enforceCapabilities: false
     dashboard:
       _comments: These are configurable properties for the dashboard

--- a/traffic_portal/app/src/common/modules/header/HeaderController.js
+++ b/traffic_portal/app/src/common/modules/header/HeaderController.js
@@ -23,9 +23,9 @@ var HeaderController = function($rootScope, $scope, $state, $uibModal, $location
 
     $scope.userLoaded = userModel.loaded;
 
-    $scope.enviroName = propertiesModel.properties.environment.name;
+    $scope.enviroName = (propertiesModel.properties.environment) ? propertiesModel.properties.environment.name : '';
 
-    $scope.isProd = propertiesModel.properties.environment.isProd;
+    $scope.isProd = (propertiesModel.properties.environment) ? propertiesModel.properties.environment.isProd : false;
 
     /* we don't want real time changes to the user showing up. we want the ability to revert changes
     if necessary. thus, we will only update this on save. see userModel::userUpdated event below.

--- a/traffic_portal/app/src/common/modules/navigation/NavigationController.js
+++ b/traffic_portal/app/src/common/modules/navigation/NavigationController.js
@@ -21,7 +21,7 @@ var NavigationController = function($scope, $log, $state, $location, $window, $t
 
     $scope.appName = propertiesModel.properties.name;
 
-    $scope.isProd = propertiesModel.properties.environment.isProd;
+    $scope.isProd = (propertiesModel.properties.environment) ? propertiesModel.properties.environment.isProd : false;
 
     $scope.enforceCapabilities = propertiesModel.properties.enforceCapabilities;
 


### PR DESCRIPTION
The changes made to traffic_portal_properties.json in #5065 are not accounted for in the ansible-based lab deployment until they are added to the proper yaml file.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
Build the lab enviro and ensure TP has environment name = Kabletown2.0 and no red header to indicate a non-prod enviro.

## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
