### PR TITLE
Removing ORT ntpd checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 ### Added
+- Traffic Ops Ort: Disabled ntpd verification (ntpd is deprecated in CentOS)
 - Traffic Ops Ort: Adds a transliteration of the traffic_ops_ort.pl perl script to the go language. See traffic_ops_ort/t3c/README.md.
 - Traffic Ops API v3
 - Added an optional readiness check service to cdn-in-a-box that exits successfully when it is able to get a `200 OK` from all delivery services

--- a/traffic_ops_ort/traffic_ops_ort.pl
+++ b/traffic_ops_ort/traffic_ops_ort.pl
@@ -263,7 +263,7 @@ if ( $sysctl_p_needed && $script_mode != $SYNCDS ) {
 	&run_sysctl_p();
 }
 
-&check_ntp();
+#&check_ntp();
 
 if ( $script_mode != $REPORT ) {
 	&update_trops();


### PR DESCRIPTION
Disabled check_ntpd as it was running at all time. Wasn't not doing anything bad but the checks are just simply not working in most scenarios. traffic_ort_goland still install ntp configuration so no change there. The ntpd failure never gave back much feedback to users anyway and should be tracked outside of ORT.

- ntpd is deprecated in Centos 7 and removed in Centos 8
- Doesn't work when ntpd is using DNS

## What does this PR (Pull Request) do?

Simply disabled ntpd checks

## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT
- CI tests

## What is the best way to verify this PR?
N/A

## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [X] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [ ] This PR includes any and all required license headers
- [ ] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
N/A