### PR TITLE
Fix GHA running when PR title or description changed

### DIFF
--- a/.github/workflows/ciab.yaml
+++ b/.github/workflows/ciab.yaml
@@ -55,10 +55,11 @@ on:
       - 'misc/**'
       - 'NOTICE'
       - 'traffic_control/java'
-    types: [ opened, reopened, edited, synchronize ]
+    types: [ opened, reopened, ready_for_review, synchronize ]
 
 jobs:
   traffic_monitor:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -74,6 +75,7 @@ jobs:
           path: ${{ github.workspace }}/dist/${{ github.job }}-*.rpm
 
   traffic_ops:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -89,6 +91,7 @@ jobs:
           path: ${{ github.workspace }}/dist/${{ github.job }}-*.rpm
 
   traffic_ops_ort:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -104,6 +107,7 @@ jobs:
           path: ${{ github.workspace }}/dist/${{ github.job }}-*.rpm
 
   traffic_portal:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -119,6 +123,7 @@ jobs:
           path: ${{ github.workspace }}/dist/${{ github.job }}-*.rpm
 
   traffic_router:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -141,6 +146,7 @@ jobs:
           path: ${{ github.workspace }}/dist/*.rpm
 
   traffic_stats:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -156,6 +162,7 @@ jobs:
           path: ${{ github.workspace }}/dist/${{ github.job }}-*.rpm
 
   grove:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -171,6 +178,7 @@ jobs:
           path: ${{ github.workspace }}/dist/${{ github.job }}-*.rpm
 
   grovetccfg:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -186,6 +194,7 @@ jobs:
           path: ${{ github.workspace }}/dist/${{ github.job }}-*.rpm
 
   ciab-build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     needs:
       - traffic_monitor

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,13 +24,14 @@ on:
       - docs/source/**
       - traffic_control/clients/python/**
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, read_for_review, synchronize]
     paths:
       - docs/source/**
       - traffic_control/clients/python/**
 
 jobs:
   documentation:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/go.fmt.yml
+++ b/.github/workflows/go.fmt.yml
@@ -27,10 +27,11 @@ on:
     paths:
       - GO_VERSION
       - "**.go"
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, read_for_review, synchronize]
 
 jobs:
   format:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/go.unit.tests.yaml
+++ b/.github/workflows/go.unit.tests.yaml
@@ -37,10 +37,11 @@ on:
       - traffic_ops/traffic_ops_golang/**.go
       - traffic_ops_ort/atstccfg/**.go
       - traffic_stats/**.go
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
   test:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tr.unit.tests.yaml
+++ b/.github/workflows/tr.unit.tests.yaml
@@ -25,10 +25,11 @@ on:
   pull_request:
     paths:
       - traffic_router/**
-    types: [ opened, reopened, edited, synchronize ]
+    types: [ opened, reopened, ready_for_review, synchronize ]
 
 jobs:
   tests:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/traffic ops.yml
+++ b/.github/workflows/traffic ops.yml
@@ -31,11 +31,12 @@ on:
       - traffic_ops/traffic_ops_golang/**.go
       - traffic_ops/testing/api/**.go
       - traffic_ops/*client/**.go
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
 
   API_tests:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/traffic.ops.database.yml
+++ b/.github/workflows/traffic.ops.database.yml
@@ -23,12 +23,13 @@ on:
     paths:
       - traffic_ops/app/db/**
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize]
     paths:
       - traffic_ops/app/db/**
 
 jobs:
-  documentation:
+  tests:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/weasel.yml
+++ b/.github/workflows/weasel.yml
@@ -21,11 +21,11 @@ on:
   push:
   create:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
   weasel:
-
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes is not related to any Issue

This PR fixes the GHA behavior where all checks would re-run when editing only PR metadata - the title or description. The downside to this is that the same trigger that fires when those events occur is also responsible for changes in the base branch of a PR. So from now on if you change the branch into which your PR goes (e.g. 4.1.x -> master) then you'll need to re-run the actions manually, if applicable. I do think that case is much less common, though.

This also disables running actions against PRs in draft mode.

## Which Traffic Control components are affected by this PR?
- CI tests

## What is the best way to verify this PR?
I'm gonna change the PR's title after actions are done running, and you should be able to look through the action history to see that they only ran once (unless I messed something up and have to push more than the initial commit).

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.0 (RC1)

## The following criteria are ALL met by this PR
- [x] This PR modifies testing automation
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**