### PR TITLE
GitHub Actions: Cache CPAN modules

### DIFF
--- a/.github/actions/run-ciab/run-ciab.sh
+++ b/.github/actions/run-ciab/run-ciab.sh
@@ -32,6 +32,8 @@ other_services='dns edge enroller mid-01 mid-02 origin trafficmonitor trafficops
 docker_compose='docker-compose -f ./docker-compose.yml -f ./docker-compose.readiness.yml';
 $docker_compose up -d $logged_services $other_services;
 $docker_compose logs -f $logged_services &
+# Copy built Perl modules for caching
+docker cp "$(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/local" "${GITHUB_WORKSPACE}/traffic_ops/app" &
 
 echo 'Waiting for the readiness container to exit...';
 if ! timeout 12m $docker_compose logs -f readiness >/dev/null; then

--- a/.github/workflows/ciab.yaml
+++ b/.github/workflows/ciab.yaml
@@ -210,6 +210,13 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: ${{ github.workspace }}/dist/
+      - name: Cache Perl modules
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/traffic_ops/app/local
+          key: ${{ runner.os }}-cpan-${{ hashFiles('cache/**.tar.gz') }}
+          restore-keys: |
+            ${{ runner.os }}-cpan-
       - name: Build CDN-in-a-Box images
         uses: ./.github/actions/build-ciab
       - name: Start CDN-in-a-Box

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ docs/build/*
 /grove/grove
 /grove/grovetccfg/grovetccfg
 local
+!/traffic_ops/app/local/
+/traffic_ops/app/local/*
+!/traffic_ops/app/local/.gitkeep
 traffic_ops_extensions/log/*
 traffic_ops_extensions/lib/Extensions/InfluxDB/log/*
 traffic_ops/app/log/*.log

--- a/docs/source/admin/quick_howto/ciab.rst
+++ b/docs/source/admin/quick_howto/ciab.rst
@@ -44,6 +44,13 @@ These can all be supplied manually via the steps in :ref:`dev-building` (for Tra
 
 .. tip:: When updating CDN-in-a-Box, there is no need to remove old images before building new ones. Docker detects which files are updated and only reuses cached layers that have not changed.
 
+The image that takes the takes the longest to build is the ``trafficops-perl`` image. In order to avoid needing to download, build, and test 239 Perl CPAN modules each time you rebuild the image from scratch, you can run the following command while running CDN in a Box in order to skip building the Perl modules next time:
+
+.. code-block:: shell
+	:caption: Make a local copy of CPAN modules used by Traffic Ops Perl
+
+	docker cp $(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/local ../../traffic_ops/app
+
 Usage
 -----
 In a typical scenario, if the steps in `Building`_ have been followed, all that's required to start the CDN in a Box is to run ``docker-compose up`` - optionally with the ``-d`` flag to run without binding to the terminal - from the :file:`infrastructure/cdn-in-a-box/` directory. This will start up the entire stack and should take care of any needed initial configuration. The services within the environment are by default not exposed locally to the host. If this is the desired behavior when bringing up CDN in a Box the command ``docker-compose -f docker-compose.yml -f docker-compose.expose-ports.yml up`` should be run. The ports are configured within the :file:`infrastructure/cdn-in-a-box/docker-compose.expose-ports.yml` file, but the default ports are shown in :ref:`ciab-service-info`. Some services have credentials associated, which are totally configurable in `variables.env`_.

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -97,7 +97,7 @@ RUN rpm -Uvh /$(basename $TRAFFIC_OPS_RPM) && \
 
 # Run carton again, in case the cpanfile included in the RPM differs from the one used earlier in the
 # build (should never happen - Perl is supposed to be going away)
-RUN POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton && \
+RUN POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 carton && \
     rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz
 
 ADD infrastructure/cdn-in-a-box/enroller/server_template.json \

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -79,6 +79,9 @@ ADD traffic_router/core/src/test/resources/geo/GeoLite2-City.mmdb.gz /opt/traffi
 
 WORKDIR /opt/traffic_ops/app
 ADD traffic_ops/app/cpanfile traffic_ops/install/bin/install_goose.sh ./
+
+# Start with the existing traffic_ops/app/local directory
+COPY traffic_ops/app/local local
 RUN cpanm -l ./local Carton && \
     POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton  && \
     rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz ./cpanfile

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -82,8 +82,8 @@ ADD traffic_ops/app/cpanfile traffic_ops/install/bin/install_goose.sh ./
 
 # Start with the existing traffic_ops/app/local directory
 COPY traffic_ops/app/local local
-RUN cpanm -l ./local Carton && \
-    POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 ./local/bin/carton  && \
+RUN cpanm Carton && \
+    POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 carton  && \
     rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz ./cpanfile
 RUN ./install_goose.sh
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile.dockerignore
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile.dockerignore
@@ -25,5 +25,6 @@
 *
 !infrastructure/cdn-in-a-box/
 !traffic_ops/app/cpanfile
+!traffic_ops/app/local/
 !traffic_ops/install/bin/install_goose.sh
 !traffic_router/core/src/test/resources/geo/GeoLite2-City.mmdb.gz


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR caches the CPAN modules built for Traffic Ops Perl during the `build-ciab` GitHub action for later reuse.

It shaves about 4 minutes off of the time required to build all of the CDN in a Box images.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- Documentation
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
* Run CDN in a Box, make sure it works
* Using the instructions added to the Docs, copy the Perl lib out of the Traffic Ops Perl container while it is running, then rebuild the `trafficops-perl` image
  ```shell script
  docker cp $(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/local ../../traffic_ops/app
  ```
  and make sure you don't need to rebuild all of the images again
* Make sure the *CDN-in-a-Box CI* GHA workflow passes

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR updates tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
