### PR TITLE
Remove test that checks system-dependent value

### DIFF
--- a/traffic_monitor/datareq/datareq_test.go
+++ b/traffic_monitor/datareq/datareq_test.go
@@ -30,8 +30,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_monitor/config"
 	"github.com/apache/trafficcontrol/traffic_monitor/peer"
-
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 type AvailabilityType string
@@ -243,9 +242,6 @@ func TestGetStats(t *testing.T) {
 	}
 	if st.FreeMemoryMB != appData.FreeMemoryMB {
 		t.Fatalf("expected getStats FreeMemoryMB '%+v', actual: '%+v'\n", appData.FreeMemoryMB, st.FreeMemoryMB)
-	}
-	if st.TotalMemoryMB <= 0 {
-		t.Fatalf("expected getStats TotalMemoryMB > 0, actual: '%+v'\n", st.TotalMemoryMB)
 	}
 	if st.Version != appData.Version {
 		t.Fatalf("expected getStats Version '%+v', actual: '%+v'\n", appData.Version, st.Version)


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR removes a test from Traffic Monitor that was checking that the machine running the tests was using more than 1MiB of memory - as that was fairly unreliable (particularly when running in GitHub Actions).

## Which Traffic Control components are affected by this PR?
- Traffic Monitor
- CI tests (indirectly)

## What is the best way to verify this PR?
Notice that the tests all pass in GHA checks

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 