### PR TITLE
Validate addition of DS required capabilities w.r.t its topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Traffic Ops: Added new topology-based delivery service fields for header rewrites: `firstHeaderRewrite`, `innerHeaderRewrite`, `lastHeaderRewrite`
     - Traffic Ops: Added validation to prohibit assigning caches to topology-based delivery services
     - Traffic Ops: Added validation to prohibit removing a capability from a server if no other server in the same cachegroup can satisfy the required capabilities of the delivery services assigned to it via topologies.
+    - Traffic Ops: Added validation to ensure that at least one server per cachegroup in a delivery service's topology has the delivery service's required capabilities.
     - Traffic Ops: Consider Topologies parentage when queueing or checking server updates
     - ORT: Added Topologies to Config Generation.
     - Traffic Portal: Added the ability to create, read, update and delete flexible topologies.

--- a/traffic_ops/testing/api/v3/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_required_capabilities_test.go
@@ -42,6 +42,12 @@ func TestDeliveryServicesRequiredCapabilities(t *testing.T) {
 	})
 }
 
+func TestTopologyBasedDeliveryServicesRequiredCapabilities(t *testing.T) {
+	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, ServerCapabilities, ServerServerCapabilitiesForTopologies, Topologies, DeliveryServices, TopologyBasedDeliveryServiceRequiredCapabilities}, func() {
+		GetTestDeliveryServicesRequiredCapabilities(t)
+	})
+}
+
 func GetTestDeliveryServicesRequiredCapabilitiesIMSAfterChange(t *testing.T, header http.Header) {
 	data := testData.DeliveryServicesRequiredCapabilities
 	ds1 := helperGetDeliveryServiceID(t, data[0].XMLID)
@@ -49,32 +55,27 @@ func GetTestDeliveryServicesRequiredCapabilitiesIMSAfterChange(t *testing.T, hea
 	testCases := []struct {
 		description string
 		capability  tc.DeliveryServicesRequiredCapability
-		expected    int
 	}{
 		{
 			description: "get all deliveryservices required capabilities",
-			expected:    len(testData.DeliveryServicesRequiredCapabilities),
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by deliveryServiceID: %d", *ds1),
 			capability: tc.DeliveryServicesRequiredCapability{
 				DeliveryServiceID: ds1,
 			},
-			expected: 1,
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by xmlID: %s", *data[0].XMLID),
 			capability: tc.DeliveryServicesRequiredCapability{
 				XMLID: data[0].XMLID,
 			},
-			expected: 1,
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by requiredCapability: %s", *data[0].RequiredCapability),
 			capability: tc.DeliveryServicesRequiredCapability{
 				RequiredCapability: data[0].RequiredCapability,
 			},
-			expected: 1,
 		},
 	}
 
@@ -113,32 +114,54 @@ func GetTestDeliveryServicesRequiredCapabilities(t *testing.T) {
 	testCases := []struct {
 		description string
 		capability  tc.DeliveryServicesRequiredCapability
-		expected    int
+		expectFunc  func(tc.DeliveryServicesRequiredCapability, []tc.DeliveryServicesRequiredCapability)
 	}{
 		{
 			description: "get all deliveryservices required capabilities",
-			expected:    len(testData.DeliveryServicesRequiredCapabilities),
+			expectFunc: func(expect tc.DeliveryServicesRequiredCapability, actual []tc.DeliveryServicesRequiredCapability) {
+				if len(actual) != len(testData.DeliveryServicesRequiredCapabilities) {
+					t.Errorf("expected length: %d, actual: %d", len(testData.DeliveryServicesRequiredCapabilities), len(actual))
+				}
+			},
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by deliveryServiceID: %d", *ds1),
 			capability: tc.DeliveryServicesRequiredCapability{
 				DeliveryServiceID: ds1,
 			},
-			expected: 1,
+			expectFunc: func(dsRequiredCapability tc.DeliveryServicesRequiredCapability, dsReqCaps []tc.DeliveryServicesRequiredCapability) {
+				for _, dsrc := range dsReqCaps {
+					if *dsrc.DeliveryServiceID != *dsRequiredCapability.DeliveryServiceID {
+						t.Errorf("expected: all delivery service IDs to equal %d, actual: found %d", *dsRequiredCapability.DeliveryServiceID, *dsrc.DeliveryServiceID)
+					}
+				}
+			},
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by xmlID: %s", *data[0].XMLID),
 			capability: tc.DeliveryServicesRequiredCapability{
 				XMLID: data[0].XMLID,
 			},
-			expected: 1,
+			expectFunc: func(dsRequiredCapability tc.DeliveryServicesRequiredCapability, dsReqCaps []tc.DeliveryServicesRequiredCapability) {
+				for _, dsrc := range dsReqCaps {
+					if *dsrc.XMLID != *dsRequiredCapability.XMLID {
+						t.Errorf("expected: all delivery service XMLIDs to equal %s, actual: found %s", *dsRequiredCapability.XMLID, *dsrc.XMLID)
+					}
+				}
+			},
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by requiredCapability: %s", *data[0].RequiredCapability),
 			capability: tc.DeliveryServicesRequiredCapability{
 				RequiredCapability: data[0].RequiredCapability,
 			},
-			expected: 1,
+			expectFunc: func(dsRequiredCapability tc.DeliveryServicesRequiredCapability, dsReqCaps []tc.DeliveryServicesRequiredCapability) {
+				for _, dsrc := range dsReqCaps {
+					if *dsrc.RequiredCapability != *dsRequiredCapability.RequiredCapability {
+						t.Errorf("expected: all delivery service required capabilities to equal %s, actual: found %s", *dsRequiredCapability.RequiredCapability, *dsrc.RequiredCapability)
+					}
+				}
+			},
 		},
 	}
 
@@ -148,9 +171,7 @@ func GetTestDeliveryServicesRequiredCapabilities(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s; got err= %v; expected err= nil", tc.description, err)
 			}
-			if len(capabilities) != tc.expected {
-				t.Errorf("got %d; expected %d required capabilities assigned to deliveryservices", len(capabilities), tc.expected)
-			}
+			tc.expectFunc(tc.capability, capabilities)
 		})
 	}
 }
