### PR TITLE
[4.1.x] change order of weasel build

### DIFF
--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -18,6 +18,12 @@
 version: '2'
 
 services:
+  weasel:
+    image: licenseweasel/weasel:v0.4
+    volumes:
+      - ../../..:/trafficcontrol:z
+    command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']
+
   source:
     image: trafficcontrol_tarball
     build:
@@ -82,12 +88,6 @@ services:
       context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
-
-  weasel:
-    image: licenseweasel/weasel:v0.4
-    volumes:
-      - ../../..:/trafficcontrol:z
-    command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']
 
   docs:
     image: docs_builder


### PR DESCRIPTION
Change the order of weasel build so that building from the tarball ignores extraneous build artifacts.