### PR TITLE
Fix CIAB mid enrollment

### DIFF
--- a/infrastructure/cdn-in-a-box/mid/init.d/99-run.sh
+++ b/infrastructure/cdn-in-a-box/mid/init.d/99-run.sh
@@ -61,7 +61,7 @@ while [[ -z $found ]]; do
     found=$(to-get api/2.0/cdns?name="$CDN_NAME" | jq -r '.response[].name')
 done
 
-hostname="$(hostname)"
+hostname="$(hostname --short)"
 mid_index="${hostname#mid-}"
 # argument 1 is server type
 to-enroll mid $CDN_NAME "CDN_in_a_Box_Mid-${mid_index}" || (while true; do echo "enroll failed."; sleep 3 ; done)


### PR DESCRIPTION
## What does this PR (Pull Request) do?
The `hostname` command, depending on particular CentOS versions, will sometimes return the FQDN or the short hostname. This fixes the mid enrollment to use `--short` in order to not try to find cachegroups with the suffix `infra.ciab.test` (which don't exist).

## Which Traffic Control components are affected by this PR?
- CDN in a Box

## What is the best way to verify this PR?
Verify the CIAB check completes successfully. If you _really_ want to verify, modify the `mid` Dockerfile to use CentOS 7.6.1810 (the version I happen to be using).

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0

## The following criteria are ALL met by this PR

- [x] ciab is a test
- [x] docs unnecessary
- [x] changelog unnecessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct OR this PR does not include a database migration
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
