### PR TITLE
Remove debug print

### DIFF
--- a/lib/go-atscfg/headerrewritemiddotconfig.go
+++ b/lib/go-atscfg/headerrewritemiddotconfig.go
@@ -20,7 +20,6 @@ package atscfg
  */
 
 import (
-	"fmt"
 	"math"
 	"regexp"
 	"strconv"
@@ -148,7 +147,6 @@ func MakeHeaderRewriteMidDotConfig(
 
 	text := makeHdrComment(hdrComment)
 
-	fmt.Printf("DEBUG moc %v usesmid %v assignedmids %v\n", ds.MaxOriginConnections, ds.Type.UsesMidCache(), len(assignedMids))
 	// write a header rewrite rule if maxOriginConnections > 0 and the ds DOES use mids
 	if ds.MaxOriginConnections > 0 && ds.Type.UsesMidCache() {
 		dsOnlineMidCount := 0


### PR DESCRIPTION
Removes a debug print that got accidentally left in.

No tests, no docs, no changelog, no interface change, it's just removing a `fmt.Printf("DEBUG`.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Verify code. It might get put in the ORT stdout log? Not sure. Might not even end up anywhere.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information