### PR TITLE
Fix creating a ds with non-existent topology causing ISE

### DIFF
--- a/traffic_ops/testing/api/v3/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_test.go
@@ -225,16 +225,35 @@ func GetTestDeliveryServicesIMSAfterChange(t *testing.T, header http.Header) {
 }
 
 func PostDeliveryServiceTest(t *testing.T) {
+	if len(testData.DeliveryServices) < 1 {
+		t.Fatal("Need at least one testing Delivery Service to test creating Delivery Services")
+	}
 	ds := testData.DeliveryServices[0]
+	if ds.XMLID == nil {
+		t.Fatal("Testing Delivery Service had no XMLID")
+	}
+	xmlid := *ds.XMLID + "-topology-test"
+
 	ds.XMLID = util.StrPtr("")
 	_, _, err := TOSession.CreateDeliveryServiceV30(ds)
 	if err == nil {
-		t.Fatal("Expected error with empty xmlid")
+		t.Error("Expected error with empty xmlid")
 	}
 	ds.XMLID = nil
 	_, _, err = TOSession.CreateDeliveryServiceV30(ds)
 	if err == nil {
-		t.Fatal("Expected error with nil xmlid")
+		t.Error("Expected error with nil xmlid")
+	}
+
+	ds.Topology = new(string)
+	ds.XMLID = &xmlid
+
+	_, reqInf, err := TOSession.CreateDeliveryServiceV30(ds)
+	if err == nil {
+		t.Error("Expected error with non-existent Topology")
+	}
+	if reqInf.StatusCode < 400 || reqInf.StatusCode >= 500 {
+		t.Errorf("Expected client-level error creating DS with non-existent Topology, got: %d", reqInf.StatusCode)
 	}
 }
 

