### PR TITLE
Refactor TO Go client internals to use a consistent, shared method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - #2881 Some API endpoints have incorrect Content-Types
 - [#5311](https://github.com/apache/trafficcontrol/issues/5311) - Better TO log messages when failures calling TM CacheStats
 
+### Changed
+- Refactored the Traffic Ops Go client internals so that all public methods have a consistent behavior/implementation
+
 ## [5.0.0] - 2020-10-20
 ### Added
 - Traffic Ops Ort: Disabled ntpd verification (ntpd is deprecated in CentOS)

--- a/lib/go-tc/parameters.go
+++ b/lib/go-tc/parameters.go
@@ -251,6 +251,10 @@ type ProfileParametersNullable struct {
 	Parameter   *int       `json:"parameter" db:"parameter_id"`
 }
 
+type ProfileParametersNullableResponse struct {
+	Response []ProfileParametersNullable `json:"response"`
+}
+
 // ProfileExportImportParameterNullable is an object of the form used by Traffic Ops
 // to represent parameters for exported and imported profiles.
 type ProfileExportImportParameterNullable struct {

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -424,9 +424,9 @@ func DeleteTestProfiles(t *testing.T) {
 		}
 
 		// Attempt to export Profile
-		profile, _, err := TOSession.ExportProfile(profileID)
-		if profile != nil {
-			t.Errorf("expected Profile: %s to be nil on export", pr.Name)
+		_, _, err = TOSession.ExportProfile(profileID)
+		if err == nil {
+			t.Errorf("export deleted profile %s - expected: error, actual: nil", pr.Name)
 		}
 	}
 }

--- a/traffic_ops/testing/api/v3/staticdnsentries_test.go
+++ b/traffic_ops/testing/api/v3/staticdnsentries_test.go
@@ -17,8 +17,8 @@ package v3
 
 import (
 	"net/http"
-	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -175,11 +175,12 @@ func UpdateTestStaticDNSEntries(t *testing.T) {
 
 func UpdateTestStaticDNSEntriesInvalidAddress(t *testing.T) {
 
-	expectedAlerts := []tc.Alerts{
-		tc.Alerts{[]tc.Alert{tc.Alert{"'address' must be a valid IPv4 address", "error"}}},
-		tc.Alerts{[]tc.Alert{tc.Alert{"'address' must be a valid DNS name", "error"}}},
-		tc.Alerts{[]tc.Alert{tc.Alert{"'address' for type: CNAME_RECORD must have a trailing period", "error"}}},
-		tc.Alerts{[]tc.Alert{tc.Alert{"'address' must be a valid IPv6 address", "error"}}}}
+	expectedAlerts := []string{
+		"'address' must be a valid IPv4 address",
+		"'address' must be a valid DNS name",
+		"'address' for type: CNAME_RECORD must have a trailing period",
+		"'address' must be a valid IPv6 address",
+	}
 
 	// A_RECORD
 	firstStaticDNSEntry := testData.StaticDNSEntries[0]
@@ -191,15 +192,15 @@ func UpdateTestStaticDNSEntriesInvalidAddress(t *testing.T) {
 	remoteStaticDNSEntry := resp[0]
 	expectedAddress := "test.testdomain.net."
 	remoteStaticDNSEntry.Address = expectedAddress
-	var alert tc.Alerts
 	var status int
-	alert, _, status, err = TOSession.UpdateStaticDNSEntryByID(remoteStaticDNSEntry.ID, remoteStaticDNSEntry)
+	_, _, status, err = TOSession.UpdateStaticDNSEntryByID(remoteStaticDNSEntry.ID, remoteStaticDNSEntry)
 	t.Log("Status Code [expect 400]: ", status)
-	if err != nil {
-		t.Logf("cannot UPDATE StaticDNSEntries using url: %v - %v\n", err, alert)
-	}
-	if !reflect.DeepEqual(alert, expectedAlerts[0]) {
-		t.Errorf("got alerts: %v but expected alerts: %v", alert, expectedAlerts[0])
+	if err == nil {
+		t.Errorf("making invalid update to static DNS entry - expected: error, actual: nil")
+	} else {
+		if !strings.Contains(err.Error(), expectedAlerts[0]) {
+			t.Errorf("got err: %v, but expected err containing: %v", err, expectedAlerts[0])
+		}
 	}
 
 	// CNAME_RECORD
@@ -212,25 +213,23 @@ func UpdateTestStaticDNSEntriesInvalidAddress(t *testing.T) {
 	remoteStaticDNSEntry = resp[0]
 	expectedAddress = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
 	remoteStaticDNSEntry.Address = expectedAddress
-	alert, _, status, err = TOSession.UpdateStaticDNSEntryByID(remoteStaticDNSEntry.ID, remoteStaticDNSEntry)
+	_, _, status, err = TOSession.UpdateStaticDNSEntryByID(remoteStaticDNSEntry.ID, remoteStaticDNSEntry)
 	t.Log("Status Code [expect 400]: ", status)
-	if err != nil {
-		t.Logf("cannot UPDATE StaticDNSEntries using url: %v - %v\n", err, alert)
-	}
-	if !reflect.DeepEqual(alert, expectedAlerts[1]) {
-		t.Errorf("got alerts: %v but expected alerts: %v", alert, expectedAlerts[1])
+	if err == nil {
+		t.Errorf("making invalid update to static DNS entry - expected: error, actual: nil")
+	} else if !strings.Contains(err.Error(), expectedAlerts[1]) {
+		t.Errorf("got err: %v, but expected err containing: %v", err, expectedAlerts[1])
 	}
 
 	//CNAME_RECORD: missing a trailing period
 	expectedAddressMissingPeriod := "cdn.test.com"
 	remoteStaticDNSEntry.Address = expectedAddressMissingPeriod
-	alert, _, status, err = TOSession.UpdateStaticDNSEntryByID(remoteStaticDNSEntry.ID, remoteStaticDNSEntry)
+	_, _, status, err = TOSession.UpdateStaticDNSEntryByID(remoteStaticDNSEntry.ID, remoteStaticDNSEntry)
 	t.Log("Status Code [expect 400]: ", status)
-	if err != nil {
-		t.Logf("cannot UPDATE StaticDNSEntries using url: %v - %v\n", err, alert)
-	}
-	if !reflect.DeepEqual(alert, expectedAlerts[2]) {
-		t.Errorf("got alerts: %v but expected alerts: %v", alert, expectedAlerts[2])
+	if err == nil {
+		t.Errorf("making invalid update to static DNS entry - expected: error, actual: nil")
+	} else if !strings.Contains(err.Error(), expectedAlerts[2]) {
+		t.Errorf("got err: %v, but expected err containing: %v", err, expectedAlerts[2])
 	}
 
 	// AAAA_RECORD
@@ -243,13 +242,12 @@ func UpdateTestStaticDNSEntriesInvalidAddress(t *testing.T) {
 	remoteStaticDNSEntry = resp[0]
 	expectedAddress = "192.168.0.1"
 	remoteStaticDNSEntry.Address = expectedAddress
-	alert, _, status, err = TOSession.UpdateStaticDNSEntryByID(remoteStaticDNSEntry.ID, remoteStaticDNSEntry)
+	_, _, status, err = TOSession.UpdateStaticDNSEntryByID(remoteStaticDNSEntry.ID, remoteStaticDNSEntry)
 	t.Log("Status Code [expect 400]: ", status)
-	if err != nil {
-		t.Logf("cannot UPDATE StaticDNSEntries using url: %v - %v\n", err, alert)
-	}
-	if !reflect.DeepEqual(alert, expectedAlerts[3]) {
-		t.Errorf("got alerts: %v but expected alerts: %v", alert, expectedAlerts[3])
+	if err == nil {
+		t.Errorf("making invalid update to static DNS entry - expected: error, actual: nil")
+	} else if !strings.Contains(err.Error(), expectedAlerts[3]) {
+		t.Errorf("got err: %v, but expected err containging: %v", err, expectedAlerts[3])
 	}
 }
 

--- a/traffic_ops/v3-client/README.md
+++ b/traffic_ops/v3-client/README.md
@@ -40,8 +40,8 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println("Connected to: " + remoteaddr.String())
-	var cdns []v13.CDN
-	cdns, _, err = session.GetCDNs()
+	var cdns []tc.CDN
+	cdns, _, err = session.GetCDNsWithHdr(nil)
 	if err != nil {
 		fmt.Printf("An error occurred while getting cdns:\n\t%v\n", err)
 		os.Exit(1)

--- a/traffic_ops/v3-client/about.go
+++ b/traffic_ops/v3-client/about.go
@@ -20,11 +20,6 @@ package client
    limitations under the License.
 */
 
-import (
-	"encoding/json"
-	"net/http"
-)
-
 const (
 	API_ABOUT = apiBase + "/about"
 )
@@ -32,17 +27,7 @@ const (
 // GetAbout gets data about the TO instance.
 func (to *Session) GetAbout() (map[string]string, ReqInf, error) {
 	route := API_ABOUT
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data, reqInf, nil
+	reqInf, err := to.get(route, nil, &data)
+	return data, reqInf, err
 }

--- a/traffic_ops/v3-client/api_capability.go
+++ b/traffic_ops/v3-client/api_capability.go
@@ -1,9 +1,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -46,15 +44,7 @@ func (to *Session) GetAPICapabilities(capability string, order string) (tc.APICa
 		path = fmt.Sprintf("%s?%s", path, vals.Encode())
 	}
 
-	httpResp, remoteAddr, err := to.request(http.MethodGet, path, nil, nil)
-	reqInf.RemoteAddr = remoteAddr
-
-	if err != nil {
-		return tc.APICapabilityResponse{}, reqInf, err
-	}
-	defer httpResp.Body.Close()
-
-	err = json.NewDecoder(httpResp.Body).Decode(&resp)
+	reqInf, err := to.get(path, nil, &resp)
 
 	return resp, reqInf, err
 }

--- a/traffic_ops/v3-client/asn.go
+++ b/traffic_ops/v3-client/asn.go
@@ -16,9 +16,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 
@@ -31,77 +29,31 @@ const (
 
 // CreateASN creates a ASN
 func (to *Session) CreateASN(entity tc.ASN) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(entity)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_ASNS, reqBody, nil)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.post(API_ASNS, entity, nil, &alerts)
+	return alerts, reqInf, err
 }
 
 // UpdateASNByID updates a ASN by ID
 func (to *Session) UpdateASNByID(id int, entity tc.ASN) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(entity)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
 	route := fmt.Sprintf("%s?id=%d", API_ASNS, id)
-	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody, nil)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.put(route, entity, nil, &alerts)
+	return alerts, reqInf, err
 }
 
 // GetASNsWithHeader Returns a list of ASNs matching query params
 func (to *Session) GetASNsWithHeader(params *url.Values, header http.Header) ([]tc.ASN, ReqInf, error) {
 	route := fmt.Sprintf("%s?%s", API_ASNS, params.Encode())
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.ASN{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.ASNsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return data.Response, reqInf, err
-	}
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &data)
+	return data.Response, reqInf, err
 }
 
 // DeleteASNByASN deletes an ASN by asn number
 func (to *Session) DeleteASNByASN(asn int) (tc.Alerts, ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", API_ASNS, asn)
-	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.del(route, nil, &alerts)
+	return alerts, reqInf, err
 }

--- a/traffic_ops/v3-client/cdn.go
+++ b/traffic_ops/v3-client/cdn.go
@@ -16,9 +16,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 
@@ -31,43 +29,16 @@ const (
 
 // CreateCDN creates a CDN.
 func (to *Session) CreateCDN(cdn tc.CDN) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(cdn)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_CDNS, reqBody, nil)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.post(API_CDNS, cdn, nil, &alerts)
+	return alerts, reqInf, err
 }
 
 func (to *Session) UpdateCDNByIDWithHdr(id int, cdn tc.CDN, header http.Header) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(cdn)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
 	route := fmt.Sprintf("%s/%d", API_CDNS, id)
-	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody, header)
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-	}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.put(route, cdn, header, &alerts)
+	return alerts, reqInf, err
 }
 
 // UpdateCDNByID updates a CDN by ID.
@@ -77,22 +48,9 @@ func (to *Session) UpdateCDNByID(id int, cdn tc.CDN) (tc.Alerts, ReqInf, error) 
 }
 
 func (to *Session) GetCDNsWithHdr(header http.Header) ([]tc.CDN, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, API_CDNS, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.CDN{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.CDNsResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(API_CDNS, header, &data)
+	return data.Response, reqInf, err
 }
 
 // GetCDNs eturns a list of CDNs.
@@ -103,25 +61,9 @@ func (to *Session) GetCDNs() ([]tc.CDN, ReqInf, error) {
 
 func (to *Session) GetCDNByIDWithHdr(id int, header http.Header) ([]tc.CDN, ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%v", API_CDNS, id)
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.CDN{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.CDNsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &data)
+	return data.Response, reqInf, err
 }
 
 // GetCDNByID a CDN by the CDN ID.
@@ -131,26 +73,10 @@ func (to *Session) GetCDNByID(id int) ([]tc.CDN, ReqInf, error) {
 }
 
 func (to *Session) GetCDNByNameWithHdr(name string, header http.Header) ([]tc.CDN, ReqInf, error) {
-	url := fmt.Sprintf("%s?name=%s", API_CDNS, url.QueryEscape(name))
-	resp, remoteAddr, err := to.request(http.MethodGet, url, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.CDN{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
+	route := fmt.Sprintf("%s?name=%s", API_CDNS, url.QueryEscape(name))
 	var data tc.CDNsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &data)
+	return data.Response, reqInf, err
 }
 
 // GetCDNByName gets a CDN by the CDN name.
@@ -162,38 +88,16 @@ func (to *Session) GetCDNByName(name string) ([]tc.CDN, ReqInf, error) {
 // DeleteCDNByID deletes a CDN by ID.
 func (to *Session) DeleteCDNByID(id int) (tc.Alerts, ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", API_CDNS, id)
-	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.del(route, nil, &alerts)
+	return alerts, reqInf, err
 }
 
 func (to *Session) GetCDNSSLKeysWithHdr(name string, header http.Header) ([]tc.CDNSSLKeys, ReqInf, error) {
-	url := fmt.Sprintf("%s/name/%s/sslkeys", API_CDNS, name)
-	resp, remoteAddr, err := to.request(http.MethodGet, url, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.CDNSSLKeys{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
+	route := fmt.Sprintf("%s/name/%s/sslkeys", API_CDNS, name)
 	var data tc.CDNSSLKeysResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &data)
+	return data.Response, reqInf, err
 }
 
 // Deprecated: GetCDNSSLKeys will be removed in 6.0. Use GetCDNSSLKeysWithHdr.

--- a/traffic_ops/v3-client/cdn_domains.go
+++ b/traffic_ops/v3-client/cdn_domains.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"github.com/apache/trafficcontrol/lib/go-tc"
 	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 /*
@@ -22,11 +23,8 @@ import (
 
 func (to *Session) GetDomainsWithHdr(header http.Header) ([]tc.Domain, ReqInf, error) {
 	var data tc.DomainsResponse
-	inf, err := get(to, apiBase+"/cdns/domains", &data, header)
-	if err != nil {
-		return nil, inf, err
-	}
-	return data.Response, inf, nil
+	inf, err := to.get(apiBase+"/cdns/domains", header, &data)
+	return data.Response, inf, err
 }
 
 // Deprecated: GetDomains will be removed in 6.0. Use GetDomainsWithHdr.

--- a/traffic_ops/v3-client/cdnfederations.go
+++ b/traffic_ops/v3-client/cdnfederations.go
@@ -16,9 +16,9 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -29,21 +29,16 @@ import (
  * keep the same behavior from perl. */
 
 func (to *Session) CreateCDNFederationByName(f tc.CDNFederation, CDNName string) (*tc.CreateCDNFederationResponse, ReqInf, error) {
-	jsonReq, err := json.Marshal(f)
-	if err != nil { //There is no remoteAddr for ReqInf at this point
-		return nil, ReqInf{CacheHitStatus: CacheHitStatusMiss}, err
-	}
-
 	data := tc.CreateCDNFederationResponse{}
-	url := fmt.Sprintf("%s/cdns/%s/federations", apiBase, CDNName)
-	inf, err := makeReq(to, "POST", url, jsonReq, &data, nil)
+	route := fmt.Sprintf("%s/cdns/%s/federations", apiBase, url.QueryEscape(CDNName))
+	inf, err := to.post(route, f, nil, &data)
 	return &data, inf, err
 }
 
 func (to *Session) GetCDNFederationsByNameWithHdr(CDNName string, header http.Header) (*tc.CDNFederationResponse, ReqInf, error) {
 	data := tc.CDNFederationResponse{}
-	url := fmt.Sprintf("%s/cdns/%s/federations", apiBase, CDNName)
-	inf, err := get(to, url, &data, header)
+	route := fmt.Sprintf("%s/cdns/%s/federations", apiBase, url.QueryEscape(CDNName))
+	inf, err := to.get(route, header, &data)
 	return &data, inf, err
 }
 
@@ -53,21 +48,18 @@ func (to *Session) GetCDNFederationsByName(CDNName string) (*tc.CDNFederationRes
 }
 
 func (to *Session) GetCDNFederationsByNameWithHdrReturnList(CDNName string, header http.Header) ([]tc.CDNFederation, ReqInf, error) {
-	url := fmt.Sprintf("%s/cdns/%s/federations", apiBase, CDNName)
+	route := fmt.Sprintf("%s/cdns/%s/federations", apiBase, url.QueryEscape(CDNName))
 	resp := struct {
 		Response []tc.CDNFederation `json:"response"`
 	}{}
-	inf, err := get(to, url, &resp, header)
-	if err != nil {
-		return nil, inf, err
-	}
-	return resp.Response, inf, nil
+	inf, err := to.get(route, header, &resp)
+	return resp.Response, inf, err
 }
 
 func (to *Session) GetCDNFederationsByIDWithHdr(CDNName string, ID int, header http.Header) (*tc.CDNFederationResponse, ReqInf, error) {
 	data := tc.CDNFederationResponse{}
-	url := fmt.Sprintf("%s/cdns/%s/federations?id=%v", apiBase, CDNName, ID)
-	inf, err := get(to, url, &data, header)
+	route := fmt.Sprintf("%s/cdns/%s/federations?id=%v", apiBase, url.QueryEscape(CDNName), ID)
+	inf, err := to.get(route, header, &data)
 	return &data, inf, err
 }
 
@@ -77,14 +69,9 @@ func (to *Session) GetCDNFederationsByID(CDNName string, ID int) (*tc.CDNFederat
 }
 
 func (to *Session) UpdateCDNFederationsByIDWithHdr(f tc.CDNFederation, CDNName string, ID int, h http.Header) (*tc.UpdateCDNFederationResponse, ReqInf, error) {
-	jsonReq, err := json.Marshal(f)
-	if err != nil { //There is no remoteAddr for ReqInf at this point
-		return nil, ReqInf{CacheHitStatus: CacheHitStatusMiss}, err
-	}
-
 	data := tc.UpdateCDNFederationResponse{}
-	url := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, CDNName, ID)
-	inf, err := makeReq(to, "PUT", url, jsonReq, &data, h)
+	route := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, url.QueryEscape(CDNName), ID)
+	inf, err := to.put(route, f, h, &data)
 	return &data, inf, err
 }
 
@@ -95,7 +82,7 @@ func (to *Session) UpdateCDNFederationsByID(f tc.CDNFederation, CDNName string, 
 
 func (to *Session) DeleteCDNFederationByID(CDNName string, ID int) (*tc.DeleteCDNFederationResponse, ReqInf, error) {
 	data := tc.DeleteCDNFederationResponse{}
-	url := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, CDNName, ID)
-	inf, err := makeReq(to, "DELETE", url, nil, &data, nil)
+	route := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, url.QueryEscape(CDNName), ID)
+	inf, err := to.del(route, nil, &data)
 	return &data, inf, err
 }

--- a/traffic_ops/v3-client/crconfig.go
+++ b/traffic_ops/v3-client/crconfig.go
@@ -18,9 +18,10 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-tc"
 	"net/http"
 	"net/url"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 const (
@@ -43,16 +44,13 @@ func (to *Session) GetCRConfig(cdn string) ([]byte, ReqInf, error) {
 	if err := json.Unmarshal(bts, &resp); err != nil {
 		return nil, reqInf, err
 	}
-	return []byte(resp.Response), reqInf, nil
+	return resp.Response, reqInf, nil
 }
 
 func (to *Session) SnapshotCRConfigWithHdr(cdn string, header http.Header) (ReqInf, error) {
 	uri := fmt.Sprintf("%s?cdn=%s", API_SNAPSHOT, url.QueryEscape(cdn))
-	resp, remoteAddr, err := to.request(http.MethodPut, uri, nil, header)
-	reqInf := ReqInf{RemoteAddr: remoteAddr, CacheHitStatus: CacheHitStatusMiss}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-	}
+	resp := OuterResponse{}
+	reqInf, err := to.put(uri, nil, header, &resp)
 	return reqInf, err
 }
 
@@ -68,7 +66,7 @@ func (to *Session) GetCRConfigNew(cdn string) ([]byte, ReqInf, error) {
 	if err := json.Unmarshal(bts, &resp); err != nil {
 		return nil, reqInf, err
 	}
-	return []byte(resp.Response), reqInf, nil
+	return resp.Response, reqInf, nil
 }
 
 // SnapshotCRConfig snapshots a CDN by name.
@@ -80,13 +78,7 @@ func (to *Session) SnapshotCRConfig(cdn string) (ReqInf, error) {
 // SnapshotCDNByID snapshots a CDN by ID.
 func (to *Session) SnapshotCRConfigByID(id int) (tc.Alerts, ReqInf, error) {
 	url := fmt.Sprintf("%s?cdnID=%d", API_SNAPSHOT, id)
-	resp, remoteAddr, err := to.request(http.MethodPut, url, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.put(url, nil, nil, &alerts)
+	return alerts, reqInf, err
 }

--- a/traffic_ops/v3-client/deliveryservice.go
+++ b/traffic_ops/v3-client/deliveryservice.go
@@ -119,7 +119,7 @@ const (
 
 func (to *Session) GetDeliveryServicesByServerV30WithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
 	var data tc.DeliveryServicesResponseV30
-	reqInf, err := get(to, fmt.Sprintf(API_SERVER_DELIVERY_SERVICES, id), &data, header)
+	reqInf, err := to.get(fmt.Sprintf(API_SERVER_DELIVERY_SERVICES, id), header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -138,12 +138,8 @@ func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryServiceNull
 func (to *Session) GetDeliveryServicesByServerWithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
 	var data tc.DeliveryServicesNullableResponse
 
-	reqInf, err := get(to, fmt.Sprintf(API_SERVER_DELIVERY_SERVICES, id), &data, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(fmt.Sprintf(API_SERVER_DELIVERY_SERVICES, id), header, &data)
+	return data.Response, reqInf, err
 }
 
 // GetDeliveryServicesV30WithHdr returns all (tenant-visible) Delivery Services that
@@ -154,10 +150,8 @@ func (to *Session) GetDeliveryServicesV30WithHdr(header http.Header, params url.
 	if params != nil {
 		uri += "?" + params.Encode()
 	}
-
 	var data tc.DeliveryServicesResponseV30
-
-	reqInf, err := get(to, uri, &data, header)
+	reqInf, err := to.get(uri, header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -165,11 +159,8 @@ func (to *Session) GetDeliveryServicesNullableWithHdr(header http.Header) ([]tc.
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
-	reqInf, err := get(to, API_DELIVERY_SERVICES, &data, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(API_DELIVERY_SERVICES, header, &data)
+	return data.Response, reqInf, err
 }
 
 // GetDeliveryServicesNullable returns a slice of Delivery Services.
@@ -187,11 +178,8 @@ func (to *Session) GetDeliveryServicesByCDNIDWithHdr(cdnID int, header http.Head
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
-	reqInf, err := get(to, API_DELIVERY_SERVICES+"?cdn="+strconv.Itoa(cdnID), &data, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(API_DELIVERY_SERVICES+"?cdn="+strconv.Itoa(cdnID), header, &data)
+	return data.Response, reqInf, err
 }
 
 // GetDeliveryServicesByCDNID returns the (tenant-visible) Delivery Services within the CDN identified
@@ -212,7 +200,7 @@ func (to *Session) GetDeliveryServiceNullableWithHdr(id string, header http.Head
 		Response []tc.DeliveryServiceNullableV30 `json:"response"`
 	}{}
 	route := fmt.Sprintf("%s?id=%s", API_DELIVERY_SERVICES, id)
-	reqInf, err := get(to, route, &data, header)
+	reqInf, err := to.get(route, header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -234,7 +222,7 @@ func (to *Session) GetDeliveryServiceNullable(id string) (*tc.DeliveryServiceNul
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
-	reqInf, err := get(to, API_DELIVERY_SERVICES+"?id="+id, &data, nil)
+	reqInf, err := to.get(API_DELIVERY_SERVICES+"?id="+url.QueryEscape(id), nil, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -248,12 +236,8 @@ func (to *Session) GetDeliveryServiceNullable(id string) (*tc.DeliveryServiceNul
 // the given XMLID.
 func (to *Session) GetDeliveryServiceByXMLIDNullableWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
 	var data tc.DeliveryServicesResponseV30
-	reqInf, err := get(to, API_DELIVERY_SERVICES+"?xmlId="+XMLID, &data, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(API_DELIVERY_SERVICES+"?xmlId="+url.QueryEscape(XMLID), header, &data)
+	return data.Response, reqInf, err
 }
 
 // GetDeliveryServiceByXMLIDNullable returns the Delivery Service identified by the passed XMLID.
@@ -281,7 +265,7 @@ func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string) ([]tc.Deliver
 func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (tc.DeliveryServiceNullableV30, ReqInf, error) {
 	var reqInf ReqInf
 	if ds.TypeID == nil && ds.Type != nil {
-		ty, _, err := to.GetTypeByName(ds.Type.String())
+		ty, _, err := to.GetTypeByNameWithHdr(ds.Type.String(), nil)
 		if err != nil {
 			return tc.DeliveryServiceNullableV30{}, reqInf, err
 		}
@@ -292,7 +276,7 @@ func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (t
 	}
 
 	if ds.CDNID == nil && ds.CDNName != nil {
-		cdns, _, err := to.GetCDNByName(*ds.CDNName)
+		cdns, _, err := to.GetCDNByNameWithHdr(*ds.CDNName, nil)
 		if err != nil {
 			return tc.DeliveryServiceNullableV30{}, reqInf, err
 		}
@@ -303,7 +287,7 @@ func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (t
 	}
 
 	if ds.ProfileID == nil && ds.ProfileName != nil {
-		profiles, _, err := to.GetProfileByName(*ds.ProfileName)
+		profiles, _, err := to.GetProfileByNameWithHdr(*ds.ProfileName, nil)
 		if err != nil {
 			return tc.DeliveryServiceNullableV30{}, reqInf, err
 		}
@@ -314,20 +298,15 @@ func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (t
 	}
 
 	if ds.TenantID == nil && ds.Tenant != nil {
-		ten, _, err := to.TenantByName(*ds.Tenant)
+		ten, _, err := to.TenantByNameWithHdr(*ds.Tenant, nil)
 		if err != nil {
 			return tc.DeliveryServiceNullableV30{}, reqInf, err
 		}
 		ds.TenantID = &ten.ID
 	}
 
-	bts, err := json.Marshal(ds)
-	if err != nil {
-		return tc.DeliveryServiceNullableV30{}, reqInf, nil
-	}
-
 	var data tc.DeliveryServicesResponseV30
-	reqInf, err = post(to, API_DELIVERY_SERVICES, bts, &data)
+	reqInf, err := to.post(API_DELIVERY_SERVICES, ds, nil, &data)
 	if err != nil {
 		return tc.DeliveryServiceNullableV30{}, reqInf, err
 	}
@@ -348,7 +327,7 @@ func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (t
 // CreateDeliveryServiceV30.
 func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable) (*tc.CreateDeliveryServiceNullableResponse, error) {
 	if ds.TypeID == nil && ds.Type != nil {
-		ty, _, err := to.GetTypeByName(ds.Type.String())
+		ty, _, err := to.GetTypeByNameWithHdr(ds.Type.String(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +338,7 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 	}
 
 	if ds.CDNID == nil && ds.CDNName != nil {
-		cdns, _, err := to.GetCDNByName(*ds.CDNName)
+		cdns, _, err := to.GetCDNByNameWithHdr(*ds.CDNName, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -370,7 +349,7 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 	}
 
 	if ds.ProfileID == nil && ds.ProfileName != nil {
-		profiles, _, err := to.GetProfileByName(*ds.ProfileName)
+		profiles, _, err := to.GetProfileByNameWithHdr(*ds.ProfileName, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +360,7 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 	}
 
 	if ds.TenantID == nil && ds.Tenant != nil {
-		ten, _, err := to.TenantByName(*ds.Tenant)
+		ten, _, err := to.TenantByNameWithHdr(*ds.Tenant, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -389,11 +368,7 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 	}
 
 	var data tc.CreateDeliveryServiceNullableResponse
-	jsonReq, err := json.Marshal(ds)
-	if err != nil {
-		return nil, err
-	}
-	_, err = post(to, API_DELIVERY_SERVICES, jsonReq, &data)
+	_, err := to.post(API_DELIVERY_SERVICES, ds, nil, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -404,14 +379,8 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 // UpdateDeliveryServiceV30WithHdr replaces the Delivery Service identified by the
 // integral, unique identifier 'id' with the one it's passed.
 func (to *Session) UpdateDeliveryServiceV30WithHdr(id int, ds tc.DeliveryServiceNullableV30, header http.Header) (tc.DeliveryServiceNullableV30, ReqInf, error) {
-	var reqInf ReqInf
-	bts, err := json.Marshal(ds)
-	if err != nil {
-		return tc.DeliveryServiceNullableV30{}, reqInf, err
-	}
-
 	var data tc.DeliveryServicesResponseV30
-	reqInf, err = put(to, fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), bts, &data, header)
+	reqInf, err := to.put(fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), ds, header, &data)
 	if err != nil {
 		return tc.DeliveryServiceNullableV30{}, reqInf, err
 	}
@@ -437,32 +406,26 @@ func (to *Session) UpdateDeliveryServiceNullable(id string, ds *tc.DeliveryServi
 
 func (to *Session) UpdateDeliveryServiceNullableWithHdr(id string, ds *tc.DeliveryServiceNullable, header http.Header) (*tc.UpdateDeliveryServiceNullableResponse, error) {
 	var data tc.UpdateDeliveryServiceNullableResponse
-	jsonReq, err := json.Marshal(ds)
+	_, err := to.put(fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), ds, header, &data)
 	if err != nil {
 		return nil, err
 	}
-	_, err = put(to, fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), jsonReq, &data, header)
-	if err != nil {
-		return nil, err
-	}
-
 	return &data, nil
 }
 
 // DeleteDeliveryService deletes the DeliveryService matching the ID it's passed.
 func (to *Session) DeleteDeliveryService(id string) (*tc.DeleteDeliveryServiceResponse, error) {
 	var data tc.DeleteDeliveryServiceResponse
-	_, err := del(to, fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), &data)
+	_, err := to.del(fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), nil, &data)
 	if err != nil {
 		return nil, err
 	}
-
 	return &data, nil
 }
 
 func (to *Session) GetDeliveryServiceHealthWithHdr(id string, header http.Header) (*tc.DeliveryServiceHealth, ReqInf, error) {
 	var data tc.DeliveryServiceHealthResponse
-	reqInf, err := get(to, fmt.Sprintf(API_DELIVERY_SERVICE_HEALTH, id), &data, nil)
+	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICE_HEALTH, id), nil, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -479,11 +442,10 @@ func (to *Session) GetDeliveryServiceHealth(id string) (*tc.DeliveryServiceHealt
 
 func (to *Session) GetDeliveryServiceCapacityWithHdr(id string, header http.Header) (*tc.DeliveryServiceCapacity, ReqInf, error) {
 	var data tc.DeliveryServiceCapacityResponse
-	reqInf, err := get(to, fmt.Sprintf(API_DELIVERY_SERVICE_CAPACITY, id), &data, header)
+	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICE_CAPACITY, id), header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
-
 	return &data.Response, reqInf, nil
 }
 
@@ -492,40 +454,6 @@ func (to *Session) GetDeliveryServiceCapacityWithHdr(id string, header http.Head
 // Deprecated: GetDeliveryServiceCapacity will be removed in 6.0. Use GetDeliveryServiceCapacityWithHdr.
 func (to *Session) GetDeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, ReqInf, error) {
 	return to.GetDeliveryServiceCapacityWithHdr(id, nil)
-}
-
-// GetDeliveryServiceServer returns associations between Delivery Services and servers using the
-// provided pagination controls.
-// Deprecated: GetDeliveryServiceServer will be removed in 6.0. Use GetDeliveryServiceServerWithHdr.
-func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, ReqInf, error) {
-	return to.GetDeliveryServiceServerWithHdr(page, limit, nil)
-}
-
-func (to *Session) GetDeliveryServiceServerWithHdr(page, limit string, header http.Header) ([]tc.DeliveryServiceServer, ReqInf, error) {
-	var data tc.DeliveryServiceServerResponse
-	reqInf, err := get(to, API_DELIVERY_SERVICE_SERVER+"?page="+page+"&limit="+limit, &data, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
-}
-
-// GetDeliveryServiceRegexes returns the "Regexes" (Regular Expressions) used by all (tenant-visible)
-// Delivery Services.
-// Deprecated: GetDeliveryServiceRegexes will be removed in 6.0. Use GetDeliveryServiceRegexesWithHdr.
-func (to *Session) GetDeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, ReqInf, error) {
-	return to.GetDeliveryServiceRegexesWithHdr(nil)
-}
-
-func (to *Session) GetDeliveryServiceRegexesWithHdr(header http.Header) ([]tc.DeliveryServiceRegexes, ReqInf, error) {
-	var data tc.DeliveryServiceRegexResponse
-	reqInf, err := get(to, API_DELIVERY_SERVICES_REGEXES, &data, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
 }
 
 // GenerateSSLKeysForDS generates ssl keys for a given cdn
@@ -543,14 +471,10 @@ func (to *Session) GenerateSSLKeysForDS(XMLID string, CDNName string, sslFields 
 		State:           sslFields.State,
 		Version:         &version,
 	}
-	jsonReq, err := json.Marshal(request)
-	if err != nil {
-		return "", ReqInf{}, err
-	}
 	response := struct {
 		Response string `json:"response"`
 	}{}
-	reqInf, err := post(to, API_DELIVERY_SERVICE_GENERATE_SSL_KEYS, jsonReq, &response)
+	reqInf, err := to.post(API_DELIVERY_SERVICE_GENERATE_SSL_KEYS, request, nil, &response)
 	if err != nil {
 		return "", reqInf, err
 	}
@@ -559,13 +483,10 @@ func (to *Session) GenerateSSLKeysForDS(XMLID string, CDNName string, sslFields 
 
 func (to *Session) DeleteDeliveryServiceSSLKeysByID(XMLID string) (string, ReqInf, error) {
 	resp := struct {
-		Response string `json:"resposne"`
+		Response string `json:"response"`
 	}{}
-	reqInf, err := del(to, fmt.Sprintf(API_DELIVERY_SERVICE_XMLID_SSL_KEYS, XMLID), &resp)
-	if err != nil {
-		return "", reqInf, err
-	}
-	return resp.Response, reqInf, nil
+	reqInf, err := to.del(fmt.Sprintf(API_DELIVERY_SERVICE_XMLID_SSL_KEYS, url.QueryEscape(XMLID)), nil, &resp)
+	return resp.Response, reqInf, err
 }
 
 // GetDeliveryServiceSSLKeysByID returns information about the SSL Keys used by the Delivery
@@ -577,11 +498,10 @@ func (to *Session) GetDeliveryServiceSSLKeysByID(XMLID string) (*tc.DeliveryServ
 
 func (to *Session) GetDeliveryServiceSSLKeysByIDWithHdr(XMLID string, header http.Header) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
 	var data tc.DeliveryServiceSSLKeysResponse
-	reqInf, err := get(to, fmt.Sprintf(API_DELIVERY_SERVICE_XMLID_SSL_KEYS, XMLID), &data, header)
+	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICE_XMLID_SSL_KEYS, url.QueryEscape(XMLID)), header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
-
 	return &data.Response, reqInf, nil
 }
 
@@ -590,11 +510,8 @@ func (to *Session) GetDeliveryServicesEligibleWithHdr(dsID int, header http.Head
 		Response []tc.DSServer `json:"response"`
 	}{Response: []tc.DSServer{}}
 
-	reqInf, err := get(to, fmt.Sprintf(API_DELIVERY_SERVICE_ELIGIBLE_SERVERS, dsID), &resp, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-	return resp.Response, reqInf, nil
+	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICE_ELIGIBLE_SERVERS, dsID), header, &resp)
+	return resp.Response, reqInf, err
 }
 
 // GetDeliveryServicesEligible returns the servers eligible for assignment to the Delivery
@@ -616,7 +533,7 @@ func (to *Session) GetDeliveryServiceURLSigKeysWithHdr(dsName string, header htt
 		Response tc.URLSigKeys `json:"response"`
 	}{}
 
-	reqInf, err := get(to, fmt.Sprintf(API_DELIVERY_SERVICES_URL_SIGNING_KEYS, dsName), &data, header)
+	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICES_URL_SIGNING_KEYS, dsName), header, &data)
 	if err != nil {
 		return tc.URLSigKeys{}, reqInf, err
 	}
@@ -632,7 +549,7 @@ func (to *Session) GetDeliveryServiceURISigningKeys(dsName string) ([]byte, ReqI
 // identified by the XMLID 'dsName'. The result is not parsed.
 func (to *Session) GetDeliveryServiceURISigningKeysWithHdr(dsName string, header http.Header) ([]byte, ReqInf, error) {
 	data := json.RawMessage{}
-	reqInf, err := get(to, fmt.Sprintf(API_DELIVERY_SERVICES_URI_SIGNING_KEYS, dsName), &data, header)
+	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICES_URI_SIGNING_KEYS, url.QueryEscape(dsName)), header, &data)
 	if err != nil {
 		return []byte{}, reqInf, err
 	}
@@ -642,14 +559,8 @@ func (to *Session) GetDeliveryServiceURISigningKeysWithHdr(dsName string, header
 // SafeDeliveryServiceUpdateV30WithHdr updates the "safe" fields of the Delivery
 // Service identified by the integral, unique identifier 'id'.
 func (to *Session) SafeDeliveryServiceUpdateV30WithHdr(id int, r tc.DeliveryServiceSafeUpdateRequest, header http.Header) (tc.DeliveryServiceNullableV30, ReqInf, error) {
-	var reqInf ReqInf
-	req, err := json.Marshal(r)
-	if err != nil {
-		return tc.DeliveryServiceNullableV30{}, reqInf, err
-	}
-
 	var data tc.DeliveryServiceSafeUpdateResponseV30
-	reqInf, err = put(to, fmt.Sprintf(API_DELIVERY_SERVICES_SAFE_UPDATE, id), req, &data, header)
+	reqInf, err := to.put(fmt.Sprintf(API_DELIVERY_SERVICES_SAFE_UPDATE, id), r, header, &data)
 	if err != nil {
 		return tc.DeliveryServiceNullableV30{}, reqInf, err
 	}
@@ -667,15 +578,9 @@ func (to *Session) SafeDeliveryServiceUpdateV30WithHdr(id int, r tc.DeliveryServ
 // versioned methods, specifically, for API v3.0 - in this case,
 // SafeDeliveryServiceUpdateV30WithHdr.
 func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUpdateRequest) ([]tc.DeliveryServiceNullable, ReqInf, error) {
-	var reqInf ReqInf
 	var resp tc.DeliveryServiceSafeUpdateResponse
-
-	req, err := json.Marshal(ds)
+	reqInf, err := to.put(fmt.Sprintf(API_DELIVERY_SERVICES_SAFE_UPDATE, id), ds, nil, &resp)
 	if err != nil {
-		return resp.Response, reqInf, err
-	}
-
-	if reqInf, err = put(to, fmt.Sprintf(API_DELIVERY_SERVICES_SAFE_UPDATE, id), req, &resp, nil); err != nil {
 		return resp.Response, reqInf, err
 	}
 
@@ -695,6 +600,6 @@ func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUp
 // GetDeliveryServicesV30WithHdr.
 func (to *Session) GetAccessibleDeliveryServicesByTenant(tenantId int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
 	data := tc.DeliveryServicesNullableResponse{}
-	reqInf, err := get(to, fmt.Sprintf("%v?accessibleTo=%v", API_DELIVERY_SERVICES, tenantId), &data, nil)
+	reqInf, err := to.get(fmt.Sprintf("%s?accessibleTo=%d", API_DELIVERY_SERVICES, tenantId), nil, &data)
 	return data.Response, reqInf, err
 }

--- a/traffic_ops/v3-client/deliveryservice_request_comments.go
+++ b/traffic_ops/v3-client/deliveryservice_request_comments.go
@@ -16,8 +16,6 @@
 package client
 
 import (
-	"encoding/json"
-	"net"
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -31,43 +29,16 @@ const (
 
 // Create a delivery service request comment
 func (to *Session) CreateDeliveryServiceRequestComment(comment tc.DeliveryServiceRequestComment) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(comment)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_DELIVERY_SERVICE_REQUEST_COMMENTS, reqBody, nil)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.post(API_DELIVERY_SERVICE_REQUEST_COMMENTS, comment, nil, &alerts)
+	return alerts, reqInf, err
 }
 
 func (to *Session) UpdateDeliveryServiceRequestCommentByIDWithHdr(id int, comment tc.DeliveryServiceRequestComment, header http.Header) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(comment)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
 	route := fmt.Sprintf("%s?id=%d", API_DELIVERY_SERVICE_REQUEST_COMMENTS, id)
-	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody, header)
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-	}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.put(route, comment, header, &alerts)
+	return alerts, reqInf, err
 }
 
 // Update a delivery service request by ID
@@ -77,22 +48,9 @@ func (to *Session) UpdateDeliveryServiceRequestCommentByID(id int, comment tc.De
 }
 
 func (to *Session) GetDeliveryServiceRequestCommentsWithHdr(header http.Header) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, API_DELIVERY_SERVICE_REQUEST_COMMENTS, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.DeliveryServiceRequestComment{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.DeliveryServiceRequestCommentsResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(API_DELIVERY_SERVICE_REQUEST_COMMENTS, header, &data)
+	return data.Response, reqInf, err
 }
 
 // Returns a list of delivery service request comments
@@ -103,25 +61,9 @@ func (to *Session) GetDeliveryServiceRequestComments() ([]tc.DeliveryServiceRequ
 
 func (to *Session) GetDeliveryServiceRequestCommentByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", API_DELIVERY_SERVICE_REQUEST_COMMENTS, id)
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.DeliveryServiceRequestComment{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.DeliveryServiceRequestCommentsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &data)
+	return data.Response, reqInf, err
 }
 
 // GET a delivery service request comment by ID
@@ -133,13 +75,7 @@ func (to *Session) GetDeliveryServiceRequestCommentByID(id int) ([]tc.DeliverySe
 // DELETE a delivery service request comment by ID
 func (to *Session) DeleteDeliveryServiceRequestCommentByID(id int) (tc.Alerts, ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", API_DELIVERY_SERVICE_REQUEST_COMMENTS, id)
-	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.del(route, nil, &alerts)
+	return alerts, reqInf, err
 }

--- a/traffic_ops/v3-client/deliveryservices_required_capabilities.go
+++ b/traffic_ops/v3-client/deliveryservices_required_capabilities.go
@@ -16,9 +16,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -33,13 +31,7 @@ const (
 // CreateDeliveryServicesRequiredCapability assigns a Required Capability to a Delivery Service
 func (to *Session) CreateDeliveryServicesRequiredCapability(capability tc.DeliveryServicesRequiredCapability) (tc.Alerts, ReqInf, error) {
 	var alerts tc.Alerts
-	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	reqBody, err := json.Marshal(capability)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	reqInf, err = post(to, API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES, reqBody, &alerts)
+	reqInf, err := to.post(API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES, capability, nil, &alerts)
 	return alerts, reqInf, err
 }
 
@@ -49,8 +41,8 @@ func (to *Session) DeleteDeliveryServicesRequiredCapability(deliveryserviceID in
 	param := url.Values{}
 	param.Add("deliveryServiceID", strconv.Itoa(deliveryserviceID))
 	param.Add("requiredCapability", capability)
-	url := fmt.Sprintf("%s?%s", API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES, param.Encode())
-	reqInf, err := del(to, url, &alerts)
+	route := fmt.Sprintf("%s?%s", API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES, param.Encode())
+	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
 }
 
@@ -66,19 +58,16 @@ func (to *Session) GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServic
 		param.Add("requiredCapability", *capability)
 	}
 
-	url := API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES
+	route := API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES
 	if len(param) > 0 {
-		url = fmt.Sprintf("%s?%s", url, param.Encode())
+		route = fmt.Sprintf("%s?%s", route, param.Encode())
 	}
 
 	resp := struct {
 		Response []tc.DeliveryServicesRequiredCapability `json:"response"`
 	}{}
-	reqInf, err := get(to, url, &resp, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-	return resp.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &resp)
+	return resp.Response, reqInf, err
 }
 
 // GetDeliveryServicesRequiredCapabilities retrieves a list of Required Capabilities that are assigned to a Delivery Service

--- a/traffic_ops/v3-client/deliveryserviceserver.go
+++ b/traffic_ops/v3-client/deliveryserviceserver.go
@@ -16,35 +16,28 @@
 package client
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 )
 
 // CreateDeliveryServiceServers associates the given servers with the given delivery services. If replace is true, it deletes any existing associations for the given delivery service.
 func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, replace bool) (*tc.DSServerIDs, ReqInf, error) {
-	path := apiBase + `/deliveryserviceserver`
+	path := API_DELIVERY_SERVICE_SERVER
 	req := tc.DSServerIDs{
 		DeliveryServiceID: util.IntPtr(dsID),
 		ServerIDs:         serverIDs,
 		Replace:           util.BoolPtr(replace),
 	}
-	jsonReq, err := json.Marshal(&req)
-	if err != nil {
-		return nil, ReqInf{}, err
-	}
 	resp := struct {
 		Response tc.DSServerIDs `json:"response"`
 	}{}
-	reqInf, err := post(to, path, jsonReq, &resp)
+	reqInf, err := to.post(path, req, nil, &resp)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -53,38 +46,32 @@ func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, repla
 
 func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alerts, ReqInf, error) {
 	route := apiBase + `/deliveryserviceserver/` + strconv.Itoa(dsID) + "/" + strconv.Itoa(serverID)
-	reqResp, remoteAddr, err := to.request(http.MethodDelete, route, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
-	}
-	defer reqResp.Body.Close()
 	resp := tc.Alerts{}
-	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
-		return tc.Alerts{}, reqInf, errors.New("decoding response: " + err.Error())
-	}
-	return resp, reqInf, nil
+	reqInf, err := to.del(route, nil, &resp)
+	return resp, reqInf, err
 }
 
 // AssignServersToDeliveryService assigns the given list of servers to the delivery service with the given xmlId.
 func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf(API_DELIVERY_SERVICES_SERVERS, xmlId)
+	route := fmt.Sprintf(API_DELIVERY_SERVICES_SERVERS, url.QueryEscape(xmlId))
 	dss := tc.DeliveryServiceServers{ServerNames: servers, XmlId: xmlId}
-	reqBody, err := json.Marshal(&dss)
-	reqResp, remoteAddr, err := to.request(http.MethodPost, route, reqBody, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if reqResp != nil {
-		reqInf.StatusCode = reqResp.StatusCode
-	}
-	if err != nil {
-		return tc.Alerts{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
-	}
-	defer log.Close(reqResp.Body, "unable to close response body")
 	resp := tc.Alerts{}
-	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
-		return tc.Alerts{}, reqInf, errors.New("decoding response: " + err.Error())
-	}
-	return resp, reqInf, nil
+	reqInf, err := to.post(route, dss, nil, &resp)
+	return resp, reqInf, err
+}
+
+// GetDeliveryServiceServer returns associations between Delivery Services and servers using the
+// provided pagination controls.
+// Deprecated: GetDeliveryServiceServer will be removed in 6.0. Use GetDeliveryServiceServerWithHdr.
+func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, ReqInf, error) {
+	return to.GetDeliveryServiceServerWithHdr(page, limit, nil)
+}
+
+func (to *Session) GetDeliveryServiceServerWithHdr(page, limit string, header http.Header) ([]tc.DeliveryServiceServer, ReqInf, error) {
+	var data tc.DeliveryServiceServerResponse
+	// TODO: page and limit should be integers not strings
+	reqInf, err := to.get(API_DELIVERY_SERVICE_SERVER+"?page="+url.QueryEscape(page)+"&limit="+url.QueryEscape(limit), header, &data)
+	return data.Response, reqInf, err
 }
 
 func (to *Session) GetDeliveryServiceServersWithHdr(h http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
@@ -140,22 +127,11 @@ func (to *Session) GetDeliveryServiceServersWithLimits(limit int, deliveryServic
 }
 
 func (to *Session) getDeliveryServiceServers(urlQuery url.Values, h http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
-	route := apiBase + `/deliveryserviceserver`
+	route := API_DELIVERY_SERVICE_SERVER
 	if qry := urlQuery.Encode(); qry != "" {
 		route += `?` + qry
 	}
-	reqResp, remoteAddr, err := to.request(http.MethodGet, route, nil, h)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if reqResp != nil {
-		reqInf.StatusCode = reqResp.StatusCode
-	}
-	if err != nil {
-		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
-	}
-	defer reqResp.Body.Close()
 	resp := tc.DeliveryServiceServerResponse{}
-	if err = json.NewDecoder(reqResp.Body).Decode(&resp); err != nil {
-		return tc.DeliveryServiceServerResponse{}, reqInf, errors.New("decoding response: " + err.Error())
-	}
-	return resp, reqInf, nil
+	reqInf, err := to.get(route, h, &resp)
+	return resp, reqInf, err
 }

--- a/traffic_ops/v3-client/division.go
+++ b/traffic_ops/v3-client/division.go
@@ -16,10 +16,9 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
+	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -30,43 +29,16 @@ const (
 
 // Create a Division
 func (to *Session) CreateDivision(division tc.Division) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(division)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_DIVISIONS, reqBody, nil)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.post(API_DIVISIONS, division, nil, &alerts)
+	return alerts, reqInf, err
 }
 
 func (to *Session) UpdateDivisionByIDWithHdr(id int, division tc.Division, header http.Header) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(division)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
 	route := fmt.Sprintf("%s/%d", API_DIVISIONS, id)
-	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody, header)
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-	}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.put(route, division, header, &alerts)
+	return alerts, reqInf, err
 }
 
 // Update a Division by ID
@@ -76,22 +48,9 @@ func (to *Session) UpdateDivisionByID(id int, division tc.Division) (tc.Alerts, 
 }
 
 func (to *Session) GetDivisionsWithHdr(header http.Header) ([]tc.Division, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, API_DIVISIONS, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Division{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.DivisionsResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(API_DIVISIONS, header, &data)
+	return data.Response, reqInf, err
 }
 
 // Returns a list of Divisions
@@ -102,25 +61,9 @@ func (to *Session) GetDivisions() ([]tc.Division, ReqInf, error) {
 
 func (to *Session) GetDivisionByIDWithHdr(id int, header http.Header) ([]tc.Division, ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", API_DIVISIONS, id)
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Division{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.DivisionsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &data)
+	return data.Response, reqInf, err
 }
 
 // GET a Division by the Division id
@@ -130,26 +73,10 @@ func (to *Session) GetDivisionByID(id int) ([]tc.Division, ReqInf, error) {
 }
 
 func (to *Session) GetDivisionByNameWithHdr(name string, header http.Header) ([]tc.Division, ReqInf, error) {
-	url := fmt.Sprintf("%s?name=%s", API_DIVISIONS, name)
-	resp, remoteAddr, err := to.request(http.MethodGet, url, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Division{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
+	route := fmt.Sprintf("%s?name=%s", API_DIVISIONS, url.QueryEscape(name))
 	var data tc.DivisionsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &data)
+	return data.Response, reqInf, err
 }
 
 // GET a Division by the Division name
@@ -161,13 +88,7 @@ func (to *Session) GetDivisionByName(name string) ([]tc.Division, ReqInf, error)
 // DELETE a Division by Division id
 func (to *Session) DeleteDivisionByID(id int) (tc.Alerts, ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", API_DIVISIONS, id)
-	resp, remoteAddr, err := to.request(http.MethodDelete, route, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.del(route, nil, &alerts)
+	return alerts, reqInf, err
 }

--- a/traffic_ops/v3-client/dsuser.go
+++ b/traffic_ops/v3-client/dsuser.go
@@ -16,7 +16,6 @@ package client
 */
 
 import (
-	"encoding/json"
 	"strconv"
 
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
@@ -26,12 +25,8 @@ import (
 func (to *Session) SetDeliveryServiceUser(userID int, dses []int, replace bool) (*tc.UserDeliveryServicePostResponse, error) {
 	uri := apiBase + `/deliveryservice_user`
 	ds := tc.DeliveryServiceUserPost{UserID: &userID, DeliveryServices: &dses, Replace: &replace}
-	jsonReq, err := json.Marshal(ds)
-	if err != nil {
-		return nil, err
-	}
 	resp := tc.UserDeliveryServicePostResponse{}
-	_, err = post(to, uri, jsonReq, &resp)
+	_, err := to.post(uri, ds, nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +37,7 @@ func (to *Session) SetDeliveryServiceUser(userID int, dses []int, replace bool) 
 func (to *Session) DeleteDeliveryServiceUser(userID int, dsID int) (*tc.UserDeliveryServiceDeleteResponse, error) {
 	uri := apiBase + `/deliveryservice_user/` + strconv.Itoa(dsID) + `/` + strconv.Itoa(userID)
 	resp := tc.UserDeliveryServiceDeleteResponse{}
-	if _, err := del(to, uri, &resp); err != nil {
+	if _, err := to.del(uri, nil, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/traffic_ops/v3-client/federation_federation_resolver.go
+++ b/traffic_ops/v3-client/federation_federation_resolver.go
@@ -14,57 +14,27 @@ package client
    limitations under the License.
 */
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 // GetFederationFederationResolversByID retrieves all Federation Resolvers belonging to Federation of ID.
 func (to *Session) GetFederationFederationResolversByID(id int) (tc.FederationFederationResolversResponse, ReqInf, error) {
-	var (
-		path   = fmt.Sprintf("%s/federations/%d/federation_resolvers", apiBase, id)
-		reqInf = ReqInf{CacheHitStatus: CacheHitStatusMiss}
-		resp   tc.FederationFederationResolversResponse
-	)
-	httpResp, remoteAddr, err := to.request(http.MethodGet, path, nil, nil)
-	reqInf.RemoteAddr = remoteAddr
-	if err != nil {
-		return resp, reqInf, err
-	}
-	defer httpResp.Body.Close()
-
-	err = json.NewDecoder(httpResp.Body).Decode(&resp)
-
+	path := fmt.Sprintf("%s/federations/%d/federation_resolvers", apiBase, id)
+	resp := tc.FederationFederationResolversResponse{}
+	reqInf, err := to.get(path, nil, &resp)
 	return resp, reqInf, err
 }
 
 // AssignFederationFederationResolver creates the Federation Resolver 'fr'.
 func (to *Session) AssignFederationFederationResolver(fedID int, resolverIDs []int, replace bool) (tc.AssignFederationFederationResolversResponse, ReqInf, error) {
-	var (
-		path = fmt.Sprintf("%s/federations/%d/federation_resolvers", apiBase, fedID)
-		req  = tc.AssignFederationResolversRequest{
-			Replace:        replace,
-			FedResolverIDs: resolverIDs,
-		}
-		reqInf = ReqInf{CacheHitStatus: CacheHitStatusMiss}
-		resp   tc.AssignFederationFederationResolversResponse
-	)
-
-	reqBody, err := json.Marshal(req)
-	if err != nil {
-		return resp, reqInf, err
+	path := fmt.Sprintf("%s/federations/%d/federation_resolvers", apiBase, fedID)
+	req := tc.AssignFederationResolversRequest{
+		Replace:        replace,
+		FedResolverIDs: resolverIDs,
 	}
-
-	httpResp, remoteAddr, err := to.request(http.MethodPost, path, reqBody, nil)
-	reqInf.RemoteAddr = remoteAddr
-	if err != nil {
-		return resp, reqInf, err
-	}
-	defer httpResp.Body.Close()
-
-	err = json.NewDecoder(httpResp.Body).Decode(&resp)
-
+	resp := tc.AssignFederationFederationResolversResponse{}
+	reqInf, err := to.post(path, req, nil, &resp)
 	return resp, reqInf, err
 }

--- a/traffic_ops/v3-client/federation_resolver.go
+++ b/traffic_ops/v3-client/federation_resolver.go
@@ -13,7 +13,7 @@ package client
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-import "encoding/json"
+
 import "fmt"
 import "net/http"
 import "net/url"
@@ -41,7 +41,7 @@ func (to *Session) getFederationResolvers(id *uint, ip *string, t *string, heade
 	var data struct {
 		Response []tc.FederationResolver `json:"response"`
 	}
-	inf, err := get(to, path, &data, header)
+	inf, err := to.get(path, header, &data)
 	return data.Response, inf, err
 }
 
@@ -98,39 +98,15 @@ func (to *Session) GetFederationResolversByType(t string) ([]tc.FederationResolv
 
 // CreateFederationResolver creates the Federation Resolver 'fr'.
 func (to *Session) CreateFederationResolver(fr tc.FederationResolver) (tc.Alerts, ReqInf, error) {
-	var reqInf = ReqInf{CacheHitStatus: CacheHitStatusMiss}
 	var alerts tc.Alerts
-
-	req, err := json.Marshal(fr)
-	if err != nil {
-		return alerts, reqInf, err
-	}
-
-	var resp *http.Response
-	resp, reqInf.RemoteAddr, err = to.request(http.MethodPost, apiBase+"/federation_resolvers", req, nil)
-	if err != nil {
-		return alerts, reqInf, err
-	}
-	defer resp.Body.Close()
-
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	reqInf, err := to.post(apiBase+"/federation_resolvers", fr, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteFederationResolver deletes the Federation Resolver identified by 'id'.
 func (to *Session) DeleteFederationResolver(id uint) (tc.Alerts, ReqInf, error) {
-	var reqInf = ReqInf{CacheHitStatus: CacheHitStatusMiss}
 	var alerts tc.Alerts
-
-	var path = fmt.Sprintf("%s/federation_resolvers?id=%d", apiBase, id)
-	var resp *http.Response
-	var err error
-	resp, reqInf.RemoteAddr, err = to.request(http.MethodDelete, path, nil, nil)
-	if err != nil {
-		return alerts, reqInf, err
-	}
-	defer resp.Body.Close()
-
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	path := fmt.Sprintf("%s/federation_resolvers?id=%d", apiBase, id)
+	reqInf, err := to.del(path, nil, &alerts)
 	return alerts, reqInf, err
 }

--- a/traffic_ops/v3-client/iso.go
+++ b/traffic_ops/v3-client/iso.go
@@ -20,9 +20,6 @@ package client
  */
 
 import (
-	"encoding/json"
-	"net/http"
-
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -36,19 +33,9 @@ const (
 //  key:   Name of OS
 //  value: Directory where the ISO source can be found
 func (to *Session) GetOSVersions() (map[string]string, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, API_OSVERSIONS, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data struct {
 		Versions tc.OSVersionsResponse `json:"response"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Versions, reqInf, nil
+	reqInf, err := to.get(API_OSVERSIONS, nil, &data)
+	return data.Versions, reqInf, err
 }

--- a/traffic_ops/v3-client/log.go
+++ b/traffic_ops/v3-client/log.go
@@ -16,9 +16,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -30,19 +28,9 @@ const (
 // GetLogsByQueryParams gets a list of logs filtered by query params.
 func (to *Session) GetLogsByQueryParams(queryParams string) ([]tc.Log, ReqInf, error) {
 	URI := API_LOGS + queryParams
-	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.LogsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(URI, nil, &data)
+	return data.Response, reqInf, err
 }
 
 // GetLogs gets a list of logs.

--- a/traffic_ops/v3-client/ping.go
+++ b/traffic_ops/v3-client/ping.go
@@ -15,25 +15,13 @@
 
 package client
 
-import (
-	"encoding/json"
-	"net/http"
-)
-
 const (
 	API_PING = apiBase + "/ping"
 )
 
 // Ping returns a static json object to show that traffic_ops is responsive
 func (to *Session) Ping() (map[string]string, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, API_PING, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data map[string]string
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	return data, reqInf, nil
+	reqInf, err := to.get(API_PING, nil, &data)
+	return data, reqInf, err
 }

--- a/traffic_ops/v3-client/profile.go
+++ b/traffic_ops/v3-client/profile.go
@@ -16,26 +16,22 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 const (
 	API_PROFILES                 = apiBase + "/profiles"
-	API_PROFILES_NAME_PARAMETERS = API_PROFILES + "/name/%v/parameters"
+	API_PROFILES_NAME_PARAMETERS = API_PROFILES + "/name/%s/parameters"
 )
 
 // CreateProfile creates a Profile.
 func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, ReqInf, error) {
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
-
 	if pl.CDNID == 0 && pl.CDNName != "" {
-		cdns, _, err := to.GetCDNByName(pl.CDNName)
+		cdns, _, err := to.GetCDNByNameWithHdr(pl.CDNName, nil)
 		if err != nil {
 			return tc.Alerts{}, ReqInf{}, err
 		}
@@ -54,46 +50,15 @@ func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, ReqInf, error) {
 		pl.CDNID = cdns[0].ID
 	}
 
-	reqBody, err := json.Marshal(pl)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-
-	resp, remoteAddr, err := to.request(http.MethodPost, API_PROFILES, reqBody, nil)
-	reqInf.RemoteAddr = remoteAddr
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-
+	reqInf, err := to.post(API_PROFILES, pl, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 func (to *Session) UpdateProfileByIDWithHdr(id int, pl tc.Profile, header http.Header) (tc.Alerts, ReqInf, error) {
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
-
-	reqBody, err := json.Marshal(pl)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-
 	route := fmt.Sprintf("%s/%d", API_PROFILES, id)
-	resp, remoteAddr, err := to.request(http.MethodPut, route, reqBody, header)
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-	}
-	reqInf.RemoteAddr = remoteAddr
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-
+	reqInf, err := to.put(route, pl, header, &alerts)
 	return alerts, reqInf, err
 }
 
@@ -104,26 +69,10 @@ func (to *Session) UpdateProfileByID(id int, pl tc.Profile) (tc.Alerts, ReqInf, 
 }
 
 func (to *Session) GetParametersByProfileNameWithHdr(profileName string, header http.Header) ([]tc.Parameter, ReqInf, error) {
-	url := fmt.Sprintf(API_PROFILES_NAME_PARAMETERS, profileName)
-	resp, remoteAddr, err := to.request(http.MethodGet, url, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Parameter{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
+	route := fmt.Sprintf(API_PROFILES_NAME_PARAMETERS, profileName)
 	var data tc.ParametersResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(route, header, &data)
+	return data.Response, reqInf, err
 }
 
 // GetParametersByProfileName gets all of the Parameters assigned to the Profile named 'profileName'.
@@ -133,24 +82,8 @@ func (to *Session) GetParametersByProfileName(profileName string) ([]tc.Paramete
 }
 
 func (to *Session) GetProfilesWithHdr(header http.Header) ([]tc.Profile, ReqInf, error) {
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
-
-	resp, remoteAddr, err := to.request(http.MethodGet, API_PROFILES, nil, header)
-	reqInf.RemoteAddr = remoteAddr
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Profile{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.ProfilesResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-
+	reqInf, err := to.get(API_PROFILES, header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -162,22 +95,8 @@ func (to *Session) GetProfiles() ([]tc.Profile, ReqInf, error) {
 
 func (to *Session) GetProfileByIDWithHdr(id int, header http.Header) ([]tc.Profile, ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", API_PROFILES, id)
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Profile{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.ProfilesResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-
+	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -189,22 +108,8 @@ func (to *Session) GetProfileByID(id int) ([]tc.Profile, ReqInf, error) {
 
 func (to *Session) GetProfileByNameWithHdr(name string, header http.Header) ([]tc.Profile, ReqInf, error) {
 	URI := fmt.Sprintf("%s?name=%s", API_PROFILES, url.QueryEscape(name))
-	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Profile{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.ProfilesResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-
+	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -216,22 +121,8 @@ func (to *Session) GetProfileByName(name string) ([]tc.Profile, ReqInf, error) {
 
 func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, ReqInf, error) {
 	URI := fmt.Sprintf("%s?param=%s", API_PROFILES, url.QueryEscape(param))
-	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Profile{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.ProfilesResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-
+	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -242,23 +133,9 @@ func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, ReqInf, er
 }
 
 func (to *Session) GetProfileByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.Profile, ReqInf, error) {
-	URI := fmt.Sprintf("%s?cdn=%s", API_PROFILES, strconv.Itoa(cdnID))
-	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Profile{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
+	URI := fmt.Sprintf("%s?cdn=%d", API_PROFILES, cdnID)
 	var data tc.ProfilesResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-
+	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -271,79 +148,31 @@ func (to *Session) GetProfileByCDNID(cdnID int) ([]tc.Profile, ReqInf, error) {
 // DeleteProfileByID DELETEs a Profile by ID.
 func (to *Session) DeleteProfileByID(id int) (tc.Alerts, ReqInf, error) {
 	URI := fmt.Sprintf("%s/%d", API_PROFILES, id)
-	resp, remoteAddr, err := to.request(http.MethodDelete, URI, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-
+	reqInf, err := to.del(URI, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // ExportProfile Returns an exported Profile.
 func (to *Session) ExportProfile(id int) (*tc.ProfileExportResponse, ReqInf, error) {
 	route := fmt.Sprintf("%s/%d/export", API_PROFILES, id)
-	resp, remoteAddr, err := to.request(http.MethodGet, route, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.ProfileExportResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-
+	reqInf, err := to.get(route, nil, &data)
 	return &data, reqInf, err
 }
 
 // ImportProfile imports an exported Profile.
 func (to *Session) ImportProfile(importRequest *tc.ProfileImportRequest) (*tc.ProfileImportResponse, ReqInf, error) {
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
-
 	route := fmt.Sprintf("%s/import", API_PROFILES)
-	reqBody, err := json.Marshal(importRequest)
-	if err != nil {
-		return nil, reqInf, err
-	}
-
-	resp, remoteAddr, err := to.request(http.MethodPost, route, reqBody, nil)
-	reqInf.RemoteAddr = remoteAddr
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	var data tc.ProfileImportResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-
+	reqInf, err := to.post(route, importRequest, nil, &data)
 	return &data, reqInf, err
 }
 
 // CopyProfile creates a new profile from an existing profile.
 func (to *Session) CopyProfile(p tc.ProfileCopy) (tc.ProfileCopyResponse, ReqInf, error) {
-	var (
-		path   = fmt.Sprintf("%s/name/%s/copy/%s", API_PROFILES, p.Name, p.ExistingName)
-		reqInf = ReqInf{CacheHitStatus: CacheHitStatusMiss}
-		resp   tc.ProfileCopyResponse
-	)
-
-	reqBody, err := json.Marshal(p)
-	if err != nil {
-		return tc.ProfileCopyResponse{}, ReqInf{}, err
-	}
-
-	httpResp, remoteAddr, err := to.request(http.MethodPost, path, reqBody, nil)
-	reqInf.RemoteAddr = remoteAddr
-	if err != nil {
-		return tc.ProfileCopyResponse{}, reqInf, err
-	}
-	defer httpResp.Body.Close()
-
-	err = json.NewDecoder(httpResp.Body).Decode(&resp)
-
+	path := fmt.Sprintf("%s/name/%s/copy/%s", API_PROFILES, p.Name, p.ExistingName)
+	resp := tc.ProfileCopyResponse{}
+	reqInf, err := to.post(path, p, nil, &resp)
 	return resp, reqInf, err
 }

--- a/traffic_ops/v3-client/profile_parameter.go
+++ b/traffic_ops/v3-client/profile_parameter.go
@@ -16,9 +16,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -32,59 +30,20 @@ const (
 
 // Create a ProfileParameter
 func (to *Session) CreateProfileParameter(pp tc.ProfileParameter) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(pp)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_PROFILE_PARAMETERS, reqBody, nil)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.post(API_PROFILE_PARAMETERS, pp, nil, &alerts)
+	return alerts, reqInf, err
 }
 
 // CreateMultipleProfileParameters creates multiple ProfileParameters at once.
 func (to *Session) CreateMultipleProfileParameters(pps []tc.ProfileParameter) (tc.Alerts, ReqInf, error) {
-
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(pps)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_PROFILE_PARAMETERS, reqBody, nil)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.post(API_PROFILE_PARAMETERS, pps, nil, &alerts)
+	return alerts, reqInf, err
 }
 
 func (to *Session) GetProfileParametersWithHdr(header http.Header) ([]tc.ProfileParameter, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, API_PROFILE_PARAMETERS, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.ProfileParameter{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
-	var data tc.ProfileParametersResponse
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	return data.Response, reqInf, nil
+	return to.GetProfileParameterByQueryParamsWithHdr("", header)
 }
 
 // Returns a list of Profile Parameters
@@ -95,25 +54,22 @@ func (to *Session) GetProfileParameters() ([]tc.ProfileParameter, ReqInf, error)
 
 func (to *Session) GetProfileParameterByQueryParamsWithHdr(queryParams string, header http.Header) ([]tc.ProfileParameter, ReqInf, error) {
 	URI := API_PROFILE_PARAMETERS + queryParams
-	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.ProfileParameter{}, reqInf, nil
-		}
-	}
+	var data tc.ProfileParametersNullableResponse
+	reqInf, err := to.get(URI, header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
-	defer resp.Body.Close()
-
-	var data tc.ProfileParametersResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
+	ret := make([]tc.ProfileParameter, len(data.Response))
+	for i, pp := range data.Response {
+		ret[i] = tc.ProfileParameter{}
+		if pp.Profile != nil {
+			ret[i].Profile = *pp.Profile
+		}
+		if pp.Parameter != nil {
+			ret[i].ParameterID = *pp.Parameter
+		}
 	}
-
-	return data.Response, reqInf, nil
+	return ret, reqInf, nil
 }
 
 // GET a Profile Parameter by the Parameter
@@ -125,13 +81,7 @@ func (to *Session) GetProfileParameterByQueryParams(queryParams string) ([]tc.Pr
 // DELETE a Parameter by Parameter
 func (to *Session) DeleteParameterByProfileParameter(profile int, parameter int) (tc.Alerts, ReqInf, error) {
 	URI := fmt.Sprintf("%s/%d/%d", API_PROFILE_PARAMETERS, profile, parameter)
-	resp, remoteAddr, err := to.request(http.MethodDelete, URI, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
-	return alerts, reqInf, nil
+	reqInf, err := to.del(URI, nil, &alerts)
+	return alerts, reqInf, err
 }

--- a/traffic_ops/v3-client/server_server_capabilities.go
+++ b/traffic_ops/v3-client/server_server_capabilities.go
@@ -16,9 +16,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -33,13 +31,7 @@ const (
 // CreateServerServerCapability assigns a Server Capability to a Server
 func (to *Session) CreateServerServerCapability(ssc tc.ServerServerCapability) (tc.Alerts, ReqInf, error) {
 	var alerts tc.Alerts
-	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	reqBody, err := json.Marshal(ssc)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	reqInf, err = post(to, API_SERVER_SERVER_CAPABILITIES, reqBody, &alerts)
+	reqInf, err := to.post(API_SERVER_SERVER_CAPABILITIES, ssc, nil, &alerts)
 	return alerts, reqInf, err
 }
 
@@ -51,7 +43,7 @@ func (to *Session) DeleteServerServerCapability(serverID int, serverCapability s
 	v.Add("serverCapability", serverCapability)
 	qStr := v.Encode()
 	queryURL := fmt.Sprintf("%s?%s", API_SERVER_SERVER_CAPABILITIES, qStr)
-	reqInf, err := del(to, queryURL, &alerts)
+	reqInf, err := to.del(queryURL, nil, &alerts)
 	return alerts, reqInf, err
 }
 
@@ -74,11 +66,8 @@ func (to *Session) GetServerServerCapabilitiesWithHdr(serverID *int, serverHostN
 	resp := struct {
 		Response []tc.ServerServerCapability `json:"response"`
 	}{}
-	reqInf, err := get(to, queryURL, &resp, header)
-	if err != nil {
-		return nil, reqInf, err
-	}
-	return resp.Response, reqInf, nil
+	reqInf, err := to.get(queryURL, header, &resp)
+	return resp.Response, reqInf, err
 }
 
 // GetServerServerCapabilities retrieves a list of Server Capabilities that are assigned to a Server

--- a/traffic_ops/v3-client/servercheck.go
+++ b/traffic_ops/v3-client/servercheck.go
@@ -16,9 +16,6 @@
 package client
 
 import (
-	"encoding/json"
-	"net"
-
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
@@ -27,14 +24,8 @@ const API_SERVERCHECK = apiBase + "/servercheck"
 // InsertServerCheckStatus Will insert/update the servercheck value based on if it already exists or not.
 func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable) (*tc.ServercheckPostResponse, ReqInf, error) {
 	uri := API_SERVERCHECK
-	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	jsonReq, err := json.Marshal(status)
-	if err != nil {
-		return nil, reqInf, err
-	}
 	resp := tc.ServercheckPostResponse{}
-	reqInf, err = post(to, uri, jsonReq, &resp)
+	reqInf, err := to.post(uri, status, nil, &resp)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -47,7 +38,6 @@ func (to *Session) GetServersChecks() ([]tc.GenericServerCheck, tc.Alerts, ReqIn
 		tc.Alerts
 		Response []tc.GenericServerCheck `json:"response"`
 	}
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
-	reqInf, err := get(to, API_SERVERCHECK, &response, nil)
+	reqInf, err := to.get(API_SERVERCHECK, nil, &response)
 	return response.Response, response.Alerts, reqInf, err
 }

--- a/traffic_ops/v3-client/servercheckextensions.go
+++ b/traffic_ops/v3-client/servercheckextensions.go
@@ -13,10 +13,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
-	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -25,45 +22,22 @@ const API_TO_EXTENSION = apiBase + "/servercheck/extensions"
 
 // CreateServerCheckExtension creates a servercheck extension.
 func (to *Session) CreateServerCheckExtension(ServerCheckExtension tc.ServerCheckExtensionNullable) (tc.Alerts, ReqInf, error) {
-	var remoteAddr net.Addr
-	reqBody, err := json.Marshal(ServerCheckExtension)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	resp, remoteAddr, err := to.request(http.MethodPost, API_TO_EXTENSION, reqBody, nil)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	reqInf, err := to.post(API_TO_EXTENSION, ServerCheckExtension, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteServerCheckExtension deletes a servercheck extension.
 func (to *Session) DeleteServerCheckExtension(id int) (tc.Alerts, ReqInf, error) {
 	URI := fmt.Sprintf("%s/%d", API_TO_EXTENSION, id)
-	resp, remoteAddr, err := to.request(http.MethodDelete, URI, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var alerts tc.Alerts
-	err = json.NewDecoder(resp.Body).Decode(&alerts)
+	reqInf, err := to.del(URI, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // GetServerCheckExtensions gets all servercheck extensions.
 func (to *Session) GetServerCheckExtensions() (tc.ServerCheckExtensionResponse, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, API_TO_EXTENSION, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return tc.ServerCheckExtensionResponse{}, reqInf, err
-	}
-	defer resp.Body.Close()
 	var toExtResp tc.ServerCheckExtensionResponse
-	err = json.NewDecoder(resp.Body).Decode(&toExtResp)
+	reqInf, err := to.get(API_TO_EXTENSION, nil, &toExtResp)
 	return toExtResp, reqInf, err
 }

--- a/traffic_ops/v3-client/session.go
+++ b/traffic_ops/v3-client/session.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/apache/trafficcontrol/lib/go-log"
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
 
 	"golang.org/x/net/publicsuffix"
@@ -124,8 +125,8 @@ func (to *Session) login() (net.Addr, error) {
 	}
 
 	path := apiBase + "/user/login"
-	resp, remoteAddr, err := to.RawRequest("POST", path, credentials)
-	resp, remoteAddr, err = to.ErrUnlessOKOrNotModified(resp, remoteAddr, err, path)
+	resp, remoteAddr, err := to.RawRequestWithHdr("POST", path, credentials, nil)
+	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
 	if err != nil {
 		return remoteAddr, errors.New("requesting: " + err.Error())
 	}
@@ -153,8 +154,8 @@ func (to *Session) login() (net.Addr, error) {
 
 func (to *Session) loginWithToken(token []byte) (net.Addr, error) {
 	path := apiBase + "/user/login/token"
-	resp, remoteAddr, err := to.RawRequest(http.MethodPost, path, token)
-	resp, remoteAddr, err = to.ErrUnlessOKOrNotModified(resp, remoteAddr, err, path)
+	resp, remoteAddr, err := to.RawRequestWithHdr(http.MethodPost, path, token, nil)
+	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
 	if err != nil {
 		return remoteAddr, fmt.Errorf("requesting: %v", err)
 	}
@@ -182,8 +183,8 @@ func (to *Session) logout() (net.Addr, error) {
 	}
 
 	path := apiBase + "/user/logout"
-	resp, remoteAddr, err := to.RawRequest("POST", path, credentials)
-	resp, remoteAddr, err = to.ErrUnlessOKOrNotModified(resp, remoteAddr, err, path)
+	resp, remoteAddr, err := to.RawRequestWithHdr("POST", path, credentials, nil)
+	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
 	if err != nil {
 		return remoteAddr, errors.New("requesting: " + err.Error())
 	}
@@ -307,10 +308,10 @@ func NewNoAuthSession(toURL string, insecure bool, userAgent string, useCache bo
 	}, useCache)
 }
 
-// ErrUnlessOKOrNotModified returns the response, the remote address, and an error if the given Response's status code is anything
+// errUnlessOKOrNotModified returns the response, the remote address, and an error if the given Response's status code is anything
 // but 200 OK/ 304 Not Modified. This includes reading the Response.Body and Closing it. Otherwise, the given response, the remote
 // address, and a nil error are returned.
-func (to *Session) ErrUnlessOKOrNotModified(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
+func (to *Session) errUnlessOKOrNotModified(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
 	if err != nil {
 		return resp, remoteAddr, err
 	}
@@ -333,6 +334,53 @@ func (to *Session) ErrUnlessOKOrNotModified(resp *http.Response, remoteAddr net.
 
 func (to *Session) getURL(path string) string { return to.URL + path }
 
+// makeRequestWithHeader marshals the response body (if non-nil), performs the HTTP request,
+// and decodes the response into the given response pointer.
+func (to *Session) makeRequestWithHeader(method, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+	var remoteAddr net.Addr
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	var reqBody []byte
+	var err error
+	if body != nil {
+		reqBody, err = json.Marshal(body)
+		if err != nil {
+			return reqInf, errors.New("marshalling request body: " + err.Error())
+		}
+	}
+	resp, remoteAddr, err := to.request(method, path, reqBody, header)
+	reqInf.RemoteAddr = remoteAddr
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+		if reqInf.StatusCode == http.StatusNotModified {
+			return reqInf, nil
+		}
+		defer log.Close(resp.Body, "unable to close response body")
+	}
+	if err != nil {
+		return reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
+	}
+	if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
+		return reqInf, errors.New("decoding response body: " + err.Error())
+	}
+	return reqInf, nil
+}
+
+func (to *Session) get(path string, header http.Header, response interface{}) (ReqInf, error) {
+	return to.makeRequestWithHeader(http.MethodGet, path, nil, header, response)
+}
+
+func (to *Session) post(path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+	return to.makeRequestWithHeader(http.MethodPost, path, body, header, response)
+}
+
+func (to *Session) put(path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+	return to.makeRequestWithHeader(http.MethodPut, path, body, header, response)
+}
+
+func (to *Session) del(path string, header http.Header, response interface{}) (ReqInf, error) {
+	return to.makeRequestWithHeader(http.MethodDelete, path, nil, header, response)
+}
+
 // request performs the HTTP request to Traffic Ops, trying to refresh the cookie if an Unauthorized or Forbidden code is received. It only tries once. If the login fails, the original Unauthorized/Forbidden response is returned. If the login succeeds and the subsequent re-request fails, the re-request's response is returned even if it's another Unauthorized/Forbidden.
 // Returns the response, the remote address of the Traffic Ops instance used, and any error.
 // The returned net.Addr is guaranteed to be either nil or valid, even if the returned error is not nil. Callers are encouraged to check and use the net.Addr if an error is returned, and use the remote address in their own error messages. This violates the Go idiom that a non-nil error implies all other values are undefined, but it's more straightforward than alternatives like typecasting.
@@ -342,15 +390,15 @@ func (to *Session) request(method, path string, body []byte, header http.Header)
 		return r, remoteAddr, err
 	}
 	if r.StatusCode != http.StatusUnauthorized && r.StatusCode != http.StatusForbidden {
-		return to.ErrUnlessOKOrNotModified(r, remoteAddr, err, path)
+		return to.errUnlessOKOrNotModified(r, remoteAddr, err, path)
 	}
 	if _, lerr := to.login(); lerr != nil {
-		return to.ErrUnlessOKOrNotModified(r, remoteAddr, err, path) // if re-logging-in fails, return the original request's response
+		return to.errUnlessOKOrNotModified(r, remoteAddr, err, path) // if re-logging-in fails, return the original request's response
 	}
 
 	// return second request, even if it's another Unauthorized or Forbidden.
 	r, remoteAddr, err = to.RawRequestWithHdr(method, path, body, header)
-	return to.ErrUnlessOKOrNotModified(r, remoteAddr, err, path)
+	return to.errUnlessOKOrNotModified(r, remoteAddr, err, path)
 }
 
 func (to *Session) RawRequestWithHdr(method, path string, body []byte, header http.Header) (*http.Response, net.Addr, error) {
@@ -387,11 +435,7 @@ func (to *Session) RawRequestWithHdr(method, path string, body []byte, header ht
 	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
 	req.Header.Set("User-Agent", to.UserAgentStr)
 	resp, err := to.Client.Do(req)
-	if err != nil {
-		return resp, remoteAddr, err
-	}
-
-	return resp, remoteAddr, nil
+	return resp, remoteAddr, err
 }
 
 // RawRequest performs the actual HTTP request to Traffic Ops, simply, without trying to refresh the cookie if an Unauthorized code is returned.

--- a/traffic_ops/v3-client/stats_summary.go
+++ b/traffic_ops/v3-client/stats_summary.go
@@ -13,9 +13,7 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net"
 	"net/url"
 
 	tc "github.com/apache/trafficcontrol/lib/go-tc"
@@ -40,11 +38,11 @@ func (to *Session) GetSummaryStats(cdn, deliveryService, statName *string) (tc.S
 		param.Add("statName", *statName)
 	}
 
-	url := API_STATS_SUMMARY
+	route := API_STATS_SUMMARY
 	if len(param) > 0 {
-		url = fmt.Sprintf("%s?%s", API_STATS_SUMMARY, param.Encode())
+		route = fmt.Sprintf("%s?%s", API_STATS_SUMMARY, param.Encode())
 	}
-	reqInf, err := get(to, url, &resp, nil)
+	reqInf, err := to.get(route, nil, &resp)
 	return resp, reqInf, err
 }
 
@@ -57,21 +55,15 @@ func (to *Session) GetSummaryStatsLastUpdated(statName *string) (tc.StatsSummary
 	if statName != nil {
 		param.Add("statName", *statName)
 	}
-	url := fmt.Sprintf("%s?%s", API_STATS_SUMMARY, param.Encode())
+	route := fmt.Sprintf("%s?%s", API_STATS_SUMMARY, param.Encode())
 
-	reqInf, err := get(to, url, &resp, nil)
+	reqInf, err := to.get(route, nil, &resp)
 	return resp, reqInf, err
 }
 
 // CreateSummaryStats creates a stats summary
 func (to *Session) CreateSummaryStats(statsSummary tc.StatsSummary) (tc.Alerts, ReqInf, error) {
 	var alerts tc.Alerts
-	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	reqBody, err := json.Marshal(statsSummary)
-	if err != nil {
-		return tc.Alerts{}, reqInf, err
-	}
-	reqInf, err = post(to, API_STATS_SUMMARY, reqBody, &alerts)
+	reqInf, err := to.post(API_STATS_SUMMARY, statsSummary, nil, &alerts)
 	return alerts, reqInf, err
 }

--- a/traffic_ops/v3-client/steering.go
+++ b/traffic_ops/v3-client/steering.go
@@ -16,30 +16,16 @@
 package client
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 func (to *Session) SteeringWithHdr(header http.Header) ([]tc.Steering, ReqInf, error) {
-	resp, remoteAddr, err := to.request(http.MethodGet, apiBase+`/steering`, nil, header)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return []tc.Steering{}, reqInf, nil
-		}
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
 	data := struct {
 		Response []tc.Steering `json:"response"`
 	}{}
-	err = json.NewDecoder(resp.Body).Decode(&data)
+	reqInf, err := to.get(apiBase+`/steering`, header, &data)
 	return data.Response, reqInf, err
 }
 

--- a/traffic_ops/v3-client/tenant.go
+++ b/traffic_ops/v3-client/tenant.go
@@ -16,7 +16,6 @@
 package client
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -26,19 +25,12 @@ import (
 )
 
 const API_TENANTS = apiBase + "/tenants"
-const API_TENANT_ID = API_TENANTS + "/%v"
+const API_TENANT_ID = API_TENANTS + "/%s"
 
 func (to *Session) TenantsWithHdr(header http.Header) ([]tc.Tenant, ReqInf, error) {
 	var data tc.GetTenantsResponse
-	reqInf, err := get(to, API_TENANTS, &data, header)
-	if reqInf.StatusCode == http.StatusNotModified {
-		return []tc.Tenant{}, reqInf, nil
-	}
-	if err != nil {
-		return nil, reqInf, err
-	}
-
-	return data.Response, reqInf, nil
+	reqInf, err := to.get(API_TENANTS, header, &data)
+	return data.Response, reqInf, err
 }
 
 // Tenants gets an array of Tenants.
@@ -49,14 +41,13 @@ func (to *Session) Tenants() ([]tc.Tenant, ReqInf, error) {
 
 func (to *Session) TenantWithHdr(id string, header http.Header) (*tc.Tenant, ReqInf, error) {
 	var data tc.GetTenantsResponse
-	reqInf, err := get(to, fmt.Sprintf("%s?id=%v", API_TENANTS, id), &data, header)
-	if reqInf.StatusCode == http.StatusNotModified {
-		return nil, reqInf, nil
-	}
+	reqInf, err := to.get(fmt.Sprintf("%s?id=%v", API_TENANTS, id), header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
-
+	if reqInf.StatusCode == http.StatusNotModified {
+		return nil, reqInf, nil
+	}
 	return &data.Response[0], reqInf, nil
 }
 
@@ -70,21 +61,18 @@ func (to *Session) Tenant(id string) (*tc.Tenant, ReqInf, error) {
 func (to *Session) TenantByNameWithHdr(name string, header http.Header) (*tc.Tenant, ReqInf, error) {
 	var data tc.GetTenantsResponse
 	query := API_TENANTS + "?name=" + url.QueryEscape(name)
-	reqInf, err := get(to, query, &data, header)
-	if reqInf.StatusCode == http.StatusNotModified {
-		return nil, reqInf, nil
-	}
+	reqInf, err := to.get(query, header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
-
-	var ten *tc.Tenant
-	if len(data.Response) > 0 {
-		ten = &data.Response[0]
-	} else {
-		err = errors.New("no tenant found with name " + name)
+	if reqInf.StatusCode == http.StatusNotModified {
+		return nil, reqInf, nil
 	}
-	return ten, reqInf, err
+	if len(data.Response) > 0 {
+		return &data.Response[0], reqInf, nil
+	} else {
+		return nil, reqInf, errors.New("no tenant found with name " + name)
+	}
 }
 
 // TenantByName gets the Tenant with the name it's passed.
@@ -96,7 +84,7 @@ func (to *Session) TenantByName(name string) (*tc.Tenant, ReqInf, error) {
 // CreateTenant creates the Tenant it's passed.
 func (to *Session) CreateTenant(t *tc.Tenant) (*tc.TenantResponse, error) {
 	if t.ParentID == 0 && t.ParentName != "" {
-		tenant, _, err := to.TenantByName(t.ParentName)
+		tenant, _, err := to.TenantByNameWithHdr(t.ParentName, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -107,29 +95,19 @@ func (to *Session) CreateTenant(t *tc.Tenant) (*tc.TenantResponse, error) {
 	}
 
 	var data tc.TenantResponse
-	jsonReq, err := json.Marshal(t)
+	_, err := to.post(API_TENANTS, t, nil, &data)
 	if err != nil {
 		return nil, err
 	}
-	_, err = post(to, API_TENANTS, jsonReq, &data)
-	if err != nil {
-		return nil, err
-	}
-
 	return &data, nil
 }
 
 func (to *Session) UpdateTenantWithHdr(id string, t *tc.Tenant, header http.Header) (*tc.TenantResponse, ReqInf, error) {
 	var data tc.TenantResponse
-	jsonReq, err := json.Marshal(t)
-	if err != nil {
-		return nil, ReqInf{}, err
-	}
-	reqInf, err := put(to, fmt.Sprintf(API_TENANT_ID, id), jsonReq, &data, header)
+	reqInf, err := to.put(fmt.Sprintf(API_TENANT_ID, id), t, header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
-
 	return &data, reqInf, nil
 }
 
@@ -144,10 +122,9 @@ func (to *Session) UpdateTenant(id string, t *tc.Tenant) (*tc.TenantResponse, er
 // DeleteTenant deletes the Tenant matching the ID it's passed.
 func (to *Session) DeleteTenant(id string) (*tc.DeleteTenantResponse, error) {
 	var data tc.DeleteTenantResponse
-	_, err := del(to, fmt.Sprintf(API_TENANT_ID, id), &data)
+	_, err := to.del(fmt.Sprintf(API_TENANT_ID, id), nil, &data)
 	if err != nil {
 		return nil, err
 	}
-
 	return &data, nil
 }

--- a/traffic_ops/v3-client/topology_queue_updates.go
+++ b/traffic_ops/v3-client/topology_queue_updates.go
@@ -20,34 +20,14 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 func (to *Session) TopologiesQueueUpdate(topologyName tc.TopologyName, req tc.TopologiesQueueUpdateRequest) (tc.TopologiesQueueUpdateResponse, ReqInf, error) {
 	path := fmt.Sprintf(ApiTopologies+"/%s/queue_update", topologyName)
-	var reqInf ReqInf
 	var resp tc.TopologiesQueueUpdateResponse
-
-	reqBody, err := json.Marshal(req)
-	if err != nil {
-		return resp, reqInf, err
-	}
-
-	httpResp, remoteAddr, err := to.request(http.MethodPost, path, reqBody, nil)
-	if httpResp != nil {
-		reqInf.StatusCode = httpResp.StatusCode
-		reqInf.RemoteAddr = remoteAddr
-	}
-	if err != nil {
-		return resp, reqInf, err
-	}
-	defer log.Close(httpResp.Body, "unable to close response")
-
-	err = json.NewDecoder(httpResp.Body).Decode(&resp)
+	reqInf, err := to.post(path, req, nil, &resp)
 	return resp, reqInf, err
 }

--- a/traffic_ops/v3-client/traffic_monitor.go
+++ b/traffic_ops/v3-client/traffic_monitor.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -48,18 +47,8 @@ func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorCon
 
 // GetTrafficMonitorConfig returns the monitoring configuration for the CDN named by 'cdn'.
 func (to *Session) GetTrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, ReqInf, error) {
-	url := fmt.Sprintf(API_CDN_MONITORING_CONFIG, cdn)
-	resp, remoteAddr, err := to.request("GET", url, nil, nil)
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	if err != nil {
-		return nil, reqInf, err
-	}
-	defer resp.Body.Close()
-
+	route := fmt.Sprintf(API_CDN_MONITORING_CONFIG, cdn)
 	var data tc.TMConfigResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, reqInf, err
-	}
-
-	return &data.Response, reqInf, nil
+	reqInf, err := to.get(route, nil, &data)
+	return &data.Response, reqInf, err
 }

--- a/traffic_ops/v3-client/traffic_stats.go
+++ b/traffic_ops/v3-client/traffic_stats.go
@@ -21,9 +21,6 @@ import (
 // GetCurrentStats gets current stats for each CDNs and a total across them
 func (to *Session) GetCurrentStats() (tc.TrafficStatsCDNStatsResponse, ReqInf, error) {
 	resp := tc.TrafficStatsCDNStatsResponse{}
-	reqInf, err := get(to, apiBase+"/current_stats", &resp, nil)
-	if err != nil {
-		return resp, reqInf, err
-	}
-	return resp, reqInf, nil
+	reqInf, err := to.get(apiBase+"/current_stats", nil, &resp)
+	return resp, reqInf, err
 }

--- a/traffic_ops/v3-client/util.go
+++ b/traffic_ops/v3-client/util.go
@@ -16,65 +16,13 @@
 package client
 
 import (
-	"encoding/json"
-	"errors"
-	"io/ioutil"
-	"net/http"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
+	"net/url"
 )
 
-func get(to *Session, endpoint string, respStruct interface{}, header http.Header) (ReqInf, error) {
-	return makeReq(to, "GET", endpoint, nil, respStruct, header)
-}
-
-func post(to *Session, endpoint string, body []byte, respStruct interface{}) (ReqInf, error) {
-	return makeReq(to, "POST", endpoint, body, respStruct, nil)
-}
-
-func put(to *Session, endpoint string, body []byte, respStruct interface{}, header http.Header) (ReqInf, error) {
-	return makeReq(to, "PUT", endpoint, body, respStruct, header)
-}
-
-func del(to *Session, endpoint string, respStruct interface{}) (ReqInf, error) {
-	return makeReq(to, "DELETE", endpoint, nil, respStruct, nil)
-}
-
-func makeReq(to *Session, method, endpoint string, body []byte, respStruct interface{}, header http.Header) (ReqInf, error) {
-	resp, remoteAddr, err := to.request(method, endpoint, body, header) // TODO change to getBytesWithTTL
-	reqInf := ReqInf{RemoteAddr: remoteAddr, CacheHitStatus: CacheHitStatusMiss}
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return reqInf, nil
-		}
+func mapToQueryParameters(paramsMap map[string]string) string {
+	params := url.Values{}
+	for key, value := range paramsMap {
+		params.Add(key, value)
 	}
-	if err != nil {
-		return reqInf, err
-	}
-	defer log.Close(resp.Body, "unable to close response body")
-
-	bts, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return reqInf, errors.New("reading body: " + err.Error())
-	}
-
-	if err := json.Unmarshal(bts, respStruct); err != nil {
-		return reqInf, errors.New("unmarshalling body '" + string(body) + "': " + err.Error())
-	}
-
-	return reqInf, nil
-}
-
-func mapToQueryParameters(params map[string]string) string {
-	path := ""
-	for key, value := range params {
-		if path == "" {
-			path += "?"
-		} else {
-			path += "&"
-		}
-		path += key + "=" + value
-	}
-	return path
+	return "?" + params.Encode()
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Refactor the TO Go client methods to all use the same set of internal methods (`to.post()`, `to.put()`, `to.get()`, `to.del()`, ) that each funnel down into the same shared method (`to.makeRequestWithHeader()`).

Before this PR, there were a handful of different ways the TO Go client methods made requests, each of them slightly different and inconsistent in their own ways. By funneling all the top-level methods down into the same, shared, consistent method, all the top-level methods now make requests in the same consistent manner. By doing this, it allows us to remove a tremendous amount of duplicated code that has been copied and pasted into new methods as the client has grown.

Additionally, this PR fixes countless little bugs among various methods in the TO Go client:
- returning `nil` instead of the `err` from decoding the response body
- not using `url.QueryEscape()` or `url.Values{}.Encode()` to properly escape query strings
- unchecked errors
- not setting `ReqInf.RemoteAddress` properly

The vast majority of top-level methods returned an error if the http status code was not 304 or < 300. There were a few I had to change in order to make them consistent with the entire client:
- deliveryservice_requests
- roles
- staticdnsentries

These client methods now return an error if the status code is not 304 or < 300, so I had to modify a few TO API tests to reflect that new change in behavior. I don't expect this change in behavior to impact client users very much, since most users (if any) will be checking `err != nil` anyways. In general, the consistency that this change brings to the client will make it less surprising and easier to use.

Note: this PR doesn't change the signatures of the top-level client methods, but it does make `ErrUnlessOkOrNotModified` private (as it should've always been), since it should not be exposed and used publicly.

## Which Traffic Control components are affected by this PR?

- Traffic Control Client (Go)

## What is the best way to verify this PR?
Verify the TO API tests pass, since they heavily exercise the TO Go client.

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] internal refactor, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)