### PR TITLE
Improve validation error message for regions with no division name

### DIFF
--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -97,8 +97,8 @@ func (region *TORegion) Validate() error {
 	if len(region.Name) < 1 {
 		return errors.New(`region 'name' is required`)
 	}
-	if region.DivisionName == "" || region.Division == 0 {
-		return errors.New(`region 'division' and 'divisionName' are required`)
+	if region.Division == 0 {
+		return errors.New(`region 'division' is are required`)
 	}
 	return nil
 }

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -98,7 +98,7 @@ func (region *TORegion) Validate() error {
 		return errors.New(`region 'name' is required`)
 	}
 	if region.Division == 0 {
-		return errors.New(`region 'division' is are required`)
+		return errors.New(`region 'division' is required`)
 	}
 	return nil
 }

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -95,7 +95,10 @@ func (region *TORegion) GetType() string {
 
 func (region *TORegion) Validate() error {
 	if len(region.Name) < 1 {
-		return errors.New(`Region 'name' is required.`)
+		return errors.New(`region 'name' is required`)
+	}
+	if region.DivisionName == "" || region.Division == 0 {
+		return errors.New(`region 'division' and 'divisionName' are required`)
 	}
 	return nil
 }

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -20,13 +20,15 @@ package region
  */
 
 import (
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
-	"github.com/jmoiron/sqlx"
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
-	"testing"
-	"time"
 )
 
 func getTestRegions() []tc.Region {

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -20,14 +20,13 @@ package region
  */
 
 import (
-	"testing"
-	"time"
-
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"testing"
+	"time"
 )
 
 func getTestRegions() []tc.Region {
@@ -46,7 +45,6 @@ func getTestRegions() []tc.Region {
 
 	return regions
 }
-
 func TestReadRegions(t *testing.T) {
 
 	mockDB, mock, err := sqlmock.New()
@@ -107,5 +105,33 @@ func TestInterfaces(t *testing.T) {
 	}
 	if _, ok := i.(api.Identifier); !ok {
 		t.Errorf("Region must be Identifier")
+	}
+}
+func TestValidation(t *testing.T) {
+	testRegion := tc.Region{
+		DivisionName: "west",
+		Division:     77,
+		ID:           1,
+		Name:         "region1",
+		LastUpdated:  tc.TimeNoMod{Time: time.Now()},
+	}
+	testTORegion := TORegion{Region: testRegion}
+	errs := test.SortErrors(test.SplitErrors(testTORegion.Validate()))
+
+	if len(errs) > 0 {
+		t.Errorf(`expected no errors,  got %v`, errs)
+	}
+
+	testRegionNoDivision := tc.Region{
+		ID:          1,
+		Name:        "region1",
+		LastUpdated: tc.TimeNoMod{Time: time.Now()},
+	}
+	testTORegionNoDivision := TORegion{Region: testRegionNoDivision}
+	errs = test.SortErrors(test.SplitErrors(testTORegionNoDivision.Validate()))
+	if len(errs) == 0 {
+		t.Errorf(`expected an error with a nil division name, received no error`)
+	} else {
+		t.Logf(`Got expected error validating region with no division: %s`, errs[0].Error())
 	}
 }

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -132,7 +132,7 @@ func TestValidation(t *testing.T) {
 	testTORegionNoDivision := TORegion{Region: testRegionNoDivision}
 	errs = test.SortErrors(test.SplitErrors(testTORegionNoDivision.Validate()))
 	if len(errs) == 0 {
-		t.Errorf(`expected an error with a nil division name, received no error`)
+		t.Errorf(`expected an error with a nil division id, received no error`)
 	} else {
 		t.Logf(`Got expected error validating region with no division: %s`, errs[0].Error())
 	}


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Improves Validation and Validation error messages for Regions, now when a `POST` is fired at that endpoint without a division name it returns an appropriate error message.

This may require additional documentation changes (swagger docs, maybe)

- [x] This PR fixes #5285 

## Which Traffic Control components are affected by this PR?

- Traffic Ops


## What is the best way to verify this PR?
Follow repro steps in #5285 description, ensure new error message is displayed

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**