### PR TITLE
Show correct CDN ID in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed Astats csv issue where it could crash if caches dont return proc data
 
 ### Fixed
+- [#5195](https://github.com/apache/trafficcontrol/issues/5195) - Correctly show CDN ID in Changelog during Snap
 - [#5294](https://github.com/apache/trafficcontrol/issues/5294) - TP ag grid tables now properly persist column filters 
     on page refresh.
 - [#5295](https://github.com/apache/trafficcontrol/issues/5295) - TP types/servers table now clears all filters instead

--- a/traffic_ops/traffic_ops_golang/crconfig/handler.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/handler.go
@@ -175,9 +175,9 @@ func snapshotHandler(w http.ResponseWriter, r *http.Request, deprecated bool) {
 		return
 	}
 
+	id := -1
 	cdn, ok := inf.Params["cdn"]
 	if !ok {
-		var id int
 		if deprecated {
 			id, ok = inf.IntParams["id"]
 			if !ok {
@@ -203,7 +203,7 @@ func snapshotHandler(w http.ResponseWriter, r *http.Request, deprecated bool) {
 		}
 		cdn = name
 	} else {
-		_, ok, err := dbhelpers.GetCDNIDFromName(inf.Tx.Tx, tc.CDNName(cdn))
+		id, ok, err = dbhelpers.GetCDNIDFromName(inf.Tx.Tx, tc.CDNName(cdn))
 		if err != nil {
 			api.HandleErrOptionalDeprecation(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("Error getting CDN ID from name: "+err.Error()), deprecated, &alt)
 			return
@@ -235,7 +235,7 @@ func snapshotHandler(w http.ResponseWriter, r *http.Request, deprecated bool) {
 		return
 	}
 
-	api.CreateChangeLogRawTx(api.ApiChange, "CDN: "+cdn+", ID: "+strconv.Itoa(inf.IntParams["id"])+", ACTION: Snapshot of CRConfig and Monitor", inf.User, inf.Tx.Tx)
+	api.CreateChangeLogRawTx(api.ApiChange, "CDN: "+cdn+", ID: "+strconv.Itoa(id)+", ACTION: Snapshot of CRConfig and Monitor", inf.User, inf.Tx.Tx)
 	if deprecated {
 		api.WriteAlertsObj(w, r, http.StatusOK, api.CreateDeprecationAlerts(&alt), "SUCCESS")
 		return

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
@@ -381,14 +381,14 @@ func TestGetCDNIDFromName(t *testing.T) {
 				mock.ExpectQuery("SELECT").WillReturnRows(rows)
 			}
 			mock.ExpectCommit()
-			_, exists, err := GetCDNIDFromName(db.MustBegin().Tx, "testCdn")
-			if testCase.storageError != nil && err == nil {
+			id, exists, err := GetCDNIDFromName(db.MustBegin().Tx, "testCdn")
+			if testCase.storageError != nil && err == nil && id != 0 {
 				t.Errorf("Storage error expected: received no storage error")
 			}
-			if testCase.storageError == nil && err != nil {
+			if testCase.storageError == nil && err != nil && id != 0 {
 				t.Errorf("Storage error not expected: received storage error")
 			}
-			if testCase.found != exists {
+			if testCase.found != exists && id == 0 {
 				t.Errorf("Expected return exists: %t, actual %t", testCase.found, exists)
 			}
 		})

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
@@ -389,6 +389,9 @@ func TestGetCDNIDFromName(t *testing.T) {
 			if testCase.storageError == nil && err != nil && id == expectedIDValue {
 				t.Errorf("Storage error not expected: received storage error")
 			}
+			if exists && testCase.storageError == nil && err == nil && id != expectedIDValue {
+				t.Errorf("Expected ID %d, but got %d", expectedIDValue, id)
+			}
 			if testCase.found != exists && id == 0 {
 				t.Errorf("Expected return exists: %t, actual %t", testCase.found, exists)
 			}

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers_test.go
@@ -372,20 +372,21 @@ func TestGetCDNIDFromName(t *testing.T) {
 				"id",
 			})
 			mock.ExpectBegin()
+			expectedIDValue := 3
 			if testCase.storageError != nil {
 				mock.ExpectQuery("SELECT").WillReturnError(testCase.storageError)
 			} else {
 				if testCase.found {
-					rows = rows.AddRow(1)
+					rows = rows.AddRow(expectedIDValue)
 				}
 				mock.ExpectQuery("SELECT").WillReturnRows(rows)
 			}
 			mock.ExpectCommit()
 			id, exists, err := GetCDNIDFromName(db.MustBegin().Tx, "testCdn")
-			if testCase.storageError != nil && err == nil && id != 0 {
+			if testCase.storageError != nil && err == nil && id == expectedIDValue {
 				t.Errorf("Storage error expected: received no storage error")
 			}
-			if testCase.storageError == nil && err != nil && id != 0 {
+			if testCase.storageError == nil && err != nil && id == expectedIDValue {
 				t.Errorf("Storage error not expected: received storage error")
 			}
 			if testCase.found != exists && id == 0 {


### PR DESCRIPTION
The Changelog contains informative data to help with review and audit of actions that have been taken. However the CDN ID that is recorded when a CDN snapshot is performed always reads "0". This PR addresses this bug by ensuring the correct ID is displayed in the Changelog.

<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #5195

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [X] This PR fixes #5195 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops
- Traffic Portal

This bug fix addresses what should have been a previously functional changelog statement. There are no references to specific or direct entries in the changelog in documentation, especially since it's subject to change.

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

~While I like to think I'm the first to promote automated tests, I believe the effort to add unit tests here would outweigh and overshadow the bug fix itself. Instituting automated tests to validate a text string for a log entry would require a somewhat significant undertaking, mocking at least a dozen DB calls to fake a snapshot, potential refactors, accounting for both current and deprecated paths, etc., would lead to fragile tests to ensure a string that is subject to change is correct.~

**EDIT** I've since added a check in the tests for one of the existing unit tests to ensure the ID value is validated as well as the previous implementations checking for errors.

Manual Testing can be performed to verify the fix.
1. Through the Traffic Portal, select CDNs from the menu
2. Select a CDN from the table
    2a. If none exist, create a CDN with +
> Note the ID value in the URL (2 in this case): https://localhost:9090/#!/cdns/2
3. Click the button labeled "Diff CDN Config Snapshot"
4. Click the button labeled "Perform Snapshot"
5. In the popup alert, click "Yes" to perform snapshot
6. Verify the ID is correct in the Changelog entry (The URL will be something like: https://localhost:9090/#!/change-logs)
    6a. The entry should contain the correct ID as noted from above

CDN: cdn-name, ID: **2**, ACTION: Snapshot of CRConfig and Monitor
-------------------^

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master (9597ead3)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [X] This PR includes tests OR I have explained why tests are unnecessary
- [X] This PR includes documentation OR I have explained why documentation is unnecessary
- [X] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
