### PR TITLE
Removes invalid leaf node UI validation from topology builder

### DIFF
--- a/infrastructure/ansible/roles/traffic_portal/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_portal/defaults/main.yml
@@ -207,6 +207,9 @@ tp_default_properties_template:
           can the charts be found? xml id will be appended to the provided url.
         show: false
         baseUrl: "{{ tp_ts_base_url }}/dashboard/script/traffic_ops_server.js?which="
+    changeLogs:
+      _comment: Change log settings
+      days: 7
     customMenu:
       _comments: These are custom items you want to add to the menu. 'items' is an array
         of hashes where each hash has 'name' (the menu item name), 'embed' (true|false

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -156,7 +156,7 @@ func (topology *TOTopology) Validate() error {
 	}
 
 	for _, leafMid := range checkForLeafMids(topology.Nodes, cacheGroups) {
-		rules[fmt.Sprintf("node %v leaf mid", leafMid.Cachegroup)] = fmt.Errorf("cachegroup %v's type is %v; it cannot be a leaf (it must have at least 1 child)", leafMid.Cachegroup, tc.CacheGroupMidTypeName)
+		rules[fmt.Sprintf("node %v leaf mid", leafMid.Cachegroup)] = fmt.Errorf("cachegroup %v's type is %v; it cannot be a leaf (it must have at least 1 primary or secondary child cache group)", leafMid.Cachegroup, tc.CacheGroupMidTypeName)
 	}
 	_, rules["topology cycles"] = checkForCycles(topology.Nodes)
 	rules["super-topology cycles"] = topology.checkForCyclesAcrossTopologies()

--- a/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
+++ b/traffic_portal/app/src/common/modules/form/topology/FormTopologyController.js
@@ -187,14 +187,6 @@ var FormTopologyController = function(topology, cacheGroups, $anchorScroll, $sco
 		scope.toggle();
 	};
 
-	$scope.nodeError = function(node) {
-		// only EDGE_LOCs can serve as a leaf node on the topology
-		if (node.type !== 'EDGE_LOC' && node.children.length === 0) {
-			return node.type + ' requires 1+ child cache group';
-		}
-		return '';
-	};
-
 	$scope.nodeWarning = function(node) {
 		// EDGE_LOCs with parent/secondary parent EDGE_LOCs require special configuration
 		let msg = 'Special Configuration Required';

--- a/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/topology/form.topology.tpl.html
@@ -90,18 +90,15 @@ under the License.
 </div>
 
 <script type="text/ng-template" id="nodes_renderer.html">
-    <!-- this hidden form field will make the form invalid (and disable the save btn) because it's a required field with no value -->
-    <input name="error" ng-if="nodeError(node)" ng-model="error" type="hidden" required>
     <!-- this hidden form field will mark the form as dirty (and enable the save btn) when the topology tree is modified in any way -->
     <input name="dirty" ng-model="dirty" type="hidden">
     <div id="{{node.cachegroup}}" ui-tree-handle class="tree-node tree-node-content"
-         ng-class="{ 'error': nodeError(node), 'warning': nodeWarning(node), 'origin': isOrigin(node), 'mid': isMid(node) }">
+         ng-class="{ 'warning': nodeWarning(node), 'origin': isOrigin(node), 'mid': isMid(node) }">
         <div class="tree-node-label pull-left">
             <a class="tree-toggle btn btn-primary btn-xs" ng-if="node.type !== 'ROOT' && hasChildren(node)" data-nodrag ng-click="toggle(this)">
                 <i class="fa" ng-class="collapsed ? 'fa-caret-right' : 'fa-caret-down'"></i>
             </a> {{::nodeLabel(node)}} <small>{{::node.type}}</small>
         </div>
-        <div ng-if="nodeError(node)" class="error-msg">{{nodeError(node)}}</div>
         <div ng-if="nodeWarning(node)" class="error-msg">{{nodeWarning(node)}}</div>
         <div class="pull-right">
             <a ng-show="node.cachegroup && node.parent.name" title="Set Secondary Parent Cache Group for {{::node.cachegroup}}" class="btn btn-primary btn-xs" data-nodrag ng-click="editSecParent(node)" style="margin-right: 8px;">


### PR DESCRIPTION
## What does this PR (Pull Request) do?
In a topology, leaf nodes are defined as a cache group with zero primary OR secondary cache group children. MID_LOC and ORG_LOC cache groups cannot be leaf nodes in a topology. Only EDGE_LOC cachegroups can be a leaf node. The UI was not taking into consideration secondary children when identifying a leaf node so it would block you from creating a valid topology (a topology that had a MID_LOC or ORG_LOC with ONLY secondary children). This leaf node validation has been removed from the UI and is delegated to the API instead.

There are no additional UI tests or documentation attached to this PR as:
a. there is no real documentation at this point for topologies
b. the existing UI topology tests are not this granular

- [x] This PR fixes #5370 

## Which Traffic Control components are affected by this PR?

- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
1. Create a topology with 2 mid cache groups. assign edges directly to one mid but not the other. save. you shoud get an api validation error regarding leaf node error.
2. set the secondary parent of the edges to the empty mid cache group. save. no error.

## If this is a bug fix, what versions of Traffic Control are affected?
- master (df92555)
- 5.0.0 (RC4)

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
