### PR TITLE
[4.1.x backport] fixed peer polling to include ipv4 and ipv6 correctly (#5239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed #4825 - Traffic Monitor error log spamming "incomparable stat type int"
 - Fixed #4899 - Traffic Monitor Web UI showing incorrect delivery service availability states
 - Fixed Traffic Monitor Web UI styling for unavailable caches
+- Fixed an issue with Traffic Monitor to fix peer polling to work as expected
 - Fixed #4845 - issue with ATS logging.yaml generation (missing newlines when filters are used)
 - Fixed ORT atstccfg to use log appending and log rotation
 - Fixed a bug in ATS remap.config generation that caused a double range directive if there was a `__RANGE_DIRECTIVE__` override

--- a/traffic_monitor/manager/statecombiner_test.go
+++ b/traffic_monitor/manager/statecombiner_test.go
@@ -1,0 +1,156 @@
+package manager
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_monitor/health"
+	"github.com/apache/trafficcontrol/traffic_monitor/peer"
+	"github.com/apache/trafficcontrol/traffic_monitor/todata"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestCombineCacheState(t *testing.T) {
+	cacheName := tc.CacheName("testCache")
+	localCacheStates := []tc.IsAvailable{
+		tc.IsAvailable{
+			IsAvailable:   true,
+			Ipv4Available: true,
+			Ipv6Available: true,
+		},
+		tc.IsAvailable{
+			IsAvailable:   true,
+			Ipv4Available: false,
+			Ipv6Available: true,
+		},
+		tc.IsAvailable{
+			IsAvailable:   true,
+			Ipv4Available: true,
+			Ipv6Available: false,
+		},
+		tc.IsAvailable{
+			IsAvailable:   false,
+			Ipv4Available: false,
+			Ipv6Available: false,
+		},
+	}
+	events := health.NewThreadsafeEvents(1)
+	peerOptimistic := true
+	peerStates := peer.NewCRStatesPeersThreadsafe(1)
+	peerStates.SetTimeout(time.Duration(rand.Int63()))
+	peerResult := peer.Result{
+		ID:        tc.TrafficMonitorName("TestTM-01"),
+		Available: true,
+		PeerStates: tc.CRStates{
+			Caches: map[tc.CacheName]tc.IsAvailable{
+				tc.CacheName(cacheName): tc.IsAvailable{
+					IsAvailable:   true,
+					Ipv4Available: true,
+					Ipv6Available: true,
+				},
+			},
+		},
+		Time: time.Now(),
+	}
+	peerStates.Set(peerResult)
+	peerSet := map[tc.TrafficMonitorName]struct{}{
+		tc.TrafficMonitorName("TestTM-01"): struct{}{},
+	}
+	peerStates.SetPeers(peerSet)
+	peerStates.SetTimeout(time.Duration(rand.Int()))
+
+	combinedStates := peer.NewCRStatesThreadsafe()
+	overrideMap := map[tc.CacheName]bool{}
+	overrideMap[cacheName] = false
+	toData := todata.TOData{}
+	toData.ServerTypes = map[tc.CacheName]tc.CacheType{
+		cacheName: tc.CacheTypeEdge,
+	}
+
+	for _, localCacheState := range localCacheStates {
+		combineCacheState(cacheName, localCacheState, events, peerOptimistic, peerStates, combinedStates, overrideMap, toData)
+
+		if !combinedStates.Get().Caches[cacheName].IsAvailable {
+			t.Fatalf("cache is unavailable and should be available")
+		}
+		if !combinedStates.Get().Caches[cacheName].Ipv4Available {
+			t.Fatalf("cache IPv4 is unavailable and should be available")
+		}
+		if !combinedStates.Get().Caches[cacheName].Ipv6Available {
+			t.Fatalf("cache IPv6 is unavailable and should be available")
+		}
+	}
+}
+
+func TestCombineCacheStateCacheDown(t *testing.T) {
+	cacheName := tc.CacheName("testCache")
+	localCacheState := tc.IsAvailable{
+		IsAvailable:   false,
+		Ipv4Available: false,
+		Ipv6Available: false,
+	}
+
+	events := health.NewThreadsafeEvents(1)
+	peerOptimistic := true
+	peerStates := peer.NewCRStatesPeersThreadsafe(1)
+	peerStates.SetTimeout(time.Duration(rand.Int63()))
+	peerResult := peer.Result{
+		ID:        tc.TrafficMonitorName("TestTM-01"),
+		Available: true,
+		PeerStates: tc.CRStates{
+			Caches: map[tc.CacheName]tc.IsAvailable{
+				tc.CacheName(cacheName): tc.IsAvailable{
+					IsAvailable:   true,
+					Ipv4Available: false,
+					Ipv6Available: true,
+				},
+			},
+		},
+		Time: time.Now(),
+	}
+	peerStates.Set(peerResult)
+	peerSet := map[tc.TrafficMonitorName]struct{}{
+		tc.TrafficMonitorName("TestTM-01"): struct{}{},
+	}
+	peerStates.SetPeers(peerSet)
+	peerStates.SetTimeout(time.Duration(rand.Int()))
+
+	combinedStates := peer.NewCRStatesThreadsafe()
+	overrideMap := map[tc.CacheName]bool{}
+	overrideMap[cacheName] = false
+	toData := todata.TOData{}
+	toData.ServerTypes = map[tc.CacheName]tc.CacheType{
+		cacheName: tc.CacheTypeEdge,
+	}
+
+	combineCacheState(cacheName, localCacheState, events, peerOptimistic, peerStates, combinedStates, overrideMap, toData)
+
+	if !combinedStates.Get().Caches[cacheName].IsAvailable {
+		t.Fatalf("cache is unavailable and should be available")
+	}
+	if combinedStates.Get().Caches[cacheName].Ipv4Available {
+		t.Fatalf("cache IPv4 is available and should be unavailable")
+	}
+	if !combinedStates.Get().Caches[cacheName].Ipv6Available {
+		t.Fatalf("cache IPv6 is unavailable and should be available")
+	}
+}


### PR DESCRIPTION
Backport #5239 into 4.1.x.