### PR TITLE
Fix servers client methods changing call signatures

### DIFF
--- a/infrastructure/cdn-in-a-box/enroller/enroller.go
+++ b/infrastructure/cdn-in-a-box/enroller/enroller.go
@@ -635,14 +635,14 @@ func enrollProfile(toSession *session, r io.Reader) error {
 // enrollServer takes a json file and creates a Server object using the TO API
 func enrollServer(toSession *session, r io.Reader) error {
 	dec := json.NewDecoder(r)
-	var s tc.ServerNullable
+	var s tc.ServerV30
 	err := dec.Decode(&s)
 	if err != nil {
 		log.Infof("error decoding Server: %s\n", err)
 		return err
 	}
 
-	alerts, _, err := toSession.CreateServer(s)
+	alerts, _, err := toSession.CreateServerWithHdr(s, nil)
 	if err != nil {
 		log.Infof("error creating Server: %s\n", err)
 		return err

--- a/lib/go-tc/servers.go
+++ b/lib/go-tc/servers.go
@@ -34,7 +34,7 @@ import (
 
 // ServersV3Response is the format of a response to a GET request for /servers.
 type ServersV3Response struct {
-	Response []ServerNullable `json:"response"`
+	Response []ServerV30 `json:"response"`
 	Summary  struct {
 		Count uint64 `json:"count"`
 	} `json:"summary"`
@@ -348,6 +348,9 @@ func InterfaceInfoToLegacyInterfaces(serverInterfaces []ServerInterfaceInfo) (Le
 	return legacyDetails, errors.New("no service addresses found")
 }
 
+// Server is a non-"nullable" representation of a Server as it appeared in API
+// version 2.0
+// Deprecated: Please use versioned and nullable structures from now on.
 type Server struct {
 	Cachegroup       string              `json:"cachegroup" db:"cachegroup"`
 	CachegroupID     int                 `json:"cachegroupId" db:"cachegroup_id"`
@@ -574,11 +577,96 @@ func (s Server) ToNullable() ServerNullableV2 {
 	}
 }
 
+// ToNonNullable converts the ServerNullableV2 safely to a Server structure.
+func (s ServerNullableV2) ToNonNullable() Server {
+	coerceBool := func(b *bool) bool {
+		if b == nil {
+			return false
+		}
+		return *b
+	}
+	coerceInt := func(i *int) int {
+		if i == nil {
+			return 0
+		}
+		return *i
+	}
+	coerceString := func(s *string) string {
+		if s == nil {
+			return ""
+		}
+		return *s
+	}
+
+	ret := Server{
+		Cachegroup:     coerceString(s.Cachegroup),
+		CachegroupID:   coerceInt(s.CachegroupID),
+		CDNID:          coerceInt((s.CDNID)),
+		CDNName:        coerceString(s.CDNName),
+		DomainName:     coerceString(s.DomainName),
+		FQDN:           s.FQDN,
+		FqdnTime:       s.FqdnTime,
+		GUID:           coerceString(s.GUID),
+		HostName:       coerceString(s.HostName),
+		HTTPSPort:      coerceInt(s.HTTPSPort),
+		ID:             coerceInt(s.ID),
+		ILOIPAddress:   coerceString(s.ILOIPAddress),
+		ILOIPGateway:   coerceString(s.ILOIPGateway),
+		ILOIPNetmask:   coerceString(s.ILOIPNetmask),
+		ILOPassword:    coerceString(s.ILOPassword),
+		ILOUsername:    coerceString(s.ILOUsername),
+		InterfaceMtu:   coerceInt(s.InterfaceMtu),
+		InterfaceName:  coerceString(s.InterfaceName),
+		IP6Address:     coerceString(s.IP6Address),
+		IP6IsService:   coerceBool(s.IP6IsService),
+		IP6Gateway:     coerceString(s.IP6Gateway),
+		IPAddress:      coerceString(s.IPAddress),
+		IPIsService:    coerceBool(s.IPIsService),
+		IPGateway:      coerceString(s.IPGateway),
+		IPNetmask:      coerceString(s.IPNetmask),
+		MgmtIPAddress:  coerceString(s.MgmtIPAddress),
+		MgmtIPGateway:  coerceString(s.MgmtIPGateway),
+		MgmtIPNetmask:  coerceString(s.MgmtIPNetmask),
+		OfflineReason:  coerceString(s.OfflineReason),
+		PhysLocation:   coerceString(s.PhysLocation),
+		PhysLocationID: coerceInt(s.PhysLocationID),
+		Profile:        coerceString(s.Profile),
+		ProfileDesc:    coerceString(s.ProfileDesc),
+		ProfileID:      coerceInt(s.ProfileID),
+		Rack:           coerceString(s.Rack),
+		RevalPending:   coerceBool(s.RevalPending),
+		RouterHostName: coerceString(s.RouterHostName),
+		RouterPortName: coerceString(s.RouterPortName),
+		Status:         coerceString(s.Status),
+		StatusID:       coerceInt(s.StatusID),
+		TCPPort:        coerceInt(s.TCPPort),
+		Type:           s.Type,
+		TypeID:         coerceInt(s.TypeID),
+		UpdPending:     coerceBool(s.UpdPending),
+		XMPPID:         coerceString(s.XMPPID),
+		XMPPPasswd:     coerceString(s.XMPPPasswd),
+	}
+
+	if s.DeliveryServices == nil {
+		ret.DeliveryServices = nil
+	} else {
+		ret.DeliveryServices = *s.DeliveryServices
+	}
+
+	if s.LastUpdated == nil {
+		ret.LastUpdated = TimeNoMod{}
+	} else {
+		ret.LastUpdated = *s.LastUpdated
+	}
+
+	return ret
+}
+
 // Upgrade upgrades the ServerNullableV2 to the new ServerNullable structure.
 //
 // Note that this makes "shallow" copies of all underlying data, so changes to
 // the original will affect the upgraded copy.
-func (s ServerNullableV2) Upgrade() (ServerNullable, error) {
+func (s ServerNullableV2) Upgrade() (ServerV30, error) {
 	ipv4IsService := false
 	if s.IPIsService != nil {
 		ipv4IsService = *s.IPIsService
@@ -588,7 +676,7 @@ func (s ServerNullableV2) Upgrade() (ServerNullable, error) {
 		ipv6IsService = *s.IP6IsService
 	}
 
-	upgraded := ServerNullable{
+	upgraded := ServerV30{
 		CommonServerProperties: s.CommonServerProperties,
 	}
 

--- a/lib/go-tc/servers.go
+++ b/lib/go-tc/servers.go
@@ -577,27 +577,28 @@ func (s Server) ToNullable() ServerNullableV2 {
 	}
 }
 
+func coerceBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}
+func coerceInt(i *int) int {
+	if i == nil {
+		return 0
+	}
+	return *i
+}
+
+func coerceString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
 // ToNonNullable converts the ServerNullableV2 safely to a Server structure.
 func (s ServerNullableV2) ToNonNullable() Server {
-	coerceBool := func(b *bool) bool {
-		if b == nil {
-			return false
-		}
-		return *b
-	}
-	coerceInt := func(i *int) int {
-		if i == nil {
-			return 0
-		}
-		return *i
-	}
-	coerceString := func(s *string) string {
-		if s == nil {
-			return ""
-		}
-		return *s
-	}
-
 	ret := Server{
 		Cachegroup:     coerceString(s.Cachegroup),
 		CachegroupID:   coerceInt(s.CachegroupID),

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -520,25 +520,25 @@ func (s TrafficOpsSessionThreadsafe) TrafficMonitorConfigMap(cdn string) (*tc.Tr
 	return mc, nil
 }
 
-func (s TrafficOpsSessionThreadsafe) fetchServerByHostname(hostName string) (tc.ServerNullable, error) {
+func (s TrafficOpsSessionThreadsafe) fetchServerByHostname(hostName string) (tc.ServerV30, error) {
 	ss := s.get()
 	if ss == nil {
-		return tc.ServerNullable{}, ErrNilSession
+		return tc.ServerV30{}, ErrNilSession
 	}
 
 	params := url.Values{}
 	params.Set("hostName", hostName)
 	resp, _, err := ss.GetServersWithHdr(&params, nil)
 	if err != nil {
-		return tc.ServerNullable{}, fmt.Errorf("fetching server by hostname '%s': %v", hostName, err)
+		return tc.ServerV30{}, fmt.Errorf("fetching server by hostname '%s': %v", hostName, err)
 	}
 
 	respLen := len(resp.Response)
 	if respLen < 1 {
-		return tc.ServerNullable{}, fmt.Errorf("no server '%s' found in Traffic Ops", hostName)
+		return tc.ServerV30{}, fmt.Errorf("no server '%s' found in Traffic Ops", hostName)
 	}
 
-	var server tc.ServerNullable
+	var server tc.ServerV30
 	var num int
 	found := false
 	for i, srv := range resp.Response {
@@ -550,7 +550,7 @@ func (s TrafficOpsSessionThreadsafe) fetchServerByHostname(hostName string) (tc.
 		}
 	}
 	if !found {
-		return tc.ServerNullable{}, fmt.Errorf("either no server '%s' found in Traffic Ops, or none by that hostName had non-nil CDN", hostName)
+		return tc.ServerV30{}, fmt.Errorf("either no server '%s' found in Traffic Ops, or none by that hostName had non-nil CDN", hostName)
 	}
 
 	if respLen > 1 {
@@ -560,20 +560,20 @@ func (s TrafficOpsSessionThreadsafe) fetchServerByHostname(hostName string) (tc.
 	return server, nil
 }
 
-func (s TrafficOpsSessionThreadsafe) fetchLegacyServerByHostname(hostName string) (tc.ServerNullable, error) {
+func (s TrafficOpsSessionThreadsafe) fetchLegacyServerByHostname(hostName string) (tc.ServerV30, error) {
 	ss := s.getLegacy()
 	if ss == nil {
-		return tc.ServerNullable{}, ErrNilSession
+		return tc.ServerV30{}, ErrNilSession
 	}
 
 	resp, _, err := ss.GetServerByHostName(hostName)
 	if err != nil {
-		return tc.ServerNullable{}, fmt.Errorf("fetching legacy server by hostname '%s': %v", hostName, err)
+		return tc.ServerV30{}, fmt.Errorf("fetching legacy server by hostname '%s': %v", hostName, err)
 	}
 
 	respLen := len(resp)
 	if respLen < 1 {
-		return tc.ServerNullable{}, fmt.Errorf("no server '%s' found in Traffic Ops", hostName)
+		return tc.ServerV30{}, fmt.Errorf("no server '%s' found in Traffic Ops", hostName)
 	}
 
 	var server tc.ServerNullableV2
@@ -589,7 +589,7 @@ func (s TrafficOpsSessionThreadsafe) fetchLegacyServerByHostname(hostName string
 
 	}
 	if !found {
-		return tc.ServerNullable{}, fmt.Errorf("either no server '%s' found in Traffic Ops, or none by that hostName had non-empty CDN", hostName)
+		return tc.ServerV30{}, fmt.Errorf("either no server '%s' found in Traffic Ops, or none by that hostName had non-empty CDN", hostName)
 	}
 	if respLen > 1 {
 		log.Warnf("Getting monitor server by hostname '%s' returned %d servers - selecting #%d", hostName, respLen, num)
@@ -606,7 +606,7 @@ func (s TrafficOpsSessionThreadsafe) fetchLegacyServerByHostname(hostName string
 // MonitorCDN returns the name of the CDN of a Traffic Monitor with the given
 // hostName.
 func (s TrafficOpsSessionThreadsafe) MonitorCDN(hostName string) (string, error) {
-	var server tc.ServerNullable
+	var server tc.ServerV30
 	var err error
 
 	if s.useLegacy {

--- a/traffic_ops/testing/api/v3/cachegroupsdeliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/cachegroupsdeliveryservices_test.go
@@ -111,16 +111,12 @@ func CreateTestCachegroupsDeliveryServices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("getting server: %v", err)
 		}
-		servers := resp.Response
+		servers := resp
 		if len(servers) != 1 {
 			t.Fatalf("getting servers: expected 1 got %v", len(servers))
 		}
 		server := servers[0]
-		if server.ID == nil {
-			t.Errorf("Server %s had nil ID", serverName)
-			continue
-		}
-		serverID := *server.ID
+		serverID := server.ID
 
 		serverDSes, _, err := TOSession.GetDeliveryServicesByServer(serverID)
 

--- a/traffic_ops/testing/api/v3/crconfig_test.go
+++ b/traffic_ops/testing/api/v3/crconfig_test.go
@@ -55,11 +55,11 @@ func UpdateTestCRConfigSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetServers err expected nil, actual %+v", err)
 	}
-	servers := resp.Response
+	servers := resp
 	serverID := 0
 	for _, server := range servers {
-		if server.Type == "EDGE" && server.CDNName != nil && *server.CDNName == "cdn1" && server.ID != nil {
-			serverID = *server.ID
+		if server.Type == "EDGE" && server.CDNName == "cdn1" {
+			serverID = server.ID
 			break
 		}
 	}

--- a/traffic_ops/testing/api/v3/monitoring_test.go
+++ b/traffic_ops/testing/api/v3/monitoring_test.go
@@ -32,7 +32,7 @@ func TestMonitoring(t *testing.T) {
 // This MUST NOT be run after a different function in the same Test creates a Snapshot, or the test will be invalid.
 // This prevents a critical bug of upgrading to 4.x bringing a CDN down until a Snapshot is performed.
 func GetTestMonitoringConfigNoSnapshotOnTheFly(t *testing.T) {
-	server := tc.ServerNullable{}
+	server := tc.ServerV30{}
 	for _, sv := range testData.Servers {
 		if sv.Type != "EDGE" {
 			continue
@@ -54,7 +54,7 @@ func GetTestMonitoringConfigNoSnapshotOnTheFly(t *testing.T) {
 
 func AllCDNsCanSnapshot(t *testing.T) {
 
-	serversByHost := make(map[string]tc.ServerNullable)
+	serversByHost := make(map[string]tc.ServerV30)
 
 	for _, server := range testData.Servers {
 		serversByHost[*server.HostName] = server

--- a/traffic_ops/testing/api/v3/servers_to_deliveryservice_assignment_test.go
+++ b/traffic_ops/testing/api/v3/servers_to_deliveryservice_assignment_test.go
@@ -45,7 +45,7 @@ func AssignTestDeliveryService(t *testing.T) {
 	params := url.Values{}
 	params.Add("hostName", *server.HostName)
 
-	rs, _, err := TOSession.GetServers(&params)
+	rs, _, err := TOSession.GetServersWithHdr(&params, nil)
 	if err != nil {
 		t.Fatalf("Failed to fetch server information: %v", err)
 	} else if len(rs.Response) == 0 {
@@ -103,7 +103,7 @@ func AssignTestDeliveryService(t *testing.T) {
 }
 
 func AssignIncorrectTestDeliveryService(t *testing.T) {
-	var server *tc.ServerNullable
+	var server *tc.ServerV30
 	for _, s := range testData.Servers {
 		if s.CDNName != nil && *s.CDNName == "cdn2" {
 			server = &s
@@ -120,7 +120,7 @@ func AssignIncorrectTestDeliveryService(t *testing.T) {
 
 	params := url.Values{}
 	params.Add("hostName", hostname)
-	rs, _, err := TOSession.GetServers(&params)
+	rs, _, err := TOSession.GetServersWithHdr(&params, nil)
 	if err != nil {
 		t.Fatalf("Failed to fetch server information: %v - %v", err, rs.Alerts)
 	} else if len(rs.Response) == 0 {
@@ -168,7 +168,7 @@ func AssignIncorrectTestDeliveryService(t *testing.T) {
 }
 
 func AssignTopologyBasedDeliveryService(t *testing.T) {
-	var server *tc.ServerNullable
+	var server *tc.ServerV30
 	for _, s := range testData.Servers {
 		if s.CDNName != nil && *s.CDNName == "cdn1" && s.Type == string(tc.CacheTypeEdge) {
 			server = &s
@@ -181,7 +181,7 @@ func AssignTopologyBasedDeliveryService(t *testing.T) {
 
 	params := url.Values{}
 	params.Add("hostName", *server.HostName)
-	rs, _, err := TOSession.GetServers(&params)
+	rs, _, err := TOSession.GetServersWithHdr(&params, nil)
 	if err != nil {
 		t.Fatalf("Failed to fetch server information: %v", err)
 	} else if len(rs.Response) == 0 {

--- a/traffic_ops/testing/api/v3/serverservercapability_test.go
+++ b/traffic_ops/testing/api/v3/serverservercapability_test.go
@@ -312,8 +312,8 @@ func DeleteTestServerServerCapabilitiesForTopologiesValidation(t *testing.T) {
 	// dtrc-edge-01 and dtrc-edge-02 (capabilities = ram, disk) are assigned to
 	// ds-top-req-cap (topology = top-for-ds-req; required capabilities = ram, disk) and
 	// ds-top-req-cap2 (topology = top-for-ds-req2; required capabilities = ram)
-	var edge1 tc.ServerNullable
-	var edge2 tc.ServerNullable
+	var edge1 tc.ServerV30
+	var edge2 tc.ServerV30
 
 	servers, _, err := TOSession.GetServersWithHdr(nil, nil)
 	if err != nil {

--- a/traffic_ops/testing/api/v3/traffic_control_test.go
+++ b/traffic_ops/testing/api/v3/traffic_control_test.go
@@ -43,7 +43,7 @@ type TrafficControl struct {
 	PhysLocations                                     []tc.PhysLocation                       `json:"physLocations"`
 	Regions                                           []tc.Region                             `json:"regions"`
 	Roles                                             []tc.Role                               `json:"roles"`
-	Servers                                           []tc.ServerNullable                     `json:"servers"`
+	Servers                                           []tc.ServerV30                          `json:"servers"`
 	ServerServerCapabilities                          []tc.ServerServerCapability             `json:"serverServerCapabilities"`
 	ServerCapabilities                                []tc.ServerCapability                   `json:"serverCapabilities"`
 	ServiceCategories                                 []tc.ServiceCategory                    `json:"serviceCategories"`

--- a/traffic_ops_ort/atstccfg/toreqnew/toreqnew.go
+++ b/traffic_ops_ort/atstccfg/toreqnew/toreqnew.go
@@ -149,11 +149,11 @@ func (cl *TOClient) GetServerUpdateStatus(cacheHostName tc.CacheName) (tc.Server
 	return status, false, nil
 }
 
-func (cl *TOClient) GetServers() ([]tc.ServerNullable, bool, error) {
-	servers := []tc.ServerNullable{}
+func (cl *TOClient) GetServers() ([]tc.ServerV30, bool, error) {
+	servers := []tc.ServerV30{}
 	unsupported := false
 	err := torequtil.GetRetry(cl.NumRetries, "servers", &servers, func(obj interface{}) error {
-		toServers, reqInf, err := cl.C.GetServers(nil)
+		toServers, reqInf, err := cl.C.GetServersWithHdr(nil, nil)
 		if err != nil {
 			if IsUnsupportedErr(err) {
 				unsupported = true
@@ -161,7 +161,7 @@ func (cl *TOClient) GetServers() ([]tc.ServerNullable, bool, error) {
 			}
 			return errors.New("getting servers from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
 		}
-		servers := obj.(*[]tc.ServerNullable)
+		servers := obj.(*[]tc.ServerV30)
 		*servers = toServers.Response
 		return nil
 	})


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

At some point (probably when I added interfaces to servers) a bunch of TO client methods dealing with servers changed their call signatures (I think it was always from `tc.Server` to `tc.ServerNullable`. This not only fixes that, but also changes client server methods that use APIv3 structures to now use `tc.ServerV30` instead of the deprecated alias `tc.ServerNullable`.

## Which Traffic Control components are affected by this PR?
- Traffic Ops Client (Go)
- Traffic Monitor
- Traffic Ops ORT (atstccfg)

## What is the best way to verify this PR?
Make sure all the existing tests are still passing.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.0RC1

## The following criteria are ALL met by this PR
- [x] No new tests because no behavior changes
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**