### PR TITLE
Fix TR warning for caches without ipv4 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - [#5195](https://github.com/apache/trafficcontrol/issues/5195) - Correctly show CDN ID in Changelog during Snap
+- Fixed Traffic Router logging unnecessary warnings for IPv6-only caches
 - [#5294](https://github.com/apache/trafficcontrol/issues/5294) - TP ag grid tables now properly persist column filters
     on page refresh.
 - [#5295](https://github.com/apache/trafficcontrol/issues/5295) - TP types/servers table now clears all filters instead


### PR DESCRIPTION
## What does this PR (Pull Request) do?
It is valid for a cache to not have an ipv4 address, so we should not
log a warning in that case.

## Which Traffic Control components are affected by this PR?
- Traffic Router

## What is the best way to verify this PR?
In an environment where there are caches with no IPv4 addresses (i.e. they're IPv6-only), run TR _without_ this PR and you'll see warnings like:
```
WARN  2020-12-11T16:36:59.705 [New I/O worker #1] com.comcast.cdn.traffic_control.traffic_router.core.dns.ZoneManager - java.lang.IllegalArgumentException: unknown address family : null
```
_With_ this PR you shouldn't see those warnings.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.x
- 5.x

## The following criteria are ALL met by this PR
- [x] no new tests, but the unit and integration tests pass (except for `itRejectsCrConfigWithMissingCert` which has been failing for quite some time now)
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
