### PR TITLE
Fix Traffic Ops looking for influxdb.conf in the wrong place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed #3548 - Prevents DS regexes with non-consecutive order from generating invalid CRconfig/snapshot.
 - Fixed #5020, #5021 - Creating an ASN with the same number and same cache group should not be allowed.
 - Fixed #4680 - Change Content-Type to application/json for TR auth calls
+- Fixed #4292 - Traffic Ops not looking for influxdb.conf in the right place
 
 ### Changed
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.

--- a/docs/source/admin/traffic_ops.rst
+++ b/docs/source/admin/traffic_ops.rst
@@ -324,7 +324,7 @@ This file deals with the configuration parameters of running Traffic Ops itself.
 	:workers:           This is used only by the `Legacy Perl Script`_, and sets the number of concurrent HTTP server workers allowed.
 
 :inactivity_timeout: This was used by the `Legacy Perl Script`_ to set timeouts on idle client connections to Traffic Ops - the exact operation (and even units) of this configuration option is unknown. `traffic_ops_golang`_ ignores this field.
-:influx_db_conf_path: An optional field which gives `traffic_ops_golang`_ the absolute or relative path to an `influxdb.conf`_ file. Default if not specified is a file named ``influxdb.conf`` in the same directory as this ``cdn.conf`` file.
+:influxdb_conf_path: An optional field which gives `traffic_ops_golang`_ the absolute or relative path to an `influxdb.conf`_ file. Default if not specified is to first check if the :envvar:`MOJO_MODE` environment variable is set. If it is, then Traffic Ops will look in the current working directory for a subdirectory named ``conf/``, then inside that for a subdirectory with the name that is the value of the :envvar:`MOJO_MODE` variable, and inside that directory for a file named ``influxdb.conf``. If :envvar:`MOJO_MODE` is *not* set, then Traffic Ops will look for a file named ``influxdb.conf`` in the same directory as this ``cdn.conf`` file.
 
 	.. versionadded:: 4.0
 

--- a/traffic_ops/traffic_ops_golang/config/config.go
+++ b/traffic_ops/traffic_ops_golang/config/config.go
@@ -298,13 +298,7 @@ func LoadConfig(cdnConfPath string, dbConfPath string, riakConfPath string, appV
 
 	idbPath := cfg.InfluxDBConfPath
 	if idbPath == "" {
-		var mojoMode string
-		for _, v := range os.Environ() {
-			if strings.HasPrefix(v, "MOJO_MODE=") {
-				mojoMode = strings.TrimPrefix(v, "MOJO_MODE=")
-				break
-			}
-		}
+		mojoMode := os.Getenv("MOJO_MODE")
 
 		if cwd, err := os.Getwd(); mojoMode != "" && err != nil {
 			idbPath = filepath.Join(cwd, "conf", mojoMode, "influxdb.conf")

--- a/traffic_ops/traffic_ops_golang/config/config.go
+++ b/traffic_ops/traffic_ops_golang/config/config.go
@@ -298,7 +298,19 @@ func LoadConfig(cdnConfPath string, dbConfPath string, riakConfPath string, appV
 
 	idbPath := cfg.InfluxDBConfPath
 	if idbPath == "" {
-		idbPath = filepath.Join(filepath.Dir(cdnConfPath), "influxdb.conf")
+		var mojoMode string
+		for _, v := range os.Environ() {
+			if strings.HasPrefix(v, "MOJO_MODE=") {
+				mojoMode = strings.TrimPrefix(v, "MOJO_MODE=")
+				break
+			}
+		}
+
+		if cwd, err := os.Getwd(); mojoMode != "" && err != nil {
+			idbPath = filepath.Join(cwd, "conf", mojoMode, "influxdb.conf")
+		} else {
+			idbPath = filepath.Join(filepath.Dir(cdnConfPath), "influxdb.conf")
+		}
 	}
 
 	if _, err = os.Stat(idbPath); err != nil {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4292 

With this PR, Traffic Ops will look for influxdb.conf in `./conf/$MOJO_MODE/` if `influxdb_conf_path` is not given in `cdn.conf` and the `MOJO_MODE` environment variable is set to any non-empty string.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Set `MOJO_MODE`, then start Traffic Ops from somewhere such that there is a valid influxdb.conf at `./conf/$MOJO_MODE/influxdb.conf`, then verify that the therein contained was picked up by Traffic Ops by requesting some endpoint that needs Traffic Stats and watching the logs output.

## If this is a bug fix, what versions of Traffic Control are affected?
- 4.1.0
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**