### PR TITLE
Exclude ORG servers from topology-based DS required capabilities validation

### DIFF
--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -4218,12 +4218,16 @@
             "description": "a topology",
             "nodes": [
                 {
-                    "cachegroup": "dtrc1",
+                    "cachegroup": "multiOriginCachegroup",
                     "parents": []
                 },
                 {
-                    "cachegroup": "dtrc2",
+                    "cachegroup": "dtrc1",
                     "parents": [0]
+                },
+                {
+                    "cachegroup": "dtrc2",
+                    "parents": [1]
                 }
             ]
         }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
@@ -343,7 +343,6 @@ func (rc *RequiredCapability) checkServerCap() (error, error, int) {
 // EnsureTopologyBasedRequiredCapabilities ensures that at least one server per cachegroup
 // in this delivery service's topology has this delivery service's required capabilities.
 func EnsureTopologyBasedRequiredCapabilities(tx *sql.Tx, dsID int, topology string, requiredCapabilities []string) (error, error, int) {
-	// language=sql
 	q := `
 SELECT
   s.id,
@@ -357,6 +356,7 @@ JOIN topology_cachegroup tc ON tc.cachegroup = c.name
 WHERE
   s.cdn_id = (SELECT cdn_id FROM deliveryservice WHERE id = $1)
   AND tc.topology = $2
+  AND c.type != (SELECT id FROM type WHERE name = '` + tc.CacheGroupOriginTypeName + `')
 GROUP BY s.id, s.cdn_id, c.name
 `
 	rows, err := tx.Query(q, dsID, topology)

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -328,7 +328,6 @@ func (topology TOTopology) validateDSRequiredCapabilities() error {
 	for cdn := range cdnMap {
 		CDNs = append(CDNs, cdn)
 	}
-	// language=sql
 	q := `
 SELECT
   s.id,
@@ -341,6 +340,7 @@ JOIN cachegroup c ON c.id = s.cachegroup
 WHERE
   c.name = ANY($1)
   AND s.cdn_id = ANY($2)
+  AND c.type != (SELECT id FROM type WHERE name = '` + tc.CacheGroupOriginTypeName + `')
 GROUP BY s.id, s.cdn_id, c.name
 `
 	rows, err := tx.Query(q, pq.Array(cachegroups), pq.Array(CDNs))


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Server capabilities do not apply to ORG servers (origins), so the
validation needs to exclude them.

- [x] This PR fixes #5268 

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Verify the TO API tests pass.

1. Create a topology with an ORG_LOC cachegroup with at least one server and an EDGE_LOC cachegroup with at least one server.
2. Create and add a server capability to the server in the EDGE_LOC cachegroup.
3. Assign a delivery service to the topology
4. Add the capability from step 2 as a required capability on the delivery service (should succeed).

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.x

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] bug fix, no docs necessary
- [x] unreleased bug, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)