### PR TITLE
Fix CHANGELOG for things that were actually in 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,6 @@ will be returned indicating that overlap exists.
 - Changed Traffic Portal to use the more performant and powerful ag-grid for the delivery service request (DSR) table.
 - Traffic Ops: removed change log entry created during server update/revalidation unqueue
 - Updated CDN in a Box to CentOS 8 and added `RHEL_VERSION` Docker build arg so CDN in a Box can be built for CentOS 7, if desired
-- Traffic Ops: removed change log entry created during server update/revalidation unqueue
 
 ### Deprecated
 - Deprecated the non-nullable `DeliveryService` Go struct and other structs that use it. `DeliveryServiceNullable` structs should be used instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
-### Added
-- Traffic Ops: added a feature to get delivery services filtered by the `active` flag
-- Traffic Ops: added validation for assigning ORG servers to topology-based delivery services
-- Traffic Ops: added validation for topology updates and server updates/deletions to ensure that topologies have at least one server per cachegroup in each CDN of any assigned delivery services
-- Traffic Ops: added validation for delivery service updates to ensure that topologies have at least one server per cachegroup in each CDN of any assigned delivery services
-- Added locationByDeepCoverageZone to the `crs/stats/ip/{ip}` endpoint in the Traffic Router API
-- Traffic Portal: upgraded change log UI table to use more powerful/performant ag-grid component
-- Traffic Portal: change log days are now configurable in traffic_portal_properties.json (default is 7 days) and can be overridden by the user in TP
-- [#5319](https://github.com/apache/trafficcontrol/issues/5319) - Added support for building RPMs that target CentOS 8
-- Traffic Ops: Added validation to ensure assigned ORG server cachegroups are in the topology when updating a delivery service
-
-### Fixed
-- [#5274](https://github.com/apache/trafficcontrol/issues/5274) - CDN in a Box's Traffic Vault image failed to build due 
-    to Basho's repo responding with 402 Payment Required. The repo has been removed from the image.
-- [#5069](https://github.com/apache/trafficcontrol/issues/5069) - For LetsEncryptDnsChallengerWatcher in Traffic Router,
-    the cr-config location is configurable instead of only looking at `/opt/traffic_router/db/cr-config.json`
-- [#5191](https://github.com/apache/trafficcontrol/issues/5191) - Error from IMS requests to /federations/all
-
-### Changed
-- Updated CDN in a Box to CentOS 8 and added `RHEL_VERSION` Docker build arg so CDN in a Box can be built for CentOS 7, if desired
-- Traffic Ops: removed change log entry created during server update/revalidation unqueue
 
 ## [5.0.0] - 2020-10-20
 ### Added
@@ -88,6 +67,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `--traffic_ops_insecure=<0|1>` optional option to traffic_ops_ort.pl
 - Added User-Agent string to Traffic Router log output.
 - Added default sort logic to GET API calls using Read()
+- Traffic Ops: added validation for assigning ORG servers to topology-based delivery services
+- Added locationByDeepCoverageZone to the `crs/stats/ip/{ip}` endpoint in the Traffic Router API
+- Traffic Ops: added validation for topology updates and server updates/deletions to ensure that topologies have at least one server per cachegroup in each CDN of any assigned delivery services
+- Traffic Ops: added validation for delivery service updates to ensure that topologies have at least one server per cachegroup in each CDN of any assigned delivery services
+- Traffic Ops: added a feature to get delivery services filtered by the `active` flag
+- Traffic Portal: upgraded change log UI table to use more powerful/performant ag-grid component
+- Traffic Portal: change log days are now configurable in traffic_portal_properties.json (default is 7 days) and can be overridden by the user in TP
+- [#5319](https://github.com/apache/trafficcontrol/issues/5319) - Added support for building RPMs that target CentOS 8
+- Traffic Ops: Added validation to ensure assigned ORG server cachegroups are in the topology when updating a delivery service
 
 ### Fixed
 - Fixed #5188 - DSR (delivery service request) incorrectly marked as complete and error message not displaying when DSR fulfilled and DS update fails in Traffic Portal. [Related Github issue](https://github.com/apache/trafficcontrol/issues/5188)
@@ -147,6 +135,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed #5161 - Fixes topology name character validation [Related Github issue](https://github.com/apache/trafficcontrol/issues/5161)
 - Fixed #5237 - /isos API endpoint rejecting valid IPv6 addresses with CIDR-notation network prefixes.
 - Fixed an issue with Traffic Monitor to fix peer polling to work as expected
+- Fixed #5274 - CDN in a Box's Traffic Vault image failed to build due to Basho's repo responding with 402 Payment Required. The repo has been removed from the image.
+- #5069 - For LetsEncryptDnsChallengerWatcher in Traffic Router, the cr-config location is configurable instead of only looking at `/opt/traffic_router/db/cr-config.json`
+- #5191 - Error from IMS requests to /federations/all
+
 
 ### Changed
 - Changed some Traffic Ops Go Client methods to use `DeliveryServiceNullable` inputs and outputs.
@@ -175,6 +167,9 @@ will be returned indicating that overlap exists.
 - Changed certificate loading code in Traffic Router to use Bouncy Castle instead of deprecated Sun libraries.
 - Changed deprecated AsyncHttpClient Java dependency to use new active mirror and updated to version 2.12.1.
 - Changed Traffic Portal to use the more performant and powerful ag-grid for the delivery service request (DSR) table.
+- Traffic Ops: removed change log entry created during server update/revalidation unqueue
+- Updated CDN in a Box to CentOS 8 and added `RHEL_VERSION` Docker build arg so CDN in a Box can be built for CentOS 7, if desired
+- Traffic Ops: removed change log entry created during server update/revalidation unqueue
 
 ### Deprecated
 - Deprecated the non-nullable `DeliveryService` Go struct and other structs that use it. `DeliveryServiceNullable` structs should be used instead.


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR fixes the CHANGELOG to put things included in the new 5.0.0-RC2 under the "5.0.0" section.

## Which Traffic Control components are affected by this PR?
None

## What is the best way to verify this PR?
Read CHANGELOG.md, make sure everything in it is accurate with respect to the current 5.0.0 Release Candidate and doesn't exclude anything or add anything that shouldn't be there.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**