### PR TITLE
Remove inline topology comment from parent.config generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - [#5195](https://github.com/apache/trafficcontrol/issues/5195) - Correctly show CDN ID in Changelog during Snap
 - Fixed Traffic Router logging unnecessary warnings for IPv6-only caches
+- Fixed parent.config generation for topology-based delivery services (inline comments not supported)
 - [#5294](https://github.com/apache/trafficcontrol/issues/5294) - TP ag grid tables now properly persist column filters
     on page refresh.
 - [#5295](https://github.com/apache/trafficcontrol/issues/5295) - TP types/servers table now clears all filters instead
     of just column filters
 - #2881 Some API endpoints have incorrect Content-Types
-
-### Fixed
-- [#5311](https://github.com/apache/trafficcontrol/issues/5311) - Better TO log messages when failures calling TM 
-    CacheStats
+- [#5311](https://github.com/apache/trafficcontrol/issues/5311) - Better TO log messages when failures calling TM CacheStats
 
 ## [5.0.0] - 2020-10-20
 ### Added

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -761,7 +761,6 @@ func getTopologyParentConfigLine(
 	txt += ` qstring=` + getTopologyQueryString(ds, serverParams, serverPlacement.IsLastCacheTier, dsParams.Algorithm, dsParams.QueryStringHandling)
 	txt += getTopologyParentIsProxyStr(serverPlacement.IsLastCacheTier)
 	txt += getParentRetryStr(serverPlacement.IsLastCacheTier, atsMajorVer, dsParams.ParentRetry, dsParams.UnavailableServerRetryResponses, dsParams.MaxSimpleRetries, dsParams.MaxUnavailableServerRetries)
-	txt += " # topology '" + *ds.Topology + "'"
 	txt += "\n"
 	return txt, warnings, nil
 }

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -539,6 +539,10 @@ func TestMakeParentDotConfigTopologies(t *testing.T) {
 	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
 		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
 	}
+	if strings.Contains(txt, "# topology") {
+		// ATS doesn't support inline comments in parent.config
+		t.Errorf("expected: no inline '# topology' comment, actual: '%v'", txt)
+	}
 }
 
 // TestMakeParentDotConfigNotInTopologies tests when a given edge is NOT in a Topology, that it doesn't add a remap line.


### PR DESCRIPTION
## What does this PR (Pull Request) do?
ATS doesn't support inline comments in parent.config.

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run the Go unit tests, make sure they pass. With a valid topology configured for a delivery service, run `traffic_ops_ort.pl` on a cache that belongs to the topology, ensure that the `# topology ...` comment no longer appears in `parent.config`.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
