### PR TITLE
Fix ORT Topology Generation to Omit OFFLINE, Other CDNs, and MSO Origins without DeliveryServiceServers

### DIFF
--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -165,9 +165,8 @@ func AddMetaObjConfigDir(
 		if ds.Topology != nil && *ds.Topology != "" {
 			topology := nameTopologies[TopologyName(*ds.Topology)]
 
-			placement := getTopologyPlacement(tc.CacheGroupName(*server.Cachegroup), topology, cacheGroups)
-			switch placement.CacheTier {
-			case TopologyCacheTierFirst:
+			placement := getTopologyPlacement(tc.CacheGroupName(*server.Cachegroup), topology, cacheGroups, &ds)
+			if placement.IsFirstCacheTier {
 				if ds.FirstHeaderRewrite != nil && *ds.FirstHeaderRewrite != "" || ds.MaxOriginConnections != nil {
 					fileName := FirstHeaderRewriteConfigFileName(*ds.XMLID)
 					scope := tc.ATSConfigMetaDataConfigFileScopeServers
@@ -175,7 +174,8 @@ func AddMetaObjConfigDir(
 						log.Errorln("meta config generation: " + err.Error())
 					}
 				}
-			case TopologyCacheTierInner:
+			}
+			if placement.IsInnerCacheTier {
 				if ds.InnerHeaderRewrite != nil && *ds.InnerHeaderRewrite != "" || ds.MaxOriginConnections != nil {
 					fileName := InnerHeaderRewriteConfigFileName(*ds.XMLID)
 					scope := tc.ATSConfigMetaDataConfigFileScopeServers
@@ -183,7 +183,8 @@ func AddMetaObjConfigDir(
 						log.Errorln("meta config generation: " + err.Error())
 					}
 				}
-			case TopologyCacheTierLast:
+			}
+			if placement.IsLastCacheTier {
 				if ds.LastHeaderRewrite != nil && *ds.LastHeaderRewrite != "" || ds.MaxOriginConnections != nil {
 					fileName := LastHeaderRewriteConfigFileName(*ds.XMLID)
 					scope := tc.ATSConfigMetaDataConfigFileScopeServers

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -39,11 +39,16 @@ const LineCommentParentDotConfig = LineCommentHash
 const ParentConfigParamQStringHandling = "psel.qstring_handling"
 const ParentConfigParamMSOAlgorithm = "mso.algorithm"
 const ParentConfigParamMSOParentRetry = "mso.parent_retry"
-const ParentConfigParamUnavailableServerRetryResponses = "mso.unavailable_server_retry_responses"
-const ParentConfigParamMaxSimpleRetries = "mso.max_simple_retries"
-const ParentConfigParamMaxUnavailableServerRetries = "mso.max_unavailable_server_retries"
+const ParentConfigParamMSOUnavailableServerRetryResponses = "mso.unavailable_server_retry_responses"
+const ParentConfigParamMSOMaxSimpleRetries = "mso.max_simple_retries"
+const ParentConfigParamMSOMaxUnavailableServerRetries = "mso.max_unavailable_server_retries"
 const ParentConfigParamAlgorithm = "algorithm"
 const ParentConfigParamQString = "qstring"
+
+const ParentConfigParamParentRetry = "parent_retry"
+const ParentConfigParamUnavailableServerRetryResponses = "unavailable_server_retry_responses"
+const ParentConfigParamMaxSimpleRetries = "max_simple_retries"
+const ParentConfigParamMaxUnavailableServerRetries = "max_unavailable_server_retries"
 
 const ParentConfigDSParamDefaultMSOAlgorithm = "consistent_hash"
 const ParentConfigDSParamDefaultMSOParentRetry = "both"
@@ -447,32 +452,9 @@ func MakeParentDotConfig(
 			continue
 		}
 
-		msoAlgorithm := ParentConfigDSParamDefaultMSOAlgorithm
-		msoParentRetry := ParentConfigDSParamDefaultMSOParentRetry
-		msoUnavailableServerRetryResponses := ParentConfigDSParamDefaultMSOUnavailableServerRetryResponses
-		msoMaxSimpleRetries := ParentConfigDSParamDefaultMaxSimpleRetries
-		msoMaxUnavailableServerRetries := ParentConfigDSParamDefaultMaxUnavailableServerRetries
-		qStringHandling := ""
-		if ds.ProfileName != nil && *ds.ProfileName != "" {
-			if dsParams, ok := profileParentConfigParams[*ds.ProfileName]; ok {
-				qStringHandling = dsParams[ParentConfigParamQStringHandling] // may be blank, no default
-				if v, ok := dsParams[ParentConfigParamMSOAlgorithm]; ok && strings.TrimSpace(v) != "" {
-					msoAlgorithm = v
-				}
-				if v, ok := dsParams[ParentConfigParamMSOParentRetry]; ok {
-					msoParentRetry = v
-				}
-				if v, ok := dsParams[ParentConfigParamUnavailableServerRetryResponses]; ok {
-					msoUnavailableServerRetryResponses = v
-				}
-				if v, ok := dsParams[ParentConfigParamMaxSimpleRetries]; ok {
-					msoMaxSimpleRetries = v
-				}
-				if v, ok := dsParams[ParentConfigParamMaxUnavailableServerRetries]; ok {
-					msoMaxUnavailableServerRetries = v
-				}
-			}
-		}
+		// Note these Parameters are only used for MSO for legacy DeliveryServiceServers DeliveryServices (except QueryStringHandling which is used by all DeliveryServices).
+		//      Topology DSes use them for all DSes, MSO and non-MSO.
+		dsParams := getParentDSParams(ds, profileParentConfigParams)
 
 		log.Infoln("parent.config processing ds '" + *ds.XMLID + "'")
 
@@ -494,12 +476,8 @@ func MakeParentDotConfig(
 				serverCapabilities,
 				dsRequiredCapabilities,
 				cacheGroups,
-				msoAlgorithm,
-				msoParentRetry,
-				msoUnavailableServerRetryResponses,
-				msoMaxSimpleRetries,
-				msoMaxUnavailableServerRetries,
-				qStringHandling,
+				dsParams,
+				atsMajorVer,
 				dsOrigins[DeliveryServiceID(*ds.ID)],
 			)
 			if err != nil {
@@ -513,7 +491,7 @@ func MakeParentDotConfig(
 		} else if IsTopLevelCache(serverParentCGData) {
 			log.Infoln("parent.config generating top level line for ds '" + *ds.XMLID + "'")
 			parentQStr := "ignore"
-			if qStringHandling == "" && msoAlgorithm == tc.AlgorithmConsistentHash && ds.QStringIgnore != nil && tc.QStringIgnore(*ds.QStringIgnore) == tc.QStringIgnoreUseInCacheKeyAndPassUp {
+			if dsParams.QueryStringHandling == "" && dsParams.Algorithm == tc.AlgorithmConsistentHash && ds.QStringIgnore != nil && tc.QStringIgnore(*ds.QStringIgnore) == tc.QStringIgnoreUseInCacheKeyAndPassUp {
 				parentQStr = "consider"
 			}
 
@@ -541,21 +519,9 @@ func MakeParentDotConfig(
 					log.Warnln("ParentInfo: delivery service " + *ds.XMLID + " has no parent servers")
 				}
 
-				parents, secondaryParents := getMSOParentStrs(&ds, parentInfos[OriginHost(orgURI.Hostname())], atsMajorVer, dsRequiredCapabilities, msoAlgorithm)
-				textLine += parents + secondaryParents + ` round_robin=` + msoAlgorithm + ` qstring=` + parentQStr + ` go_direct=false parent_is_proxy=false`
-
-				parentRetry := msoParentRetry
-				if atsMajorVer >= 6 && parentRetry != "" {
-					if unavailableServerRetryResponsesValid(msoUnavailableServerRetryResponses) {
-						textLine += ` parent_retry=` + parentRetry + ` unavailable_server_retry_responses=` + msoUnavailableServerRetryResponses
-					} else {
-						if msoUnavailableServerRetryResponses != "" {
-							log.Errorln("Malformed unavailable_server_retry_responses parameter '" + msoUnavailableServerRetryResponses + "', not using!")
-						}
-						textLine += ` parent_retry=` + parentRetry
-					}
-					textLine += ` max_simple_retries=` + msoMaxSimpleRetries + ` max_unavailable_server_retries=` + msoMaxUnavailableServerRetries
-				}
+				parents, secondaryParents := getMSOParentStrs(&ds, parentInfos[OriginHost(orgURI.Hostname())], atsMajorVer, dsRequiredCapabilities, dsParams.Algorithm)
+				textLine += parents + secondaryParents + ` round_robin=` + dsParams.Algorithm + ` qstring=` + parentQStr + ` go_direct=false parent_is_proxy=false`
+				textLine += getParentRetryStr(true, atsMajorVer, dsParams.ParentRetry, dsParams.UnavailableServerRetryResponses, dsParams.MaxSimpleRetries, dsParams.MaxUnavailableServerRetries)
 				textLine += "\n" // TODO remove, and join later on "\n" instead of ""?
 				textArr = append(textArr, textLine)
 			}
@@ -590,7 +556,7 @@ func MakeParentDotConfig(
 				// TODO refactor this logic, hard to understand (transliterated from Perl)
 				dsQSH := queryStringHandling
 				if dsQSH == "" {
-					dsQSH = qStringHandling
+					dsQSH = dsParams.QueryStringHandling
 				}
 				parentQStr := dsQSH
 				if parentQStr == "" {
@@ -630,6 +596,85 @@ func MakeParentDotConfig(
 	return text
 }
 
+type ParentDSParams struct {
+	Algorithm                       string
+	ParentRetry                     string
+	UnavailableServerRetryResponses string
+	MaxSimpleRetries                string
+	MaxUnavailableServerRetries     string
+	QueryStringHandling             string
+}
+
+// getDSParameters returns the Delivery Service Profile Parameters used in parent.config.
+// If Parameters don't exist, defaults are returned. Non-MSO Delivery Services default to no custom retry logic (we should reevaluate that).
+// Note these Parameters are only used for MSO for legacy DeliveryServiceServers DeliveryServices.
+//      Topology DSes use them for all DSes, MSO and non-MSO.
+func getParentDSParams(ds tc.DeliveryServiceNullableV30, profileParentConfigParams map[string]map[string]string) ParentDSParams {
+	params := ParentDSParams{}
+	isMSO := ds.MultiSiteOrigin != nil && *ds.MultiSiteOrigin
+	if isMSO {
+		params.Algorithm = ParentConfigDSParamDefaultMSOAlgorithm
+		params.ParentRetry = ParentConfigDSParamDefaultMSOParentRetry
+		params.UnavailableServerRetryResponses = ParentConfigDSParamDefaultMSOUnavailableServerRetryResponses
+		params.MaxSimpleRetries = ParentConfigDSParamDefaultMaxSimpleRetries
+		params.MaxUnavailableServerRetries = ParentConfigDSParamDefaultMaxUnavailableServerRetries
+	}
+	if ds.ProfileName == nil || *ds.ProfileName == "" {
+		return params
+	}
+	dsParams, ok := profileParentConfigParams[*ds.ProfileName]
+	if !ok {
+		return params
+	}
+
+	params.QueryStringHandling = dsParams[ParentConfigParamQStringHandling] // may be blank, no default
+	// TODO deprecate & remove "mso." Parameters - there was never a reason to restrict these settings to MSO.
+	if isMSO {
+		if v, ok := dsParams[ParentConfigParamMSOAlgorithm]; ok && strings.TrimSpace(v) != "" {
+			params.Algorithm = v
+		}
+		if v, ok := dsParams[ParentConfigParamMSOParentRetry]; ok {
+			params.ParentRetry = v
+		}
+		if v, ok := dsParams[ParentConfigParamMSOUnavailableServerRetryResponses]; ok {
+			if v != "" && !unavailableServerRetryResponsesValid(v) {
+				log.Errorln("Malformed " + ParentConfigParamMSOUnavailableServerRetryResponses + " parameter '" + v + "', not using!")
+			} else if v != "" {
+				params.UnavailableServerRetryResponses = v
+			}
+		}
+		if v, ok := dsParams[ParentConfigParamMSOMaxSimpleRetries]; ok {
+			params.MaxSimpleRetries = v
+		}
+		if v, ok := dsParams[ParentConfigParamMSOMaxUnavailableServerRetries]; ok {
+			params.MaxUnavailableServerRetries = v
+		}
+	}
+
+	// Even if the DS is MSO, non-"mso." Parameters override "mso." ones, because they're newer.
+	if v, ok := dsParams[ParentConfigParamAlgorithm]; ok && strings.TrimSpace(v) != "" {
+		params.Algorithm = v
+	}
+	if v, ok := dsParams[ParentConfigParamParentRetry]; ok {
+		params.ParentRetry = v
+	}
+	if v, ok := dsParams[ParentConfigParamUnavailableServerRetryResponses]; ok {
+		if v != "" && !unavailableServerRetryResponsesValid(v) {
+			log.Errorln("Malformed " + ParentConfigParamUnavailableServerRetryResponses + " parameter '" + v + "', not using!")
+		} else if v != "" {
+			params.UnavailableServerRetryResponses = v
+		}
+	}
+	if v, ok := dsParams[ParentConfigParamMaxSimpleRetries]; ok {
+		params.MaxSimpleRetries = v
+	}
+	if v, ok := dsParams[ParentConfigParamMaxUnavailableServerRetries]; ok {
+		params.MaxUnavailableServerRetries = v
+	}
+
+	return params
+}
+
 func GetTopologyParentConfigLine(
 	server *tc.ServerNullable,
 	servers []tc.ServerNullable,
@@ -640,12 +685,8 @@ func GetTopologyParentConfigLine(
 	serverCapabilities map[int]map[ServerCapability]struct{},
 	dsRequiredCapabilities map[int]map[ServerCapability]struct{},
 	cacheGroups map[tc.CacheGroupName]tc.CacheGroupNullable,
-	msoAlgorithm string,
-	msoParentRetry string,
-	msoUnavailableServerRetryResponses string,
-	msoMaxSimpleRetries string,
-	msoMaxUnavailableServerRetries string,
-	qStringHandling string,
+	dsParams ParentDSParams,
+	atsMajorVer int,
 	dsOrigins map[ServerID]struct{},
 ) (string, error) {
 	txt := ""
@@ -666,7 +707,7 @@ func GetTopologyParentConfigLine(
 
 	txt += "dest_domain=" + orgURI.Hostname() + " port=" + orgURI.Port()
 
-	serverPlacement := getTopologyPlacement(tc.CacheGroupName(*server.Cachegroup), topology, cacheGroups)
+	serverPlacement := getTopologyPlacement(tc.CacheGroupName(*server.Cachegroup), topology, cacheGroups, ds)
 	if !serverPlacement.InTopology {
 		return "", nil // server isn't in topology, no error
 	}
@@ -684,17 +725,47 @@ func GetTopologyParentConfigLine(
 	if len(secondaryParents) > 0 {
 		txt += ` secondary_parent="` + strings.Join(secondaryParents, `;`) + `"`
 	}
-	txt += ` round_robin=` + getTopologyRoundRobin(ds, serverParams, serverPlacement.IsLastTier, msoAlgorithm)
+	txt += ` round_robin=` + getTopologyRoundRobin(ds, serverParams, serverPlacement.IsLastCacheTier, dsParams.Algorithm)
 	txt += ` go_direct=` + getTopologyGoDirect(ds, serverPlacement.IsLastTier)
-	txt += ` qstring=` + getTopologyQueryString(ds, serverParams, serverPlacement.IsLastTier, msoAlgorithm, qStringHandling)
-	txt += getTopologyParentIsProxyStr(serverPlacement.IsLastTier)
+	txt += ` qstring=` + getTopologyQueryString(ds, serverParams, serverPlacement.IsLastCacheTier, dsParams.Algorithm, dsParams.QueryStringHandling)
+	txt += getTopologyParentIsProxyStr(serverPlacement.IsLastCacheTier)
+	txt += getParentRetryStr(serverPlacement.IsLastCacheTier, atsMajorVer, dsParams.ParentRetry, dsParams.UnavailableServerRetryResponses, dsParams.MaxSimpleRetries, dsParams.MaxUnavailableServerRetries)
 	txt += " # topology '" + *ds.Topology + "'"
 	txt += "\n"
 	return txt, nil
 }
 
-func getTopologyParentIsProxyStr(serverIsLastTier bool) string {
-	if serverIsLastTier {
+// getParentRetryStr builds the parent retry directive(s).
+// If atsMajorVer < 6, "" is returned (ATS 5 and below don't support retry directives).
+// If isLastCacheTier is false, "" is returned. This argument exists to simplify usage.
+// If parentRetry is "", "" is returned (because the other directives are unused if parent_retry doesn't exist). This is allowed to simplify usage.
+// If unavailableServerRetryResponses is not "", it must be valid. Use unavailableServerRetryResponsesValid to check.
+// If maxSimpleRetries is "", ParentConfigDSParamDefaultMaxSimpleRetries will be used.
+// If maxUnavailableServerRetries is "", ParentConfigDSParamDefaultMaxUnavailableServerRetries will be used.
+func getParentRetryStr(isLastCacheTier bool, atsMajorVer int, parentRetry string, unavailableServerRetryResponses string, maxSimpleRetries string, maxUnavailableServerRetries string) string {
+	if !isLastCacheTier || // allow !isLastCacheTier, to simplify usage.
+		parentRetry == "" || // allow parentRetry to be empty, to simplify usage.
+		atsMajorVer < 6 { // ATS 5 and below don't support parent_retry directives
+		return ""
+	}
+
+	if maxSimpleRetries == "" {
+		maxSimpleRetries = ParentConfigDSParamDefaultMaxSimpleRetries
+	}
+	if maxUnavailableServerRetries == "" {
+		maxUnavailableServerRetries = ParentConfigDSParamDefaultMaxUnavailableServerRetries
+	}
+
+	txt := ` parent_retry=` + parentRetry
+	if unavailableServerRetryResponses != "" {
+		txt += ` unavailable_server_retry_responses=` + unavailableServerRetryResponses
+	}
+	txt += ` max_simple_retries=` + maxSimpleRetries + ` max_unavailable_server_retries=` + maxUnavailableServerRetries
+	return txt
+}
+
+func getTopologyParentIsProxyStr(serverIsLastCacheTier bool) string {
+	if serverIsLastCacheTier {
 		return ` parent_is_proxy=false`
 	}
 	return ""
@@ -704,7 +775,7 @@ func getTopologyRoundRobin(
 	ds *tc.DeliveryServiceNullableV30,
 	serverParams map[string]string,
 	serverIsLastTier bool,
-	msoAlgorithm string,
+	algorithm string,
 ) string {
 	roundRobinConsistentHash := "consistent_hash"
 	if !serverIsLastTier {
@@ -713,8 +784,8 @@ func getTopologyRoundRobin(
 	if parentSelectAlg := serverParams[ParentConfigParamAlgorithm]; ds.OriginShield != nil && *ds.OriginShield != "" && strings.TrimSpace(parentSelectAlg) != "" {
 		return parentSelectAlg
 	}
-	if ds.MultiSiteOrigin != nil && *ds.MultiSiteOrigin {
-		return msoAlgorithm
+	if algorithm != "" {
+		return algorithm
 	}
 	return roundRobinConsistentHash
 }
@@ -736,11 +807,11 @@ func getTopologyQueryString(
 	ds *tc.DeliveryServiceNullableV30,
 	serverParams map[string]string,
 	serverIsLastTier bool,
-	msoAlgorithm string,
+	algorithm string,
 	qStringHandling string,
 ) string {
 	if serverIsLastTier {
-		if ds.MultiSiteOrigin != nil && *ds.MultiSiteOrigin && qStringHandling == "" && msoAlgorithm == tc.AlgorithmConsistentHash && ds.QStringIgnore != nil && tc.QStringIgnore(*ds.QStringIgnore) == tc.QStringIgnoreUseInCacheKeyAndPassUp {
+		if ds.MultiSiteOrigin != nil && *ds.MultiSiteOrigin && qStringHandling == "" && algorithm == tc.AlgorithmConsistentHash && ds.QStringIgnore != nil && tc.QStringIgnore(*ds.QStringIgnore) == tc.QStringIgnoreUseInCacheKeyAndPassUp {
 			return "consider"
 		}
 		return "ignore"

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -1068,6 +1068,7 @@ func TestMakeParentDotConfigTopologiesOmitDifferentCDNParents(t *testing.T) {
 		t.Errorf("Topology expected to omit parent with a different CDN, actual: '%v'", txt)
 	}
 }
+
 func TestMakeParentDotConfigTopologiesMSO(t *testing.T) {
 	serverName := "myserver"
 	toolName := "myToolName"
@@ -1080,6 +1081,7 @@ func TestMakeParentDotConfigTopologiesMSO(t *testing.T) {
 	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
 	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
 	ds1.Topology = util.StrPtr("t0")
+	ds1.MultiSiteOrigin = util.BoolPtr(true)
 
 	dses := []tc.DeliveryServiceNullableV30{*ds1}
 
@@ -1189,14 +1191,359 @@ func TestMakeParentDotConfigTopologiesMSO(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !strings.Contains(txt, "myorigin0") {
+		t.Errorf("expected origin0 with DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
+	}
+	if strings.Contains(txt, "myorigin1") {
+		t.Errorf("expected no origin1 without DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
+	}
+}
+
+func TestMakeParentDotConfigTopologiesMSOParams(t *testing.T) {
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	ds1 := makeParentDS()
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+	ds1.Topology = util.StrPtr("t0")
+	ds1.ProfileName = util.StrPtr("ds1Profile")
+	ds1.ProfileID = util.IntPtr(994)
+	ds1.MultiSiteOrigin = util.BoolPtr(true)
+
+	dses := []tc.DeliveryServiceNullableV30{*ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMSOAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      "consistent_hash",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMSOParentRetry,
+			ConfigFile: "parent.config",
+			Value:      "both",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMSOUnavailableServerRetryResponses,
+			ConfigFile: "parent.config",
+			Value:      `"400,503"`,
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMSOMaxSimpleRetries,
+			ConfigFile: "parent.config",
+			Value:      "14",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMSOMaxUnavailableServerRetries,
+			ConfigFile: "parent.config",
+			Value:      "9",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "8",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+	server.Cachegroup = util.StrPtr("edgeCG")
+	server.CachegroupID = util.IntPtr(400)
+
+	origin0 := makeTestParentServer()
+	origin0.Cachegroup = util.StrPtr("originCG")
+	origin0.CachegroupID = util.IntPtr(500)
+	origin0.HostName = util.StrPtr("myorigin0")
+	origin0.ID = util.IntPtr(45)
+	setIP(origin0, "192.168.2.2")
+	origin0.Type = tc.OriginTypeName
+	origin0.TypeID = util.IntPtr(991)
+
+	origin1 := makeTestParentServer()
+	origin1.Cachegroup = util.StrPtr("originCG")
+	origin1.CachegroupID = util.IntPtr(500)
+	origin1.HostName = util.StrPtr("myorigin1")
+	origin1.ID = util.IntPtr(46)
+	setIP(origin1, "192.168.2.3")
+	origin1.Type = tc.OriginTypeName
+	origin1.TypeID = util.IntPtr(991)
+
+	servers := []tc.ServerNullable{*server, *origin0, *origin1}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "originCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = origin0.Cachegroup
+	eCG.ParentCachegroupID = origin0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	oCG := &tc.CacheGroupNullable{}
+	oCG.Name = origin0.Cachegroup
+	oCG.ID = origin0.CachegroupID
+	oCGType := tc.CacheGroupOriginTypeName
+	oCG.Type = &oCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *oCG}
+
+	dss := []tc.DeliveryServiceServer{
+		tc.DeliveryServiceServer{
+			Server:          util.IntPtr(*origin0.ID),
+			DeliveryService: util.IntPtr(*ds1.ID),
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	txt := MakeParentDotConfig(toolName, toURL, dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
 	if !strings.Contains(txt, "myorigin0") {
 		t.Errorf("expected origin0 with DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
 	}
 	if strings.Contains(txt, "myorigin1") {
 		t.Errorf("expected no origin1 without DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "parent_retry=both") {
+		t.Errorf("expected DS MSO parent_retry param 'both', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, `unavailable_server_retry_responses="400,503"`) {
+		t.Errorf(`expected DS MSO unavailable_server_retry_responses param '"400,503"'', actual: '%v'`, txt)
+	}
+	if !strings.Contains(txt, "max_simple_retries=14") {
+		t.Errorf("expected DS MSO max_simple_retries param '14', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "max_unavailable_server_retries=9") {
+		t.Errorf("expected DS MSO max_unavailable_server_retries param '9', actual: '%v'", txt)
+	}
+}
+
+func TestMakeParentDotConfigTopologiesParams(t *testing.T) {
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	ds1 := makeParentDS()
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+	ds1.Topology = util.StrPtr("t0")
+	ds1.ProfileName = util.StrPtr("ds1Profile")
+	ds1.ProfileID = util.IntPtr(994)
+	ds1.MultiSiteOrigin = util.BoolPtr(true)
+
+	dses := []tc.DeliveryServiceNullableV30{*ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      "consistent_hash",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamParentRetry,
+			ConfigFile: "parent.config",
+			Value:      "both",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamUnavailableServerRetryResponses,
+			ConfigFile: "parent.config",
+			Value:      `"400,503"`,
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMaxSimpleRetries,
+			ConfigFile: "parent.config",
+			Value:      "14",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMaxUnavailableServerRetries,
+			ConfigFile: "parent.config",
+			Value:      "9",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "8",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+	server.Cachegroup = util.StrPtr("edgeCG")
+	server.CachegroupID = util.IntPtr(400)
+
+	origin0 := makeTestParentServer()
+	origin0.Cachegroup = util.StrPtr("originCG")
+	origin0.CachegroupID = util.IntPtr(500)
+	origin0.HostName = util.StrPtr("myorigin0")
+	origin0.ID = util.IntPtr(45)
+	setIP(origin0, "192.168.2.2")
+	origin0.Type = tc.OriginTypeName
+	origin0.TypeID = util.IntPtr(991)
+
+	origin1 := makeTestParentServer()
+	origin1.Cachegroup = util.StrPtr("originCG")
+	origin1.CachegroupID = util.IntPtr(500)
+	origin1.HostName = util.StrPtr("myorigin1")
+	origin1.ID = util.IntPtr(46)
+	setIP(origin1, "192.168.2.3")
+	origin1.Type = tc.OriginTypeName
+	origin1.TypeID = util.IntPtr(991)
+
+	servers := []tc.ServerNullable{*server, *origin0, *origin1}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "originCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = origin0.Cachegroup
+	eCG.ParentCachegroupID = origin0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	oCG := &tc.CacheGroupNullable{}
+	oCG.Name = origin0.Cachegroup
+	oCG.ID = origin0.CachegroupID
+	oCGType := tc.CacheGroupOriginTypeName
+	oCG.Type = &oCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *oCG}
+
+	dss := []tc.DeliveryServiceServer{
+		tc.DeliveryServiceServer{
+			Server:          util.IntPtr(*origin0.ID),
+			DeliveryService: util.IntPtr(*ds1.ID),
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	txt := MakeParentDotConfig(toolName, toURL, dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "myorigin0") {
+		t.Errorf("expected origin0 with DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
+	}
+	if strings.Contains(txt, "myorigin1") {
+		t.Errorf("expected no origin1 without DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "parent_retry=both") {
+		t.Errorf("expected DS MSO parent_retry param 'both', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, `unavailable_server_retry_responses="400,503"`) {
+		t.Errorf(`expected DS MSO unavailable_server_retry_responses param '"400,503"'', actual: '%v'`, txt)
+	}
+	if !strings.Contains(txt, "max_simple_retries=14") {
+		t.Errorf("expected DS MSO max_simple_retries param '14', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "max_unavailable_server_retries=9") {
+		t.Errorf("expected DS MSO max_unavailable_server_retries param '9', actual: '%v'", txt)
 	}
 }
 

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -786,6 +786,420 @@ func TestMakeParentDotConfigTopologiesCapabilities(t *testing.T) {
 	}
 }
 
+func TestMakeParentDotConfigTopologiesOmitOfflineParents(t *testing.T) {
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	ds0 := makeParentDS()
+	ds0Type := tc.DSTypeHTTP
+	ds0.Type = &ds0Type
+	ds0.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreUseInCacheKeyAndPassUp))
+	ds0.OrgServerFQDN = util.StrPtr("http://ds0.example.net")
+
+	ds1 := makeParentDS()
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+	ds1.Topology = util.StrPtr("t0")
+
+	dses := []tc.DeliveryServiceNullableV30{*ds0, *ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+	server.Cachegroup = util.StrPtr("edgeCG")
+	server.CachegroupID = util.IntPtr(400)
+
+	mid0 := makeTestParentServer()
+	mid0.Cachegroup = util.StrPtr("midCG")
+	mid0.CachegroupID = util.IntPtr(500)
+	mid0.HostName = util.StrPtr("mymid-should-omit")
+	mid0.ID = util.IntPtr(45)
+	setIP(mid0, "192.168.2.2")
+	statusOffline := string(tc.CacheStatusOffline)
+	mid0.Status = &statusOffline
+
+	mid1 := makeTestParentServer()
+	mid1.Cachegroup = util.StrPtr("midCG")
+	mid1.CachegroupID = util.IntPtr(500)
+	mid1.HostName = util.StrPtr("mymid1")
+	mid1.ID = util.IntPtr(46)
+	setIP(mid1, "192.168.2.3")
+
+	servers := []tc.ServerNullable{*server, *mid0, *mid1}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = mid0.Cachegroup
+	eCG.ParentCachegroupID = mid0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	mCG := &tc.CacheGroupNullable{}
+	mCG.Name = mid0.Cachegroup
+	mCG.ID = mid0.CachegroupID
+	mCGType := tc.CacheGroupMidTypeName
+	mCG.Type = &mCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *mCG}
+
+	dss := []tc.DeliveryServiceServer{
+		tc.DeliveryServiceServer{
+			Server:          util.IntPtr(*server.ID),
+			DeliveryService: util.IntPtr(*ds0.ID),
+		},
+		tc.DeliveryServiceServer{
+			Server:          util.IntPtr(*server.ID),
+			DeliveryService: util.IntPtr(*ds1.ID),
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	txt := MakeParentDotConfig(toolName, toURL, dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	if !strings.Contains(txt, "dest_domain=ds0.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
+		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	}
+
+	if strings.Contains(txt, "should-omit") {
+		t.Errorf("Topology expected to omit OFFLINE mid, actual: '%v'", txt)
+	}
+}
+
+func TestMakeParentDotConfigTopologiesOmitDifferentCDNParents(t *testing.T) {
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	ds0 := makeParentDS()
+	ds0Type := tc.DSTypeHTTP
+	ds0.Type = &ds0Type
+	ds0.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreUseInCacheKeyAndPassUp))
+	ds0.OrgServerFQDN = util.StrPtr("http://ds0.example.net")
+
+	ds1 := makeParentDS()
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+	ds1.Topology = util.StrPtr("t0")
+
+	dses := []tc.DeliveryServiceNullableV30{*ds0, *ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+	server.Cachegroup = util.StrPtr("edgeCG")
+	server.CachegroupID = util.IntPtr(400)
+
+	mid0 := makeTestParentServer()
+	mid0.Cachegroup = util.StrPtr("midCG")
+	mid0.CachegroupID = util.IntPtr(500)
+	mid0.HostName = util.StrPtr("mymid-should-omit")
+	mid0.ID = util.IntPtr(45)
+	setIP(mid0, "192.168.2.2")
+	mid0.CDNName = util.StrPtr("myCDN-different-than-edge")
+	mid0CDNID := *server.CDNID + 1
+	mid0.CDNID = &mid0CDNID
+
+	mid1 := makeTestParentServer()
+	mid1.Cachegroup = util.StrPtr("midCG")
+	mid1.CachegroupID = util.IntPtr(500)
+	mid1.HostName = util.StrPtr("mymid1")
+	mid1.ID = util.IntPtr(46)
+	setIP(mid1, "192.168.2.3")
+
+	servers := []tc.ServerNullable{*server, *mid0, *mid1}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = mid0.Cachegroup
+	eCG.ParentCachegroupID = mid0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	mCG := &tc.CacheGroupNullable{}
+	mCG.Name = mid0.Cachegroup
+	mCG.ID = mid0.CachegroupID
+	mCGType := tc.CacheGroupMidTypeName
+	mCG.Type = &mCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *mCG}
+
+	dss := []tc.DeliveryServiceServer{
+		tc.DeliveryServiceServer{
+			Server:          util.IntPtr(*server.ID),
+			DeliveryService: util.IntPtr(*ds0.ID),
+		},
+		tc.DeliveryServiceServer{
+			Server:          util.IntPtr(*server.ID),
+			DeliveryService: util.IntPtr(*ds1.ID),
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	txt := MakeParentDotConfig(toolName, toURL, dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	if !strings.Contains(txt, "dest_domain=ds0.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
+		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	}
+
+	if strings.Contains(txt, "should-omit") {
+		t.Errorf("Topology expected to omit parent with a different CDN, actual: '%v'", txt)
+	}
+}
+func TestMakeParentDotConfigTopologiesMSO(t *testing.T) {
+	serverName := "myserver"
+	toolName := "myToolName"
+	toURL := "https://myto.example.net"
+
+	ds1 := makeParentDS()
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+	ds1.Topology = util.StrPtr("t0")
+
+	dses := []tc.DeliveryServiceNullableV30{*ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+	server.Cachegroup = util.StrPtr("edgeCG")
+	server.CachegroupID = util.IntPtr(400)
+
+	origin0 := makeTestParentServer()
+	origin0.Cachegroup = util.StrPtr("originCG")
+	origin0.CachegroupID = util.IntPtr(500)
+	origin0.HostName = util.StrPtr("myorigin0")
+	origin0.ID = util.IntPtr(45)
+	setIP(origin0, "192.168.2.2")
+	origin0.Type = tc.OriginTypeName
+	origin0.TypeID = util.IntPtr(991)
+
+	origin1 := makeTestParentServer()
+	origin1.Cachegroup = util.StrPtr("originCG")
+	origin1.CachegroupID = util.IntPtr(500)
+	origin1.HostName = util.StrPtr("myorigin1")
+	origin1.ID = util.IntPtr(46)
+	setIP(origin1, "192.168.2.3")
+	origin1.Type = tc.OriginTypeName
+	origin1.TypeID = util.IntPtr(991)
+
+	servers := []tc.ServerNullable{*server, *origin0, *origin1}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "originCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = origin0.Cachegroup
+	eCG.ParentCachegroupID = origin0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	oCG := &tc.CacheGroupNullable{}
+	oCG.Name = origin0.Cachegroup
+	oCG.ID = origin0.CachegroupID
+	oCGType := tc.CacheGroupOriginTypeName
+	oCG.Type = &oCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *oCG}
+
+	dss := []tc.DeliveryServiceServer{
+		tc.DeliveryServiceServer{
+			Server:          util.IntPtr(*origin0.ID),
+			DeliveryService: util.IntPtr(*ds1.ID),
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	txt := MakeParentDotConfig(toolName, toURL, dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn)
+
+	testComment(t, txt, serverName, toolName, toURL)
+
+	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
+		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
+		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "myorigin0") {
+		t.Errorf("expected origin0 with DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
+	}
+	if strings.Contains(txt, "myorigin1") {
+		t.Errorf("expected no origin1 without DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
+	}
+}
+
 func makeTestParentServer() *tc.ServerNullable {
 	server := &tc.ServerNullable{}
 	server.ProfileID = util.IntPtr(42)

--- a/traffic_ops_ort/atstccfg/cfgfile/cfgfile.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/cfgfile.go
@@ -131,16 +131,17 @@ func GetTOData(cfg config.TCCfg) (*config.TOData, error) {
 			}
 			toData.DeliveryServices = dses
 
-			allDSesHaveTopologies := true
-			for _, ds := range toData.DeliveryServices {
-				if ds.CDNID == nil || *ds.CDNID != *server.CDNID {
-					continue
-				}
-				if ds.Topology == nil {
-					allDSesHaveTopologies = false
-					break
-				}
-			}
+			// TODO uncomment when MSO Origins are changed to not use DSS, to avoid the DSS call if it isn't necessary
+			// allDSesHaveTopologies := true
+			// for _, ds := range toData.DeliveryServices {
+			// 	if ds.CDNID == nil || *ds.CDNID != *server.CDNID {
+			// 		continue
+			// 	}
+			// 	if ds.Topology == nil {
+			// 		allDSesHaveTopologies = false
+			// 		break
+			// 	}
+			// }
 
 			dssF := func() error {
 				defer func(start time.Time) { log.Infof("dssF took %v\n", time.Since(start)) }(time.Now())
@@ -208,9 +209,8 @@ func GetTOData(cfg config.TCCfg) (*config.TOData, error) {
 			if !cfg.RevalOnly {
 				fs = append([]func() error{uriSignKeysF, urlSigKeysF}, fs...) // skip keys for reval-only, which doesn't need them
 			}
-			if !cfg.RevalOnly && !allDSesHaveTopologies {
+			if !cfg.RevalOnly { // TODO when MSO Origins are changed to not use DSS, we can add `&& !allDSesHaveTopologies` here, to avoid the DSS call if it isn't necessary
 				// skip DSS if reval-only (which doesn't need DSS)
-				// or if all DSes have Topologies (which don't use DSS)
 				fs = append([]func() error{dssF}, fs...)
 			}
 

--- a/traffic_ops_ort/atstccfg/cfgfile/topologyheaderrewritedotconfig.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/topologyheaderrewritedotconfig.go
@@ -35,6 +35,18 @@ func GetConfigFileServerTopologyHeaderRewrite(toData *config.TOData, fileName st
 	dsName = strings.TrimPrefix(dsName, atscfg.HeaderRewriteInnerPrefix)
 	dsName = strings.TrimPrefix(dsName, atscfg.HeaderRewriteLastPrefix)
 
+	tier := atscfg.TopologyCacheTierInvalid
+	switch {
+	case strings.HasPrefix(fileName, atscfg.HeaderRewriteFirstPrefix):
+		tier = atscfg.TopologyCacheTierFirst
+	case strings.HasPrefix(fileName, atscfg.HeaderRewriteInnerPrefix):
+		tier = atscfg.TopologyCacheTierInner
+	case strings.HasPrefix(fileName, atscfg.HeaderRewriteLastPrefix):
+		tier = atscfg.TopologyCacheTierLast
+	default:
+		return "", "", "", errors.New("topology header rewrite called for unknown tier: '" + fileName + "'")
+	}
+
 	tcDS := tc.DeliveryServiceNullableV30{}
 	for _, ds := range toData.DeliveryServices {
 		if ds.XMLID == nil || *ds.XMLID != dsName {
@@ -53,9 +65,9 @@ func GetConfigFileServerTopologyHeaderRewrite(toData *config.TOData, fileName st
 		toData.TOURL,
 		tcDS,
 		toData.Topologies,
-		toData.CacheGroups,
 		toData.Servers,
 		toData.ServerCapabilities,
 		toData.DSRequiredCapabilities[*tcDS.ID],
+		tier,
 	), atscfg.ContentTypeHeaderRewriteDotConfig, atscfg.LineCommentHeaderRewriteDotConfig, nil
 }


### PR DESCRIPTION
Fixes ORT generation for Topology DSes to omit parents that are
not ONLINE or REPORTED, as well as parents assigned to other CDNs.

Also fixes Topologies on MSO Delivery Services to consider
Delivery Service Servers, and omit Origins not assigned to a DS.

Includes tests.
No docs, no interface change.
No changelog, no interface change, and bug is not in an existing release.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests.
Run ORT with a Topology DS, with OFFLINE Mids in the Topology, and Mids in other CDNs in the Topology, and with MSO Delivery Services with assigned Origin Servers, and with Origin Servers belonging to other DSes which aren't assigned; verify OFFLINE and other-cdn mids are not added to parent.config, verify MSO origins are in parent.config, verify origins on other DSes are not on the DS parent.config line.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
