### PR TITLE
Traffic Ops API Errors structure

### DIFF
--- a/traffic_ops/traffic_ops_golang/acme/acme_account.go
+++ b/traffic_ops/traffic_ops_golang/acme/acme_account.go
@@ -39,13 +39,13 @@ const selectLimitedQuery = `SELECT email, provider from acme_account where email
 
 // Read handles GET requests for all information about the ACME accounts.
 func Read(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	tx := inf.Tx.Tx
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
+	tx := inf.Tx.Tx
 
 	acmeAccounts := []tc.AcmeAccount{}
 	rows, err := tx.Query(readQuery)
@@ -69,13 +69,13 @@ func Read(w http.ResponseWriter, r *http.Request) {
 
 // ReadProviders returns a list of unique ACME provider both from the database and cdn.conf
 func ReadProviders(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	tx := inf.Tx.Tx
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
+	tx := inf.Tx.Tx
 
 	acmeProviders := []string{}
 	rows, err := tx.Query(readProvidersQuery)
@@ -111,9 +111,9 @@ func ReadProviders(w http.ResponseWriter, r *http.Request) {
 
 // Create handles POST requests to add a new ACME provider.
 func Create(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -163,9 +163,9 @@ func Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func Update(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -214,9 +214,9 @@ func Update(w http.ResponseWriter, r *http.Request) {
 
 // Delete removes the information about an ACME account.
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"provider", "email"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"provider", "email"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/acme/acme_account.go
+++ b/traffic_ops/traffic_ops_golang/acme/acme_account.go
@@ -141,8 +141,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 	resultRows, err := inf.Tx.NamedQuery(createQuery, acmeAccount)
 	if err != nil {
-		userErr, sysErr, errCode := api.ParseDBError(err)
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 	defer resultRows.Close()
@@ -192,8 +191,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 
 	resultRows, err := inf.Tx.NamedQuery(updateQuery, acmeAccount)
 	if err != nil {
-		userErr, sysErr, errCode := api.ParseDBError(err)
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 	defer resultRows.Close()

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -715,6 +715,16 @@ func (inf *APIInfo) Close() {
 	}
 }
 
+// HandleErrs writes the appropriate response to the client given the provided
+// errors.
+func (inf APIInfo) HandleErrs(w http.ResponseWriter, r *http.Request, e Errors) {
+	if inf.Tx == nil {
+		HandleErr(w, r, nil, e.Code, e.UserError, e.SystemError)
+		return
+	}
+	HandleErr(w, r, inf.Tx.Tx, e.Code, e.UserError, e.SystemError)
+}
+
 // SendMail is a convenience method used to call SendMail using an APIInfo structure's configuration.
 func (inf *APIInfo) SendMail(to rfc.EmailAddress, msg []byte) (int, error, error) {
 	return SendMail(to, msg, inf.Config)

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -104,6 +104,49 @@ type APIResponseWithSummary struct {
 	} `json:"summary"`
 }
 
+// Errors represents a set of errors to be handled by the API.
+type Errors struct {
+	// Code is the HTTP response code. If no error has occurred, this *should*
+	// be http.StatusOK.
+	Code int
+	// SystemError is an error that occurred internally; not safe for exposure
+	// to the user.
+	SystemError error
+	// UserError is an error that should be shown to the user to explain why
+	// their request failed.
+	UserError error
+}
+
+// NewErrors constructs a new Errors where no error has actually occurred.
+func NewErrors() Errors {
+	return Errors{
+		Code:        http.StatusOK,
+		SystemError: nil,
+		UserError:   nil,
+	}
+}
+
+// Occurred returns whether at least one error has occurred (is non-nil).
+func (e Errors) Occurred() bool {
+	return e.SystemError != nil || e.UserError != nil
+}
+
+// SetSystemError sets the Errors' system-level error to a new error containing
+// the passed message.
+func (e *Errors) SetSystemError(err string) {
+	e.SystemError = errors.New(err)
+}
+
+// SetUserError sets the Errors' user-level error to a new error containing the
+// passed message.
+func (e *Errors) SetUserError(err string) {
+	e.UserError = errors.New(err)
+}
+
+func (e Errors) String() string {
+	return fmt.Sprintf("Errors(Code=%d, SystemError='%v', UserError='%v')", e.Code, e.SystemError, e.UserError)
+}
+
 // GoneHandler is an http.Handler function that just writes a 410 Gone response
 // back to the client, along with an error-level alert stating that the endpoint
 // is no longer available.

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -853,7 +853,7 @@ func (inf APIInfo) HandleDeprecatedErrs(w http.ResponseWriter, r *http.Request, 
 }
 
 // SendMail is a convenience method used to call SendMail using an APIInfo structure's configuration.
-func (inf *APIInfo) SendMail(to rfc.EmailAddress, msg []byte) (int, error, error) {
+func (inf *APIInfo) SendMail(to rfc.EmailAddress, msg []byte) Errors {
 	return SendMail(to, msg, inf.Config)
 }
 
@@ -874,9 +874,12 @@ func (inf *APIInfo) IsResourceAuthorizedToCurrentUser(resourceTenantID int) (boo
 // SendMail returns (in order) an HTTP status code, a user-friendly error, and an error fit for
 // logging to system error logs. If either the user or system error is non-nil, the operation failed,
 // and the HTTP status code indicates the type of failure.
-func SendMail(to rfc.EmailAddress, msg []byte, cfg *config.Config) (int, error, error) {
+func SendMail(to rfc.EmailAddress, msg []byte, cfg *config.Config) Errors {
+	errs := NewErrors()
 	if !cfg.SMTP.Enabled {
-		return http.StatusInternalServerError, nil, errors.New("SMTP is not enabled; mail cannot be sent")
+		errs.Code = http.StatusInternalServerError
+		errs.SetSystemError("SMTP is not enabled; mail cannot be sent")
+		return errs
 	}
 	var auth smtp.Auth
 	if cfg.SMTP.User != "" {
@@ -884,9 +887,10 @@ func SendMail(to rfc.EmailAddress, msg []byte, cfg *config.Config) (int, error, 
 	}
 	err := smtp.SendMail(cfg.SMTP.Address, auth, cfg.ConfigTO.EmailFrom.Address.Address, []string{to.Address.Address}, msg)
 	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Errorf("Failed to send email: %v", err)
+		errs.Code = http.StatusInternalServerError
+		errs.SystemError = fmt.Errorf("Failed to send email: %v", err)
 	}
-	return http.StatusOK, nil, nil
+	return errs
 }
 
 // CreateInfluxClient constructs and returns an InfluxDB HTTP client, if enabled and when possible.
@@ -1303,14 +1307,17 @@ func AddUserToReq(r *http.Request, u auth.CurrentUser) {
 // SendEmailFromTemplate returns (in order) an HTTP status code, a user-friendly error, and an error fit for
 // logging to system error logs. If either the user or system error is non-nil, the operation failed,
 // and the HTTP status code indicates the type of failure.
-func SendEmailFromTemplate(config config.Config, header string, data interface{}, templateFile string, toEmail string) (int, error, error) {
+func SendEmailFromTemplate(config config.Config, header string, data interface{}, templateFile string, toEmail string) Errors {
 	email := rfc.EmailAddress{
 		Address: mail.Address{Name: "", Address: toEmail},
 	}
 
 	msgBodyBuffer, err := parseTemplate(templateFile, data)
 	if err != nil {
-		return http.StatusInternalServerError, err, nil
+		return Errors{
+			Code:        http.StatusInternalServerError,
+			SystemError: err,
+		}
 	}
 	msg := append([]byte(header), msgBodyBuffer.Bytes()...)
 

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -274,6 +274,14 @@ func HandleErrOptionalDeprecation(w http.ResponseWriter, r *http.Request, tx *sq
 	}
 }
 
+// HandleErrsOptionalDeprecation handles a set of API Errors. If 'deprecated'
+// is true, then a deprecation alert will be added to the response, and if
+// alternative is not nil it will be presented to the client as the replacement
+// for the deprecated route.
+func HandleErrsOptionalDeprecation(w http.ResponseWriter, r *http.Request, tx *sql.Tx, errs Errors, deprecated bool, alternative *string) {
+	HandleErrOptionalDeprecation(w, r, tx, errs.Code, errs.UserError, errs.SystemError, deprecated, alternative)
+}
+
 // HandleDeprecatedErr handles an API error, adding a deprecation alert, rolling back the transaction, writing the given statusCode and userErr to the user, and logging the sysErr. If userErr is nil, the text of the HTTP statusCode is written.
 //
 // The alternative may be nil if there is no alternative and the deprecation message will be selected appropriately.

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -615,39 +615,56 @@ type APIInfo struct {
 //    api.WriteResp(w, r, respObj)
 //  }
 //
-func NewInfo(r *http.Request, requiredParams []string, intParamNames []string) (*APIInfo, error, error, int) {
+func NewInfo(r *http.Request, requiredParams []string, intParamNames []string) (*APIInfo, Errors) {
+	inf := &APIInfo{
+		Tx: &sqlx.Tx{},
+	}
+
+	errs := Errors{
+		Code: http.StatusInternalServerError,
+	}
+
 	db, err := GetDB(r.Context())
 	if err != nil {
-		return &APIInfo{Tx: &sqlx.Tx{}}, errors.New("getting db: " + err.Error()), nil, http.StatusInternalServerError
+		errs.SystemError = fmt.Errorf("getting db: %v", err)
+		return inf, errs
 	}
+
 	cfg, err := GetConfig(r.Context())
 	if err != nil {
-		return &APIInfo{Tx: &sqlx.Tx{}}, errors.New("getting config: " + err.Error()), nil, http.StatusInternalServerError
+		errs.SystemError = fmt.Errorf("getting config: %v", err)
+		return inf, errs
 	}
 	tv, err := GetTrafficVault(r.Context())
 	if err != nil {
-		return &APIInfo{Tx: &sqlx.Tx{}}, errors.New("getting TrafficVault: " + err.Error()), nil, http.StatusInternalServerError
+		errs.SystemError = fmt.Errorf("getting TrafficVault: %w", err)
+		errs.Code = http.StatusInternalServerError
+		return inf, errs
 	}
 	reqID, err := getReqID(r.Context())
 	if err != nil {
-		return &APIInfo{Tx: &sqlx.Tx{}}, errors.New("getting reqID: " + err.Error()), nil, http.StatusInternalServerError
+		errs.SystemError = fmt.Errorf("getting reqID: %v", err)
+		return inf, errs
 	}
 	version := getRequestedAPIVersion(r.URL.Path)
 
 	user, err := auth.GetCurrentUser(r.Context())
 	if err != nil {
-		return &APIInfo{Tx: &sqlx.Tx{}}, errors.New("getting user: " + err.Error()), nil, http.StatusInternalServerError
+		errs.SystemError = fmt.Errorf("getting user: %v", err)
+		return inf, errs
 	}
+
 	params, intParams, errs := AllParams(r, requiredParams, intParamNames)
 	if errs.Occurred() {
-		return &APIInfo{Tx: &sqlx.Tx{}}, errs.UserError, errs.SystemError, errs.Code
+		return inf, errs
 	}
 	dbCtx, cancelTx := context.WithTimeout(r.Context(), time.Duration(cfg.DBQueryTimeoutSeconds)*time.Second) //only place we could call cancel here is in APIInfo.Close(), which already will rollback the transaction (which is all cancel will do.)
 	tx, err := db.BeginTxx(dbCtx, nil)                                                                        // must be last, MUST not return an error if this succeeds, without closing the tx
 	if err != nil {
-		return &APIInfo{Tx: &sqlx.Tx{}, CancelTx: cancelTx}, nil, fmt.Errorf("could not begin transaction: %w", err), http.StatusInternalServerError
+		return &APIInfo{Tx: &sqlx.Tx{}, CancelTx: cancelTx}, Errors{SystemError: fmt.Errorf("could not begin transaction: %w", err), Code: http.StatusInternalServerError}
 	}
-	return &APIInfo{
+
+	inf = &APIInfo{
 		Config:    cfg,
 		ReqID:     reqID,
 		Version:   version,
@@ -658,7 +675,8 @@ func NewInfo(r *http.Request, requiredParams []string, intParamNames []string) (
 		CancelTx:  cancelTx,
 		Vault:     tv,
 		request:   r,
-	}, nil, nil, http.StatusOK
+	}
+	return inf, errs
 }
 
 const createChangeLogQuery = `

--- a/traffic_ops/traffic_ops_golang/api/api_test.go
+++ b/traffic_ops/traffic_ops_golang/api/api_test.go
@@ -24,7 +24,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -33,31 +32,6 @@ import (
 
 	"github.com/lib/pq"
 )
-
-func ExampleErrors_String() {
-	fmt.Println(NewErrors())
-
-	// Output: Errors(Code=200, SystemError='<nil>', UserError='<nil>')
-}
-
-func ExampleErrors_Occurred() {
-	err := NewErrors()
-	fmt.Println(err.Occurred())
-
-	err.SetSystemError("test")
-	fmt.Println(err.Occurred())
-
-	err.SetUserError("test")
-	fmt.Println(err.Occurred())
-
-	err.SystemError = nil
-	fmt.Println(err.Occurred())
-
-	// Output: false
-	// true
-	// true
-	// true
-}
 
 func TestCamelCase(t *testing.T) {
 	testStrings := []string{"hello_world", "trailing_underscore_", "w_h_a_t____"}

--- a/traffic_ops/traffic_ops_golang/api/api_test.go
+++ b/traffic_ops/traffic_ops_golang/api/api_test.go
@@ -24,14 +24,40 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
 
-	"github.com/lib/pq"
-
 	"github.com/apache/trafficcontrol/lib/go-tc"
+
+	"github.com/lib/pq"
 )
+
+func ExampleErrors_String() {
+	fmt.Println(NewErrors())
+
+	// Output: Errors(Code=200, SystemError='<nil>', UserError='<nil>')
+}
+
+func ExampleErrors_Occurred() {
+	err := NewErrors()
+	fmt.Println(err.Occurred())
+
+	err.SetSystemError("test")
+	fmt.Println(err.Occurred())
+
+	err.SetUserError("test")
+	fmt.Println(err.Occurred())
+
+	err.SystemError = nil
+	fmt.Println(err.Occurred())
+
+	// Output: false
+	// true
+	// true
+	// true
+}
 
 func TestCamelCase(t *testing.T) {
 	testStrings := []string{"hello_world", "trailing_underscore_", "w_h_a_t____"}

--- a/traffic_ops/traffic_ops_golang/api/api_test.go
+++ b/traffic_ops/traffic_ops_golang/api/api_test.go
@@ -269,9 +269,9 @@ func TestParseRestrictFKConstraint(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Log("Starting test scenario: ", tc.description)
-			_, _, sc := parseRestrictFKConstraint(&tc.storageError)
-			if sc != tc.expectedReturnCode {
-				t.Errorf("code expected: %v, actual %v", tc.expectedReturnCode, sc)
+			errs := parseRestrictFKConstraint(&tc.storageError)
+			if errs.Code != tc.expectedReturnCode {
+				t.Errorf("code expected: %v, actual %v", tc.expectedReturnCode, errs.Code)
 			}
 		})
 	}

