### PR TITLE
Fix example path in parameterprofile docs

### DIFF
--- a/docs/source/api/v1/parameterprofile.rst
+++ b/docs/source/api/v1/parameterprofile.rst
@@ -36,7 +36,7 @@ Request Structure
 .. code-block:: http
 	:caption: Request Example
 
-	POST /api/1.4/profileparameter HTTP/1.1
+	POST /api/1.4/parameterprofile HTTP/1.1
 	Host: trafficops.infra.ciab.test
 	User-Agent: curl/7.47.0
 	Accept: */*

--- a/docs/source/api/v2/parameterprofile.rst
+++ b/docs/source/api/v2/parameterprofile.rst
@@ -36,7 +36,7 @@ Request Structure
 .. code-block:: http
 	:caption: Request Example
 
-	POST /api/2.0/profileparameter HTTP/1.1
+	POST /api/2.0/parameterprofile HTTP/1.1
 	Host: trafficops.infra.ciab.test
 	User-Agent: curl/7.47.0
 	Accept: */*

--- a/docs/source/api/v3/parameterprofile.rst
+++ b/docs/source/api/v3/parameterprofile.rst
@@ -36,7 +36,7 @@ Request Structure
 .. code-block:: http
 	:caption: Request Example
 
-	POST /api/3.0/profileparameter HTTP/1.1
+	POST /api/3.0/parameterprofile HTTP/1.1
 	Host: trafficops.infra.ciab.test
 	User-Agent: curl/7.47.0
 	Accept: */*


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Fix docs

## Which Traffic Control components are affected by this PR?

- Documentation

## What is the best way to verify this PR?
Build the docs, view them

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.x
- 4.1.x

## The following criteria are ALL met by this PR
- [x] doc fix, no tests necessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] doc fix, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
