### PR TITLE
[4.1.x backport] Remove Basho Apt repo (#5275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed #5180 - Global Max Mbps and Tps is not send to TM
 - Fixed #3528 - Fix Traffic Ops monitoring.json missing DeliveryServices
 - Fixed #5074 - Traffic Monitor logging "CreateStats not adding availability data for server: not found in DeliveryServices" for MID caches
+- Fixed #5274 - CDN in a Box's Traffic Vault image failed to build due to Basho's repo responding with 402 Payment Required. The repo has been removed from the image.
 - Fixed an issue that causes Traffic Router to mistakenly route to caches that had recently been set from ADMIN_DOWN to OFFLINE
 - Fixed a NullPointerException in Traffic Router that prevented it from properly updating cache health states
 - Fixed an issue where Traffic Router would erroneously return 503s or NXDOMAINs if the caches in a cachegroup were all unavailable for a client's requested IP version, rather than selecting caches from the next closest available cachegroup.

--- a/infrastructure/cdn-in-a-box/traffic_vault/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_vault/Dockerfile
@@ -22,6 +22,7 @@ RUN rm -rfv /etc/riak/prestart.d/* /etc/riak/poststart.d/*
 
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
+ && rm /etc/apt/sources.list.d/basho_riak.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y net-tools ca-certificates dnsutils gettext-base \
  && rm -rf /var/lib/apt/lists/* && rm -rf /etc/apt/apt.conf.d/docker-gzip-indexes


### PR DESCRIPTION
Backport #5275 into 4.1.x.