### PR TITLE
GHA: Cache CPAN modules by OS version

### DIFF
--- a/.github/actions/run-ciab/run-ciab.sh
+++ b/.github/actions/run-ciab/run-ciab.sh
@@ -33,7 +33,7 @@ docker_compose='docker-compose -f ./docker-compose.yml -f ./docker-compose.readi
 $docker_compose up -d $logged_services $other_services;
 $docker_compose logs -f $logged_services &
 # Copy built Perl modules for caching
-docker cp "$(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/local" "${GITHUB_WORKSPACE}/traffic_ops/app" &
+docker cp "$(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/local" "${GITHUB_WORKSPACE}/infrastructure/cdn-in-a-box/traffic_ops" &
 
 echo 'Waiting for the readiness container to exit...';
 if ! timeout 12m $docker_compose logs -f readiness >/dev/null; then

--- a/.github/workflows/ciab.yaml
+++ b/.github/workflows/ciab.yaml
@@ -211,13 +211,19 @@ jobs:
         with:
           path: ${{ github.workspace }}/dist/
       - name: Cache Perl modules
+        env:
+          CENTOS_VERSION: 7
         uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/traffic_ops/app/local
-          key: ${{ runner.os }}-cpan-${{ hashFiles('cache/**.tar.gz') }}
+          key: ${{ runner.os }}-cpan-centos-${{ env.CENTOS_VERSION }}-${{ hashFiles('cache/**.tar.gz') }}-${{ hashFiles('**/perllocal.pod') }}
           restore-keys: |
-            ${{ runner.os }}-cpan-
+            ${{ runner.os }}-cpan-centos-${{ env.CENTOS_VERSION }}-${{ hashFiles('cache/**.tar.gz') }}-${{ hashFiles('**/perllocal.pod') }}
+            ${{ runner.os }}-cpan-centos-${{ env.CENTOS_VERSION }}-${{ hashFiles('cache/**.tar.gz') }}-
+            ${{ runner.os }}-cpan-centos-${{ env.CENTOS_VERSION }}-
       - name: Build CDN-in-a-Box images
+        env:
+          CENTOS_VERSION: 7
         uses: ./.github/actions/build-ciab
       - name: Start CDN-in-a-Box
         uses: ./.github/actions/run-ciab

--- a/.github/workflows/ciab.yaml
+++ b/.github/workflows/ciab.yaml
@@ -215,7 +215,7 @@ jobs:
           CENTOS_VERSION: 7
         uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/traffic_ops/app/local
