### PR TITLE
Add validation to topology updates and server updates/deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [unreleased]
 ### Added
 - Traffic Ops: added validation for assigning ORG servers to topology-based delivery services
+- Traffic Ops: added validation for topology updates and server updates/deletions to ensure that topologies have at least one server per cachegroup in each CDN of any assigned delivery services
 - Added locationByDeepCoverageZone to the `crs/stats/ip/{ip}` endpoint in the Traffic Router API
 
 ### Fixed

--- a/traffic_ops/testing/api/v3/tc-fixtures.json
+++ b/traffic_ops/testing/api/v3/tc-fixtures.json
@@ -222,6 +222,13 @@
             "name": "dtrc3",
             "shortName": "dtrc3",
             "typeName": "EDGE_LOC"
+        },
+        {
+            "latitude": 0,
+            "longitude": 0,
+            "name": "cdn1-only",
+            "shortName": "cdn1-only",
+            "typeName": "EDGE_LOC"
         }
     ],
     "cdns": [
@@ -1065,6 +1072,198 @@
             "tenantName": "tenant1",
             "type": "CLIENT_STEERING",
             "xmlId": "ds-client-steering",
+            "anonymousBlockingEnabled": false
+        },
+        {
+            "active": true,
+            "cdnName": "cdn2",
+            "cacheurl": "",
+            "ccrDnsTtl": 3600,
+            "checkPath": "",
+            "consistentHashQueryParams": [],
+            "deepCachingType": "NEVER",
+            "displayName": "ds-forked-topology",
+            "dnsBypassCname": null,
+            "dnsBypassIp": "",
+            "dnsBypassIp6": "",
+            "dnsBypassTtl": 30,
+            "dscp": 40,
+            "edgeHeaderRewrite": null,
+            "fqPacingRate": 0,
+            "geoLimit": 0,
+            "geoLimitCountries": "",
+            "geoLimitRedirectURL": null,
+            "geoProvider": 0,
+            "globalMaxMbps": 0,
+            "globalMaxTps": 0,
+            "httpBypassFqdn": "",
+            "infoUrl": "TBD",
+            "initialDispersion": 1,
+            "ipv6RoutingEnabled": true,
+            "lastUpdated": "2018-04-06 16:48:51+00",
+            "logsEnabled": false,
+            "longDesc": "",
+            "longDesc1": "",
+            "longDesc2": "",
+            "matchList": [
+                {
+                    "pattern": ".*\\.ds-forked-topology\\..*",
+                    "setNumber": 0,
+                    "type": "HOST_REGEXP"
+                }
+            ],
+            "maxDnsAnswers": 0,
+            "midHeaderRewrite": null,
+            "missLat": 41.881944,
+            "missLong": -87.627778,
+            "multiSiteOrigin": false,
+            "orgServerFqdn": "http://example.org",
+            "originShield": null,
+            "profileDescription": null,
+            "profileName": null,
+            "protocol": 0,
+            "qstringIgnore": 0,
+            "rangeRequestHandling": 0,
+            "regexRemap": null,
+            "regionalGeoBlocking": false,
+            "remapText": null,
+            "routingName": "cdn",
+            "signed": false,
+            "signingAlgorithm": null,
+            "sslKeyVersion": 0,
+            "tenant": "tenant1",
+            "tenantName": "tenant1",
+            "topology": "forked-topology",
+            "type": "HTTP",
+            "xmlId": "ds-forked-topology",
+            "anonymousBlockingEnabled": false
+        },
+        {
+            "active": true,
+            "cdnName": "cdn1",
+            "cacheurl": "",
+            "ccrDnsTtl": 3600,
+            "checkPath": "",
+            "consistentHashQueryParams": [],
+            "deepCachingType": "NEVER",
+            "displayName": "top-ds-in-cdn1",
+            "dnsBypassCname": null,
+            "dnsBypassIp": "",
+            "dnsBypassIp6": "",
+            "dnsBypassTtl": 30,
+            "dscp": 40,
+            "edgeHeaderRewrite": null,
+            "fqPacingRate": 0,
+            "geoLimit": 0,
+            "geoLimitCountries": "",
+            "geoLimitRedirectURL": null,
+            "geoProvider": 0,
+            "globalMaxMbps": 0,
+            "globalMaxTps": 0,
+            "httpBypassFqdn": "",
+            "infoUrl": "TBD",
+            "initialDispersion": 1,
+            "ipv6RoutingEnabled": true,
+            "lastUpdated": "2018-04-06 16:48:51+00",
+            "logsEnabled": false,
+            "longDesc": "",
+            "longDesc1": "",
+            "longDesc2": "",
+            "matchList": [
+                {
+                    "pattern": ".*\\.top-ds-in-cdn1\\..*",
+                    "setNumber": 0,
+                    "type": "HOST_REGEXP"
+                }
+            ],
+            "maxDnsAnswers": 0,
+            "midHeaderRewrite": null,
+            "missLat": 41.881944,
+            "missLong": -87.627778,
+            "multiSiteOrigin": false,
+            "orgServerFqdn": "http://example.org",
+            "originShield": null,
+            "profileDescription": null,
+            "profileName": null,
+            "protocol": 0,
+            "qstringIgnore": 0,
+            "rangeRequestHandling": 0,
+            "regexRemap": null,
+            "regionalGeoBlocking": false,
+            "remapText": null,
+            "routingName": "cdn",
+            "signed": false,
+            "signingAlgorithm": null,
+            "sslKeyVersion": 0,
+            "tenant": "tenant1",
+            "tenantName": "tenant1",
+            "topology": "top-used-by-cdn1-and-cdn2",
+            "type": "HTTP",
+            "xmlId": "top-ds-in-cdn1",
+            "anonymousBlockingEnabled": false
+        },
+        {
+            "active": true,
+            "cdnName": "cdn2",
+            "cacheurl": "",
+            "ccrDnsTtl": 3600,
+            "checkPath": "",
+            "consistentHashQueryParams": [],
+            "deepCachingType": "NEVER",
+            "displayName": "top-ds-in-cdn2",
+            "dnsBypassCname": null,
+            "dnsBypassIp": "",
+            "dnsBypassIp6": "",
+            "dnsBypassTtl": 30,
+            "dscp": 40,
+            "edgeHeaderRewrite": null,
+            "fqPacingRate": 0,
+            "geoLimit": 0,
+            "geoLimitCountries": "",
+            "geoLimitRedirectURL": null,
+            "geoProvider": 0,
+            "globalMaxMbps": 0,
+            "globalMaxTps": 0,
+            "httpBypassFqdn": "",
+            "infoUrl": "TBD",
+            "initialDispersion": 1,
+            "ipv6RoutingEnabled": true,
+            "lastUpdated": "2018-04-06 16:48:51+00",
+            "logsEnabled": false,
+            "longDesc": "",
+            "longDesc1": "",
+            "longDesc2": "",
+            "matchList": [
+                {
+                    "pattern": ".*\\.top-ds-in-cdn2\\..*",
+                    "setNumber": 0,
+                    "type": "HOST_REGEXP"
+                }
+            ],
+            "maxDnsAnswers": 0,
+            "midHeaderRewrite": null,
+            "missLat": 41.881944,
+            "missLong": -87.627778,
+            "multiSiteOrigin": false,
+            "orgServerFqdn": "http://example.org",
+            "originShield": null,
+            "profileDescription": null,
+            "profileName": null,
+            "protocol": 0,
+            "qstringIgnore": 0,
+            "rangeRequestHandling": 0,
+            "regexRemap": null,
+            "regionalGeoBlocking": false,
+            "remapText": null,
+            "routingName": "cdn",
+            "signed": false,
+            "signingAlgorithm": null,
+            "sslKeyVersion": 0,
+            "tenant": "tenant1",
+            "tenantName": "tenant1",
+            "topology": "top-used-by-cdn1-and-cdn2",
+            "type": "HTTP",
+            "xmlId": "top-ds-in-cdn2",
             "anonymousBlockingEnabled": false
         }
     ],
