### PR TITLE
[Backport 4.1.x] Add availability data for mids not associated with a delivery service #5088

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fixed #5006 - Traffic Ops now generates the Monitoring on-the-fly if the snapshot doesn't exist, and logs an error. This fixes upgrading to 4.x to not break the CDN until a Snapshot is done.
+- Fixed #5074 - Traffic Monitor logging "CreateStats not adding availability data for server: not found in DeliveryServices" for MID cachces
 - Fixed an issue that causes Traffic Router to mistakenly route to caches that had recently been set from ADMIN_DOWN to OFFLINE
 
 ### Deprecated

--- a/docs/source/development/traffic_monitor.rst
+++ b/docs/source/development/traffic_monitor.rst
@@ -175,7 +175,7 @@ The State Combiner is a microthread started in ``traffic_monitor/manager/manager
 
 Aggregated Stat Data
 --------------------
-The Stat pipeline Manager is responsible for aggregating stats from all :term:`cache server` s, into :term:`Delivery Services` statistics. This is done via a call to ``traffic_monitor/deliveryservice/stat.go:CreateStats()``.
+The Stat pipeline Manager is responsible for aggregating stats from all :term:`Edge-tier cache servers`, into :term:`Delivery Services` statistics. This is done via a call to ``traffic_monitor/deliveryservice/stat.go:CreateStats()``.
 
 Aggregated Availability Data
 ----------------------------

--- a/traffic_monitor/ds/stat.go
+++ b/traffic_monitor/ds/stat.go
@@ -49,14 +49,14 @@ func addAvailableData(dsStats *dsdata.Stats, crStates tc.CRStates, serverCachegr
 			log.Infof("CreateStats not adding availability data for '%s': not found in Cachegroups\n", cache)
 			continue
 		}
-		deliveryServices, ok := serverDs[cache]
-		if !ok {
-			log.Infof("CreateStats not adding availability data for '%s': not found in DeliveryServices\n", cache)
-			continue
-		}
 		cacheType, ok := serverTypes[cache]
 		if !ok {
 			log.Infof("CreateStats not adding availability data for '%s': not found in Server Types\n", cache)
+			continue
+		}
+		deliveryServices, ok := serverDs[cache]
+		if !ok && cacheType != tc.CacheTypeMid {
+			log.Infof("CreateStats not adding availability data for '%s': not found in DeliveryServices\n", cache)
 			continue
 		}
 

--- a/traffic_monitor/ds/stat_test.go
+++ b/traffic_monitor/ds/stat_test.go
@@ -20,13 +20,17 @@ package ds
  */
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"math"
 	"math/rand"
+	"regexp"
 	"testing"
 	"time"
 
+	tc_log "github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_monitor/cache"
 	"github.com/apache/trafficcontrol/traffic_monitor/dsdata"
@@ -35,6 +39,22 @@ import (
 	"github.com/apache/trafficcontrol/traffic_monitor/threadsafe"
 	"github.com/apache/trafficcontrol/traffic_monitor/todata"
 )
+
+func checkLogOutput(t *testing.T, buffer *bytes.Buffer, toData todata.TOData, caches []tc.CacheName) {
+	output := buffer.String()
+	for _, cacheName := range caches {
+		match, err := regexp.MatchString(string(cacheName)+".*not found in DeliveryServices", output)
+		if err != nil {
+			t.Fatalf("cannot match cache name %s against output", cacheName)
+		}
+		if toData.ServerTypes[cacheName] != tc.CacheTypeMid && !match {
+			t.Fatalf("expected to find info-level message about cache %s with cache type %s not being found in DeliveryServices, no message found", cacheName, toData.ServerTypes[cacheName])
+		}
+		if toData.ServerTypes[cacheName] == tc.CacheTypeMid && match {
+			t.Fatalf("expected not to find info-level message about cache %s with cache type %s not being found in DeliveryServices, but message was found", cacheName, toData.ServerTypes[cacheName])
+		}
+	}
+}
 
 func TestCreateStats(t *testing.T) {
 	toData := getMockTOData()
@@ -66,11 +86,23 @@ func TestCreateStats(t *testing.T) {
 
 	lastStatsVal := lastStatsThs.Get()
 	lastStatsCopy := lastStatsVal.Copy()
+
 	dsStats, err := CreateStats(precomputeds, toData, combinedCRStates.Get(), lastStatsCopy, now, monitorConfig, events, localCRStates)
 
 	if err != nil {
 		t.Fatalf("CreateStats err expected: nil, actual: " + err.Error())
 	}
+
+	serverDeliveryServices := toData.ServerDeliveryServices
+	toData.ServerDeliveryServices = map[tc.CacheName][]tc.DeliveryServiceName{} // temporarily unassign servers to generate warnings about caches not assigned to delivery services
+	buffer := bytes.NewBuffer(make([]byte, 0, 10000))
+	tc_log.Info = log.New(buffer, "TestAddAvailabilityDataNotFoundInDeliveryService", log.Lshortfile)
+	_, err = CreateStats(precomputeds, toData, combinedCRStates.Get(), lastStatsCopy, now, monitorConfig, events, localCRStates)
+	if err != nil {
+		t.Fatalf("CreateStats err expected: nil, actual: " + err.Error())
+	}
+	checkLogOutput(t, buffer, toData, caches)
+	toData.ServerDeliveryServices = serverDeliveryServices
 
 	lastStatsThs.Set(*lastStatsCopy)
 


### PR DESCRIPTION
Backport #5088 into 4.1.x.