### PR TITLE
Set root ownership of TM logrotate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed #4981 - Cannot create routing regular expression with a blank pattern param in Delivery Service [Related github issues](https://github.com/apache/trafficcontrol/issues/4981)
 - Fixed #4979 - Returns a Bad Request error during server creation with missing profileId [Related github issue](https://github.com/apache/trafficcontrol/issues/4979)
 - Fixed #4237 - Do not return an internal server error when delivery service's capacity is zero. [Related github issue](https://github.com/apache/trafficcontrol/issues/4237)
+- Fixed #2712 - Invalid TM logrotate configuration permissions causing TM logs to be ignored by logrotate. [Related github issue](https://github.com/apache/trafficcontrol/issues/2712)
 - Fixed #3400 - Allow "0" as a TTL value for Static DNS entries [Related github issue](https://github.com/apache/trafficcontrol/issues/3400)
 - Fixed #5050 - Allows the TP administrator to name a TP instance (production, staging, etc) and flag whether it is production or not in traffic_portal_properties.json [Related github issue](https://github.com/apache/trafficcontrol/issues/5050)
 - Fixed #4743 - Validate absolute DNS name requirement on Static DNS entry for CNAME type [Related github issue](https://github.com/apache/trafficcontrol/issues/4743)

--- a/traffic_monitor/build/traffic_monitor.spec
+++ b/traffic_monitor/build/traffic_monitor.spec
@@ -101,7 +101,7 @@ fi
 %defattr(644, traffic_monitor, traffic_monitor, 755)
 %config(noreplace) %attr(600, traffic_monitor, traffic_monitor) /opt/traffic_monitor/conf/traffic_monitor.cfg
 %config(noreplace) %attr(600, traffic_monitor, traffic_monitor) /opt/traffic_monitor/conf/traffic_ops.cfg
-%config(noreplace) /etc/logrotate.d/traffic_monitor
+%config(noreplace) %attr(644, root, root) /etc/logrotate.d/traffic_monitor
 
 %dir /opt/traffic_monitor
 %dir /opt/traffic_monitor/bin


### PR DESCRIPTION
## What does this PR (Pull Request) do?
The TM logrotate config file needs to be owned by root in order for
logrotate to rotate the TM logs.

- [x] This PR fixes #2712

## Which Traffic Control components are affected by this PR?

- Traffic Monitor

## What is the best way to verify this PR?
Install the resulting TM rpm, verify that the ownership of `/etc/logrotate.d/traffic_monitor` is `root:root`.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.x
- 3.x

## The following criteria are ALL met by this PR

- [x] rpm spec file change, no tests
- [x] no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
