### PR TITLE
Add http_polling_format defaults and set to json

### DIFF
--- a/infrastructure/ansible/roles/traffic-monitor/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-monitor/defaults/main.yml
@@ -43,6 +43,7 @@ tm_stat_flush_interval_ms: 20
 tm_serve_read_timeout_ms: 10000
 tm_serve_write_timeout_ms: 10000
 tm_http_poll_no_sleep: false
+tm_http_polling_format: "text/json"
 tm_to_min_retry_interval: 100
 tm_to_max_retry_interval: 60000
 tm_static_file_dir: "{{ tm_base_dir}}/static"

--- a/infrastructure/ansible/roles/traffic-monitor/templates/traffic_monitor.cfg.j2
+++ b/infrastructure/ansible/roles/traffic-monitor/templates/traffic_monitor.cfg.j2
@@ -31,6 +31,7 @@
         "serve_read_timeout_ms": {{ tm_serve_read_timeout_ms }},
         "serve_write_timeout_ms": {{ tm_serve_write_timeout_ms }},
         "http_poll_no_sleep": {{ tm_http_poll_no_sleep | lower }},
+	"http_polling_format": {{ tm_http_polling_format }},
         "traffic_ops_min_retry_interval_ms": {{ tm_to_min_retry_interval }},
         "traffic_ops_max_retry_interval_ms": {{ tm_to_max_retry_interval }},
         "static_file_dir": "{{ tm_static_file_dir }}"

--- a/infrastructure/ansible/roles/traffic-monitor/templates/traffic_monitor.cfg.j2
+++ b/infrastructure/ansible/roles/traffic-monitor/templates/traffic_monitor.cfg.j2
@@ -31,7 +31,7 @@
         "serve_read_timeout_ms": {{ tm_serve_read_timeout_ms }},
         "serve_write_timeout_ms": {{ tm_serve_write_timeout_ms }},
         "http_poll_no_sleep": {{ tm_http_poll_no_sleep | lower }},
-	"http_polling_format": {{ tm_http_polling_format }},
+        "http_polling_format": {{ tm_http_polling_format }},
         "traffic_ops_min_retry_interval_ms": {{ tm_to_min_retry_interval }},
         "traffic_ops_max_retry_interval_ms": {{ tm_to_max_retry_interval }},
         "static_file_dir": "{{ tm_static_file_dir }}"


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Use an ansible setup and verify that http_polling_format gets created in the TM config file

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->
This is creating a default value of text/json which is also the internal default. If a user wishes it can be set to `text/csv` as well to have TM polling using CSV formatted stats

Relevant PRs include:
https://github.com/apache/trafficcontrol/pull/4713/
https://github.com/apache/trafficcontrol/pull/4993 

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
