### PR TITLE
Adding atscfg overrides to insert the Release version in via string

### DIFF
--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -472,6 +472,14 @@ def main() -> int:
 	                    help="Sets the timeout in milliseconds for requests made to Traffic Ops.",
 	                    type=int,
 	                    default=None)
+	parser.add_argument("--via_string_release",
+			    		help="set the ATS via string to the package release instead of version",
+			    		type=int,
+			    		default=0)
+	parser.add_argument("--disable-parent-config-comments",
+						help="Do not insert comments in parent.config files",
+						type=int,
+						default=0)
 	parser.add_argument("-v", "--version",
 	                    action="version",
 	                    version="%(prog)s v"+__version__,

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/__init__.py
@@ -472,7 +472,7 @@ def main() -> int:
 	                    help="Sets the timeout in milliseconds for requests made to Traffic Ops.",
 	                    type=int,
 	                    default=None)
-	parser.add_argument("--via_string_release",
+	parser.add_argument("--via-string-release",
 			    		help="set the ATS via string to the package release instead of version",
 			    		type=int,
 			    		default=0)

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/configuration.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/configuration.py
@@ -113,6 +113,8 @@ class Configuration():
 		self.rev_proxy_disable = args.rev_proxy_disable
 		self.verify = not args.insecure
 		self.timeout = args.timeout
+		self.via_string_release = args.via_string_release
+		self.disable_parent_config_comments = args.disable_parent_config_comments
 
 		setLogLevel(args.log_level)
 

--- a/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
+++ b/infrastructure/cdn-in-a-box/ort/traffic_ops_ort/to_api.py
@@ -91,7 +91,10 @@ class API(TOSession):
 			self.atstccfg_cmd.append("--traffic-ops-disable-proxy")
 		if not conf.verify:
 			self.atstccfg_cmd.append("--traffic-ops-insecure")
-
+		if conf.via_string_release > 0:
+			self.atstccfg_cmd.append("--via-string-release")
+		if conf.disable_parent_config_comments > 0:
+			self.atstccfg_cmd.append("--disable-parent-config-comments")
 
 	def __enter__(self):
 		"""

--- a/lib/go-atscfg/recordsdotconfig_test.go
+++ b/lib/go-atscfg/recordsdotconfig_test.go
@@ -41,8 +41,8 @@ func TestMakeRecordsDotConfig(t *testing.T) {
 	ipStr := "192.168.2.99"
 	setIP(server, ipStr)
 	server.Profile = util.StrPtr(profileName)
-
-	cfg, err := MakeRecordsDotConfig(server, paramData, hdr)
+	opt := RecordsConfigOpts{}
+	cfg, err := MakeRecordsDotConfig(server, paramData, hdr, opt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/traffic_ops_ort/atstccfg/README.md
+++ b/traffic_ops_ort/atstccfg/README.md
@@ -105,6 +105,13 @@ The available options are:
     invalidation jobs. For Apache Traffic Server implementations, this limits
     the output to be only files named 'regex_revalidate.config'. Has no effect
     if --get-data or --set-queue-status/--set-reval-status is/are used.
+--via_string_release
+    Using this option will set the via string records.config options for Apache
+    Traffic Server so that it will have the rpm file release information in the via
+    string instead of the actual ATS version
+--disable-parent-config-comments
+    Disables having per-line parent.config comments. The file header will still be
+    generated.
 ```
 
 # Development

--- a/traffic_ops_ort/atstccfg/atstccfg.go
+++ b/traffic_ops_ort/atstccfg/atstccfg.go
@@ -120,7 +120,7 @@ func main() {
 		os.Exit(config.ExitCodeErrGeneric)
 	}
 
-	configs, err := cfgfile.GetAllConfigs(toData, tccfg.RevalOnly, tccfg.Dir, config.UserAgent, tccfg.TOClient.C.URL, toIPs)
+	configs, err := cfgfile.GetAllConfigs(toData, config.UserAgent, toIPs, tccfg)
 	if err != nil {
 		log.Errorln("Getting config for'" + cfg.CacheHostName + "': " + err.Error())
 		os.Exit(config.ExitCodeErrGeneric)

--- a/traffic_ops_ort/atstccfg/cfgfile/all.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/all.go
@@ -42,32 +42,30 @@ import (
 // GetAllConfigs gets all config files for cfg.CacheHostName.
 func GetAllConfigs(
 	toData *config.TOData,
-	revalOnly bool,
-	dir string,
 	appVersion string,
-	toURL string,
 	toIPs []net.Addr,
+	cfg config.TCCfg,
 ) ([]config.ATSConfigFile, error) {
 	if toData.Server.HostName == nil {
 		return nil, errors.New("server hostname is nil")
 	}
 
-	configFiles, warnings, err := MakeConfigFilesList(toData, dir)
+	configFiles, warnings, err := MakeConfigFilesList(toData, cfg.Dir)
 	logWarnings("generating config files list: ", warnings)
 	if err != nil {
 		return nil, errors.New("creating meta: " + err.Error())
 	}
 
 	genTime := time.Now()
-	hdrCommentTxt := makeHeaderComment(*toData.Server.HostName, appVersion, toURL, toIPs, genTime)
+	hdrCommentTxt := makeHeaderComment(*toData.Server.HostName, appVersion, cfg.TOClient.C.URL, toIPs, genTime)
 
 	hasSSLMultiCertConfig := false
 	configs := []config.ATSConfigFile{}
 	for _, fi := range configFiles {
-		if revalOnly && fi.Name != atscfg.RegexRevalidateFileName {
+		if cfg.RevalOnly && fi.Name != atscfg.RegexRevalidateFileName {
 			continue
 		}
-		txt, contentType, lineComment, err := GetConfigFile(toData, fi, hdrCommentTxt)
+		txt, contentType, lineComment, err := GetConfigFile(toData, fi, hdrCommentTxt, cfg)
 		if err != nil {
 			return nil, errors.New("getting config file '" + fi.Name + "': " + err.Error())
 		}

--- a/traffic_ops_ort/atstccfg/cfgfile/cfgfile_test.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/cfgfile_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+	client "github.com/apache/trafficcontrol/traffic_ops/v1-client"
 	"github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg/config"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/atstccfg/toreq"
 )
 
 func TestWriteConfigs(t *testing.T) {
@@ -140,7 +142,14 @@ func TestGetAllConfigsWriteConfigsDeterministic(t *testing.T) {
 	revalOnly := false
 	cfgPath := "/etc/trafficserver/"
 
-	configs, err := GetAllConfigs(toData, revalOnly, cfgPath, "", "", nil)
+	cfg := config.TCCfg{}
+	cfg.Dir = cfgPath
+	cfg.RevalOnly = revalOnly
+	cfg.TOClient = &toreq.TOClient{}
+	cfg.TOClient.C = &client.Session{}
+	cfg.TOClient.C.URL = ""
+
+	configs, err := GetAllConfigs(toData, "", nil, cfg)
 	if err != nil {
 		t.Fatalf("error getting configs: " + err.Error())
 	}
@@ -149,11 +158,10 @@ func TestGetAllConfigsWriteConfigsDeterministic(t *testing.T) {
 		t.Fatalf("error writing configs: " + err.Error())
 	}
 	configStr := buf.String()
-
 	configStr = removeComments(configStr)
 
 	for i := 0; i < 10; i++ {
-		configs2, err := GetAllConfigs(toData, revalOnly, cfgPath, "", "", nil)
+		configs2, err := GetAllConfigs(toData, "", nil, cfg)
 		if err != nil {
 			t.Fatalf("error getting configs2: " + err.Error())
 		}

--- a/traffic_ops_ort/atstccfg/cfgfile/routing.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/routing.go
@@ -31,7 +31,7 @@ import (
 // # DO NOT EDIT - Generated for odol-atsec-sea-22 by Traffic Ops (https://trafficops.comcast.net/) on Mon Oct 26 16:22:19 UTC 2020
 
 // GetConfigFile returns the text of the generated config file, the MIME Content Type of the config file, and any error.
-func GetConfigFile(toData *config.TOData, fileInfo atscfg.CfgMeta, hdrCommentTxt string) (string, string, string, error) {
+func GetConfigFile(toData *config.TOData, fileInfo atscfg.CfgMeta, hdrCommentTxt string, thiscfg config.TCCfg) (string, string, string, error) {
 	start := time.Now()
 	defer func() {
 		log.Infof("GetConfigFile %v took %v\n", fileInfo.Name, time.Since(start).Round(time.Millisecond))
@@ -39,7 +39,7 @@ func GetConfigFile(toData *config.TOData, fileInfo atscfg.CfgMeta, hdrCommentTxt
 	log.Infoln("GetConfigFile '" + fileInfo.Name + "'")
 
 	getConfigFile := getConfigFileFunc(fileInfo.Name)
-	cfg, err := getConfigFile(toData, fileInfo.Name, hdrCommentTxt)
+	cfg, err := getConfigFile(toData, fileInfo.Name, hdrCommentTxt, thiscfg)
 	logWarnings("getting config file '"+fileInfo.Name+"': ", cfg.Warnings)
 
 	if err != nil {
@@ -48,7 +48,7 @@ func GetConfigFile(toData *config.TOData, fileInfo atscfg.CfgMeta, hdrCommentTxt
 	return cfg.Text, cfg.ContentType, cfg.LineComment, nil
 }
 
-type ConfigFileFunc func(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error)
+type ConfigFileFunc func(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error)
 
 type ConfigFilePrefixSuffixFunc struct {
 	Prefix string

--- a/traffic_ops_ort/atstccfg/cfgfile/wrappers.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/wrappers.go
@@ -47,47 +47,47 @@ func MakeConfigFilesList(toData *config.TOData, dir string) ([]atscfg.CfgMeta, [
 	return configFiles, warnings, err
 }
 
-func Make12MFacts(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func Make12MFacts(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.Make12MFacts(toData.Server, hdrCommentTxt)
 }
 
-func MakeATSDotRules(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeATSDotRules(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeATSDotRules(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeAstatsDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeAstatsDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeAStatsDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeBGFetchDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeBGFetchDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeBGFetchDotConfig(toData.Server, hdrCommentTxt)
 }
 
-func MakeCacheDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeCacheDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeCacheDotConfig(toData.Server, toData.Servers, toData.DeliveryServices, toData.DeliveryServiceServers, hdrCommentTxt)
 }
 
-func MakeCacheURL(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeCacheURL(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeCacheURLDotConfig(fileName, toData.Server, toData.DeliveryServices, toData.DeliveryServiceServers, hdrCommentTxt)
 }
 
-func MakeCacheURLPlain(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
-	return MakeCacheURL(toData, "cacheurl.config", hdrCommentTxt)
+func MakeCacheURLPlain(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
+	return MakeCacheURL(toData, "cacheurl.config", hdrCommentTxt, cfg)
 }
 
-func MakeChkconfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeChkconfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeChkconfig(toData.ServerParams)
 }
 
-func MakeDropQStringDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeDropQStringDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeDropQStringDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeHostingDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeHostingDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeHostingDotConfig(toData.Server, toData.Servers, toData.ServerParams, toData.DeliveryServices, toData.DeliveryServiceServers, toData.Topologies, hdrCommentTxt)
 }
 
-func MakeIPAllowDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeIPAllowDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeIPAllowDotConfig(
 		toData.ServerParams,
 		toData.Server,
@@ -98,23 +98,23 @@ func MakeIPAllowDotConfig(toData *config.TOData, fileName string, hdrCommentTxt 
 	)
 }
 
-func MakeLoggingDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeLoggingDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeLoggingDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeLoggingDotYAML(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeLoggingDotYAML(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeLoggingDotYAML(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeLogsXMLDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeLogsXMLDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeLogsXMLDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakePackages(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakePackages(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakePackages(toData.ServerParams)
 }
 
-func MakeParentDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeParentDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeParentDotConfig(
 		toData.DeliveryServices,
 		toData.Server,
@@ -129,24 +129,31 @@ func MakeParentDotConfig(toData *config.TOData, fileName string, hdrCommentTxt s
 		toData.CDN,
 		atscfg.ParentConfigOpts{
 			HdrComment:  hdrCommentTxt,
-			AddComments: true, // TODO add a CLI flag?
+			AddComments: cfg.ParentComments, // TODO add a CLI flag?
 		},
 	)
 }
 
-func MakePluginDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakePluginDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakePluginDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeRecordsDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
-	return atscfg.MakeRecordsDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
+func MakeRecordsDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
+	return atscfg.MakeRecordsDotConfig(
+		toData.Server,
+		toData.ServerParams,
+		hdrCommentTxt,
+		atscfg.RecordsConfigOpts{
+			ReleaseViaStr: cfg.ViaRelease,
+		},
+	)
 }
 
-func MakeRegexRevalidateDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeRegexRevalidateDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeRegexRevalidateDotConfig(toData.Server, toData.DeliveryServices, toData.GlobalParams, toData.Jobs, hdrCommentTxt)
 }
 
-func MakeRemapDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeRemapDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeRemapDotConfig(
 		toData.Server,
 		toData.DeliveryServices,
@@ -163,27 +170,27 @@ func MakeRemapDotConfig(toData *config.TOData, fileName string, hdrCommentTxt st
 	)
 }
 
-func MakeSSLMultiCertDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeSSLMultiCertDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeSSLMultiCertDotConfig(toData.Server, toData.DeliveryServices, hdrCommentTxt)
 }
 
-func MakeStorageDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeStorageDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeStorageDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeSysCtlDotConf(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeSysCtlDotConf(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeSysCtlDotConf(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeVolumeDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeVolumeDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeVolumeDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
 }
 
-func MakeHeaderRewriteMid(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeHeaderRewriteMid(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeHeaderRewriteMidDotConfig(fileName, toData.DeliveryServices, toData.DeliveryServiceServers, toData.Server, toData.Servers, toData.CacheGroups, hdrCommentTxt)
 }
 
-func MakeTopologyHeaderRewrite(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeTopologyHeaderRewrite(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeTopologyHeaderRewriteDotConfig(
 		fileName,
 		toData.Server,
@@ -196,26 +203,26 @@ func MakeTopologyHeaderRewrite(toData *config.TOData, fileName string, hdrCommen
 	)
 }
 
-func MakeHeaderRewrite(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeHeaderRewrite(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeHeaderRewriteDotConfig(fileName, toData.DeliveryServices, toData.DeliveryServiceServers, toData.Server, toData.Servers, hdrCommentTxt)
 }
 
-func MakeRegexRemap(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeRegexRemap(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeRegexRemapDotConfig(fileName, toData.Server, toData.DeliveryServices, hdrCommentTxt)
 }
 
-func MakeSetDSCP(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeSetDSCP(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeSetDSCPDotConfig(fileName, toData.Server, hdrCommentTxt)
 }
 
-func MakeURLSigConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeURLSigConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeURLSigConfig(fileName, toData.Server, toData.ServerParams, toData.URLSigKeys, hdrCommentTxt)
 }
 
-func MakeURISigningConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeURISigningConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeURISigningConfig(fileName, toData.URISigningKeys)
 }
 
-func MakeUnknownConfig(toData *config.TOData, fileName string, hdrCommentTxt string) (atscfg.Cfg, error) {
+func MakeUnknownConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeServerUnknown(fileName, toData.Server, toData.ServerParams, hdrCommentTxt)
 }

--- a/traffic_ops_ort/atstccfg/config/config.go
+++ b/traffic_ops_ort/atstccfg/config/config.go
@@ -66,6 +66,8 @@ type Cfg struct {
 	TOURL           *url.URL
 	TOUser          string
 	Dir             string
+	ViaRelease      bool
+	ParentComments  bool
 }
 
 type TCCfg struct {
@@ -101,6 +103,8 @@ func GetCfg() (Cfg, error) {
 	revalOnlyPtr := flag.BoolP("revalidate-only", "y", false, "Whether to exclude files not named 'regex_revalidate.config'")
 	disableProxyPtr := flag.BoolP("traffic-ops-disable-proxy", "p", false, "Whether to not use the Traffic Ops proxy specified in the GLOBAL Parameter tm.rev_proxy.url")
 	dirPtr := flag.StringP("dir", "D", "", "ATS config directory, used for config files without location parameters or with relative paths. May be blank. If blank and any required config file location parameter is missing or relative, will error.")
+	viaReleasePtr := flag.BoolP("via-string-release", "", false, "Whether to use the Release value from the RPM package as a replacement for the ATS version specified in the build that is returned in the Via and Server headers from ATS.")
+	disableParentConfigComments := flag.BoolP("disable-parent-config-comments", "", false, "Disable adding a comments to parent.config individual lines")
 
 	flag.Parse()
 
@@ -131,6 +135,8 @@ func GetCfg() (Cfg, error) {
 	revalOnly := *revalOnlyPtr
 	disableProxy := *disableProxyPtr
 	dir := *dirPtr
+	viaRelease := *viaReleasePtr
+	parentComments := !(*disableParentConfigComments) //we use this as a boolean value so reverse it here to not have negative logic
 
 	urlSourceStr := "argument" // for error messages
 	if toURL == "" {
@@ -190,6 +196,8 @@ func GetCfg() (Cfg, error) {
 		RevalOnly:       revalOnly,
 		DisableProxy:    disableProxy,
 		Dir:             dir,
+		ViaRelease:      viaRelease,
+		ParentComments:  parentComments,
 	}
 	if err := log.InitCfg(cfg); err != nil {
 		return Cfg{}, errors.New("Initializing loggers: " + err.Error() + "\n")

--- a/traffic_ops_ort/traffic_ops_ort.pl
+++ b/traffic_ops_ort/traffic_ops_ort.pl
@@ -184,7 +184,7 @@ if ($via_string_release == 1) {
 
 my $atstccfg_parent_config_comments = "";
 if ($disable_parent_config_comments == 1) {
-	$atstccfg_parent_config_comments = "--disable-parent-config-header";
+	$atstccfg_parent_config_comments = "--disable-parent-config-comments";
 }
 
 my $TMP_BASE  = "/tmp/ort";

--- a/traffic_ops_ort/traffic_ops_ort.pl
+++ b/traffic_ops_ort/traffic_ops_ort.pl
@@ -57,8 +57,8 @@ GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "to_timeout_ms=i" => \$to_timeout_ms,
             "syncds_updates_ipallow=i" => \$syncds_updates_ipallow,
             "traffic_ops_insecure=i" => \$traffic_ops_insecure,
-			"via_string_release=i" => \$via_string_release,
-			"disable_parent_config_comments=i" => \$parent_config_comments,
+            "via_string_release=i" => \$via_string_release,
+            "disable_parent_config_comments=i" => \$disable_parent_config_comments,
           );
 
 if ( $#ARGV < 1 ) {
@@ -368,7 +368,7 @@ sub usage {
 	print "\t   syncds_updates_ipallow=<0|1>   => Update ip_allow.config in syncds mode, which may trigger an ATS bug blocking random addresses on load! Default = 0, only update on badass and restart.\n";
 	print "\t   traffic_ops_insecure=<0|1>     => Turns off certificate checking when connecting to Traffic Ops.\n";
 	print "\t   via_string_release=<0|1>       => change the ATS via string to be the rpm release instead of the actual ATS version number\n";
-	print "\t   parent_config_header=<0|1>     => add comment header to the parent.config file\n";
+	print "\t   disable_parent_config_comments=<0|1>     => do not write line comments to the parent.config file\n";
 	print "====-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-====\n";
 	exit 1;
 }


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
The release version can be a user definable build option of ATS, instead of the actual ATS version number. So being able to set this as the via string can be useful for both debug to get a specific build value that was in use as well as obfuscation of the ATS version in use

This also adds atscfg and ort command line options for both the release version via string as well as a previous option
to disable per line comments in parent.config

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- Traffic Ops ORT

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Run atstccfg with the `--via_string_release` option, or set that as an option in the crontab for ciab. Then check the via string output from a cache request in the headers and verify that it now shows the release value from the rpm instead of the ATS version

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
