### PR TITLE
Disallow deleting or moving the last server in a Cache Group used by a topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the ability to view Hash ID field (aka xmppID) on Traffic Portals' server summary page
 - Added the ability to delete invalidation requests in Traffic Portal
 - Added the ability to set TLS config provided here: https://golang.org/pkg/crypto/tls/#Config in Traffic Ops
-- Added an indiciator to the Traffic Monitor UI when using a disk backup of Traffic ops.
+- Added support for the `cachegroupName` query parameter for `GET /api/3.0/servers` in Traffic Ops
+- Added an indiciator to the Traffic Monitor UI when using a disk backup of Traffic Ops.
 - Added debugging functionality to CDN-in-a-Box for Traffic Stats.
 - Added debugging functionality to the Traffic Router unit tests runner at [`/traffic_router/tests`](https://github.com/apache/trafficcontrol/tree/master/traffic_router/tests)
 - Made the Traffic Router unit tests runner at [`/traffic_router/tests`](https://github.com/apache/trafficcontrol/tree/master/traffic_router/tests) run in Alpine Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - Traffic Ops: Added validation to prohibit assigning caches to topology-based delivery services
     - Traffic Ops: Added validation to prohibit removing a capability from a server if no other server in the same cachegroup can satisfy the required capabilities of the delivery services assigned to it via topologies.
     - Traffic Ops: Added validation to ensure that at least one server per cachegroup in a delivery service's topology has the delivery service's required capabilities.
-    - Traffic Ops: Added validation to ensure that at least one server exists in each cachegroup that that is used in a Topology.
+    - Traffic Ops: Added validation to ensure that at least one server exists in each cachegroup that is used in a Topology on the `/api/3.0/topologies` endpoint and the `/api/3.0/servers/{{ID}}` endpoint.
     - Traffic Ops: Consider Topologies parentage when queueing or checking server updates
     - ORT: Added Topologies to Config Generation.
     - Traffic Portal: Added the ability to create, read, update and delete flexible topologies.

--- a/docs/source/api/v3/cachegroups.rst
+++ b/docs/source/api/v3/cachegroups.rst
@@ -36,6 +36,8 @@ Request Structure
 	+===========+==========+==========================================================================================================================+
 	| id        | no       | Return the only :term:`Cache Group` that has this id                                                                     |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| name      | no       | Return only the :term:`Cache Group` identified by this :ref:`cache-group-name`                                           |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| type      | no       | Return only :term:`Cache Groups` that are of the :ref:`cache-group-type` identified by this integral, unique identifier  |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 	| topology  | no       | Return only :term:`Cache Groups` that are used in the :term:`Topology` identified by this unique identifier              |

--- a/docs/source/api/v3/servers.rst
+++ b/docs/source/api/v3/servers.rst
@@ -31,39 +31,41 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| Name       | Required | Description                                                                                                       |
-	+============+==========+===================================================================================================================+
-	| cachegroup | no       | Return only those servers within the :term:`Cache Group` that has this :ref:`cache-group-id`                      |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| dsId       | no       | Return only those servers assigned to the :term:`Delivery Service` identified by this integral, unique identifier.|
-	|            |          | If the Delivery Service has a :term:`Topology` assigned to it, the :ref:`to-api-servers` endpoint will return     |
-	|            |          | each server whose :term:`Cache Group` is associated with a :term:`Topology Node` of that Topology and has the     |
-	|            |          | :term:`Server Capabilities` that are                                                                              |
-	|            |          | :term:`required by the Delivery Service <Delivery Service required capabilities>`.                                |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| hostName   | no       | Return only those servers that have this (short) hostname                                                         |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| id         | no       | Return only the server with this integral, unique identifier                                                      |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| profileId  | no       | Return only those servers that are using the :term:`Profile` that has this :ref:`profile-id`                      |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| status     | no       | Return only those servers with this status - see :ref:`health-proto`                                              |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| type       | no       | Return only servers of this :term:`Type`                                                                          |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| topology   | no       | Return only servers who belong to cachegroups assigned to the :term:`Topology` identified by this name            |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| sortOrder  | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                          |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| limit      | no       | Choose the maximum number of results to return                                                                    |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| offset     | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit              |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
-	| page       | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and   |
-	|            |          | the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to  |
-	|            |          | make use of ``page``.                                                                                             |
-	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| Name           | Required | Description                                                                                                       |
+	+================+==========+===================================================================================================================+
+	| cachegroup     | no       | Return only those servers within the :term:`Cache Group` that has this :ref:`cache-group-id`                      |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| cachegroupName | no       | Return only those servers within the :term:`Cache Group` that has this :ref:`cache-group-name`                    |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| dsId           | no       | Return only those servers assigned to the :term:`Delivery Service` identified by this integral, unique identifier.|
+	|                |          | If the Delivery Service has a :term:`Topology` assigned to it, the :ref:`to-api-servers` endpoint will return     |
+	|                |          | each server whose :term:`Cache Group` is associated with a :term:`Topology Node` of that Topology and has the     |
+	|                |          | :term:`Server Capabilities` that are                                                                              |
+	|                |          | :term:`required by the Delivery Service <Delivery Service required capabilities>`.                                |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| hostName       | no       | Return only those servers that have this (short) hostname                                                         |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| id             | no       | Return only the server with this integral, unique identifier                                                      |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| profileId      | no       | Return only those servers that are using the :term:`Profile` that has this :ref:`profile-id`                      |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| status         | no       | Return only those servers with this status - see :ref:`health-proto`                                              |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| type           | no       | Return only servers of this :term:`Type`                                                                          |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| topology       | no       | Return only servers who belong to cachegroups assigned to the :term:`Topology` identified by this name            |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| sortOrder      | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                          |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| limit          | no       | Choose the maximum number of results to return                                                                    |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| offset         | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit              |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| page           | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and   |
+	|                |          | the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to  |
+	|                |          | make use of ``page``.                                                                                             |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/traffic_ops/testing/api/v3/servers_test.go
+++ b/traffic_ops/testing/api/v3/servers_test.go
@@ -45,7 +45,51 @@ func TestServers(t *testing.T) {
 		CreateTestServerWithoutProfileId(t)
 		UniqueIPProfileTestServers(t)
 		UpdateTestServerStatus(t)
+		LastServerInTopologyCacheGroup(t)
 	})
+}
+
+func LastServerInTopologyCacheGroup(t *testing.T) {
+	const cacheGroupName = "topology-mid-cg-01"
+	const moveToCacheGroup = "topology-mid-cg-02"
+	const topologyName = "forked-topology"
+	const expectedLength = 1
+	params := url.Values{}
+	params.Add("cachegroupName", cacheGroupName)
+	params.Add("topology", topologyName)
+	servers, _, err := TOSession.GetServersWithHdr(&params, nil)
+	if err != nil {
+		t.Fatalf("getting server from cachegroup %s in topology %s: %s", cacheGroupName, topologyName, err.Error())
+	}
+	if len(servers.Response) != expectedLength {
+		t.Fatalf("expected to get %d server from cachegroup %s in topology %s, got %d servers", expectedLength, cacheGroupName, topologyName, len(servers.Response))
+	}
+	server := servers.Response[0]
+	_, reqInf, err := TOSession.DeleteServerByID(*server.ID)
+	if err == nil {
+		t.Fatalf("expected an error deleting server with id %d, received no error", *server.ID)
+	}
+	if reqInf.StatusCode < http.StatusBadRequest || reqInf.StatusCode >= http.StatusInternalServerError {
+		t.Fatalf("expected a 400-level error deleting server with id %d, got status code %d: %s", *server.ID, reqInf.StatusCode, err.Error())
+	}
+
+	params = url.Values{}
+	params.Add("name", moveToCacheGroup)
+	cgs, _, err := TOSession.GetCacheGroupsByQueryParamsWithHdr(params, nil)
+	if err != nil {
+		t.Fatalf("getting cachegroup with hostname %s: %s", moveToCacheGroup, err.Error())
+	}
+	if len(cgs) != expectedLength {
+		t.Fatalf("expected %d cachegroup with hostname %s, received %d cachegroups", expectedLength, moveToCacheGroup, len(cgs))
+	}
+	*server.CachegroupID = *cgs[0].ID
+	_, _, err = TOSession.UpdateServerByID(*server.ID, server)
+	if err == nil {
+		t.Fatalf("expected an error moving server with id %d to a different cachegroup, received no error", *server.ID)
+	}
+	if reqInf.StatusCode < http.StatusBadRequest || reqInf.StatusCode >= http.StatusInternalServerError {
+		t.Fatalf("expected a 400-level error moving server with id %d to a different cachegroup, got status code %d: %s", *server.ID, reqInf.StatusCode, err.Error())
+	}
 }
 
 func UpdateTestServerStatus(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/topology"
 	"net"
 	"net/http"
 	"strconv"
@@ -1214,6 +1215,13 @@ func Update(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		cacheGroupIds := []int{*origSer[0].CachegroupID}
+		serverIds := []int{*origSer[0].ID}
+		if err := topology.CheckForEmptyCacheGroups(inf.Tx, cacheGroupIds, true, serverIds); err != nil {
+			api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("server is the last one in its cachegroup, which is used by a topology, so it cannot be moved to another cachegroup: "+err.Error()), nil)
+			return
+		}
+
 		server, err = newServer.ToServerV2()
 		if err != nil {
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, fmt.Errorf("converting v3 server to v2 for update: %v", err))
@@ -1594,6 +1602,14 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	if len(servers) > 1 {
 		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, fmt.Errorf("there are somehow two servers with id %d - cannot delete", id))
 		return
+	}
+	if version.Major >= 3 {
+		cacheGroupIds := []int{*servers[0].CachegroupID}
+		serverIds := []int{*servers[0].ID}
+		if err := topology.CheckForEmptyCacheGroups(inf.Tx, cacheGroupIds, true, serverIds); err != nil {
+			api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("server is the last one in its cachegroup, which is used by a topology: "+err.Error()), nil)
+			return
+		}
 	}
 
 	userErr, sysErr, errCode = deleteInterfaces(id, tx)

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -779,6 +779,10 @@ func getServers(h http.Header, params map[string]string, tx *sqlx.Tx, user *auth
 		"dsId":             dbhelpers.WhereColumnInfo{"dss.deliveryservice", nil},
 	}
 
