### PR TITLE
Idempotentiate create_tables.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added Delivery Service Raw Remap `__RANGE_DIRECTIVE__` directive to allow inserting the Range Directive after the Raw Remap text. This allows Raw Remaps which manipulate the Range.
 - Added an option for `coordinateRange` in the RGB configuration file, so that in case a client doesn't have a postal code, we can still determine if it should be allowed or not, based on whether or not the latitude/ longitude of the client falls within the supplied ranges. [Related github issue](https://github.com/apache/trafficcontrol/issues/4372)
 - Fixed #3548 - Prevents DS regexes with non-consecutive order from generating invalid CRconfig/snapshot.
+- Fixes #4984 - Lets `create_tables.sql` be run concurrently without issue
 - Fixed #5020, #5021 - Creating an ASN with the same number and same cache group should not be allowed.
 - Fixed #5006 - Traffic Ops now generates the Monitoring on-the-fly if the snapshot doesn't exist, and logs an error. This fixes upgrading to 4.x to not break the CDN until a Snapshot is done.
 - Fixed #4680 - Change Content-Type to application/json for TR auth calls

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -189,7 +189,8 @@ CREATE TABLE IF NOT EXISTS asn (
     id bigint NOT NULL,
     asn bigint NOT NULL,
     cachegroup bigint DEFAULT '0'::bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89468_primary PRIMARY KEY (id, cachegroup)
 );
 
 
@@ -228,7 +229,8 @@ CREATE TABLE IF NOT EXISTS cachegroup (
     type bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
     fallback_to_closest boolean DEFAULT TRUE,
-    coordinate bigint
+    coordinate bigint,
+    CONSTRAINT idx_89476_primary PRIMARY KEY (id, type)
 );
 
 
