### PR TITLE
Change lib/go-log to always log UTC

### DIFF
--- a/lib/go-log/log.go
+++ b/lib/go-log/log.go
@@ -76,14 +76,14 @@ func logf(logger *log.Logger, format string, v ...interface{}) {
 	if logger == nil {
 		return
 	}
-	logger.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
+	logger.Output(stackFrame, time.Now().UTC().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
 }
 
 func logln(logger *log.Logger, v ...interface{}) {
 	if logger == nil {
 		return
 	}
-	logger.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
+	logger.Output(stackFrame, time.Now().UTC().Format(timeFormat)+": "+fmt.Sprintln(v...))
 }
 
 const timeFormat = time.RFC3339Nano

--- a/lib/go-log/log_test.go
+++ b/lib/go-log/log_test.go
@@ -1,0 +1,44 @@
+package log
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+type writeCloser struct {
+	io.Writer
+}
+
+func (writeCloser) Close() error { return nil }
+
+func TestUTC(t *testing.T) {
+	buf := &bytes.Buffer{}
+	Init(nil, writeCloser{buf}, nil, nil, nil)
+	Errorln("test")
+	actual := buf.String()
+
+	if !strings.Contains(actual, "Z: test") {
+		t.Errorf("expected UTC time, actual '" + actual + "'")
+	}
+}


### PR DESCRIPTION
Without this, log time format will be arbitrary dependent on the OS.

This came out of a conversation with our logs team. It's easier for log tools if the prefix format is consistent. We noticed it was different on dev laptops versus production CentOS servers. Because without this fix, the format is arbitrary depending on how the OS reports the timezone to Go.

ATC officially supports CentOS, which appears to report UTC. So this shouldn't change production servers. But it will guarantee the format is always UTC going forward.

Includes tests.
No docs, log format is not documented.
No changelog, log format is not documented, and this shouldn't change the supported CentOS behavior.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- library; error logs of all apps using lib/go-log (TO, TM, ORT)

## What is the best way to verify this PR?
Run tests. Print a log from lib/go-log on a machine reporting local time, like a laptop, before this fix, verify format is local, build again with this fix, verify time format is UTC.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information
