### PR TITLE
TR: set cache to unavailable if not found in TM health data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed ORT config generation not using the coalesce_number_v6 Parameter.
 - Fixed POST deliveryservices/request (designed to simple send an email) regression which erroneously required deep caching type and routing name. [Related github issue](https://github.com/apache/trafficcontrol/issues/4735)
 - Removed audit logging from the `POST /api/x/serverchecks` Traffic Ops API endpoint in order to reduce audit log spam
+- Fixed an issue that causes Traffic Router to mistakenly route to caches that had recently been set from ADMIN_DOWN to OFFLINE
 - Fixed an issue that caused Traffic Monitor to poll caches that did not have the status ONLINE/REPORTED/ADMIN_DOWN
 - Fixed /deliveryservice_stats regression restricting metric type to a predefined set of values. [Related github issue](https://github.com/apache/trafficcontrol/issues/4740)
 - Fixed audit logging from the `/jobs` APIs to bring them back to the same level of information provided by TO-Perl

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/edge/Node.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/edge/Node.java
@@ -200,9 +200,18 @@ public class Node extends DefaultHashable {
 
 	@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
 	public void setState(final JsonNode state) {
-		final boolean isAvailable = JsonUtils.optBoolean(state, "isAvailable", true);
-		final boolean ipv4Available = JsonUtils.optBoolean(state, "ipv4Available", true);
-		final boolean ipv6Available = JsonUtils.optBoolean(state, "ipv6Available", true);
+		final boolean ipv4Available;
+		final boolean ipv6Available;
+		if (state == null) {
+			LOGGER.warn("got null health state for " + fqdn + ". Setting it to unavailable!");
+			isAvailable = false;
+			ipv4Available = false;
+			ipv6Available = false;
+		} else {
+			isAvailable = JsonUtils.optBoolean(state, "isAvailable", true);
+			ipv4Available = JsonUtils.optBoolean(state, "ipv4Available", true);
+			ipv6Available = JsonUtils.optBoolean(state, "ipv6Available", true);
+		}
 
 		final List<InetRecord> newlyAvailable = new ArrayList<>();
 		final List<InetRecord> newlyUnavailable = new ArrayList<>();


### PR DESCRIPTION
## What does this PR (Pull Request) do?
In Traffic Router, set a cache to unavailable if it's not found in the TM health data (CrStates). Otherwise, when a cache is set to OFFLINE and removed from TM health data, there is a short window where TR sets it to available until it has finished processing the new snapshot. OFFLINE caches should never be considered available.

## Which Traffic Control components are affected by this PR?
- Traffic Router

## What is the best way to verify this PR?
This is a race condition, which makes it difficult to verify manually, but it can be attempted by:
1. Assign a DS to a single cache
2. Repeatedly request the DS
3. Set the cache to ADMIN_DOWN, snapshot (TR should be returning 5xx shortly)
4. Set the cache to OFFLINE, snapshot

Without this fix, you might be able to get TR to 302 to the offlined cache for a short period until TR has finished processing the new snapshot. With this fix, that should not happen.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.x
- 3.x

## The following criteria are ALL met by this PR

- [x] This section of the code currently lacks tests, but I did manually verify the expected behavior before/after
- [x] bug fix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
