### PR TITLE
[4.1.x partial-backport] Fix TM UI coloring for unavailable/admin_down cache states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue with Traffic Router failing to authenticate if secrets are changed
 - Fixed #4825 - Traffic Monitor error log spamming "incomparable stat type int"
 - Fixed #4899 - Traffic Monitor Web UI showing incorrect delivery service availability states
+- Fixed Traffic Monitor Web UI styling for unavailable caches
 - Fixed #4845 - issue with ATS logging.yaml generation (missing newlines when filters are used)
 - Fixed ORT atstccfg to use log appending and log rotation
 - Fixed a bug in ATS remap.config generation that caused a double range directive if there was a `__RANGE_DIRECTIVE__` override

--- a/traffic_monitor/static/style.css
+++ b/traffic_monitor/static/style.css
@@ -44,11 +44,11 @@ tbody tr:nth-child(odd) {
 	background: #fff;
 }
 .error {
-	background-color: #f00;
+	background-color: #f00!important;
 }
 
 .warning {
-	background-color: #f80;
+	background-color: #f80!important;
 }
 
 #cache-states td:nth-child(n+4),


### PR DESCRIPTION
Backport https://github.com/apache/trafficcontrol/pull/4916/commits/5a477a4ad2ac4bbb5cbd0b89a83fce8e66cea5df into 4.1.x.