### PR TITLE
Fix 4.1.x ORT perl missing character

### DIFF
--- a/traffic_ops/ort/traffic_ops_ort.pl
+++ b/traffic_ops/ort/traffic_ops_ort.pl
@@ -30,7 +30,7 @@ chomp($date);
 print "$date\n";
 
 # supported redhat/centos releases
-my %supported_el_release = ( "EL6" => 1, "EL7" => 1, "EL8" = 1);
+my %supported_el_release = ( "EL6" => 1, "EL7" => 1, "EL8" => 1);
 
 my $dispersion = 300;
 my $retries = 5;


### PR DESCRIPTION
Fixes a missing `>` in a Perl map, causing the script to fail to compile/run.

No tests, ORT doesn't have an integration test framework yet (we're working on it).
No docs, no interface change
No changelog, bug was introduced since the last release.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Build and install ORT, run it.

## If this is a bug fix, what versions of Traffic Control are affected?
- 4.1.x branch, but no release

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information