### PR TITLE
[Backport 4.1.x] TR: set cache to unavailable if not found in TM health data (#5133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added the ability to set TLS config provided here: https://golang.org/pkg/crypto/tls/#Config in Traffic Ops
 
+### Fixed
+- Fixed an issue that causes Traffic Router to mistakenly route to caches that had recently been set from ADMIN_DOWN to OFFLINE
+
 ### Deprecated
 - Deprecated the `insecure` option in `traffic_ops_golang` in favor of `"tls_config": { "InsecureSkipVerify": <bool> }`
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/cache/Cache.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/cache/Cache.java
@@ -236,9 +236,18 @@ public class Cache implements Comparable<Cache>, Hashable<Cache> {
 
 	@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
 	public void setState(final JsonNode state) {
-		final boolean isAvailable = JsonUtils.optBoolean(state, "isAvailable", true);
-		final boolean ipv4Available = JsonUtils.optBoolean(state, "ipv4Available", true);
-		final boolean ipv6Available = JsonUtils.optBoolean(state, "ipv6Available", true);
+		final boolean ipv4Available;
+		final boolean ipv6Available;
+		if (state == null) {
+			LOGGER.warn("got null health state for " + fqdn + ". Setting it to unavailable!");
+			isAvailable = false;
+			ipv4Available = false;
+			ipv6Available = false;
+		} else {
+			isAvailable = JsonUtils.optBoolean(state, "isAvailable", true);
+			ipv4Available = JsonUtils.optBoolean(state, "ipv4Available", true);
+			ipv6Available = JsonUtils.optBoolean(state, "ipv6Available", true);
+		}
 
 		final List<InetRecord> newlyAvailable = new ArrayList<>();
 		final List<InetRecord> newlyUnavailable = new ArrayList<>();


### PR DESCRIPTION
Backport #5133 to 4.1.x.