### PR TITLE
Fix 4.1.x Backport bad cherrypick missing file

### DIFF
--- a/traffic_ops/build/atstccfg.logrotate
+++ b/traffic_ops/build/atstccfg.logrotate
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+/var/log/ort/atstccfg.log {
+        compress
+        maxage 30
+        missingok
+        nomail
+        size 10M
+        rotate 5
+        copytruncate
+}

--- a/traffic_ops/build/build_rpm.sh
+++ b/traffic_ops/build/build_rpm.sh
@@ -89,6 +89,7 @@ function initBuildArea() {
 	to_ort_dest=$(createSourceDir traffic_ops_ort)
 	cp -p ort/traffic_ops_ort.pl "$to_ort_dest"
 	cp -p ort/supermicro_udev_mapper.pl "$to_ort_dest"
+	cp -p build/atstccfg.logrotate "$to_ort_dest"
 	mkdir -p "${to_ort_dest}/atstccfg"
 	cp -R -p ort/atstccfg/* "${to_ort_dest}/atstccfg"
 

--- a/traffic_ops/build/traffic_ops_ort.spec
+++ b/traffic_ops/build/traffic_ops_ort.spec
@@ -55,7 +55,7 @@ cp -p ${RPM_SOURCE_DIR}/traffic_ops_ort-%{version}/traffic_ops_ort.pl ${RPM_BUIL
 cp -p ${RPM_SOURCE_DIR}/traffic_ops_ort-%{version}/supermicro_udev_mapper.pl ${RPM_BUILD_ROOT}/opt/ort
 
 src=src/github.com/apache/trafficcontrol/traffic_ops/ort/atstccfg
-cp -p ${RPM_SOURCE_DIR}/traffic_ops_ort-%{version}/build/atstccfg.logrotate "${RPM_BUILD_ROOT}"/etc/logrotate.d/atstccfg
+cp -p ${RPM_SOURCE_DIR}/traffic_ops_ort-%{version}/atstccfg.logrotate "${RPM_BUILD_ROOT}"/etc/logrotate.d/atstccfg
 touch ${RPM_BUILD_ROOT}/var/log/ort/atstccfg.log
 cp -p "$src"/atstccfg ${RPM_BUILD_ROOT}/opt/ort
 


### PR DESCRIPTION
Fixes a file that got dropped, and a broken path, from the cherrypick from `master`.

No tests, ORT doesn't have an integration test framework yet.
No docs, no interface change.
No changelog, no release since bug.

I've manually tested building, installing, and running. Everything works, except running from an unrelated bug that will be fixed shortly.

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Build Traffic Ops+ORT, install ORT, run ORT.

## If this is a bug fix, what versions of Traffic Control are affected?
- 4.1.x, only the branch, no release

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information