--- a/traffic_ops/traffic_ops_golang/api/async_status.go
+++ b/traffic_ops/traffic_ops_golang/api/async_status.go
@@ -85,8 +85,8 @@ func InsertAsyncStatus(tx *sql.Tx, message string) (int, int, error, error) {
 
 	resultRows, err := tx.Query(insertAsyncStatusQuery, AsyncPending, message)
 	if err != nil {
-		userErr, sysErr, errCode := ParseDBError(err)
-		return 0, errCode, userErr, sysErr
+		errs := ParseDBError(err)
+		return 0, errs.Code, errs.UserError, errs.SystemError
 	}
 	defer resultRows.Close()
 

--- a/traffic_ops/traffic_ops_golang/api/async_status.go
+++ b/traffic_ops/traffic_ops_golang/api/async_status.go
@@ -44,9 +44,9 @@ const updateAsyncStatusQuery = `UPDATE async_status SET status = $1, message = $
 
 // GetAsyncStatus returns the status of an asynchronous job.
 func GetAsyncStatus(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/api/change_log.go
+++ b/traffic_ops/traffic_ops_golang/api/change_log.go
@@ -39,8 +39,9 @@ type ChangeLog struct {
 	LastUpdated tc.TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }
 
-type ChangeLogger interface {
-	ChangeLogMessage(action string) (string, error)
+type KeyFieldInfo struct {
+	Field string
+	Func  func(string) (interface{}, error)
 }
 
 const (
@@ -49,21 +50,6 @@ const (
 	Created   = "Created"
 	Deleted   = "Deleted"
 )
-
-func CreateChangeLog(level string, action string, i Identifier, user *auth.CurrentUser, tx *sql.Tx) error {
-	t, ok := i.(ChangeLogger)
-	if !ok {
-		keys, _ := i.GetKeys()
-		return CreateChangeLogBuildMsg(level, action, user, tx, i.GetType(), i.GetAuditName(), keys)
-	}
-	msg, err := t.ChangeLogMessage(action)
-	if err != nil {
-		log.Errorf("%++v creating log message for %++v", err, t)
-		keys, _ := i.GetKeys()
-		return CreateChangeLogBuildMsg(level, action, user, tx, i.GetType(), i.GetAuditName(), keys)
-	}
-	return CreateChangeLogRawErr(level, msg, user, tx)
-}
 
 func CreateChangeLogBuildMsg(level string, action string, user *auth.CurrentUser, tx *sql.Tx, objType string, auditName string, keys map[string]interface{}) error {
 	keyStr := "{ "

--- a/traffic_ops/traffic_ops_golang/api/errors.go
+++ b/traffic_ops/traffic_ops_golang/api/errors.go
@@ -1,0 +1,89 @@
+package api
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Errors represents a set of errors to be handled by the API.
+type Errors struct {
+	// Code is the HTTP response code. If no error has occurred, this *should*
+	// be http.StatusOK.
+	Code int
+	// SystemError is an error that occurred internally; not safe for exposure
+	// to the user.
+	SystemError error
+	// UserError is an error that should be shown to the user to explain why
+	// their request failed.
+	UserError error
+}
+
+// NewErrors constructs a new Errors where no error has actually occurred.
+func NewErrors() Errors {
+	return Errors{
+		Code:        http.StatusOK,
+		SystemError: nil,
+		UserError:   nil,
+	}
+}
+
+// NewSystemError creates an Errors that only contains the given system error,
+// and has the appropriate response code.
+func NewSystemError(err error) Errors {
+	return Errors{
+		Code:        http.StatusInternalServerError,
+		SystemError: err,
+		UserError:   nil,
+	}
+}
+
+// NewModifiedError creates an Errors that only contains an HTTP Precondition
+// Failed status code and associated error message.
+func NewModifiedError() Errors {
+	return Errors{
+		Code:        http.StatusPreconditionFailed,
+		SystemError: nil,
+		UserError:   ResourceModifiedError,
+	}
+}
+
+// Occurred returns whether at least one error has occurred (is non-nil).
+func (e Errors) Occurred() bool {
+	return e.SystemError != nil || e.UserError != nil
+}
+
+// SetSystemError sets the Errors' system-level error to a new error containing
+// the passed message.
+func (e *Errors) SetSystemError(err string) {
+	e.SystemError = errors.New(err)
+}
+
+// SetUserError sets the Errors' user-level error to a new error containing the
+// passed message.
+func (e *Errors) SetUserError(err string) {
+	e.UserError = errors.New(err)
+}
+
+func (e Errors) String() string {
+	return fmt.Sprintf("Errors(Code=%d, SystemError='%v', UserError='%v')", e.Code, e.SystemError, e.UserError)
+}

--- a/traffic_ops/traffic_ops_golang/api/errors_test.go
+++ b/traffic_ops/traffic_ops_golang/api/errors_test.go
@@ -1,0 +1,55 @@
+package api
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "fmt"
+
+func ExampleErrors_String() {
+	fmt.Println(NewErrors())
+
+	// Output: Errors(Code=200, SystemError='<nil>', UserError='<nil>')
+}
+
+func ExamlpleNewErrors() {
+	fmt.Println(NewErrors())
+	fmt.Println(NewErrors().Occurred())
+
+	// Output: Errors(Code=200, SystemError='<nil>', UserError='<nil>')
+	// false
+}
+
+func ExampleErrors_Occurred() {
+	err := NewErrors()
+	fmt.Println(err.Occurred())
+
+	err.SetSystemError("test")
+	fmt.Println(err.Occurred())
+
+	err.SetUserError("test")
+	fmt.Println(err.Occurred())
+
+	err.SystemError = nil
+	fmt.Println(err.Occurred())
+
+	// Output: false
+	// true
+	// true
+	// true
+}

--- a/traffic_ops/traffic_ops_golang/api/generic_crud.go
+++ b/traffic_ops/traffic_ops_golang/api/generic_crud.go
@@ -78,7 +78,8 @@ type GenericOptionsDeleter interface {
 func GenericCreate(val GenericCreator) (error, error, int) {
 	resultRows, err := val.APIInfo().Tx.NamedQuery(val.InsertQuery(), val)
 	if err != nil {
-		return ParseDBError(err)
+		errs := ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer resultRows.Close()
 
@@ -115,7 +116,8 @@ func GenericCreate(val GenericCreator) (error, error, int) {
 func GenericCreateNameBasedID(val GenericCreator) (error, error, int) {
 	resultRows, err := val.APIInfo().Tx.NamedQuery(val.InsertQuery(), val)
 	if err != nil {
-		return ParseDBError(err)
+		errs := ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer resultRows.Close()
 
@@ -239,7 +241,8 @@ func GenericUpdate(h http.Header, val GenericUpdater) (error, error, int) {
 
 	rows, err := val.APIInfo().Tx.NamedQuery(val.UpdateQuery(), val)
 	if err != nil {
-		return ParseDBError(err)
+		errs := ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer rows.Close()
 
@@ -270,7 +273,8 @@ func GenericOptionsDelete(val GenericOptionsDeleter) (error, error, int) {
 	tx := val.APIInfo().Tx
 	result, err := tx.NamedExec(query, queryValues)
 	if err != nil {
-		return ParseDBError(err)
+		errs := ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 
 	if rowsAffected, err := result.RowsAffected(); err != nil {
@@ -288,7 +292,8 @@ func GenericOptionsDelete(val GenericOptionsDeleter) (error, error, int) {
 func GenericDelete(val GenericDeleter) (error, error, int) {
 	result, err := val.APIInfo().Tx.NamedExec(val.DeleteQuery(), val)
 	if err != nil {
-		return ParseDBError(err)
+		errs := ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 
 	if rowsAffected, err := result.RowsAffected(); err != nil {

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -181,9 +181,9 @@ func DeprecatedReadHandler(reader Reader, alternative *string) http.HandlerFunc 
 func readHandlerHelper(reader Reader, errHandler errWriterFunc, successHandler readSuccessWriterFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		useIMS := false
-		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
-		if userErr != nil || sysErr != nil {
-			errHandler(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		inf, errs := NewInfo(r, nil, nil)
+		if errs.Occurred() {
+			errHandler(w, r, inf.Tx.Tx, errs.Code, errs.UserError, errs.SystemError)
 			return
 		}
 		defer inf.Close()
@@ -226,9 +226,9 @@ func readHandlerHelper(reader Reader, errHandler errWriterFunc, successHandler r
 //   *forming and writing the body over the wire
 func UpdateHandler(updater Updater) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
-		if userErr != nil || sysErr != nil {
-			HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		inf, errs := NewInfo(r, nil, nil)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 		defer inf.Close()
@@ -291,7 +291,7 @@ func UpdateHandler(updater Updater) http.HandlerFunc {
 			}
 		}
 
-		userErr, sysErr, errCode = obj.Update(r.Header)
+		userErr, sysErr, errCode := obj.Update(r.Header)
 		if userErr != nil || sysErr != nil {
 			HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 			return
@@ -351,9 +351,9 @@ func DeprecatedDeleteHandler(deleter Deleter, alternative *string) http.HandlerF
 // DeprecatedDeleteHandler always returns a deprecation alert in its response, whereas DeleteHandler does not.
 func deleteHandlerHelper(deleter Deleter, errHandler errWriterFunc, successHandler deleteSuccessWriterFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
-		if userErr != nil || sysErr != nil {
-			errHandler(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		inf, errs := NewInfo(r, nil, nil)
+		if errs.Occurred() {
+			errHandler(w, r, inf.Tx.Tx, errs.Code, errs.UserError, errs.SystemError)
 			return
 		}
 		defer inf.Close()
@@ -457,9 +457,9 @@ func deleteHandlerHelper(deleter Deleter, errHandler errWriterFunc, successHandl
 //   *forming and writing the body over the wire
 func CreateHandler(creator Creator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
-		if userErr != nil || sysErr != nil {
-			HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		inf, errs := NewInfo(r, nil, nil)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 		defer inf.Close()
@@ -507,7 +507,7 @@ func CreateHandler(creator Creator) http.HandlerFunc {
 					}
 				}
 
-				userErr, sysErr, errCode = objElem.Create()
+				userErr, sysErr, errCode := objElem.Create()
 				if userErr != nil || sysErr != nil {
 					HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 					return
@@ -559,7 +559,7 @@ func CreateHandler(creator Creator) http.HandlerFunc {
 				}
 			}
 
-			userErr, sysErr, errCode = obj.Create()
+			userErr, sysErr, errCode := obj.Create()
 			if userErr != nil || sysErr != nil {
 				HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 				return

--- a/traffic_ops/traffic_ops_golang/apicapability/api_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/apicapability/api_capabilities.go
@@ -41,9 +41,9 @@ import (
 // it will return only those with an exact match.
 // Deprecated: This API endpoint is deprecated, and will be removed in api v4 and above.
 func GetAPICapabilitiesHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/apicapability/api_capabilities_test.go
+++ b/traffic_ops/traffic_ops_golang/apicapability/api_capabilities_test.go
@@ -62,10 +62,10 @@ func TestGetAPICapabilities(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	results, _, userErr, sysErr := getAPICapabilities(db.MustBegin(), map[string]string{})
+	results, errs := getAPICapabilities(db.MustBegin(), map[string]string{})
 
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %v", errs)
 	}
 
 	if len(results) != 4 {

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant.go
@@ -291,6 +291,7 @@ func parseDeleteErr(err error, id int, tx *sql.Tx) api.Errors {
 	default:
 		existing = pqErr.Table
 	}
+
 	return api.Errors{
 		UserError: errors.New("Tenant '" + strconv.Itoa(id) + "' has " + existing + ". Please update these " + existing + " and retry."),
 		Code:      http.StatusBadRequest,

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant.go
@@ -135,14 +135,14 @@ func (ten TOTenant) Validate() error {
 
 func (ten *TOTenant) Create() api.Errors { return crudder.GenericCreate(ten) }
 
-func (ten *TOTenant) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (ten *TOTenant) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	if ten.APIInfo().User.TenantID == auth.TenantIDInvalid {
-		return nil, nil, nil, http.StatusOK, nil
+		return nil, api.NewErrors(), nil
 	}
 	api.DefaultSort(ten.APIInfo(), "name")
-	tenants, userErr, sysErr, errCode, maxTime := crudder.GenericRead(h, ten, useIMS)
-	if userErr != nil || sysErr != nil {
-		return nil, userErr, sysErr, errCode, nil
+	tenants, errs, maxTime := crudder.GenericRead(h, ten, useIMS)
+	if errs.Occurred() {
+		return nil, errs, nil
 	}
 
 	tenantNames := map[int]*string{}
@@ -159,7 +159,7 @@ func (ten *TOTenant) Read(h http.Header, useIMS bool) ([]interface{}, error, err
 		p := *tenantNames[*t.ParentID]
 		t.ParentName = &p // copy
 	}
-	return tenants, nil, nil, errCode, maxTime
+	return tenants, errs, maxTime
 }
 
 // IsTenantAuthorized implements the Tenantable interface for TOTenant

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant_test.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant_test.go
@@ -51,7 +51,7 @@ func TestInterfaces(t *testing.T) {
 	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("Tenant must be Identifier")
 	}
-	if _, ok := i.(api.Tenantable); !ok {
+	if _, ok := i.(crudder.Tenantable); !ok {
 		t.Errorf("Tenant must be Tenantable")
 	}
 }
@@ -71,9 +71,9 @@ func TestIsUpdateable(t *testing.T) {
 
 	// First test, attempt to change root
 	root := getRootTestTenant()
-	userErr, _, statusCode := root.isUpdatable()
-	if userErr == nil && statusCode != http.StatusBadRequest {
-		t.Errorf("Should not be able to update root tenant. userErr = %s, statuscode = %d", userErr, statusCode)
+	errs := root.isUpdatable()
+	if errs.UserError == nil && errs.Code != http.StatusBadRequest {
+		t.Errorf("Should not be able to update root tenant. userErr = %s, statuscode = %d", errs.UserError, errs.Code)
 	}
 
 	// Second test, attempt to change Child's (ID:7) parent from ID:3 to ID:1 (root)
@@ -85,9 +85,9 @@ func TestIsUpdateable(t *testing.T) {
 	mock.ExpectQuery("SELECT")
 
 	child.ReqInfo = &api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": strconv.Itoa(*child.ID)}}
-	userErr, _, statusCode = child.isUpdatable()
-	if userErr != nil && statusCode != http.StatusOK {
-		t.Errorf("Should be able to update child to new parent (from Parent to Root). userErr = %s, statuscode = %d", userErr, statusCode)
+	errs = child.isUpdatable()
+	if errs.UserError != nil && errs.Code != http.StatusOK {
+		t.Errorf("Should be able to update child to new parent (from Parent to Root). userErr = %s, statuscode = %d", errs.UserError, errs.Code)
 	}
 
 	// Third test, attempt to change Parent from ID:3 to ID:7 (Child)
@@ -108,9 +108,9 @@ func TestIsUpdateable(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 
 	parent.ReqInfo = &api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": strconv.Itoa(*parent.ID)}}
-	userErr, _, statusCode = parent.isUpdatable()
-	if userErr == nil && statusCode != http.StatusBadRequest {
-		t.Errorf("Should NOT be able to update parent to own child (from Parent to Child). userErr = %s, statuscode = %d", userErr, statusCode)
+	errs = parent.isUpdatable()
+	if errs.UserError == nil && errs.Code != http.StatusBadRequest {
+		t.Errorf("Should NOT be able to update parent to own child (from Parent to Child). userErr = %s, statuscode = %d", errs.UserError, errs.Code)
 	}
 
 }

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant_test.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -35,19 +36,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOTenant{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("Tenant must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("Tenant must be Reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("Tenant must be Updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("Tenant must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("Tenant must be Identifier")
 	}
 	if _, ok := i.(api.Tenantable); !ok {

--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -114,7 +114,8 @@ func (as *TOASNV11) Create() api.Errors {
 	}
 	return crudder.GenericCreate(as)
 }
-func (as *TOASNV11) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+
+func (as *TOASNV11) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(as.APIInfo(), "asn")
 	return crudder.GenericRead(h, as, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 	validation "github.com/go-ozzo/ozzo-validation"
@@ -103,16 +104,19 @@ func (asn TOASNV11) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (as *TOASNV11) Create() (error, error, int) {
+func (as *TOASNV11) Create() api.Errors {
 	err := as.ASNExists(true)
 	if err != nil {
-		return err, nil, http.StatusBadRequest
+		return api.Errors{
+			Code:      http.StatusBadRequest,
+			UserError: err,
+		}
 	}
-	return api.GenericCreate(as)
+	return crudder.GenericCreate(as)
 }
 func (as *TOASNV11) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
 	api.DefaultSort(as.APIInfo(), "asn")
-	return api.GenericRead(h, as, useIMS)
+	return crudder.GenericRead(h, as, useIMS)
 }
 func (v *TOASNV11) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {
 	return `SELECT max(t) from (
@@ -123,14 +127,15 @@ JOIN
 	select max(last_updated) as t from last_deleted l where l.table_name='asn') as res`
 }
 
-func (as *TOASNV11) Update(h http.Header) (error, error, int) {
+func (as *TOASNV11) Update(h http.Header) api.Errors {
 	err := as.ASNExists(false)
 	if err != nil {
-		return err, nil, http.StatusBadRequest
+		return api.Errors{UserError: err, Code: http.StatusBadRequest}
 	}
-	return api.GenericUpdate(h, as)
+	return crudder.GenericUpdate(h, as)
 }
-func (as *TOASNV11) Delete() (error, error, int) { return api.GenericDelete(as) }
+
+func (as *TOASNV11) Delete() api.Errors { return crudder.GenericDelete(as) }
 
 func (asn TOASNV11) ASNExists(create bool) error {
 	if asn.APIInfo() == nil || asn.APIInfo().Tx == nil {

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -88,9 +88,9 @@ func TestGetASNs(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.ASNNullable{},
 	}
-	asns, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	asns, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(asns) != 2 {

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -102,19 +103,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOASNV11{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("asn must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("asn must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("asn must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("asn must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("asn must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/auth/authorize.go
+++ b/traffic_ops/traffic_ops_golang/auth/authorize.go
@@ -116,14 +116,7 @@ WHERE
   u.username = $1
 `
 
-	u := CurrentUser{
-		UserName:     "-",
-		ID:           -1,
-		PrivLevel:    PrivLevelInvalid,
-		TenantID:     TenantIDInvalid,
-		Role:         -1,
-		Capabilities: []string{},
-	}
+	var u CurrentUser
 
 	var currentUserInfo CurrentUser
 	if DB == nil {

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -307,7 +307,8 @@ func (cg *TOCacheGroup) Create() (error, error, int) {
 		&cg.SecondaryParentName,
 	)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 
 	coordinateID, err := cg.createCoordinate()
@@ -371,10 +372,10 @@ func (cg *TOCacheGroup) createCacheGroupFallbacks() error {
 func (cg *TOCacheGroup) isValidCacheGroupFallback(fallbackName string) (bool, error) {
 	var isValid bool
 	query := `SELECT(
-SELECT cachegroup.id 
-FROM cachegroup 
-JOIN type on type.id = cachegroup.type 
-WHERE cachegroup.name = $1 
+SELECT cachegroup.id
+FROM cachegroup
+JOIN type on type.id = cachegroup.type
+WHERE cachegroup.name = $1
 AND (type.name = 'EDGE_LOC')
 ) IS NOT NULL;`
 
@@ -389,9 +390,9 @@ AND (type.name = 'EDGE_LOC')
 func (cg *TOCacheGroup) isAllowedToFallback(cacheGroupType int) (bool, error) {
 	var isValid bool
 	query := `SELECT(
-SELECT type.name 
-FROM type 
-WHERE type.id = $1 
+SELECT type.name
+FROM type
+WHERE type.id = $1
 AND (type.name = 'EDGE_LOC')
 ) IS NOT NULL;`
 
@@ -492,8 +493,8 @@ func GetCacheGroupsByName(names []string, Tx *sqlx.Tx) (map[string]tc.CacheGroup
 	namesPqArray := pq.Array(names)
 	rows, err := Tx.Query(query, namesPqArray)
 	if err != nil {
-		userErr, sysErr, errCode := api.ParseDBError(err)
-		return nil, userErr, sysErr, errCode
+		errs := api.ParseDBError(err)
+		return nil, errs.UserError, errs.SystemError, errs.Code
 	}
 	defer log.Close(rows, "unable to close DB connection")
 	cacheGroupMap := map[string]tc.CacheGroupNullable{}
@@ -664,7 +665,8 @@ func (cg *TOCacheGroup) Update(h http.Header) (error, error, int) {
 		&cg.LastUpdated,
 	)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 
 	if err = cg.createLocalizationMethods(); err != nil {

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -143,10 +143,10 @@ func TestReadCacheGroups(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{},
 	}
-	cachegroups, userErr, sysErr, _, _ := obj.Read(nil, false)
+	cachegroups, errs, _ := obj.Read(nil, false)
 
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(cachegroups) != 2 {
@@ -337,14 +337,14 @@ func TestBadTypeParamCacheGroups(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{},
 	}
-	_, userErr, _, sc, _ := obj.Read(nil, false)
-	if sc != http.StatusBadRequest {
-		t.Errorf("Read expected status code: Bad Request, actual: %v ", sc)
+	_, errs, _ := obj.Read(nil, false)
+	if errs.Code != http.StatusBadRequest {
+		t.Errorf("Read expected status code: Bad Request, actual: %v ", errs.Code)
 	}
-	if userErr == nil {
+	if errs.UserError == nil {
 		t.Fatalf("Read expected: user error with details %v, actual: nil", detail)
 	}
-	if userErr.Error() != detail {
-		t.Fatalf("Read expected: user error with details %v, actual: %v", detail, userErr.Error())
+	if errs.UserError.Error() != detail {
+		t.Fatalf("Read expected: user error with details %v, actual: %v", detail, errs.UserError.Error())
 	}
 }

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 
@@ -172,19 +173,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOCacheGroup{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("cachegroup must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("cachegroup must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("cachegroup must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("cachegroup must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("cachegroup must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
@@ -38,9 +38,9 @@ import (
 )
 
 func DSPostHandlerV31(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -71,9 +71,9 @@ func DSPostHandlerV31(w http.ResponseWriter, r *http.Request) {
 }
 
 func DSPostHandlerV40(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
@@ -33,9 +33,9 @@ import (
 )
 
 func QueueUpdates(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -218,9 +218,9 @@ func (cgparam *TOCacheGroupParameter) Delete() (error, error, int) {
 
 // ReadAllCacheGroupParameters reads all cachegroup parameter associations.
 func ReadAllCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleDeprecatedErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr, nil)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleDeprecatedErrs(w, r, errs, nil)
 		return
 	}
 	defer inf.Close()
@@ -273,9 +273,9 @@ func GetAllCacheGroupParameters(tx *sqlx.Tx, parameters map[string]string) (tc.C
 // AddCacheGroupParameters performs a Create for cachegroup parameter associations.
 // AddCacheGroupParameters accepts data as a single association or an array of multiple.
 func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleDeprecatedErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr, nil)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleDeprecatedErrs(w, r, errs, nil)
 		return
 	}
 	defer inf.Close()
@@ -327,7 +327,7 @@ func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
 		}
 		cachegroups = append(cachegroups, *p.CacheGroup)
 	}
-	userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCachegroups(inf.Tx.Tx, cachegroups, inf.User.UserName)
+	userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCachegroups(inf.Tx.Tx, cachegroups, inf.User.UserName)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -341,8 +341,7 @@ func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
 	_, err = inf.Tx.Tx.Query(insertQuery() + insQuery)
 
 	if err != nil {
-		userErr, sysErr, code := api.ParseDBError(err)
-		api.HandleDeprecatedErr(w, r, inf.Tx.Tx, code, userErr, sysErr, nil)
+		inf.HandleDeprecatedErrs(w, r, api.ParseDBError(err), nil)
 		return
 	}
 
@@ -352,14 +351,14 @@ func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
 }
 
 func selectAllQuery() string {
-	return `SELECT cgp.cachegroup, cgp.parameter, cgp.last_updated, cg.name 
-				FROM cachegroup_parameter AS cgp 
+	return `SELECT cgp.cachegroup, cgp.parameter, cgp.last_updated, cg.name
+				FROM cachegroup_parameter AS cgp
 				JOIN cachegroup AS cg ON cg.id = cachegroup`
 }
 
 func insertQuery() string {
-	return `INSERT INTO cachegroup_parameter 
-		(cachegroup, 
-		parameter) 
+	return `INSERT INTO cachegroup_parameter
+		(cachegroup,
+		parameter)
 		VALUES `
 }

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
@@ -150,7 +151,7 @@ func TestReadCacheGroupParameters(t *testing.T) {
 			expectedReturnCode:   http.StatusNotFound,
 		},
 	}
-	toParameterReaders := map[string]api.Reader{
+	toParameterReaders := map[string]crudder.Reader{
 		"Parameters": &TOCacheGroupParameter{},
 	}
 	for _, testCase := range testCases {
@@ -245,7 +246,7 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOCacheGroupParameter{}
 
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("CacheGroupParameter must be Reader")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters_test.go
@@ -198,30 +198,30 @@ func TestReadCacheGroupParameters(t *testing.T) {
 				reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: testCase.params}
 				toParameterReader.SetInfo(&reqInfo)
 
-				parameters, userErr, sysErr, returnCode, _ := toParameterReader.Read(nil, false)
+				parameters, errs, _ := toParameterReader.Read(nil, false)
 
 				if testCase.storageError != nil {
-					if sysErr == nil {
+					if errs.SystemError == nil {
 						t.Errorf("Read error expected: received no sysErr")
 					}
 				} else if testCase.expectedUserError {
-					if userErr == nil {
+					if errs.UserError == nil {
 						t.Errorf("User error expected: received no userErr")
 					}
 				} else if testCase.cgExistsStorageError != nil {
-					if sysErr == nil {
+					if errs.SystemError == nil {
 						t.Errorf("Read error expected: received no sysErr")
 					}
 				} else {
-					if userErr != nil || sysErr != nil {
-						t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+					if errs.Occurred() {
+						t.Errorf("Read expected: no errors, actual: %s", errs)
 					}
 					if len(parameters) != len(testCase.cgParams) {
 						t.Errorf("cdn.Read expected: len(parameters) == %v, actual: %v", len(testCase.cgParams), len(parameters))
 					}
 				}
-				if testCase.expectedReturnCode != returnCode {
-					t.Errorf("Expected return code: %d, actual %d", testCase.expectedReturnCode, returnCode)
+				if testCase.expectedReturnCode != errs.Code {
+					t.Errorf("Expected return code: %d, actual %d", testCase.expectedReturnCode, errs.Code)
 				}
 			})
 		}

--- a/traffic_ops/traffic_ops_golang/cachesstats/cachesstats.go
+++ b/traffic_ops/traffic_ops_golang/cachesstats/cachesstats.go
@@ -35,9 +35,9 @@ import (
 const ATSCurrentConnectionsStat = "ats.proxy.process.http.current_client_connections"
 
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cdn/capacity.go
+++ b/traffic_ops/traffic_ops_golang/cdn/capacity.go
@@ -39,9 +39,9 @@ import (
 )
 
 func GetCapacity(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -137,7 +137,7 @@ func (cdn *TOCDN) Create() api.Errors {
 	return crudder.GenericCreate(cdn)
 }
 
-func (cdn *TOCDN) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (cdn *TOCDN) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(cdn.APIInfo(), "name")
 	return crudder.GenericRead(h, cdn, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 	"github.com/asaskevich/govalidator"
@@ -131,35 +132,35 @@ func (cdn TOCDN) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (cdn *TOCDN) Create() (error, error, int) {
+func (cdn *TOCDN) Create() api.Errors {
 	*cdn.DomainName = strings.ToLower(*cdn.DomainName)
-	return api.GenericCreate(cdn)
+	return crudder.GenericCreate(cdn)
 }
 
 func (cdn *TOCDN) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
 	api.DefaultSort(cdn.APIInfo(), "name")
-	return api.GenericRead(h, cdn, useIMS)
+	return crudder.GenericRead(h, cdn, useIMS)
 }
 
-func (cdn *TOCDN) Update(h http.Header) (error, error, int) {
+func (cdn *TOCDN) Update(h http.Header) api.Errors {
 	if cdn.ID != nil {
-		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(cdn.APIInfo().Tx.Tx, int64(*cdn.ID), cdn.APIInfo().User.UserName)
-		if userErr != nil || sysErr != nil {
-			return userErr, sysErr, errCode
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(cdn.APIInfo().Tx.Tx, int64(*cdn.ID), cdn.APIInfo().User.UserName)
+		if errs.Occurred() {
+			return errs
 		}
 	}
 	*cdn.DomainName = strings.ToLower(*cdn.DomainName)
-	return api.GenericUpdate(h, cdn)
+	return crudder.GenericUpdate(h, cdn)
 }
 
-func (cdn *TOCDN) Delete() (error, error, int) {
+func (cdn *TOCDN) Delete() api.Errors {
 	if cdn.ID != nil {
-		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(cdn.APIInfo().Tx.Tx, int64(*cdn.ID), cdn.APIInfo().User.UserName)
-		if userErr != nil || sysErr != nil {
-			return userErr, sysErr, errCode
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(cdn.APIInfo().Tx.Tx, int64(*cdn.ID), cdn.APIInfo().User.UserName)
+		if errs.Occurred() {
+			return errs
 		}
 	}
-	return api.GenericDelete(cdn)
+	return crudder.GenericDelete(cdn)
 }
 
 func selectQuery() string {

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -87,9 +87,9 @@ func TestReadCDNs(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.CDNNullable{},
 	}
-	cdns, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	cdns, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(cdns) != 2 {

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -115,19 +116,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOCDN{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("cdn must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("cdn must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("cdn must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("cdn must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("cdn must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/cdn/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssec.go
@@ -88,9 +88,9 @@ func CreateDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("cdn '"+cdnName+"' not found"), nil)
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, cdnName, inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, cdnName, inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	if err := generateStoreDNSSECKeys(inf.Tx.Tx, cdnName, cdnDomain, uint64(*req.TTL), uint64(*req.KSKExpirationDays), uint64(*req.ZSKExpirationDays), int64(*req.EffectiveDateUnix), inf.Vault, r.Context()); err != nil {
@@ -413,9 +413,9 @@ func DeleteDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, key, inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, key, inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	if err := inf.Vault.DeleteDNSSECKeys(key, inf.Tx.Tx, r.Context()); err != nil {

--- a/traffic_ops/traffic_ops_golang/cdn/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssec.go
@@ -48,9 +48,9 @@ const (
 )
 
 func CreateDNSSECKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -130,9 +130,9 @@ func CreateDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 const DefaultDSTTL = 60 * time.Second
 
 func GetDNSSECKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -392,9 +392,9 @@ WHERE cdn.name = $1
 }
 
 func DeleteDNSSECKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cdn/domains.go
+++ b/traffic_ops/traffic_ops_golang/cdn/domains.go
@@ -21,10 +21,11 @@ package cdn
 
 import (
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 	"net/http"
 	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
@@ -82,9 +83,9 @@ func getDomainsList(useIMS bool, header http.Header, tx *sqlx.Tx) ([]tc.Domain, 
 
 func DomainsHandler(w http.ResponseWriter, r *http.Request) {
 	useIMS := false
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cdn/genksk.go
+++ b/traffic_ops/traffic_ops_golang/cdn/genksk.go
@@ -39,9 +39,9 @@ const DefaultKSKExpiration = 365 * 24 * time.Hour
 const DefaultZSKExpiration = 30 * 24 * time.Hour
 
 func GenerateKSK(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cdn/genksk.go
+++ b/traffic_ops/traffic_ops_golang/cdn/genksk.go
@@ -79,9 +79,9 @@ func GenerateKSK(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 		return
 	}
-	userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	ttl, multiplier, err := getKSKParams(inf.Tx.Tx, cdnName)

--- a/traffic_ops/traffic_ops_golang/cdn/health.go
+++ b/traffic_ops/traffic_ops_golang/cdn/health.go
@@ -31,9 +31,9 @@ import (
 )
 
 func GetHealth(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -48,9 +48,9 @@ func GetHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetNameHealth(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cdn/namedelete.go
+++ b/traffic_ops/traffic_ops_golang/cdn/namedelete.go
@@ -54,9 +54,9 @@ func DeleteName(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("Failed to delete cdn name = "+string(cdnName)+" has delivery services or servers"), nil)
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	if err := deleteCDNByName(inf.Tx.Tx, cdnName); err != nil {

--- a/traffic_ops/traffic_ops_golang/cdn/namedelete.go
+++ b/traffic_ops/traffic_ops_golang/cdn/namedelete.go
@@ -31,9 +31,9 @@ import (
 )
 
 func DeleteName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cdn/queue.go
+++ b/traffic_ops/traffic_ops_golang/cdn/queue.go
@@ -42,9 +42,9 @@ func Queue(w http.ResponseWriter, r *http.Request) {
 	var str string
 	params := make(map[string]string, 0)
 
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -113,10 +113,10 @@ func Queue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, cols)
-	if len(errs) > 0 {
-		errCode = http.StatusBadRequest
-		userErr = util.JoinErrs(errs)
+	where, orderBy, pagination, queryValues, es := dbhelpers.BuildWhereAndOrderByAndPagination(params, cols)
+	if len(es) > 0 {
+		errCode := http.StatusBadRequest
+		userErr = util.JoinErrs(es)
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, nil)
 		return
 	}

--- a/traffic_ops/traffic_ops_golang/cdn/sslkeys.go
+++ b/traffic_ops/traffic_ops_golang/cdn/sslkeys.go
@@ -27,9 +27,9 @@ import (
 )
 
 func GetSSLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/cdn_lock/cdn_lock.go
+++ b/traffic_ops/traffic_ops_golang/cdn_lock/cdn_lock.go
@@ -112,8 +112,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 	cdnLock.UserName = inf.User.UserName
 	resultRows, err := inf.Tx.NamedQuery(insertQuery, cdnLock)
 	if err != nil {
-		userErr, sysErr, errCode := api.ParseDBError(err)
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 	defer resultRows.Close()

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
@@ -136,10 +136,8 @@ func (v *TOCoordinate) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tab
 	select max(last_updated) as t from last_deleted l where l.table_name='` + tableName + `') as res`
 }
 
-func (coord *TOCoordinate) Update(h http.Header) api.Errors {
-	return crudder.GenericUpdate(h, coord)
-}
-func (coord *TOCoordinate) Delete() api.Errors { return crudder.GenericDelete(coord) }
+func (coord *TOCoordinate) Update(h http.Header) api.Errors { return crudder.GenericUpdate(h, coord) }
+func (coord *TOCoordinate) Delete() api.Errors              { return crudder.GenericDelete(coord) }
 
 func selectQuery() string {
 	query := `SELECT

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 	validation "github.com/go-ozzo/ozzo-validation"
@@ -123,10 +124,10 @@ func (coordinate TOCoordinate) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (coord *TOCoordinate) Create() (error, error, int) { return api.GenericCreate(coord) }
+func (coord *TOCoordinate) Create() api.Errors { return crudder.GenericCreate(coord) }
 func (coord *TOCoordinate) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
 	api.DefaultSort(coord.APIInfo(), "name")
-	return api.GenericRead(h, coord, useIMS)
+	return crudder.GenericRead(h, coord, useIMS)
 }
 func (v *TOCoordinate) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {
 	return `SELECT max(t) from (
@@ -135,10 +136,10 @@ func (v *TOCoordinate) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tab
 	select max(last_updated) as t from last_deleted l where l.table_name='` + tableName + `') as res`
 }
 
-func (coord *TOCoordinate) Update(h http.Header) (error, error, int) {
-	return api.GenericUpdate(h, coord)
+func (coord *TOCoordinate) Update(h http.Header) api.Errors {
+	return crudder.GenericUpdate(h, coord)
 }
-func (coord *TOCoordinate) Delete() (error, error, int) { return api.GenericDelete(coord) }
+func (coord *TOCoordinate) Delete() api.Errors { return crudder.GenericDelete(coord) }
 
 func selectQuery() string {
 	query := `SELECT

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
@@ -125,7 +125,7 @@ func (coordinate TOCoordinate) Validate() error {
 }
 
 func (coord *TOCoordinate) Create() api.Errors { return crudder.GenericCreate(coord) }
-func (coord *TOCoordinate) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (coord *TOCoordinate) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(coord.APIInfo(), "name")
 	return crudder.GenericRead(h, coord, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
@@ -91,9 +91,9 @@ func TestReadCoordinates(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.CoordinateNullable{},
 	}
-	coordinates, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	coordinates, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 	if len(coordinates) != 2 {
 		t.Errorf("coordinate.Read expected: len(coordinates) == 2, actual: %v", len(coordinates))

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -118,19 +119,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOCoordinate{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("coordinate must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("coordinate must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("coordinate must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("coordinate must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("coordinate must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/crconfig/handler.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/handler.go
@@ -39,9 +39,9 @@ import (
 // Handler creates and serves the CRConfig from the raw SQL data.
 // This MUST only be used for debugging or previewing, the raw un-snapshotted data MUST NOT be used by any component of the CDN.
 func Handler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"cdn"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -59,9 +59,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 // SnapshotGetHandler gets and serves the CRConfig from the snapshot table.
 func SnapshotGetHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"cdn"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -89,9 +89,9 @@ func SnapshotGetHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func SnapshotGetMonitoringLegacyHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"cdn"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -116,9 +116,9 @@ func SnapshotGetMonitoringLegacyHandler(w http.ResponseWriter, r *http.Request) 
 
 // SnapshotGetMonitoringHandler gets and serves the CRConfig from the snapshot table.
 func SnapshotGetMonitoringHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"cdn"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -138,9 +138,9 @@ func SnapshotGetMonitoringHandler(w http.ResponseWriter, r *http.Request) {
 
 // SnapshotHandler creates the CRConfig JSON and writes it to the snapshot table in the database.
 func SnapshotHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id", "cdnID"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"id", "cdnID"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/crstats/cdnrouting.go
+++ b/traffic_ops/traffic_ops_golang/crstats/cdnrouting.go
@@ -30,9 +30,9 @@ import (
 
 // GetCDNRouting is the handler for getting aggregated routing percentages across CDNs.
 func GetCDNRouting(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/crstats/dsrouting.go
+++ b/traffic_ops/traffic_ops_golang/crstats/dsrouting.go
@@ -36,18 +36,17 @@ import (
 
 // GetDSRouting is the handler for getting aggregated routing percentages for a DS.
 func GetDSRouting(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	tx := inf.Tx.Tx
-
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	dsID := inf.IntParams["id"]
 
-	userErr, sysErr, errCode = tenant.CheckID(tx, inf.User, dsID)
+	tx := inf.Tx.Tx
+	userErr, sysErr, errCode := tenant.CheckID(tx, inf.User, dsID)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/crudder/change_log_test.go
+++ b/traffic_ops/traffic_ops_golang/crudder/change_log_test.go
@@ -1,4 +1,4 @@
-package api
+package crudder
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -27,6 +27,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 )
 
@@ -34,8 +35,8 @@ type testIdentifier struct {
 	ID int
 }
 
-func (i testIdentifier) GetKeyFieldsInfo() []KeyFieldInfo {
-	return []KeyFieldInfo{{"id", GetIntKey}}
+func (i testIdentifier) GetKeyFieldsInfo() []api.KeyFieldInfo {
+	return []api.KeyFieldInfo{{"id", api.GetIntKey}}
 }
 
 func (i *testIdentifier) SetKeys(keys map[string]interface{}) {
@@ -67,12 +68,12 @@ func TestCreateChangeLog(t *testing.T) {
 	i := testIdentifier{}
 
 	keys, _ := i.GetKeys()
-	expectedMessage := strings.ToUpper(i.GetType()) + ": " + i.GetAuditName() + ", ID: " + strconv.Itoa(keys["id"].(int)) + ", ACTION: " + Created + " " + i.GetType() + ", keys: { id:" + strconv.Itoa(keys["id"].(int)) + " }"
+	expectedMessage := strings.ToUpper(i.GetType()) + ": " + i.GetAuditName() + ", ID: " + strconv.Itoa(keys["id"].(int)) + ", ACTION: " + api.Created + " " + i.GetType() + ", keys: { id:" + strconv.Itoa(keys["id"].(int)) + " }"
 
 	mock.ExpectBegin()
-	mock.ExpectExec("INSERT").WithArgs(ApiChange, expectedMessage, 1).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT").WithArgs(api.ApiChange, expectedMessage, 1).WillReturnResult(sqlmock.NewResult(1, 1))
 	user := auth.CurrentUser{ID: 1}
-	err = CreateChangeLog(ApiChange, Created, &i, &user, db.MustBegin().Tx)
+	err = CreateChangeLog(api.ApiChange, api.Created, &i, &user, db.MustBegin().Tx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/traffic_ops/traffic_ops_golang/crudder/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/crudder/shared_handlers.go
@@ -137,16 +137,16 @@ func readHandlerHelper(reader Reader, errHandler errWriterFunc, successHandler r
 		if cfg != nil {
 			useIMS = cfg.UseIMS
 		}
-		results, userErr, sysErr, errCode, maxTime := obj.Read(r.Header, useIMS)
-		if userErr != nil || sysErr != nil {
-			errHandler(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		results, errs, maxTime := obj.Read(r.Header, useIMS)
+		if errs.Occurred() {
+			errHandler(w, r, inf.Tx.Tx, errs.Code, errs.UserError, errs.SystemError)
 			return
 		}
 		if maxTime != nil && SetLastModifiedHeader(r, useIMS) {
 			date := maxTime.Format(rfc.LastModifiedFormat)
 			w.Header().Add(rfc.LastModified, date)
 		}
-		successHandler(w, r, errCode, results)
+		successHandler(w, r, errs.Code, results)
 	}
 }
 
@@ -364,7 +364,7 @@ func deleteHandlerHelper(deleter Deleter, errHandler errWriterFunc, successHandl
 		if isOptionsDeleter {
 			obj := reflect.New(objectType).Interface().(OptionsDeleter)
 			obj.SetInfo(inf)
-			userErr, sysErr, errCode = obj.OptionsDelete()
+			errs = obj.OptionsDelete()
 		} else {
 			errs = obj.Delete()
 		}

--- a/traffic_ops/traffic_ops_golang/crudder/shared_handlers_test.go
+++ b/traffic_ops/traffic_ops_golang/crudder/shared_handlers_test.go
@@ -90,17 +90,17 @@ func (i *tester) Create() api.Errors {
 }
 
 //Reader interface functions
-func (i *tester) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (i *tester) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	if h.Get(rfc.IfModifiedSince) != "" {
 		if imsDate, ok := rfc.ParseHTTPDate(h.Get(rfc.IfModifiedSince)); !ok {
-			return []interface{}{tester{ID: 1}}, nil, nil, http.StatusOK, nil
+			return []interface{}{tester{ID: 1}}, api.NewErrors(), nil
 		} else {
 			if imsDate.UTC().After(time.Now().UTC()) {
-				return []interface{}{}, nil, nil, http.StatusNotModified, &imsDate
+				return []interface{}{}, api.Errors{Code: http.StatusNotModified}, &imsDate
 			}
 		}
 	}
-	return []interface{}{tester{ID: 1}}, nil, nil, http.StatusOK, nil
+	return []interface{}{tester{ID: 1}}, api.NewErrors(), nil
 }
 
 //Updater interface functions

--- a/traffic_ops/traffic_ops_golang/crudder/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/crudder/shared_interfaces.go
@@ -33,7 +33,7 @@ import (
 
 type CRUDer interface {
 	Create() api.Errors
-	Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time)
+	Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time)
 	Update(http.Header) api.Errors
 	Delete() api.Errors
 	APIInfoer
@@ -97,7 +97,7 @@ type MultipleCreator interface {
 
 type Reader interface {
 	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
-	Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time)
+	Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time)
 	APIInfoer
 }
 
@@ -120,7 +120,7 @@ type Deleter interface {
 type OptionsDeleter interface {
 	// OptionsDelete returns any user error, any system error, and the HTTP error code to be returned if there was an
 	// error.
-	OptionsDelete() (error, error, int)
+	OptionsDelete() api.Errors
 	APIInfoer
 	Identifier
 	DeleteKeyOptions() map[string]dbhelpers.WhereColumnInfo

--- a/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
@@ -297,16 +297,16 @@ func RunAutorenewal(existingCerts []ExistingCerts, cfg *config.Config, ctx conte
 	}
 
 	if cfg.SMTP.Enabled && cfg.ConfigAcmeRenewal.SummaryEmail != "" {
-		errCode, userErr, sysErr := AlertExpiringCerts(keysFound, *cfg)
-		if userErr != nil || sysErr != nil {
-			log.Errorf("cert autorenewal: sending email: errCode: %d userErr: %v sysErr: %v", errCode, userErr, sysErr)
+		errs := AlertExpiringCerts(keysFound, *cfg)
+		if errs.Occurred() {
+			log.Errorf("cert autorenewal: sending email: errCode: %d userErr: %v sysErr: %v", errs.Code, errs.UserError, errs.SystemError)
 			return
 		}
 
 	}
 }
 
-func AlertExpiringCerts(certsFound ExpirationSummary, config config.Config) (int, error, error) {
+func AlertExpiringCerts(certsFound ExpirationSummary, config config.Config) api.Errors {
 	header := "From: " + config.ConfigTO.EmailFrom.String() + "\r\n" +
 		"To: " + config.ConfigAcmeRenewal.SummaryEmail + "\r\n" +
 		"MIME-version: 1.0;\r\n" +

--- a/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
@@ -74,9 +74,9 @@ func RenewCertificates(w http.ResponseWriter, r *http.Request) {
 
 func renewCertificates(w http.ResponseWriter, r *http.Request, deprecated bool) {
 	deprecation := util.StrPtr(API_ACME_AUTORENEW)
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErrOptionalDeprecation(w, r, inf.Tx.Tx, errCode, userErr, sysErr, deprecated, deprecation)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		api.HandleErrOptionalDeprecation(w, r, inf.Tx.Tx, errs.Code, errs.UserError, errs.SystemError, deprecated, deprecation)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/deliveryservice/capacity.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/capacity.go
@@ -36,16 +36,16 @@ import (
 )
 
 func GetCapacity(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	dsID := inf.IntParams["id"]
 
-	userErr, sysErr, errCode = tenant.CheckID(inf.Tx.Tx, inf.User, dsID)
+	userErr, sysErr, errCode := tenant.CheckID(inf.Tx.Tx, inf.User, dsID)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/consistenthash/consistenthash.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/consistenthash/consistenthash.go
@@ -23,12 +23,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 )
 
 // struct for the response object from Traffic Router
@@ -47,9 +48,9 @@ type TRConsistentHashRequest struct {
 
 // Post is the handler for POST requests to /consistenthash.
 func Post(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -136,9 +136,9 @@ func GetDSTLSVersions(dsID int, tx *sql.Tx) ([]string, error) {
 // But it'd be much more convenient for users. Alternatively, remove IDs from
 // the database entirely and use real candidate keys.
 func CreateV15(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -157,9 +157,9 @@ func CreateV15(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service creation was successful", []tc.DeliveryServiceNullableV15{*res})
 }
 func CreateV30(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -178,9 +178,9 @@ func CreateV30(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service creation was successful", []tc.DeliveryServiceV30{*res})
 }
 func CreateV31(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -199,9 +199,9 @@ func CreateV31(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service creation was successful", []tc.DeliveryServiceV31{*res})
 }
 func CreateV40(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -621,9 +621,9 @@ func (ds *TODeliveryService) Read(h http.Header, useIMS bool) ([]interface{}, er
 }
 
 func UpdateV15(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -645,9 +645,9 @@ func UpdateV15(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service update was successful", []tc.DeliveryServiceNullableV15{*res})
 }
 func UpdateV30(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -669,9 +669,9 @@ func UpdateV30(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service update was successful", []tc.DeliveryServiceV30{*res})
 }
 func UpdateV31(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -692,9 +692,9 @@ func UpdateV31(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service update was successful", []tc.DeliveryServiceV31{*res})
 }
 func UpdateV40(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -534,8 +534,8 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 		if !inf.Config.TrafficVaultEnabled {
 			return nil, http.StatusInternalServerError, nil, errors.New("cannot create DNSSEC keys for delivery service: Traffic Vault is not configured")
 		}
-		if userErr, sysErr, statusCode := PutDNSSecKeys(tx, *ds.XMLID, cdnName, ds.ExampleURLs, inf.Vault, r.Context()); userErr != nil || sysErr != nil {
-			return nil, statusCode, userErr, sysErr
+		if errs := PutDNSSecKeys(tx, *ds.XMLID, cdnName, ds.ExampleURLs, inf.Vault, r.Context()); errs.Occurred() {
+			return nil, errs.Code, errs.UserError, errs.SystemError
 		}
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -255,8 +255,8 @@ func createV31(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV31 t
 			&dsV31.CacheURL,
 			&ds.ID)
 		if err != nil {
-			usrErr, sysErr, code := api.ParseDBError(err)
-			return nil, code, usrErr, sysErr
+			errs := api.ParseDBError(err)
+			return nil, errs.Code, errs.UserError, errs.SystemError
 		}
 	}
 
@@ -456,8 +456,8 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 	}
 
 	if err != nil {
-		usrErr, sysErr, code := api.ParseDBError(err)
-		return nil, code, usrErr, sysErr
+		errs := api.ParseDBError(err)
+		return nil, errs.Code, errs.UserError, errs.SystemError
 	}
 	defer resultRows.Close()
 
@@ -504,8 +504,8 @@ func createV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 t
 	}
 
 	if _, err := createConsistentHashQueryParams(tx, *ds.ID, ds.ConsistentHashQueryParams); err != nil {
-		usrErr, sysErr, code := api.ParseDBError(err)
-		return nil, code, usrErr, sysErr
+		errs := api.ParseDBError(err)
+		return nil, errs.Code, errs.UserError, errs.SystemError
 	}
 
 	matchlists, err := GetDeliveryServicesMatchLists([]string{*ds.XMLID}, tx)
@@ -807,8 +807,8 @@ func updateV31(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV31 *
 			&dsV31.CacheURL,
 			&ds.ID)
 		if err != nil {
-			usrErr, sysErr, code := api.ParseDBError(err)
-			return nil, code, usrErr, sysErr
+			errs := api.ParseDBError(err)
+			return nil, errs.Code, errs.UserError, errs.SystemError
 		}
 	}
 
@@ -1042,8 +1042,8 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 	}
 
 	if err != nil {
-		usrErr, sysErr, code := api.ParseDBError(err)
-		return nil, code, usrErr, sysErr
+		errs := api.ParseDBError(err)
+		return nil, errs.Code, errs.UserError, errs.SystemError
 	}
 	defer resultRows.Close()
 	if !resultRows.Next() {
@@ -1124,8 +1124,8 @@ func updateV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, dsV40 *
 	}
 
 	if _, err = createConsistentHashQueryParams(tx, *ds.ID, ds.ConsistentHashQueryParams); err != nil {
-		usrErr, sysErr, code := api.ParseDBError(err)
-		return nil, code, usrErr, sysErr
+		errs := api.ParseDBError(err)
+		return nil, errs.Code, errs.UserError, errs.SystemError
 	}
 
 	if err := api.CreateChangeLogRawErr(api.ApiChange, "Updated ds: "+*ds.XMLID+" id: "+strconv.Itoa(*ds.ID), user, tx); err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
@@ -318,7 +318,8 @@ func (rc *RequiredCapability) Create() (error, error, int) {
 
 	rows, err := rc.APIInfo().Tx.NamedQuery(rcInsertQuery(), rc)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer log.Close(rows, "closing rows in RequiredCapability.Create()")
 
@@ -344,8 +345,8 @@ func (rc *RequiredCapability) checkServerCap() (error, error, int) {
 	// Get server capability name
 	name := ""
 	if err := tx.QueryRow(`
-		SELECT name 
-		FROM server_capability 
+		SELECT name
+		FROM server_capability
 		WHERE name = $1`, rc.RequiredCapability).Scan(&name); err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("querying server capability for name '%v': %v", rc.RequiredCapability, err), http.StatusInternalServerError
 	}
@@ -436,7 +437,7 @@ func (rc *RequiredCapability) ensureDSServerCap() (error, error, int) {
 	dsServerIDs := []int64{}
 	if err := tx.Tx.QueryRow(`
 	SELECT ARRAY(
-		SELECT ds.server 
+		SELECT ds.server
 		FROM deliveryservice_server ds
 		JOIN server s ON ds.server = s.id
 		JOIN type t ON s.type = t.id
@@ -455,7 +456,7 @@ func (rc *RequiredCapability) ensureDSServerCap() (error, error, int) {
 	if err := tx.QueryRow(`
 	SELECT ARRAY(
 		SELECT server
-		FROM server_server_capability 
+		FROM server_server_capability
 		WHERE server = ANY($1)
 		AND server_capability=$2
 	)`, pq.Array(dsServerIDs), rc.RequiredCapability).Scan(pq.Array(&capServerIDs)); err != nil && err != sql.ErrNoRows {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
@@ -166,8 +166,8 @@ func (rc RequiredCapability) Validate() error {
 }
 
 // Update implements the api.CRUDer interface.
-func (rc *RequiredCapability) Update(http.Header) (error, error, int) {
-	return nil, nil, http.StatusNotImplemented
+func (rc *RequiredCapability) Update() api.Errors {
+	return api.Errors{Code: http.StatusNotImplemented}
 }
 
 // Read implements the api.CRUDer interface.

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
@@ -303,12 +303,15 @@ func TestUnauthorizedDeleteDeliveryServicesRequiredCapability(t *testing.T) {
 
 	errs := rc.Delete()
 
+	// TODO: this could segfault before failing
 	expErr := "not authorized on this tenant"
 	if errs.UserError.Error() != expErr {
 		t.Fatalf("got %s; expected %s", errs.UserError, expErr)
 	}
 
 	if errs.SystemError != nil {
+		// TODO: I think this should be failing with the system error, and also
+		// it seems like this would segfault.
 		t.Fatalf(errs.UserError.Error())
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
@@ -197,14 +197,11 @@ func TestReadDeliveryServicesRequiredCapability(t *testing.T) {
 	)
 	mock.ExpectQuery("SELECT .* FROM deliveryservices_required_capability").WillReturnRows(rows)
 
-	results, userErr, sysErr, errCode, _ := rc.Read(nil, false)
-	if userErr != nil {
-		t.Fatalf(userErr.Error())
+	results, errs, _ := rc.Read(nil, false)
+	if errs.Occurred() {
+		t.Fatal(errs)
 	}
-	if sysErr != nil {
-		t.Fatalf(sysErr.Error())
-	}
-	if got, want := errCode, http.StatusOK; got != want {
+	if got, want := errs.Code, http.StatusOK; got != want {
 		t.Fatalf(fmt.Sprintf("got %d; expected http status code %d", got, want))
 	}
 	if got, want := len(results), 1; got != want {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_test.go
@@ -412,11 +412,11 @@ func TestReadGetDeliveryServices(t *testing.T) {
 	regexRows.AddRow("demo1", "hostregexp", "", 0)
 	mock.ExpectQuery("SELECT ds\\.xml_id as ds_name, t\\.name as type, r\\.pattern, COALESCE\\(dsr\\.set_number, 0\\) FROM regex").WillReturnRows(regexRows)
 
-	_, userErr, sysErr, _, _ := readGetDeliveryServices(nil, nil, db.MustBegin(), &u, false)
-	if userErr != nil {
-		t.Errorf("Unexpected user error reading Delivery Services: %v", userErr)
+	_, errs, _ := readGetDeliveryServices(nil, nil, db.MustBegin(), &u, false)
+	if errs.UserError != nil {
+		t.Errorf("Unexpected user error reading Delivery Services: %v", errs.UserError)
 	}
-	if sysErr != nil {
-		t.Errorf("Unexpected system error reading Delivery Services: %v", sysErr)
+	if errs.SystemError != nil {
+		t.Errorf("Unexpected system error reading Delivery Services: %v", errs.SystemError)
 	}
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_test.go
@@ -55,12 +55,12 @@ func TestGetDetails(t *testing.T) {
 	mock.ExpectQuery("SELECT ds.routing_name, ds.ssl_key_version, cdn.name, cdn.id").WillReturnRows(rows)
 	mock.ExpectQuery("SELECT ds.xml_id as ds_name, t.name as type, r.pattern").WillReturnRows(rows2)
 
-	oldDetails, userErr, sysErr, code := getOldDetails(1, db.MustBegin().Tx)
-	if userErr != nil || sysErr != nil {
-		t.Fatalf("didn't expect an error but got user err %v, sys err %v", userErr, sysErr)
+	oldDetails, errs := getOldDetails(1, db.MustBegin().Tx)
+	if errs.Occurred() {
+		t.Fatalf("didn't expect an error but got user err %v, sys err %v", errs.UserError, errs.SystemError)
 	}
-	if code != http.StatusOK {
-		t.Fatalf("expected status OK 200, but got %d", code)
+	if errs.Code != http.StatusOK {
+		t.Fatalf("expected status OK 200, but got %d", errs.Code)
 	}
 	if oldDetails.OldOrgServerFqdn == nil {
 		t.Fatalf("old org server fqdn is nil")
@@ -96,15 +96,15 @@ func TestGetOldDetailsError(t *testing.T) {
 	rows := sqlmock.NewRows([]string{""})
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT ds.routing_name, ds.ssl_key_version, cdn.name, cdn.id").WillReturnRows(rows)
-	_, userErr, _, code := getOldDetails(1, db.MustBegin().Tx)
-	if userErr == nil {
+	_, errs := getOldDetails(1, db.MustBegin().Tx)
+	if errs.UserError == nil {
 		t.Fatalf("expected error %v, but got none", expected)
 	}
-	if userErr.Error() != expected {
-		t.Errorf("expected error %v, but got %v", expected, userErr.Error())
+	if errs.UserError.Error() != expected {
+		t.Errorf("expected error %v, but got %v", expected, errs.UserError.Error())
 	}
-	if code != http.StatusNotFound {
-		t.Errorf("expected error code : %d, but got : %d", http.StatusNotFound, code)
+	if errs.Code != http.StatusNotFound {
+		t.Errorf("expected error code : %d, but got : %d", http.StatusNotFound, errs.Code)
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/eligible.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/eligible.go
@@ -35,9 +35,9 @@ import (
 )
 
 func GetServersEligible(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -137,7 +137,7 @@ JOIN type t ON s.type = t.id
 WHERE s.cdn_id = (SELECT cdn_id from deliveryservice where id = (select v from ds_id))
 	AND (t.name LIKE 'EDGE%' OR t.name LIKE 'ORG%')
 `
-	dataFetchQuery := `, 
+	dataFetchQuery := `,
 cg.name as cachegroup,
 s.cachegroup as cachegroup_id,
 s.cdn_id,

--- a/traffic_ops/traffic_ops_golang/deliveryservice/health.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/health.go
@@ -33,16 +33,16 @@ import (
 )
 
 func GetHealth(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	dsID := inf.IntParams["id"]
 
-	userErr, sysErr, errCode = tenant.CheckID(inf.Tx.Tx, inf.User, dsID)
+	userErr, sysErr, errCode := tenant.CheckID(inf.Tx.Tx, inf.User, dsID)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
@@ -48,9 +48,9 @@ const (
 
 // AddSSLKeys adds the given ssl keys to the given delivery service.
 func AddSSLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -138,9 +138,9 @@ func AddSSLKeys(w http.ResponseWriter, r *http.Request) {
 
 // GetSSLKeysByXMLID fetches the deliveryservice ssl keys by the specified xmlID. V15 includes expiration date.
 func GetSSLKeysByXMLID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"xmlid"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"xmlid"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -256,14 +256,14 @@ func base64EncodeCertificate(cert *tc.DeliveryServiceSSLKeysCertificate) {
 
 // DeleteSSLKeys deletes a Delivery Service's sslkeys via a DELETE method
 func DeleteSSLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"xmlid"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"xmlid"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 	if !inf.Config.TrafficVaultEnabled {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("deliveryservice.DeleteSSLKeys: Traffic Vault is not configured"))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.DeleteSSLKeys: Traffic Vault is not configured"))
 		return
 	}
 	xmlID := inf.Params["xmlid"]

--- a/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
@@ -76,9 +76,9 @@ func AddSSLKeys(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("no DS with name "+*req.DeliveryService), nil)
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	// ECDSA keys support is only permitted for DNS delivery services
@@ -276,9 +276,9 @@ func DeleteSSLKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 
@@ -287,7 +287,7 @@ func DeleteSSLKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := inf.Vault.DeleteDeliveryServiceSSLKeys(xmlID, inf.Params["version"], inf.Tx.Tx, r.Context()); err != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("deliveryservice.DeleteSSLKeys: deleting SSL keys: "+err.Error()))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.DeleteSSLKeys: deleting SSL keys: "+err.Error()))
 		return
 	}
 	api.CreateChangeLogRawTx(api.ApiChange, "DS: "+xmlID+", ID: "+strconv.Itoa(dsID)+", ACTION: Deleted SSL keys", inf.User, inf.Tx.Tx)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/letsencrypt_dns_challenge.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/letsencrypt_dns_challenge.go
@@ -37,9 +37,9 @@ type DnsRecord struct {
 }
 
 func GetDnsChallengeRecords(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -50,9 +50,9 @@ func GetDnsChallengeRecords(w http.ResponseWriter, r *http.Request) {
 		"fqdn": dbhelpers.WhereColumnInfo{Column: "fqdn"},
 	}
 
-	where, _, _, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
-	if len(errs) > 0 {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, util.JoinErrs(errs))
+	where, _, _, queryValues, dbErrs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
+	if len(dbErrs) > 0 {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, util.JoinErrs(dbErrs))
 		return
 	}
 	getQuery += where

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/assign.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/assign.go
@@ -194,9 +194,9 @@ func PutAssignment(w http.ResponseWriter, r *http.Request) {
 
 	if dsr.ChangeType == tc.DSRChangeTypeUpdate {
 		query := deliveryservice.SelectDeliveryServicesQuery + `WHERE xml_id=:XMLID`
-		originals, userErr, sysErr, errCode := deliveryservice.GetDeliveryServices(query, map[string]interface{}{"XMLID": dsr.XMLID}, inf.Tx)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		originals, errs := deliveryservice.GetDeliveryServices(query, map[string]interface{}{"XMLID": dsr.XMLID}, inf.Tx)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 		if len(originals) < 1 {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/assign.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/assign.go
@@ -194,8 +194,7 @@ func PutAssignment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := tx.QueryRow(assignDSRQuery, req.AssigneeID, *dsr.ID).Scan(&dsr.LastUpdated); err != nil {
-		userErr, sysErr, errCode = api.ParseDBError(err)
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 	dsr.Assignee = req.Assignee

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
@@ -31,7 +31,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
-	"github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation"
 )
 
 //we need a type alias to define functions on
@@ -121,7 +121,8 @@ func (comment *TODeliveryServiceRequestComment) Update(h http.Header) (error, er
 	current := TODeliveryServiceRequestComment{}
 	err := comment.ReqInfo.Tx.QueryRowx(selectQuery() + `WHERE dsrc.id=` + strconv.Itoa(*comment.ID)).StructScan(&current)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 
 	userID := tc.IDNoMod(comment.ReqInfo.User.ID)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
@@ -114,7 +114,7 @@ func (comment *TODeliveryServiceRequestComment) Create() api.Errors {
 	return crudder.GenericCreate(comment)
 }
 
-func (comment *TODeliveryServiceRequestComment) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (comment *TODeliveryServiceRequestComment) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(comment.APIInfo(), "xmlId")
 	return crudder.GenericRead(h, comment, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 )
 
@@ -50,19 +50,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TODeliveryServiceRequestComment{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("comment must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("comment must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("comment must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("comment must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("comment must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/status.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/status.go
@@ -220,8 +220,7 @@ func PutStatus(w http.ResponseWriter, r *http.Request) {
 			*dsr.Original = original[0]
 		}
 	} else {
-		userErr, sysErr, errCode = api.ParseDBError(err)
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -121,9 +121,9 @@ func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 	} else {
 		log.Warnf("Couldn't get config %v", e)
 	}
-	dses, userErr, sysErr, errCode, _ := readGetDeliveryServices(r.Header, inf.Params, inf.Tx, inf.User, useIMS)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	dses, errs, _ := readGetDeliveryServices(r.Header, inf.Params, inf.Tx, inf.User, useIMS)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	if len(dses) != 1 {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -57,10 +57,10 @@ RETURNING id
 func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 	var ok bool
 	var err error
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -75,7 +75,7 @@ func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 	}
 	dsID := inf.IntParams["id"]
 
-	userErr, sysErr, errCode = tenant.CheckID(tx, inf.User, dsID)
+	userErr, sysErr, errCode := tenant.CheckID(tx, inf.User, dsID)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -92,9 +92,9 @@ func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice update safe: getting CDN from DS ID "+err.Error()))
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdn), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdn), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	if version.Major > 3 && version.Minor >= 0 {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -97,17 +97,17 @@ func checkLastAvailableEdgeOrOrigin(dsID, serverID int, usesMSO bool, tx *sql.Tx
 }
 
 func deleteDSS(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"serverid", "dsid"}, []string{"serverid", "dsid"})
+	inf, errs := api.NewInfo(r, []string{"serverid", "dsid"}, []string{"serverid", "dsid"})
 	tx := inf.Tx.Tx
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	if tx == nil {
-		errCode = http.StatusInternalServerError
-		sysErr = errors.New("nil transaction")
+		errCode := http.StatusInternalServerError
+		sysErr := errors.New("nil transaction")
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, nil, sysErr)
 		return
 	}
@@ -115,7 +115,7 @@ func deleteDSS(w http.ResponseWriter, r *http.Request) {
 	dsID := inf.IntParams["dsid"]
 	serverID := inf.IntParams["serverid"]
 
-	userErr, sysErr, errCode = tenant.CheckID(tx, inf.User, dsID)
+	userErr, sysErr, errCode := tenant.CheckID(tx, inf.User, dsID)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -123,9 +123,9 @@ func deleteDSS(w http.ResponseWriter, r *http.Request) {
 
 	query := deliveryservice.SelectDeliveryServicesQuery + " WHERE ds.id=:dsid"
 	vals := map[string]interface{}{"dsid": dsID}
-	dses, userErr, sysErr, errCode := deliveryservice.GetDeliveryServices(query, vals, inf.Tx)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	dses, errs := deliveryservice.GetDeliveryServices(query, vals, inf.Tx)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	if len(dses) < 1 {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -166,9 +166,9 @@ func deleteDSS(w http.ResponseWriter, r *http.Request) {
 	dsName := *ds.XMLID
 
 	if ds.CDNName != nil {
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *ds.CDNName, inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *ds.CDNName, inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
@@ -157,7 +158,7 @@ func ReadDSSHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	results, err, maxTime := dss.readDSS(r.Header, inf.Tx, inf.User, inf.Params, inf.IntParams, dsIDs, serverIDs, useIMS)
-	if maxTime != nil && api.SetLastModifiedHeader(r, useIMS) {
+	if maxTime != nil && crudder.SetLastModifiedHeader(r, useIMS) {
 		// RFC1123
 		date := maxTime.Format("Mon, 02 Jan 2006 15:04:05 MST")
 		w.Header().Add(rfc.LastModified, date)
@@ -396,9 +397,9 @@ func GetReplaceHandler(w http.ResponseWriter, r *http.Request) {
 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 			return
 		}
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdn), inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdn), inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}
@@ -481,9 +482,9 @@ func GetCreateHandler(w http.ResponseWriter, r *http.Request) {
 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 			return
 		}
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdn), inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdn), inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -29,9 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apache/trafficcontrol/lib/go-rfc"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
-
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -109,9 +109,9 @@ func (dss *TODeliveryServiceServer) Validate(tx *sql.Tx) error {
 
 // ReadDSSHandler is the handler for GET requests to /deliveryserviceserver.
 func ReadDSSHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"limit", "page"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"limit", "page"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -346,9 +346,9 @@ func hasAvailableEdgesCurrentlyAssigned(tx *sql.Tx, dsID int) (bool, error) {
 
 // GetReplaceHandler is the handler for POST requests to the /deliveryserviceserver API endpoint.
 func GetReplaceHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"limit", "page"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"limit", "page"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -449,9 +449,9 @@ type TODeliveryServiceServers tc.DeliveryServiceServers
 
 // GetCreateHandler is the handler for POST requests to /deliveryservices/{{XMLID}}/servers.
 func GetCreateHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"xml_id"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"xml_id"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -673,9 +673,9 @@ VALUES (:id, :server )`
 
 // GetReadAssigned is the handler for GET requests to /deliveryservices/{id}/servers.
 func GetReadAssigned(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -29,6 +29,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-rfc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
+
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -427,8 +430,7 @@ func GetReplaceHandler(w http.ResponseWriter, r *http.Request) {
 	for _, server := range servers {
 		dtos := map[string]interface{}{"id": dsId, "server": server}
 		if _, err := inf.Tx.NamedExec(insertIdsQuery(), dtos); err != nil {
-			usrErr, sysErr, code := api.ParseDBError(err)
-			api.HandleErr(w, r, inf.Tx.Tx, code, usrErr, sysErr)
+			inf.HandleErrs(w, r, api.ParseDBError(err))
 			return
 		}
 		respServers = append(respServers, server)
@@ -512,9 +514,7 @@ func GetCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	res, err := inf.Tx.Tx.Exec(`INSERT INTO deliveryservice_server (deliveryservice, server) SELECT $1, id FROM server WHERE host_name = ANY($2::text[])`, ds.ID, pq.Array(serverNames))
 	if err != nil {
-
-		usrErr, sysErr, code := api.ParseDBError(err)
-		api.HandleErr(w, r, inf.Tx.Tx, code, usrErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers_test.go
@@ -45,17 +45,17 @@ func TestValidateDSSAssignments(t *testing.T) {
 		Type:     "",
 	}
 	servers = append(servers, server)
-	userErr, _, _ := validateDSS(nil, ds, servers)
-	if userErr == nil {
+	errs := validateDSS(nil, ds, servers)
+	if errs.UserError == nil {
 		t.Fatalf("Expected user error with mismatching ds and server CDN IDs, got no error instead")
 	}
-	if userErr.Error() != expected {
-		t.Errorf("Expected error details %v, got %v", expected, userErr.Error())
+	if errs.UserError.Error() != expected {
+		t.Errorf("Expected error details %v, got %v", expected, errs.UserError)
 	}
 	servers[0].CDNID = 1
-	userErr, _, _ = validateDSS(nil, ds, servers)
-	if userErr != nil {
-		t.Fatalf("Expected no user error, got %v", userErr.Error())
+	errs = validateDSS(nil, ds, servers)
+	if errs.UserError != nil {
+		t.Fatalf("Expected no user error, got %v", errs.UserError)
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/sslkeys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/sslkeys.go
@@ -68,9 +68,9 @@ func GenerateSSLKeys(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("no DS with name "+*req.DeliveryService), nil)
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	if err := generatePutTrafficVaultSSLKeys(req, inf.Tx.Tx, inf.Vault, r.Context()); err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/sslkeys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/sslkeys.go
@@ -40,9 +40,9 @@ import (
 // certificate based on the values submitted. It then stores these values in
 // TrafficVault and updates the SSL key version.
 func GenerateSSLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/deliveryservice/urlkey.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/urlkey.go
@@ -212,9 +212,9 @@ func CopyURLKeys(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("no DS with name "+string(ds)), nil)
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(destinationCDNID), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(destinationCDNID), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 
@@ -267,9 +267,9 @@ func GenerateURLKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 
@@ -362,9 +362,9 @@ func DeleteURLKeysByID(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.DeleteURLKeysByID: getting CDN from DS ID "+err.Error()))
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdn), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdn), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 
@@ -418,9 +418,9 @@ func DeleteURLKeysByName(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, errors.New("no DS with name "+string(ds)), nil)
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/urlkey.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/urlkey.go
@@ -35,15 +35,15 @@ import (
 
 // GetURLKeysByID returns the URL sig keys for a delivery service identified by the id in the path parameter.
 func GetURLKeysByID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	if !inf.Config.TrafficVaultEnabled {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("deliveryservice.GetURLKeysByID: Traffic Vault is not configured"))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.GetURLKeysByID: Traffic Vault is not configured"))
 		return
 	}
 
@@ -88,15 +88,15 @@ func GetURLKeysByID(w http.ResponseWriter, r *http.Request) {
 
 // GetURLKeysByName returns the URL sig keys for a delivery service identified by the xmlId in the path parameter.
 func GetURLKeysByName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	if !inf.Config.TrafficVaultEnabled {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("deliveryservice.GetURLKeysByName: Traffic Vault is not configured"))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.GetURLKeysByName: Traffic Vault is not configured"))
 		return
 	}
 
@@ -134,15 +134,15 @@ func GetURLKeysByName(w http.ResponseWriter, r *http.Request) {
 // CopyURLKeys copies the URL sig keys from a delivery service in the 'copy-name' path parameter
 // to the delivery service in the 'name' path parameter.
 func CopyURLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name", "copy-name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name", "copy-name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	if !inf.Config.TrafficVaultEnabled {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("deliveryservice.CopyURLKeys: Traffic Vault is not configured"))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.CopyURLKeys: Traffic Vault is not configured"))
 		return
 	}
 
@@ -228,14 +228,14 @@ func CopyURLKeys(w http.ResponseWriter, r *http.Request) {
 
 // GenerateURLKeys generates new URL sig keys for the delivery service identified by the xmlId in the path parameter.
 func GenerateURLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 	if !inf.Config.TrafficVaultEnabled {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("deliveryservice.GenerateURLKeys: Traffic Vault is not configured"))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.GenerateURLKeys: Traffic Vault is not configured"))
 		return
 	}
 
@@ -317,15 +317,15 @@ func GenerateURLSigKeys() (tc.URLSigKeys, error) {
 
 // DeleteURLKeysByID deletes the URL sig keys for the delivery service identified by the id in the path parameter.
 func DeleteURLKeysByID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	if !inf.Config.TrafficVaultEnabled {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("deliveryservice.DeleteURLKeysByID: Traffic Vault is not configured"))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.DeleteURLKeysByID: Traffic Vault is not configured"))
 		return
 	}
 
@@ -379,15 +379,15 @@ func DeleteURLKeysByID(w http.ResponseWriter, r *http.Request) {
 
 // DeleteURLKeysByName deletes the URL sig keys for the delivery service identified by the xmlId in the path parameter.
 func DeleteURLKeysByName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	if !inf.Config.TrafficVaultEnabled {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("deliveryservice.DeleteURLKeysByName: Traffic Vault is not configured"))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deliveryservice.DeleteURLKeysByName: Traffic Vault is not configured"))
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservicerequests/deliveryservicerequests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservicerequests/deliveryservicerequests.go
@@ -83,9 +83,9 @@ func Request(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body = fmt.Sprintf(msg, inf.Config.ConfigTO.EmailFrom, addr, dsr.Details.Customer, body)
-	errCode, userErr, sysErr := inf.SendMail(rfc.EmailAddress{Address: *addr}, []byte(body))
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	errs = inf.SendMail(rfc.EmailAddress{Address: *addr}, []byte(body))
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
@@ -185,9 +185,9 @@ func Post(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
-	userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 
@@ -286,9 +286,9 @@ func Put(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
-	userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	// Get current details to make sure that you're not trying to change a regex that has set number = 0 and type = HOST_REGEXP
@@ -397,9 +397,9 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 		return
 	}
-	userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	regexID := inf.IntParams["regexid"]

--- a/traffic_ops/traffic_ops_golang/division/divisions.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 	validation "github.com/go-ozzo/ozzo-validation"
@@ -102,7 +103,7 @@ func (division TODivision) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (dv *TODivision) Create() (error, error, int) { return api.GenericCreate(dv) }
+func (dv *TODivision) Create() api.Errors { return crudder.GenericCreate(dv) }
 func (dv *TODivision) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
 	params := dv.APIInfo().Params
 	// TODO move to router, and do for all endpoints
@@ -110,10 +111,10 @@ func (dv *TODivision) Read(h http.Header, useIMS bool) ([]interface{}, error, er
 		params["name"] = params["name"][:len(params["name"])-len(".json")]
 	}
 	api.DefaultSort(dv.APIInfo(), "name")
-	return api.GenericRead(h, dv, useIMS)
+	return crudder.GenericRead(h, dv, useIMS)
 }
-func (dv *TODivision) Update(h http.Header) (error, error, int) { return api.GenericUpdate(h, dv) }
-func (dv *TODivision) Delete() (error, error, int)              { return api.GenericDelete(dv) }
+func (dv *TODivision) Update(h http.Header) api.Errors { return crudder.GenericUpdate(h, dv) }
+func (dv *TODivision) Delete() api.Errors              { return crudder.GenericDelete(dv) }
 
 func insertQuery() string {
 	return `INSERT INTO division (name) VALUES (:name) RETURNING id,last_updated`

--- a/traffic_ops/traffic_ops_golang/division/divisions.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions.go
@@ -104,7 +104,7 @@ func (division TODivision) Validate() error {
 }
 
 func (dv *TODivision) Create() api.Errors { return crudder.GenericCreate(dv) }
-func (dv *TODivision) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (dv *TODivision) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	params := dv.APIInfo().Params
 	// TODO move to router, and do for all endpoints
 	if strings.HasSuffix(params["name"], ".json") {

--- a/traffic_ops/traffic_ops_golang/division/divisions_test.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -92,19 +93,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TODivision{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("division must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("division must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("division must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("division must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("division must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/division/divisions_test.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions_test.go
@@ -79,9 +79,9 @@ func TestGetDivisions(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.DivisionNullable{},
 	}
-	vals, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	vals, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 	if len(vals) != 2 {
 		t.Errorf("read expected: len(vals) == 1, actual: %v", len(vals))

--- a/traffic_ops/traffic_ops_golang/federation_resolvers/federation_resolvers.go
+++ b/traffic_ops/traffic_ops_golang/federation_resolvers/federation_resolvers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
@@ -176,7 +177,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 		resolvers = append(resolvers, resolver)
 	}
 
-	if api.SetLastModifiedHeader(r, useIMS) {
+	if crudder.SetLastModifiedHeader(r, useIMS) {
 		// RFC1123
 		date := maxTime.Format("Mon, 02 Jan 2006 15:04:05 MST")
 		w.Header().Add(rfc.LastModified, date)

--- a/traffic_ops/traffic_ops_golang/federations/allfederations.go
+++ b/traffic_ops/traffic_ops_golang/federations/allfederations.go
@@ -33,9 +33,9 @@ import (
 
 func GetAll(w http.ResponseWriter, r *http.Request) {
 	var maxTime *time.Time
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/federations/allfederations.go
+++ b/traffic_ops/traffic_ops_golang/federations/allfederations.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 )
 
 func GetAll(w http.ResponseWriter, r *http.Request) {
@@ -57,7 +58,7 @@ func GetAll(w http.ResponseWriter, r *http.Request) {
 		cdnName := tc.CDNName(cdnParam)
 		feds, err, code, maxTime = getAllFederationsForCDN(inf.Tx.Tx, cdnName, useIMS, r.Header)
 		if code == http.StatusNotModified {
-			if maxTime != nil && api.SetLastModifiedHeader(r, useIMS) {
+			if maxTime != nil && crudder.SetLastModifiedHeader(r, useIMS) {
 				// RFC1123
 				date := maxTime.Format("Mon, 02 Jan 2006 15:04:05 MST")
 				w.Header().Add(rfc.LastModified, date)
@@ -74,7 +75,7 @@ func GetAll(w http.ResponseWriter, r *http.Request) {
 	} else {
 		feds, err, code, maxTime = getAllFederations(inf.Tx.Tx, useIMS, r.Header)
 		if code == http.StatusNotModified {
-			if maxTime != nil && api.SetLastModifiedHeader(r, useIMS) {
+			if maxTime != nil && crudder.SetLastModifiedHeader(r, useIMS) {
 				// RFC1123
 				date := maxTime.Format("Mon, 02 Jan 2006 15:04:05 MST")
 				w.Header().Add(rfc.LastModified, date)

--- a/traffic_ops/traffic_ops_golang/federations/ds.go
+++ b/traffic_ops/traffic_ops_golang/federations/ds.go
@@ -35,9 +35,9 @@ import (
 )
 
 func PostDSes(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/federations/ds.go
+++ b/traffic_ops/traffic_ops_golang/federations/ds.go
@@ -178,7 +178,7 @@ func (v *TOFedDSes) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	}
 }
 
-func (v *TOFedDSes) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (v *TOFedDSes) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(v.APIInfo(), "xmlId")
 	return crudder.GenericRead(h, v, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/federations/ds.go
+++ b/traffic_ops/traffic_ops_golang/federations/ds.go
@@ -75,8 +75,7 @@ func PostDSes(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := deleteDSFeds(inf.Tx.Tx, fedID); err != nil {
-			userErr, sysErr, errCode := api.ParseDBError(err)
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+			inf.HandleErrs(w, r, api.ParseDBError(err))
 			return
 		}
 	}
@@ -84,8 +83,7 @@ func PostDSes(w http.ResponseWriter, r *http.Request) {
 	if len(post.DSIDs) > 0 {
 		// there might be no DSes, if the user is trying to clear the assignments
 		if err := insertDSFeds(inf.Tx.Tx, fedID, post.DSIDs); err != nil {
-			userErr, sysErr, errCode := api.ParseDBError(err)
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+			inf.HandleErrs(w, r, api.ParseDBError(err))
 			return
 		}
 	}
@@ -213,7 +211,8 @@ func (v *TOFedDSes) Delete() (error, error, int) {
 
 	// Actually delete the DS from the Federation
 	if err := deleteFedDS(v.APIInfo().Tx.Tx, *v.fedID, dsID); err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 
 	return nil, nil, http.StatusOK

--- a/traffic_ops/traffic_ops_golang/federations/ds_test.go
+++ b/traffic_ops/traffic_ops_golang/federations/ds_test.go
@@ -78,19 +78,19 @@ func TestCheckFedDSDeletion(t *testing.T) {
 			mock.ExpectBegin()
 			mock.ExpectQuery("SELECT").WillReturnRows(rows)
 			mock.ExpectCommit()
-			_, usrErr, sysErr := checkFedDSDeletion(db.MustBegin().Tx, 1, tc.inputDSID)
+			errs := checkFedDSDeletion(db.MustBegin().Tx, 1, tc.inputDSID)
 			if tc.expectUsrErr {
-				if usrErr == nil {
+				if errs.UserError == nil {
 					t.Errorf("User error expected: received none")
 				}
-				if usrErr.Error() != tc.expectUsrStr {
-					t.Errorf("Expected error with text %v: received %v", tc.expectUsrStr, usrErr.Error())
+				if errs.UserError.Error() != tc.expectUsrStr {
+					t.Errorf("Expected error with text %s: received %v", tc.expectUsrStr, errs.UserError)
 				}
 			}
-			if !tc.expectUsrErr && usrErr != nil {
+			if !tc.expectUsrErr && errs.UserError != nil {
 				t.Errorf("User error not expected: received error %v", err)
 			}
-			if sysErr != nil {
+			if errs.SystemError != nil {
 				t.Errorf("System error not expected: received error %v", err)
 			}
 		})

--- a/traffic_ops/traffic_ops_golang/federations/federation_resolvers.go
+++ b/traffic_ops/traffic_ops_golang/federations/federation_resolvers.go
@@ -36,9 +36,9 @@ WHERE ffr.federation = $1
 
 // GetFederationFederationResolversHandler returns a subset of federation_resolvers belonging to the federation ID supplied.
 func GetFederationFederationResolversHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -56,9 +56,9 @@ func GetFederationFederationResolversHandler(w http.ResponseWriter, r *http.Requ
 
 // AssignFederationResolversToFederationHandler associates one or more federation_resolver to the federation ID supplied.
 func AssignFederationResolversToFederationHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/federations/federation_resolvers.go
+++ b/traffic_ops/traffic_ops_golang/federations/federation_resolvers.go
@@ -85,9 +85,9 @@ func AssignFederationResolversToFederationHandler(w http.ResponseWriter, r *http
 		return
 	}
 	if ok {
-		userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		errs = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(cdnID), inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
 
@@ -109,7 +110,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	allFederations := addResolvers([]tc.IAllFederation{}, feds, fedsResolvers)
-	if maxTime != nil && api.SetLastModifiedHeader(r, useIMS) {
+	if maxTime != nil && crudder.SetLastModifiedHeader(r, useIMS) {
 		api.AddLastModifiedHdr(w, *maxTime)
 	}
 	api.WriteResp(w, r, allFederations)

--- a/traffic_ops/traffic_ops_golang/federations/federations_test.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations_test.go
@@ -281,15 +281,12 @@ func TestRemoveFederationResolverMappingsForCurrentUser(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when beginning a mock transaction", err)
 	}
 
-	returnedIPs, userErr, sysErr, errCode := removeFederationResolverMappingsForCurrentUser(tx, &u)
-	if userErr != nil {
-		t.Errorf("Unexpected user error removing resolvers: %v", userErr)
+	returnedIPs, errs := removeFederationResolverMappingsForCurrentUser(tx, &u)
+	if errs.Occurred() {
+		t.Errorf("Unexpected error(s) removing resolvers: %s", errs)
 	}
-	if sysErr != nil {
-		t.Errorf("Unexpected system error removing resolvers: %v", sysErr)
-	}
-	if errCode != http.StatusOK {
-		t.Errorf("Expected return code %d when removing resolvers, but got %d", http.StatusOK, errCode)
+	if errs.Code != http.StatusOK {
+		t.Errorf("Expected return code %d when removing resolvers, but got %d", http.StatusOK, errs.Code)
 	}
 
 	if len(returnedIPs) != len(ips) {

--- a/traffic_ops/traffic_ops_golang/federations/federations_test.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations_test.go
@@ -96,15 +96,12 @@ func positiveTestAddFederationResolverMappingsForCurrentUser(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when beginning a mock transaction", err)
 	}
 
-	userErr, sysErr, errCode := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
-	if userErr != nil {
-		t.Errorf("Unexpected user error: %v", userErr)
+	errs := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
+	if errs.Occurred() {
+		t.Errorf("Unexpected error(s): %s", errs)
 	}
-	if sysErr != nil {
-		t.Errorf("Unexpected system error: %v", sysErr)
-	}
-	if errCode != http.StatusOK {
-		t.Errorf("Expected response code %d, got %d", http.StatusOK, errCode)
+	if errs.Code != http.StatusOK {
+		t.Errorf("Expected response code %d, got %d", http.StatusOK, errs.Code)
 	}
 }
 
@@ -149,17 +146,17 @@ func testAddFederationResolverMappingsForCurrentUserWithoutFederations(t *testin
 		t.Fatalf("an error '%s' was not expected when beginning a mock transaction", err)
 	}
 
-	userErr, sysErr, errCode := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
-	if userErr == nil {
+	errs := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
+	if errs.UserError == nil {
 		t.Errorf("Unexpected a user error, but didn't get one")
 	} else {
-		t.Logf("Got expected user error: %v", userErr)
+		t.Logf("Got expected user error: %v", errs.UserError)
 	}
-	if sysErr != nil {
-		t.Errorf("Unexpected system error: %v", sysErr)
+	if errs.SystemError != nil {
+		t.Errorf("Unexpected system error: %v", errs.SystemError)
 	}
-	if errCode != http.StatusConflict {
-		t.Errorf("Expected response code %d, got %d", http.StatusConflict, errCode)
+	if errs.Code != http.StatusConflict {
+		t.Errorf("Expected response code %d, got %d", http.StatusConflict, errs.Code)
 	}
 }
 
@@ -203,19 +200,19 @@ func testUnauthorizedDSOnResolverAdd(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when beginning a mock transaction", err)
 	}
 
-	userErr, sysErr, errCode := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
-	if userErr == nil {
+	errs := addFederationResolverMappingsForCurrentUser(&u, tx, mappings)
+	if errs.UserError == nil {
 		t.Errorf("Unexpected a user error, but didn't get one")
 	} else {
-		t.Logf("Got expected user error: %v", userErr)
+		t.Logf("Got expected user error: %v", errs.UserError)
 	}
-	if sysErr == nil {
+	if errs.SystemError == nil {
 		t.Errorf("Unexpected a system error, but didn't get one")
 	} else {
-		t.Logf("Got expected system error: %v", sysErr)
+		t.Logf("Got expected system error: %v", errs.SystemError)
 	}
-	if errCode != http.StatusConflict {
-		t.Errorf("Expected response code %d, got %d", http.StatusConflict, errCode)
+	if errs.Code != http.StatusConflict {
+		t.Errorf("Expected response code %d, got %d", http.StatusConflict, errs.Code)
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/federations/user.go
+++ b/traffic_ops/traffic_ops_golang/federations/user.go
@@ -169,16 +169,14 @@ func PostUsers(w http.ResponseWriter, r *http.Request) {
 
 	if post.Replace != nil && *post.Replace {
 		if err := deleteFedUsers(inf.Tx.Tx, fedID); err != nil {
-			userErr, sysErr, errCode := api.ParseDBError(err)
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+			inf.HandleErrs(w, r, api.ParseDBError(err))
 			return
 		}
 	}
 
 	if len(post.IDs) > 0 {
 		if err := insertFedUsers(inf.Tx.Tx, fedID, post.IDs); err != nil {
-			userErr, sysErr, errCode := api.ParseDBError(err)
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+			inf.HandleErrs(w, r, api.ParseDBError(err))
 			return
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/federations/user.go
+++ b/traffic_ops/traffic_ops_golang/federations/user.go
@@ -144,9 +144,9 @@ func (v *TOUsers) Read(h http.Header, useIMS bool) ([]interface{}, error, error,
 func (v *TOUsers) Delete() (error, error, int) { return api.GenericDelete(v) }
 
 func PostUsers(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/federations/user.go
+++ b/traffic_ops/traffic_ops_golang/federations/user.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/lib/pq"
 )
@@ -138,10 +139,10 @@ func (v *TOUsers) Read(h http.Header, useIMS bool) ([]interface{}, error, error,
 	} else if !exists {
 		return nil, fmt.Errorf("federation %v not found", fedID), nil, http.StatusNotFound, nil
 	}
-	return api.GenericRead(h, v, useIMS)
+	return crudder.GenericRead(h, v, useIMS)
 }
 
-func (v *TOUsers) Delete() (error, error, int) { return api.GenericDelete(v) }
+func (v *TOUsers) Delete() api.Errors { return crudder.GenericDelete(v) }
 
 func PostUsers(w http.ResponseWriter, r *http.Request) {
 	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -394,8 +394,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		&result.Parameters,
 		&result.StartTime)
 	if err != nil {
-		userErr, sysErr, errCode = api.ParseDBError(err)
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -375,9 +375,9 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting delivery service and CDN name from ID: "+err.Error()))
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	row := inf.Tx.Tx.QueryRow(insertQuery,
@@ -566,9 +566,9 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting delivery service and CDN name from ID: "+err.Error()))
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 
@@ -685,9 +685,9 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting delivery service and CDN name from ID: "+err.Error()))
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/iso/iso.go
+++ b/traffic_ops/traffic_ops_golang/iso/iso.go
@@ -85,9 +85,9 @@ const (
 //   Content-Type: application/download
 //
 func ISOs(w http.ResponseWriter, req *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(req, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, req, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(req, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, req, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/iso/osversions.go
+++ b/traffic_ops/traffic_ops_golang/iso/osversions.go
@@ -43,9 +43,9 @@ import (
 // endpoint returned a single JSON object, whereas the CRUDer interface returns an array of JSON
 // objects per the Read method.
 func GetOSVersions(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/login/login.go
+++ b/traffic_ops/traffic_ops_golang/login/login.go
@@ -516,8 +516,8 @@ func ResetPassword(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 
 		log.Debugf("Sending password reset email to %s", req.Email)
 
-		if errCode, userErr, sysErr = api.SendMail(req.Email, msg, &cfg); userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, nil, errCode, userErr, sysErr)
+		if errs := api.SendMail(req.Email, msg, &cfg); errs.Occurred() {
+			api.HandleErrs(w, r, nil, errs)
 			return
 		}
 

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -284,8 +284,8 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 
 	log.Debugf("Sending registration email to %s", email)
 
-	if errCode, userErr, sysErr = inf.SendMail(email, msg); userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	if errs = inf.SendMail(email, msg); errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -156,15 +156,18 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	var req tc.UserRegistrationRequest
 	var reqV4 tc.UserRegistrationRequestV4
 	var email rfc.EmailAddress
+	var sysErr error
+	var userErr error
+	var errCode int
 
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	var tx = inf.Tx.Tx
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 	defer r.Body.Close()
+	tx := inf.Tx.Tx
 
 	// ToDo: uncomment this once the perm based roles and config options are implemented
 	if inf.Version.Major >= 4 {

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -21,21 +21,20 @@ package login
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 )
-import "database/sql"
-import "errors"
-import "fmt"
-import "html/template"
-import "net/http"
-
-import "github.com/apache/trafficcontrol/lib/go-log"
-import "github.com/apache/trafficcontrol/lib/go-rfc"
-import "github.com/apache/trafficcontrol/lib/go-tc"
-
-import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
-import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
-import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 type registrationEmailFormatter struct {
 	From         rfc.EmailAddress
@@ -268,8 +267,7 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		log.Errorf("Bare error: %v", err)
-		userErr, sysErr, errCode = api.ParseDBError(err)
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/logs/log.go
+++ b/traffic_ops/traffic_ops_golang/logs/log.go
@@ -47,9 +47,9 @@ const (
 
 // Get is the handler for GET requests to /logs.
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"days", "limit"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -74,9 +74,9 @@ func Get(w http.ResponseWriter, r *http.Request) {
 
 // Get is the handler for GET requests to /logs V4.0.
 func Getv40(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"days", "limit"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -103,9 +103,9 @@ func Getv40(w http.ResponseWriter, r *http.Request) {
 
 // GetNewCount is the handler for GET requests to /logs/newcount.
 func GetNewCount(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, []string{"days", "limit"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/origin/origins.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins.go
@@ -328,7 +328,8 @@ func (origin *TOOrigin) Update(h http.Header) (error, error, int) {
 	log.Debugf("about to run exec query: %s with origin: %++v", updateQuery(), origin)
 	resultRows, err := origin.ReqInfo.Tx.NamedQuery(updateQuery(), origin)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer resultRows.Close()
 
@@ -393,7 +394,8 @@ func (origin *TOOrigin) Create() (error, error, int) {
 
 	resultRows, err := origin.ReqInfo.Tx.NamedQuery(insertQuery(), origin)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer resultRows.Close()
 

--- a/traffic_ops/traffic_ops_golang/origin/origins.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins.go
@@ -339,7 +339,7 @@ func (origin *TOOrigin) Update(h http.Header) api.Errors {
 	}
 
 	if !api.IsUnmodified(h, existingLastUpdated.Time) {
-		return api.ModifiedError()
+		return api.NewModifiedError()
 	}
 
 	if isPrimary && *origin.DeliveryServiceID != ds {

--- a/traffic_ops/traffic_ops_golang/origin/origins_test.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins_test.go
@@ -21,7 +21,6 @@ package origin
 
 import (
 	"errors"
-	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -122,9 +121,9 @@ func TestReadOrigins(t *testing.T) {
 	v := map[string]string{}
 
 	testUser := auth.CurrentUser{TenantID: 1}
-	origins, userErr, sysErr, errCode, _ := getOrigins(nil, v, db.MustBegin(), &testUser, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("getOrigins expected: no errors, actual: %v %v with status: %s", userErr, sysErr, http.StatusText(errCode))
+	origins, errs, _ := getOrigins(nil, v, db.MustBegin(), &testUser, false)
+	if errs.Occurred() {
+		t.Errorf("getOrigins expected: no errors, actual: %s", errs)
 	}
 
 	if len(origins) != 3 {

--- a/traffic_ops/traffic_ops_golang/origin/origins_test.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins_test.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 
 	"github.com/jmoiron/sqlx"
@@ -152,22 +152,22 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOOrigin{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("origin must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("origin must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("origin must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("origin must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("origin must be Identifier")
 	}
-	if _, ok := i.(api.Tenantable); !ok {
+	if _, ok := i.(crudder.Tenantable); !ok {
 		t.Errorf("origin must be tenantable")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/parameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
@@ -136,11 +137,11 @@ func (param TOParameter) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (pa *TOParameter) Create() (error, error, int) {
+func (pa *TOParameter) Create() api.Errors {
 	if pa.Value == nil {
 		pa.Value = util.StrPtr("")
 	}
-	return api.GenericCreate(pa)
+	return crudder.GenericCreate(pa)
 }
 
 func (param *TOParameter) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
@@ -184,14 +185,14 @@ func (param *TOParameter) Read(h http.Header, useIMS bool) ([]interface{}, error
 	return params, nil, nil, code, &maxTime
 }
 
-func (pa *TOParameter) Update(h http.Header) (error, error, int) {
+func (pa *TOParameter) Update(h http.Header) api.Errors {
 	if pa.Value == nil {
 		pa.Value = util.StrPtr("")
 	}
-	return api.GenericUpdate(h, pa)
+	return crudder.GenericUpdate(h, pa)
 }
 
-func (pa *TOParameter) Delete() (error, error, int) { return api.GenericDelete(pa) }
+func (pa *TOParameter) Delete() api.Errors { return crudder.GenericDelete(pa) }
 
 func insertQuery() string {
 	query := `INSERT INTO parameter (

--- a/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -118,19 +119,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOParameter{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("Parameter must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("Parameter must be Reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("Parameter must be Updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("Parameter must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("Parameter must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
@@ -104,9 +104,9 @@ func TestGetParameters(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.ParameterNullable{},
 	}
-	pps, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	pps, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(pps) != 2 {

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -107,7 +107,7 @@ func (pl *TOPhysLocation) Validate() error {
 	return nil
 }
 
-func (pl *TOPhysLocation) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (pl *TOPhysLocation) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(pl.APIInfo(), "name")
 	return crudder.GenericRead(h, pl, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -116,19 +117,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOPhysLocation{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("PhysLocation must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("PhysLocation must be Reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("PhysLocation must be Updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("PhysLocation must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("PhysLocation must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -102,9 +102,9 @@ func TestGetPhysLocations(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.PhysLocationNullable{},
 	}
-	physLocations, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	physLocations, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(physLocations) != 2 {

--- a/traffic_ops/traffic_ops_golang/ping/vault.go
+++ b/traffic_ops/traffic_ops_golang/ping/vault.go
@@ -27,9 +27,9 @@ import (
 )
 
 func Vault(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/plugin/proxy.go
+++ b/traffic_ops/traffic_ops_golang/plugin/proxy.go
@@ -92,9 +92,9 @@ func proxyOnReq(d OnRequestData) IsRequestHandled {
 }
 
 func proxyHandle(w http.ResponseWriter, r *http.Request, d OnRequestData, proxyURI *url.URL) IsRequestHandled {
-	_, userErr, sysErr, errCode := api.GetUserFromReq(w, r, d.AppCfg.Secrets[0]) // require login
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, nil, errCode, userErr, sysErr)
+	_, errs := api.GetUserFromReq(w, r, d.AppCfg.Secrets[0]) // require login
+	if errs.Occurred() {
+		api.HandleErr(w, r, nil, errs.Code, errs.UserError, errs.SystemError)
 		return RequestHandled
 	}
 	rp := httputil.NewSingleHostReverseProxy(proxyURI)

--- a/traffic_ops/traffic_ops_golang/plugins/plugins.go
+++ b/traffic_ops/traffic_ops_golang/plugins/plugins.go
@@ -32,9 +32,9 @@ import (
 // Get handler for getting enabled TO Plugins.
 func Get(p plugin.Plugins) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, sysErr, userErr, errCode := api.NewInfo(r, nil, nil)
-		if sysErr != nil || userErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		inf, errs := api.NewInfo(r, nil, nil)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 		// Add plugins

--- a/traffic_ops/traffic_ops_golang/profile/copy.go
+++ b/traffic_ops/traffic_ops_golang/profile/copy.go
@@ -105,13 +105,9 @@ func copyProfile(inf *api.APIInfo, p *tc.ProfileCopy) api.Errors {
 		tc.ProfileNullable{},
 	}
 
-	profiles, userErr, sysErr, errCode, _ := toProfile.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		return api.Errors{
-			UserError:   userErr,
-			SystemError: sysErr,
-			Code:        errCode,
-		}
+	profiles, errs, _ := toProfile.Read(nil, false)
+	if errs.Occurred() {
+		return errs
 	}
 
 	if len(profiles) == 0 {
@@ -141,7 +137,7 @@ func copyProfile(inf *api.APIInfo, p *tc.ProfileCopy) api.Errors {
 			Code:        http.StatusInternalServerError,
 		}
 	}
-	errs := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
 	if errs.Occurred() {
 		return errs
 	}
@@ -172,13 +168,9 @@ func copyParameters(inf *api.APIInfo, p *tc.ProfileCopy) api.Errors {
 		},
 	}
 
-	parameters, userErr, sysErr, errCode, _ := toParam.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		return api.Errors{
-			UserError:   userErr,
-			SystemError: sysErr,
-			Code:        errCode,
-		}
+	parameters, errs, _ := toParam.Read(nil, false)
+	if errs.Occurred() {
+		return errs
 	}
 
 	var newParams int

--- a/traffic_ops/traffic_ops_golang/profile/copy_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/copy_test.go
@@ -110,19 +110,19 @@ func TestCopyProfileInvalidExistingProfile(t *testing.T) {
 
 			errs := copyProfile(&inf, &c.profile.Response)
 			if c.userErr != "" { // Check if we expect a user error for this test
-				if got, want := errs.userErr.Error(), c.userErr; got != want {
+				if got, want := errs.UserError.Error(), c.userErr; got != want {
 					t.Fatalf("got err=%s; expected err=%s", got, want)
 				}
-			} else if errs.userErr != nil {
-				t.Fatalf(errs.userErr.Error())
+			} else if errs.UserError != nil {
+				t.Fatalf(errs.UserError.Error())
 			}
 
 			if c.sysErr != "" { // Check if we expect a sys error for this test
-				if got, want := errs.sysErr.Error(), c.sysErr; got != want {
+				if got, want := errs.SystemError.Error(), c.sysErr; got != want {
 					t.Fatalf("got err=%s; expected err=%s", got, want)
 				}
-			} else if errs.sysErr != nil {
-				t.Fatalf(errs.sysErr.Error())
+			} else if errs.SystemError != nil {
+				t.Fatalf(errs.SystemError.Error())
 			}
 
 			if err := mock.ExpectationsWereMet(); err != nil {
@@ -164,12 +164,12 @@ func TestCopyNewProfileExists(t *testing.T) {
 	}
 
 	errs := copyProfile(&inf, &profile.Response)
-	if got, want := errs.userErr.Error(), expectedErr; got != want {
+	if got, want := errs.UserError.Error(), expectedErr; got != want {
 		t.Fatalf("got err=%s; expected err=%s", got, want)
 	}
 
-	if errs.sysErr != nil {
-		t.Fatalf(errs.sysErr.Error())
+	if errs.SystemError != nil {
+		t.Fatalf(errs.SystemError.Error())
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/traffic_ops/traffic_ops_golang/profile/profile_export.go
+++ b/traffic_ops/traffic_ops_golang/profile/profile_export.go
@@ -34,9 +34,9 @@ import (
 
 // ExportProfileHandler exports a profile per ID
 func ExportProfileHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{IDQueryParam}, []string{IDQueryParam})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{IDQueryParam}, []string{IDQueryParam})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/profile/profile_import.go
+++ b/traffic_ops/traffic_ops_golang/profile/profile_import.go
@@ -50,9 +50,9 @@ func ImportProfileHandler(w http.ResponseWriter, r *http.Request) {
 	if importedProfile.Profile.CDNName == nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("no CDN Name in the profile to be imported"), nil)
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *importedProfile.Profile.CDNName, inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *importedProfile.Profile.CDNName, inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 	}
 
 	id, err := importProfile(&importedProfile.Profile, inf.Tx.Tx)

--- a/traffic_ops/traffic_ops_golang/profile/profile_import.go
+++ b/traffic_ops/traffic_ops_golang/profile/profile_import.go
@@ -34,9 +34,9 @@ import (
 
 // ImportProfileHandler handles importing profile
 func ImportProfileHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -130,7 +130,7 @@ func (prof *TOProfile) Validate() error {
 	return nil
 }
 
-func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	var maxTime time.Time
 	var runSecond bool
 	// Query Parameters to Database Query column mappings
@@ -152,15 +152,19 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 		}
 	}
 
+	e := api.NewErrors()
 	if len(errs) > 0 {
-		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
+		e.Code = http.StatusBadRequest
+		e.UserError = util.JoinErrs(errs)
+		return nil, e, nil
 	}
 
 	if useIMS {
 		runSecond, maxTime = ims.TryIfModifiedSinceQuery(prof.APIInfo().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
 		if !runSecond {
 			log.Debugln("IMS HIT")
-			return []interface{}{}, nil, nil, http.StatusNotModified, &maxTime
+			e.Code = http.StatusNotModified
+			return []interface{}{}, e, &maxTime
 		}
 		log.Debugln("IMS MISS")
 	} else {
@@ -172,7 +176,9 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 
 	rows, err := prof.ReqInfo.Tx.NamedQuery(query, queryValues)
 	if err != nil {
-		return nil, nil, errors.New("profile read querying: " + err.Error()), http.StatusInternalServerError, nil
+		e.SetSystemError("profile read querying: " + err.Error())
+		e.Code = http.StatusInternalServerError
+		return nil, e, nil
 	}
 	defer rows.Close()
 
@@ -181,7 +187,9 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 	for rows.Next() {
 		var p tc.ProfileNullable
 		if err = rows.StructScan(&p); err != nil {
-			return nil, nil, errors.New("profile read scanning: " + err.Error()), http.StatusInternalServerError, nil
+			e.SetSystemError("profile read scanning: " + err.Error())
+			e.Code = http.StatusInternalServerError
+			return nil, e, nil
 		}
 		profiles = append(profiles, p)
 	}
@@ -192,13 +200,15 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 		if _, ok := prof.APIInfo().Params[IDQueryParam]; ok {
 			profile.Parameters, err = ReadParameters(prof.ReqInfo.Tx, prof.APIInfo().Params, prof.ReqInfo.User, profile)
 			if err != nil {
-				return nil, nil, errors.New("profile read reading parameters: " + err.Error()), http.StatusInternalServerError, nil
+				e.SetSystemError("profile read reading parameters: " + err.Error())
+				e.Code = http.StatusInternalServerError
+				return nil, e, nil
 			}
 		}
 		profileInterfaces = append(profileInterfaces, profile)
 	}
 
-	return profileInterfaces, nil, nil, http.StatusOK, &maxTime
+	return profileInterfaces, e, &maxTime
 
 }
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -119,19 +120,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOProfile{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("Profile must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("Profile must be Reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("Profile must be Updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("Profile must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("Profile must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -105,9 +105,9 @@ func TestGetProfiles(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.ProfileNullable{},
 	}
-	profiles, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	profiles, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(profiles) != 2 {

--- a/traffic_ops/traffic_ops_golang/profileparameter/parameterprofilebyid.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/parameterprofilebyid.go
@@ -29,9 +29,9 @@ import (
 )
 
 func GetProfileID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/profileparameter/parameterprofilebyname.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/parameterprofilebyname.go
@@ -29,9 +29,9 @@ import (
 )
 
 func GetProfileName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/profileparameter/postparameterprofile.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postparameterprofile.go
@@ -34,9 +34,9 @@ import (
 )
 
 func PostParamProfile(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/profileparameter/postparameterprofile.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postparameterprofile.go
@@ -52,7 +52,7 @@ func PostParamProfile(w http.ResponseWriter, r *http.Request) {
 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 			return
 		}
-		userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDNs(inf.Tx.Tx, cdnNames, inf.User.UserName)
+		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDNs(inf.Tx.Tx, cdnNames, inf.User.UserName)
 		if userErr != nil || sysErr != nil {
 			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 			return

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparameter.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparameter.go
@@ -63,9 +63,9 @@ func PostProfileParam(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
-	userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	api.CreateChangeLogRawTx(api.ApiChange, "PROFILE: "+profileName+", ID: "+strconv.FormatInt(*profileParam.ProfileID, 10)+", ACTION: Assigned "+strconv.Itoa(len(*profileParam.ParamIDs))+" parameters to profile", inf.User, inf.Tx.Tx)

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparameter.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparameter.go
@@ -34,9 +34,9 @@ import (
 )
 
 func PostProfileParam(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyid.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyid.go
@@ -59,9 +59,9 @@ func PostProfileParamsByID(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
-	userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	insertedObjs, err := insertParametersForProfile(profileName, profParams, inf.Tx.Tx)

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyid.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyid.go
@@ -31,9 +31,9 @@ import (
 )
 
 func PostProfileParamsByID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyname.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyname.go
@@ -58,9 +58,9 @@ func PostProfileParamsByName(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
-	userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	insertedObjs, err := insertParametersForProfile(profileName, profParams, inf.Tx.Tx)

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyname.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyname.go
@@ -33,9 +33,9 @@ import (
 )
 
 func PostProfileParamsByName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -174,7 +174,7 @@ parameter) VALUES (
 func (pp *TOProfileParameter) Update(h http.Header) (error, error, int) {
 	return nil, nil, http.StatusNotImplemented
 }
-func (pp *TOProfileParameter) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (pp *TOProfileParameter) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(pp.APIInfo(), "parameter")
 	return crudder.GenericRead(h, pp, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -131,7 +131,8 @@ func (pp *TOProfileParameter) Create() (error, error, int) {
 	}
 	resultRows, err := pp.APIInfo().Tx.NamedQuery(insertQuery(), pp)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer resultRows.Close()
 

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -171,8 +171,8 @@ parameter) VALUES (
 :parameter_id) RETURNING profile, parameter, last_updated`
 }
 
-func (pp *TOProfileParameter) Update(h http.Header) (error, error, int) {
-	return nil, nil, http.StatusNotImplemented
+func (pp *TOProfileParameter) Update(http.Header) api.Errors {
+	return api.Errors{Code: http.StatusNotImplemented}
 }
 func (pp *TOProfileParameter) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(pp.APIInfo(), "parameter")

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
@@ -85,9 +85,9 @@ func TestGetProfileParameters(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.ProfileParameterNullable{},
 	}
-	pps, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	pps, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(pps) != 2 {

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -99,16 +100,16 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOProfileParameter{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("ProfileParameter must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("ProfileParameter must be Reader")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("ProfileParameter must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("ProfileParameter must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -121,7 +121,8 @@ func (rg *TORegion) Update(h http.Header) (error, error, int) { return api.Gener
 func (rg *TORegion) Create() (error, error, int) {
 	resultRows, err := rg.APIInfo().Tx.NamedQuery(rg.InsertQuery(), rg)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer resultRows.Close()
 

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -105,7 +105,7 @@ func (region *TORegion) Validate() error {
 	return nil
 }
 
-func (rg *TORegion) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (rg *TORegion) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(rg.APIInfo(), "name")
 	return crudder.GenericRead(h, rg, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -80,9 +80,9 @@ func TestReadRegions(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.Region{},
 	}
-	regions, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	regions, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(regions) != 2 {

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 )
 
@@ -93,19 +94,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TORegion{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("Region must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("Region must be Reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("Region must be Updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("Region must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("Region must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -202,14 +202,14 @@ func (role *TORole) deleteRoleCapabilityAssociations(tx *sqlx.Tx) api.Errors {
 	return api.NewErrors()
 }
 
-func (role *TORole) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (role *TORole) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(role.APIInfo(), "name")
-	vals, userErr, sysErr, errCode, maxTime := crudder.GenericRead(h, role, useIMS)
-	if errCode == http.StatusNotModified {
-		return []interface{}{}, nil, nil, errCode, maxTime
+	vals, errs, maxTime := crudder.GenericRead(h, role, useIMS)
+	if errs.Code == http.StatusNotModified {
+		return []interface{}{}, errs, maxTime
 	}
-	if userErr != nil || sysErr != nil {
-		return nil, userErr, sysErr, errCode, maxTime
+	if errs.Occurred() {
+		return nil, errs, maxTime
 	}
 
 	returnable := []interface{}{}
@@ -219,7 +219,7 @@ func (role *TORole) Read(h http.Header, useIMS bool) ([]interface{}, error, erro
 		rl.Capabilities = &caps
 		returnable = append(returnable, rl)
 	}
-	return returnable, nil, nil, http.StatusOK, maxTime
+	return returnable, errs, maxTime
 }
 
 func (role *TORole) Update(h http.Header) api.Errors {

--- a/traffic_ops/traffic_ops_golang/role/roles_test.go
+++ b/traffic_ops/traffic_ops_golang/role/roles_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 )
 
@@ -59,19 +60,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TORole{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("role must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("role must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("role must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("role must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("role must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers.go
@@ -96,9 +96,9 @@ func (a AuthBase) GetWrapper(privLevelRequired int) Middleware {
 	}
 	return func(handlerFunc http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
-			user, userErr, sysErr, errCode := api.GetUserFromReq(w, r, a.Secret)
-			if userErr != nil || sysErr != nil {
-				api.HandleErr(w, r, nil, errCode, userErr, sysErr)
+			user, errs := api.GetUserFromReq(w, r, a.Secret)
+			if errs.Occurred() {
+				api.HandleErr(w, r, nil, errs.Code, errs.UserError, errs.SystemError)
 				return
 			}
 			ctx := r.Context()
@@ -305,12 +305,10 @@ func RequiredPermissionsMiddleware(requiredPerms []string) Middleware {
 
 			u := ctx.Value(auth.CurrentUserKey)
 			if u == nil {
-				var userErr error
-				var sysErr error
-				var errCode int
-				user, userErr, sysErr, errCode = api.GetUserFromReq(w, r, cfg.Secrets[0])
-				if userErr != nil || sysErr != nil {
-					api.HandleErr(w, r, nil, errCode, userErr, sysErr)
+				var errs api.Errors
+				user, errs = api.GetUserFromReq(w, r, cfg.Secrets[0])
+				if errs.Occurred() {
+					api.HandleErr(w, r, nil, errs.Code, errs.UserError, errs.SystemError)
 					return
 				}
 			} else {

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -48,6 +48,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/coordinate"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crconfig"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crstats"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbdump"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice/consistenthash"
@@ -150,14 +151,14 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `async_status/{id}$`, api.GetAsyncStatus, auth.PrivLevelOperations, nil, Authenticated, nil, 2534390575},
 
 		//ASNs
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `asns/?$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42641723173},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `asns/?$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 402048983},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `asns/?$`, crudder.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42641723173},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `asns/?$`, crudder.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 402048983},
 
 		//ASN: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `asns/?$`, api.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4738777223},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `asns/{id}$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 49511986293},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `asns/?$`, api.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 49994921883},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `asns/{id}$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 46725247693},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `asns/?$`, crudder.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4738777223},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `asns/{id}$`, crudder.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 49511986293},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `asns/?$`, crudder.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 49994921883},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `asns/{id}$`, crudder.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 46725247693},
 
 		// Traffic Stats access
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservice_stats`, trafficstats.GetDSStats, auth.PrivLevelReadOnly, nil, Authenticated, nil, 43195690283},
@@ -167,10 +168,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `caches/stats/?$`, cachesstats.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 48132065883},
 
 		//CacheGroup: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cachegroups/?$`, api.ReadHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4230791103},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `cachegroups/{id}$`, api.UpdateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4129545463},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cachegroups/?$`, api.CreateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 429826653},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cachegroups/{id}$`, api.DeleteHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4278693653},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cachegroups/?$`, crudder.ReadHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4230791103},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `cachegroups/{id}$`, crudder.UpdateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4129545463},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cachegroups/?$`, crudder.CreateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 429826653},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cachegroups/{id}$`, crudder.DeleteHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4278693653},
 
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cachegroups/{id}/queue_update$`, cachegroup.QueueUpdates, auth.PrivLevelOperations, nil, Authenticated, nil, 40716441103},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cachegroups/{id}/deliveryservices/?$`, cachegroup.DSPostHandlerV40, auth.PrivLevelOperations, nil, Authenticated, nil, 45202404313},
@@ -207,16 +208,16 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `dbdump/?`, dbdump.DBDump, auth.PrivLevelAdmin, nil, Authenticated, nil, 4240166473},
 
 		//Division: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `divisions/?$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 40851815343},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `divisions/{id}$`, api.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4063691403},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `divisions/?$`, api.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4537138003},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `divisions/{id}$`, api.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43253822373},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `divisions/?$`, crudder.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 40851815343},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `divisions/{id}$`, crudder.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4063691403},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `divisions/?$`, crudder.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4537138003},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `divisions/{id}$`, crudder.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43253822373},
 
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `logs/?$`, logs.Getv40, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4483405503},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `logs/newcount/?$`, logs.GetNewCount, auth.PrivLevelReadOnly, nil, Authenticated, nil, 44058330123},
 
 		//Content invalidation jobs
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `jobs/?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 49667820413},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `jobs/?$`, crudder.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 49667820413},
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `jobs/?$`, invalidationjobs.Delete, auth.PrivLevelPortal, nil, Authenticated, nil, 4167807763},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `jobs/?$`, invalidationjobs.Update, auth.PrivLevelPortal, nil, Authenticated, nil, 4861342263},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `jobs/?`, invalidationjobs.Create, auth.PrivLevelPortal, nil, Authenticated, nil, 404509553},
@@ -243,26 +244,26 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `user/current/?$`, user.ReplaceCurrent, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4203},
 
 		//Parameter: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `parameters/?$`, api.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42125542923},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `parameters/{id}$`, api.UpdateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 48739361153},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `parameters/?$`, api.CreateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 46695108593},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `parameters/{id}$`, api.DeleteHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4262771183},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `parameters/?$`, crudder.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42125542923},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `parameters/{id}$`, crudder.UpdateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 48739361153},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `parameters/?$`, crudder.CreateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 46695108593},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `parameters/{id}$`, crudder.DeleteHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4262771183},
 
 		//Phys_Location: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `phys_locations/?$`, api.ReadHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4204051823},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `phys_locations/{id}$`, api.UpdateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4227950213},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `phys_locations/?$`, api.CreateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42464566483},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `phys_locations/{id}$`, api.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 456142213},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `phys_locations/?$`, crudder.ReadHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4204051823},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `phys_locations/{id}$`, crudder.UpdateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4227950213},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `phys_locations/?$`, crudder.CreateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42464566483},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `phys_locations/{id}$`, crudder.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 456142213},
 
 		//Ping
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `ping$`, ping.Handler, 0, nil, NoAuth, nil, 45556615973},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `vault/ping/?$`, ping.Vault, auth.PrivLevelReadOnly, nil, Authenticated, nil, 48840121143},
 
 		//Profile: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `profiles/?$`, api.ReadHandler(&profile.TOProfile{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4687585893},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `profiles/{id}$`, api.UpdateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 484391723},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profiles/?$`, api.CreateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 45402115563},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `profiles/{id}$`, api.DeleteHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42055944653},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `profiles/?$`, crudder.ReadHandler(&profile.TOProfile{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4687585893},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `profiles/{id}$`, crudder.UpdateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 484391723},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profiles/?$`, crudder.CreateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 45402115563},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `profiles/{id}$`, crudder.DeleteHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42055944653},
 
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `profiles/{id}/export/?$`, profile.ExportProfileHandler, auth.PrivLevelReadOnly, nil, Authenticated, nil, 401335173},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profiles/import/?$`, profile.ImportProfileHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 4061432083},
@@ -271,15 +272,15 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profiles/name/{new_profile}/copy/{existing_profile}`, profile.CopyProfileHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 4061432093},
 
 		//Region: CRUDs
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `regions/?$`, api.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4100370853},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `regions/{id}$`, api.UpdateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4223082243},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `regions/?$`, api.CreateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42883344883},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `regions/?$`, api.DeleteHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42326267583},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `regions/?$`, crudder.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4100370853},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `regions/{id}$`, crudder.UpdateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4223082243},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `regions/?$`, crudder.CreateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42883344883},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `regions/?$`, crudder.DeleteHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42326267583},
 
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `topologies/?$`, api.CreateHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4871452221},
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `topologies/?$`, api.ReadHandler(&topology.TOTopology{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4871452222},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `topologies/?$`, api.UpdateHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4871452223},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `topologies/?$`, api.DeleteHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4871452224},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `topologies/?$`, crudder.CreateHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4871452221},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `topologies/?$`, crudder.ReadHandler(&topology.TOTopology{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4871452222},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `topologies/?$`, crudder.UpdateHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4871452223},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `topologies/?$`, crudder.DeleteHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4871452224},
 
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `topologies/{name}/queue_update$`, topology.QueueUpdateHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 4205351748},
 
@@ -289,7 +290,7 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryserviceserver$`, dsserver.GetReplaceHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 4297997883},
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryserviceserver/{dsid}/{serverid}`, dsserver.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 45321845233},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices/{xml_id}/servers$`, dsserver.GetCreateHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 44281812063},
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `servers/{id}/deliveryservices$`, api.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4331154113},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `servers/{id}/deliveryservices$`, crudder.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4331154113},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 4801282533},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/{id}/servers$`, dsserver.GetReadAssigned, auth.PrivLevelReadOnly, nil, Authenticated, nil, 43451212233},
 
@@ -319,39 +320,39 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `servers/{id}$`, server.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 4923222333},
 
 		//Server Capability
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `server_capabilities$`, api.ReadHandler(&servercapability.TOServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4104073913},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `server_capabilities$`, api.CreateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40744707083},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `server_capabilities$`, api.UpdateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42543770109},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `server_capabilities$`, api.DeleteHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4364150383},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `server_capabilities$`, crudder.ReadHandler(&servercapability.TOServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4104073913},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `server_capabilities$`, crudder.CreateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40744707083},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `server_capabilities$`, crudder.UpdateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42543770109},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `server_capabilities$`, crudder.DeleteHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4364150383},
 
 		//Server Server Capabilities: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `server_server_capabilities/?$`, api.ReadHandler(&server.TOServerServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 48002318893},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `server_server_capabilities/?$`, api.CreateHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42931668343},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `server_server_capabilities/?$`, api.DeleteHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40587140583},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `server_server_capabilities/?$`, crudder.ReadHandler(&server.TOServerServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 48002318893},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `server_server_capabilities/?$`, crudder.CreateHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42931668343},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `server_server_capabilities/?$`, crudder.DeleteHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40587140583},
 
 		//Status: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `statuses/?$`, api.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42449056563},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `statuses/{id}$`, api.UpdateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42079665043},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `statuses/?$`, api.CreateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43691236123},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `statuses/{id}$`, api.DeleteHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4551113603},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `statuses/?$`, crudder.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42449056563},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `statuses/{id}$`, crudder.UpdateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 42079665043},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `statuses/?$`, crudder.CreateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43691236123},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `statuses/{id}$`, crudder.DeleteHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4551113603},
 
 		//System
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `system/info/?$`, systeminfo.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4210474753},
 
 		//Type: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `types/?$`, api.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42267018233},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `types/{id}$`, api.UpdateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 488601153},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `types/?$`, api.CreateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 45133081953},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `types/{id}$`, api.DeleteHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 431757733},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `types/?$`, crudder.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42267018233},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `types/{id}$`, crudder.UpdateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 488601153},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `types/?$`, crudder.CreateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 45133081953},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `types/{id}$`, crudder.DeleteHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 431757733},
 
 		//About
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `about/?$`, about.Handler(), auth.PrivLevelReadOnly, nil, Authenticated, nil, 43175011663},
 
 		//Coordinates
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `coordinates/?$`, api.ReadHandler(&coordinate.TOCoordinate{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4967007453},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `coordinates/?$`, api.UpdateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4689261743},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `coordinates/?$`, api.CreateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 44281121573},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `coordinates/?$`, api.DeleteHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43038498893},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `coordinates/?$`, crudder.ReadHandler(&coordinate.TOCoordinate{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4967007453},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `coordinates/?$`, crudder.UpdateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4689261743},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `coordinates/?$`, crudder.CreateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 44281121573},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `coordinates/?$`, crudder.DeleteHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43038498893},
 
 		//CDN notification
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdn_notifications/?$`, cdnnotification.Read, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2221224514},
@@ -359,10 +360,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cdn_notifications/?$`, cdnnotification.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 2722411851},
 
 		//CDN generic handlers:
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdns/?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42303186213},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43111789343},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 41605052893},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4276946573},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdns/?$`, crudder.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42303186213},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `cdns/{id}$`, crudder.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43111789343},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cdns/?$`, crudder.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 41605052893},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cdns/{id}$`, crudder.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4276946573},
 
 		//Delivery service requests
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservice_requests/?$`, dsrequest.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 46811639353},
@@ -377,10 +378,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `deliveryservice_requests/{id}/status$`, dsrequest.PutStatus, auth.PrivLevelPortal, nil, Authenticated, nil, 4684150993},
 
 		//Delivery service request comment: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservice_request_comments/?$`, api.ReadHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 40326507373},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `deliveryservice_request_comments/?$`, api.UpdateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 4604878473},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservice_request_comments/?$`, api.CreateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 4272276723},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservice_request_comments/?$`, api.DeleteHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 4995046683},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservice_request_comments/?$`, crudder.ReadHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 40326507373},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `deliveryservice_request_comments/?$`, crudder.UpdateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 4604878473},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservice_request_comments/?$`, crudder.CreateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 4272276723},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservice_request_comments/?$`, crudder.DeleteHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 4995046683},
 
 		//Delivery service uri signing keys: CRUD
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.GetURIsignkeysHandler, auth.PrivLevelAdmin, nil, Authenticated, nil, 42930785583},
@@ -389,23 +390,23 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.RemoveDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, nil, Authenticated, nil, 4299254173},
 
 		//Delivery Service Required Capabilities: CRUD
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices_required_capabilities/?$`, api.ReadHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 41585222273},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices_required_capabilities/?$`, api.CreateHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40968739923},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservices_required_capabilities/?$`, api.DeleteHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 44962893043},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices_required_capabilities/?$`, crudder.ReadHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 41585222273},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices_required_capabilities/?$`, crudder.CreateHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40968739923},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservices_required_capabilities/?$`, crudder.DeleteHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 44962893043},
 
 		// Federations by CDN (the actual table for federation)
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdns/{name}/federations/?$`, api.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4892250323},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cdns/{name}/federations/?$`, api.CreateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 49548942193},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `cdns/{name}/federations/{id}$`, api.UpdateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 4260654663},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cdns/{name}/federations/{id}$`, api.DeleteHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 44428529023},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdns/{name}/federations/?$`, crudder.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4892250323},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cdns/{name}/federations/?$`, crudder.CreateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 49548942193},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `cdns/{name}/federations/{id}$`, crudder.UpdateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 4260654663},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cdns/{name}/federations/{id}$`, crudder.DeleteHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 44428529023},
 
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cdns/{name}/dnsseckeys/ksk/generate$`, cdn.GenerateKSK, auth.PrivLevelAdmin, nil, Authenticated, nil, 4729242813},
 
 		//Origins
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `origins/?$`, api.ReadHandler(&origin.TOOrigin{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4446492563},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `origins/?$`, api.UpdateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 415677463},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `origins/?$`, api.CreateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40995616433},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `origins/?$`, api.DeleteHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4602732633},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `origins/?$`, crudder.ReadHandler(&origin.TOOrigin{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4446492563},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `origins/?$`, crudder.UpdateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 415677463},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `origins/?$`, crudder.CreateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40995616433},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `origins/?$`, crudder.DeleteHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4602732633},
 
 		//Roles
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `roles/?$`, role.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4870885833},
@@ -421,33 +422,33 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 42467316633},
 
 		//ServiceCategories
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `service_categories/?$`, api.ReadHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4085181543},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `service_categories/?$`, crudder.ReadHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4085181543},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `service_categories/{name}/?$`, servicecategory.Update, auth.PrivLevelOperations, nil, Authenticated, nil, 406369141},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `service_categories/?$`, api.CreateHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelOperations, nil, Authenticated, nil, 453713801},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `service_categories/{name}$`, api.DeleteHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4325382238},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `service_categories/?$`, crudder.CreateHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelOperations, nil, Authenticated, nil, 453713801},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `service_categories/{name}$`, crudder.DeleteHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4325382238},
 
 		//StaticDNSEntries
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `staticdnsentries/?$`, api.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4289394773},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `staticdnsentries/?$`, api.UpdateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4424571113},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `staticdnsentries/?$`, api.CreateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 46291482383},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `staticdnsentries/?$`, api.DeleteHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 48460311323},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `staticdnsentries/?$`, crudder.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4289394773},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `staticdnsentries/?$`, crudder.UpdateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4424571113},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `staticdnsentries/?$`, crudder.CreateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 46291482383},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `staticdnsentries/?$`, crudder.DeleteHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 48460311323},
 
 		//ProfileParameters
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `profiles/{id}/parameters/?$`, profileparameter.GetProfileID, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4764649753},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `profiles/name/{name}/parameters/?$`, profileparameter.GetProfileName, auth.PrivLevelReadOnly, nil, Authenticated, nil, 42677378323},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profiles/name/{name}/parameters/?$`, profileparameter.PostProfileParamsByName, auth.PrivLevelOperations, nil, Authenticated, nil, 43559455823},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profiles/{id}/parameters/?$`, profileparameter.PostProfileParamsByID, auth.PrivLevelOperations, nil, Authenticated, nil, 4168187083},
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `profileparameters/?$`, api.ReadHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4506098053},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profileparameters/?$`, api.CreateHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4288096933},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `profileparameters/?$`, crudder.ReadHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4506098053},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profileparameters/?$`, crudder.CreateHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4288096933},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `profileparameter/?$`, profileparameter.PostProfileParam, auth.PrivLevelOperations, nil, Authenticated, nil, 4242753},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `parameterprofile/?$`, profileparameter.PostParamProfile, auth.PrivLevelOperations, nil, Authenticated, nil, 40806108613},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `profileparameters/{profileId}/{parameterId}$`, api.DeleteHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4248395293},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `profileparameters/{profileId}/{parameterId}$`, crudder.DeleteHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4248395293},
 
 		//Tenants
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `tenants/?$`, api.ReadHandler(&apitenant.TOTenant{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 46779678143},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `tenants/{id}$`, api.UpdateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40941314783},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `tenants/?$`, api.CreateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4172480133},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `tenants/{id}$`, api.DeleteHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4163655583},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `tenants/?$`, crudder.ReadHandler(&apitenant.TOTenant{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 46779678143},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `tenants/{id}$`, crudder.UpdateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 40941314783},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `tenants/?$`, crudder.CreateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4172480133},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `tenants/{id}$`, crudder.DeleteHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4163655583},
 
 		//CRConfig
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdns/{cdn}/snapshot/?$`, crconfig.SnapshotGetHandler, auth.PrivLevelReadOnly, nil, Authenticated, nil, 49572736953},
@@ -461,8 +462,8 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `federations/?$`, federations.RemoveFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, nil, Authenticated, nil, 420983233},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `federations/?$`, federations.ReplaceFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, nil, Authenticated, nil, 42831825163},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `federations/{id}/deliveryservices/?$`, federations.PostDSes, auth.PrivLevelAdmin, nil, Authenticated, nil, 46828635133},
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `federations/{id}/deliveryservices/?$`, api.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4537730343},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?$`, api.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 44174025703},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `federations/{id}/deliveryservices/?$`, crudder.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4537730343},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?$`, crudder.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 44174025703},
 
 		// Federation Resolvers
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `federation_resolvers/?$`, federation_resolvers.Create, auth.PrivLevelAdmin, nil, Authenticated, nil, 41343736613},
@@ -473,15 +474,15 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 
 		// Federations Users
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `federations/{id}/users/?$`, federations.PostUsers, auth.PrivLevelAdmin, nil, Authenticated, nil, 47793349303},
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `federations/{id}/users/?$`, api.ReadHandler(&federations.TOUsers{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4940750153},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `federations/{id}/users/{userID}/?$`, api.DeleteHandler(&federations.TOUsers{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 49491028823},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `federations/{id}/users/?$`, crudder.ReadHandler(&federations.TOUsers{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 4940750153},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `federations/{id}/users/{userID}/?$`, crudder.DeleteHandler(&federations.TOUsers{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 49491028823},
 
 		////DeliveryServices
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/?$`, api.ReadHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42383172943},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/?$`, crudder.ReadHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 42383172943},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices/?$`, deliveryservice.CreateV40, auth.PrivLevelOperations, nil, Authenticated, nil, 4064315323},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `deliveryservices/{id}/?$`, deliveryservice.UpdateV40, auth.PrivLevelOperations, nil, Authenticated, nil, 47665675673},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `deliveryservices/{id}/safe/?$`, deliveryservice.UpdateSafe, auth.PrivLevelOperations, nil, Authenticated, nil, 4472109313},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservices/{id}/?$`, api.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4226420743},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservices/{id}/?$`, crudder.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4226420743},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/{id}/servers/eligible/?$`, deliveryservice.GetServersEligible, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4747615843},
 
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/xmlId/{xmlid}/sslkeys$`, deliveryservice.GetSSLKeysByXMLID, auth.PrivLevelAdmin, nil, Authenticated, nil, 41357729073},
@@ -504,10 +505,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/{id}/routing$`, crstats.GetDSRouting, auth.PrivLevelReadOnly, nil, Authenticated, nil, 467339833},
 
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `steering/{deliveryservice}/targets/?$`, api.ReadHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 45696078243},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `steering/{deliveryservice}/targets/?$`, api.CreateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 43382163973},
-		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?$`, api.UpdateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 44386082953},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?$`, api.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 42880215153},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `steering/{deliveryservice}/targets/?$`, crudder.ReadHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 45696078243},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `steering/{deliveryservice}/targets/?$`, crudder.CreateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 43382163973},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?$`, crudder.UpdateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 44386082953},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?$`, crudder.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 42880215153},
 
 		// Stats Summary
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `stats_summary/?$`, trafficstats.GetStatsSummary, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4804985983},
@@ -538,14 +539,14 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `api_capabilities/?$`, apicapability.GetAPICapabilitiesHandler, auth.PrivLevelReadOnly, nil, Authenticated, nil, 28132065893},
 
 		//ASNs
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `asns/?$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22641723173},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `asns/?$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 202048983},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `asns/?$`, crudder.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22641723173},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `asns/?$`, crudder.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 202048983},
 
 		//ASN: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `asns/?$`, api.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2738777223},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `asns/{id}$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 29511986293},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `asns/?$`, api.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 29994921883},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `asns/{id}$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 26725247693},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `asns/?$`, crudder.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2738777223},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `asns/{id}$`, crudder.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 29511986293},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `asns/?$`, crudder.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 29994921883},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `asns/{id}$`, crudder.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 26725247693},
 
 		// Traffic Stats access
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservice_stats`, trafficstats.GetDSStats, auth.PrivLevelReadOnly, nil, Authenticated, nil, 23195690283},
@@ -555,10 +556,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `caches/stats/?$`, cachesstats.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 28132065883},
 
 		//CacheGroup: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cachegroups/?$`, api.ReadHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2230791103},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `cachegroups/{id}$`, api.UpdateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2129545463},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cachegroups/?$`, api.CreateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 229826653},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `cachegroups/{id}$`, api.DeleteHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2278693653},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cachegroups/?$`, crudder.ReadHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2230791103},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `cachegroups/{id}$`, crudder.UpdateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2129545463},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cachegroups/?$`, crudder.CreateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 229826653},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `cachegroups/{id}$`, crudder.DeleteHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2278693653},
 
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cachegroups/{id}/queue_update$`, cachegroup.QueueUpdates, auth.PrivLevelOperations, nil, Authenticated, nil, 20716441103},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cachegroups/{id}/deliveryservices/?$`, cachegroup.DSPostHandlerV31, auth.PrivLevelOperations, nil, Authenticated, nil, 25202404313},
@@ -566,8 +567,8 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		//CacheGroup Parameters: CRUD
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cachegroupparameters/?$`, cachegroupparameter.ReadAllCacheGroupParameters, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2124497243},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cachegroupparameters/?$`, cachegroupparameter.AddCacheGroupParameters, auth.PrivLevelOperations, nil, Authenticated, nil, 2124497253},
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cachegroups/{id}/parameters/?$`, api.DeprecatedReadHandler(&cachegroupparameter.TOCacheGroupParameter{}, nil), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2124497233},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `cachegroupparameters/{cachegroupID}/{parameterId}$`, api.DeprecatedDeleteHandler(&cachegroupparameter.TOCacheGroupParameter{}, nil), auth.PrivLevelOperations, nil, Authenticated, nil, 2124497333},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cachegroups/{id}/parameters/?$`, crudder.DeprecatedReadHandler(&cachegroupparameter.TOCacheGroupParameter{}, nil), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2124497233},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `cachegroupparameters/{cachegroupID}/{parameterId}$`, crudder.DeprecatedDeleteHandler(&cachegroupparameter.TOCacheGroupParameter{}, nil), auth.PrivLevelOperations, nil, Authenticated, nil, 2124497333},
 
 		//Capabilities
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `capabilities/?$`, capabilities.Read, auth.PrivLevelReadOnly, nil, Authenticated, nil, 20081353},
@@ -601,16 +602,16 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `dbdump/?`, dbdump.DBDump, auth.PrivLevelAdmin, nil, Authenticated, nil, 2240166473},
 
 		//Division: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `divisions/?$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 20851815343},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `divisions/{id}$`, api.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2063691403},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `divisions/?$`, api.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2537138003},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `divisions/{id}$`, api.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23253822373},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `divisions/?$`, crudder.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 20851815343},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `divisions/{id}$`, crudder.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2063691403},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `divisions/?$`, crudder.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2537138003},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `divisions/{id}$`, crudder.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23253822373},
 
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `logs/?$`, logs.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2483405503},
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `logs/newcount/?$`, logs.GetNewCount, auth.PrivLevelReadOnly, nil, Authenticated, nil, 24058330123},
 
 		//Content invalidation jobs
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `jobs/?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 29667820413},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `jobs/?$`, crudder.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 29667820413},
 		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `jobs/?$`, invalidationjobs.Delete, auth.PrivLevelPortal, nil, Authenticated, nil, 2167807763},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `jobs/?$`, invalidationjobs.Update, auth.PrivLevelPortal, nil, Authenticated, nil, 2861342263},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `jobs/?`, invalidationjobs.Create, auth.PrivLevelPortal, nil, Authenticated, nil, 204509553},
@@ -628,36 +629,36 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `isos/?$`, iso.ISOs, auth.PrivLevelOperations, nil, Authenticated, nil, 2760336573},
 
 		//User: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `users/?$`, api.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 24919299003},
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `users/{id}$`, api.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2138099803},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `users/{id}$`, api.UpdateHandler(&user.TOUser{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2354334043},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `users/?$`, api.CreateHandler(&user.TOUser{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2762448163},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `users/?$`, crudder.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 24919299003},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `users/{id}$`, crudder.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2138099803},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `users/{id}$`, crudder.UpdateHandler(&user.TOUser{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2354334043},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `users/?$`, crudder.CreateHandler(&user.TOUser{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2762448163},
 
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `user/current/?$`, user.Current, auth.PrivLevelReadOnly, nil, Authenticated, nil, 26107016143},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `user/current/?$`, user.ReplaceCurrent, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2203},
 
 		//Parameter: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `parameters/?$`, api.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22125542923},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `parameters/{id}$`, api.UpdateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 28739361153},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `parameters/?$`, api.CreateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 26695108593},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `parameters/{id}$`, api.DeleteHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2262771183},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `parameters/?$`, crudder.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22125542923},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `parameters/{id}$`, crudder.UpdateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 28739361153},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `parameters/?$`, crudder.CreateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 26695108593},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `parameters/{id}$`, crudder.DeleteHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2262771183},
 
 		//Phys_Location: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `phys_locations/?$`, api.ReadHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2204051823},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `phys_locations/{id}$`, api.UpdateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2227950213},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `phys_locations/?$`, api.CreateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22464566483},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `phys_locations/{id}$`, api.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 256142213},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `phys_locations/?$`, crudder.ReadHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2204051823},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `phys_locations/{id}$`, crudder.UpdateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2227950213},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `phys_locations/?$`, crudder.CreateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22464566483},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `phys_locations/{id}$`, crudder.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 256142213},
 
 		//Ping
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `ping$`, ping.Handler, 0, nil, NoAuth, nil, 25556615973},
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `vault/ping/?$`, ping.Vault, auth.PrivLevelReadOnly, nil, Authenticated, nil, 28840121143},
 
 		//Profile: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `profiles/?$`, api.ReadHandler(&profile.TOProfile{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2687585893},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `profiles/?$`, crudder.ReadHandler(&profile.TOProfile{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2687585893},
 
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `profiles/{id}$`, api.UpdateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 284391723},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profiles/?$`, api.CreateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 25402115563},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `profiles/{id}$`, api.DeleteHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22055944653},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `profiles/{id}$`, crudder.UpdateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 284391723},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profiles/?$`, crudder.CreateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 25402115563},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `profiles/{id}$`, crudder.DeleteHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22055944653},
 
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `profiles/{id}/export/?$`, profile.ExportProfileHandler, auth.PrivLevelReadOnly, nil, Authenticated, nil, 201335173},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profiles/import/?$`, profile.ImportProfileHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 2061432083},
@@ -666,15 +667,15 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profiles/name/{new_profile}/copy/{existing_profile}`, profile.CopyProfileHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 2061432093},
 
 		//Region: CRUDs
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `regions/?$`, api.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2100370853},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `regions/{id}$`, api.UpdateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2223082243},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `regions/?$`, api.CreateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22883344883},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `regions/?$`, api.DeleteHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22326267583},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `regions/?$`, crudder.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2100370853},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `regions/{id}$`, crudder.UpdateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2223082243},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `regions/?$`, crudder.CreateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22883344883},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `regions/?$`, crudder.DeleteHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22326267583},
 
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `topologies/?$`, api.CreateHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 3871452221},
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `topologies/?$`, api.ReadHandler(&topology.TOTopology{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 3871452222},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `topologies/?$`, api.UpdateHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 3871452223},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `topologies/?$`, api.DeleteHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 3871452224},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `topologies/?$`, crudder.CreateHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 3871452221},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `topologies/?$`, crudder.ReadHandler(&topology.TOTopology{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 3871452222},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `topologies/?$`, crudder.UpdateHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 3871452223},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `topologies/?$`, crudder.DeleteHandler(&topology.TOTopology{}), auth.PrivLevelOperations, nil, Authenticated, nil, 3871452224},
 
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `topologies/{name}/queue_update$`, topology.QueueUpdateHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 3205351748},
 
@@ -684,7 +685,7 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `deliveryserviceserver$`, dsserver.GetReplaceHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 2297997883},
 		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryserviceserver/{dsid}/{serverid}`, dsserver.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 25321845233},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `deliveryservices/{xml_id}/servers$`, dsserver.GetCreateHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 24281812063},
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `servers/{id}/deliveryservices$`, api.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2331154113},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `servers/{id}/deliveryservices$`, crudder.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2331154113},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 2801282533},
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices/{id}/servers$`, dsserver.GetReadAssigned, auth.PrivLevelReadOnly, nil, Authenticated, nil, 23451212233},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `deliveryservices/request`, deliveryservicerequests.Request, auth.PrivLevelPortal, nil, Authenticated, nil, 2408752993},
@@ -715,44 +716,44 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `servers/{id}$`, server.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 2923222333},
 
 		//Server Capability
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `server_capabilities$`, api.ReadHandler(&servercapability.TOServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2104073913},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `server_capabilities$`, api.CreateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20744707083},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `server_capabilities$`, api.DeleteHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2364150383},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `server_capabilities$`, crudder.ReadHandler(&servercapability.TOServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2104073913},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `server_capabilities$`, crudder.CreateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20744707083},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `server_capabilities$`, crudder.DeleteHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2364150383},
 
 		//Server Server Capabilities: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `server_server_capabilities/?$`, api.ReadHandler(&server.TOServerServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 28002318893},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `server_server_capabilities/?$`, api.CreateHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22931668343},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `server_server_capabilities/?$`, api.DeleteHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20587140583},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `server_server_capabilities/?$`, crudder.ReadHandler(&server.TOServerServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 28002318893},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `server_server_capabilities/?$`, crudder.CreateHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22931668343},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `server_server_capabilities/?$`, crudder.DeleteHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20587140583},
 
 		//Status: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `statuses/?$`, api.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22449056563},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `statuses/{id}$`, api.UpdateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22079665043},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `statuses/?$`, api.CreateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23691236123},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `statuses/{id}$`, api.DeleteHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2551113603},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `statuses/?$`, crudder.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22449056563},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `statuses/{id}$`, crudder.UpdateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22079665043},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `statuses/?$`, crudder.CreateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23691236123},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `statuses/{id}$`, crudder.DeleteHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2551113603},
 
 		//System
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `system/info/?$`, systeminfo.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2210474753},
 
 		//Type: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `types/?$`, api.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22267018233},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `types/{id}$`, api.UpdateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 288601153},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `types/?$`, api.CreateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 25133081953},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `types/{id}$`, api.DeleteHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 231757733},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `types/?$`, crudder.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22267018233},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `types/{id}$`, crudder.UpdateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 288601153},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `types/?$`, crudder.CreateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 25133081953},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `types/{id}$`, crudder.DeleteHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 231757733},
 
 		//About
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `about/?$`, about.Handler(), auth.PrivLevelReadOnly, nil, Authenticated, nil, 23175011663},
 
 		//Coordinates
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `coordinates/?$`, api.ReadHandler(&coordinate.TOCoordinate{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2967007453},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `coordinates/?$`, api.UpdateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2689261743},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `coordinates/?$`, api.CreateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 24281121573},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `coordinates/?$`, api.DeleteHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23038498893},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `coordinates/?$`, crudder.ReadHandler(&coordinate.TOCoordinate{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2967007453},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `coordinates/?$`, crudder.UpdateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2689261743},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `coordinates/?$`, crudder.CreateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 24281121573},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `coordinates/?$`, crudder.DeleteHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23038498893},
 
 		//CDN generic handlers:
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cdns/?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22303186213},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23111789343},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 21605052893},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2276946573},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cdns/?$`, crudder.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22303186213},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `cdns/{id}$`, crudder.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23111789343},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cdns/?$`, crudder.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 21605052893},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `cdns/{id}$`, crudder.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2276946573},
 
 		//Delivery service requests
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservice_requests/?$`, dsrequest.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 26811639353},
@@ -765,10 +766,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `deliveryservice_requests/{id}/status$`, dsrequest.PutStatus, auth.PrivLevelPortal, nil, Authenticated, nil, 2684150993},
 
 		//Delivery service request comment: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservice_request_comments/?$`, api.ReadHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 20326507373},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `deliveryservice_request_comments/?$`, api.UpdateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 2604878473},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `deliveryservice_request_comments/?$`, api.CreateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 2272276723},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryservice_request_comments/?$`, api.DeleteHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 2995046683},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservice_request_comments/?$`, crudder.ReadHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 20326507373},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `deliveryservice_request_comments/?$`, crudder.UpdateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 2604878473},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `deliveryservice_request_comments/?$`, crudder.CreateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 2272276723},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryservice_request_comments/?$`, crudder.DeleteHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 2995046683},
 
 		//Delivery service uri signing keys: CRUD
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.GetURIsignkeysHandler, auth.PrivLevelAdmin, nil, Authenticated, nil, 22930785583},
@@ -777,29 +778,29 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.RemoveDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, nil, Authenticated, nil, 2299254173},
 
 		//Delivery Service Required Capabilities: CRUD
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices_required_capabilities/?$`, api.ReadHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 21585222273},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `deliveryservices_required_capabilities/?$`, api.CreateHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20968739923},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryservices_required_capabilities/?$`, api.DeleteHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 24962893043},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices_required_capabilities/?$`, crudder.ReadHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 21585222273},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `deliveryservices_required_capabilities/?$`, crudder.CreateHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20968739923},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryservices_required_capabilities/?$`, crudder.DeleteHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 24962893043},
 
 		// Federations by CDN (the actual table for federation)
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cdns/{name}/federations/?$`, api.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2892250323},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cdns/{name}/federations/?$`, api.CreateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 29548942193},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `cdns/{name}/federations/{id}$`, api.UpdateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2260654663},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `cdns/{name}/federations/{id}$`, api.DeleteHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 24428529023},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cdns/{name}/federations/?$`, crudder.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2892250323},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cdns/{name}/federations/?$`, crudder.CreateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 29548942193},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `cdns/{name}/federations/{id}$`, crudder.UpdateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2260654663},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `cdns/{name}/federations/{id}$`, crudder.DeleteHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 24428529023},
 
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `cdns/{name}/dnsseckeys/ksk/generate$`, cdn.GenerateKSK, auth.PrivLevelAdmin, nil, Authenticated, nil, 2729242813},
 
 		//Origins
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `origins/?$`, api.ReadHandler(&origin.TOOrigin{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2446492563},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `origins/?$`, api.UpdateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 215677463},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `origins/?$`, api.CreateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20995616433},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `origins/?$`, api.DeleteHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2602732633},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `origins/?$`, crudder.ReadHandler(&origin.TOOrigin{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2446492563},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `origins/?$`, crudder.UpdateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 215677463},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `origins/?$`, crudder.CreateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20995616433},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `origins/?$`, crudder.DeleteHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2602732633},
 
 		//Roles
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `roles/?$`, api.ReadHandler(&role.TORole{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2870885833},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `roles/?$`, api.UpdateHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 26128974893},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `roles/?$`, api.CreateHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2306524063},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `roles/?$`, api.DeleteHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 23567059823},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `roles/?$`, crudder.ReadHandler(&role.TORole{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2870885833},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `roles/?$`, crudder.UpdateHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 26128974893},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `roles/?$`, crudder.CreateHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2306524063},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `roles/?$`, crudder.DeleteHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 23567059823},
 
 		//Delivery Services Regexes
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices_regexes/?$`, deliveryservicesregexes.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2055014533},
@@ -809,33 +810,33 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 22467316633},
 
 		//ServiceCategories
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `service_categories/?$`, api.ReadHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 1085181543},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `service_categories/?$`, crudder.ReadHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 1085181543},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `service_categories/{name}/?$`, servicecategory.Update, auth.PrivLevelOperations, nil, Authenticated, nil, 306369141},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `service_categories/?$`, api.CreateHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelOperations, nil, Authenticated, nil, 553713801},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `service_categories/{name}$`, api.DeleteHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelOperations, nil, Authenticated, nil, 1325382238},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `service_categories/?$`, crudder.CreateHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelOperations, nil, Authenticated, nil, 553713801},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `service_categories/{name}$`, crudder.DeleteHandler(&servicecategory.TOServiceCategory{}), auth.PrivLevelOperations, nil, Authenticated, nil, 1325382238},
 
 		//StaticDNSEntries
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `staticdnsentries/?$`, api.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2289394773},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `staticdnsentries/?$`, api.UpdateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2424571113},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `staticdnsentries/?$`, api.CreateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 26291482383},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `staticdnsentries/?$`, api.DeleteHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 28460311323},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `staticdnsentries/?$`, crudder.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2289394773},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `staticdnsentries/?$`, crudder.UpdateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2424571113},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `staticdnsentries/?$`, crudder.CreateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 26291482383},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `staticdnsentries/?$`, crudder.DeleteHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 28460311323},
 
 		//ProfileParameters
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `profiles/{id}/parameters/?$`, profileparameter.GetProfileID, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2764649753},
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `profiles/name/{name}/parameters/?$`, profileparameter.GetProfileName, auth.PrivLevelReadOnly, nil, Authenticated, nil, 22677378323},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profiles/name/{name}/parameters/?$`, profileparameter.PostProfileParamsByName, auth.PrivLevelOperations, nil, Authenticated, nil, 23559455823},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profiles/{id}/parameters/?$`, profileparameter.PostProfileParamsByID, auth.PrivLevelOperations, nil, Authenticated, nil, 2168187083},
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `profileparameters/?$`, api.ReadHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2506098053},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profileparameters/?$`, api.CreateHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2288096933},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `profileparameters/?$`, crudder.ReadHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2506098053},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profileparameters/?$`, crudder.CreateHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2288096933},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `profileparameter/?$`, profileparameter.PostProfileParam, auth.PrivLevelOperations, nil, Authenticated, nil, 2242753},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `parameterprofile/?$`, profileparameter.PostParamProfile, auth.PrivLevelOperations, nil, Authenticated, nil, 20806108613},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `profileparameters/{profileId}/{parameterId}$`, api.DeleteHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2248395293},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `profileparameters/{profileId}/{parameterId}$`, crudder.DeleteHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2248395293},
 
 		//Tenants
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `tenants/?$`, api.ReadHandler(&apitenant.TOTenant{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 26779678143},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `tenants/{id}$`, api.UpdateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20941314783},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `tenants/?$`, api.CreateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2172480133},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `tenants/{id}$`, api.DeleteHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2163655583},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `tenants/?$`, crudder.ReadHandler(&apitenant.TOTenant{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 26779678143},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `tenants/{id}$`, crudder.UpdateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20941314783},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `tenants/?$`, crudder.CreateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2172480133},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `tenants/{id}$`, crudder.DeleteHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2163655583},
 
 		//CRConfig
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `cdns/{cdn}/snapshot/?$`, crconfig.SnapshotGetHandler, auth.PrivLevelReadOnly, nil, Authenticated, nil, 29572736953},
@@ -849,8 +850,8 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `federations/?$`, federations.RemoveFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, nil, Authenticated, nil, 220983233},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `federations/?$`, federations.ReplaceFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, nil, Authenticated, nil, 22831825163},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `federations/{id}/deliveryservices/?$`, federations.PostDSes, auth.PrivLevelAdmin, nil, Authenticated, nil, 26828635133},
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `federations/{id}/deliveryservices/?$`, api.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2537730343},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?$`, api.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 24174025703},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `federations/{id}/deliveryservices/?$`, crudder.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2537730343},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?$`, crudder.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 24174025703},
 
 		// Federation Resolvers
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `federation_resolvers/?$`, federation_resolvers.Create, auth.PrivLevelAdmin, nil, Authenticated, nil, 21343736613},
@@ -861,15 +862,15 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 
 		// Federations Users
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `federations/{id}/users/?$`, federations.PostUsers, auth.PrivLevelAdmin, nil, Authenticated, nil, 27793349303},
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `federations/{id}/users/?$`, api.ReadHandler(&federations.TOUsers{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2940750153},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `federations/{id}/users/{userID}/?$`, api.DeleteHandler(&federations.TOUsers{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 29491028823},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `federations/{id}/users/?$`, crudder.ReadHandler(&federations.TOUsers{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2940750153},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `federations/{id}/users/{userID}/?$`, crudder.DeleteHandler(&federations.TOUsers{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 29491028823},
 
 		////DeliveryServices
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices/?$`, api.ReadHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22383172943},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices/?$`, crudder.ReadHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 22383172943},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `deliveryservices/?$`, deliveryservice.CreateV30, auth.PrivLevelOperations, nil, Authenticated, nil, 2064314323},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `deliveryservices/{id}/?$`, deliveryservice.UpdateV30, auth.PrivLevelOperations, nil, Authenticated, nil, 27665675273},
 		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `deliveryservices/{id}/safe/?$`, deliveryservice.UpdateSafe, auth.PrivLevelOperations, nil, Authenticated, nil, 2472109313},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryservices/{id}/?$`, api.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2226420743},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `deliveryservices/{id}/?$`, crudder.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2226420743},
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices/{id}/servers/eligible/?$`, deliveryservice.GetServersEligible, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2747615843},
 
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices/xmlId/{xmlid}/sslkeys$`, deliveryservice.GetSSLKeysByXMLID, auth.PrivLevelAdmin, nil, Authenticated, nil, 21357729073},
@@ -891,10 +892,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `deliveryservices/{id}/routing$`, crstats.GetDSRouting, auth.PrivLevelReadOnly, nil, Authenticated, nil, 667339833},
 
-		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `steering/{deliveryservice}/targets/?$`, api.ReadHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 25696078243},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `steering/{deliveryservice}/targets/?$`, api.CreateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 23382163973},
-		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?$`, api.UpdateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 24386082953},
-		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?$`, api.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 22880215153},
+		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `steering/{deliveryservice}/targets/?$`, crudder.ReadHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 25696078243},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPost, `steering/{deliveryservice}/targets/?$`, crudder.CreateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 23382163973},
+		{api.Version{Major: 3, Minor: 0}, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?$`, crudder.UpdateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 24386082953},
+		{api.Version{Major: 3, Minor: 0}, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?$`, crudder.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 22880215153},
 
 		// Stats Summary
 		{api.Version{Major: 3, Minor: 0}, http.MethodGet, `stats_summary/?$`, trafficstats.GetStatsSummary, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2804985983},
@@ -915,14 +916,14 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `api_capabilities/?$`, apicapability.GetAPICapabilitiesHandler, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2813206589},
 
 		//ASNs
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `asns/?$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2264172317},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `asns/?$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20204898},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `asns/?$`, crudder.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2264172317},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `asns/?$`, crudder.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 20204898},
 
 		//ASN: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `asns/?$`, api.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 273877722},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `asns/{id}$`, api.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2951198629},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `asns/?$`, api.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2999492188},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `asns/{id}$`, api.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2672524769},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `asns/?$`, crudder.ReadHandler(&asn.TOASNV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 273877722},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `asns/{id}$`, crudder.UpdateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2951198629},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `asns/?$`, crudder.CreateHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2999492188},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `asns/{id}$`, crudder.DeleteHandler(&asn.TOASNV11{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2672524769},
 
 		// Traffic Stats access
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservice_stats`, trafficstats.GetDSStats, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2319569028},
@@ -932,10 +933,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `caches/stats/?$`, cachesstats.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2813206588},
 
 		//CacheGroup: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cachegroups/?$`, api.ReadHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 223079110},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `cachegroups/{id}$`, api.UpdateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 212954546},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cachegroups/?$`, api.CreateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22982665},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `cachegroups/{id}$`, api.DeleteHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 227869365},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cachegroups/?$`, crudder.ReadHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 223079110},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `cachegroups/{id}$`, crudder.UpdateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 212954546},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cachegroups/?$`, crudder.CreateHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 22982665},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `cachegroups/{id}$`, crudder.DeleteHandler(&cachegroup.TOCacheGroup{}), auth.PrivLevelOperations, nil, Authenticated, nil, 227869365},
 
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cachegroups/{id}/queue_update$`, cachegroup.QueueUpdates, auth.PrivLevelOperations, nil, Authenticated, nil, 2071644110},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cachegroups/{id}/deliveryservices/?$`, cachegroup.DSPostHandlerV31, auth.PrivLevelOperations, nil, Authenticated, nil, 2520240431},
@@ -943,8 +944,8 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		//CacheGroup Parameters: CRUD
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cachegroupparameters/?$`, cachegroupparameter.ReadAllCacheGroupParameters, auth.PrivLevelReadOnly, nil, Authenticated, nil, 212449724},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cachegroupparameters/?$`, cachegroupparameter.AddCacheGroupParameters, auth.PrivLevelOperations, nil, Authenticated, nil, 212449725},
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cachegroups/{id}/parameters/?$`, api.DeprecatedReadHandler(&cachegroupparameter.TOCacheGroupParameter{}, nil), auth.PrivLevelReadOnly, nil, Authenticated, nil, 212449723},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `cachegroupparameters/{cachegroupID}/{parameterId}$`, api.DeprecatedDeleteHandler(&cachegroupparameter.TOCacheGroupParameter{}, nil), auth.PrivLevelOperations, nil, Authenticated, nil, 212449733},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cachegroups/{id}/parameters/?$`, crudder.DeprecatedReadHandler(&cachegroupparameter.TOCacheGroupParameter{}, nil), auth.PrivLevelReadOnly, nil, Authenticated, nil, 212449723},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `cachegroupparameters/{cachegroupID}/{parameterId}$`, crudder.DeprecatedDeleteHandler(&cachegroupparameter.TOCacheGroupParameter{}, nil), auth.PrivLevelOperations, nil, Authenticated, nil, 212449733},
 
 		//Capabilities
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `capabilities/?$`, capabilities.Read, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2008135},
@@ -978,16 +979,16 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `dbdump/?`, dbdump.DBDump, auth.PrivLevelAdmin, nil, Authenticated, nil, 224016647},
 
 		//Division: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `divisions/?$`, api.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2085181534},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `divisions/{id}$`, api.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 206369140},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `divisions/?$`, api.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 253713800},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `divisions/{id}$`, api.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2325382237},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `divisions/?$`, crudder.ReadHandler(&division.TODivision{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2085181534},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `divisions/{id}$`, crudder.UpdateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 206369140},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `divisions/?$`, crudder.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 253713800},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `divisions/{id}$`, crudder.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2325382237},
 
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `logs/?$`, logs.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 248340550},
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `logs/newcount/?$`, logs.GetNewCount, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2405833012},
 
 		//Content invalidation jobs
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `jobs/?$`, api.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2966782041},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `jobs/?$`, crudder.ReadHandler(&invalidationjobs.InvalidationJob{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2966782041},
 		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `jobs/?$`, invalidationjobs.Delete, auth.PrivLevelPortal, nil, Authenticated, nil, 216780776},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `jobs/?$`, invalidationjobs.Update, auth.PrivLevelPortal, nil, Authenticated, nil, 286134226},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `jobs/?`, invalidationjobs.Create, auth.PrivLevelPortal, nil, Authenticated, nil, 20450955},
@@ -1005,36 +1006,36 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `isos/?$`, iso.ISOs, auth.PrivLevelOperations, nil, Authenticated, nil, 276033657},
 
 		//User: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `users/?$`, api.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2491929900},
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `users/{id}$`, api.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 213809980},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `users/{id}$`, api.UpdateHandler(&user.TOUser{}), auth.PrivLevelOperations, nil, Authenticated, nil, 235433404},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `users/?$`, api.CreateHandler(&user.TOUser{}), auth.PrivLevelOperations, nil, Authenticated, nil, 276244816},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `users/?$`, crudder.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2491929900},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `users/{id}$`, crudder.ReadHandler(&user.TOUser{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 213809980},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `users/{id}$`, crudder.UpdateHandler(&user.TOUser{}), auth.PrivLevelOperations, nil, Authenticated, nil, 235433404},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `users/?$`, crudder.CreateHandler(&user.TOUser{}), auth.PrivLevelOperations, nil, Authenticated, nil, 276244816},
 
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `user/current/?$`, user.Current, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2610701614},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `user/current/?$`, user.ReplaceCurrent, auth.PrivLevelReadOnly, nil, Authenticated, nil, 220},
 
 		//Parameter: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `parameters/?$`, api.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2212554292},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `parameters/{id}$`, api.UpdateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2873936115},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `parameters/?$`, api.CreateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2669510859},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `parameters/{id}$`, api.DeleteHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 226277118},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `parameters/?$`, crudder.ReadHandler(&parameter.TOParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2212554292},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `parameters/{id}$`, crudder.UpdateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2873936115},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `parameters/?$`, crudder.CreateHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2669510859},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `parameters/{id}$`, crudder.DeleteHandler(&parameter.TOParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 226277118},
 
 		//Phys_Location: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `phys_locations/?$`, api.ReadHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 220405182},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `phys_locations/{id}$`, api.UpdateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 222795021},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `phys_locations/?$`, api.CreateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2246456648},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `phys_locations/{id}$`, api.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 25614221},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `phys_locations/?$`, crudder.ReadHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 220405182},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `phys_locations/{id}$`, crudder.UpdateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 222795021},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `phys_locations/?$`, crudder.CreateHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2246456648},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `phys_locations/{id}$`, crudder.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, nil, Authenticated, nil, 25614221},
 
 		//Ping
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `ping$`, ping.Handler, 0, nil, NoAuth, nil, 2555661597},
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `vault/ping/?$`, ping.Vault, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2884012114},
 
 		//Profile: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `profiles/?$`, api.ReadHandler(&profile.TOProfile{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 268758589},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `profiles/?$`, crudder.ReadHandler(&profile.TOProfile{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 268758589},
 
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `profiles/{id}$`, api.UpdateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 28439172},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profiles/?$`, api.CreateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2540211556},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `profiles/{id}$`, api.DeleteHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2205594465},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `profiles/{id}$`, crudder.UpdateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 28439172},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profiles/?$`, crudder.CreateHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2540211556},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `profiles/{id}$`, crudder.DeleteHandler(&profile.TOProfile{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2205594465},
 
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `profiles/{id}/export/?$`, profile.ExportProfileHandler, auth.PrivLevelReadOnly, nil, Authenticated, nil, 20133517},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profiles/import/?$`, profile.ImportProfileHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 206143208},
@@ -1043,10 +1044,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profiles/name/{new_profile}/copy/{existing_profile}`, profile.CopyProfileHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 206143209},
 
 		//Region: CRUDs
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `regions/?$`, api.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 210037085},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `regions/{id}$`, api.UpdateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 222308224},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `regions/?$`, api.CreateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2288334488},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `regions/?$`, api.DeleteHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2232626758},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `regions/?$`, crudder.ReadHandler(&region.TORegion{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 210037085},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `regions/{id}$`, crudder.UpdateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 222308224},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `regions/?$`, crudder.CreateHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2288334488},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `regions/?$`, crudder.DeleteHandler(&region.TORegion{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2232626758},
 
 		// get all edge servers associated with a delivery service (from deliveryservice_server table)
 
@@ -1054,7 +1055,7 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `deliveryserviceserver$`, dsserver.GetReplaceHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 229799788},
 		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryserviceserver/{dsid}/{serverid}`, dsserver.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 2532184523},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `deliveryservices/{xml_id}/servers$`, dsserver.GetCreateHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 2428181206},
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `servers/{id}/deliveryservices$`, api.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 233115411},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `servers/{id}/deliveryservices$`, crudder.ReadHandler(&dsserver.TODSSDeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 233115411},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `servers/{id}/deliveryservices$`, server.AssignDeliveryServicesToServerHandler, auth.PrivLevelOperations, nil, Authenticated, nil, 280128253},
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices/{id}/servers$`, dsserver.GetReadAssigned, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2345121223},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `deliveryservices/request`, deliveryservicerequests.Request, auth.PrivLevelPortal, nil, Authenticated, nil, 240875299},
@@ -1085,44 +1086,44 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `servers/{id}$`, server.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 292322233},
 
 		//Server Capability
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `server_capabilities$`, api.ReadHandler(&servercapability.TOServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 210407391},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `server_capabilities$`, api.CreateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2074470708},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `server_capabilities$`, api.DeleteHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 236415038},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `server_capabilities$`, crudder.ReadHandler(&servercapability.TOServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 210407391},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `server_capabilities$`, crudder.CreateHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2074470708},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `server_capabilities$`, crudder.DeleteHandler(&servercapability.TOServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 236415038},
 
 		//Server Server Capabilities: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `server_server_capabilities/?$`, api.ReadHandler(&server.TOServerServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2800231889},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `server_server_capabilities/?$`, api.CreateHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2293166834},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `server_server_capabilities/?$`, api.DeleteHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2058714058},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `server_server_capabilities/?$`, crudder.ReadHandler(&server.TOServerServerCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2800231889},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `server_server_capabilities/?$`, crudder.CreateHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2293166834},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `server_server_capabilities/?$`, crudder.DeleteHandler(&server.TOServerServerCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2058714058},
 
 		//Status: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `statuses/?$`, api.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2244905656},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `statuses/{id}$`, api.UpdateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2207966504},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `statuses/?$`, api.CreateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2369123612},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `statuses/{id}$`, api.DeleteHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 255111360},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `statuses/?$`, crudder.ReadHandler(&status.TOStatus{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2244905656},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `statuses/{id}$`, crudder.UpdateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2207966504},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `statuses/?$`, crudder.CreateHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2369123612},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `statuses/{id}$`, crudder.DeleteHandler(&status.TOStatus{}), auth.PrivLevelOperations, nil, Authenticated, nil, 255111360},
 
 		//System
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `system/info/?$`, systeminfo.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 221047475},
 
 		//Type: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `types/?$`, api.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2226701823},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `types/{id}$`, api.UpdateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 28860115},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `types/?$`, api.CreateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2513308195},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `types/{id}$`, api.DeleteHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23175773},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `types/?$`, crudder.ReadHandler(&types.TOType{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2226701823},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `types/{id}$`, crudder.UpdateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 28860115},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `types/?$`, crudder.CreateHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2513308195},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `types/{id}$`, crudder.DeleteHandler(&types.TOType{}), auth.PrivLevelOperations, nil, Authenticated, nil, 23175773},
 
 		//About
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `about/?$`, about.Handler(), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2317501166},
 
 		//Coordinates
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `coordinates/?$`, api.ReadHandler(&coordinate.TOCoordinate{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 296700745},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `coordinates/?$`, api.UpdateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 268926174},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `coordinates/?$`, api.CreateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2428112157},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `coordinates/?$`, api.DeleteHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2303849889},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `coordinates/?$`, crudder.ReadHandler(&coordinate.TOCoordinate{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 296700745},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `coordinates/?$`, crudder.UpdateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 268926174},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `coordinates/?$`, crudder.CreateHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2428112157},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `coordinates/?$`, crudder.DeleteHandler(&coordinate.TOCoordinate{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2303849889},
 
 		//CDN generic handlers:
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cdns/?$`, api.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2230318621},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2311178934},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cdns/?$`, api.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2160505289},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 227694657},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cdns/?$`, crudder.ReadHandler(&cdn.TOCDN{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2230318621},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `cdns/{id}$`, crudder.UpdateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2311178934},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cdns/?$`, crudder.CreateHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2160505289},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `cdns/{id}$`, crudder.DeleteHandler(&cdn.TOCDN{}), auth.PrivLevelOperations, nil, Authenticated, nil, 227694657},
 
 		//Delivery service requests
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservice_requests/?$`, dsrequest.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2681163935},
@@ -1135,10 +1136,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `deliveryservice_requests/{id}/status$`, dsrequest.PutStatus, auth.PrivLevelPortal, nil, Authenticated, nil, 268415099},
 
 		//Delivery service request comment: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservice_request_comments/?$`, api.ReadHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2032650737},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `deliveryservice_request_comments/?$`, api.UpdateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 260487847},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `deliveryservice_request_comments/?$`, api.CreateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 227227672},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryservice_request_comments/?$`, api.DeleteHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 299504668},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservice_request_comments/?$`, crudder.ReadHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2032650737},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `deliveryservice_request_comments/?$`, crudder.UpdateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 260487847},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `deliveryservice_request_comments/?$`, crudder.CreateHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 227227672},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryservice_request_comments/?$`, crudder.DeleteHandler(&comment.TODeliveryServiceRequestComment{}), auth.PrivLevelPortal, nil, Authenticated, nil, 299504668},
 
 		//Delivery service uri signing keys: CRUD
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.GetURIsignkeysHandler, auth.PrivLevelAdmin, nil, Authenticated, nil, 2293078558},
@@ -1147,29 +1148,29 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryservices/{xmlID}/urisignkeys$`, urisigning.RemoveDeliveryServiceURIKeysHandler, auth.PrivLevelAdmin, nil, Authenticated, nil, 229925417},
 
 		//Delivery Service Required Capabilities: CRUD
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices_required_capabilities/?$`, api.ReadHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2158522227},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `deliveryservices_required_capabilities/?$`, api.CreateHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2096873992},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryservices_required_capabilities/?$`, api.DeleteHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2496289304},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices_required_capabilities/?$`, crudder.ReadHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2158522227},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `deliveryservices_required_capabilities/?$`, crudder.CreateHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2096873992},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryservices_required_capabilities/?$`, crudder.DeleteHandler(&deliveryservice.RequiredCapability{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2496289304},
 
 		// Federations by CDN (the actual table for federation)
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cdns/{name}/federations/?$`, api.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 289225032},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cdns/{name}/federations/?$`, api.CreateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2954894219},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `cdns/{name}/federations/{id}$`, api.UpdateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 226065466},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `cdns/{name}/federations/{id}$`, api.DeleteHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2442852902},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cdns/{name}/federations/?$`, crudder.ReadHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 289225032},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cdns/{name}/federations/?$`, crudder.CreateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2954894219},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `cdns/{name}/federations/{id}$`, crudder.UpdateHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 226065466},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `cdns/{name}/federations/{id}$`, crudder.DeleteHandler(&cdnfederation.TOCDNFederation{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2442852902},
 
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `cdns/{name}/dnsseckeys/ksk/generate$`, cdn.GenerateKSK, auth.PrivLevelAdmin, nil, Authenticated, nil, 272924281},
 
 		//Origins
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `origins/?$`, api.ReadHandler(&origin.TOOrigin{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 244649256},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `origins/?$`, api.UpdateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 21567746},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `origins/?$`, api.CreateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2099561643},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `origins/?$`, api.DeleteHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 260273263},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `origins/?$`, crudder.ReadHandler(&origin.TOOrigin{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 244649256},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `origins/?$`, crudder.UpdateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 21567746},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `origins/?$`, crudder.CreateHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2099561643},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `origins/?$`, crudder.DeleteHandler(&origin.TOOrigin{}), auth.PrivLevelOperations, nil, Authenticated, nil, 260273263},
 
 		//Roles
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `roles/?$`, api.ReadHandler(&role.TORole{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 287088583},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `roles/?$`, api.UpdateHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2612897489},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `roles/?$`, api.CreateHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 230652406},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `roles/?$`, api.DeleteHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2356705982},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `roles/?$`, crudder.ReadHandler(&role.TORole{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 287088583},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `roles/?$`, crudder.UpdateHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2612897489},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `roles/?$`, crudder.CreateHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 230652406},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `roles/?$`, crudder.DeleteHandler(&role.TORole{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2356705982},
 
 		//Delivery Services Regexes
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices_regexes/?$`, deliveryservicesregexes.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 205501453},
@@ -1179,27 +1180,27 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryservices/{dsid}/regexes/{regexid}?$`, deliveryservicesregexes.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 2246731663},
 
 		//StaticDNSEntries
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `staticdnsentries/?$`, api.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 228939477},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `staticdnsentries/?$`, api.UpdateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 242457111},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `staticdnsentries/?$`, api.CreateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2629148238},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `staticdnsentries/?$`, api.DeleteHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2846031132},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `staticdnsentries/?$`, crudder.ReadHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 228939477},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `staticdnsentries/?$`, crudder.UpdateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 242457111},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `staticdnsentries/?$`, crudder.CreateHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2629148238},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `staticdnsentries/?$`, crudder.DeleteHandler(&staticdnsentry.TOStaticDNSEntry{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2846031132},
 
 		//ProfileParameters
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `profiles/{id}/parameters/?$`, profileparameter.GetProfileID, auth.PrivLevelReadOnly, nil, Authenticated, nil, 276464975},
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `profiles/name/{name}/parameters/?$`, profileparameter.GetProfileName, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2267737832},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profiles/name/{name}/parameters/?$`, profileparameter.PostProfileParamsByName, auth.PrivLevelOperations, nil, Authenticated, nil, 2355945582},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profiles/{id}/parameters/?$`, profileparameter.PostProfileParamsByID, auth.PrivLevelOperations, nil, Authenticated, nil, 216818708},
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `profileparameters/?$`, api.ReadHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 250609805},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profileparameters/?$`, api.CreateHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 228809693},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `profileparameters/?$`, crudder.ReadHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 250609805},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profileparameters/?$`, crudder.CreateHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 228809693},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `profileparameter/?$`, profileparameter.PostProfileParam, auth.PrivLevelOperations, nil, Authenticated, nil, 224275},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `parameterprofile/?$`, profileparameter.PostParamProfile, auth.PrivLevelOperations, nil, Authenticated, nil, 2080610861},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `profileparameters/{profileId}/{parameterId}$`, api.DeleteHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 224839529},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `profileparameters/{profileId}/{parameterId}$`, crudder.DeleteHandler(&profileparameter.TOProfileParameter{}), auth.PrivLevelOperations, nil, Authenticated, nil, 224839529},
 
 		//Tenants
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `tenants/?$`, api.ReadHandler(&apitenant.TOTenant{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2677967814},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `tenants/{id}$`, api.UpdateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2094131478},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `tenants/?$`, api.CreateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 217248013},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `tenants/{id}$`, api.DeleteHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 216365558},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `tenants/?$`, crudder.ReadHandler(&apitenant.TOTenant{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2677967814},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `tenants/{id}$`, crudder.UpdateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 2094131478},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `tenants/?$`, crudder.CreateHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 217248013},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `tenants/{id}$`, crudder.DeleteHandler(&apitenant.TOTenant{}), auth.PrivLevelOperations, nil, Authenticated, nil, 216365558},
 
 		//CRConfig
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `cdns/{cdn}/snapshot/?$`, crconfig.SnapshotGetHandler, auth.PrivLevelReadOnly, nil, Authenticated, nil, 2957273695},
@@ -1213,8 +1214,8 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `federations/?$`, federations.RemoveFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, nil, Authenticated, nil, 22098323},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `federations/?$`, federations.ReplaceFederationResolverMappingsForCurrentUser, auth.PrivLevelFederation, nil, Authenticated, nil, 2283182516},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `federations/{id}/deliveryservices/?$`, federations.PostDSes, auth.PrivLevelAdmin, nil, Authenticated, nil, 2682863513},
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `federations/{id}/deliveryservices/?$`, api.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 253773034},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?$`, api.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2417402570},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `federations/{id}/deliveryservices/?$`, crudder.ReadHandler(&federations.TOFedDSes{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 253773034},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `federations/{id}/deliveryservices/{dsID}/?$`, crudder.DeleteHandler(&federations.TOFedDSes{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2417402570},
 
 		// Federation Resolvers
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `federation_resolvers/?$`, federation_resolvers.Create, auth.PrivLevelAdmin, nil, Authenticated, nil, 2134373661},
@@ -1225,15 +1226,15 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 
 		// Federations Users
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `federations/{id}/users/?$`, federations.PostUsers, auth.PrivLevelAdmin, nil, Authenticated, nil, 2779334930},
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `federations/{id}/users/?$`, api.ReadHandler(&federations.TOUsers{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 294075015},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `federations/{id}/users/{userID}/?$`, api.DeleteHandler(&federations.TOUsers{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2949102882},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `federations/{id}/users/?$`, crudder.ReadHandler(&federations.TOUsers{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 294075015},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `federations/{id}/users/{userID}/?$`, crudder.DeleteHandler(&federations.TOUsers{}), auth.PrivLevelAdmin, nil, Authenticated, nil, 2949102882},
 
 		////DeliveryServices
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices/?$`, api.ReadHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2238317294},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices/?$`, crudder.ReadHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2238317294},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `deliveryservices/?$`, deliveryservice.CreateV15, auth.PrivLevelOperations, nil, Authenticated, nil, 206431432},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `deliveryservices/{id}/?$`, deliveryservice.UpdateV15, auth.PrivLevelOperations, nil, Authenticated, nil, 2766567527},
 		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `deliveryservices/{id}/safe/?$`, deliveryservice.UpdateSafe, auth.PrivLevelOperations, nil, Authenticated, nil, 247210931},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryservices/{id}/?$`, api.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, nil, Authenticated, nil, 222642074},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `deliveryservices/{id}/?$`, crudder.DeleteHandler(&deliveryservice.TODeliveryService{}), auth.PrivLevelOperations, nil, Authenticated, nil, 222642074},
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices/{id}/servers/eligible/?$`, deliveryservice.GetServersEligible, auth.PrivLevelReadOnly, nil, Authenticated, nil, 274761584},
 
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices/xmlId/{xmlid}/sslkeys$`, deliveryservice.GetSSLKeysByXMLID, auth.PrivLevelAdmin, nil, Authenticated, nil, 2135772907},
@@ -1255,10 +1256,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `deliveryservices/{id}/routing$`, crstats.GetDSRouting, auth.PrivLevelReadOnly, nil, Authenticated, nil, 66733983},
 
-		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `steering/{deliveryservice}/targets/?$`, api.ReadHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2569607824},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `steering/{deliveryservice}/targets/?$`, api.CreateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 2338216397},
-		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?$`, api.UpdateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 2438608295},
-		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?$`, api.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 2288021515},
+		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `steering/{deliveryservice}/targets/?$`, crudder.ReadHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelReadOnly, nil, Authenticated, nil, 2569607824},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPost, `steering/{deliveryservice}/targets/?$`, crudder.CreateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 2338216397},
+		{api.Version{Major: 2, Minor: 0}, http.MethodPut, `steering/{deliveryservice}/targets/{target}/?$`, crudder.UpdateHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 2438608295},
+		{api.Version{Major: 2, Minor: 0}, http.MethodDelete, `steering/{deliveryservice}/targets/{target}/?$`, crudder.DeleteHandler(&steeringtargets.TOSteeringTargetV11{}), auth.PrivLevelSteering, nil, Authenticated, nil, 2288021515},
 
 		// Stats Summary
 		{api.Version{Major: 2, Minor: 0}, http.MethodGet, `stats_summary/?$`, trafficstats.GetStatsSummary, auth.PrivLevelReadOnly, nil, Authenticated, nil, 280498598},

--- a/traffic_ops/traffic_ops_golang/server/detail.go
+++ b/traffic_ops/traffic_ops_golang/server/detail.go
@@ -37,9 +37,9 @@ import (
 )
 
 func GetDetailParamHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/server/put_status.go
+++ b/traffic_ops/traffic_ops_golang/server/put_status.go
@@ -66,13 +66,14 @@ func InvalidStatusForDeliveryServicesAlertText(prefix, serverType string, dsIDs 
 
 // UpdateStatusHandler is the handler for PUT requests to the /servers/{{ID}}/status API endpoint.
 func UpdateStatusHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	tx := inf.Tx.Tx
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
+	tx := inf.Tx.Tx
+
 	reqObj := tc.ServerPutStatus{}
 	if err := json.NewDecoder(r.Body).Decode(&reqObj); err != nil {
 		api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("malformed JSON: "+err.Error()), nil)

--- a/traffic_ops/traffic_ops_golang/server/queue_update.go
+++ b/traffic_ops/traffic_ops_golang/server/queue_update.go
@@ -35,9 +35,9 @@ import (
 // QueueUpdateHandler implements an http handler that updates a server's
 // upd_pending value.
 func QueueUpdateHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id"}, []string{"id"})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/routing/middleware"
@@ -849,7 +850,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 	}
 
 	servers, serverCount, userErr, sysErr, errCode, maxTime := getServers(r.Header, inf.Params, inf.Tx, inf.User, useIMS, *version)
-	if maxTime != nil && api.SetLastModifiedHeader(r, useIMS) {
+	if maxTime != nil && crudder.SetLastModifiedHeader(r, useIMS) {
 		api.AddLastModifiedHdr(w, *maxTime)
 	}
 	if errCode == http.StatusNotModified {
@@ -1567,15 +1568,15 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if server.CDNName != nil {
-		userErr, sysErr, statusCode = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	} else if server.CDNID != nil {
-		userErr, sysErr, statusCode = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}
@@ -1669,15 +1670,15 @@ func createV2(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if server.CDNName != nil {
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	} else if server.CDNID != nil {
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}
@@ -1754,15 +1755,15 @@ func createV3(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 	server.StatusLastUpdated = &currentTime
 
 	if server.CDNName != nil {
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	} else if server.CDNID != nil {
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}
@@ -1841,15 +1842,15 @@ func createV4(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 	server.StatusLastUpdated = &currentTime
 
 	if server.CDNName != nil {
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	} else if server.CDNID != nil {
-		userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}
@@ -2017,15 +2018,15 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	}
 	server := servers[0]
 	if server.CDNName != nil {
-		userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
-		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, *server.CDNName, inf.User.UserName)
+		if errs.Occurred() {
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	} else if server.CDNID != nil {
-		userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
+		errs := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(inf.Tx.Tx, int64(*server.CDNID), inf.User.UserName)
 		if userErr != nil || sysErr != nil {
-			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+			inf.HandleErrs(w, r, errs)
 			return
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -166,9 +166,9 @@ func AssignDeliveryServicesToServerHandler(w http.ResponseWriter, r *http.Reques
 		api.HandleErr(w, r, tx, errCode, nil, sysErr)
 		return
 	}
-	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(serverCDN), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(serverCDN), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	if len(dsList) > 0 {
@@ -187,7 +187,7 @@ func AssignDeliveryServicesToServerHandler(w http.ResponseWriter, r *http.Reques
 	if replace && (serverInfo.Status == tc.CacheStatusOnline.String() || serverInfo.Status == tc.CacheStatusReported.String()) {
 		currentDSIDs, err := checkForLastServerInActiveDeliveryServices(server, serverInfo.Type, dsList, tx)
 		if err != nil {
-			sysErr = fmt.Errorf("checking for deliveryservices to which server #%d is the last assigned: %v", server, err)
+			sysErr := fmt.Errorf("checking for deliveryservices to which server #%d is the last assigned: %v", server, err)
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
 			return
 		}

--- a/traffic_ops/traffic_ops_golang/server/servers_server_capability.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_server_capability.go
@@ -123,7 +123,7 @@ func (ssc TOServerServerCapability) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (ssc *TOServerServerCapability) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (ssc *TOServerServerCapability) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(ssc.APIInfo(), "serverHostName")
 	return crudder.GenericRead(h, ssc, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/server/servers_server_capability.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_server_capability.go
@@ -315,7 +315,8 @@ func (ssc *TOServerServerCapability) Create() (error, error, int) {
 
 	resultRows, err := tx.NamedQuery(scInsertQuery(), ssc)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer resultRows.Close()
 
@@ -375,7 +376,7 @@ SELECT ARRAY(
 	SELECT dsrc.deliveryservice_id
 	FROM deliveryservices_required_capability as dsrc
 	WHERE deliveryservice_id IN (
-		SELECT deliveryservice 
+		SELECT deliveryservice
 		FROM deliveryservice_server
 		WHERE server = $1)
 	AND dsrc.required_capability = $2)`

