### PR TITLE
Add PUSH and PURGE denial to mid tier caches.

### DIFF
--- a/lib/go-atscfg/ipallowdotconfig.go
+++ b/lib/go-atscfg/ipallowdotconfig.go
@@ -301,6 +301,22 @@ func MakeIPAllowDotConfig(
 		// order matters, so sort before adding the denys
 		sort.Sort(IPAllowDatas(ipAllowData))
 
+		// start with a deny for PUSH and PURGE - TODO CDL: parameterize
+		if isMid { // Edges already deny PUSH and PURGE
+			ipAllowData = append([]IPAllowData{
+				{
+					Src:    `0.0.0.0-255.255.255.255`,
+					Action: ActionDeny,
+					Method: `PUSH|PURGE`,
+				},
+				{
+					Src:    `::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff`,
+					Action: ActionDeny,
+					Method: `PUSH|PURGE`,
+				},
+			}, ipAllowData...)
+		}
+
 		// end with a deny
 		ipAllowData = append(ipAllowData, IPAllowData{
 			Src:    `0.0.0.0-255.255.255.255`,

--- a/lib/go-atscfg/ipallowdotconfig_test.go
+++ b/lib/go-atscfg/ipallowdotconfig_test.go
@@ -97,6 +97,26 @@ func TestMakeIPAllowDotConfig(t *testing.T) {
 
 	lines = lines[1:] // remove comment line
 
+	/* Test that PUSH and PURGE are denied ere the allowance of anything else. */
+	{
+		ip4deny := false
+		ip6deny := false
+	eachLine:
+		for i, line := range lines {
+			switch {
+			case strings.Contains(line, `0.0.0.0-255.255.255.255`) && strings.Contains(line, `ip_deny`) && strings.Contains(line, `PUSH`) && strings.Contains(line, `PURGE`):
+				ip4deny = true
+			case strings.Contains(line, `::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff`) && strings.Contains(line, `ip_deny`) && strings.Contains(line, `PUSH`) && strings.Contains(line, `PURGE`):
+				ip6deny = true
+			case strings.Contains(line, `ip_allow`):
+				if !(ip4deny && ip6deny) {
+					t.Errorf("Expected denies for PUSH and PURGE before any ips are allowed; pre-denial allowance on line %d.", i+1)
+				}
+				break eachLine
+			}
+		}
+	}
+
 	for _, expected := range expecteds {
 		if !strings.Contains(txt, expected) {
 			t.Errorf("expected %+v actual '%v'\n", expected, txt)


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?

This adjusts the ip_allow lists produced for ATS to remove unnecessary methods.

<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops ORT

## What is the best way to verify this PR?
Use ORT to generate an ip_allow config and ensure that PUSH and PURGE are not allowed when ATS uses the config, but everything else is.

<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

## If this is a bug fix, what versions of Traffic Control are affected?

This configuration change improves a situation that has been in place in all versions of ATC.

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