+          path: ${{ github.workspace }}/infrastructure/cdn-in-a-box/traffic_ops/local
           key: ${{ runner.os }}-cpan-centos-${{ env.CENTOS_VERSION }}-${{ hashFiles('cache/**.tar.gz') }}-${{ hashFiles('**/perllocal.pod') }}
           restore-keys: |
             ${{ runner.os }}-cpan-centos-${{ env.CENTOS_VERSION }}-${{ hashFiles('cache/**.tar.gz') }}-${{ hashFiles('**/perllocal.pod') }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,9 @@ docs/build/*
 /grove/grove
 /grove/grovetccfg/grovetccfg
 local
-!/traffic_ops/app/local/
-/traffic_ops/app/local/*
-!/traffic_ops/app/local/.gitkeep
+!/infrastructure/cdn-in-a-box/traffic_ops/local/
+/infrastructure/cdn-in-a-box/traffic_ops/local/*
+!/infrastructure/cdn-in-a-box/traffic_ops/local/.gitkeep
 traffic_ops_extensions/log/*
 traffic_ops_extensions/lib/Extensions/InfluxDB/log/*
 traffic_ops/app/log/*.log

--- a/docs/source/admin/quick_howto/ciab.rst
+++ b/docs/source/admin/quick_howto/ciab.rst
@@ -49,7 +49,7 @@ The image that takes the takes the longest to build is the ``trafficops-perl`` i
 .. code-block:: shell
 	:caption: Make a local copy of CPAN modules used by Traffic Ops Perl
 
-	docker cp $(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/local ../../traffic_ops/app
+	docker cp $(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/local traffic_ops
 
 Usage
 -----

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -81,7 +81,7 @@ WORKDIR /opt/traffic_ops/app
 ADD traffic_ops/app/cpanfile traffic_ops/install/bin/install_goose.sh ./
 
 # Start with the existing traffic_ops/app/local directory
-COPY traffic_ops/app/local local
+COPY infrastructure/cdn-in-a-box/traffic_ops/local local
 RUN cpanm Carton && \
     export POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 && \
     echo 'Running carton...' && \

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -83,7 +83,14 @@ ADD traffic_ops/app/cpanfile traffic_ops/install/bin/install_goose.sh ./
 # Start with the existing traffic_ops/app/local directory
 COPY traffic_ops/app/local local
 RUN cpanm Carton && \
-    POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 carton  && \
+    export POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 && \
+    echo 'Running carton...' && \
+    [[ -d "${PERL5LIB}/x86_64-linux-thread-multi" ]]; existing_install=$? && \
+    if ! carton && [[ $existing_install -eq 0 ]]; then \
+        rm -rf "$PERL5LIB" && \
+        echo 'Removed modules, retrying carton...' && \
+        carton || exit 1; \
+    fi && \
     rm -rf $HOME/.cpan* /tmp/Dockerfile /tmp/local.tar.gz ./cpanfile
 RUN ./install_goose.sh
 

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -73,7 +73,9 @@ RUN yum install -y          \
         postgresql96-devel  \
         postgresql96-libs   \
         tar &&              \
-    yum -y clean all && mkdir -p /opt/traffic_ops/app/public
+    yum -y clean all && \
+    mkdir -p /opt/traffic_ops/app/public && \
+    cpanm Carton
 
 ADD traffic_router/core/src/test/resources/geo/GeoLite2-City.mmdb.gz /opt/traffic_ops/app/public/
 
@@ -82,8 +84,7 @@ ADD traffic_ops/app/cpanfile traffic_ops/install/bin/install_goose.sh ./
 
 # Start with the existing traffic_ops/app/local directory
 COPY infrastructure/cdn-in-a-box/traffic_ops/local local
-RUN cpanm Carton && \
-    export POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 && \
+RUN export POSTGRES_HOME=/usr/pgsql-9.6 PERL5LIB=$(pwd)/local/lib/perl5 && \
     echo 'Running carton...' && \
     [[ -d "${PERL5LIB}/x86_64-linux-thread-multi" ]]; existing_install=$? && \
     if ! carton && [[ $existing_install -eq 0 ]]; then \

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile.dockerignore
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile.dockerignore
@@ -25,6 +25,6 @@
 *
 !infrastructure/cdn-in-a-box/
 !traffic_ops/app/cpanfile
-!traffic_ops/app/local/
+!infrastructure/cdn-in-a-box/traffic_ops/local/
 !traffic_ops/install/bin/install_goose.sh
 !traffic_router/core/src/test/resources/geo/GeoLite2-City.mmdb.gz


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue

As a follow-up to #5253, this PR
- adds CentOS version to the cache keys
- Uses `infrastructure/cdn-in-a-box/traffic_ops/local` as the modules cache location
- Removes copied-in modules and reruns `carton` if modules were copied in and `carton` failed

Caching modules by the version of the OS they were built on is necessary to avoid issues related to version differences in Perl and dynamically-linked libraries.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- Documentation
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
* Run CDN in a Box, make sure it works
* Using the instructions added to the Docs, copy the Perl lib out of the Traffic Ops Perl container while it is running, then rebuild the `trafficops-perl` image
  ```shell script
  docker cp $(docker-compose ps -q trafficops-perl):/opt/traffic_ops/app/local traffic_ops
  ```
  and make sure you don't need to rebuild all of the modules again
* Make sure the *CDN-in-a-Box CI* GHA workflow passes

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
 - master (bfcf04a3f1)


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR updates tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
