### PR TITLE
Add license to RPMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added API endpoints for ACME accounts
 - Traffic Ops: Added validation to ensure that the cachegroups of a delivery services' assigned ORG servers are present in the topology
 - Traffic Ops: Added validation to ensure that the `weight` parameter of `parent.config` is a float
+- Added license files to the RPMs
 
 ### Fixed
 - [#5335](https://github.com/apache/trafficcontrol/issues/5335) - Don't create a change log entry if the delivery service primary origin hasn't changed

--- a/grove/build/grove.spec
+++ b/grove/build/grove.spec
@@ -31,6 +31,10 @@ An HTTP Caching Proxy
 %prep
 
 %build
+set -o nounset
+# copy license
+cp "${TC_DIR}/LICENSE" %{_builddir}
+
 tar -xvzf %{_sourcedir}/%{name}-%{version}.tgz --directory %{_builddir}
 
 %install
@@ -56,6 +60,7 @@ echo "cleaning"
 rm -r -f %{buildroot}
 
 %files
+%license LICENSE
 /usr/sbin/%{name}
 /var/log/%{name}
 %config(noreplace) /etc/%{name}

--- a/grove/grovetccfg/build/grovetccfg.spec
+++ b/grove/grovetccfg/build/grovetccfg.spec
@@ -31,6 +31,10 @@ A Traffic Control config generator for the Grove HTTP Caching Proxy
 %prep
 
 %build
+set -o nounset
+# copy license
+cp "${TC_DIR}/LICENSE" %{_builddir}
+
 tar -xvzf %{_sourcedir}/%{name}-%{version}.tgz --directory %{_builddir}
 
 %install
@@ -43,4 +47,5 @@ echo "cleaning"
 rm -r -f %{buildroot}
 
 %files
+%license LICENSE
 /usr/sbin/%{name}

--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -143,5 +143,5 @@ clean:
 
 very-clean: clean
 	$(warning This will destroy ALL OUTPUT RPMS IN 'dist'. Please be sure this is what you want)
-	sleep 2 # Give users a sceond to cancel
-	$(RM) ../../dist/*
+	sleep 2 # Give users a second to cancel
+	$(RM) -r ../../dist/*

--- a/test/fakeOrigin/build/build_rpm.sh
+++ b/test/fakeOrigin/build/build_rpm.sh
@@ -70,7 +70,7 @@ cp $BUILDDIR/RPMS/x86_64/*.rpm ./dist/
 # Cross compile because we can
 GOBINEXT=""
 for GOOS in darwin linux windows; do
-  for GOARCH in 386 amd64; do
+  for GOARCH in amd64; do
     if [[ "$GOOS" == "windows" ]]
     then
       GOBINEXT=".exe"

--- a/test/fakeOrigin/build/build_rpm.sh
+++ b/test/fakeOrigin/build/build_rpm.sh
@@ -71,10 +71,13 @@ cp $BUILDDIR/RPMS/x86_64/*.rpm ./dist/
 # Cross compile because we can
 GOBINEXT=""
 for GOOS in darwin linux windows; do
-  for GOARCH in amd64; do
+  for GOARCH in 386 amd64; do
     if [[ "$GOOS" == "windows" ]]
     then
       GOBINEXT=".exe"
+    elif [[ "$GOOS" == darwin && "$GOARCH" == 386 ]] ; then
+      # Go 1.15 and up does not support the darwin/386 GOOS/GOARCH pair (golang/go@65a4dc9c18)
+      continue;
     else
       GOBINEXT=""
     fi

--- a/test/fakeOrigin/build/build_rpm.sh
+++ b/test/fakeOrigin/build/build_rpm.sh
@@ -22,6 +22,7 @@ env
 
 BUILDDIR="$HOME/rpmbuild"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export DIR
 pwd
 cd $DIR/..
 pwd

--- a/test/fakeOrigin/build/fakeOrigin.spec
+++ b/test/fakeOrigin/build/fakeOrigin.spec
@@ -35,6 +35,10 @@ A fake HTTP CDN Origin for testing
 %prep
 
 %build
+set -o nounset
+# copy license
+cp "${DIR}/../../../LICENSE" %{_builddir}
+
 tar -xvzf %{_sourcedir}/%{name}-%{_version}-%{_release}.tgz --directory %{_builddir}
 
 %install
@@ -62,6 +66,7 @@ echo "cleaning"
 rm -r -f %{buildroot}
 
 %files
+%license LICENSE
 /opt/%{name}/%{name}
 /opt/%{name}/example
 /var/log/%{name}

--- a/traffic_monitor/build/build_rpm.sh
+++ b/traffic_monitor/build/build_rpm.sh
@@ -74,6 +74,9 @@ initBuildArea() {
 	cp -av "$TM_DIR"/build/*.spec "$RPMBUILD"/SPECS/. || \
 		 { echo "Could not copy spec files: $?"; return 1; }
 
+	# include LICENSE in the source RPM
+	cp "${TC_DIR}/LICENSE" "$tm_dest"
+
 	tar -czvf "$tm_dest".tgz -C "$RPMBUILD"/SOURCES "$(basename "$tm_dest")" || { echo "Could not create tar archive $tm_dest.tgz: $?"; return 1; }
 	cp "$TM_DIR"/build/*.spec "$RPMBUILD"/SPECS/. || { echo "Could not copy spec files: $?"; return 1; }
 

--- a/traffic_monitor/build/traffic_monitor.spec
+++ b/traffic_monitor/build/traffic_monitor.spec
@@ -98,6 +98,7 @@ fi
 /sbin/chkconfig traffic_monitor on
 
 %files
+%license LICENSE
 %defattr(644, traffic_monitor, traffic_monitor, 755)
 %config(noreplace) %attr(600, traffic_monitor, traffic_monitor) /opt/traffic_monitor/conf/traffic_monitor.cfg
 %config(noreplace) %attr(600, traffic_monitor, traffic_monitor) /opt/traffic_monitor/conf/traffic_ops.cfg

--- a/traffic_ops/build/build_rpm.sh
+++ b/traffic_ops/build/build_rpm.sh
@@ -93,8 +93,13 @@ initBuildArea() {
 		echo "Could not copy to $dest/app"
 		return 1
 	fi
+
+	# include LICENSE in the tarball
+	cp "${TC_DIR}/LICENSE" "$dest"
+
 	tar -czvf "$dest".tgz -C "$RPMBUILD"/SOURCES "$(basename "$dest")" || \
 		 { echo "Could not create tar archive $dest.tgz: $?"; return 1; }
+
 	cp "$TO_DIR"/build/traffic_ops.spec "$RPMBUILD"/SPECS/. || \
 		 { echo "Could not copy spec files: $?"; return 1; }
 

--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -56,6 +56,12 @@ Built: %(date) by %{getenv: USER}
 %setup
 
 %build
+		set -o nounset
+		# copy LICENSE
+		cp "${TC_DIR}/LICENSE" %{_builddir}
+		# avoid detecting LICENSE as an unpackaged RPM file
+		rm LICENSE
+
 		# update version referenced in the source
 		sed -i.bak 's/__VERSION__/%{version}-%{release}/g' app/lib/UI/Utils.pm
 
@@ -205,6 +211,7 @@ if [ "$1" = "0" ]; then
 fi
 
 %files
+%license ../LICENSE
 %defattr(644,root,root,755)
 %attr(755,%{TRAFFIC_OPS_USER},%{TRAFFIC_OPS_GROUP}) %{PACKAGEDIR}/app/bin/config2json
 %attr(755,%{TRAFFIC_OPS_USER},%{TRAFFIC_OPS_GROUP}) %{PACKAGEDIR}/app/bin/extensions

--- a/traffic_ops_ort/build/build_rpm.sh
+++ b/traffic_ops_ort/build/build_rpm.sh
@@ -78,6 +78,10 @@ initBuildArea() {
 	cp -p build/atstccfg.logrotate "$dest"/build;
 	mkdir -p "${dest}/atstccfg";
 	cp -a atstccfg/* "${dest}/atstccfg";
+
+	# include LICENSE in the tarball
+	cp "${TC_DIR}/LICENSE" "$dest"
+
 	tar -czvf "$dest".tgz -C "$RPMBUILD"/SOURCES "$(basename "$dest")";
 	cp build/traffic_ops_ort.spec "$RPMBUILD"/SPECS/.;
 	cp build/atstccfg.logrotate "$RPMBUILD"/.;

--- a/traffic_ops_ort/build/traffic_ops_ort.spec
+++ b/traffic_ops_ort/build/traffic_ops_ort.spec
@@ -39,6 +39,10 @@ tar xvf %{SOURCE0} -C $RPM_SOURCE_DIR
 
 
 %build
+set -o nounset
+# copy license
+cp "${TC_DIR}/LICENSE" %{_builddir}
+
 # copy atstccfg binary
 godir=src/github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg
 ( mkdir -p "$godir" && \
@@ -76,6 +80,7 @@ rm -rf ${RPM_BUILD_ROOT}
 %post
 
 %files
+%license LICENSE
 %attr(755, root, root)
 /opt/ort/traffic_ops_ort.pl
 /opt/ort/supermicro_udev_mapper.pl

--- a/traffic_portal/build/build_rpm.sh
+++ b/traffic_portal/build/build_rpm.sh
@@ -49,6 +49,9 @@ initBuildArea() {
 		 { echo "Could not copy to $to_dest: $?"; return 1; }
 	cp -r "$TP_DIR"/ "$tp_dest" || { echo "Could not copy $TP_DIR to $tp_dest: $?"; return 1; }
 
+	# include LICENSE in the tarball
+	cp "${TC_DIR}/LICENSE" "$tp_dest"
+
 	tar -czvf "$tp_dest".tgz -C "$RPMBUILD"/SOURCES "$(basename "$tp_dest")" || { echo "Could not create tar archive ${tp_dest}.tgz: $?"; return 1; }
 	cp "$TP_DIR"/build/*.spec "$RPMBUILD"/SPECS/. || { echo "Could not copy spec files: $?"; return 1; }
 

--- a/traffic_portal/build/traffic_portal.spec
+++ b/traffic_portal/build/traffic_portal.spec
@@ -79,6 +79,7 @@ tar -xzvf $RPM_SOURCE_DIR/traffic_portal-%{version}.tgz
 		echo "Start with 'service traffic_portal start'"
 
 %files
+%license LICENSE
 %defattr(644,root,root,755)
 %attr(755,root,root) /etc/init.d/traffic_portal
 %attr(755,root,root) %{traffic_portal_home}/node_modules/forever/bin/forever

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -133,6 +133,7 @@
 							<group>Applications/Internet</group>
 							<name>${project.parent.artifactId}</name>
 							<release>${env.BUILD_NUMBER}.${env.RHEL_VERSION}</release>
+							<license>Apache License, Version 2.0</license>
 							<needarch>x86_64</needarch>
 							<targetOS>${env.RPM_TARGET_OS}</targetOS>
 							<defineStatements>
@@ -221,6 +222,18 @@
 											<include>com.comcast.cdn.traffic_control.traffic_router:ROOT</include>
 										</includes>
 									</dependency>
+								</mapping>
+								<mapping>
+									<directory>/usr/share/licenses/traffic_router-${project.parent.version}</directory>
+									<documentation>true</documentation>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+									<sources>
+										<source>
+											<location>../../LICENSE</location>
+										</source>
+									</sources>
 								</mapping>
 							</mappings>
 							<requires>

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -68,6 +68,7 @@ fi
 %pre
 
 %files
+%license LICENSE
 %defattr(-,root,root)
 %{tomcat_home}
 

--- a/traffic_server/plugins/astats_over_http/astats-git-build.spec
+++ b/traffic_server/plugins/astats_over_http/astats-git-build.spec
@@ -45,6 +45,8 @@ git checkout master
 git checkout %{commit} .
 cd ..
 mv trafficcontrol/traffic_server/plugins/astats_over_http %{name}
+# copy license
+cp trafficcontrol/LICENSE %{_builddir}
 rm -rf trafficcontrol
 %setup -D -n %{name} -T
 
@@ -64,4 +66,5 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root)
+%license LICENSE
 /opt/trafficserver/libexec/trafficserver/%{name}.so

--- a/traffic_server/spec/trafficserver.spec
+++ b/traffic_server/spec/trafficserver.spec
@@ -77,6 +77,7 @@ if [ "$1" = "0" ]; then
 fi
 
 %files
+%license LICENSE
 %defattr(-,root,root)
 %attr(755,-,-) /etc/init.d/trafficserver
 %dir /opt/trafficserver

--- a/traffic_server/tsb/trafficserver.spec
+++ b/traffic_server/tsb/trafficserver.spec
@@ -98,6 +98,7 @@ if [ "$1" = "0" ]; then
 fi
 
 %files
+%license LICENSE
 %defattr(-,root,root)
 %attr(644,-,-) /usr/lib/systemd/system/trafficserver.service
 %dir /opt/trafficserver

--- a/traffic_stats/build/build_rpm.sh
+++ b/traffic_stats/build/build_rpm.sh
@@ -83,6 +83,9 @@ initBuildArea() {
 	cp "$TS_DIR"/build/*.spec "$RPMBUILD"/SPECS/. || \
 		 { echo "Could not copy spec files: $?"; return 1; }
 
+	# include LICENSE in the tarball
+	cp "${TC_DIR}/LICENSE" "$ts_dest"
+
 	tar -czvf "$ts_dest".tgz -C "$RPMBUILD"/SOURCES "$(basename "$ts_dest")" || { echo "Could not create tar archive $ts_dest.tgz: $?"; return 1; }
 	cp "$TS_DIR"/build/*.spec "$RPMBUILD"/SPECS/. || { echo "Could not copy spec files: $?"; return 1; }
 

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -111,6 +111,7 @@ fi
 /sbin/chkconfig traffic_stats on
 
 %files
+%license LICENSE
 %defattr(644, traffic_stats, traffic_stats, 755)
 
 %config(noreplace) %attr(600, traffic_stats, traffic_stats) /opt/traffic_stats/conf/traffic_stats.cfg


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5462 by adding a license to each of our RPMs.<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

-  Fake Origin testing tool
-  Grove
-  Traffic Monitor
-  Traffic Ops
-  Traffic Ops ORT
-  Traffic Portal
-  Traffic Router
-  Traffic Server
-  Traffic Stats

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
- Build RPMs
  * Build the ATC RPMs:
  ```shell
  ./pkg -v && echo 'ATC RPMs built successfully';
  ```
  * Build the Transitive Source Build ATS RPM:
  ```shell
  ./pkg -v -o && echo 'Traffic Server TSB RPM built successfully';
  ```
  * Build the fakeOrigin RPM:
  ```shell
  docker-compose -f test/fakeOrigin/docker-compose.build_rpm.yml up --build
  ```
- Make sure the binary RPMs have license files:
  ```shell
  set -o pipefail;
  cd dist;
  for rpm in *.x86_64.rpm; do
    if [[ "$rpm" == trafficserver-debuginfo-* ]]; then
      continue;
    fi;
    if ! rpm -ql "$rpm" | grep '/usr/share/licenses/.*/LICENSE'; then
      echo "No LICENSE file was found for ${rpm}"
      break;
    fi;
  done;
  ```
- Extract the source RPMs using bsdtar (included in [libarchive](https://formulae.brew.sh/formula/libarchive)) and verify that they contain LICENSE files:
  ```shell
  for rpm in *.src.rpm; do
    mkdir "${rpm%.rpm}";
      (cd "${rpm%.rpm}";
      bsdtar xf "../${rpm}";
      tar xf *.tgz;
      if ! ls */LICENSE; then
        echo "No LICENSE file was found for ${rpm}"
        break;
      fi;)
  done;
  ```

In the future, we may want to consider adding a check to ensure the RPMs include license files in `/usr/share/licenses`.

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes instructions for testing
- [x] Only RPM spec files changed, no documentation necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
