### PR TITLE
t3c should send atstccfg the default ATS configuration directory

### DIFF
--- a/traffic_ops_ort/t3c/config/config.go
+++ b/traffic_ops_ort/t3c/config/config.go
@@ -33,6 +33,7 @@ import (
 )
 
 var TSHome string = "/opt/trafficserver"
+var TSConfigDir string = "/opt/trafficserver/etc/trafficserver"
 
 const (
 	StatusDir          = "/opt/ort/status"
@@ -248,24 +249,30 @@ func GetCfg() (Cfg, error) {
 	if *toPassPtr == "" {
 		toPass = os.Getenv("TO_PASS")
 	}
+
 	// set TSHome
+	var tsHome = ""
 	if *tsHomePtr != "" {
-		TSHome = *tsHomePtr
-		fmt.Printf("\nset TSHome from command line: '%s'\n\n", TSHome)
+		tsHome = *tsHomePtr
+		fmt.Printf("set TSHome from command line: '%s'\n\n", TSHome)
 	}
-	if *tsHomePtr == "" {
-		tsHome := os.Getenv("TS_HOME") // check for the environment variable.
+	if *tsHomePtr == "" { // evironment or rpm check.
+		tsHome = os.Getenv("TS_HOME") // check for the environment variable.
 		if tsHome != "" {
-			fmt.Printf("\nset TSHome from TS_HOME environment variable '%s'\n\n", TSHome)
+			fmt.Printf("set TSHome from TS_HOME environment variable '%s'\n", TSHome)
 		} else { // finally check using the config file listing from the rpm package.
 			tsHome = GetTSPackageHome()
 			if tsHome != "" {
-				TSHome = tsHome
-				fmt.Printf("\nset TSHome from the RPM config file  list '%s'\n\n", TSHome)
+				fmt.Printf("set TSHome from the RPM config file  list '%s'\n", tsHome)
 			} else {
-				fmt.Printf("\nno override for TSHome was found, using the configured default: '%s'\n\n", TSHome)
+				fmt.Printf("no override for TSHome was found, using the configured default: '%s'\n", TSHome)
 			}
 		}
+	}
+	if tsHome != "" {
+		TSHome = tsHome
+		TSConfigDir = tsHome + "/etc/trafficserver"
+		fmt.Printf("TSHome: %s, TSConfigDir: %s\n", TSHome, TSConfigDir)
 	}
 
 	usageStr := "basic usage: t3c  --traffic-ops-url=myurl --traffic-ops-user=myuser --traffic-ops-password=mypass --cache-host-name=my-cache"

--- a/traffic_ops_ort/t3c/t3c.go
+++ b/traffic_ops_ort/t3c/t3c.go
@@ -113,14 +113,6 @@ func main() {
 		}
 	}
 
-	log.Debugf("Preparing to fetch the config files for %s, cfg.RunMode: %s, syncdsUpdate: %s\n", cfg.CacheHostName, cfg.RunMode, syncdsUpdate)
-
-	err = trops.GetConfigFileList()
-	if err != nil {
-		log.Errorf("Unable to continue: %s\n", err)
-		os.Exit(ConfigFilesError)
-	}
-
 	if cfg.RunMode == config.Revalidate {
 		log.Infoln("======== Revalidating, no package processing needed ========")
 	} else {
@@ -139,6 +131,12 @@ func main() {
 		}
 	}
 
+	log.Debugf("Preparing to fetch the config files for %s, cfg.RunMode: %s, syncdsUpdate: %s\n", cfg.CacheHostName, cfg.RunMode, syncdsUpdate)
+	err = trops.GetConfigFileList()
+	if err != nil {
+		log.Errorf("Unable to continue: %s\n", err)
+		os.Exit(ConfigFilesError)
+	}
 	syncdsUpdate, err = trops.ProcessConfigFiles()
 	if err != nil {
 		log.Errorf("Error while processing config files: %s\n", err.Error())

--- a/traffic_ops_ort/t3c/torequest/torequest.go
+++ b/traffic_ops_ort/t3c/torequest/torequest.go
@@ -212,6 +212,7 @@ func (r *TrafficOpsReq) atsTcExecCommand(cmdstr string, queueState int, revalSta
 	}
 
 	args := []string{
+		"--dir=" + config.TSConfigDir,
 		"--traffic-ops-timeout-milliseconds=" + strconv.FormatInt(int64(r.Cfg.TOTimeoutMS), 10),
 		"--traffic-ops-disable-proxy=" + strconv.FormatBool(r.Cfg.ReverseProxyDisable),
 		"--traffic-ops-user=" + r.Cfg.TOUser,


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This PR fixes a bug where t3c does not send the default ATS config
directory to atstccfg.  The default ATS configuration directory is used
for config files that have a relative or nil 'Path'.  Also, this re-orders the rpm
package check to occur before any config files are request from
traffic ops.

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue 

No issue was created because t3c doesn't have integration tests yet
and is not yet used in production.  This problem was detected while
developing tests for t3c.

## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT

## The following criteria are ALL met by this PR

t3c is not currently used in production and an integration test framework is still being
developed for it so this tests are forthcoming along with documentation and there is
no need to update the CHANGELOG at this time.

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