@@ -285,7 +287,8 @@ CREATE TABLE IF NOT EXISTS cachegroup_localization_method (
 CREATE TABLE IF NOT EXISTS cachegroup_parameter (
     cachegroup bigint DEFAULT '0'::bigint NOT NULL,
     parameter bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89484_primary PRIMARY KEY (cachegroup, parameter)
 );
 
 
@@ -298,7 +301,8 @@ ALTER TABLE cachegroup_parameter OWNER TO traffic_ops;
 CREATE TABLE IF NOT EXISTS capability (
     name text NOT NULL,
     description text,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT capability_pkey PRIMARY KEY (name)
 );
 
 ALTER TABLE capability OWNER TO traffic_ops;
@@ -313,7 +317,8 @@ CREATE TABLE IF NOT EXISTS cdn (
     last_updated timestamp with time zone DEFAULT now() NOT NULL,
     dnssec_enabled boolean DEFAULT false NOT NULL,
     domain_name text NOT NULL,
-    CONSTRAINT cdn_domain_name_unique UNIQUE (domain_name)
+    CONSTRAINT cdn_domain_name_unique UNIQUE (domain_name),
+    CONSTRAINT idx_89491_primary PRIMARY KEY (id)
 );
 
 
@@ -410,7 +415,8 @@ CREATE TABLE IF NOT EXISTS deliveryservice (
     deep_caching_type deep_caching_type NOT NULL DEFAULT 'NEVER',
     fq_pacing_rate bigint DEFAULT 0,
     anonymous_blocking_enabled boolean NOT NULL DEFAULT FALSE,
-    CONSTRAINT routing_name_not_empty CHECK ((length(routing_name) > 0))
+    CONSTRAINT routing_name_not_empty CHECK ((length(routing_name) > 0)),
+    CONSTRAINT idx_89502_primary PRIMARY KEY (id, type)
 );
 
 
@@ -445,7 +451,8 @@ CREATE TABLE IF NOT EXISTS deliveryservice_regex (
     deliveryservice bigint NOT NULL,
     regex bigint NOT NULL,
     set_number bigint DEFAULT '0'::bigint,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89517_primary PRIMARY KEY (deliveryservice, regex)
 );
 
 
@@ -464,7 +471,8 @@ CREATE TABLE IF NOT EXISTS deliveryservice_request (
     last_edited_by_id bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
     deliveryservice jsonb NOT NULL,
-    status workflow_states NOT NULL
+    status workflow_states NOT NULL,
+    CONSTRAINT deliveryservice_request_pkey PRIMARY KEY (id)
 );
 
 ALTER TABLE deliveryservice_request OWNER TO traffic_ops;
@@ -478,7 +486,8 @@ CREATE TABLE IF NOT EXISTS deliveryservice_request_comment (
     deliveryservice_request_id bigint NOT NULL,
     id bigserial,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
-    value text NOT NULL
+    value text NOT NULL,
+    CONSTRAINT deliveryservice_request_comment_pkey PRIMARY KEY (id)
 );
 
 --
@@ -488,7 +497,8 @@ CREATE TABLE IF NOT EXISTS deliveryservice_request_comment (
 CREATE TABLE IF NOT EXISTS deliveryservice_server (
     deliveryservice bigint NOT NULL,
     server bigint NOT NULL,
-    last_updated timestamp with time zone DEFAULT now() NOT NULL
+    last_updated timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT idx_89521_primary PRIMARY KEY (deliveryservice, server)
 );
 
 
@@ -501,7 +511,8 @@ ALTER TABLE deliveryservice_server OWNER TO traffic_ops;
 CREATE TABLE IF NOT EXISTS deliveryservice_tmuser (
     deliveryservice bigint NOT NULL,
     tm_user_id bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89525_primary PRIMARY KEY (deliveryservice, tm_user_id)
 );
 
 
@@ -514,7 +525,8 @@ ALTER TABLE deliveryservice_tmuser OWNER TO traffic_ops;
 CREATE TABLE IF NOT EXISTS division (
     id bigint NOT NULL,
     name text NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89531_primary PRIMARY KEY (id)
 );
 
 
@@ -550,7 +562,8 @@ CREATE TABLE IF NOT EXISTS federation (
     cname text NOT NULL,
     description text,
     ttl integer NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89541_primary PRIMARY KEY (id)
 );
 
 
@@ -563,7 +576,8 @@ ALTER TABLE federation OWNER TO traffic_ops;
 CREATE TABLE IF NOT EXISTS federation_deliveryservice (
     federation bigint NOT NULL,
     deliveryservice bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89549_primary PRIMARY KEY (federation, deliveryservice)
 );
 
 
@@ -576,7 +590,8 @@ ALTER TABLE federation_deliveryservice OWNER TO traffic_ops;
 CREATE TABLE IF NOT EXISTS federation_federation_resolver (
     federation bigint NOT NULL,
     federation_resolver bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89553_primary PRIMARY KEY (federation, federation_resolver)
 );
 
 
@@ -611,7 +626,8 @@ CREATE TABLE IF NOT EXISTS federation_resolver (
     id bigint NOT NULL,
     ip_address text NOT NULL,
     type bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89559_primary PRIMARY KEY (id)
 );
 
 
@@ -646,7 +662,8 @@ CREATE TABLE IF NOT EXISTS federation_tmuser (
     federation bigint NOT NULL,
     tm_user bigint NOT NULL,
     role bigint,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89567_primary PRIMARY KEY (federation, tm_user)
 );
 
 
@@ -661,7 +678,8 @@ CREATE TABLE IF NOT EXISTS hwinfo (
     serverid bigint NOT NULL,
     description text NOT NULL,
     val text NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89583_primary PRIMARY KEY (id)
 );
 
 
@@ -706,7 +724,8 @@ CREATE TABLE IF NOT EXISTS job (
     entered_time timestamp with time zone NOT NULL,
     job_user bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
-    job_deliveryservice bigint
+    job_deliveryservice bigint,
+    CONSTRAINT idx_89593_primary PRIMARY KEY (id)
 );
 
 
@@ -722,7 +741,8 @@ CREATE TABLE IF NOT EXISTS job_agent (
     description text,
     active integer DEFAULT 0 NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
-    CONSTRAINT job_agent_name_unique UNIQUE (name)
+    CONSTRAINT job_agent_name_unique UNIQUE (name),
+    CONSTRAINT idx_89603_primary PRIMARY KEY (id)
 );
 
 
@@ -778,7 +798,8 @@ CREATE TABLE IF NOT EXISTS job_status (
     name text,
     description text,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
-    CONSTRAINT job_status_name_unique UNIQUE (name)
+    CONSTRAINT job_status_name_unique UNIQUE (name),
+    CONSTRAINT idx_89624_primary PRIMARY KEY (id)
 );
 
 
@@ -815,7 +836,8 @@ CREATE TABLE IF NOT EXISTS log (
     message text NOT NULL,
     tm_user bigint NOT NULL,
     ticketnum text,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89634_primary PRIMARY KEY (id, tm_user)
 );
 
 
@@ -859,7 +881,8 @@ CREATE TABLE IF NOT EXISTS origin (
     profile bigint,
     cachegroup bigint,
     tenant bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT origin_pkey PRIMARY KEY (id)
 );
 
 ALTER TABLE origin OWNER TO traffic_ops;
@@ -875,7 +898,8 @@ CREATE TABLE IF NOT EXISTS parameter (
     value text NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
     secure boolean DEFAULT false NOT NULL,
-    CONSTRAINT unique_param UNIQUE (name, config_file, value)
+    CONSTRAINT unique_param UNIQUE (name, config_file, value),
+    CONSTRAINT idx_89644_primary PRIMARY KEY (id)
 );
 
 
@@ -919,7 +943,8 @@ CREATE TABLE IF NOT EXISTS phys_location (
     email text,
     comments text,
     region bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89655_primary PRIMARY KEY (id)
 );
 
 
@@ -956,7 +981,8 @@ CREATE TABLE IF NOT EXISTS profile (
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
     type profile_type NOT NULL,
     cdn bigint NOT NULL,
-    routing_disabled boolean NOT NULL DEFAULT FALSE
+    routing_disabled boolean NOT NULL DEFAULT FALSE,
+    CONSTRAINT idx_89665_primary PRIMARY KEY (id)
 );
 
 
@@ -990,7 +1016,8 @@ ALTER SEQUENCE profile_id_seq OWNED BY profile.id;
 CREATE TABLE IF NOT EXISTS profile_parameter (
     profile bigint NOT NULL,
     parameter bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89673_primary PRIMARY KEY (profile, parameter)
 );
 
 
@@ -1004,7 +1031,8 @@ CREATE TABLE IF NOT EXISTS regex (
     id bigint NOT NULL,
     pattern text DEFAULT ''::text NOT NULL,
     type bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89679_primary PRIMARY KEY (id, type)
 );
 
 
@@ -1039,7 +1067,8 @@ CREATE TABLE IF NOT EXISTS region (
     id bigint NOT NULL,
     name text NOT NULL,
     division bigint NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89690_primary PRIMARY KEY (id)
 );
 
 
@@ -1076,7 +1105,8 @@ CREATE TABLE IF NOT EXISTS role (
     description text,
     priv_level bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
-    CONSTRAINT role_name_unique UNIQUE (name)
+    CONSTRAINT role_name_unique UNIQUE (name),
+    CONSTRAINT idx_89700_primary PRIMARY KEY (id)
 );
 
 
@@ -1155,7 +1185,8 @@ CREATE TABLE IF NOT EXISTS server (
     guid text,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
     https_port bigint,
-    reval_pending boolean NOT NULL DEFAULT FALSE
+    reval_pending boolean NOT NULL DEFAULT FALSE,
+    CONSTRAINT idx_89709_primary PRIMARY KEY (id, cachegroup, type, status, profile)
 );
 
 
@@ -1220,7 +1251,8 @@ CREATE TABLE IF NOT EXISTS servercheck (
     bc bigint,
     bd bigint,
     be bigint,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89722_primary PRIMARY KEY (id, server)
 );
 
 
@@ -1253,7 +1285,8 @@ ALTER SEQUENCE servercheck_id_seq OWNED BY servercheck.id;
 CREATE TABLE IF NOT EXISTS snapshot (
     cdn text NOT NULL,
     content json NOT NULL,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT snapshot_pkey PRIMARY KEY (cdn)
 );
 
 ALTER TABLE snapshot OWNER TO traffic_ops;
@@ -1270,7 +1303,8 @@ CREATE TABLE IF NOT EXISTS staticdnsentry (
     ttl bigint DEFAULT '3600'::bigint NOT NULL,
     deliveryservice bigint NOT NULL,
     cachegroup bigint,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT idx_89729_primary PRIMARY KEY (id)
 );
 
 
@@ -1308,7 +1342,8 @@ CREATE TABLE IF NOT EXISTS stats_summary (
     stat_name text NOT NULL,
     stat_value double precision NOT NULL,
     summary_time timestamp with time zone DEFAULT now() NOT NULL,
-    stat_date date
+    stat_date date,
+    CONSTRAINT idx_89740_primary PRIMARY KEY (id)
 );
 
 
@@ -1344,7 +1379,8 @@ CREATE TABLE IF NOT EXISTS status (
     name text NOT NULL,
     description text,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
-    CONSTRAINT status_name_unique UNIQUE (name)
+    CONSTRAINT status_name_unique UNIQUE (name),
+    CONSTRAINT idx_89751_primary PRIMARY KEY (id)
 );
 
 
@@ -1380,7 +1416,8 @@ CREATE TABLE IF NOT EXISTS steering_target (
     target bigint NOT NULL,
     value bigint NOT NULL,
     last_updated timestamp with time zone DEFAULT now() NOT NULL,
-    type bigint NOT NULL
+    type bigint NOT NULL,
+    CONSTRAINT idx_89759_primary PRIMARY KEY (deliveryservice, target)
 );
 
 
@@ -1395,7 +1432,8 @@ CREATE TABLE IF NOT EXISTS tenant (
     name text UNIQUE NOT NULL,
     active boolean NOT NULL DEFAULT FALSE,
     parent_id bigint DEFAULT 1 CHECK (id != parent_id),
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT tenant_pkey PRIMARY KEY (id)
 );
 
 --
@@ -1425,7 +1463,8 @@ CREATE TABLE IF NOT EXISTS tm_user (
     country text,
     token text,
     registration_sent timestamp with time zone,
-    tenant_id bigint NOT NULL
+    tenant_id bigint NOT NULL,
+    CONSTRAINT idx_89765_primary PRIMARY KEY (id)
 );
 
 
@@ -1468,7 +1507,8 @@ CREATE TABLE IF NOT EXISTS to_extension (
     servercheck_short_name text,
     servercheck_column_name text,
     type bigint NOT NULL,
-    last_updated timestamp with time zone DEFAULT now() NOT NULL
+    last_updated timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT idx_89776_primary PRIMARY KEY (id)
 );
 
 
@@ -1505,7 +1545,8 @@ CREATE TABLE IF NOT EXISTS type (
     description text,
     use_in_table text,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
-    CONSTRAINT type_name_unique UNIQUE(name)
+    CONSTRAINT type_name_unique UNIQUE(name),
+    CONSTRAINT idx_89786_primary PRIMARY KEY (id)
 );
 
 
@@ -1740,324 +1781,6 @@ ALTER TABLE ONLY to_extension ALTER COLUMN id SET DEFAULT nextval('to_extension_
 
 ALTER TABLE ONLY type ALTER COLUMN id SET DEFAULT nextval('type_id_seq'::regclass);
 
---
--- Name: idx_89468_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY asn
-    ADD CONSTRAINT idx_89468_primary PRIMARY KEY (id, cachegroup);
-
-
---
--- Name: idx_89476_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup
-    ADD CONSTRAINT idx_89476_primary PRIMARY KEY (id, type);
-
---
--- Name: idx_89484_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup_parameter
-    ADD CONSTRAINT idx_89484_primary PRIMARY KEY (cachegroup, parameter);
-
---
--- Name: capability_pkey; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY capability
-    ADD CONSTRAINT capability_pkey PRIMARY KEY (name);
-
---
--- Name: idx_89491_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cdn
-    ADD CONSTRAINT idx_89491_primary PRIMARY KEY (id);
-
---
--- Name: coordinate_pkey; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY coordinate
-    ADD CONSTRAINT coordinate_pkey PRIMARY KEY (id);
-
---
--- Name: idx_89502_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice
-    ADD CONSTRAINT idx_89502_primary PRIMARY KEY (id, type);
-
-
---
--- Name: idx_89517_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_regex
-    ADD CONSTRAINT idx_89517_primary PRIMARY KEY (deliveryservice, regex);
-
---
--- Name: deliveryservice_request_pkey; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_request
-    ADD CONSTRAINT deliveryservice_request_pkey PRIMARY KEY (id);
-
---
--- Name: deliveryservice_request_comment_pkey; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_request_comment
-    ADD CONSTRAINT deliveryservice_request_comment_pkey PRIMARY KEY (id);
-
---
--- Name: idx_89521_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_server
-    ADD CONSTRAINT idx_89521_primary PRIMARY KEY (deliveryservice, server);
-
-
---
--- Name: idx_89525_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_tmuser
-    ADD CONSTRAINT idx_89525_primary PRIMARY KEY (deliveryservice, tm_user_id);
-
-
---
--- Name: idx_89531_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY division
-    ADD CONSTRAINT idx_89531_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89541_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation
-    ADD CONSTRAINT idx_89541_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89549_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_deliveryservice
-    ADD CONSTRAINT idx_89549_primary PRIMARY KEY (federation, deliveryservice);
-
-
---
--- Name: idx_89553_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_federation_resolver
-    ADD CONSTRAINT idx_89553_primary PRIMARY KEY (federation, federation_resolver);
-
-
---
--- Name: idx_89559_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_resolver
-    ADD CONSTRAINT idx_89559_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89567_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_tmuser
-    ADD CONSTRAINT idx_89567_primary PRIMARY KEY (federation, tm_user);
-
-
---
--- Name: idx_89583_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY hwinfo
-    ADD CONSTRAINT idx_89583_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89593_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY job
-    ADD CONSTRAINT idx_89593_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89603_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY job_agent
-    ADD CONSTRAINT idx_89603_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89624_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY job_status
-    ADD CONSTRAINT idx_89624_primary PRIMARY KEY (id);
-
---
--- Name: idx_89634_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY log
-    ADD CONSTRAINT idx_89634_primary PRIMARY KEY (id, tm_user);
-
---
--- Name: origin_pkey; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY origin
-    ADD CONSTRAINT origin_pkey PRIMARY KEY (id);
-
---
--- Name: idx_89644_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY parameter
-    ADD CONSTRAINT idx_89644_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89655_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY phys_location
-    ADD CONSTRAINT idx_89655_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89665_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY profile
-    ADD CONSTRAINT idx_89665_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89673_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY profile_parameter
-    ADD CONSTRAINT idx_89673_primary PRIMARY KEY (profile, parameter);
-
-
---
--- Name: idx_89679_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY regex
-    ADD CONSTRAINT idx_89679_primary PRIMARY KEY (id, type);
-
-
---
--- Name: idx_89690_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY region
-    ADD CONSTRAINT idx_89690_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89700_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY role
-    ADD CONSTRAINT idx_89700_primary PRIMARY KEY (id);
-
---
--- Name: idx_89709_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY server
-    ADD CONSTRAINT idx_89709_primary PRIMARY KEY (id, cachegroup, type, status, profile);
-
-
---
--- Name: idx_89722_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY servercheck
-    ADD CONSTRAINT idx_89722_primary PRIMARY KEY (id, server);
-
---
--- Name: snapshot_pkey; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY snapshot
-    ADD CONSTRAINT snapshot_pkey PRIMARY KEY (cdn);
-
---
--- Name: idx_89729_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY staticdnsentry
-    ADD CONSTRAINT idx_89729_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89740_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY stats_summary
-    ADD CONSTRAINT idx_89740_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89751_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY status
-    ADD CONSTRAINT idx_89751_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89759_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY steering_target
-    ADD CONSTRAINT idx_89759_primary PRIMARY KEY (deliveryservice, target);
-
---
--- Name: tenant_pkey; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY tenant
-    ADD CONSTRAINT tenant_pkey PRIMARY KEY (id);
-
---
--- Name: idx_89765_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY tm_user
-    ADD CONSTRAINT idx_89765_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89776_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY to_extension
-    ADD CONSTRAINT idx_89776_primary PRIMARY KEY (id);
-
-
---
--- Name: idx_89786_primary; Type: CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY type
-    ADD CONSTRAINT idx_89786_primary PRIMARY KEY (id);
 
 --
 -- Name: idx_89468_cr_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -1543,16 +1543,21 @@ CREATE TABLE IF NOT EXISTS user_role (
 
 ALTER TABLE user_role OWNER TO traffic_ops;
 
---
--- Name: profile_type_values; Type: VIEW; Schema: public; Owner: traffic_ops
---
+DO $$ BEGIN
+IF NOT EXISTS (SELECT FROM information_schema.tables
+    WHERE table_name = 'profile_type_values'
+    AND table_type = 'VIEW') THEN
+    --
+    -- Name: profile_type_values; Type: VIEW; Schema: public; Owner: traffic_ops
+    --
 
-CREATE VIEW profile_type_values AS
-    SELECT unnest(enum_range(NULL::profile_type)) AS VALUE
-        ORDER BY (unnest(enum_range(NULL::profile_type)));
+    CREATE VIEW profile_type_values AS
+        SELECT unnest(enum_range(NULL::profile_type)) AS VALUE
+            ORDER BY (unnest(enum_range(NULL::profile_type)));
 
-
-ALTER TABLE profile_type_values OWNER TO traffic_ops;
+    ALTER TABLE profile_type_values OWNER TO traffic_ops;
+END IF;
+END$$;
 
 --
 -- Name: id; Type: DEFAULT; Schema: public; Owner: traffic_ops

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -41,7 +41,7 @@ SET search_path = public, pg_catalog;
 -- Name: on_update_current_timestamp_last_updated(); Type: FUNCTION; Schema: public; Owner: traffic_ops
 --
 
-CREATE FUNCTION on_update_current_timestamp_last_updated() RETURNS trigger
+CREATE OR REPLACE FUNCTION on_update_current_timestamp_last_updated() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -2318,286 +2318,85 @@ CREATE INDEX IF NOT EXISTS origin_cachegroup_fkey ON origin USING btree (cachegr
 
 CREATE INDEX IF NOT EXISTS origin_tenant_fkey ON origin USING btree (tenant);
 
-
 --
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON api_capability FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: idx_89786_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON asn FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON cachegroup FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON cachegroup_parameter FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON capability FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON cdn FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON coordinate FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON deliveryservice FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON deliveryservice_regex FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON deliveryservice_request FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON deliveryservice_request_comment FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON deliveryservice_server FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON deliveryservice_tmuser FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON division FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON federation FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON federation_deliveryservice FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON federation_federation_resolver FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON federation_resolver FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON federation_tmuser FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON hwinfo FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON job FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON job_agent FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON job_status FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON log FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON origin FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON parameter FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON phys_location FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON profile FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON profile_parameter FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON regex FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON region FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON role FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON role_capability FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON server FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON servercheck FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON snapshot FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON staticdnsentry FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON status FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON steering_target FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON tenant FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON tm_user FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON type FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
-
---
--- Name: on_update_current_timestamp; Type: TRIGGER; Schema: public; Owner: traffic_ops
---
-
-CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON user_role FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
+-- Add on_update_current_timestamp TRIGGER to all tables
+--
+DO $$
+DECLARE
+    table_names VARCHAR[] := CAST(ARRAY[
+        'api_capability',
+        'asn',
+        'cachegroup',
+        'cachegroup_parameter',
+        'capability',
+        'cdn',
+        'coordinate',
+        'deliveryservice',
+        'deliveryservice_regex',
+        'deliveryservice_request',
+        'deliveryservice_request_comment',
+        'deliveryservice_server',
+        'deliveryservice_tmuser',
+        'division',
+        'federation',
+        'federation_deliveryservice',
+        'federation_federation_resolver',
+        'federation_resolver',
+        'federation_tmuser',
+        'hwinfo',
+        'job',
+        'job_agent',
+        'job_status',
+        'log',
+        'origin',
+        'parameter',
+        'phys_location',
+        'profile',
+        'profile_parameter',
+        'regex',
+        'region',
+        'role',
+        'role_capability',
+        'server',
+        'servercheck',
+        'snapshot',
+        'staticdnsentry',
+        'status',
+        'steering_target',
+        'tenant',
+        'tm_user',
+        'type',
+        'user_role'
+    ] AS VARCHAR[]);
+    table_name TEXT;
+    trigger_name TEXT := 'on_update_current_timestamp';
+    trigger_exists BOOLEAN;
+BEGIN
+    FOREACH table_name IN ARRAY table_names
+    LOOP
+        EXECUTE FORMAT('SELECT EXISTS (
+            SELECT
+            FROM pg_catalog.pg_trigger
+            WHERE tgname = ''%s''
+            AND tgrelid = CAST(''%s'' AS REGCLASS))
+            ',
+            QUOTE_IDENT(trigger_name),
+            QUOTE_IDENT(table_name)) INTO trigger_exists;
+        IF NOT trigger_exists
+        THEN
+            EXECUTE FORMAT('
+                    CREATE TRIGGER %s
+                    BEFORE UPDATE ON %s
+                    FOR EACH ROW
+                        EXECUTE PROCEDURE %s_last_updated();
+                ',
+                QUOTE_IDENT(trigger_name),
+                QUOTE_IDENT(table_name),
+                QUOTE_IDENT(trigger_name)
+            );
+        END IF;
+    END LOOP;
+END$$;
 
 --
 -- Name: fk_atsprofile_atsparameters_atsparameters1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -2398,564 +2398,665 @@ BEGIN
     END LOOP;
 END$$;
 
---
--- Name: fk_atsprofile_atsparameters_atsparameters1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY profile_parameter
-    ADD CONSTRAINT fk_atsprofile_atsparameters_atsparameters1 FOREIGN KEY (parameter) REFERENCES parameter(id) ON DELETE CASCADE;
-
-
---
--- Name: fk_atsprofile_atsparameters_atsprofile1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY profile_parameter
-    ADD CONSTRAINT fk_atsprofile_atsparameters_atsprofile1 FOREIGN KEY (profile) REFERENCES profile(id) ON DELETE CASCADE;
-
-
---
--- Name: fk_cdn1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice
-    ADD CONSTRAINT fk_cdn1 FOREIGN KEY (cdn_id) REFERENCES cdn(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
-
-
---
--- Name: fk_cdn2; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY server
-    ADD CONSTRAINT fk_cdn2 FOREIGN KEY (cdn_id) REFERENCES cdn(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
-
-
---
--- Name: fk_cg_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup
-    ADD CONSTRAINT fk_cg_1 FOREIGN KEY (parent_cachegroup_id) REFERENCES cachegroup(id);
-
-
---
--- Name: fk_cg_param_cachegroup1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup_parameter
-    ADD CONSTRAINT fk_cg_param_cachegroup1 FOREIGN KEY (cachegroup) REFERENCES cachegroup(id) ON DELETE CASCADE;
-
-
---
--- Name: fk_cg_secondary; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup
-    ADD CONSTRAINT fk_cg_secondary FOREIGN KEY (secondary_parent_cachegroup_id) REFERENCES cachegroup(id);
-
-
---
--- Name: fk_cg_type1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup
-    ADD CONSTRAINT fk_cg_type1 FOREIGN KEY (type) REFERENCES type(id);
-
-
---
--- Name: fk_contentserver_atsprofile1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY server
-    ADD CONSTRAINT fk_contentserver_atsprofile1 FOREIGN KEY (profile) REFERENCES profile(id);
-
-
---
--- Name: fk_contentserver_contentserverstatus1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY server
-    ADD CONSTRAINT fk_contentserver_contentserverstatus1 FOREIGN KEY (status) REFERENCES status(id);
-
-
---
--- Name: fk_contentserver_contentservertype1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY server
-    ADD CONSTRAINT fk_contentserver_contentservertype1 FOREIGN KEY (type) REFERENCES type(id);
-
-
---
--- Name: fk_contentserver_phys_location1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY server
-    ADD CONSTRAINT fk_contentserver_phys_location1 FOREIGN KEY (phys_location) REFERENCES phys_location(id);
-
-
---
--- Name: fk_cran_cachegroup1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY asn
-    ADD CONSTRAINT fk_cran_cachegroup1 FOREIGN KEY (cachegroup) REFERENCES cachegroup(id);
-
-
---
--- Name: fk_deliveryservice_profile1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice
-    ADD CONSTRAINT fk_deliveryservice_profile1 FOREIGN KEY (profile) REFERENCES profile(id);
-
-
---
--- Name: fk_deliveryservice_type1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice
-    ADD CONSTRAINT fk_deliveryservice_type1 FOREIGN KEY (type) REFERENCES type(id);
-
-
---
--- Name: fk_ds_to_cs_contentserver1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_server
-    ADD CONSTRAINT fk_ds_to_cs_contentserver1 FOREIGN KEY (server) REFERENCES server(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_ds_to_cs_deliveryservice1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_server
-    ADD CONSTRAINT fk_ds_to_cs_deliveryservice1 FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_ds_to_regex_deliveryservice1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_regex
-    ADD CONSTRAINT fk_ds_to_regex_deliveryservice1 FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_ds_to_regex_regex1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_regex
-    ADD CONSTRAINT fk_ds_to_regex_regex1 FOREIGN KEY (regex) REFERENCES regex(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_ext_type; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY to_extension
-    ADD CONSTRAINT fk_ext_type FOREIGN KEY (type) REFERENCES type(id);
-
-
---
--- Name: fk_federation_federation_resolver1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_federation_resolver
-    ADD CONSTRAINT fk_federation_federation_resolver1 FOREIGN KEY (federation) REFERENCES federation(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_federation_mapping_type; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_resolver
-    ADD CONSTRAINT fk_federation_mapping_type FOREIGN KEY (type) REFERENCES type(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_federation_resolver_to_fed1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_federation_resolver
-    ADD CONSTRAINT fk_federation_resolver_to_fed1 FOREIGN KEY (federation_resolver) REFERENCES federation_resolver(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_federation_tmuser_federation; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_tmuser
-    ADD CONSTRAINT fk_federation_tmuser_federation FOREIGN KEY (federation) REFERENCES federation(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_federation_tmuser_role; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_tmuser
-    ADD CONSTRAINT fk_federation_tmuser_role FOREIGN KEY (role) REFERENCES role(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_federation_tmuser_tmuser; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_tmuser
-    ADD CONSTRAINT fk_federation_tmuser_tmuser FOREIGN KEY (tm_user) REFERENCES tm_user(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_federation_to_ds1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_deliveryservice
-    ADD CONSTRAINT fk_federation_to_ds1 FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_federation_to_fed1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY federation_deliveryservice
-    ADD CONSTRAINT fk_federation_to_fed1 FOREIGN KEY (federation) REFERENCES federation(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_hwinfo1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY hwinfo
-    ADD CONSTRAINT fk_hwinfo1 FOREIGN KEY (serverid) REFERENCES server(id) ON DELETE CASCADE;
-
-
---
--- Name: fk_job_agent_id1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY job
-    ADD CONSTRAINT fk_job_agent_id1 FOREIGN KEY (agent) REFERENCES job_agent(id) ON DELETE CASCADE;
-
-
---
--- Name: fk_job_deliveryservice1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY job
-    ADD CONSTRAINT fk_job_deliveryservice1 FOREIGN KEY (job_deliveryservice) REFERENCES deliveryservice(id) ON DELETE CASCADE ON UPDATE CASCADE;
-
-
---
--- Name: fk_job_status_id1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY job
-    ADD CONSTRAINT fk_job_status_id1 FOREIGN KEY (status) REFERENCES job_status(id);
-
-
---
--- Name: fk_job_user_id1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY job
-    ADD CONSTRAINT fk_job_user_id1 FOREIGN KEY (job_user) REFERENCES tm_user(id);
-
-
---
--- Name: fk_log_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY log
-    ADD CONSTRAINT fk_log_1 FOREIGN KEY (tm_user) REFERENCES tm_user(id);
-
-
---
--- Name: fk_parameter; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup_parameter
-    ADD CONSTRAINT fk_parameter FOREIGN KEY (parameter) REFERENCES parameter(id) ON DELETE CASCADE;
-
-
---
--- Name: fk_phys_location_region; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY phys_location
-    ADD CONSTRAINT fk_phys_location_region FOREIGN KEY (region) REFERENCES region(id);
-
-
---
--- Name: fk_regex_type1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY regex
-    ADD CONSTRAINT fk_regex_type1 FOREIGN KEY (type) REFERENCES type(id);
-
-
---
--- Name: fk_region_division1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY region
-    ADD CONSTRAINT fk_region_division1 FOREIGN KEY (division) REFERENCES division(id);
-
-
---
--- Name: fk_server_cachegroup1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY server
-    ADD CONSTRAINT fk_server_cachegroup1 FOREIGN KEY (cachegroup) REFERENCES cachegroup(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
-
-
---
--- Name: fk_serverstatus_server1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY servercheck
-    ADD CONSTRAINT fk_serverstatus_server1 FOREIGN KEY (server) REFERENCES server(id) ON DELETE CASCADE;
-
-
---
--- Name: fk_staticdnsentry_cachegroup1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY staticdnsentry
-    ADD CONSTRAINT fk_staticdnsentry_cachegroup1 FOREIGN KEY (cachegroup) REFERENCES cachegroup(id);
-
-
---
--- Name: fk_staticdnsentry_ds; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY staticdnsentry
-    ADD CONSTRAINT fk_staticdnsentry_ds FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON DELETE CASCADE ON UPDATE CASCADE;
-
-
---
--- Name: fk_staticdnsentry_type; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY staticdnsentry
-    ADD CONSTRAINT fk_staticdnsentry_type FOREIGN KEY (type) REFERENCES type(id);
-
-
---
--- Name: fk_steering_target_delivery_service; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY steering_target
-    ADD CONSTRAINT fk_steering_target_delivery_service FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_steering_target_target; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY steering_target
-    ADD CONSTRAINT fk_steering_target_target FOREIGN KEY (target) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_tm_user_ds; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_tmuser
-    ADD CONSTRAINT fk_tm_user_ds FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_tm_user_id; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_tmuser
-    ADD CONSTRAINT fk_tm_user_id FOREIGN KEY (tm_user_id) REFERENCES tm_user(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: fk_user_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY tm_user
-    ADD CONSTRAINT fk_user_1 FOREIGN KEY (role) REFERENCES role(id) ON DELETE SET NULL;
-
-
---
--- Name: fk_capability; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY api_capability
-    ADD CONSTRAINT fk_capability FOREIGN KEY (capability) REFERENCES capability (name) ON DELETE RESTRICT;
-
---
--- Name: steering_target_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY steering_target
-    ADD CONSTRAINT steering_target_type_fkey FOREIGN KEY (type) REFERENCES type (id);
-
---
--- Name: fk_tenantid; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice
-    ADD CONSTRAINT fk_tenantid FOREIGN KEY (tenant_id) REFERENCES tenant (id) MATCH FULL;
-
---
--- Name: fk_author; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_request
-    ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES tm_user(id) ON DELETE CASCADE;
-
---
--- Name: fk_assignee; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_request
-    ADD CONSTRAINT fk_assignee FOREIGN KEY (assignee_id) REFERENCES tm_user(id) ON DELETE SET NULL;
-
---
--- Name: fk_last_edited_by; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_request
-    ADD CONSTRAINT fk_last_edited_by FOREIGN KEY (last_edited_by_id) REFERENCES tm_user (id) ON DELETE CASCADE;
-
---
--- Name: fk_author; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_request_comment
-    ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES tm_user (id) ON DELETE CASCADE;
-
---
--- Name: origin_profile_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY origin
-    ADD CONSTRAINT origin_profile_fkey FOREIGN KEY (profile) REFERENCES profile (id) ON DELETE RESTRICT;
-
---
--- Name: origin_deliveryservice_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY origin
-    ADD CONSTRAINT origin_deliveryservice_fkey FOREIGN KEY (deliveryservice) REFERENCES deliveryservice (id) ON DELETE CASCADE;
-
---
--- Name: origin_coordinate_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY origin
-    ADD CONSTRAINT origin_coordinate_fkey FOREIGN KEY (coordinate) REFERENCES coordinate (id) ON DELETE RESTRICT;
-
---
--- Name: origin_cachegroup_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY origin
-    ADD CONSTRAINT origin_cachegroup_fkey FOREIGN KEY (cachegroup) REFERENCES cachegroup (id) ON DELETE RESTRICT;
-
---
--- Name: origin_tenant_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY origin
-    ADD CONSTRAINT origin_tenant_fkey FOREIGN KEY (tenant) REFERENCES tenant (id) ON DELETE RESTRICT;
-
---
--- Name: cachegroup_coordinate_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup
-    ADD CONSTRAINT cachegroup_coordinate_fkey FOREIGN KEY (coordinate) REFERENCES coordinate (id);
-
---
--- Name: fk_primary_cg; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup_fallbacks
-    ADD CONSTRAINT fk_primary_cg FOREIGN KEY (primary_cg) REFERENCES cachegroup (id) ON DELETE CASCADE;
-
---
--- Name: fk_backup_cg; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup_fallbacks
-    ADD CONSTRAINT fk_backup_cg FOREIGN KEY (backup_cg) REFERENCES cachegroup (id) ON DELETE CASCADE;
-
---
--- Name: cachegroup_localization_method_cachegroup_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY cachegroup_localization_method
-    ADD CONSTRAINT cachegroup_localization_method_cachegroup_fkey FOREIGN KEY (cachegroup) REFERENCES cachegroup (id) ON DELETE CASCADE;
-
---
--- Name: fk_deliveryservice_request; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY deliveryservice_request_comment
-    ADD CONSTRAINT fk_deliveryservice_request FOREIGN KEY (deliveryservice_request_id) REFERENCES deliveryservice_request (id) ON DELETE CASCADE;
-
---
--- Name: fk_cdn1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY profile
-    ADD CONSTRAINT fk_cdn1 FOREIGN KEY (cdn) REFERENCES cdn (id) ON UPDATE RESTRICT ON DELETE RESTRICT;
-
---
--- Name: fk_role_id; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY role_capability
-    ADD CONSTRAINT fk_role_id FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE CASCADE;
-
---
--- Name: fk_cap_name; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY role_capability
-    ADD CONSTRAINT fk_cap_name FOREIGN KEY (cap_name) REFERENCES capability (name) ON DELETE RESTRICT;
-
---
--- Name: snapshot_cdn_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY snapshot
-    ADD CONSTRAINT snapshot_cdn_fkey FOREIGN KEY (cdn) REFERENCES cdn (name) ON UPDATE CASCADE ON DELETE CASCADE;
-
---
--- Name: fk_parentid; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY tenant
-    ADD CONSTRAINT fk_parentid FOREIGN KEY (parent_id) REFERENCES tenant (id);
-
---
--- Name: fk_tenantid; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY tm_user
-    ADD CONSTRAINT fk_tenantid FOREIGN KEY (tenant_id) REFERENCES tenant (id) MATCH FULL;
-
---
--- Name: fk_user_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY user_role
-    ADD CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES tm_user (id) ON DELETE CASCADE;
-
---
--- Name: fk_role_id; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
---
-
-ALTER TABLE ONLY user_role
-    ADD CONSTRAINT fk_role_id FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE RESTRICT;
+-- New code block to deallocate table_name variable to avoid identifier collision
+DO $$ BEGIN
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_atsprofile_atsparameters_atsparameters1' AND table_name = 'profile_parameter') THEN
+    --
+    -- Name: fk_atsprofile_atsparameters_atsparameters1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY profile_parameter
+        ADD CONSTRAINT fk_atsprofile_atsparameters_atsparameters1 FOREIGN KEY (parameter) REFERENCES parameter(id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_atsprofile_atsparameters_atsprofile1' AND table_name = 'profile_parameter') THEN
+    --
+    -- Name: fk_atsprofile_atsparameters_atsprofile1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY profile_parameter
+        ADD CONSTRAINT fk_atsprofile_atsparameters_atsprofile1 FOREIGN KEY (profile) REFERENCES profile(id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cdn1' AND table_name = 'deliveryservice') THEN
+    --
+    -- Name: fk_cdn1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice
+        ADD CONSTRAINT fk_cdn1 FOREIGN KEY (cdn_id) REFERENCES cdn(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cdn2' AND table_name = 'server') THEN
+    --
+    -- Name: fk_cdn2; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY server
+        ADD CONSTRAINT fk_cdn2 FOREIGN KEY (cdn_id) REFERENCES cdn(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cg_1' AND table_name = 'cachegroup') THEN
+    --
+    -- Name: fk_cg_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup
+        ADD CONSTRAINT fk_cg_1 FOREIGN KEY (parent_cachegroup_id) REFERENCES cachegroup(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cg_param_cachegroup1' AND table_name = 'cachegroup_parameter') THEN
+    --
+    -- Name: fk_cg_param_cachegroup1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup_parameter
+        ADD CONSTRAINT fk_cg_param_cachegroup1 FOREIGN KEY (cachegroup) REFERENCES cachegroup(id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cg_secondary' AND table_name = 'cachegroup') THEN
+    --
+    -- Name: fk_cg_secondary; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup
+        ADD CONSTRAINT fk_cg_secondary FOREIGN KEY (secondary_parent_cachegroup_id) REFERENCES cachegroup(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cg_type1' AND table_name = 'cachegroup') THEN
+    --
+    -- Name: fk_cg_type1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup
+        ADD CONSTRAINT fk_cg_type1 FOREIGN KEY (type) REFERENCES type(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_contentserver_atsprofile1' AND table_name = 'server') THEN
+    --
+    -- Name: fk_contentserver_atsprofile1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY server
+        ADD CONSTRAINT fk_contentserver_atsprofile1 FOREIGN KEY (profile) REFERENCES profile(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_contentserver_contentserverstatus1' AND table_name = 'server') THEN
+    --
+    -- Name: fk_contentserver_contentserverstatus1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY server
+        ADD CONSTRAINT fk_contentserver_contentserverstatus1 FOREIGN KEY (status) REFERENCES status(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_contentserver_contentservertype1' AND table_name = 'server') THEN
+    --
+    -- Name: fk_contentserver_contentservertype1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY server
+        ADD CONSTRAINT fk_contentserver_contentservertype1 FOREIGN KEY (type) REFERENCES type(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_contentserver_phys_location1' AND table_name = 'server') THEN
+    --
+    -- Name: fk_contentserver_phys_location1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY server
+        ADD CONSTRAINT fk_contentserver_phys_location1 FOREIGN KEY (phys_location) REFERENCES phys_location(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cran_cachegroup1' AND table_name = 'asn') THEN
+    --
+    -- Name: fk_cran_cachegroup1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY asn
+        ADD CONSTRAINT fk_cran_cachegroup1 FOREIGN KEY (cachegroup) REFERENCES cachegroup(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_deliveryservice_profile1' AND table_name = 'deliveryservice') THEN
+    --
+    -- Name: fk_deliveryservice_profile1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice
+        ADD CONSTRAINT fk_deliveryservice_profile1 FOREIGN KEY (profile) REFERENCES profile(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_deliveryservice_type1' AND table_name = 'deliveryservice') THEN
+    --
+    -- Name: fk_deliveryservice_type1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice
+        ADD CONSTRAINT fk_deliveryservice_type1 FOREIGN KEY (type) REFERENCES type(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_ds_to_cs_contentserver1' AND table_name = 'deliveryservice_server') THEN
+    --
+    -- Name: fk_ds_to_cs_contentserver1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_server
+        ADD CONSTRAINT fk_ds_to_cs_contentserver1 FOREIGN KEY (server) REFERENCES server(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_ds_to_cs_deliveryservice1' AND table_name = 'deliveryservice_server') THEN
+    --
+    -- Name: fk_ds_to_cs_deliveryservice1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_server
+        ADD CONSTRAINT fk_ds_to_cs_deliveryservice1 FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_ds_to_regex_deliveryservice1' AND table_name = 'deliveryservice_regex') THEN
+    --
+    -- Name: fk_ds_to_regex_deliveryservice1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_regex
+        ADD CONSTRAINT fk_ds_to_regex_deliveryservice1 FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_ds_to_regex_regex1' AND table_name = 'deliveryservice_regex') THEN
+    --
+    -- Name: fk_ds_to_regex_regex1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_regex
+        ADD CONSTRAINT fk_ds_to_regex_regex1 FOREIGN KEY (regex) REFERENCES regex(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_ext_type' AND table_name = 'to_extension') THEN
+    --
+    -- Name: fk_ext_type; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY to_extension
+        ADD CONSTRAINT fk_ext_type FOREIGN KEY (type) REFERENCES type(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_federation_federation_resolver1' AND table_name = 'federation_federation_resolver') THEN
+    --
+    -- Name: fk_federation_federation_resolver1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY federation_federation_resolver
+        ADD CONSTRAINT fk_federation_federation_resolver1 FOREIGN KEY (federation) REFERENCES federation(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_federation_mapping_type' AND table_name = 'federation_resolver') THEN
+    --
+    -- Name: fk_federation_mapping_type; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY federation_resolver
+        ADD CONSTRAINT fk_federation_mapping_type FOREIGN KEY (type) REFERENCES type(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_federation_resolver_to_fed1' AND table_name = 'federation_federation_resolver') THEN
+    --
+    -- Name: fk_federation_resolver_to_fed1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY federation_federation_resolver
+        ADD CONSTRAINT fk_federation_resolver_to_fed1 FOREIGN KEY (federation_resolver) REFERENCES federation_resolver(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_federation_tmuser_federation' AND table_name = 'federation_tmuser') THEN
+    --
+    -- Name: fk_federation_tmuser_federation; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY federation_tmuser
+        ADD CONSTRAINT fk_federation_tmuser_federation FOREIGN KEY (federation) REFERENCES federation(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_federation_tmuser_role' AND table_name = 'federation_tmuser') THEN
+    --
+    -- Name: fk_federation_tmuser_role; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY federation_tmuser
+        ADD CONSTRAINT fk_federation_tmuser_role FOREIGN KEY (role) REFERENCES role(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_federation_tmuser_tmuser' AND table_name = 'federation_tmuser') THEN
+    --
+    -- Name: fk_federation_tmuser_tmuser; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY federation_tmuser
+        ADD CONSTRAINT fk_federation_tmuser_tmuser FOREIGN KEY (tm_user) REFERENCES tm_user(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_federation_to_ds1' AND table_name = 'federation_deliveryservice') THEN
+    --
+    -- Name: fk_federation_to_ds1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY federation_deliveryservice
+        ADD CONSTRAINT fk_federation_to_ds1 FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_federation_to_fed1' AND table_name = 'federation_deliveryservice') THEN
+    --
+    -- Name: fk_federation_to_fed1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY federation_deliveryservice
+        ADD CONSTRAINT fk_federation_to_fed1 FOREIGN KEY (federation) REFERENCES federation(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_hwinfo1' AND table_name = 'hwinfo') THEN
+    --
+    -- Name: fk_hwinfo1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY hwinfo
+        ADD CONSTRAINT fk_hwinfo1 FOREIGN KEY (serverid) REFERENCES server(id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_job_agent_id1' AND table_name = 'job') THEN
+    --
+    -- Name: fk_job_agent_id1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY job
+        ADD CONSTRAINT fk_job_agent_id1 FOREIGN KEY (agent) REFERENCES job_agent(id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_job_deliveryservice1' AND table_name = 'job') THEN
+    --
+    -- Name: fk_job_deliveryservice1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY job
+        ADD CONSTRAINT fk_job_deliveryservice1 FOREIGN KEY (job_deliveryservice) REFERENCES deliveryservice(id) ON DELETE CASCADE ON UPDATE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_job_status_id1' AND table_name = 'job') THEN
+    --
+    -- Name: fk_job_status_id1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY job
+        ADD CONSTRAINT fk_job_status_id1 FOREIGN KEY (status) REFERENCES job_status(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_job_user_id1' AND table_name = 'job') THEN
+    --
+    -- Name: fk_job_user_id1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY job
+        ADD CONSTRAINT fk_job_user_id1 FOREIGN KEY (job_user) REFERENCES tm_user(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_log_1' AND table_name = 'log') THEN
+    --
+    -- Name: fk_log_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY log
+        ADD CONSTRAINT fk_log_1 FOREIGN KEY (tm_user) REFERENCES tm_user(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_parameter' AND table_name = 'cachegroup_parameter') THEN
+    --
+    -- Name: fk_parameter; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup_parameter
+        ADD CONSTRAINT fk_parameter FOREIGN KEY (parameter) REFERENCES parameter(id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_phys_location_region' AND table_name = 'phys_location') THEN
+    --
+    -- Name: fk_phys_location_region; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY phys_location
+        ADD CONSTRAINT fk_phys_location_region FOREIGN KEY (region) REFERENCES region(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_regex_type1' AND table_name = 'regex') THEN
+    --
+    -- Name: fk_regex_type1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY regex
+        ADD CONSTRAINT fk_regex_type1 FOREIGN KEY (type) REFERENCES type(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_region_division1' AND table_name = 'region') THEN
+    --
+    -- Name: fk_region_division1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY region
+        ADD CONSTRAINT fk_region_division1 FOREIGN KEY (division) REFERENCES division(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_server_cachegroup1' AND table_name = 'server') THEN
+    --
+    -- Name: fk_server_cachegroup1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY server
+        ADD CONSTRAINT fk_server_cachegroup1 FOREIGN KEY (cachegroup) REFERENCES cachegroup(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_serverstatus_server1' AND table_name = 'servercheck') THEN
+    --
+    -- Name: fk_serverstatus_server1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY servercheck
+        ADD CONSTRAINT fk_serverstatus_server1 FOREIGN KEY (server) REFERENCES server(id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_staticdnsentry_cachegroup1' AND table_name = 'staticdnsentry') THEN
+    --
+    -- Name: fk_staticdnsentry_cachegroup1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY staticdnsentry
+        ADD CONSTRAINT fk_staticdnsentry_cachegroup1 FOREIGN KEY (cachegroup) REFERENCES cachegroup(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_staticdnsentry_ds' AND table_name = 'staticdnsentry') THEN
+    --
+    -- Name: fk_staticdnsentry_ds; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY staticdnsentry
+        ADD CONSTRAINT fk_staticdnsentry_ds FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON DELETE CASCADE ON UPDATE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_staticdnsentry_type' AND table_name = 'staticdnsentry') THEN
+    --
+    -- Name: fk_staticdnsentry_type; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY staticdnsentry
+        ADD CONSTRAINT fk_staticdnsentry_type FOREIGN KEY (type) REFERENCES type(id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_steering_target_delivery_service' AND table_name = 'steering_target') THEN
+    --
+    -- Name: fk_steering_target_delivery_service; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY steering_target
+        ADD CONSTRAINT fk_steering_target_delivery_service FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_steering_target_target' AND table_name = 'steering_target') THEN
+    --
+    -- Name: fk_steering_target_target; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY steering_target
+        ADD CONSTRAINT fk_steering_target_target FOREIGN KEY (target) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_tm_user_ds' AND table_name = 'deliveryservice_tmuser') THEN
+    --
+    -- Name: fk_tm_user_ds; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_tmuser
+        ADD CONSTRAINT fk_tm_user_ds FOREIGN KEY (deliveryservice) REFERENCES deliveryservice(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_tm_user_id' AND table_name = 'deliveryservice_tmuser') THEN
+    --
+    -- Name: fk_tm_user_id; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_tmuser
+        ADD CONSTRAINT fk_tm_user_id FOREIGN KEY (tm_user_id) REFERENCES tm_user(id) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_user_1' AND table_name = 'tm_user') THEN
+    --
+    -- Name: fk_user_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY tm_user
+        ADD CONSTRAINT fk_user_1 FOREIGN KEY (role) REFERENCES role(id) ON DELETE SET NULL;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_capability' AND table_name = 'api_capability') THEN
+    --
+    -- Name: fk_capability; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY api_capability
+        ADD CONSTRAINT fk_capability FOREIGN KEY (capability) REFERENCES capability (name) ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'steering_target_type_fkey' AND table_name = 'steering_target') THEN
+    --
+    -- Name: steering_target_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY steering_target
+        ADD CONSTRAINT steering_target_type_fkey FOREIGN KEY (type) REFERENCES type (id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_tenantid' AND table_name = 'deliveryservice') THEN
+    --
+    -- Name: fk_tenantid; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice
+        ADD CONSTRAINT fk_tenantid FOREIGN KEY (tenant_id) REFERENCES tenant (id) MATCH FULL;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_author' AND table_name = 'deliveryservice_request') THEN
+    --
+    -- Name: fk_author; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_request
+        ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES tm_user(id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_assignee' AND table_name = 'deliveryservice_request') THEN
+    --
+    -- Name: fk_assignee; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_request
+        ADD CONSTRAINT fk_assignee FOREIGN KEY (assignee_id) REFERENCES tm_user(id) ON DELETE SET NULL;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_last_edited_by' AND table_name = 'deliveryservice_request') THEN
+    --
+    -- Name: fk_last_edited_by; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_request
+        ADD CONSTRAINT fk_last_edited_by FOREIGN KEY (last_edited_by_id) REFERENCES tm_user (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_author' AND table_name = 'deliveryservice_request_comment') THEN
+    --
+    -- Name: fk_author; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_request_comment
+        ADD CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES tm_user (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'origin_profile_fkey' AND table_name = 'origin') THEN
+    --
+    -- Name: origin_profile_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY origin
+        ADD CONSTRAINT origin_profile_fkey FOREIGN KEY (profile) REFERENCES profile (id) ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'origin_deliveryservice_fkey' AND table_name = 'origin') THEN
+    --
+    -- Name: origin_deliveryservice_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY origin
+        ADD CONSTRAINT origin_deliveryservice_fkey FOREIGN KEY (deliveryservice) REFERENCES deliveryservice (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'origin_coordinate_fkey' AND table_name = 'origin') THEN
+    --
+    -- Name: origin_coordinate_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY origin
+        ADD CONSTRAINT origin_coordinate_fkey FOREIGN KEY (coordinate) REFERENCES coordinate (id) ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'origin_cachegroup_fkey' AND table_name = 'origin') THEN
+    --
+    -- Name: origin_cachegroup_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY origin
+        ADD CONSTRAINT origin_cachegroup_fkey FOREIGN KEY (cachegroup) REFERENCES cachegroup (id) ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'origin_tenant_fkey' AND table_name = 'origin') THEN
+    --
+    -- Name: origin_tenant_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY origin
+        ADD CONSTRAINT origin_tenant_fkey FOREIGN KEY (tenant) REFERENCES tenant (id) ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'cachegroup_coordinate_fkey' AND table_name = 'cachegroup') THEN
+    --
+    -- Name: cachegroup_coordinate_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup
+        ADD CONSTRAINT cachegroup_coordinate_fkey FOREIGN KEY (coordinate) REFERENCES coordinate (id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_primary_cg' AND table_name = 'cachegroup_fallbacks') THEN
+    --
+    -- Name: fk_primary_cg; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup_fallbacks
+        ADD CONSTRAINT fk_primary_cg FOREIGN KEY (primary_cg) REFERENCES cachegroup (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_backup_cg' AND table_name = 'cachegroup_fallbacks') THEN
+    --
+    -- Name: fk_backup_cg; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup_fallbacks
+        ADD CONSTRAINT fk_backup_cg FOREIGN KEY (backup_cg) REFERENCES cachegroup (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'cachegroup_localization_method_cachegroup_fkey' AND table_name = 'cachegroup_localization_method') THEN
+    --
+    -- Name: cachegroup_localization_method_cachegroup_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY cachegroup_localization_method
+        ADD CONSTRAINT cachegroup_localization_method_cachegroup_fkey FOREIGN KEY (cachegroup) REFERENCES cachegroup (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_deliveryservice_request' AND table_name = 'deliveryservice_request_comment') THEN
+    --
+    -- Name: fk_deliveryservice_request; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY deliveryservice_request_comment
+        ADD CONSTRAINT fk_deliveryservice_request FOREIGN KEY (deliveryservice_request_id) REFERENCES deliveryservice_request (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cdn1' AND table_name = 'profile') THEN
+    --
+    -- Name: fk_cdn1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY profile
+        ADD CONSTRAINT fk_cdn1 FOREIGN KEY (cdn) REFERENCES cdn (id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_role_id' AND table_name = 'role_capability') THEN
+    --
+    -- Name: fk_role_id; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY role_capability
+        ADD CONSTRAINT fk_role_id FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_cap_name' AND table_name = 'role_capability') THEN
+    --
+    -- Name: fk_cap_name; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY role_capability
+        ADD CONSTRAINT fk_cap_name FOREIGN KEY (cap_name) REFERENCES capability (name) ON DELETE RESTRICT;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'snapshot_cdn_fkey' AND table_name = 'snapshot') THEN
+    --
+    -- Name: snapshot_cdn_fkey; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY snapshot
+        ADD CONSTRAINT snapshot_cdn_fkey FOREIGN KEY (cdn) REFERENCES cdn (name) ON UPDATE CASCADE ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_parentid' AND table_name = 'tenant') THEN
+    --
+    -- Name: fk_parentid; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY tenant
+        ADD CONSTRAINT fk_parentid FOREIGN KEY (parent_id) REFERENCES tenant (id);
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_tenantid' AND table_name = 'tm_user') THEN
+    --
+    -- Name: fk_tenantid; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY tm_user
+        ADD CONSTRAINT fk_tenantid FOREIGN KEY (tenant_id) REFERENCES tenant (id) MATCH FULL;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_user_id' AND table_name = 'user_role') THEN
+    --
+    -- Name: fk_user_1; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY user_role
+        ADD CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES tm_user (id) ON DELETE CASCADE;
+END IF;
+
+IF NOT EXISTS (SELECT FROM information_schema.table_constraints WHERE constraint_name = 'fk_role_id' AND table_name = 'user_role') THEN
+    --
+    -- Name: fk_role_id; Type: FK CONSTRAINT; Schema: public; Owner: traffic_ops
+    --
+
+    ALTER TABLE ONLY user_role
+        ADD CONSTRAINT fk_role_id FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE RESTRICT;
+END IF;
+END$$;
 
 
 --

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -1786,537 +1786,537 @@ ALTER TABLE ONLY type ALTER COLUMN id SET DEFAULT nextval('type_id_seq'::regclas
 -- Name: idx_89468_cr_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89468_cr_id_unique ON asn USING btree (id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89468_cr_id_unique ON asn USING btree (id);
 
 
 --
 -- Name: idx_89468_fk_cran_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89468_fk_cran_cachegroup1 ON asn USING btree (cachegroup);
+CREATE INDEX IF NOT EXISTS idx_89468_fk_cran_cachegroup1 ON asn USING btree (cachegroup);
 
 
 --
 -- Name: idx_89476_cg_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89476_cg_name_unique ON cachegroup USING btree (name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_cg_name_unique ON cachegroup USING btree (name);
 
 
 --
 -- Name: idx_89476_cg_short_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89476_cg_short_unique ON cachegroup USING btree (short_name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_cg_short_unique ON cachegroup USING btree (short_name);
 
 
 --
 -- Name: idx_89476_fk_cg_1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89476_fk_cg_1 ON cachegroup USING btree (parent_cachegroup_id);
+CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_1 ON cachegroup USING btree (parent_cachegroup_id);
 
 
 --
 -- Name: idx_89476_fk_cg_secondary; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89476_fk_cg_secondary ON cachegroup USING btree (secondary_parent_cachegroup_id);
+CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_secondary ON cachegroup USING btree (secondary_parent_cachegroup_id);
 
 
 --
 -- Name: idx_89476_fk_cg_type1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89476_fk_cg_type1 ON cachegroup USING btree (type);
+CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_type1 ON cachegroup USING btree (type);
 
 
 --
 -- Name: idx_89476_lo_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89476_lo_id_unique ON cachegroup USING btree (id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_lo_id_unique ON cachegroup USING btree (id);
 
 
 --
 -- Name: idx_89484_fk_parameter; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89484_fk_parameter ON cachegroup_parameter USING btree (parameter);
+CREATE INDEX IF NOT EXISTS idx_89484_fk_parameter ON cachegroup_parameter USING btree (parameter);
 
 
 --
 -- Name: idx_89491_cdn_cdn_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89491_cdn_cdn_unique ON cdn USING btree (name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89491_cdn_cdn_unique ON cdn USING btree (name);
 
 --
 -- Name: idx_89502_ds_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89502_ds_id_unique ON deliveryservice USING btree (id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89502_ds_id_unique ON deliveryservice USING btree (id);
 
 --
 -- Name: idx_k_deliveryservice_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_k_deliveryservice_tenant_idx ON deliveryservice USING btree (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_k_deliveryservice_tenant_idx ON deliveryservice USING btree (tenant_id);
 
 --
 -- Name: idx_89502_ds_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89502_ds_name_unique ON deliveryservice USING btree (xml_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89502_ds_name_unique ON deliveryservice USING btree (xml_id);
 
 
 --
 -- Name: idx_89502_fk_cdn1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89502_fk_cdn1 ON deliveryservice USING btree (cdn_id);
+CREATE INDEX IF NOT EXISTS idx_89502_fk_cdn1 ON deliveryservice USING btree (cdn_id);
 
 
 --
 -- Name: idx_89502_fk_deliveryservice_profile1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89502_fk_deliveryservice_profile1 ON deliveryservice USING btree (profile);
+CREATE INDEX IF NOT EXISTS idx_89502_fk_deliveryservice_profile1 ON deliveryservice USING btree (profile);
 
 
 --
 -- Name: idx_89502_fk_deliveryservice_type1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89502_fk_deliveryservice_type1 ON deliveryservice USING btree (type);
+CREATE INDEX IF NOT EXISTS idx_89502_fk_deliveryservice_type1 ON deliveryservice USING btree (type);
 
 
 --
 -- Name: idx_89517_fk_ds_to_regex_regex1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89517_fk_ds_to_regex_regex1 ON deliveryservice_regex USING btree (regex);
+CREATE INDEX IF NOT EXISTS idx_89517_fk_ds_to_regex_regex1 ON deliveryservice_regex USING btree (regex);
 
 
 --
 -- Name: idx_89521_fk_ds_to_cs_contentserver1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89521_fk_ds_to_cs_contentserver1 ON deliveryservice_server USING btree (server);
+CREATE INDEX IF NOT EXISTS idx_89521_fk_ds_to_cs_contentserver1 ON deliveryservice_server USING btree (server);
 
 
 --
 -- Name: idx_89525_fk_tm_userid; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89525_fk_tm_userid ON deliveryservice_tmuser USING btree (tm_user_id);
+CREATE INDEX IF NOT EXISTS idx_89525_fk_tm_userid ON deliveryservice_tmuser USING btree (tm_user_id);
 
 
 --
 -- Name: idx_89531_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89531_name_unique ON division USING btree (name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89531_name_unique ON division USING btree (name);
 
 
 --
 -- Name: idx_89549_fk_fed_to_ds1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89549_fk_fed_to_ds1 ON federation_deliveryservice USING btree (deliveryservice);
+CREATE INDEX IF NOT EXISTS idx_89549_fk_fed_to_ds1 ON federation_deliveryservice USING btree (deliveryservice);
 
 
 --
 -- Name: idx_89553_fk_federation_federation_resolver; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89553_fk_federation_federation_resolver ON federation_federation_resolver USING btree (federation);
+CREATE INDEX IF NOT EXISTS idx_89553_fk_federation_federation_resolver ON federation_federation_resolver USING btree (federation);
 
 
 --
 -- Name: idx_89553_fk_federation_resolver_to_fed1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89553_fk_federation_resolver_to_fed1 ON federation_federation_resolver USING btree (federation_resolver);
+CREATE INDEX IF NOT EXISTS idx_89553_fk_federation_resolver_to_fed1 ON federation_federation_resolver USING btree (federation_resolver);
 
 
 --
 -- Name: idx_89559_federation_resolver_ip_address; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89559_federation_resolver_ip_address ON federation_resolver USING btree (ip_address);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89559_federation_resolver_ip_address ON federation_resolver USING btree (ip_address);
 
 
 --
 -- Name: idx_89559_fk_federation_mapping_type; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89559_fk_federation_mapping_type ON federation_resolver USING btree (type);
+CREATE INDEX IF NOT EXISTS idx_89559_fk_federation_mapping_type ON federation_resolver USING btree (type);
 
 
 --
 -- Name: idx_89567_fk_federation_federation_resolver; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89567_fk_federation_federation_resolver ON federation_tmuser USING btree (federation);
+CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_federation_resolver ON federation_tmuser USING btree (federation);
 
 
 --
 -- Name: idx_89567_fk_federation_tmuser_role; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89567_fk_federation_tmuser_role ON federation_tmuser USING btree (role);
+CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_tmuser_role ON federation_tmuser USING btree (role);
 
 
 --
 -- Name: idx_89567_fk_federation_tmuser_tmuser; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89567_fk_federation_tmuser_tmuser ON federation_tmuser USING btree (tm_user);
+CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_tmuser_tmuser ON federation_tmuser USING btree (tm_user);
 
 
 --
 -- Name: idx_89583_fk_hwinfo1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89583_fk_hwinfo1 ON hwinfo USING btree (serverid);
+CREATE INDEX IF NOT EXISTS idx_89583_fk_hwinfo1 ON hwinfo USING btree (serverid);
 
 
 --
 -- Name: idx_89583_serverid; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89583_serverid ON hwinfo USING btree (serverid, description);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89583_serverid ON hwinfo USING btree (serverid, description);
 
 
 --
 -- Name: idx_89593_fk_job_agent_id1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89593_fk_job_agent_id1 ON job USING btree (agent);
+CREATE INDEX IF NOT EXISTS idx_89593_fk_job_agent_id1 ON job USING btree (agent);
 
 
 --
 -- Name: idx_89593_fk_job_deliveryservice1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89593_fk_job_deliveryservice1 ON job USING btree (job_deliveryservice);
+CREATE INDEX IF NOT EXISTS idx_89593_fk_job_deliveryservice1 ON job USING btree (job_deliveryservice);
 
 
 --
 -- Name: idx_89593_fk_job_status_id1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89593_fk_job_status_id1 ON job USING btree (status);
+CREATE INDEX IF NOT EXISTS idx_89593_fk_job_status_id1 ON job USING btree (status);
 
 
 --
 -- Name: idx_89593_fk_job_user_id1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89593_fk_job_user_id1 ON job USING btree (job_user);
+CREATE INDEX IF NOT EXISTS idx_89593_fk_job_user_id1 ON job USING btree (job_user);
 
 
 --
 -- Name: idx_89634_fk_log_1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89634_fk_log_1 ON log USING btree (tm_user);
+CREATE INDEX IF NOT EXISTS idx_89634_fk_log_1 ON log USING btree (tm_user);
 
 
 --
 -- Name: idx_89634_idx_last_updated; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89634_idx_last_updated ON log USING btree (last_updated);
+CREATE INDEX IF NOT EXISTS idx_89634_idx_last_updated ON log USING btree (last_updated);
 
 
 --
 -- Name: idx_89644_parameter_name_value_idx; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89644_parameter_name_value_idx ON parameter USING btree (name, value);
+CREATE INDEX IF NOT EXISTS idx_89644_parameter_name_value_idx ON parameter USING btree (name, value);
 
 
 --
 -- Name: idx_89655_fk_phys_location_region_idx; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89655_fk_phys_location_region_idx ON phys_location USING btree (region);
+CREATE INDEX IF NOT EXISTS idx_89655_fk_phys_location_region_idx ON phys_location USING btree (region);
 
 
 --
 -- Name: idx_89655_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89655_name_unique ON phys_location USING btree (name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89655_name_unique ON phys_location USING btree (name);
 
 
 --
 -- Name: idx_89655_short_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89655_short_name_unique ON phys_location USING btree (short_name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89655_short_name_unique ON phys_location USING btree (short_name);
 
 
 --
 -- Name: idx_89665_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89665_name_unique ON profile USING btree (name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89665_name_unique ON profile USING btree (name);
 
 --
 -- Name: idx_181818_fk_cdn1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_181818_fk_cdn1 ON profile USING btree (cdn);
+CREATE INDEX IF NOT EXISTS idx_181818_fk_cdn1 ON profile USING btree (cdn);
 
 
 --
 -- Name: idx_89673_fk_atsprofile_atsparameters_atsparameters1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89673_fk_atsprofile_atsparameters_atsparameters1 ON profile_parameter USING btree (parameter);
+CREATE INDEX IF NOT EXISTS idx_89673_fk_atsprofile_atsparameters_atsparameters1 ON profile_parameter USING btree (parameter);
 
 
 --
 -- Name: idx_89673_fk_atsprofile_atsparameters_atsprofile1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89673_fk_atsprofile_atsparameters_atsprofile1 ON profile_parameter USING btree (profile);
+CREATE INDEX IF NOT EXISTS idx_89673_fk_atsprofile_atsparameters_atsprofile1 ON profile_parameter USING btree (profile);
 
 
 --
 -- Name: idx_89679_fk_regex_type1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89679_fk_regex_type1 ON regex USING btree (type);
+CREATE INDEX IF NOT EXISTS idx_89679_fk_regex_type1 ON regex USING btree (type);
 
 
 --
 -- Name: idx_89679_re_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89679_re_id_unique ON regex USING btree (id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89679_re_id_unique ON regex USING btree (id);
 
 
 --
 -- Name: idx_89690_fk_region_division1_idx; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89690_fk_region_division1_idx ON region USING btree (division);
+CREATE INDEX IF NOT EXISTS idx_89690_fk_region_division1_idx ON region USING btree (division);
 
 
 --
 -- Name: idx_89690_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89690_name_unique ON region USING btree (name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89690_name_unique ON region USING btree (name);
 
 
 --
 -- Name: idx_89709_fk_cdn2; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89709_fk_cdn2 ON server USING btree (cdn_id);
+CREATE INDEX IF NOT EXISTS idx_89709_fk_cdn2 ON server USING btree (cdn_id);
 
 
 --
 -- Name: idx_89709_fk_contentserver_atsprofile1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89709_fk_contentserver_atsprofile1 ON server USING btree (profile);
+CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_atsprofile1 ON server USING btree (profile);
 
 
 --
 -- Name: idx_89709_fk_contentserver_contentserverstatus1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89709_fk_contentserver_contentserverstatus1 ON server USING btree (status);
+CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_contentserverstatus1 ON server USING btree (status);
 
 
 --
 -- Name: idx_89709_fk_contentserver_contentservertype1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89709_fk_contentserver_contentservertype1 ON server USING btree (type);
+CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_contentservertype1 ON server USING btree (type);
 
 
 --
 -- Name: idx_89709_fk_contentserver_phys_location1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89709_fk_contentserver_phys_location1 ON server USING btree (phys_location);
+CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_phys_location1 ON server USING btree (phys_location);
 
 
 --
 -- Name: idx_89709_fk_server_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89709_fk_server_cachegroup1 ON server USING btree (cachegroup);
+CREATE INDEX IF NOT EXISTS idx_89709_fk_server_cachegroup1 ON server USING btree (cachegroup);
 
 
 --
 -- Name: idx_89709_ip6_profile; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89709_ip6_profile ON server USING btree (ip6_address, profile);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_ip6_profile ON server USING btree (ip6_address, profile);
 
 
 --
 -- Name: idx_89709_ip_profile; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89709_ip_profile ON server USING btree (ip_address, profile);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_ip_profile ON server USING btree (ip_address, profile);
 
 
 --
 -- Name: idx_89709_se_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89709_se_id_unique ON server USING btree (id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_se_id_unique ON server USING btree (id);
 
 
 --
 -- Name: idx_89722_fk_serverstatus_server1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89722_fk_serverstatus_server1 ON servercheck USING btree (server);
+CREATE INDEX IF NOT EXISTS idx_89722_fk_serverstatus_server1 ON servercheck USING btree (server);
 
 
 --
 -- Name: idx_89722_server; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89722_server ON servercheck USING btree (server);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89722_server ON servercheck USING btree (server);
 
 
 --
 -- Name: idx_89722_ses_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89722_ses_id_unique ON servercheck USING btree (id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89722_ses_id_unique ON servercheck USING btree (id);
 
 
 --
 -- Name: idx_89729_combi_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89729_combi_unique ON staticdnsentry USING btree (host, address, deliveryservice, cachegroup);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89729_combi_unique ON staticdnsentry USING btree (host, address, deliveryservice, cachegroup);
 
 
 --
 -- Name: idx_89729_fk_staticdnsentry_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89729_fk_staticdnsentry_cachegroup1 ON staticdnsentry USING btree (cachegroup);
+CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_cachegroup1 ON staticdnsentry USING btree (cachegroup);
 
 
 --
 -- Name: idx_89729_fk_staticdnsentry_ds; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89729_fk_staticdnsentry_ds ON staticdnsentry USING btree (deliveryservice);
+CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_ds ON staticdnsentry USING btree (deliveryservice);
 
 
 --
 -- Name: idx_89729_fk_staticdnsentry_type; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89729_fk_staticdnsentry_type ON staticdnsentry USING btree (type);
+CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_type ON staticdnsentry USING btree (type);
 
 --
 -- Name: idx_k_tenant_parent_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_k_tenant_parent_tenant_idx ON tenant USING btree (parent_id);
+CREATE INDEX IF NOT EXISTS idx_k_tenant_parent_tenant_idx ON tenant USING btree (parent_id);
 
 --
 -- Name: idx_89765_fk_user_1; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89765_fk_user_1 ON tm_user USING btree (role);
+CREATE INDEX IF NOT EXISTS idx_89765_fk_user_1 ON tm_user USING btree (role);
 
 --
 -- Name: idx_k_tm_user_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_k_tm_user_tenant_idx ON tm_user USING btree (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_k_tm_user_tenant_idx ON tm_user USING btree (tenant_id);
 
 --
 -- Name: idx_89765_tmuser_email_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89765_tmuser_email_unique ON tm_user USING btree (email);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89765_tmuser_email_unique ON tm_user USING btree (email);
 
 
 --
 -- Name: idx_89765_username_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89765_username_unique ON tm_user USING btree (username);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89765_username_unique ON tm_user USING btree (username);
 
 
 --
 -- Name: idx_89776_fk_ext_type_idx; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX idx_89776_fk_ext_type_idx ON to_extension USING btree (type);
+CREATE INDEX IF NOT EXISTS idx_89776_fk_ext_type_idx ON to_extension USING btree (type);
 
 
 --
 -- Name: idx_89776_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX idx_89776_id_unique ON to_extension USING btree (id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_89776_id_unique ON to_extension USING btree (id);
 
 --
 -- Name: cachegroup_coordinate_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX cachegroup_coordinate_fkey ON cachegroup USING btree (coordinate);
+CREATE INDEX IF NOT EXISTS cachegroup_coordinate_fkey ON cachegroup USING btree (coordinate);
 
 --
 -- Name: cachegroup_localization_method_cachegroup_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX cachegroup_localization_method_cachegroup_fkey ON cachegroup_localization_method USING btree(cachegroup);
+CREATE INDEX IF NOT EXISTS cachegroup_localization_method_cachegroup_fkey ON cachegroup_localization_method USING btree(cachegroup);
 
 --
 -- Name: origin_is_primary_deliveryservice_constraint; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE UNIQUE INDEX origin_is_primary_deliveryservice_constraint ON origin (is_primary, deliveryservice) WHERE is_primary;
+CREATE UNIQUE INDEX IF NOT EXISTS origin_is_primary_deliveryservice_constraint ON origin (is_primary, deliveryservice) WHERE is_primary;
 
 --
 -- Name: origin_deliveryservice_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX origin_deliveryservice_fkey ON origin USING btree (deliveryservice);
+CREATE INDEX IF NOT EXISTS origin_deliveryservice_fkey ON origin USING btree (deliveryservice);
 
 --
 -- Name: origin_coordinate_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX origin_coordinate_fkey ON origin USING btree (coordinate);
+CREATE INDEX IF NOT EXISTS origin_coordinate_fkey ON origin USING btree (coordinate);
 
 --
 -- Name: origin_profile_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX origin_profile_fkey ON origin USING btree (profile);
+CREATE INDEX IF NOT EXISTS origin_profile_fkey ON origin USING btree (profile);
 
 --
 -- Name: origin_cachegroup_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX origin_cachegroup_fkey ON origin USING btree (cachegroup);
+CREATE INDEX IF NOT EXISTS origin_cachegroup_fkey ON origin USING btree (cachegroup);
 
 --
 -- Name: origin_tenant_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
 --
 
-CREATE INDEX origin_tenant_fkey ON origin USING btree (tenant);
+CREATE INDEX IF NOT EXISTS origin_tenant_fkey ON origin USING btree (tenant);
 
 
 --

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -57,95 +57,114 @@ SET default_tablespace = '';
 
 SET default_with_oids = false;
 
---
--- Name: change_types; Type: TYPE; Schema: public; Owner: traffic_ops
---
+DO $$
+BEGIN
+IF NOT EXISTS (SELECT FROM pg_type WHERE typname = 'change_types') THEN
+    --
+    -- Name: change_types; Type: TYPE; Schema: public; Owner: traffic_ops
+    --
 
-CREATE TYPE change_types AS ENUM (
-    'create',
-    'update',
-    'delete'
-);
+    CREATE TYPE change_types AS ENUM (
+        'create',
+        'update',
+        'delete'
+    );
+END IF;
 
---
--- Name: deep_caching_type; Type: TYPE; Schema: public; Owner: traffic_ops
---
+IF NOT EXISTS (SELECT FROM pg_type WHERE typname = 'deep_caching_type') THEN
+    --
+    -- Name: deep_caching_type; Type: TYPE; Schema: public; Owner: traffic_ops
+    --
 
-CREATE TYPE deep_caching_type AS ENUM (
-    'NEVER',
-    'ALWAYS'
-);
+    CREATE TYPE deep_caching_type AS ENUM (
+        'NEVER',
+        'ALWAYS'
+    );
+END IF;
 
---
--- Name: http_method_t; Type: TYPE; Schema: public; Owner: traffic_ops
---
+IF NOT EXISTS (SELECT FROM pg_type WHERE typname = 'http_method_t') THEN
+    --
+    -- Name: http_method_t; Type: TYPE; Schema: public; Owner: traffic_ops
+    --
 
-CREATE TYPE http_method_t AS ENUM (
-    'GET',
-    'POST',
-    'PUT',
-    'PATCH',
-    'DELETE'
-);
+    CREATE TYPE http_method_t AS ENUM (
+        'GET',
+        'POST',
+        'PUT',
+        'PATCH',
+        'DELETE'
+    );
+END IF;
 
---
--- Name: localization_method; Type: TYPE; Schema: public; Owner: traffic_ops
---
+IF NOT EXISTS (SELECT FROM pg_type WHERE typname = 'origin_protocol') THEN
+    --
+    -- Name: localization_method; Type: TYPE; Schema: public; Owner: traffic_ops
+    --
 
-CREATE TYPE localization_method AS ENUM (
-    'CZ',
-    'DEEP_CZ',
-    'GEO'
-);
+    CREATE TYPE localization_method AS ENUM (
+        'CZ',
+        'DEEP_CZ',
+        'GEO'
+    );
+END IF;
 
---
--- Name: origin_protocol; Type: TYPE; Schema: public; Owner: traffic_ops
---
+IF NOT EXISTS (SELECT FROM pg_type WHERE typname = 'origin_protocol') THEN
+    --
+    -- Name: origin_protocol; Type: TYPE; Schema: public; Owner: traffic_ops
+    --
 
-CREATE TYPE origin_protocol AS ENUM (
-    'http',
-    'https'
-);
+    CREATE TYPE origin_protocol AS ENUM (
+        'http',
+        'https'
+    );
+END IF;
 
---
--- Name: profile_type; Type: TYPE; Schema: public; Owner: traffic_ops
---
+IF NOT EXISTS (SELECT FROM pg_type WHERE typname = 'profile_type') THEN
+    --
+    -- Name: profile_type; Type: TYPE; Schema: public; Owner: traffic_ops
+    --
 
-CREATE TYPE profile_type AS ENUM (
-    'ATS_PROFILE',
-    'TR_PROFILE',
-    'TM_PROFILE',
-    'TS_PROFILE',
-    'TP_PROFILE',
-    'INFLUXDB_PROFILE',
-    'RIAK_PROFILE',
-    'SPLUNK_PROFILE',
-    'DS_PROFILE',
-    'ORG_PROFILE',
-    'KAFKA_PROFILE',
-    'LOGSTASH_PROFILE',
-    'ES_PROFILE',
-    'UNK_PROFILE',
-    'GROVE_PROFILE'
-);
+    CREATE TYPE profile_type AS ENUM (
+        'ATS_PROFILE',
+        'TR_PROFILE',
+        'TM_PROFILE',
+        'TS_PROFILE',
+        'TP_PROFILE',
+        'INFLUXDB_PROFILE',
+        'RIAK_PROFILE',
+        'SPLUNK_PROFILE',
+        'DS_PROFILE',
+        'ORG_PROFILE',
+        'KAFKA_PROFILE',
+        'LOGSTASH_PROFILE',
+        'ES_PROFILE',
+        'UNK_PROFILE',
+        'GROVE_PROFILE'
+    );
+END IF;
 
---
--- Name: workflow_states; Type: TYPE; Schema: public; Owner: traffic_ops
---
+IF NOT EXISTS (SELECT FROM pg_type WHERE typname = 'workflow_states') THEN
+    --
+    -- Name: workflow_states; Type: TYPE; Schema: public; Owner: traffic_ops
+    --
 
-CREATE TYPE workflow_states AS ENUM (
-    'draft',
-    'submitted',
-    'rejected',
-    'pending',
-    'complete'
-);
+    CREATE TYPE workflow_states AS ENUM (
+        'draft',
+        'submitted',
+        'rejected',
+        'pending',
+        'complete'
+    );
+END IF;
 
---
--- Name: deliveryservice_signature_type; Type: DOMAIN; Schema: public; Owner: traffic_ops
---
+IF NOT EXISTS (SELECT FROM pg_type WHERE typname = 'deliveryservice_signature_type') THEN
+    --
+    -- Name: deliveryservice_signature_type; Type: DOMAIN; Schema: public; Owner: traffic_ops
+    --
 
-CREATE DOMAIN deliveryservice_signature_type AS text CHECK (VALUE IN ('url_sig', 'uri_signing'));
+    CREATE DOMAIN deliveryservice_signature_type AS text CHECK (VALUE IN ('url_sig', 'uri_signing'));
+END IF;
+END$$;
 
 --
 -- Name: api_capability; Type: TABLE; Schema: public; Owner: traffic_ops

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -1781,542 +1781,648 @@ ALTER TABLE ONLY to_extension ALTER COLUMN id SET DEFAULT nextval('to_extension_
 
 ALTER TABLE ONLY type ALTER COLUMN id SET DEFAULT nextval('type_id_seq'::regclass);
 
+DO $$ BEGIN
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'asn' AND column_name = 'id') THEN
+    --
+    -- Name: idx_89468_cr_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89468_cr_id_unique ON asn USING btree (id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'asn' AND column_name = 'cachegroup') THEN
+    --
+    -- Name: idx_89468_fk_cran_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89468_fk_cran_cachegroup1 ON asn USING btree (cachegroup);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup' AND column_name = 'name') THEN
+    --
+    -- Name: idx_89476_cg_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_cg_name_unique ON cachegroup USING btree (name);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup' AND column_name = 'short_name') THEN
+    --
+    -- Name: idx_89476_cg_short_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_cg_short_unique ON cachegroup USING btree (short_name);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup' AND column_name = 'parent_cachegroup_id') THEN
+    --
+    -- Name: idx_89476_fk_cg_1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_1 ON cachegroup USING btree (parent_cachegroup_id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup' AND column_name = 'secondary_parent_cachegroup_id') THEN
+    --
+    -- Name: idx_89476_fk_cg_secondary; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_secondary ON cachegroup USING btree (secondary_parent_cachegroup_id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup' AND column_name = 'type') THEN
+    --
+    -- Name: idx_89476_fk_cg_type1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_type1 ON cachegroup USING btree (type);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup' AND column_name = 'id') THEN
+    --
+    -- Name: idx_89476_lo_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_lo_id_unique ON cachegroup USING btree (id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup_parameter' AND column_name = 'parameter') THEN
+    --
+    -- Name: idx_89484_fk_parameter; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89484_fk_parameter ON cachegroup_parameter USING btree (parameter);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cdn' AND column_name = 'name') THEN
+    --
+    -- Name: idx_89491_cdn_cdn_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89491_cdn_cdn_unique ON cdn USING btree (name);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice' AND column_name = 'id') THEN
+    --
+    -- Name: idx_89502_ds_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89502_ds_id_unique ON deliveryservice USING btree (id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice' AND column_name = 'tenant_id') THEN
+    --
+    -- Name: idx_k_deliveryservice_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_k_deliveryservice_tenant_idx ON deliveryservice USING btree (tenant_id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice' AND column_name = 'xml_id') THEN
+    --
+    -- Name: idx_89502_ds_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
---
--- Name: idx_89468_cr_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89502_ds_name_unique ON deliveryservice USING btree (xml_id);
+END IF;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89468_cr_id_unique ON asn USING btree (id);
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice' AND column_name = 'cdn_id') THEN
+    --
+    -- Name: idx_89502_fk_cdn1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
+    CREATE INDEX IF NOT EXISTS idx_89502_fk_cdn1 ON deliveryservice USING btree (cdn_id);
+END IF;
 
---
--- Name: idx_89468_fk_cran_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
---
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice' AND column_name = 'profile') THEN
+    --
+    -- Name: idx_89502_fk_deliveryservice_profile1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
-CREATE INDEX IF NOT EXISTS idx_89468_fk_cran_cachegroup1 ON asn USING btree (cachegroup);
+    CREATE INDEX IF NOT EXISTS idx_89502_fk_deliveryservice_profile1 ON deliveryservice USING btree (profile);
+END IF;
 
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice' AND column_name = 'type') THEN
+    --
+    -- Name: idx_89502_fk_deliveryservice_type1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
---
--- Name: idx_89476_cg_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
+    CREATE INDEX IF NOT EXISTS idx_89502_fk_deliveryservice_type1 ON deliveryservice USING btree (type);
+END IF;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_cg_name_unique ON cachegroup USING btree (name);
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice_regex' AND column_name = 'regex') THEN
+    --
+    -- Name: idx_89517_fk_ds_to_regex_regex1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
+    CREATE INDEX IF NOT EXISTS idx_89517_fk_ds_to_regex_regex1 ON deliveryservice_regex USING btree (regex);
+END IF;
 
---
--- Name: idx_89476_cg_short_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice_server' AND column_name = 'server') THEN
+    --
+    -- Name: idx_89521_fk_ds_to_cs_contentserver1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89521_fk_ds_to_cs_contentserver1 ON deliveryservice_server USING btree (server);
+END IF;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_cg_short_unique ON cachegroup USING btree (short_name);
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'deliveryservice_tmuser' AND column_name = 'tm_user_id') THEN
+    --
+    -- Name: idx_89525_fk_tm_userid; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89525_fk_tm_userid ON deliveryservice_tmuser USING btree (tm_user_id);
+END IF;
 
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'division' AND column_name = 'name') THEN
+    --
+    -- Name: idx_89531_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89531_name_unique ON division USING btree (name);
+END IF;
 
---
--- Name: idx_89476_fk_cg_1; Type: INDEX; Schema: public; Owner: traffic_ops
---
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'federation_deliveryservice' AND column_name = 'deliveryservice') THEN
+    --
+    -- Name: idx_89549_fk_fed_to_ds1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89549_fk_fed_to_ds1 ON federation_deliveryservice USING btree (deliveryservice);
+END IF;
 
-CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_1 ON cachegroup USING btree (parent_cachegroup_id);
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'federation_federation_resolver' AND column_name = 'federation') THEN
+    --
+    -- Name: idx_89553_fk_federation_federation_resolver; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89553_fk_federation_federation_resolver ON federation_federation_resolver USING btree (federation);
+END IF;
 
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'federation_federation_resolver' AND column_name = 'federation_resolver') THEN
+    --
+    -- Name: idx_89553_fk_federation_resolver_to_fed1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89553_fk_federation_resolver_to_fed1 ON federation_federation_resolver USING btree (federation_resolver);
+END IF;
 
---
--- Name: idx_89476_fk_cg_secondary; Type: INDEX; Schema: public; Owner: traffic_ops
---
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'federation_resolver' AND column_name = 'ip_address') THEN
+    --
+    -- Name: idx_89559_federation_resolver_ip_address; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89559_federation_resolver_ip_address ON federation_resolver USING btree (ip_address);
+END IF;
 
-CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_secondary ON cachegroup USING btree (secondary_parent_cachegroup_id);
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'federation_resolver' AND column_name = 'type') THEN
+    --
+    -- Name: idx_89559_fk_federation_mapping_type; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89559_fk_federation_mapping_type ON federation_resolver USING btree (type);
+END IF;
 
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'federation_tmuser' AND column_name = 'federation') THEN
+    --
+    -- Name: idx_89567_fk_federation_federation_resolver; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_federation_resolver ON federation_tmuser USING btree (federation);
+END IF;
 
---
--- Name: idx_89476_fk_cg_type1; Type: INDEX; Schema: public; Owner: traffic_ops
---
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'federation_tmuser' AND column_name = 'role') THEN
+    --
+    -- Name: idx_89567_fk_federation_tmuser_role; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_tmuser_role ON federation_tmuser USING btree (role);
+END IF;
 
-CREATE INDEX IF NOT EXISTS idx_89476_fk_cg_type1 ON cachegroup USING btree (type);
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'federation_tmuser' AND column_name = 'tm_user') THEN
+    --
+    -- Name: idx_89567_fk_federation_tmuser_tmuser; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_tmuser_tmuser ON federation_tmuser USING btree (tm_user);
+END IF;
 
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'hwinfo' AND column_name = 'serverid') THEN
+    --
+    -- Name: idx_89583_fk_hwinfo1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89583_fk_hwinfo1 ON hwinfo USING btree (serverid);
+END IF;
 
---
--- Name: idx_89476_lo_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'hwinfo' AND column_name = 'serverid')
+    AND EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'hwinfo' AND column_name = 'description') THEN
+    --
+    -- Name: idx_89583_serverid; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89583_serverid ON hwinfo USING btree (serverid, description);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'job' AND column_name = 'agent') THEN
+    --
+    -- Name: idx_89593_fk_job_agent_id1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89593_fk_job_agent_id1 ON job USING btree (agent);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'job' AND column_name = 'job_deliveryservice') THEN
+    --
+    -- Name: idx_89593_fk_job_deliveryservice1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89593_fk_job_deliveryservice1 ON job USING btree (job_deliveryservice);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'job' AND column_name = 'status') THEN
+    --
+    -- Name: idx_89593_fk_job_status_id1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89593_fk_job_status_id1 ON job USING btree (status);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'job' AND column_name = 'job_user') THEN
+    --
+    -- Name: idx_89593_fk_job_user_id1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89593_fk_job_user_id1 ON job USING btree (job_user);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'log' AND column_name = 'tm_user') THEN
+    --
+    -- Name: idx_89634_fk_log_1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89634_fk_log_1 ON log USING btree (tm_user);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'log' AND column_name = 'last_updated') THEN
+    --
+    -- Name: idx_89634_idx_last_updated; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89634_idx_last_updated ON log USING btree (last_updated);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'parameter' AND column_name = 'name')
+    AND EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'parameter' AND column_name = 'value') THEN
+    --
+    -- Name: idx_89644_parameter_name_value_idx; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89476_lo_id_unique ON cachegroup USING btree (id);
+    CREATE INDEX IF NOT EXISTS idx_89644_parameter_name_value_idx ON parameter USING btree (name, value);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'phys_location' AND column_name = 'region') THEN
+    --
+    -- Name: idx_89655_fk_phys_location_region_idx; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
+    CREATE INDEX IF NOT EXISTS idx_89655_fk_phys_location_region_idx ON phys_location USING btree (region);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'phys_location' AND column_name = 'name') THEN
+    --
+    -- Name: idx_89655_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
---
--- Name: idx_89484_fk_parameter; Type: INDEX; Schema: public; Owner: traffic_ops
---
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89655_name_unique ON phys_location USING btree (name);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'phys_location' AND column_name = 'short_name') THEN
+    --
+    -- Name: idx_89655_short_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
-CREATE INDEX IF NOT EXISTS idx_89484_fk_parameter ON cachegroup_parameter USING btree (parameter);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89655_short_name_unique ON phys_location USING btree (short_name);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'profile' AND column_name = 'name') THEN
+    --
+    -- Name: idx_89665_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89665_name_unique ON profile USING btree (name);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'profile' AND column_name = 'cdn') THEN
+    --
+    -- Name: idx_181818_fk_cdn1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
 
---
--- Name: idx_89491_cdn_cdn_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
+    CREATE INDEX IF NOT EXISTS idx_181818_fk_cdn1 ON profile USING btree (cdn);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'profile_parameter' AND column_name = 'parameter') THEN
+    --
+    -- Name: idx_89673_fk_atsprofile_atsparameters_atsparameters1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89673_fk_atsprofile_atsparameters_atsparameters1 ON profile_parameter USING btree (parameter);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'profile_parameter' AND column_name = 'profile') THEN
+    --
+    -- Name: idx_89673_fk_atsprofile_atsparameters_atsprofile1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89673_fk_atsprofile_atsparameters_atsprofile1 ON profile_parameter USING btree (profile);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'regex' AND column_name = 'type') THEN
+    --
+    -- Name: idx_89679_fk_regex_type1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89679_fk_regex_type1 ON regex USING btree (type);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'regex' AND column_name = 'id') THEN
+    --
+    -- Name: idx_89679_re_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89679_re_id_unique ON regex USING btree (id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'region' AND column_name = 'division') THEN
+    --
+    -- Name: idx_89690_fk_region_division1_idx; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89690_fk_region_division1_idx ON region USING btree (division);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'region' AND column_name = 'name') THEN
+    --
+    -- Name: idx_89690_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89690_name_unique ON region USING btree (name);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'cdn_id') THEN
+    --
+    -- Name: idx_89709_fk_cdn2; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89709_fk_cdn2 ON server USING btree (cdn_id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'profile') THEN
+    --
+    -- Name: idx_89709_fk_contentserver_atsprofile1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_atsprofile1 ON server USING btree (profile);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'status') THEN
+    --
+    -- Name: idx_89709_fk_contentserver_contentserverstatus1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_contentserverstatus1 ON server USING btree (status);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'type') THEN
+    --
+    -- Name: idx_89709_fk_contentserver_contentservertype1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_contentservertype1 ON server USING btree (type);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'phys_location') THEN
+    --
+    -- Name: idx_89709_fk_contentserver_phys_location1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_phys_location1 ON server USING btree (phys_location);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'cachegroup') THEN
+    --
+    -- Name: idx_89709_fk_server_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89709_fk_server_cachegroup1 ON server USING btree (cachegroup);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'ip6_address')
+    AND EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'profile') THEN
+    --
+    -- Name: idx_89709_ip6_profile; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_ip6_profile ON server USING btree (ip6_address, profile);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'ip_address')
+    AND EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'profile') THEN
+    --
+    -- Name: idx_89709_ip_profile; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_ip_profile ON server USING btree (ip_address, profile);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'server' AND column_name = 'id') THEN
+    --
+    -- Name: idx_89709_se_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_se_id_unique ON server USING btree (id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'servercheck' AND column_name = 'server') THEN
+    --
+    -- Name: idx_89722_fk_serverstatus_server1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89722_fk_serverstatus_server1 ON servercheck USING btree (server);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'servercheck' AND column_name = 'server') THEN
+    --
+    -- Name: idx_89722_server; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89722_server ON servercheck USING btree (server);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'servercheck' AND column_name = 'id') THEN
+    --
+    -- Name: idx_89722_ses_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89722_ses_id_unique ON servercheck USING btree (id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'staticdnsentry' AND column_name = 'host')
+    AND EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'staticdnsentry' AND column_name = 'address')
+    AND EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'staticdnsentry' AND column_name = 'deliveryservice')
+    AND EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'staticdnsentry' AND column_name = 'cachegroup') THEN
+    --
+    -- Name: idx_89729_combi_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89729_combi_unique ON staticdnsentry USING btree (host, address, deliveryservice, cachegroup);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'staticdnsentry' AND column_name = 'cachegroup') THEN
+    --
+    -- Name: idx_89729_fk_staticdnsentry_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_cachegroup1 ON staticdnsentry USING btree (cachegroup);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'staticdnsentry' AND column_name = 'deliveryservice') THEN
+    --
+    -- Name: idx_89729_fk_staticdnsentry_ds; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_ds ON staticdnsentry USING btree (deliveryservice);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'staticdnsentry' AND column_name = 'type') THEN
+    --
+    -- Name: idx_89729_fk_staticdnsentry_type; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_type ON staticdnsentry USING btree (type);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'tenant' AND column_name = 'parent_id') THEN
+    --
+    -- Name: idx_k_tenant_parent_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_k_tenant_parent_tenant_idx ON tenant USING btree (parent_id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'tm_user' AND column_name = 'role') THEN
+    --
+    -- Name: idx_89765_fk_user_1; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89765_fk_user_1 ON tm_user USING btree (role);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'tm_user' AND column_name = 'tenant_id') THEN
+    --
+    -- Name: idx_k_tm_user_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_k_tm_user_tenant_idx ON tm_user USING btree (tenant_id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'tm_user' AND column_name = 'email') THEN
+    --
+    -- Name: idx_89765_tmuser_email_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89765_tmuser_email_unique ON tm_user USING btree (email);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'tm_user' AND column_name = 'username') THEN
+    --
+    -- Name: idx_89765_username_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89765_username_unique ON tm_user USING btree (username);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'to_extension' AND column_name = 'type') THEN
+    --
+    -- Name: idx_89776_fk_ext_type_idx; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS idx_89776_fk_ext_type_idx ON to_extension USING btree (type);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'to_extension' AND column_name = 'id') THEN
+    --
+    -- Name: idx_89776_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_89776_id_unique ON to_extension USING btree (id);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup' AND column_name = 'coordinate') THEN
+    --
+    -- Name: cachegroup_coordinate_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS cachegroup_coordinate_fkey ON cachegroup USING btree (coordinate);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'cachegroup_localization_method' AND column_name = 'cachegroup') THEN
+    --
+    -- Name: cachegroup_localization_method_cachegroup_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS cachegroup_localization_method_cachegroup_fkey ON cachegroup_localization_method USING btree(cachegroup);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'origin' AND column_name = 'is_primary')
+    AND EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'origin' AND column_name = 'deliveryservice') THEN
+    --
+    -- Name: origin_is_primary_deliveryservice_constraint; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE UNIQUE INDEX IF NOT EXISTS origin_is_primary_deliveryservice_constraint ON origin (is_primary, deliveryservice) WHERE is_primary;
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'origin' AND column_name = 'deliveryservice') THEN
+    --
+    -- Name: origin_deliveryservice_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS origin_deliveryservice_fkey ON origin USING btree (deliveryservice);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'origin' AND column_name = 'coordinate') THEN
+    --
+    -- Name: origin_coordinate_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS origin_coordinate_fkey ON origin USING btree (coordinate);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'origin' AND column_name = 'profile') THEN
+    --
+    -- Name: origin_profile_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS origin_profile_fkey ON origin USING btree (profile);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'origin' AND column_name = 'cachegroup') THEN
+    --
+    -- Name: origin_cachegroup_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS origin_cachegroup_fkey ON origin USING btree (cachegroup);
+END IF;
+
+IF EXISTS (SELECT FROM information_schema.columns WHERE table_name = 'origin' AND column_name = 'tenant') THEN
+    --
+    -- Name: origin_tenant_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
+    --
+
+    CREATE INDEX IF NOT EXISTS origin_tenant_fkey ON origin USING btree (tenant);
+END IF;
+END$$;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89491_cdn_cdn_unique ON cdn USING btree (name);
-
---
--- Name: idx_89502_ds_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89502_ds_id_unique ON deliveryservice USING btree (id);
-
---
--- Name: idx_k_deliveryservice_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_k_deliveryservice_tenant_idx ON deliveryservice USING btree (tenant_id);
-
---
--- Name: idx_89502_ds_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89502_ds_name_unique ON deliveryservice USING btree (xml_id);
-
-
---
--- Name: idx_89502_fk_cdn1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89502_fk_cdn1 ON deliveryservice USING btree (cdn_id);
-
-
---
--- Name: idx_89502_fk_deliveryservice_profile1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89502_fk_deliveryservice_profile1 ON deliveryservice USING btree (profile);
-
-
---
--- Name: idx_89502_fk_deliveryservice_type1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89502_fk_deliveryservice_type1 ON deliveryservice USING btree (type);
-
-
---
--- Name: idx_89517_fk_ds_to_regex_regex1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89517_fk_ds_to_regex_regex1 ON deliveryservice_regex USING btree (regex);
-
-
---
--- Name: idx_89521_fk_ds_to_cs_contentserver1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89521_fk_ds_to_cs_contentserver1 ON deliveryservice_server USING btree (server);
-
-
---
--- Name: idx_89525_fk_tm_userid; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89525_fk_tm_userid ON deliveryservice_tmuser USING btree (tm_user_id);
-
-
---
--- Name: idx_89531_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89531_name_unique ON division USING btree (name);
-
-
---
--- Name: idx_89549_fk_fed_to_ds1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89549_fk_fed_to_ds1 ON federation_deliveryservice USING btree (deliveryservice);
-
-
---
--- Name: idx_89553_fk_federation_federation_resolver; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89553_fk_federation_federation_resolver ON federation_federation_resolver USING btree (federation);
-
-
---
--- Name: idx_89553_fk_federation_resolver_to_fed1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89553_fk_federation_resolver_to_fed1 ON federation_federation_resolver USING btree (federation_resolver);
-
-
---
--- Name: idx_89559_federation_resolver_ip_address; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89559_federation_resolver_ip_address ON federation_resolver USING btree (ip_address);
-
-
---
--- Name: idx_89559_fk_federation_mapping_type; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89559_fk_federation_mapping_type ON federation_resolver USING btree (type);
-
-
---
--- Name: idx_89567_fk_federation_federation_resolver; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_federation_resolver ON federation_tmuser USING btree (federation);
-
-
---
--- Name: idx_89567_fk_federation_tmuser_role; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_tmuser_role ON federation_tmuser USING btree (role);
-
-
---
--- Name: idx_89567_fk_federation_tmuser_tmuser; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89567_fk_federation_tmuser_tmuser ON federation_tmuser USING btree (tm_user);
-
-
---
--- Name: idx_89583_fk_hwinfo1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89583_fk_hwinfo1 ON hwinfo USING btree (serverid);
-
-
---
--- Name: idx_89583_serverid; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89583_serverid ON hwinfo USING btree (serverid, description);
-
-
---
--- Name: idx_89593_fk_job_agent_id1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89593_fk_job_agent_id1 ON job USING btree (agent);
-
-
---
--- Name: idx_89593_fk_job_deliveryservice1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89593_fk_job_deliveryservice1 ON job USING btree (job_deliveryservice);
-
-
---
--- Name: idx_89593_fk_job_status_id1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89593_fk_job_status_id1 ON job USING btree (status);
-
-
---
--- Name: idx_89593_fk_job_user_id1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89593_fk_job_user_id1 ON job USING btree (job_user);
-
-
---
--- Name: idx_89634_fk_log_1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89634_fk_log_1 ON log USING btree (tm_user);
-
-
---
--- Name: idx_89634_idx_last_updated; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89634_idx_last_updated ON log USING btree (last_updated);
-
-
---
--- Name: idx_89644_parameter_name_value_idx; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89644_parameter_name_value_idx ON parameter USING btree (name, value);
-
-
---
--- Name: idx_89655_fk_phys_location_region_idx; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89655_fk_phys_location_region_idx ON phys_location USING btree (region);
-
-
---
--- Name: idx_89655_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89655_name_unique ON phys_location USING btree (name);
-
-
---
--- Name: idx_89655_short_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89655_short_name_unique ON phys_location USING btree (short_name);
-
-
---
--- Name: idx_89665_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89665_name_unique ON profile USING btree (name);
-
---
--- Name: idx_181818_fk_cdn1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_181818_fk_cdn1 ON profile USING btree (cdn);
-
-
---
--- Name: idx_89673_fk_atsprofile_atsparameters_atsparameters1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89673_fk_atsprofile_atsparameters_atsparameters1 ON profile_parameter USING btree (parameter);
-
-
---
--- Name: idx_89673_fk_atsprofile_atsparameters_atsprofile1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89673_fk_atsprofile_atsparameters_atsprofile1 ON profile_parameter USING btree (profile);
-
-
---
--- Name: idx_89679_fk_regex_type1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89679_fk_regex_type1 ON regex USING btree (type);
-
-
---
--- Name: idx_89679_re_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89679_re_id_unique ON regex USING btree (id);
-
-
---
--- Name: idx_89690_fk_region_division1_idx; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89690_fk_region_division1_idx ON region USING btree (division);
-
-
---
--- Name: idx_89690_name_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89690_name_unique ON region USING btree (name);
-
-
---
--- Name: idx_89709_fk_cdn2; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89709_fk_cdn2 ON server USING btree (cdn_id);
-
-
---
--- Name: idx_89709_fk_contentserver_atsprofile1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_atsprofile1 ON server USING btree (profile);
-
-
---
--- Name: idx_89709_fk_contentserver_contentserverstatus1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_contentserverstatus1 ON server USING btree (status);
-
-
---
--- Name: idx_89709_fk_contentserver_contentservertype1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_contentservertype1 ON server USING btree (type);
-
-
---
--- Name: idx_89709_fk_contentserver_phys_location1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89709_fk_contentserver_phys_location1 ON server USING btree (phys_location);
-
-
---
--- Name: idx_89709_fk_server_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89709_fk_server_cachegroup1 ON server USING btree (cachegroup);
-
-
---
--- Name: idx_89709_ip6_profile; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_ip6_profile ON server USING btree (ip6_address, profile);
-
-
---
--- Name: idx_89709_ip_profile; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_ip_profile ON server USING btree (ip_address, profile);
-
-
---
--- Name: idx_89709_se_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89709_se_id_unique ON server USING btree (id);
-
-
---
--- Name: idx_89722_fk_serverstatus_server1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89722_fk_serverstatus_server1 ON servercheck USING btree (server);
-
-
---
--- Name: idx_89722_server; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89722_server ON servercheck USING btree (server);
-
-
---
--- Name: idx_89722_ses_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89722_ses_id_unique ON servercheck USING btree (id);
-
-
---
--- Name: idx_89729_combi_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89729_combi_unique ON staticdnsentry USING btree (host, address, deliveryservice, cachegroup);
-
-
---
--- Name: idx_89729_fk_staticdnsentry_cachegroup1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_cachegroup1 ON staticdnsentry USING btree (cachegroup);
-
-
---
--- Name: idx_89729_fk_staticdnsentry_ds; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_ds ON staticdnsentry USING btree (deliveryservice);
-
-
---
--- Name: idx_89729_fk_staticdnsentry_type; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89729_fk_staticdnsentry_type ON staticdnsentry USING btree (type);
-
---
--- Name: idx_k_tenant_parent_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_k_tenant_parent_tenant_idx ON tenant USING btree (parent_id);
-
---
--- Name: idx_89765_fk_user_1; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89765_fk_user_1 ON tm_user USING btree (role);
-
---
--- Name: idx_k_tm_user_tenant_idx; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_k_tm_user_tenant_idx ON tm_user USING btree (tenant_id);
-
---
--- Name: idx_89765_tmuser_email_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89765_tmuser_email_unique ON tm_user USING btree (email);
-
-
---
--- Name: idx_89765_username_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89765_username_unique ON tm_user USING btree (username);
-
-
---
--- Name: idx_89776_fk_ext_type_idx; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS idx_89776_fk_ext_type_idx ON to_extension USING btree (type);
-
-
---
--- Name: idx_89776_id_unique; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_89776_id_unique ON to_extension USING btree (id);
-
---
--- Name: cachegroup_coordinate_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS cachegroup_coordinate_fkey ON cachegroup USING btree (coordinate);
-
---
--- Name: cachegroup_localization_method_cachegroup_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS cachegroup_localization_method_cachegroup_fkey ON cachegroup_localization_method USING btree(cachegroup);
-
---
--- Name: origin_is_primary_deliveryservice_constraint; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE UNIQUE INDEX IF NOT EXISTS origin_is_primary_deliveryservice_constraint ON origin (is_primary, deliveryservice) WHERE is_primary;
-
---
--- Name: origin_deliveryservice_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS origin_deliveryservice_fkey ON origin USING btree (deliveryservice);
-
---
--- Name: origin_coordinate_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS origin_coordinate_fkey ON origin USING btree (coordinate);
-
---
--- Name: origin_profile_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS origin_profile_fkey ON origin USING btree (profile);
-
---
--- Name: origin_cachegroup_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS origin_cachegroup_fkey ON origin USING btree (cachegroup);
-
---
--- Name: origin_tenant_fkey; Type: INDEX; Schema: public; Owner: traffic_ops
---
-
-CREATE INDEX IF NOT EXISTS origin_tenant_fkey ON origin USING btree (tenant);
 
 --
 -- Add on_update_current_timestamp TRIGGER to all tables

--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -170,7 +170,7 @@ END$$;
 -- Name: api_capability; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE api_capability (
+CREATE TABLE IF NOT EXISTS api_capability (
     id bigserial PRIMARY KEY,
     http_method http_method_t NOT NULL,
     route text NOT NULL,
@@ -185,7 +185,7 @@ ALTER TABLE api_capability OWNER TO traffic_ops;
 -- Name: asn; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE asn (
+CREATE TABLE IF NOT EXISTS asn (
     id bigint NOT NULL,
     asn bigint NOT NULL,
     cachegroup bigint DEFAULT '0'::bigint NOT NULL,
@@ -199,7 +199,7 @@ ALTER TABLE asn OWNER TO traffic_ops;
 -- Name: asn_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE asn_id_seq
+CREATE SEQUENCE IF NOT EXISTS asn_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -219,7 +219,7 @@ ALTER SEQUENCE asn_id_seq OWNED BY asn.id;
 -- Name: cachegroup; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE cachegroup (
+CREATE TABLE IF NOT EXISTS cachegroup (
     id bigint,
     name text NOT NULL,
     short_name text NOT NULL,
@@ -238,7 +238,7 @@ ALTER TABLE cachegroup OWNER TO traffic_ops;
 -- Name: cachegroup_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE cachegroup_id_seq
+CREATE SEQUENCE IF NOT EXISTS cachegroup_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -258,7 +258,7 @@ ALTER SEQUENCE cachegroup_id_seq OWNED BY cachegroup.id;
 -- Name: cachegroup_fallbacks; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE cachegroup_fallbacks (
+CREATE TABLE IF NOT EXISTS cachegroup_fallbacks (
     primary_cg bigint NOT NULL,
     backup_cg bigint NOT NULL CHECK (primary_cg != backup_cg),
     set_order bigint NOT NULL,
@@ -272,7 +272,7 @@ ALTER TABLE cachegroup_fallbacks OWNER TO traffic_ops;
 -- Name: cachegroup_localization_method; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE cachegroup_localization_method (
+CREATE TABLE IF NOT EXISTS cachegroup_localization_method (
     cachegroup bigint NOT NULL,
     method localization_method NOT NULL,
     UNIQUE (cachegroup, method)
@@ -282,7 +282,7 @@ CREATE TABLE cachegroup_localization_method (
 -- Name: cachegroup_parameter; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE cachegroup_parameter (
+CREATE TABLE IF NOT EXISTS cachegroup_parameter (
     cachegroup bigint DEFAULT '0'::bigint NOT NULL,
     parameter bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now()
@@ -295,7 +295,7 @@ ALTER TABLE cachegroup_parameter OWNER TO traffic_ops;
 -- Name: capability; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE capability (
+CREATE TABLE IF NOT EXISTS capability (
     name text NOT NULL,
     description text,
     last_updated timestamp with time zone NOT NULL DEFAULT now()
@@ -307,7 +307,7 @@ ALTER TABLE capability OWNER TO traffic_ops;
 -- Name: cdn; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE cdn (
+CREATE TABLE IF NOT EXISTS cdn (
     id bigint,
     name text NOT NULL,
     last_updated timestamp with time zone DEFAULT now() NOT NULL,
@@ -323,7 +323,7 @@ ALTER TABLE cdn OWNER TO traffic_ops;
 -- Name: cdn_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE cdn_id_seq
+CREATE SEQUENCE IF NOT EXISTS cdn_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -343,19 +343,20 @@ ALTER SEQUENCE cdn_id_seq OWNED BY cdn.id;
 -- Name: coordinate; Type: TABLE; Schema: public: Owner: traffic_ops
 --
 
-CREATE TABLE coordinate (
+CREATE TABLE IF NOT EXISTS coordinate (
     id bigserial,
     name text UNIQUE NOT NULL,
     latitude numeric NOT NULL DEFAULT 0.0,
     longitude numeric NOT NULL DEFAULT 0.0,
-    last_updated timestamp with time zone NOT NULL DEFAULT now()
+    last_updated timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT coordinate_pkey PRIMARY KEY (id)
 );
 
 --
 -- Name: deliveryservice; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE deliveryservice (
+CREATE TABLE IF NOT EXISTS deliveryservice (
     id bigint,
     xml_id text NOT NULL,
     active boolean DEFAULT false NOT NULL,
@@ -419,7 +420,7 @@ ALTER TABLE deliveryservice OWNER TO traffic_ops;
 -- Name: deliveryservice_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE deliveryservice_id_seq
+CREATE SEQUENCE IF NOT EXISTS deliveryservice_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -440,7 +441,7 @@ ALTER SEQUENCE deliveryservice_id_seq OWNED BY deliveryservice.id;
 -- Name: deliveryservice_regex; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE deliveryservice_regex (
+CREATE TABLE IF NOT EXISTS deliveryservice_regex (
     deliveryservice bigint NOT NULL,
     regex bigint NOT NULL,
     set_number bigint DEFAULT '0'::bigint,
@@ -454,7 +455,7 @@ ALTER TABLE deliveryservice_regex OWNER TO traffic_ops;
 -- Name: deliveryservice_request; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE deliveryservice_request (
+CREATE TABLE IF NOT EXISTS deliveryservice_request (
     assignee_id bigint,
     author_id bigint NOT NULL,
     change_type change_types NOT NULL,
@@ -472,7 +473,7 @@ ALTER TABLE deliveryservice_request OWNER TO traffic_ops;
 -- Name: deliveryservice_request_comment; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE deliveryservice_request_comment (
+CREATE TABLE IF NOT EXISTS deliveryservice_request_comment (
     author_id bigint NOT NULL,
     deliveryservice_request_id bigint NOT NULL,
     id bigserial,
@@ -484,7 +485,7 @@ CREATE TABLE deliveryservice_request_comment (
 -- Name: deliveryservice_server; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE deliveryservice_server (
+CREATE TABLE IF NOT EXISTS deliveryservice_server (
     deliveryservice bigint NOT NULL,
     server bigint NOT NULL,
     last_updated timestamp with time zone DEFAULT now() NOT NULL
@@ -497,7 +498,7 @@ ALTER TABLE deliveryservice_server OWNER TO traffic_ops;
 -- Name: deliveryservice_tmuser; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE deliveryservice_tmuser (
+CREATE TABLE IF NOT EXISTS deliveryservice_tmuser (
     deliveryservice bigint NOT NULL,
     tm_user_id bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now()
@@ -510,7 +511,7 @@ ALTER TABLE deliveryservice_tmuser OWNER TO traffic_ops;
 -- Name: division; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE division (
+CREATE TABLE IF NOT EXISTS division (
     id bigint NOT NULL,
     name text NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now()
@@ -523,7 +524,7 @@ ALTER TABLE division OWNER TO traffic_ops;
 -- Name: division_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE division_id_seq
+CREATE SEQUENCE IF NOT EXISTS division_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -544,7 +545,7 @@ ALTER SEQUENCE division_id_seq OWNED BY division.id;
 -- Name: federation; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE federation (
+CREATE TABLE IF NOT EXISTS federation (
     id bigint NOT NULL,
     cname text NOT NULL,
     description text,
@@ -559,7 +560,7 @@ ALTER TABLE federation OWNER TO traffic_ops;
 -- Name: federation_deliveryservice; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE federation_deliveryservice (
+CREATE TABLE IF NOT EXISTS federation_deliveryservice (
     federation bigint NOT NULL,
     deliveryservice bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now()
@@ -572,7 +573,7 @@ ALTER TABLE federation_deliveryservice OWNER TO traffic_ops;
 -- Name: federation_federation_resolver; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE federation_federation_resolver (
+CREATE TABLE IF NOT EXISTS federation_federation_resolver (
     federation bigint NOT NULL,
     federation_resolver bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now()
@@ -585,7 +586,7 @@ ALTER TABLE federation_federation_resolver OWNER TO traffic_ops;
 -- Name: federation_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE federation_id_seq
+CREATE SEQUENCE IF NOT EXISTS federation_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -606,7 +607,7 @@ ALTER SEQUENCE federation_id_seq OWNED BY federation.id;
 -- Name: federation_resolver; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE federation_resolver (
+CREATE TABLE IF NOT EXISTS federation_resolver (
     id bigint NOT NULL,
     ip_address text NOT NULL,
     type bigint NOT NULL,
@@ -620,7 +621,7 @@ ALTER TABLE federation_resolver OWNER TO traffic_ops;
 -- Name: federation_resolver_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE federation_resolver_id_seq
+CREATE SEQUENCE IF NOT EXISTS federation_resolver_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -641,7 +642,7 @@ ALTER SEQUENCE federation_resolver_id_seq OWNED BY federation_resolver.id;
 -- Name: federation_tmuser; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE federation_tmuser (
+CREATE TABLE IF NOT EXISTS federation_tmuser (
     federation bigint NOT NULL,
     tm_user bigint NOT NULL,
     role bigint,
@@ -655,7 +656,7 @@ ALTER TABLE federation_tmuser OWNER TO traffic_ops;
 -- Name: hwinfo; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE hwinfo (
+CREATE TABLE IF NOT EXISTS hwinfo (
     id bigint NOT NULL,
     serverid bigint NOT NULL,
     description text NOT NULL,
@@ -670,7 +671,7 @@ ALTER TABLE hwinfo OWNER TO traffic_ops;
 -- Name: hwinfo_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE hwinfo_id_seq
+CREATE SEQUENCE IF NOT EXISTS hwinfo_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -691,7 +692,7 @@ ALTER SEQUENCE hwinfo_id_seq OWNED BY hwinfo.id;
 -- Name: job; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE job (
+CREATE TABLE IF NOT EXISTS job (
     id bigint NOT NULL,
     agent bigint,
     object_type text,
@@ -715,7 +716,7 @@ ALTER TABLE job OWNER TO traffic_ops;
 -- Name: job_agent; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE job_agent (
+CREATE TABLE IF NOT EXISTS job_agent (
     id bigint NOT NULL,
     name text,
     description text,
@@ -731,7 +732,7 @@ ALTER TABLE job_agent OWNER TO traffic_ops;
 -- Name: job_agent_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE job_agent_id_seq
+CREATE SEQUENCE IF NOT EXISTS job_agent_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -752,7 +753,7 @@ ALTER SEQUENCE job_agent_id_seq OWNED BY job_agent.id;
 -- Name: job_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE job_id_seq
+CREATE SEQUENCE IF NOT EXISTS job_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -772,7 +773,7 @@ ALTER SEQUENCE job_id_seq OWNED BY job.id;
 -- Name: job_status; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE job_status (
+CREATE TABLE IF NOT EXISTS job_status (
     id bigint NOT NULL,
     name text,
     description text,
@@ -787,7 +788,7 @@ ALTER TABLE job_status OWNER TO traffic_ops;
 -- Name: job_status_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE job_status_id_seq
+CREATE SEQUENCE IF NOT EXISTS job_status_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -808,7 +809,7 @@ ALTER SEQUENCE job_status_id_seq OWNED BY job_status.id;
 -- Name: log; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE log (
+CREATE TABLE IF NOT EXISTS log (
     id bigint NOT NULL,
     level text,
     message text NOT NULL,
@@ -824,7 +825,7 @@ ALTER TABLE log OWNER TO traffic_ops;
 -- Name: log_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE log_id_seq
+CREATE SEQUENCE IF NOT EXISTS log_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -844,7 +845,7 @@ ALTER SEQUENCE log_id_seq OWNED BY log.id;
 -- Name: origin; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE origin (
+CREATE TABLE IF NOT EXISTS origin (
     id bigserial NOT NULL,
     name text UNIQUE NOT NULL,
     fqdn text NOT NULL,
@@ -867,7 +868,7 @@ ALTER TABLE origin OWNER TO traffic_ops;
 -- Name: parameter; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE parameter (
+CREATE TABLE IF NOT EXISTS parameter (
     id bigint NOT NULL,
     name text NOT NULL,
     config_file text,
@@ -884,7 +885,7 @@ ALTER TABLE parameter OWNER TO traffic_ops;
 -- Name: parameter_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE parameter_id_seq
+CREATE SEQUENCE IF NOT EXISTS parameter_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -905,7 +906,7 @@ ALTER SEQUENCE parameter_id_seq OWNED BY parameter.id;
 -- Name: phys_location; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE phys_location (
+CREATE TABLE IF NOT EXISTS phys_location (
     id bigint NOT NULL,
     name text NOT NULL,
     short_name text NOT NULL,
@@ -928,7 +929,7 @@ ALTER TABLE phys_location OWNER TO traffic_ops;
 -- Name: phys_location_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE phys_location_id_seq
+CREATE SEQUENCE IF NOT EXISTS phys_location_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -948,7 +949,7 @@ ALTER SEQUENCE phys_location_id_seq OWNED BY phys_location.id;
 -- Name: profile; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE profile (
+CREATE TABLE IF NOT EXISTS profile (
     id bigint NOT NULL,
     name text NOT NULL,
     description text,
@@ -965,7 +966,7 @@ ALTER TABLE profile OWNER TO traffic_ops;
 -- Name: profile_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE profile_id_seq
+CREATE SEQUENCE IF NOT EXISTS profile_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -986,7 +987,7 @@ ALTER SEQUENCE profile_id_seq OWNED BY profile.id;
 -- Name: profile_parameter; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE profile_parameter (
+CREATE TABLE IF NOT EXISTS profile_parameter (
     profile bigint NOT NULL,
     parameter bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now()
@@ -999,7 +1000,7 @@ ALTER TABLE profile_parameter OWNER TO traffic_ops;
 -- Name: regex; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE regex (
+CREATE TABLE IF NOT EXISTS regex (
     id bigint NOT NULL,
     pattern text DEFAULT ''::text NOT NULL,
     type bigint NOT NULL,
@@ -1013,7 +1014,7 @@ ALTER TABLE regex OWNER TO traffic_ops;
 -- Name: regex_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE regex_id_seq
+CREATE SEQUENCE IF NOT EXISTS regex_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1034,7 +1035,7 @@ ALTER SEQUENCE regex_id_seq OWNED BY regex.id;
 -- Name: region; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE region (
+CREATE TABLE IF NOT EXISTS region (
     id bigint NOT NULL,
     name text NOT NULL,
     division bigint NOT NULL,
@@ -1048,7 +1049,7 @@ ALTER TABLE region OWNER TO traffic_ops;
 -- Name: region_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE region_id_seq
+CREATE SEQUENCE IF NOT EXISTS region_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1069,7 +1070,7 @@ ALTER SEQUENCE region_id_seq OWNED BY region.id;
 -- Name: role; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE role (
+CREATE TABLE IF NOT EXISTS role (
     id bigint,
     name text NOT NULL,
     description text,
@@ -1085,7 +1086,7 @@ ALTER TABLE role OWNER TO traffic_ops;
 -- Name: role_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE role_id_seq
+CREATE SEQUENCE IF NOT EXISTS role_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1105,7 +1106,7 @@ ALTER SEQUENCE role_id_seq OWNED BY role.id;
 -- Name: role_capability; Type TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE role_capability (
+CREATE TABLE IF NOT EXISTS role_capability (
     role_id bigint NOT NULL,
     cap_name text NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now(),
@@ -1118,7 +1119,7 @@ ALTER TABLE role_capability OWNER TO traffic_ops;
 -- Name: server; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE server (
+CREATE TABLE IF NOT EXISTS server (
     id bigint NOT NULL,
     host_name text NOT NULL,
     domain_name text NOT NULL,
@@ -1164,7 +1165,7 @@ ALTER TABLE server OWNER TO traffic_ops;
 -- Name: server_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE server_id_seq
+CREATE SEQUENCE IF NOT EXISTS server_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1185,7 +1186,7 @@ ALTER SEQUENCE server_id_seq OWNED BY server.id;
 -- Name: servercheck; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE servercheck (
+CREATE TABLE IF NOT EXISTS servercheck (
     id bigint NOT NULL,
     server bigint NOT NULL,
     aa bigint,
@@ -1229,7 +1230,7 @@ ALTER TABLE servercheck OWNER TO traffic_ops;
 -- Name: servercheck_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE servercheck_id_seq
+CREATE SEQUENCE IF NOT EXISTS servercheck_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1249,7 +1250,7 @@ ALTER SEQUENCE servercheck_id_seq OWNED BY servercheck.id;
 -- Name: snapshot; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE snapshot (
+CREATE TABLE IF NOT EXISTS snapshot (
     cdn text NOT NULL,
     content json NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now()
@@ -1261,7 +1262,7 @@ ALTER TABLE snapshot OWNER TO traffic_ops;
 -- Name: staticdnsentry; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE staticdnsentry (
+CREATE TABLE IF NOT EXISTS staticdnsentry (
     id bigint NOT NULL,
     host text NOT NULL,
     address text NOT NULL,
@@ -1279,7 +1280,7 @@ ALTER TABLE staticdnsentry OWNER TO traffic_ops;
 -- Name: staticdnsentry_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE staticdnsentry_id_seq
+CREATE SEQUENCE IF NOT EXISTS staticdnsentry_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1300,7 +1301,7 @@ ALTER SEQUENCE staticdnsentry_id_seq OWNED BY staticdnsentry.id;
 -- Name: stats_summary; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE stats_summary (
+CREATE TABLE IF NOT EXISTS stats_summary (
     id bigint NOT NULL,
     cdn_name text DEFAULT 'all'::text NOT NULL,
     deliveryservice_name text NOT NULL,
@@ -1317,7 +1318,7 @@ ALTER TABLE stats_summary OWNER TO traffic_ops;
 -- Name: stats_summary_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE stats_summary_id_seq
+CREATE SEQUENCE IF NOT EXISTS stats_summary_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1338,7 +1339,7 @@ ALTER SEQUENCE stats_summary_id_seq OWNED BY stats_summary.id;
 -- Name: status; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE status (
+CREATE TABLE IF NOT EXISTS status (
     id bigint NOT NULL,
     name text NOT NULL,
     description text,
@@ -1353,7 +1354,7 @@ ALTER TABLE status OWNER TO traffic_ops;
 -- Name: status_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE status_id_seq
+CREATE SEQUENCE IF NOT EXISTS status_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1374,7 +1375,7 @@ ALTER SEQUENCE status_id_seq OWNED BY status.id;
 -- Name: steering_target; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE steering_target (
+CREATE TABLE IF NOT EXISTS steering_target (
     deliveryservice bigint NOT NULL,
     target bigint NOT NULL,
     value bigint NOT NULL,
@@ -1389,7 +1390,7 @@ ALTER TABLE steering_target OWNER TO traffic_ops;
 -- Name: tenant; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE tenant (
+CREATE TABLE IF NOT EXISTS tenant (
     id bigserial,
     name text UNIQUE NOT NULL,
     active boolean NOT NULL DEFAULT FALSE,
@@ -1401,7 +1402,7 @@ CREATE TABLE tenant (
 -- Name: tm_user; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE tm_user (
+CREATE TABLE IF NOT EXISTS tm_user (
     id bigint NOT NULL,
     username text,
     public_ssh_key text,
@@ -1434,7 +1435,7 @@ ALTER TABLE tm_user OWNER TO traffic_ops;
 -- Name: tm_user_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE tm_user_id_seq
+CREATE SEQUENCE IF NOT EXISTS tm_user_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1455,7 +1456,7 @@ ALTER SEQUENCE tm_user_id_seq OWNED BY tm_user.id;
 -- Name: to_extension; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE to_extension (
+CREATE TABLE IF NOT EXISTS to_extension (
     id bigint NOT NULL,
     name text NOT NULL,
     version text NOT NULL,
@@ -1477,7 +1478,7 @@ ALTER TABLE to_extension OWNER TO traffic_ops;
 -- Name: to_extension_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE to_extension_id_seq
+CREATE SEQUENCE IF NOT EXISTS to_extension_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1498,7 +1499,7 @@ ALTER SEQUENCE to_extension_id_seq OWNED BY to_extension.id;
 -- Name: type; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE type (
+CREATE TABLE IF NOT EXISTS type (
     id bigint NOT NULL,
     name text NOT NULL,
     description text,
@@ -1514,7 +1515,7 @@ ALTER TABLE type OWNER TO traffic_ops;
 -- Name: type_id_seq; Type: SEQUENCE; Schema: public; Owner: traffic_ops
 --
 
-CREATE SEQUENCE type_id_seq
+CREATE SEQUENCE IF NOT EXISTS type_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1534,7 +1535,7 @@ ALTER SEQUENCE type_id_seq OWNED BY type.id;
 -- Name: user_role; Type: TABLE; Schema: public; Owner: traffic_ops
 --
 
-CREATE TABLE user_role (
+CREATE TABLE IF NOT EXISTS user_role (
     user_id bigint NOT NULL,
     role_id bigint NOT NULL,
     last_updated timestamp with time zone NOT NULL DEFAULT now()

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -85,6 +85,12 @@ fi
 
 ./db/admin --env=production upgrade || { echo "DB upgrade failed!"; exit 1; }
 
+if ! ./db/admin -env=production load_schema ||
+  ! ./db/admin -env=production load_schema; then
+  echo 'Could not re-run create_tables.sql!'
+  exit 1
+fi;
+
 new_db_version=$(get_current_db_version)
 [[ "$new_db_version" =~ ^failed ]] && { echo "get_current_db_version failed: $new_db_version"; exit 1; }
 


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR  #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR closes #4984<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
- This PR makes it so that, even if `./admin load_schema` is run more than once (for example, installing TO, with a shared database, on more than 1 host simultaneously), an SQL error should not result.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->
- Traffic Ops (initial `create_tables.sql` seed data)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Run the Traffic Ops DB tests
    ```shell script
    ./pkg traffic_ops_build;
    cd traffic_ops_db/test/docker;
    cp ../../../dist/traffic_ops-5.0.0-10961.9250b20e.el7.x86_64.rpm traffic_ops.rpm;
    docker-compose up --build;
    ```

2. Check that the resultant schema is identical to the one we would have gotten from `create_tables.sql` previously.
    ```shell script
    import_and_dump_schema() {
        output_file="$1";
        <<'DOCKER_COMMANDS' docker run --rm -i \
            -v "$(pwd)/traffic_ops/app/db/create_tables.sql:/create_tables.sql" \
            -e POSTGRES_USER=traffic_ops \
            -e POSTGRES_PASSWORD=twelve \
            -e PGPASSWORD=twelve \
            -e POSTGRES_DB=traffic_ops \
            postgres:9.6-alpine bash >"$output_file";
        trap 'echo "Error on line ${LINENO} of ${0}" >/dev/stderr; exit 1' ERR;
        set -o errexit;
        /docker-entrypoint.sh postgres >/dev/stderr &
        echo 'Waiting for Postgres to start...' >/dev/stderr;
        sleep 10;
        psql -Utraffic_ops -fcreate_tables.sql >/dev/stderr;
        pg_dump -Utraffic_ops;
    DOCKER_COMMANDS
    };
    git checkout origin/master;
    import_and_dump_schema upstream.sql;
    git checkout zrhoffman/postinstall-twice;
    import_and_dump_schema pr.sql;
    wc -l upstream.sql pr.sql; # Should be 4429 lines
    openssl sha256 upstream.sql pr.sql; # Hash should be 794fd7a23fa690eec67f6cd1257a9a8d900ac59edbdc487119ef73023a938d84
    ```

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] You should never actually run `create_tables.sql` twice, no documentation necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
