### PR TITLE
Removing atscfg as a dependency in traffic_ops_golang

### DIFF
--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -33,6 +33,7 @@ import (
 
 const InvalidID = -1
 const DefaultATSVersion = "5" // TODO Emulates Perl; change to 6? ATC no longer officially supports ATS 5.
+// todo also unused
 const HeaderCommentDateFormat = "Mon Jan 2 15:04:05 MST 2006"
 const ContentTypeTextASCII = `text/plain; charset=us-ascii`
 const LineCommentHash = "#"
@@ -243,6 +244,7 @@ func trimParamUnderscoreNumSuffix(paramName string) string {
 }
 
 // topologyIncludesServer returns whether the given topology includes the given server.
+// todo also unused
 func topologyIncludesServer(topology tc.Topology, server *tc.Server) bool {
 	for _, node := range topology.Nodes {
 		if node.Cachegroup == server.Cachegroup {
@@ -607,10 +609,7 @@ func makeErr(warnings []string, err string) error {
 }
 
 // makeErrf is a convenience for formatting errors for makeErr.
+// todo also unused, maybe remove?
 func makeErrf(warnings []string, format string, v ...interface{}) error {
 	return makeErr(warnings, fmt.Sprintf(format, v...))
-}
-
-func GetConfigFile(prefix string, xmlId string) string {
-	return prefix + xmlId + ConfigSuffix
 }

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -58,7 +58,8 @@ WHERE deliveryservice.id = ANY($1)
 `
 
 func getConfigFile(prefix string, xmlId string) string {
-	return prefix + xmlId + `.config`
+	const configSuffix = `.config`
+	return prefix + xmlId + configSuffix
 }
 
 func AssignDeliveryServicesToServerHandler(w http.ResponseWriter, r *http.Request) {
@@ -272,10 +273,11 @@ INSERT INTO deliveryservice_server (deliveryservice, server)
 
 	//need remap config location
 	var atsConfigLocation string
+	const remapFile = `remap.config`
 	if err := tx.QueryRow(
 		`SELECT value FROM parameter
 		WHERE name = 'location'
-		AND config_file = 'remap.config'`).Scan(&atsConfigLocation); err != nil {
+		AND config_file = '` + remapFile + `'`).Scan(&atsConfigLocation); err != nil {
 		return nil, errors.New("scanning location parameter: " + err.Error())
 	}
 	if strings.HasSuffix(atsConfigLocation, "/") {
@@ -305,21 +307,24 @@ INSERT INTO deliveryservice_server (deliveryservice, server)
 		if err := rows.Scan(&xmlID, &edgeHeaderRewrite, &regexRemap, &cacheURL); err != nil {
 			return nil, errors.New("scanning deliveryservice: " + err.Error())
 		}
+		const headerRewritePrefix = `hdr_rw_`
+		const regexRemapPrefix = `regex_remap_`
+		const cacheURLPrefix = `cacheurl_`
 		if xmlID.Valid && len(xmlID.String) > 0 {
 			//param := "hdr_rw_" + xmlID.String + ".config"
-			param := getConfigFile(`hdr_rw_`, xmlID.String)
+			param := getConfigFile(headerRewritePrefix, xmlID.String)
 			if edgeHeaderRewrite.Valid && len(edgeHeaderRewrite.String) > 0 {
 				insert = append(insert, param)
 			} else {
 				delete = append(delete, param)
 			}
-			param = getConfigFile(`regex_remap_`, xmlID.String)
+			param = getConfigFile(regexRemapPrefix, xmlID.String)
 			if regexRemap.Valid && len(regexRemap.String) > 0 {
 				insert = append(insert, param)
 			} else {
 				delete = append(delete, param)
 			}
-			param = getConfigFile(`cacheurl_`, xmlID.String)
+			param = getConfigFile(cacheURLPrefix, xmlID.String)
 			if cacheURL.Valid && len(cacheURL.String) > 0 {
 				insert = append(insert, param)
 			} else {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #5301
- necessary consts moved into `traffic_ops_golang/server/servers_assignment.go`
- `GetConfigFile` added to `traffic_ops_golang/server/servers_assignment.go` and renamed to `getConfigFile` (isn't used elsewhere in package)

Does not seem to require updating any tests, nor does there seem to be any specific documentation related to this that needs updated.

Will update `CHANGELOG` if required, there should also be some corresponding documentation surrounding updating the consts that were moved over.


## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Intentionally break `go-atscfg` and ensure `traffic_ops_golang` still builds and performs expected duties

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**