+	if version.Major >= 3 {
+		queryParamsToSQLCols["cachegroupName"] = dbhelpers.WhereColumnInfo{"cg.name", nil}
+	}
+
 	usesMids := false
 	queryAddition := ""
 	dsHasRequiredCapabilities := false

--- a/traffic_ops/v3-client/server.go
+++ b/traffic_ops/v3-client/server.go
@@ -249,6 +249,9 @@ func (to *Session) DeleteServerByID(id int) (tc.Alerts, ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", API_SERVERS, id)
 	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+	}
 	if err != nil {
 		return tc.Alerts{}, reqInf, err
 	}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5154 OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
- Keeps you from deleting a Server from a CacheGroup used by a Topology or moving a Server from a CacheGroup used by a Topology if it means that Cache Group would no longer have any servers in it
- Adds the `cachegroupName` query parameter to `GET /api/3.0/servers`

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Documentation
- Traffic Control Client <!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Run the API tests

2. Test manually:
    For `DELETE /api/3.0/servers/{{id}}`:
    1. Make a Cache Group
    2. Add only 1 Server to the Cache Group
    3. Make a Topology with that Cache Group
    4. Delete the Server (should fail)

    For `PUT /api/3.0/servers/{{id}}`:
    1. Make a Cache Group
    2. Add only 1 Server to the Cache Group
    3. Make a Topology with that Cache Group
    4. Move the Server to a different Cache Group (should fail)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->