### PR TITLE
Updated Traffic Portal Installation Doc to NodeJS 12

### DIFF
--- a/docs/source/admin/traffic_portal/installation.rst
+++ b/docs/source/admin/traffic_portal/installation.rst
@@ -16,7 +16,7 @@
 *****************************
 Traffic Portal Administration
 *****************************
-Traffic Portal is only supported on CentOS Linux distributions version 7.x. It runs on `NodeJS <https://nodejs.org/>`_ and requires version 6.0 or higher.
+Traffic Portal is only supported on CentOS Linux distributions version 7.x. It runs on `NodeJS <https://nodejs.org/>`_ and requires version 12 or higher.
 
 
 Installing Traffic Portal
@@ -24,7 +24,7 @@ Installing Traffic Portal
 
 #. Download the Traffic Portal RPM from `Apache Jenkins <https://builds.apache.org/job/trafficcontrol-master-build/>`_ or build the Traffic Portal RPM from source using the instructions in :ref:`dev-building`.
 #. Copy the Traffic Portal RPM to your server
-#. Install NodeJS. This can be done by building it from source, installing with :manpage:`yum(8)` if it happens to be in your available repositories (at version 6.0+), or using the NodeSource setup script.
+#. Install NodeJS. This can be done by building it from source, installing with :manpage:`yum(8)` if it happens to be in your available repositories (at version 12+), or using the NodeSource setup script.
 
 	.. code-block:: bash
 		:caption: Installing NodeJS using the NodeSource Setup Script


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR updates Traffic Portal docs to use NodeJS 12

I tried using NodeJS 6 (epel yum repo) in CentOS 7 and it does not work anymore.

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
Documentation update only.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
