### PR TITLE
TO unable to unassign ORG server from delivery services if it's the last assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     of just column filters
 - #2881 Some API endpoints have incorrect Content-Types
 - [#5311](https://github.com/apache/trafficcontrol/issues/5311) - Better TO log messages when failures calling TM CacheStats
+- [#5390](https://github.com/apache/trafficcontrol/issues/5390) - Improve the way TO deals with delivery service server assignments
 
 ## [5.0.0] - 2020-10-20
 ### Added

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -279,15 +279,13 @@ func UpdateValidateTopologyORGServerCacheGroup(t *testing.T) {
 
 	}
 
-	//TODO: Need to fix the query in deliveryservice/servers/delete.go for DeleteDeliveryServiceServer() to work correctly.
-
-	// Remove org server assignment and reset DS back to as it was for further testing
-	//params.Set("hostName", "denver-mso-org-01")
-	//serverResp, _, err := TOSession.GetServersWithHdr(&params, nil)
-	//_, _, err = TOSession.DeleteDeliveryServiceServer(*remoteDS[0].ID, *serverResp.Response[0].ID)
-	//if err != nil {
-	//	t.Errorf("cannot delete assigned server from Delivery Services: %v", err)
-	//}
+	//Remove org server assignment and reset DS back to as it was for further testing
+	params.Set("hostName", "denver-mso-org-01")
+	serverResp, _, err := TOSession.GetServersWithHdr(&params, nil)
+	_, _, err = TOSession.DeleteDeliveryServiceServer(*remoteDS[0].ID, *serverResp.Response[0].ID)
+	if err != nil {
+		t.Errorf("cannot delete assigned server from Delivery Services: %v", err)
+	}
 }
 
 func DeleteTestTopologies(t *testing.T) {

--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -282,6 +282,12 @@ func UpdateValidateTopologyORGServerCacheGroup(t *testing.T) {
 	//Remove org server assignment and reset DS back to as it was for further testing
 	params.Set("hostName", "denver-mso-org-01")
 	serverResp, _, err := TOSession.GetServersWithHdr(&params, nil)
+	if len(serverResp.Response) == 0 {
+		t.Fatal("no servers in response, quitting")
+	}
+	if serverResp.Response[0].ID == nil {
+		t.Fatal("ID of the response server is nil, quitting")
+	}
 	_, _, err = TOSession.DeleteDeliveryServiceServer(*remoteDS[0].ID, *serverResp.Response[0].ID)
 	if err != nil {
 		t.Errorf("cannot delete assigned server from Delivery Services: %v", err)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -79,7 +79,7 @@ func checkLastServer(dsID, serverID int, tx *sql.Tx) (int, error, error) {
 		return http.StatusInternalServerError, nil, fmt.Errorf("checking if server #%d is the last one assigned to DS #%d: %v", serverID, dsID, err)
 	}
 	if isLast {
-		return http.StatusConflict, fmt.Errorf("removing server #%d from active Delivery Service #%d would leave it with no REPORTED/ ONLINE assigned servers", serverID, dsID), nil
+		return http.StatusConflict, fmt.Errorf("removing server #%d from active Delivery Service #%d would leave it with no REPORTED/ONLINE assigned servers", serverID, dsID), nil
 	}
 	return http.StatusOK, nil, nil
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -44,12 +44,22 @@ func DeleteDeprecated(w http.ResponseWriter, r *http.Request) {
 	delete(w, r, true)
 }
 
-//TODO: Check if the query works correctly when last assigned server is a ORG server
 const lastServerQuery = `
-SELECT COUNT(*) = 0
+SELECT
+(SELECT (CASE WHEN t.name LIKE '` + string(tc.EdgeTypePrefix) + `%' THEN TRUE ELSE FALSE END) AS available
+FROM type t
+JOIN server s ON s.type = t.id
+WHERE s.id = $2)
+AND
+(SELECT COUNT(*) = 0 AS available
 FROM deliveryservice_server
-WHERE deliveryservice = $1
-	AND server <> $2
+JOIN server s ON deliveryservice_server.server = s.id 
+JOIN type t ON t.id = s.type
+JOIN status st ON st.id = s.status
+WHERE (st.name = '` + string(tc.CacheStatusOnline) + `' OR st.name = '` + string(tc.CacheStatusReported) + `')
+AND t.name LIKE '` + string(tc.EdgeTypePrefix) + `%'
+AND deliveryservice = $1
+AND server <> $2)
 `
 
 // checkLastServer checks if the given Server ID identifies the last server
@@ -69,7 +79,7 @@ func checkLastServer(dsID, serverID int, tx *sql.Tx) (int, error, error) {
 		return http.StatusInternalServerError, nil, fmt.Errorf("checking if server #%d is the last one assigned to DS #%d: %v", serverID, dsID, err)
 	}
 	if isLast {
-		return http.StatusConflict, fmt.Errorf("removing server #%d from active Delivery Service #%d would leave it with no assigned servers", serverID, dsID), nil
+		return http.StatusConflict, fmt.Errorf("removing server #%d from active Delivery Service #%d would leave it with no REPORTED/ ONLINE assigned servers", serverID, dsID), nil
 	}
 	return http.StatusOK, nil, nil
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -585,7 +585,7 @@ func validateDSSAssignments(tx *sql.Tx, ds DSInfo, serverInfos []tc.ServerInfo, 
 		// that assignment with the new assignment of an online/ reported ORG, this should be prohibited by TO.
 		err, preExistingEdges := checkIfEdgesExistedBefore(tx, ds.ID)
 		if err != nil {
-			return nil, err, http.StatusInternalServerError
+			return nil, fmt.Errorf("checking for pre existing ONLINE/ REPORTED EDGES: %v", err), http.StatusInternalServerError
 		}
 		if preExistingEdges {
 			ok, err := verifyAtLeastOneAvailableServer(ids, tx)


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5390  <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Create a new active DS in TP
Try to assign a server to this DS that is not in the ONLINE/ REPORTED state -> this should fail
Now, try to assign an EDGE that is in ONLINE/ REPORTED state -> this should pass
Try deleting this EDGE server from TP and also from the backend API call -> both these actions should be prevented

Now create a new active DS in TP
Assign an ONLINE/ REPORTED ORG server to this DS from TP -> this should pass
Now, try to unassign this server from TP -> this should be prevented, because TP uses the `replace=true` mode, and you cannot unassign(or replace) all servers from an active DS
Try to delete this server from the backend call -> this should pass, since this is an ORG server

Note: to make a backend call to the DELETE api, use this endpoint:
`DELETE https://<TO HOST:PORT>/api/3.0/deliveryserviceserver/<DS ID>/<SERVER ID>`

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master
## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR does not include documentation 
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