--- a/traffic_ops/traffic_ops_golang/server/servers_server_capability_test.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_server_capability_test.go
@@ -22,23 +22,23 @@ package server
 import (
 	"testing"
 
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 )
 
 func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOServerServerCapability{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("ServerServerCapability must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("ServerServerCapability must be Reader")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("ServerServerCapability must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("ServerServerCapability must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/server/servers_test.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_test.go
@@ -157,13 +157,13 @@ func TestUpdateServer(t *testing.T) {
 		ID:       &testServers[0].Server.ID,
 	}
 
-	userErr, _, errCode := checkTypeChangeSafety(s, db.MustBegin())
-	if errCode != 409 {
-		t.Errorf("Update servers: Expected error code of %v, but got %v", 409, errCode)
+	errs := checkTypeChangeSafety(s, db.MustBegin())
+	if errs.Code != 409 {
+		t.Errorf("Update servers: Expected error code of %v, but got %v", 409, errs.Code)
 	}
 	expectedErr := "server cdn can not be updated when it is currently assigned to delivery services"
-	if userErr == nil {
-		t.Errorf("Update expected error: %v, but got no error with status: %s", expectedErr, http.StatusText(errCode))
+	if errs.UserError == nil {
+		t.Errorf("Update expected error: %v, but got no error with status: %s", expectedErr, http.StatusText(errs.Code))
 	}
 }
 
@@ -265,9 +265,9 @@ func TestGetServersByCachegroup(t *testing.T) {
 
 	version := api.Version{Major: 4, Minor: 0}
 
-	servers, _, userErr, sysErr, errCode, _ := getServers(nil, v, db.MustBegin(), &user, false, version)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("getServers expected: no errors, actual: %v %v with status: %s", userErr, sysErr, http.StatusText(errCode))
+	servers, _, errs, _ := getServers(nil, v, db.MustBegin(), &user, false, version)
+	if errs.Occurred() {
+		t.Errorf("getServers expected: no errors, actual: %s", errs)
 	}
 
 	if len(servers) != 3 {
@@ -372,10 +372,10 @@ func TestGetMidServers(t *testing.T) {
 
 	user := auth.CurrentUser{}
 	version := api.Version{Major: 3, Minor: 0}
-	servers, _, userErr, sysErr, errCode, _ := getServers(nil, v, db.MustBegin(), &user, false, version)
+	servers, _, errs, _ := getServers(nil, v, db.MustBegin(), &user, false, version)
 
-	if userErr != nil || sysErr != nil {
-		t.Errorf("getServers expected: no errors, actual: %v %v with status: %s", userErr, sysErr, http.StatusText(errCode))
+	if errs.Occurred() {
+		t.Errorf("getServers expected: no errors, actual: %s", errs)
 	}
 
 	cols2 := test.ColsFromStructByTag("db", tc.CommonServerProperties{})
@@ -481,10 +481,10 @@ func TestGetMidServers(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT").WillReturnRows(rows2)
-	mid, userErr, sysErr, errCode := getMidServers(serverIDs, serverMap, 0, 0, db.MustBegin(), false)
+	mid, errs := getMidServers(serverIDs, serverMap, 0, 0, db.MustBegin(), false)
 
-	if userErr != nil || sysErr != nil {
-		t.Fatalf("getMidServers expected: no errors, actual: %v %v with status: %s", userErr, sysErr, http.StatusText(errCode))
+	if errs.Occurred() {
+		t.Fatalf("getMidServers expected: no errors, actual: %s", errs)
 	}
 	if len(mid) != 1 {
 		t.Fatalf("getMidServers expected: len(mid) == 1, actual: %v", len(mid))

--- a/traffic_ops/traffic_ops_golang/server/servers_update_status.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_update_status.go
@@ -32,9 +32,9 @@ import (
 )
 
 func GetServerUpdateStatusHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"host_name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"host_name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/server/update.go
+++ b/traffic_ops/traffic_ops_golang/server/update.go
@@ -33,9 +33,9 @@ import (
 
 // UpdateHandler implements an http handler that updates a server's upd_pending and reval_pending values.
 func UpdateHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"id-or-name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
+++ b/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
@@ -117,26 +117,22 @@ func (v *TOServerCapability) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (v *TOServerCapability) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (v *TOServerCapability) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(v.APIInfo(), "name")
 	return crudder.GenericRead(h, v, useIMS)
 }
 
 func (v *TOServerCapability) Update(h http.Header) api.Errors {
-	sc, userErr, sysErr, errCode, _ := v.Read(h, false)
-	if userErr != nil || sysErr != nil {
-		return api.Errors{
-			UserError:   userErr,
-			SystemError: sysErr,
-			Code:        errCode,
-		}
+	sc, errs, _ := v.Read(h, false)
+	if errs.Occurred() {
+		return errs
 	}
 	if len(sc) != 1 {
 		return api.Errors{UserError: errors.New("cannot find exactly one server capability with the query string provided"), Code: http.StatusBadRequest}
 	}
 
 	// check if the entity was already updated
-	errs := api.CheckIfUnModifiedByName(h, v.ReqInfo.Tx, v.Name, "server_capability")
+	errs = api.CheckIfUnModifiedByName(h, v.ReqInfo.Tx, v.Name, "server_capability")
 	if errs.Occurred() {
 		return errs
 	}

--- a/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
+++ b/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
@@ -145,7 +145,8 @@ func (v *TOServerCapability) Update(h http.Header) (error, error, int) {
 	for rows.Next() {
 		err = rows.Scan(&v.Name, &v.LastUpdated)
 		if err != nil {
-			return api.ParseDBError(err)
+			errs := api.ParseDBError(err)
+			return errs.UserError, errs.SystemError, errs.Code
 		}
 	}
 	return nil, nil, http.StatusOK

--- a/traffic_ops/traffic_ops_golang/servercheck/extensions/extension.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/extensions/extension.go
@@ -280,7 +280,8 @@ func deleteServerCheckExtension(id int, tx *sqlx.Tx) (error, error, int) {
 
 	result, err := tx.NamedExec(updateQuery(), openTOExt)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 
 	if rowsAffected, err := result.RowsAffected(); err != nil {

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -101,9 +101,9 @@ WHERE (type.name = 'CHECK_EXTENSION_BOOL' OR
 
 // CreateUpdateServercheck handles creating or updating an existing servercheck
 func CreateUpdateServercheck(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -196,14 +196,14 @@ DO UPDATE SET %[1]s = EXCLUDED.%[1]s`, colName)
 
 // ReadServerCheck is the handler for GET requests for /servercheck
 func ReadServerCheck(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	tx := inf.Tx.Tx
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
+	tx := inf.Tx.Tx
 	data, userErr, sysErr, errCode := handleReadServerCheck(inf, tx)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
+++ b/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
@@ -31,7 +31,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
-	"github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation"
 )
 
 type TOServiceCategory struct {
@@ -150,8 +150,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := inf.Tx.Tx.Exec(updateQuery(), newSC.Name, name)
 	if err != nil {
-		userErr, sysErr, errCode = api.ParseDBError(err)
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		inf.HandleErrs(w, r, api.ParseDBError(err))
 		return
 	}
 	api.CreateChangeLogRawTx(api.ApiChange, api.Updated+" Service Category from "+name+" to "+newSC.Name, inf.User, inf.Tx.Tx)

--- a/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
+++ b/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	validation "github.com/go-ozzo/ozzo-validation"
 )
@@ -99,13 +100,13 @@ func (serviceCategory TOServiceCategory) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (serviceCategory *TOServiceCategory) Create() (error, error, int) {
-	return api.GenericCreate(serviceCategory)
+func (serviceCategory *TOServiceCategory) Create() api.Errors {
+	return crudder.GenericCreate(serviceCategory)
 }
 
 func (serviceCategory *TOServiceCategory) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
 	api.DefaultSort(serviceCategory.APIInfo(), "name")
-	serviceCategories, userErr, sysErr, errCode, maxTime := api.GenericRead(h, serviceCategory, useIMS)
+	serviceCategories, userErr, sysErr, errCode, maxTime := crudder.GenericRead(h, serviceCategory, useIMS)
 	if userErr != nil || sysErr != nil {
 		return nil, userErr, sysErr, errCode, nil
 	}
@@ -114,9 +115,9 @@ func (serviceCategory *TOServiceCategory) Read(h http.Header, useIMS bool) ([]in
 }
 
 func Update(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -157,8 +158,8 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Service Category update from "+name+" to "+newSC.Name+" was successful.", resp)
 }
 
-func (serviceCategory *TOServiceCategory) Delete() (error, error, int) {
-	return api.GenericDelete(serviceCategory)
+func (serviceCategory *TOServiceCategory) Delete() api.Errors {
+	return crudder.GenericDelete(serviceCategory)
 }
 
 func insertQuery() string {

--- a/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
+++ b/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
@@ -104,14 +104,10 @@ func (serviceCategory *TOServiceCategory) Create() api.Errors {
 	return crudder.GenericCreate(serviceCategory)
 }
 
-func (serviceCategory *TOServiceCategory) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (serviceCategory *TOServiceCategory) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(serviceCategory.APIInfo(), "name")
-	serviceCategories, userErr, sysErr, errCode, maxTime := crudder.GenericRead(h, serviceCategory, useIMS)
-	if userErr != nil || sysErr != nil {
-		return nil, userErr, sysErr, errCode, nil
-	}
-
-	return serviceCategories, nil, nil, errCode, maxTime
+	serviceCategories, errs, maxTime := crudder.GenericRead(h, serviceCategory, useIMS)
+	return serviceCategories, errs, maxTime
 }
 
 func Update(w http.ResponseWriter, r *http.Request) {

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
@@ -138,7 +138,7 @@ func (staticDNSEntry TOStaticDNSEntry) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(errs))
 }
 
-func (en *TOStaticDNSEntry) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (en *TOStaticDNSEntry) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(en.APIInfo(), "host")
 	return crudder.GenericRead(h, en, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
@@ -27,6 +27,7 @@ import (
 
 	util "github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -52,19 +53,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOStaticDNSEntry{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("staticDNSEntry must be creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("staticDNSEntry must be reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("staticDNSEntry must be updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("staticDNSEntry must be deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("staticDNSEntry must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/status/statuses.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 	validation "github.com/go-ozzo/ozzo-validation"
@@ -106,7 +107,7 @@ func (status TOStatus) Validate() error {
 func (st *TOStatus) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
 	errCode := http.StatusOK
 	api.DefaultSort(st.APIInfo(), "name")
-	readVals, userErr, sysErr, errCode, maxTime := api.GenericRead(h, st, useIMS)
+	readVals, userErr, sysErr, errCode, maxTime := crudder.GenericRead(h, st, useIMS)
 	if userErr != nil || sysErr != nil {
 		return nil, userErr, sysErr, errCode, nil
 	}
@@ -114,7 +115,7 @@ func (st *TOStatus) Read(h http.Header, useIMS bool) ([]interface{}, error, erro
 	for _, iStatus := range readVals {
 		status, ok := iStatus.(*TOStatus)
 		if !ok {
-			return nil, nil, fmt.Errorf("TOStatus.Read: api.GenericRead returned unexpected type %T\n", iStatus), http.StatusInternalServerError, nil
+			return nil, nil, fmt.Errorf("TOStatus.Read: crudder.GenericRead returned unexpected type %T\n", iStatus), http.StatusInternalServerError, nil
 		}
 		if status.SQLDescription.Valid {
 			status.Description = &status.SQLDescription.String
@@ -124,9 +125,9 @@ func (st *TOStatus) Read(h http.Header, useIMS bool) ([]interface{}, error, erro
 	return readVals, nil, nil, errCode, maxTime
 }
 
-func (st *TOStatus) Update(h http.Header) (error, error, int) { return api.GenericUpdate(h, st) }
-func (st *TOStatus) Create() (error, error, int)              { return api.GenericCreate(st) }
-func (st *TOStatus) Delete() (error, error, int)              { return api.GenericDelete(st) }
+func (st *TOStatus) Update(h http.Header) api.Errors { return crudder.GenericUpdate(h, st) }
+func (st *TOStatus) Create() api.Errors              { return crudder.GenericCreate(st) }
+func (st *TOStatus) Delete() api.Errors              { return crudder.GenericDelete(st) }
 
 func selectQuery() string {
 	return `

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -97,19 +98,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOStatus{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("Status must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("Status must be Reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("Status must be Updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("Status must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("Status must be Identifier")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -84,9 +84,9 @@ func TestReadStatuses(t *testing.T) {
 		tc.StatusNullable{},
 		sql.NullString{},
 	}
-	statuses, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	statuses, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(statuses) != 2 {

--- a/traffic_ops/traffic_ops_golang/steering/steering.go
+++ b/traffic_ops/traffic_ops_golang/steering/steering.go
@@ -33,9 +33,9 @@ import (
 )
 
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
@@ -214,7 +214,8 @@ func (st *TOSteeringTargetV11) Create() (error, error, int) {
 
 	rows, err := st.ReqInfo.Tx.NamedQuery(insertQuery(), st)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer rows.Close()
 
@@ -275,7 +276,8 @@ func (st *TOSteeringTargetV11) Update(h http.Header) (error, error, int) {
 
 	rows, err := st.ReqInfo.Tx.NamedQuery(updateQuery(), st)
 	if err != nil {
-		return api.ParseDBError(err)
+		errs := api.ParseDBError(err)
+		return errs.UserError, errs.SystemError, errs.Code
 	}
 	defer rows.Close()
 

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
@@ -296,7 +296,7 @@ func (st *TOSteeringTargetV11) Update(h http.Header) api.Errors {
 	}
 
 	if !api.IsUnmodified(h, *existingLastUpdated) {
-		return api.ModifiedError()
+		return api.NewModifiedError()
 	}
 
 	rows, err := st.ReqInfo.Tx.NamedQuery(updateQuery(), st)

--- a/traffic_ops/traffic_ops_golang/systeminfo/system_info.go
+++ b/traffic_ops/traffic_ops_golang/systeminfo/system_info.go
@@ -32,9 +32,9 @@ import (
 )
 
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/topology/queue_update.go
+++ b/traffic_ops/traffic_ops_golang/topology/queue_update.go
@@ -61,9 +61,9 @@ func Validate(reqObj tc.TopologiesQueueUpdateRequest, topologyName tc.TopologyNa
 
 // QueueUpdateHandler queues server updates for all servers in all cachegroups included in a given topology.
 func QueueUpdateHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, []string{})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"name"}, []string{})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -156,7 +156,7 @@ func (topology *TOTopology) Validate() error {
 
 	//Get current Topology-CG for the requested change.
 	topoCachegroupNames := topology.getCachegroupNames()
-	userErr, sysErr, _ = dbhelpers.CheckTopologyOrgServerCGInDSCG(topology.ReqInfo.Tx.Tx, dsCDNs, currentTopoName, topoCachegroupNames)
+	userErr, sysErr, _ := dbhelpers.CheckTopologyOrgServerCGInDSCG(topology.ReqInfo.Tx.Tx, dsCDNs, currentTopoName, topoCachegroupNames)
 	if userErr != nil {
 		return userErr
 	}

--- a/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
@@ -33,9 +33,9 @@ import (
 
 // GetStatsSummary handler for getting stats summaries
 func GetStatsSummary(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{}, []string{})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{}, []string{})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -113,9 +113,9 @@ func queryStatsSummary(tx *sqlx.Tx, q string, queryValues map[string]interface{}
 
 // CreateStatsSummary handler for creating stats summaries
 func CreateStatsSummary(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{}, []string{})
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{}, []string{})
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -106,7 +106,7 @@ func (typ *TOType) Validate() error {
 	return nil
 }
 
-func (tp *TOType) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
+func (tp *TOType) Read(h http.Header, useIMS bool) ([]interface{}, api.Errors, *time.Time) {
 	api.DefaultSort(tp.APIInfo(), "name")
 	return crudder.GenericRead(h, tp, useIMS)
 }

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -22,7 +22,6 @@ package types
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -31,6 +30,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc/tovalidate"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 	validation "github.com/go-ozzo/ozzo-validation"
@@ -108,28 +108,31 @@ func (typ *TOType) Validate() error {
 
 func (tp *TOType) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
 	api.DefaultSort(tp.APIInfo(), "name")
-	return api.GenericRead(h, tp, useIMS)
+	return crudder.GenericRead(h, tp, useIMS)
 }
 
-func (tp *TOType) Update(h http.Header) (error, error, int) {
+func (tp *TOType) Update(h http.Header) api.Errors {
 	if !tp.AllowMutation(false) {
-		return errors.New("can not update type"), nil, http.StatusBadRequest
+		return api.Errors{UserError: errors.New("can not update type"), Code: http.StatusBadRequest}
 	}
-	return api.GenericUpdate(h, tp)
+	return crudder.GenericUpdate(h, tp)
 }
 
-func (tp *TOType) Delete() (error, error, int) {
+func (tp *TOType) Delete() api.Errors {
 	if !tp.AllowMutation(false) {
-		return errors.New(fmt.Sprintf("can not delete type")), nil, http.StatusBadRequest
+		return api.Errors{UserError: errors.New("can not delete type"), Code: http.StatusBadRequest}
 	}
-	return api.GenericDelete(tp)
+	return crudder.GenericDelete(tp)
 }
 
-func (tp *TOType) Create() (error, error, int) {
+func (tp *TOType) Create() api.Errors {
 	if !tp.AllowMutation(true) {
-		return errors.New("can not create type"), nil, http.StatusBadRequest
+		return api.Errors{
+			Code:      http.StatusBadRequest,
+			UserError: errors.New("can not create type"),
+		}
 	}
-	return api.GenericCreate(tp)
+	return crudder.GenericCreate(tp)
 }
 
 func (tp *TOType) AllowMutation(forCreation bool) bool {

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -93,9 +93,9 @@ func TestGetType(t *testing.T) {
 		api.APIInfoImpl{ReqInfo: &reqInfo},
 		tc.TypeNullable{},
 	}
-	types, userErr, sysErr, _, _ := obj.Read(nil, false)
-	if userErr != nil || sysErr != nil {
-		t.Errorf("Read expected: no errors, actual: %v %v", userErr, sysErr)
+	types, errs, _ := obj.Read(nil, false)
+	if errs.Occurred() {
+		t.Errorf("Read expected: no errors, actual: %s", errs)
 	}
 
 	if len(types) != 2 {

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/crudder"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -107,19 +108,19 @@ func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOType{}
 
-	if _, ok := i.(api.Creator); !ok {
+	if _, ok := i.(crudder.Creator); !ok {
 		t.Errorf("Type must be Creator")
 	}
-	if _, ok := i.(api.Reader); !ok {
+	if _, ok := i.(crudder.Reader); !ok {
 		t.Errorf("Type must be Reader")
 	}
-	if _, ok := i.(api.Updater); !ok {
+	if _, ok := i.(crudder.Updater); !ok {
 		t.Errorf("Type must be Updater")
 	}
-	if _, ok := i.(api.Deleter); !ok {
+	if _, ok := i.(crudder.Deleter); !ok {
 		t.Errorf("Type must be Deleter")
 	}
-	if _, ok := i.(api.Identifier); !ok {
+	if _, ok := i.(crudder.Identifier); !ok {
 		t.Errorf("Type must be Identifier")
 	}
 }
@@ -146,11 +147,11 @@ func createDummyType(field string) *TOType {
 
 func TestUpdateInvalidType(t *testing.T) {
 	invalidUpdateType := createDummyType("test")
-	err, _, statusCode := invalidUpdateType.Update(nil)
-	if err == nil {
+	errs := invalidUpdateType.Update(nil)
+	if errs.UserError == nil {
 		t.Fatalf("expected update type tp have an error")
 	}
-	if statusCode != http.StatusBadRequest {
+	if errs.Code != http.StatusBadRequest {
 		t.Fatalf("expected update to return a 400 error")
 	}
 }
@@ -158,11 +159,11 @@ func TestUpdateInvalidType(t *testing.T) {
 func TestDeleteInvalidType(t *testing.T) {
 	invalidDeleteType := createDummyType("other")
 
-	err, _, statusCode := invalidDeleteType.Delete()
-	if err == nil {
+	errs := invalidDeleteType.Delete()
+	if errs.UserError == nil {
 		t.Fatalf("expected delete type to have an error")
 	}
-	if statusCode != http.StatusBadRequest {
+	if errs.Code != http.StatusBadRequest {
 		t.Fatalf("expected delete type to return a %v error", http.StatusBadRequest)
 	}
 }
@@ -170,12 +171,12 @@ func TestDeleteInvalidType(t *testing.T) {
 func TestCreateInvalidType(t *testing.T) {
 	invalidCreateType := createDummyType("test")
 
-	err, _, statusCode := invalidCreateType.Create()
-	if err == nil {
-		t.Fatalf("expected create type to have an error")
+	errs := invalidCreateType.Create()
+	if !errs.Occurred() {
+		t.Error("expected create type to have an error")
 	}
-	if statusCode != http.StatusBadRequest {
-		t.Fatalf("expected create type to return a %v error", http.StatusBadRequest)
+	if errs.Code != http.StatusBadRequest {
+		t.Errorf("expected create type to return a %v error", http.StatusBadRequest)
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
+++ b/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
@@ -38,9 +38,9 @@ import (
 
 // endpoint handler for fetching uri signing keys from riak
 func GetURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -72,11 +72,11 @@ func GetURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
 	api.WriteAndLogErr(w, r, ro)
 }
 
-// removeDeliveryServiceURIKeysHandler is the HTTP DELETE handler used to remove urisigning keys assigned to a delivery service.
+// RemoveDeliveryServiceURIKeysHandler is the HTTP DELETE handler used to remove urisigning keys assigned to a delivery service.
 func RemoveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
@@ -132,11 +132,11 @@ func RemoveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request)
 	return
 }
 
-// saveDeliveryServiceURIKeysHandler is the HTTP POST or PUT handler used to store urisigning keys to a delivery service.
+// SaveDeliveryServiceURIKeysHandler is the HTTP POST or PUT handler used to store urisigning keys to a delivery service.
 func SaveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, nil, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()

--- a/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
+++ b/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
@@ -108,9 +108,9 @@ func RemoveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request)
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 		return
 	}
-	userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	_, found, err := inf.Vault.GetURISigningKeys(xmlID, inf.Tx.Tx, r.Context())
@@ -168,9 +168,9 @@ func SaveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 		return
 	}
-	userErr, sysErr, errCode = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	errs = dbhelpers.CheckIfCurrentUserCanModifyCDN(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	data, err := ioutil.ReadAll(r.Body)

--- a/traffic_ops/traffic_ops_golang/vault/bucket.go
+++ b/traffic_ops/traffic_ops_golang/vault/bucket.go
@@ -39,15 +39,15 @@ func GetBucketKeyDeprecated(w http.ResponseWriter, r *http.Request) {
 }
 
 func getBucketKey(w http.ResponseWriter, r *http.Request, a tc.Alerts) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"bucket", "key"}, nil)
-	if userErr != nil || sysErr != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+	inf, errs := api.NewInfo(r, []string{"bucket", "key"}, nil)
+	if errs.Occurred() {
+		inf.HandleErrs(w, r, errs)
 		return
 	}
 	defer inf.Close()
 
 	if !inf.Config.TrafficVaultEnabled {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, userErr, errors.New("getting bucket key: Traffic Vault is not configured"))
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting bucket key: Traffic Vault is not configured"))
 		return
 	}
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This adds a new, fairly small package to Traffic Ops: `apierrors`. It exposes a structure for containing a user-facing error, a system-only error, and an HTTP response code, like so:

```go
type Errors struct {
	Code        int
	SystemError error
	UserError   error
}
```

This is meant to replace the `(error, error, int)` and `(int, error, error)` call signatures common throughout TO code. In fact, this PR changes such signatures to unify them all to return just that `Errors` structure instead. As well as making the TO codebase more compliant with the convention that "error values should be last function return signatures" - which is followed throughout the Go standard library, but is not actually enforced within our project - this eliminates any confusion about which error in the return signature is meant for clients and which is only meant for logs. It also makes it harder to make mistakes regarding those associations by making the assignment and use of such errors more explicit.

It also adds helper functions similar to those that already exist for the old, "exploded" format of passing in all three bits of information separately, which allows one to change comparatively complex error handling into something much simpler:
```go
// The old way
inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
if userErr != nil || sysErr != nil {
	api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
}

// The new way
inf, errs := api.NewInfo(r, nil, nil)
if errs.Occurred() {
	inf.HandleErrs(w, r, errs)
	return
}
```

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
All existing API and unit tests should pass. This PR adds a few tests related to the new `Errors` structure, as well.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation in the form of GoDocs - nothing external has changed, so no other documentation is necessary
- [x] An update to CHANGELOG.md is not necessary for refactors
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**