### PR TITLE
[4.1.x backport] fix typo for peer_optimisitc_quorum_min #5201

### DIFF
--- a/traffic_monitor/conf/traffic_monitor.cfg
+++ b/traffic_monitor/conf/traffic_monitor.cfg
@@ -5,7 +5,7 @@
 	"http_timeout_ms": 2000,
 	"peer_polling_interval_ms": 5000,
 	"peer_optimistic": true,
-	"peer_optimisitc_quorum_min": 0,
+	"peer_optimistic_quorum_min": 0,
 	"max_events": 200,
 	"max_stat_history": 5,
 	"max_health_history": 5,


### PR DESCRIPTION
Backport #5201 into 4.1.x.