@@ -3426,6 +3625,90 @@
             "updPending": false
         },
         {
+            "cachegroup": "secondaryCachegroup",
+            "cdnName": "cdn1",
+            "domainName": "kabletown.net",
+            "hostName": "midInSecondaryCachegroupInCDN1",
+            "httpsPort": 443,
+            "interfaces": [
+                {
+                    "ipAddresses": [
+                        {
+                            "address": "2001:db8:deed:beef::12/64",
+                            "gateway": "2001:db8:deed:beef::1",
+                            "serviceAddress": false
+                        },
+                        {
+                            "address": "192.0.7.15/24",
+                            "gateway": "192.0.7.1",
+                            "serviceAddress": true
+                        }
+                    ],
+                    "monitor": true,
+                    "mtu": 9000,
+                    "name": "bond0"
+                }
+            ],
+            "physLocation": "Denver",
+            "profile": "MID1",
+            "rack": "RR 119.02",
+            "revalPending": false,
+            "status": "REPORTED",
+            "tcpPort": 80,
+            "type": "MID",
+            "updPending": false
+        },
+        {
+            "cachegroup": "cdn1-only",
+            "cdnName": "cdn1",
+            "domainName": "foo.kabletown.net",
+            "guid": null,
+            "hostName": "edge-in-cdn1-only",
+            "httpsPort": 443,
+            "iloIpAddress": "",
+            "iloIpGateway": "",
+            "iloIpNetmask": "",
+            "iloPassword": "",
+            "iloUsername": "",
+            "interfaces": [
+                {
+                    "ipAddresses": [
+                        {
+                            "address": "192.0.2.88/24",
+                            "gateway": "192.0.2.1",
+                            "serviceAddress": true
+                        },
+                        {
+                            "address": "2001:db8:f33d:beef::2/64",
+                            "gateway": "2001:db8:f33d:beef::1",
+                            "serviceAddress": false
+                        }
+                    ],
+                    "maxBandwidth": null,
+                    "monitor": true,
+                    "mtu": 9000,
+                    "name": "bond0"
+                }
+            ],
+            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+            "mgmtIpAddress": "",
+            "mgmtIpGateway": "",
+            "mgmtIpNetmask": "",
+            "offlineReason": null,
+            "physLocation": "Denver",
+            "profile": "EDGE1",
+            "rack": "RR 119.02",
+            "revalPending": false,
+            "routerHostName": "",
+            "routerPortName": "",
+            "status": "REPORTED",
+            "tcpPort": 80,
+            "type": "EDGE",
+            "updPending": false,
+            "xmppId": "",
+            "xmppPasswd": ""
+        },
+        {
             "cachegroup": "fallback1",
             "cdnName": "cdn2",
             "domainName": "kabletown.net",
@@ -3622,6 +3905,40 @@
             ],
             "physLocation": "Denver",
             "profile": "CDN2_MID",
