### PR TITLE
Fixed /ping route having incorrect content-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Router: log warnings when requests to Traffic Monitor return a 503 status code
 - #5344 - Add a page that addresses migrating from Traffic Ops API v1 for each endpoint
 - [#5296](https://github.com/apache/trafficcontrol/issues/5296) - Fixed a bug where users couldn't update any regex in Traffic Ops/ Traffic Portal
-- Fixed Astats csv issue where it could crash if caches dont return proc data
 
 ### Fixed
 - [#5195](https://github.com/apache/trafficcontrol/issues/5195) - Correctly show CDN ID in Changelog during Snap
-- [#5294](https://github.com/apache/trafficcontrol/issues/5294) - TP ag grid tables now properly persist column filters 
+- [#5294](https://github.com/apache/trafficcontrol/issues/5294) - TP ag grid tables now properly persist column filters
     on page refresh.
 - [#5295](https://github.com/apache/trafficcontrol/issues/5295) - TP types/servers table now clears all filters instead
     of just column filters
+- #2881 Some API endpoints have incorrect Content-Types
 
 ## [5.0.0] - 2020-10-20
 ### Added
@@ -150,6 +150,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed #5274 - CDN in a Box's Traffic Vault image failed to build due to Basho's repo responding with 402 Payment Required. The repo has been removed from the image.
 - #5069 - For LetsEncryptDnsChallengerWatcher in Traffic Router, the cr-config location is configurable instead of only looking at `/opt/traffic_router/db/cr-config.json`
 - #5191 - Error from IMS requests to /federations/all
+- Fixed Astats csv issue where it could crash if caches dont return proc data
 
 
 ### Changed

--- a/traffic_ops/traffic_ops_golang/ping/ping.go
+++ b/traffic_ops/traffic_ops_golang/ping/ping.go
@@ -20,15 +20,16 @@ package ping
  */
 
 import (
-	"encoding/json"
 	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 )
 
-// PingHandler simply returns a canned response to show that the server is responding
-func PingHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		m := map[string]string{"ping": "pong"}
-		enc := json.NewEncoder(w)
-		enc.Encode(m)
-	}
+const pingResponse = `{"ping":"pong"}`
+
+// Handler simply sends a static response to the client to show that the
+// server is responding.
+func Handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
+	w.Write(append([]byte(pingResponse), '\n'))
 }

--- a/traffic_ops/traffic_ops_golang/ping/ping_test.go
+++ b/traffic_ops/traffic_ops_golang/ping/ping_test.go
@@ -33,7 +33,7 @@ func TestPingHandler(t *testing.T) {
 		t.Error("Error creating new request")
 	}
 
-	PingHandler()(w, r)
+	Handler(w, r)
 
 	// note the newline...
 	expected := `{"ping":"pong"}

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -259,7 +259,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{3, 0}, http.MethodDelete, `phys_locations/{id}$`, api.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, Authenticated, nil, 256142213, noPerlBypass},
 
 		//Ping
-		{api.Version{3, 0}, http.MethodGet, `ping$`, ping.PingHandler(), 0, NoAuth, nil, 25556615973, noPerlBypass},
+		{api.Version{3, 0}, http.MethodGet, `ping$`, ping.Handler, 0, NoAuth, nil, 25556615973, noPerlBypass},
 		{api.Version{3, 0}, http.MethodGet, `vault/ping/?$`, ping.Vault, auth.PrivLevelReadOnly, Authenticated, nil, 28840121143, noPerlBypass},
 
 		//Profile: CRUD
@@ -636,7 +636,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{2, 0}, http.MethodDelete, `phys_locations/{id}$`, api.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, Authenticated, nil, 25614221, noPerlBypass},
 
 		//Ping
-		{api.Version{2, 0}, http.MethodGet, `ping$`, ping.PingHandler(), 0, NoAuth, nil, 2555661597, noPerlBypass},
+		{api.Version{2, 0}, http.MethodGet, `ping$`, ping.Handler, 0, NoAuth, nil, 2555661597, noPerlBypass},
 		{api.Version{2, 0}, http.MethodGet, `vault/ping/?$`, ping.Vault, auth.PrivLevelReadOnly, Authenticated, nil, 2884012114, noPerlBypass},
 
 		//Profile: CRUD
@@ -1022,7 +1022,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{1, 1}, http.MethodDelete, `phys_locations/{id}$`, api.DeleteHandler(&physlocation.TOPhysLocation{}), auth.PrivLevelOperations, Authenticated, nil, 15614221, noPerlBypass},
 
 		//Ping
-		{api.Version{1, 1}, http.MethodGet, `ping$`, ping.PingHandler(), 0, NoAuth, nil, 1555661597, noPerlBypass},
+		{api.Version{1, 1}, http.MethodGet, `ping$`, ping.Handler, 0, NoAuth, nil, 1555661597, noPerlBypass},
 		{api.Version{1, 1}, http.MethodGet, `riak/ping/?(\.json)?$`, ping.Riak, auth.PrivLevelReadOnly, Authenticated, nil, 1884012114, noPerlBypass},
 		{api.Version{1, 1}, http.MethodGet, `keys/ping/?(\.json)?$`, ping.Keys, auth.PrivLevelReadOnly, Authenticated, nil, 318416022, noPerlBypass},
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #2881 by setting the `Content-Type` property to its appropriate value (`application/json`) for the `/ping` route.


## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Using CiaB or a locally running Traffic Ops, send a GET request to `/ping` and note that it has the appropriate `Content-Type` header in the response to all API versions.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.0 (RC3)
- 4.1.1
- 4.0
- 3.1

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**