@@ -167,32 +188,27 @@ func GetTestDeliveryServicesRequiredCapabilitiesIMS(t *testing.T) {
 	testCases := []struct {
 		description string
 		capability  tc.DeliveryServicesRequiredCapability
-		expected    int
 	}{
 		{
 			description: "get all deliveryservices required capabilities",
-			expected:    len(testData.DeliveryServicesRequiredCapabilities),
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by deliveryServiceID: %d", *ds1),
 			capability: tc.DeliveryServicesRequiredCapability{
 				DeliveryServiceID: ds1,
 			},
-			expected: 1,
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by xmlID: %s", *data[0].XMLID),
 			capability: tc.DeliveryServicesRequiredCapability{
 				XMLID: data[0].XMLID,
 			},
-			expected: 1,
 		},
 		{
 			description: fmt.Sprintf("get all deliveryservices required capabilities by requiredCapability: %s", *data[0].RequiredCapability),
 			capability: tc.DeliveryServicesRequiredCapability{
 				RequiredCapability: data[0].RequiredCapability,
 			},
-			expected: 1,
 		},
 	}
 
@@ -208,6 +224,7 @@ func GetTestDeliveryServicesRequiredCapabilitiesIMS(t *testing.T) {
 		})
 	}
 }
+
 func CreateTestTopologyBasedDeliveryServicesRequiredCapabilities(t *testing.T) {
 	for _, td := range testData.TopologyBasedDeliveryServicesRequiredCapabilities {
 
@@ -220,6 +237,21 @@ func CreateTestTopologyBasedDeliveryServicesRequiredCapabilities(t *testing.T) {
 		if err != nil {
 			t.Fatalf("cannot create delivery service required capability: %v", err)
 		}
+	}
+
+	invalid := tc.DeliveryServicesRequiredCapability{
+		DeliveryServiceID:  helperGetDeliveryServiceID(t, util.StrPtr("ds-top-req-cap")),
+		RequiredCapability: util.StrPtr("foo"),
+	}
+	_, reqInf, err := TOSession.CreateDeliveryServicesRequiredCapability(invalid)
+	if err == nil {
+		t.Fatal("when adding delivery service required capability to a delivery service with a topology that " +
+			"doesn't have cachegroups with at least one server with the required capabilities - expected: error, actual: nil")
+	}
+	if reqInf.StatusCode != http.StatusBadRequest {
+		t.Fatalf("when adding delivery service required capability to a delivery service with a topology that "+
+			"doesn't have cachegroups with at least one server with the required capabilities - expected status code: "+
+			"%d, actual: %d", http.StatusBadRequest, reqInf.StatusCode)
 	}
 }
 

--- a/traffic_ops/testing/api/v3/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_required_capabilities_test.go
@@ -241,7 +241,7 @@ func CreateTestTopologyBasedDeliveryServicesRequiredCapabilities(t *testing.T) {
 
 	invalid := tc.DeliveryServicesRequiredCapability{
 		DeliveryServiceID:  helperGetDeliveryServiceID(t, util.StrPtr("ds-top-req-cap")),
-		RequiredCapability: util.StrPtr("foo"),
+		RequiredCapability: util.StrPtr("asdf"),
 	}
 	_, reqInf, err := TOSession.CreateDeliveryServicesRequiredCapability(invalid)
 	if err == nil {

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -3172,6 +3172,10 @@
             "serverCapability": "disk"
         },
         {
+            "serverHostName": "dtrc-edge-01",
+            "serverCapability": "foo"
+        },
+        {
             "serverHostName": "dtrc-edge-02",
             "serverCapability": "ram"
         },

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -1837,6 +1837,13 @@
             "name": "MSO",
             "routing_disabled": false,
             "type": "ORG_PROFILE"
+        },
+        {
+            "cdnName": "cdn2",
+            "description": "cdn2 mid description",
+            "name": "CDN2_MID",
+            "routing_disabled": false,
+            "type": "ATS_PROFILE"
         }
     ],
     "regions": [
@@ -3122,6 +3129,108 @@
             "tcpPort": 80,
             "type": "EDGE",
             "updPending": false
+        },
+        {
+            "cachegroup": "dtrc2",
+            "cdnName": "cdn2",
+            "domainName": "kabletown.net",
+            "hostName": "dtrc-edge-07",
+            "httpsPort": 443,
+            "interfaces": [
+                {
+                    "ipAddresses": [
+                        {
+                            "address": "2001:db8:dead:beef::11/64",
+                            "gateway": "2001:db8:dead:beef::1",
+                            "serviceAddress": false
+                        },
+                        {
+                            "address": "192.0.2.11/24",
+                            "gateway": "192.0.2.1",
+                            "serviceAddress": true
+                        }
+                    ],
+                    "monitor": true,
+                    "mtu": 9000,
+                    "name": "bond0"
+                }
+            ],
+            "physLocation": "Denver",
+            "profile": "CDN2_EDGE",
+            "rack": "RR 119.02",
+            "revalPending": false,
+            "status": "REPORTED",
+            "tcpPort": 80,
+            "type": "EDGE",
+            "updPending": false
+        },
+        {
+            "cachegroup": "dtrc3",
+            "cdnName": "cdn2",
+            "domainName": "kabletown.net",
+            "hostName": "dtrc-edge-08",
+            "httpsPort": 443,
+            "interfaces": [
+                {
+                    "ipAddresses": [
+                        {
+                            "address": "2001:db8:dead:beef::12/64",
+                            "gateway": "2001:db8:dead:beef::1",
+                            "serviceAddress": false
+                        },
+                        {
+                            "address": "192.0.2.12/24",
+                            "gateway": "192.0.2.1",
+                            "serviceAddress": true
+                        }
+                    ],
+                    "monitor": true,
+                    "mtu": 9000,
+                    "name": "bond0"
+                }
+            ],
+            "physLocation": "Denver",
+            "profile": "CDN2_EDGE",
+            "rack": "RR 119.02",
+            "revalPending": false,
+            "status": "REPORTED",
+            "tcpPort": 80,
+            "type": "EDGE",
+            "updPending": false
+        },
+        {
+            "cachegroup": "dtrc1",
+            "cdnName": "cdn2",
+            "domainName": "kabletown.net",
+            "hostName": "dtrc-mid-04",
+            "httpsPort": 443,
+            "interfaces": [
+                {
+                    "ipAddresses": [
+                        {
+                            "address": "2001:db8:dead:beef::13/64",
+                            "gateway": "2001:db8:dead:beef::1",
+                            "serviceAddress": false
+                        },
+                        {
+                            "address": "192.0.2.13/24",
+                            "gateway": "192.0.2.1",
+                            "serviceAddress": true
+                        }
+                    ],
+                    "monitor": true,
+                    "mtu": 9000,
+                    "name": "bond0"
+                }
+            ],
+            "physLocation": "Denver",
+            "profile": "CDN2_MID",
+            "rack": "RR 119.02",
+            "revalPending": false,
+            "status": "REPORTED",
+            "tcpPort": 80,
+            "type": "MID",
+            "updPending": false
         }
     ],
     "serverCapabilities": [
@@ -3201,6 +3310,18 @@
         {
             "serverHostName": "dtrc-edge-05",
             "serverCapability": "disk"
+        },
+        {
+            "serverHostName": "dtrc-edge-07",
+            "serverCapability": "asdf"
+        },
+        {
+            "serverHostName": "dtrc-edge-08",
+            "serverCapability": "asdf"
+        },
+        {
+            "serverHostName": "dtrc-mid-04",
+            "serverCapability": "asdf"
         }
     ],
     "serviceCategories": [

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -3136,6 +3136,9 @@
         },
         {
             "name": "disk"
+        },
+        {
+            "name": "asdf"
         }
     ],
     "serverServerCapabilities": [
@@ -3173,7 +3176,7 @@
         },
         {
             "serverHostName": "dtrc-edge-01",
-            "serverCapability": "foo"
+            "serverCapability": "asdf"
         },
         {
             "serverHostName": "dtrc-edge-02",

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
@@ -355,7 +355,7 @@ JOIN topology_cachegroup tc ON tc.cachegroup = c.name
 JOIN deliveryservice d ON d.topology = tc.topology
 WHERE
   d.id = $1
-  AND s.cdn_id = (SELECT cdn_id FROM deliveryservice WHERE id = $1)
+  AND s.cdn_id = d.cdn_id
 GROUP BY s.id, c.name
 `
 	rows, err := tx.Query(q, dsID)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
@@ -266,7 +266,7 @@ func (rc *RequiredCapability) Create() (error, error, int) {
 	}
 
 	// Ensure DS type is only of HTTP*, DNS* types
-	dsType, dsExists, err := dbhelpers.GetDeliveryServiceType(*rc.DeliveryServiceID, rc.APIInfo().Tx.Tx)
+	dsType, reqCaps, topology, dsExists, err := dbhelpers.GetDeliveryServiceTypeRequiredCapabilitiesAndTopology(*rc.DeliveryServiceID, rc.APIInfo().Tx.Tx)
 	if err != nil {
 		return nil, err, http.StatusInternalServerError
 	}
@@ -283,16 +283,27 @@ func (rc *RequiredCapability) Create() (error, error, int) {
 		return usrErr, sysErr, rCode
 	}
 
-	usrErr, sysErr, rCode = rc.ensureDSServerCap()
-	if usrErr != nil || sysErr != nil {
-		return usrErr, sysErr, rCode
+	if topology == nil {
+		usrErr, sysErr, rCode = rc.ensureDSServerCap()
+		if usrErr != nil || sysErr != nil {
+			return usrErr, sysErr, rCode
+		}
+	} else {
+		newReqCaps := append(reqCaps, *rc.RequiredCapability)
+		usrErr, sysErr, rCode = EnsureTopologyBasedRequiredCapabilities(rc.APIInfo().Tx.Tx, *rc.DeliveryServiceID, newReqCaps)
+		if usrErr != nil {
+			return fmt.Errorf("cannot add required capability: %v", usrErr), sysErr, rCode
+		}
+		if sysErr != nil {
+			return usrErr, sysErr, rCode
+		}
 	}
 
 	rows, err := rc.APIInfo().Tx.NamedQuery(rcInsertQuery(), rc)
 	if err != nil {
 		return api.ParseDBError(err)
 	}
-	defer rows.Close()
+	defer log.Close(rows, "closing rows in RequiredCapability.Create()")
 
 	rowsAffected := 0
 	for rows.Next() {
@@ -326,6 +337,72 @@ func (rc *RequiredCapability) checkServerCap() (error, error, int) {
 		return fmt.Errorf("server_capability not found"), nil, http.StatusNotFound
 	}
 
+	return nil, nil, http.StatusOK
+}
+
+// EnsureTopologyBasedRequiredCapabilities ensures that at least one server per cachegroup
+// in this delivery service's topology has this delivery service's required capabilities.
+func EnsureTopologyBasedRequiredCapabilities(tx *sql.Tx, dsID int, requiredCapabilities []string) (error, error, int) {
+	q := `
+SELECT
+  s.id,
+  c.name,
+  ARRAY_REMOVE(ARRAY_AGG(ssc.server_capability ORDER BY ssc.server_capability), NULL) AS capabilities
+FROM server s
+LEFT JOIN server_server_capability ssc ON ssc.server = s.id
+JOIN cachegroup c ON c.id = s.cachegroup
+JOIN topology_cachegroup tc ON tc.cachegroup = c.name
+JOIN deliveryservice d ON d.topology = tc.topology
+WHERE
+  d.id = $1
+  AND s.cdn_id = (SELECT cdn_id FROM deliveryservice WHERE id = $1)
+GROUP BY s.id, c.name
+`
+	rows, err := tx.Query(q, dsID)
+	if err != nil {
+		return nil, fmt.Errorf("querying server capabilities in EnsureTopologyBasedRequiredCapabilities: %v", err), http.StatusInternalServerError
+	}
+	defer log.Close(rows, "closing rows in EnsureTopologyBasedRequiredCapabilities")
+
+	cachegroupServers := make(map[string][]int)
+	serverCapabilities := make(map[int]map[string]struct{})
+	for rows.Next() {
+		serverID := 0
+		cachegroup := ""
+		serverCap := []string{}
+		if err := rows.Scan(&serverID, &cachegroup, pq.Array(&serverCap)); err != nil {
+			return nil, fmt.Errorf("scanning rows in EnsureTopologyBasedRequiredCapabilities: %v", err), http.StatusInternalServerError
+		}
+		cachegroupServers[cachegroup] = append(cachegroupServers[cachegroup], serverID)
+		serverCapabilities[serverID] = make(map[string]struct{}, len(serverCap))
+		for _, sc := range serverCap {
+			serverCapabilities[serverID][sc] = struct{}{}
+		}
+	}
+
+	invalidCachegroups := []string{}
+	for cachegroup, servers := range cachegroupServers {
+		cgIsValid := false
+		for _, server := range servers {
+			serverHasCapabilities := true
+			for _, dsReqCap := range requiredCapabilities {
+				if _, ok := serverCapabilities[server][dsReqCap]; !ok {
+					serverHasCapabilities = false
+					break
+				}
+			}
+			if serverHasCapabilities {
+				cgIsValid = true
+				break
+			}
+		}
+		if !cgIsValid {
+			invalidCachegroups = append(invalidCachegroups, cachegroup)
+		}
+	}
+	if len(invalidCachegroups) > 0 {
+		return fmt.Errorf("the following cachegroups in this delivery service's topology do not contain at least one server with the required capabilities: %s", strings.Join(invalidCachegroups, ", ")), nil, http.StatusBadRequest
+	}
 	return nil, nil, http.StatusOK
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
@@ -77,10 +77,10 @@ func TestCreateDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mockTenantID(t, mock, 1)
 
-	typeRows := sqlmock.NewRows([]string{"name"}).AddRow(
-		"HTTP",
+	typeRows := sqlmock.NewRows([]string{"name", "required_capabilities", "topology"}).AddRow(
+		"HTTP", "{}", nil,
 	)
-	mock.ExpectQuery("SELECT t.name FROM deliveryservice as ds").WillReturnRows(typeRows)
+	mock.ExpectQuery("SELECT t.name.*").WillReturnRows(typeRows)
 
 	scRows := sqlmock.NewRows([]string{"name"}).AddRow(
 		"mem",
@@ -363,10 +363,10 @@ func TestCreateDeliveryServicesRequiredCapabilityInvalidDSType(t *testing.T) {
 
 	mockTenantID(t, mock, 1)
 
-	typeRows := sqlmock.NewRows([]string{"name"}).AddRow(
-		"ANY_MAP",
+	typeRows := sqlmock.NewRows([]string{"name", "required_capabilities", "topology"}).AddRow(
+		"ANY_MAP", "{}", nil,
 	)
-	mock.ExpectQuery("SELECT t.name FROM deliveryservice as ds").WillReturnRows(typeRows)
+	mock.ExpectQuery("SELECT t.name.*").WillReturnRows(typeRows)
 
 	userErr, sysErr, errCode := rc.Create()
 	if userErr == nil {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
When adding a required capability to a topology-based delivery service,
there must be at least one server (in the DS's CDN) per cachegroup in
the topology with all the required capabilities.

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Review the TO API tests, verify they're sufficient, and verify the tests pass.

Manually attempt to add a DS required capability to a DS that is assigned to a Topology that contains at least one cachegroup that doesn't meet the criteria (must have at least one server in the DS's CDN with the required capabilities).

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] Validation, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)