### PR TITLE
Add ORT Secondary Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added Traffic Monitor: Support astats CSV output. Includes http_polling_format configuration option to specify the Accept header sent to stats endpoints. Adds CSV parsing ability (~100% faster than JSON) to the astats plugin
 - Added Traffic Monitor: Support stats over http CSV output. Officially supported in ATS 9.0 unless backported by users. Users must also include `system_stats.so` when using stats over http in order to keep all the same functionality (and included stats) that astats_over_http provides.
 - Added ability for Traffic Monitor to determine health of cache based on interface data and aggregate data. Using the new `stats_over_http` `health.polling.format` value that allows monitoring of multiple interfaces will first require that *all* Traffic Monitors monitoring the affected cache server be upgraded.
+- Added ORT option to try all primaries before falling back to secondary parents, via Delivery Service Profile Parameter "try_all_primaries_before_secondary".
 - Traffic Ops, Traffic Ops ORT, Traffic Monitor, Traffic Stats, and Grove are now compiled using Go version 1.15.
 - Added `--traffic_ops_insecure=<0|1>` optional option to traffic_ops_ort.pl
 - Added User-Agent string to Traffic Router log output.

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -743,6 +743,20 @@ Routing Name
 ------------
 A DNS label in the Delivery Service's domain that forms the :abbr:`FQDN (Fully Qualified Domain Name)` that is used by clients to request content. All together, the constructed :abbr:`FQDN (Fully Qualified Domain Name)` looks like: :file:`{Delivery Service Routing Name}.{Delivery Service xml_id}.{CDN Subdomain}.{CDN Domain}.{Top-Level Domain}`\ [#xmlValid]_.
 
+.. _ds-secondary-mode:
+
+Secondary Mode
+--------------
+By default, cache configuration will immediately try a Secondary Parent when the first Primary Parent fails.
+
+.. note:: Recall for Delivery Services using pre-Topology DeliveryService-Server Assignments, the Primary Parent is the Parent CacheGroup of the Edge Cache's CacheGroup, and the Secondary Parent is the Secondary CacheGroup of the Edge's Cachegroup. For Topology Delivery Services, the Primary is the first assigned Parent in the Topology, and the Secondary is the second assigned Parent in the Topology.
+
+This is typically ideal when the requested object is likely to be in the cache of all CacheGroups, since the Secondary parent is the first Primary Parent in the hash ring for its own CacheGroup. However, it is likely slightly higher latency to go to the further parent.
+
+However, if the resource is unlikely to be in cache, for example with live streaming video, it's probably ideal to try another parent in the same Primary CacheGroup.
+
+To configure a Delivery Service to retry all Primary Parents first before falling back to Secondary Parents, create a Parameter assigned to the Delivery Service's Profile with the Config File ``parent.config`` and the Name ``try_all_primaries_before_secondary``. The Parameter Value is ignored.
+
 .. _ds-servers:
 
 Servers

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -743,20 +743,6 @@ Routing Name
 ------------
 A DNS label in the Delivery Service's domain that forms the :abbr:`FQDN (Fully Qualified Domain Name)` that is used by clients to request content. All together, the constructed :abbr:`FQDN (Fully Qualified Domain Name)` looks like: :file:`{Delivery Service Routing Name}.{Delivery Service xml_id}.{CDN Subdomain}.{CDN Domain}.{Top-Level Domain}`\ [#xmlValid]_.
 
-.. _ds-secondary-mode:
-
-Secondary Mode
---------------
-By default, cache configuration will immediately try a Secondary Parent when the first Primary Parent fails.
-
-.. note:: Recall for Delivery Services using pre-Topology DeliveryService-Server Assignments, the Primary Parent is the Parent CacheGroup of the Edge Cache's CacheGroup, and the Secondary Parent is the Secondary CacheGroup of the Edge's Cachegroup. For Topology Delivery Services, the Primary is the first assigned Parent in the Topology, and the Secondary is the second assigned Parent in the Topology.
-
-This is typically ideal when the requested object is likely to be in the cache of all CacheGroups, since the Secondary parent is the first Primary Parent in the hash ring for its own CacheGroup. However, it is likely slightly higher latency to go to the further parent.
-
-However, if the resource is unlikely to be in cache, for example with live streaming video, it's probably ideal to try another parent in the same Primary CacheGroup.
-
-To configure a Delivery Service to retry all Primary Parents first before falling back to Secondary Parents, create a Parameter assigned to the Delivery Service's Profile with the Config File ``parent.config`` and the Name ``try_all_primaries_before_secondary``. The Parameter Value is ignored.
-
 .. _ds-servers:
 
 Servers

--- a/docs/source/overview/profiles_and_parameters.rst
+++ b/docs/source/overview/profiles_and_parameters.rst
@@ -494,6 +494,7 @@ This configuration file is generated entirely from :term:`Cache Group` relations
 - ``qstring``
 - ``psel.qstring_handling``
 - ``not_a_parent`` - unlike the other Parameters listed (which have a 1:1 correspondence with Apache Traffic Server configuration options), this Parameter affects the generation of :term:`parent` relationships between :term:`cache servers`. When a Parameter with this :ref:`parameter-name` and Config File exists on a :ref:`Profile <profiles>` used by a :term:`cache server`, it will not be added as a :term:`parent` of any other :term:`cache server`, regardless of :term:`Cache Group` hierarchy. Under ordinary circumstances, there's no real reason for this Parameter to exist.
+- ``try_all_primaries_before_secondary`` - on a Delivery Service Profile, if this exists, try all primary parents before failing over to secondary parents, which may be ideal if objects are unlikely to be in cache. The default behavior is to immediately fail to a secondary, which is ideal if objects are likely to be in cache, as the first consistent-hashed secondary parent will be the primary parent in its own cachegroup and therefore receive requests for that object from clients near its own cachegroup.
 
 Additionally, :term:`Delivery Service` :ref:`Profiles <ds-profile>` can have special Parameters with the :ref:`parameter-name` "mso.parent_retry" to :ref:`multi-site-origin-qht`.
 


### PR DESCRIPTION
Adds support to ORT to set the ATS parent secondary_mode=2 setting, which will make ATS try all primary parents before falling back to secondaries. The default is to immediately try a secondary on primary failure.

Immediately trying a secondary is usually preferable when the object is likely to be in cache, such as VOD libraries.
Trying all primaries first is preferable when the object is unlikely to be in cache very long, such as LIVE video.
This allows Delivery Services to set their behavior based on the use case.

Includes tests.
Includes changelog.
Includes docs.

- [x] This PR Closes #5097

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests.
Add the DS Parameter (see docs), run ORT, verify `secondary_mode` directive is inserted in parent.config line.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information