### PR TITLE
TP: fixes broken context menus due to missing id

### DIFF
--- a/traffic_portal/app/src/common/modules/table/cacheGroupServers/table.cacheGroupServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroupServers/table.cacheGroupServers.tpl.html
@@ -70,7 +70,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>

--- a/traffic_portal/app/src/common/modules/table/cdnServers/table.cdnServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdnServers/table.cdnServers.tpl.html
@@ -70,7 +70,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceJobs/table.deliveryServiceJobs.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceJobs/table.deliveryServiceJobs.tpl.html
@@ -67,7 +67,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <button type="button" ng-click="confirmRemoveJob(job, $event)">Delete Invalidation Request</button>

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceServers/table.deliveryServiceServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceServers/table.deliveryServiceServers.tpl.html
@@ -69,7 +69,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>

--- a/traffic_portal/app/src/common/modules/table/physLocationServers/table.physLocationServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/physLocationServers/table.physLocationServers.tpl.html
@@ -67,7 +67,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>

--- a/traffic_portal/app/src/common/modules/table/profileServers/table.profileServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/profileServers/table.profileServers.tpl.html
@@ -67,7 +67,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>

--- a/traffic_portal/app/src/common/modules/table/statusServers/table.statusServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/statusServers/table.statusServers.tpl.html
@@ -68,7 +68,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>

--- a/traffic_portal/app/src/common/modules/table/topologyServers/table.topologyServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/topologyServers/table.topologyServers.tpl.html
@@ -68,7 +68,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>

--- a/traffic_portal/app/src/common/modules/table/typeServers/table.typeServers.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/typeServers/table.typeServers.tpl.html
@@ -67,7 +67,7 @@ under the License.
     </div>
 </div>
 
-<menu class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
+<menu id="context-menu" class="dropdown-menu" ng-style="menuStyle" type="contextmenu" ng-show="showMenu">
     <ul>
         <li role="menuitem">
             <a ng-href="#!/servers/{{server.id}}" target="_blank">Open in New Tab</a>


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #5213 in addition to all the other broken context menus

source of the problem:

```
const boundingRect = document.getElementById("context-menu").getBoundingClientRect();
```

And many context menus that use that code are missing id.

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
- Run the UI tests or
- Navigate to all of the jobs and servers tables in TP and ensure the context menu is now working.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.0

## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
