### PR TITLE
In monitoring.json ignore non-ONLINE/REPORTED/ADMIN_DOWN caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed ORT config generation not using the coalesce_number_v6 Parameter.
 - Fixed POST deliveryservices/request (designed to simple send an email) regression which erroneously required deep caching type and routing name. [Related github issue](https://github.com/apache/trafficcontrol/issues/4735)
 - Removed audit logging from the `POST /api/x/serverchecks` Traffic Ops API endpoint in order to reduce audit log spam
+- Fixed an issue that caused Traffic Monitor to poll caches that did not have the status ONLINE/REPORTED/ADMIN_DOWN
 - Fixed /deliveryservice_stats regression restricting metric type to a predefined set of values. [Related github issue](https://github.com/apache/trafficcontrol/issues/4740)
 - Fixed audit logging from the `/jobs` APIs to bring them back to the same level of information provided by TO-Perl
 - Fixed `maxRevalDurationDays` validation for `POST /api/1.x/user/current/jobs` and added that validation to the `/api/x/jobs` endpoints

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
@@ -302,6 +302,7 @@ AND cdn.name = $3
 		if err := rows.Scan(&hostName, &fqdn, &status, &cachegroup, &port, &profile, &ttype, &hashID, &serverID); err != nil {
 			return nil, nil, nil, err
 		}
+		cacheStatus := tc.CacheStatusFromString(status.String)
 
 		if ttype.String == tc.MonitorTypeName {
 			monitors = append(monitors, Monitor{
@@ -316,7 +317,8 @@ AND cdn.name = $3
 					},
 				},
 			})
-		} else if strings.HasPrefix(ttype.String, "EDGE") || strings.HasPrefix(ttype.String, "MID") {
+		} else if (strings.HasPrefix(ttype.String, "EDGE") || strings.HasPrefix(ttype.String, "MID")) &&
+			(cacheStatus == tc.CacheStatusOnline || cacheStatus == tc.CacheStatusReported || cacheStatus == tc.CacheStatusAdminDown) {
 			var cacheInterfaces []tc.ServerInterfaceInfo
 			if _, ok := interfacesByNameAndServer[int(serverID.Int64)]; ok {
 				for _, interf := range interfacesByNameAndServer[int(serverID.Int64)] {

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -58,9 +58,13 @@ func TestGetMonitoringServers(t *testing.T) {
 	otherCache.Type = "MID"
 	cacheID := uint64(1)
 	otherCacheID := uint64(2)
+	cache3 := createMockCache("test")
+	cache3.Type = "MID"
+	cache3.Status = string(tc.CacheStatusOffline) // should be ignored
+	cache3ID := uint64(3)
 
 	mock.ExpectBegin()
-	setupMockGetMonitoringServers(mock, monitor, router, []Cache{cache, otherCache}, []uint64{cacheID, otherCacheID}, cdn)
+	setupMockGetMonitoringServers(mock, monitor, router, []Cache{cache, otherCache, cache3}, []uint64{cacheID, otherCacheID, cache3ID}, cdn)
 
 	dbCtx, _ := context.WithTimeout(context.Background(), time.Duration(10)*time.Second)
 	tx, err := db.BeginTx(dbCtx, nil)
@@ -722,7 +726,7 @@ func createMockCache(interfaceName string) Cache {
 	return Cache{
 		CommonServerProperties: CommonServerProperties{
 			Profile:    "cacheProfile",
-			Status:     "cacheStatus",
+			Status:     "REPORTED",
 			Port:       8081,
 			Cachegroup: "cacheCachegroup",
 			HostName:   "cacheHost",


### PR DESCRIPTION
## What does this PR (Pull Request) do?
TM should only poll ONLINE/REPORTED/ADMIN_DOWN caches. This PR filters out caches that don't have one of those statuses from `monitoring.json`.

## Which Traffic Control components are affected by this PR?

- Traffic Monitor
- Traffic Ops

## What is the best way to verify this PR?
With caches of status `REPORTED`, `ONLINE`, `ADMIN_DOWN`, and `OFFLINE` in TO, snapshot their CDN, then view `https://<your-TO-host>/api/3.0/cdns/<your-CDN-name>/configs/monitoring` and verify that it does not contain the `OFFLINE` servers.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.x
- 3.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] Docs not necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)