### PR TITLE
Fix parent.config generation for MSO with required capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5195](https://github.com/apache/trafficcontrol/issues/5195) - Correctly show CDN ID in Changelog during Snap
 - Fixed Traffic Router logging unnecessary warnings for IPv6-only caches
 - Fixed parent.config generation for topology-based delivery services (inline comments not supported)
+- Fixed parent.config generation for MSO delivery services with required capabilities
 - [#5294](https://github.com/apache/trafficcontrol/issues/5294) - TP ag grid tables now properly persist column filters
     on page refresh.
 - [#5295](https://github.com/apache/trafficcontrol/issues/5295) - TP types/servers table now clears all filters instead


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Server capabilities do not apply to ORG servers (origins), so don't
check for them.

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Create an MSO delivery service (`multiSiteOrigin: true`) and a required capability. Assign 2 ORG servers and at least 1 EDGE server to the delivery service. The EDGE server must have the required capability. Make sure at least 1 MID in the CDN also has the required capability. On that MID, run ORT and verify that the line in `parent.config` for this delivery service contains the 2 ORG servers.

Next, create a topology with your edge -> mid -> origin cachegroups, and assign it to your MSO delivery service. On the same MID as before, run ORT and verify that the line in `parent.config` for this delivery service contains the 2 ORG servers.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0.x
- 4.x

## The following criteria are ALL met by this PR

- [x] This PR includes tests
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
