### PR TITLE
Only run Last-Server-In-Cache Group validation when Cache Group has changed

### DIFF
--- a/traffic_ops/testing/api/v3/servers_test.go
+++ b/traffic_ops/testing/api/v3/servers_test.go
@@ -82,10 +82,16 @@ func LastServerInTopologyCacheGroup(t *testing.T) {
 	if len(cgs) != expectedLength {
 		t.Fatalf("expected %d cachegroup with hostname %s, received %d cachegroups", expectedLength, moveToCacheGroup, len(cgs))
 	}
+
+	_, _, err = TOSession.UpdateServerByID(*server.ID, server)
+	if err != nil {
+		t.Fatalf("error updating server with hostname %s without moving it to a different cachegroup: %s", *server.HostName, err.Error())
+	}
+
 	*server.CachegroupID = *cgs[0].ID
 	_, _, err = TOSession.UpdateServerByID(*server.ID, server)
 	if err == nil {
-		t.Fatalf("expected an error moving server with id %d to a different cachegroup, received no error", *server.ID)
+		t.Fatalf("expected an error moving server with id %s to a different cachegroup, received no error", *server.HostName)
 	}
 	if reqInf.StatusCode < http.StatusBadRequest || reqInf.StatusCode >= http.StatusInternalServerError {
 		t.Fatalf("expected a 400-level error moving server with id %d to a different cachegroup, got status code %d: %s", *server.ID, reqInf.StatusCode, err.Error())

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -3599,7 +3599,7 @@
             "cachegroup": "topology-mid-cg-01",
             "cdnName": "cdn2",
             "domainName": "kabletown.net",
-            "hostName": "midInTopologyEdgeCg01",
+            "hostName": "midInTopologyMidCg01",
             "httpsPort": 443,
             "interfaces": [
                 {
@@ -3633,7 +3633,7 @@
             "cachegroup": "topology-mid-cg-02",
             "cdnName": "cdn2",
             "domainName": "kabletown.net",
-            "hostName": "midInTopologyEdgeCg02",
+            "hostName": "midInTopologyMidCg02",
             "httpsPort": 443,
             "interfaces": [
                 {
@@ -3667,7 +3667,7 @@
             "cachegroup": "topology-mid-cg-03",
             "cdnName": "cdn2",
             "domainName": "kabletown.net",
-            "hostName": "midInTopologyEdgeCg03",
+            "hostName": "midInTopologyMidCg03",
             "httpsPort": 443,
             "interfaces": [
                 {
@@ -3701,7 +3701,7 @@
             "cachegroup": "topology-mid-cg-04",
             "cdnName": "cdn2",
             "domainName": "kabletown.net",
-            "hostName": "midInTopologyEdgeCg04",
+            "hostName": "midInTopologyMidCg04",
             "httpsPort": 443,
             "interfaces": [
                 {
@@ -3735,7 +3735,7 @@
             "cachegroup": "topology-mid-cg-05",
             "cdnName": "cdn2",
             "domainName": "kabletown.net",
-            "hostName": "midInTopologyEdgeCg05",
+            "hostName": "midInTopologyMidCg05",
             "httpsPort": 443,
             "interfaces": [
                 {
@@ -3769,7 +3769,7 @@
             "cachegroup": "topology-mid-cg-06",
             "cdnName": "cdn2",
             "domainName": "kabletown.net",
-            "hostName": "midInTopologyEdgeCg06",
+            "hostName": "midInTopologyMidCg06",
             "httpsPort": 443,
             "interfaces": [
                 {
@@ -3803,7 +3803,7 @@
             "cachegroup": "topology-mid-cg-07",
             "cdnName": "cdn2",
             "domainName": "kabletown.net",
-            "hostName": "midInTopologyEdgeCg07",
+            "hostName": "midInTopologyMidCg07",
             "httpsPort": 443,
             "interfaces": [
                 {

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -1226,9 +1226,11 @@ func Update(w http.ResponseWriter, r *http.Request) {
 
 		cacheGroupIds := []int{*origSer[0].CachegroupID}
 		serverIds := []int{*origSer[0].ID}
-		if err := topology.CheckForEmptyCacheGroups(inf.Tx, cacheGroupIds, true, serverIds); err != nil {
-			api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("server is the last one in its cachegroup, which is used by a topology, so it cannot be moved to another cachegroup: "+err.Error()), nil)
-			return
+		if *origSer[0].CachegroupID != *newServer.CachegroupID {
+			if err = topology.CheckForEmptyCacheGroups(inf.Tx, cacheGroupIds, true, serverIds); err != nil {
+				api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("server is the last one in its cachegroup, which is used by a topology, so it cannot be moved to another cachegroup: "+err.Error()), nil)
+				return
+			}
 		}
 
 		server, err = newServer.ToServerV2()


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5165 OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
- This PR makes Last-Server-In-Cache Group validation from #5155 only run if the Cache Group has changed

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run API tests or

1. Make a Cache Group
2. Make a Server
3. Add the Server to the Cache Group
4. Make a Topology
5. Add the Server to the Topology
6. Update the Server without changing anything

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
 - master (bda1a51d70)


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] Intended behavior is unchanged, no documentation necessary
- [x] Bugfix for a feature not yet in a release, no CHANGELOG.md entry necessary
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
