### PR TITLE
fix broken weasel in pkg-generated source tarballs

### DIFF
--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -18,6 +18,12 @@
 version: '2.1'
 
 services:
+  weasel:
+    image: licenseweasel/weasel:v0.4
+    volumes:
+      - ../../..:/trafficcontrol:z
+    command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']
+
   source:
     image: apache/traffic_source_tarballer:master
     build:
@@ -108,12 +114,6 @@ services:
         RHEL_VERSION: ${RHEL_VERSION:-8}
     volumes:
       - ../../..:/trafficcontrol:z
-
-  weasel:
-    image: licenseweasel/weasel:v0.4
-    volumes:
-      - ../../..:/trafficcontrol:z
-    command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']
 
   docs:
     image: apache/traffic_docs_builder:master


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR fixes weasel not passing in tarballs generated from `pkg source`.

## Which Traffic Control components are affected by this PR?
None.

## What is the best way to verify this PR?
Build a source tarball for the repository and then unpack it and run weasel within the decompressed directory.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.0 (RC3)

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**