### PR TITLE
Fix TR NullPointerException in LetsEncryptDnsChallengeWatcher

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/LetsEncryptDnsChallengeWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/LetsEncryptDnsChallengeWatcher.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.log4j.Logger;
 
 import java.io.*;
-import java.nio.file.Path;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -40,7 +39,6 @@ public class LetsEncryptDnsChallengeWatcher extends AbstractResourceWatcher {
 
     private String configFile;
     private ConfigHandler configHandler;
-    private Path databasesDirectory;
 
     public LetsEncryptDnsChallengeWatcher() {
         setDatabaseUrl(DEFAULT_LE_DNS_CHALLENGE_URL);
@@ -106,7 +104,7 @@ public class LetsEncryptDnsChallengeWatcher extends AbstractResourceWatcher {
 
             return true;
         } catch (Exception e) {
-            LOGGER.warn("Failed updating dns challenge txt record with data from " + dataBaseURL + ": " + e.getMessage());
+            LOGGER.warn("Failed updating dns challenge txt record with data from " + dataBaseURL + ":", e);
         }
 
         return false;
@@ -119,7 +117,7 @@ public class LetsEncryptDnsChallengeWatcher extends AbstractResourceWatcher {
             mapper.readValue(data, new TypeReference<HashMap<String, List<LetsEncryptDnsChallenge>>>() { });
             return true;
         } catch (Exception e) {
-            LOGGER.warn("Failed to build dns challenge data while verifying");
+            LOGGER.warn("Failed to build dns challenge data while verifying:", e);
         }
 
         return false;
@@ -142,7 +140,7 @@ public class LetsEncryptDnsChallengeWatcher extends AbstractResourceWatcher {
             }
             return sb.toString();
         } catch (Exception e) {
-            LOGGER.error("Could not read cr-config file " + configFile + ".");
+            LOGGER.error("Could not read cr-config file " + configFile + ":", e);
             return null;
         }
     }
@@ -181,10 +179,6 @@ public class LetsEncryptDnsChallengeWatcher extends AbstractResourceWatcher {
     }
     public ConfigHandler getConfigHandler() {
         return this.configHandler;
-    }
-
-    public void setDatabasesDirectory(final Path databasesDirectory) {
-        this.databasesDirectory = databasesDirectory;
     }
 
     public void setConfigFile(final String configFile) {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Fixes a `NullPointerException` in `LetsEncryptDnsChallengeWatcher` which I believe is breaking the Let's Encrypt functionality.

Because `databasesDirectory` is already a property of the extended class `AbstractServiceUpdater`, it should not be redeclared in `LetsEncryptDnsChallengeWatcher`. The Spring framework was setting the value in `LetsEncryptDnsChallengeWatcher`, but the `AbstractServiceUpdater` uses its own value which was null because `setDatabasesDirectory` was overridden by `LetsEncryptDnsChallengeWatcher`.

Also, log exceptions when catching them in order to capture the full stacktraces in the log.


## Which Traffic Control components are affected by this PR?

- Traffic Router

## What is the best way to verify this PR?
Run TR, view the logs to ensure that the following NPE does not occur periodically:
```
2020-12-01 16:30:33,834 [ERROR] traffic_router.core.loc.AbstractServiceUpdater: [] Failed updating database!
java.lang.NullPointerException
	at java.nio.file.Files.provider(Files.java:97)
	at java.nio.file.Files.exists(Files.java:2385)
	at com.comcast.cdn.traffic_control.traffic_router.core.loc.AbstractServiceUpdater.updateDatabase(AbstractServiceUpdater.java:104)
	at com.comcast.cdn.traffic_control.traffic_router.core.loc.AbstractServiceUpdater$1.run(AbstractServiceUpdater.java:86)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
and instead see logs like this: 
```
2020-12-01 16:33:06,704 [INFO ] traffic_router.core.util.Fetcher: GETing: https://trafficops.example.org/api/2.0/letsencrypt/dnsrecords/; timeout is 15000
2020-12-01 16:33:06,900 [INFO ] traffic_router.core.loc.AbstractServiceUpdater: [LetsEncryptDnsChallengeWatcher] database unchanged.
```

Verify the TR unit and integration tests pass.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.x

## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [x] bug fix, no docs necessary
- [x] unreleased bug, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
