### PR TITLE
GHA: Pin each third-party action and Docker image to a commit hash

### DIFF
--- a/.github/actions/tr-tests/Dockerfile
+++ b/.github/actions/tr-tests/Dockerfile
@@ -16,7 +16,7 @@ FROM alpine:3.12.0
 RUN apk add --no-cache \
 		openjdk8=8.252.09-r0 \
 		maven=3.6.3-r0 \
-		tomcat-native=1.2.24-r0
+		tomcat-native
 
 ENTRYPOINT	cd traffic_router && \
 			mvn "-Dmaven.repo.local=${GITHUB_WORKSPACE}/.m2/repository" \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,13 @@ on:
   push:
     paths:
       - docs/source/**
+      - .github/workflows/docs.yml
       - traffic_control/clients/python/**
   pull_request:
     types: [opened, reopened, read_for_review, synchronize]
     paths:
       - docs/source/**
+      - .github/workflows/docs.yml
       - traffic_control/clients/python/**
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,9 +35,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+      - name: Checkout sphinx-action
+        uses: actions/checkout@v2
+        with:
+          repository: ammaraskar/sphinx-action
+          ref: 35082eb35b69713fe335801c4d5846a4cc3c91ff # Mon Apr 20 15:25:33 2020 -0700 Fix travis for docker image change
+          path: .github/actions/sphinx-action
       - name: Build Documentation
-        uses: ammaraskar/sphinx-action@master
+        uses: ./.github/actions/sphinx-action
         with:
           docs-folder: "docs/"
           pre-build-command: "apt-get update -y && apt-get install -y python3-dev build-essential"

--- a/.github/workflows/tr.unit.tests.yaml
+++ b/.github/workflows/tr.unit.tests.yaml
@@ -20,10 +20,14 @@ name: Traffic Router Unit Tests
 on:
   push:
     paths:
+      - .github/actions/tr-tests/**
+      - .github/workflows/tr.unit.tests.yaml
       - traffic_router/**
   create:
   pull_request:
     paths:
+      - .github/actions/tr-tests/**
+      - .github/workflows/tr.unit.tests.yaml
       - traffic_router/**
     types: [ opened, reopened, ready_for_review, synchronize ]
 

--- a/.github/workflows/tr.unit.tests.yaml
+++ b/.github/workflows/tr.unit.tests.yaml
@@ -49,7 +49,14 @@ jobs:
         with:
           name: surefire-reports
           path: ${{ github.workspace }}/traffic_router/core/target/surefire-reports/TEST-*.xml
-      - uses: zrhoffman/junit-report-annotations-action@master
+      - name: Checkout junit-report-annotations action
+        uses: actions/checkout@v2
+        with:
+          repository: zrhoffman/junit-report-annotations-action
+          ref: 399056ab38c3da69c5b27f924357e10aec3caf8f # Fri Sep 25 02:02:53 2020 -0600 Make all properties string type (see actions/toolkit#398)
+          path: .github/actions/junit-report-annotations
+      - name: Convert Junit Report to Annotations
+        uses: ./.github/actions/junit-report-annotations
         with:
           path: ${{ github.workspace }}/traffic_router/core/target/surefire-reports/TEST-*.xml
           numFailures: 999 # The maximum number of test failures to annotate

--- a/.github/workflows/weasel.yml
+++ b/.github/workflows/weasel.yml
@@ -32,4 +32,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Run weasel
-      uses: docker://licenseweasel/weasel:v0.4
+      run: |
+        # Image is licenseweasel/weasel:v0.4
+        docker run --rm --workdir=/github/workspace --volume="${GITHUB_WORKSPACE}:/github/workspace" licenseweasel/weasel@sha256:85196092a84315d2ebb9db32f3f6113d288256dba7f7855ca0d3483ef787cb4e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5296](https://github.com/apache/trafficcontrol/issues/5296) - Fixed a bug where users couldn't update any regex in Traffic Ops/ Traffic Portal
 - Added API endpoints for ACME accounts
 - Traffic Ops: Added validation to ensure that the cachegroups of a delivery services' assigned ORG servers are present in the topology
+- Pinned external actions used by Documentation Build and TR Unit Tests workflows to commit SHA-1 and the Docker image used by the Weasel workflow to a SHA-256 digest
 
 ### Fixed
 - [#5192](https://github.com/apache/trafficcontrol/issues/5192) - Fixed TO log warnings when generating snapshots for topology-based delivery services.


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- - [x] This PR fixes #5433 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
- Verify that the Documentation Build workflow ran and passed
- Verify that the Traffic Router Unit Tests workflow ran and passed
- Verify that the Weasel workflow ran and passed

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (222da3e3df)
- 5.0.0 (RC6)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] Bugfix in CI tests, documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Is this approach okay?
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->
Yes. Among the list of workflow patterns whitelisted is

```gitignore
*/*@[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]+
```

This pattern (provided by the Apache GitHub org) doesn't work for some reason, but the intent is clear: 3rd-party actions are allowed if you pin them to a commit hash.

In the same vein, 3rd-party Docker images pinned to a SHA-256 digest are safe, as well.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