+            "rack": "RR 119.02",
+            "revalPending": false,
+            "status": "REPORTED",
+            "tcpPort": 80,
+            "type": "MID",
+            "updPending": false
+        },
+        {
+            "cachegroup": "topology-mid-cg-01",
+            "cdnName": "cdn1",
+            "domainName": "kabletown.net",
+            "hostName": "midInTopologyMidCg01InCDN1",
+            "httpsPort": 443,
+            "interfaces": [
+                {
+                    "ipAddresses": [
+                        {
+                            "address": "2001:db8:de4d:beef::12/64",
+                            "gateway": "2001:db8:de4d:beef::1",
+                            "serviceAddress": false
+                        },
+                        {
+                            "address": "192.0.12.21/24",
+                            "gateway": "192.0.12.1",
+                            "serviceAddress": true
+                        }
+                    ],
+                    "monitor": true,
+                    "mtu": 9000,
+                    "name": "bond0"
+                }
+            ],
+            "physLocation": "Denver",
+            "profile": "MID1",
             "rack": "RR 119.02",
             "revalPending": false,
             "status": "REPORTED",
@@ -4228,6 +4545,24 @@
                 {
                     "cachegroup": "dtrc2",
                     "parents": [1]
+                }
+            ]
+        },
+        {
+            "name": "top-used-by-cdn1-and-cdn2",
+            "description": "a topology",
+            "nodes": [
+                {
+                    "cachegroup": "dtrc1",
+                    "parents": []
+                },
+                {
+                    "cachegroup": "dtrc2",
+                    "parents": [0]
+                },
+                {
+                    "cachegroup": "dtrc3",
+                    "parents": [0]
                 }
             ]
         }

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -142,7 +142,12 @@ func (topology *TOTopology) Validate() error {
 	for index, cacheGroup := range cacheGroups {
 		cacheGroupIds[index] = *cacheGroup.ID
 	}
-	rules["empty cachegroups"] = CheckForEmptyCacheGroups(topology.ReqInfo.Tx, cacheGroupIds, false, nil)
+	dsCDNs, err := dbhelpers.GetDeliveryServiceCDNsByTopology(topology.ReqInfo.Tx.Tx, topology.Name)
+	if err != nil {
+		log.Errorf("validating topology: %v", err)
+		return errors.New("unable to validate topology")
+	}
+	rules["empty cachegroups"] = CheckForEmptyCacheGroups(topology.ReqInfo.Tx, cacheGroupIds, dsCDNs, false, nil)
 	rules["required capabilities"] = topology.validateDSRequiredCapabilities()
 
 	/* Only perform further checks if everything so far is valid */
@@ -159,7 +164,10 @@ func (topology *TOTopology) Validate() error {
 	return util.JoinErrs(tovalidate.ToErrors(rules))
 }
 
-func CheckForEmptyCacheGroups(tx *sqlx.Tx, cacheGroupIds []int, cachegroupsInTopology bool, excludeServerIds []int) error {
+// CheckForEmptyCacheGroups checks if the cachegroups are empty (altogether) or empty in any of the given CDN IDs.
+// If cachegroupsInTopology is true, it will only check cachegroups that are used in a topology. Any server IDs in
+// excludeServerIds will not be counted.
+func CheckForEmptyCacheGroups(tx *sqlx.Tx, cacheGroupIds []int, CDNIDs []int, cachegroupsInTopology bool, excludeServerIds []int) error {
 	if excludeServerIds == nil {
 		excludeServerIds = []int{}
 	}
@@ -180,14 +188,16 @@ func CheckForEmptyCacheGroups(tx *sqlx.Tx, cacheGroupIds []int, cachegroupsInTop
 	}
 
 	var (
-		serverCount int
-		cacheGroup  string
-		cacheGroups []string
-		topologies  []string
+		serverCountByCDN int
+		cacheGroup       string
+		cdnID            *int
 	)
+	cgServerCountsByCDN := make(map[int]map[string]int)
+	cgServerCounts := make(map[string]int)
+	topologySetByCachegroup := make(map[string]map[string]struct{})
 	defer log.Close(rows, "unable to close DB connection when checking for cachegroups with no servers")
 	for rows.Next() {
-		var scanTo = []interface{}{&cacheGroup, &serverCount}
+		var scanTo = []interface{}{&cacheGroup, &cdnID, &serverCountByCDN}
 		var topologiesForRow []string
 		if cachegroupsInTopology {
 			scanTo = append(scanTo, pq.Array(&topologiesForRow))
@@ -196,23 +206,70 @@ func CheckForEmptyCacheGroups(tx *sqlx.Tx, cacheGroupIds []int, cachegroupsInTop
 			log.Errorf(systemError, err.Error())
 			return baseError
 		}
-		if serverCount != 0 {
-			break
+		if cdnID != nil {
+			if _, ok := cgServerCountsByCDN[*cdnID]; !ok {
+				cgServerCountsByCDN[*cdnID] = make(map[string]int)
+			}
+			cgServerCountsByCDN[*cdnID][cacheGroup] = serverCountByCDN
 		}
-		cacheGroups = append(cacheGroups, cacheGroup)
+		cgServerCounts[cacheGroup] += serverCountByCDN
+
 		if cachegroupsInTopology {
-			topologies = append(topologies, topologiesForRow...)
+			if _, ok := topologySetByCachegroup[cacheGroup]; !ok {
+				topologySetByCachegroup[cacheGroup] = make(map[string]struct{})
+			}
+			for _, topology := range topologiesForRow {
+				topologySetByCachegroup[cacheGroup][topology] = struct{}{}
+			}
+		}
+	}
+	topologiesByCachegroup := make(map[string][]string, len(topologySetByCachegroup))
+	for cg, topologySet := range topologySetByCachegroup {
+		for topology := range topologySet {
+			topologiesByCachegroup[cg] = append(topologiesByCachegroup[cg], topology)
+		}
+	}
+	emptyCachegroups := []string{}
+	for cg, count := range cgServerCounts {
+		if count == 0 {
+			messageEntry := cg
+			if cachegroupsInTopology {
+				messageEntry += " (in topologies: " + strings.Join(topologiesByCachegroup[cg], ", ") + ")"
+			}
+			emptyCachegroups = append(emptyCachegroups, messageEntry)
 		}
 	}
 
-	if len(cacheGroups) > 0 {
-		errMessage := "cachegroups with no servers in them: " + strings.Join(cacheGroups, ", ")
-		if cachegroupsInTopology {
-			errMessage += " in topologies: " + strings.Join(topologies, ", ")
-		}
-		err = errors.New(errMessage)
+	if len(emptyCachegroups) > 0 {
+		errMessage := "cachegroups with no servers in them: " + strings.Join(emptyCachegroups, ", ")
+		return errors.New(errMessage)
 	}
-	return err
+
+	errMessage := []string{}
+	for _, cdnID := range CDNIDs {
+		if _, ok := cgServerCountsByCDN[cdnID]; !ok {
+			return fmt.Errorf("topology is assigned to delivery service on CDN %d, but that CDN has no servers", cdnID)
+		}
+		emptyCachegroupsByCDN := []string{}
+		for cg, serverCount := range cgServerCountsByCDN[cdnID] {
+			if serverCount == 0 {
+				emptyCachegroupsByCDN = append(emptyCachegroupsByCDN, cg)
+			}
+		}
+		// check that this CDN has a count for all given cachegroups
+		for cg := range cgServerCounts {
+			if _, ok := cgServerCountsByCDN[cdnID][cg]; !ok {
+				emptyCachegroupsByCDN = append(emptyCachegroupsByCDN, cg)
+			}
+		}
+		if len(emptyCachegroupsByCDN) > 0 {
+			errMessage = append(errMessage, fmt.Sprintf("topology is assigned to delivery service(s) on CDN %d, but the following cachegroups have no servers in CDN %d: %s", cdnID, cdnID, strings.Join(emptyCachegroupsByCDN, ", ")))
+		}
+	}
+	if len(errMessage) > 0 {
+		return errors.New(strings.Join(errMessage, "; "))
+	}
+	return nil
 }
 
 func (topology *TOTopology) nodesInOtherTopologies() ([]tc.TopologyNode, map[string][]string, error) {
@@ -769,6 +826,7 @@ func selectEmptyCacheGroupsQuery(cachegroupsInTopology bool) string {
 	query := fmt.Sprintf(`
 		SELECT
 			c."name",
+			s.cdn_id,
 			COUNT(*) FILTER (
 			    WHERE s.id IS NOT NULL
 			    AND NOT(s."id" = ANY(CAST(:exclude_server_ids AS INT[])))
@@ -777,8 +835,7 @@ func selectEmptyCacheGroupsQuery(cachegroupsInTopology bool) string {
 		%s
 		LEFT JOIN "server" s ON c.id = s.cachegroup
 		WHERE c."id" = ANY(CAST(:cachegroup_ids AS BIGINT[]))
-		GROUP BY c."name"
-		ORDER BY server_count
+		GROUP BY c."name", s.cdn_id
 	`, topologyNames, joinTopologyCachegroups)
 	return query
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Adds the following validation to topology updates and server updates/deletions:

Topologies must contain at least 1 server per cachegroup in each of the
CDNs of any assigned delivery services. Otherwise, a delivery service's
topology is not truly representative of reality.

- [x] This PR fixes #5171 and fixes #5286 

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?
Review the added tests, ensure they pass.

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] validation, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
