### PR TITLE
Fix POST /profileparameters validation error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed an issue where the jobs and servers table in Traffic Portal would not clear a column's filter when it's hidden
 - Fixed an issue with Traffic Router failing to authenticate if secrets are changed
+- Fixed validation error message for Traffic Ops `POST /api/x/profileparameters` route
 
 ### Added
 - Added If-Match and If-Unmodified-Since Support in Server and Clients.

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -102,8 +102,8 @@ func (pp *TOProfileParameter) SetKeys(keys map[string]interface{}) {
 func (pp *TOProfileParameter) Validate() error {
 
 	errs := validation.Errors{
-		"profile":   validation.Validate(pp.ProfileID, validation.Required),
-		"parameter": validation.Validate(pp.ParameterID, validation.Required),
+		"profileId":   validation.Validate(pp.ProfileID, validation.Required),
+		"parameterId": validation.Validate(pp.ParameterID, validation.Required),
 	}
 
 	return util.JoinErrs(tovalidate.ToErrors(errs))


### PR DESCRIPTION
## What does this PR (Pull Request) do?
The error message should say "profileId" and "parameterId" to make it clear the IDs are
missing, not the names.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
- Review the added test, verify the checks pass

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.x
- 4.x

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)