### PR TITLE
Fix an issue with API v1/2 tests not cleaning up certain v3 structures (topologies)

### DIFF
--- a/traffic_ops/testing/api/v1/todb_test.go
+++ b/traffic_ops/testing/api/v1/todb_test.go
@@ -333,6 +333,7 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM profile;
 	DELETE FROM parameter;
 	DELETE FROM profile_parameter;
+	DELETE FROM topology;
 	DELETE FROM cachegroup;
 	DELETE FROM coordinate;
 	DELETE FROM type;

--- a/traffic_ops/testing/api/v2/todb_test.go
+++ b/traffic_ops/testing/api/v2/todb_test.go
@@ -333,6 +333,7 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM profile;
 	DELETE FROM parameter;
 	DELETE FROM profile_parameter;
+	DELETE FROM topology;
 	DELETE FROM cachegroup;
 	DELETE FROM coordinate;
 	DELETE FROM type;


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [X] This PR is not related to any Issue

This PR fixes an issue when API v1 and v2 tests would fail to run against a database containing Topologies and Delivery Services using some or all of those Topologies, e.g. when running API v3 tests followed by v2 and/or v1.

## Which Traffic Control components are affected by this PR?
- Traffic Ops Client (Go) - tests

## What is the best way to verify this PR?
Run the API v3 tests, then the v1 or v2 tests, verify the database cleanup is successful and testing can proceed.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.0 (RC1)

## The following criteria are ALL met by this PR
- [x] This PR fixes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**