### PR TITLE
Fix TO API test for CheckOriginServerInCacheGroupTopology

### DIFF
--- a/traffic_ops/testing/api/v3/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_test.go
@@ -904,10 +904,8 @@ func UpdateValidateORGServerCacheGroup(t *testing.T) {
 	ds, reqInf, err := TOSession.UpdateDeliveryServiceV30WithHdr(*remoteDS[0].ID, remoteDS[0], nil)
 	if err == nil {
 		t.Errorf("shouldnot UPDATE DeliveryService by ID: %v, but update was successful", ds.XMLID)
-	} else {
-		if !strings.Contains(err.Error(), "the following ORG server cachegroups are not in the delivery service's topology") {
-			t.Errorf("expected: error containing \"the following ORG server cachegroups are not in the delivery service's topology\", actual: %s", err.Error())
-		}
+	} else if !strings.Contains(err.Error(), "the following ORG server cachegroups are not in the delivery service's topology") {
+		t.Errorf("expected: error containing \"the following ORG server cachegroups are not in the delivery service's topology\", actual: %s", err.Error())
 	}
 	if reqInf.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected to fail since ORG server's topology not part of DS. Expected:%v, Got: :%v", http.StatusBadRequest, reqInf.StatusCode)

--- a/traffic_ops/testing/api/v3/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_test.go
@@ -900,10 +900,14 @@ func UpdateValidateORGServerCacheGroup(t *testing.T) {
 
 	//Update DS's Topology to a non-ORG server's cachegroup
 	origTopo := *remoteDS[0].Topology
-	*remoteDS[0].Topology = "4-tiers"
+	remoteDS[0].Topology = util.StrPtr("another-topology")
 	ds, reqInf, err := TOSession.UpdateDeliveryServiceV30WithHdr(*remoteDS[0].ID, remoteDS[0], nil)
 	if err == nil {
 		t.Errorf("shouldnot UPDATE DeliveryService by ID: %v, but update was successful", ds.XMLID)
+	} else {
+		if !strings.Contains(err.Error(), "the following ORG server cachegroups are not in the delivery service's topology") {
+			t.Errorf("expected: error containing \"the following ORG server cachegroups are not in the delivery service's topology\", actual: %s", err.Error())
+		}
 	}
 	if reqInf.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected to fail since ORG server's topology not part of DS. Expected:%v, Got: :%v", http.StatusBadRequest, reqInf.StatusCode)


### PR DESCRIPTION
## What does this PR (Pull Request) do?
The test was giving us a false positive because the validation was still
prohibiting the DS update for a different reason than the expected
reason.

## Which Traffic Control components are affected by this PR?
- CI tests

## What is the best way to verify this PR?
Ensure the updated test still passes.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] test fix, no docs needed
- [x] test fix, no changelog needed
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)