--- a/traffic_ops/testing/api/v3/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_test.go
@@ -436,8 +436,12 @@ func UpdateDeliveryServiceWithInvalidTopology(t *testing.T) {
 		if *ds.Type == tc.DSTypeClientSteering {
 			found = true
 			ds.Topology = util.StrPtr("my-topology")
-			if _, _, err := TOSession.UpdateDeliveryServiceV30(*ds.ID, ds); err == nil {
+			_, inf, err := TOSession.UpdateDeliveryServiceV30(*ds.ID, ds)
+			if err == nil {
 				t.Errorf("assigning topology to CLIENT_STEERING delivery service - expected: error, actual: no error")
+			}
+			if inf.StatusCode < 400 || inf.StatusCode >= 500 {
+				t.Errorf("Expected client-level error updating a DS with an invalid Topology, got: %d", inf.StatusCode)
 			}
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -427,6 +427,10 @@ func AllParams(req *http.Request, required []string, ints []string) (map[string]
 	return params, intParams, nil, nil, 0
 }
 
+// ParseValidator objects can make use of api.Parse to handle parsing and
+// validating at the same time.
+//
+// TODO: Rework validation to be able to return system-level errors
 type ParseValidator interface {
 	Validate(tx *sql.Tx) error
 }

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -812,23 +812,17 @@ func GetCacheGroupNameFromID(tx *sql.Tx, id int) (tc.CacheGroupName, bool, error
 	return tc.CacheGroupName(name), true, nil
 }
 
-// TopologyExistsString is a convenience function for checking if a Topology exists
-// when its name is an actual string instead of a github.com/apache/trafficcontrol/lib/go-tc.TopologyName
-func TopologyExistsString(tx *sql.Tx, name string) (bool, error) {
-	return TopologyExists(tx, tc.TopologyName(name))
-}
-
 // TopologyExists checks if a Topology with the given name exists.
 // Returns whether or not the Topology exists, along with any encountered error.
-func TopologyExists(tx *sql.Tx, topologyName tc.TopologyName) (bool, error) {
+func TopologyExists(tx *sql.Tx, name string) (bool, error) {
 	q := `
-SELECT COUNT("name")
-FROM topology
-WHERE name = $1
-`
+	SELECT COUNT("name")
+	FROM topology
+	WHERE name = $1
+	`
 	var count int
 	var err error
-	if err = tx.QueryRow(q, topologyName).Scan(&count); err != nil {
+	if err = tx.QueryRow(q, name).Scan(&count); err != nil {
 		err = fmt.Errorf("querying topologies: %s", err)
 	}
 	return count > 0, err

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -812,6 +812,14 @@ func GetCacheGroupNameFromID(tx *sql.Tx, id int) (tc.CacheGroupName, bool, error
 	return tc.CacheGroupName(name), true, nil
 }
 
+// TopologyExistsString is a convenience function for checking if a Topology exists
+// when its name is an actual string instead of a github.com/apache/trafficcontrol/lib/go-tc.TopologyName
+func TopologyExistsString(tx *sql.Tx, name string) (bool, error) {
+	return TopologyExists(tx, tc.TopologyName(name))
+}
+
+// TopologyExists checks if a Topology with the given name exists.
+// Returns whether or not the Topology exists, along with any encountered error.
 func TopologyExists(tx *sql.Tx, topologyName tc.TopologyName) (bool, error) {
 	q := `
 SELECT COUNT("name")

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -788,6 +788,14 @@ func updateV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, ds *tc.
 		deepCachingType = ds.DeepCachingType.String() // necessary, because DeepCachingType's default needs to insert the string, not "", and Query doesn't call .String().
 	}
 
+	if ds.Topology != nil {
+		if ok, err := dbhelpers.TopologyExists(tx, *ds.Topology); err != nil {
+			return nil, http.StatusInternalServerError, nil, fmt.Errorf("checking topology existence: %v", err)
+		} else if !ok {
+			return nil, http.StatusBadRequest, fmt.Errorf("no such Topology '%s'", *ds.Topology), nil
+		}
+	}
+
 	resultRows, err := tx.Query(updateDSQuery(),
 		&ds.Active,
 		&ds.CacheURL,

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -266,6 +266,14 @@ func createV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, ds tc.D
 		deepCachingType = ds.DeepCachingType.String() // necessary, because DeepCachingType's default needs to insert the string, not "", and Query doesn't call .String().
 	}
 
+	if ds.Topology != nil {
+		if ok, err := dbhelpers.TopologyExistsString(tx, *ds.Topology); err != nil {
+			return nil, http.StatusInternalServerError, nil, fmt.Errorf("checking topology existence: %v", err)
+		} else if !ok {
+			return nil, http.StatusConflict, fmt.Errorf("no such Topology '%s'", *ds.Topology), nil
+		}
+	}
+
 	resultRows, err := tx.Query(insertQuery(),
 		&ds.Active,
 		&ds.AnonymousBlockingEnabled,

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -270,7 +270,7 @@ func createV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, ds tc.D
 		if ok, err := dbhelpers.TopologyExists(tx, *ds.Topology); err != nil {
 			return nil, http.StatusInternalServerError, nil, fmt.Errorf("checking topology existence: %v", err)
 		} else if !ok {
-			return nil, http.StatusConflict, fmt.Errorf("no such Topology '%s'", *ds.Topology), nil
+			return nil, http.StatusBadRequest, fmt.Errorf("no such Topology '%s'", *ds.Topology), nil
 		}
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -267,7 +267,7 @@ func createV30(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, ds tc.D
 	}
 
 	if ds.Topology != nil {
-		if ok, err := dbhelpers.TopologyExistsString(tx, *ds.Topology); err != nil {
+		if ok, err := dbhelpers.TopologyExists(tx, *ds.Topology); err != nil {
 			return nil, http.StatusInternalServerError, nil, fmt.Errorf("checking topology existence: %v", err)
 		} else if !ok {
 			return nil, http.StatusConflict, fmt.Errorf("no such Topology '%s'", *ds.Topology), nil

--- a/traffic_ops/traffic_ops_golang/topology/queue_update.go
+++ b/traffic_ops/traffic_ops_golang/topology/queue_update.go
@@ -24,8 +24,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	validation "github.com/go-ozzo/ozzo-validation"
 	"net/http"
+
+	validation "github.com/go-ozzo/ozzo-validation"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
@@ -48,7 +49,7 @@ func Validate(reqObj tc.TopologiesQueueUpdateRequest, topologyName tc.TopologyNa
 		errorMap["cdnId"] = fmt.Errorf("no cdn exists with id %d", reqObj.CDNID)
 	}
 
-	if topologyExists, err := dbhelpers.TopologyExists(tx, topologyName); err != nil {
+	if topologyExists, err := dbhelpers.TopologyExists(tx, string(topologyName)); err != nil {
 		errorMap["topology"] = fmt.Errorf("could not check whether topology %s exists", topologyName)
 	} else if !topologyExists {
 		errorMap["topology"] = fmt.Errorf("no topology exists by the name of %s", topologyName)


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4738 

Fixes an issue where creating a Delivery Service with a non-existent Topology caused an Internal Server Error. It now instead returns a 409 Conflict response with an error stating that the Topology does not exist.


## Which Traffic Control components are affected by this PR?
- Traffic Ops

No docs changes because it's just a bug fix.

## What is the best way to verify this PR?
Try to create a Delivery Service with a non-existent Topology - easiest is probably just an empty string: `""` - and observe that the returned error is in the client error range with an appropriate alert.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**