### PR TITLE
Fix service categories if-not-modified/if-match functionality

### DIFF
--- a/traffic_ops/app/db/migrations/2020110200000000_add_service_category_deleted.sql
+++ b/traffic_ops/app/db/migrations/2020110200000000_add_service_category_deleted.sql
@@ -1,0 +1,28 @@
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+CREATE TRIGGER on_delete_current_timestamp
+AFTER DELETE
+ON service_category
+FOR EACH ROW EXECUTE PROCEDURE on_delete_current_timestamp_last_updated('service_category');
+
+CREATE INDEX service_category_last_updated_idx ON service_category (last_updated DESC NULLS LAST);
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP INDEX IF EXISTS service_category_last_updated_idx;
+
+DROP TRIGGER IF EXISTS on_delete_current_timestamp ON service_category;

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -950,4 +950,5 @@ insert into last_deleted (table_name) VALUES ('type') ON CONFLICT (table_name) D
 insert into last_deleted (table_name) VALUES ('user_role') ON CONFLICT (table_name) DO NOTHING;
 insert into last_deleted (table_name) VALUES ('server_capability') ON CONFLICT (table_name) DO NOTHING;
 insert into last_deleted (table_name) VALUES ('server_server_capability') ON CONFLICT (table_name) DO NOTHING;
+insert into last_deleted (table_name) VALUES ('service_category') ON CONFLICT (table_name) DO NOTHING;
 insert into last_deleted (table_name) VALUES ('deliveryservices_required_capability') ON CONFLICT (table_name) DO NOTHING;

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -3927,12 +3927,10 @@
     ],
     "serviceCategories": [
         {
-            "name": "serviceCategory1",
-            "tenant": "tenant3"
+            "name": "serviceCategory1"
         },
         {
-            "name": "barServiceCategory2",
-            "tenant": "tenant4"
+            "name": "barServiceCategory2"
         }
     ],
     "staticdnsentries": [

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -1016,11 +1016,20 @@ func CheckIfUnModified(h http.Header, tx *sqlx.Tx, ID int, tableName string) (er
 	return nil, nil, http.StatusOK
 }
 
-// GetLastUpdated checks for the resource in the database, and returns its last_updated timestamp, if available.
+// GetLastUpdated checks for the resource by ID in the database, and returns its last_updated timestamp, if available.
 func GetLastUpdated(tx *sqlx.Tx, ID int, tableName string) (*time.Time, bool, error) {
+	return getLastUpdatedByIdentifier(tx, "id", ID, tableName)
+}
+
+// GetLastUpdatedByName checks for the resource by name in the database, and returns its last_updated timestamp, if available.
+func GetLastUpdatedByName(tx *sqlx.Tx, name string, tableName string) (*time.Time, bool, error) {
+	return getLastUpdatedByIdentifier(tx, "name", name, tableName)
+}
+
+func getLastUpdatedByIdentifier(tx *sqlx.Tx, IDColumn string, IDValue interface{}, tableName string) (*time.Time, bool, error) {
 	lastUpdated := time.Time{}
 	found := false
-	rows, err := tx.Query(fmt.Sprintf(`select last_updated from %s where id=$1`, pq.QuoteIdentifier(tableName)), ID)
+	rows, err := tx.Query(fmt.Sprintf(`select last_updated from %s where %s = $1`, pq.QuoteIdentifier(tableName), pq.QuoteIdentifier(IDColumn)), IDValue)
 	if err != nil {
 		return nil, found, errors.New("querying last_updated: " + err.Error())
 	}

--- a/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
+++ b/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
@@ -144,7 +144,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !api.IsUnmodified(r.Header, origSC.LastUpdated.Time) {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusPreconditionFailed, errors.New("service category has been modified"), nil)
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusPreconditionFailed, errors.New("service category could not be modified because the precondition failed"), nil)
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
+++ b/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
@@ -40,21 +40,7 @@ type TOServiceCategory struct {
 }
 
 func (v *TOServiceCategory) GetLastUpdated() (*time.Time, bool, error) {
-	found := false
-	lastUpdated := time.Time{}
-	rows, err := v.APIInfo().Tx.Query(`select last_updated from service_category where name=$1`, v.Name)
-	if err != nil {
-		return nil, found, errors.New("querying last_updated: " + err.Error())
-	}
-	defer rows.Close()
-	if !rows.Next() {
-		return nil, found, errors.New("no resource found with this id")
-	}
-	found = true
-	if err := rows.Scan(&lastUpdated); err != nil {
-		return nil, found, errors.New("scanning last_updated: " + err.Error())
-	}
-	return &lastUpdated, found, nil
+	return api.GetLastUpdatedByName(v.APIInfo().Tx, v.Name, "service_category")
 }
 
 func (v *TOServiceCategory) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = t }
@@ -149,12 +135,16 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var origSC TOServiceCategory
-	if err := inf.Tx.QueryRow(`SELECT name FROM service_category WHERE name = $1`, name).Scan(&origSC.Name); err != nil {
+	if err := inf.Tx.QueryRow(`SELECT name, last_updated FROM service_category WHERE name = $1`, name).Scan(&origSC.Name, &origSC.LastUpdated); err != nil {
 		if err == sql.ErrNoRows {
 			api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("no service category found with name "+name), nil)
 			return
 		}
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
+		return
+	}
+	if !api.IsUnmodified(r.Header, origSC.LastUpdated.Time) {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusPreconditionFailed, errors.New("service category has been modified"), nil)
 		return
 	}
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
This functionality was accidentally lost due to a recent change. Also,
add the missing last_deleted functionality in order for deletions to
count as modifications.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Verify the checks pass. Run the DB upgrade and downgrade, verify they're successful. Make `if-not-modified` and `if-match` `PUT /3.0/service_categories/{name}` with given timestamps and ETags, verify either 200 or 412 status codes as expected (this is what the added test does).

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.x

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] bug fix, no docs necessary
- [x] bug not yet released, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR ensures that database migration sequence is correct
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)