### PR TITLE
[4.1.x backport] Fixed logging.yaml generation to properly add a newline after filters are emitted. #4846

### DIFF
--- a/lib/go-atscfg/loggingdotyaml.go
+++ b/lib/go-atscfg/loggingdotyaml.go
@@ -125,7 +125,7 @@ func MakeLoggingDotYAML(
 			}
 			if logObjectFilters != "" {
 				logObjectFilters = strings.Replace(logObjectFilters, "\v", "", -1)
-				text += "  filters: [" + logObjectFilters + "]"
+				text += "  filters: [" + logObjectFilters + "]\n"
 			}
 		}
 	}

--- a/lib/go-atscfg/loggingdotyaml_test.go
+++ b/lib/go-atscfg/loggingdotyaml_test.go
@@ -70,6 +70,7 @@ func TestMakeLoggingDotYAMLMultiFormat(t *testing.T) {
 		"LogFormat.Format":         "myFormat0",
 		"LogFormat1.Name":          "myFormatName1",
 		"LogFormat1.Format":        "myFormat1",
+		"LogFormat1.Filters":       "myFilter",
 		"LogFormat9.Name":          "myFormatName9",
 		"LogFormat9.Format":        "myFormat9",
 		"LogFormat2.Name":          "myFormatName2",
@@ -89,6 +90,8 @@ func TestMakeLoggingDotYAMLMultiFormat(t *testing.T) {
 		"LogObject9.Format":        "myFormatName9",
 		"LogObject1.Filename":      "myFilename1",
 		"LogObject1.Format":        "myFormatName1",
+		"LogFilter.Name":           "myFilterName",
+		"LogFilter.Filter":         "myFilter",
 	}
 
 	txt := MakeLoggingDotYAML(profileName, paramData, toolName, toURL)


### PR DESCRIPTION
Backport #4846 into 4.1.x.