### PR TITLE
TP: do not mark DSR (ds request) complete if ds update fails due to validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added default sort logic to GET API calls using Read()
 
 ### Fixed
+- Fixed #5188 - DSR (delivery service request) incorrectly marked as complete and error message not displaying when DSR fulfilled and DS update fails in Traffic Portal. [Related Github issues](https://github.com/apache/trafficcontrol/issues/5188)
 - Fixed #3455 - Alphabetically sorting CDN Read API call [Related Github issues](https://github.com/apache/trafficcontrol/issues/3455)
 - Fixed #5010 - Fixed Reference urls for Cache Config on Delivery service pages (HTTP, DNS) in Traffic Portal. [Related Github issues](https://github.com/apache/trafficcontrol/issues/5010)
 - Fixed #5147 - GET /servers?dsId={id} should only return mid servers (in addition to edge servers) for the cdn of the delivery service if the mid tier is employed. [Related github issues](https://github.com/apache/trafficcontrol/issues/5147)

--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -150,7 +150,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 						// assign the ds request
 						promises.push(deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.id));
 						// set the status to 'complete'
-						promises.push(deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, 'complete'));
+						promises.push(deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, 'submitted'));
 					}
 				}
 			);
@@ -234,13 +234,20 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 							deliveryServiceService.updateDeliveryService(deliveryService).
 								then(
 									function() {
+										// upon successful update of ds, set the dsr to 'complete'
+										deliveryServiceRequestService.getDeliveryServiceRequests({ xmlId: deliveryService.xmlId, status: 'submitted' }).then(
+											function(response) {
+												deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response[0].id, 'complete');
+											}
+										);
 										$state.reload(); // reloads all the resolves for the view
 										messageModel.setMessages([ { level: 'success', text: 'Delivery Service [ ' + deliveryService.xmlId + ' ] updated' } ], false);
 									}
 								).catch(function(fault) {
-									$anchorScroll(); // scrolls window to top
-									messageModel.setMessages(fault.data.alerts, false);
-								});
+									// if the ds update fails, send to dsr view w/ error message
+									locationUtils.navigateToPath('/delivery-service-requests');
+									messageModel.setMessages(fault.data.alerts, true);
+							});
 						}).catch(function(fault) {
 							$anchorScroll(); // scrolls window to top
 							messageModel.setMessages(fault.data.alerts, false);

--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -149,7 +149,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 					if (autoFulfilled) {
 						// assign the ds request
 						promises.push(deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.id));
-						// set the status to 'complete'
+						// set the status to 'submitted'
 						promises.push(deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, 'submitted'));
 					}
 				}


### PR DESCRIPTION
- [x] This PR fixes #5188 

If DSRs are enabled in traffic_portal_properties.json and your user has the override role, when you make a change to an existing DS, you must create a DSR first and you have the following options:

![image](https://user-images.githubusercontent.com/251272/97235182-f148f600-17a7-11eb-9f4e-0aaa7902cd08.png)

If you have the override role, you will see the `Fulfill Request Immediately` option which will do 2 things:

1. it creates a DSR (for historical purposes) and sets it to "complete"
2. it updates the DS

However, if #2 fails API validation, the DSR should not be marked as "complete" but should rather be left in the "submitted" state so it can be modified per the error message.

## Which Traffic Control components are affected by this PR?

- Traffic Portal

## What is the best way to verify this PR?
- enable dsRequests in traffic_portal_properties.json, set overrideRole=admin, login as an admin user.
- make a change to an existing DS that you know will fail backend validation (see #5188 for example), fulfill DSR immediately. ensure error message is displayed in TP and a DSR is created but NOT marked as complete.

## If this is a bug fix, what versions of Traffic Control are affected?
- master (5940129)
- 4.1.0
- 5.0.0 (RC1)

## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
