### PR TITLE
TR: Fix potential steering registry race, improve steering logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5382](https://github.com/apache/trafficcontrol/issues/5382) - Fixed API documentation and TP helptext for "Max DNS Answers" field with respect to DNS, HTTP, Steering Delivery Service
 - [#5396](https://github.com/apache/trafficcontrol/issues/5396) - Return the correct error type if user tries to update the root tenant
 - [#5378](https://github.com/apache/trafficcontrol/issues/5378) - Updating a non existent DS should return a 404, instead of a 500
+- Fixed a potential Traffic Router race condition that could cause erroneous 503s for CLIENT_STEERING delivery services when loading new steering changes
 - [#5195](https://github.com/apache/trafficcontrol/issues/5195) - Correctly show CDN ID in Changelog during Snap
 - [#5438](https://github.com/apache/trafficcontrol/issues/5438) - Correctly specify nodejs version requirements in traffic_portal.spec
 - Fixed Traffic Router logging unnecessary warnings for IPv6-only caches

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/Steering.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/Steering.java
@@ -93,15 +93,9 @@ public class Steering {
 		}
 
 		final Steering steering = (Steering) o;
-
-		if (!Objects.equals(deliveryService, steering.deliveryService)) {
-			return false;
-		}
-		if (!Objects.equals(targets, steering.targets)) {
-			return false;
-		}
-		return Objects.equals(filters, steering.filters);
-
+		return Objects.equals(deliveryService, steering.deliveryService)
+				&& Objects.equals(targets, steering.targets)
+				&& Objects.equals(filters, steering.filters);
 	}
 
 	@Override

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/Steering.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/Steering.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class Steering {
 	@JsonProperty
@@ -83,17 +84,23 @@ public class Steering {
 	}
 
 	@Override
-	@SuppressWarnings("PMD")
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-
-		Steering steering = (Steering) o;
-
-		if (deliveryService != null ? !deliveryService.equals(steering.deliveryService) : steering.deliveryService != null)
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
 			return false;
-		if (targets != null ? !targets.equals(steering.targets) : steering.targets != null) return false;
-		return filters != null ? filters.equals(steering.filters) : steering.filters == null;
+		}
+
+		final Steering steering = (Steering) o;
+
+		if (!Objects.equals(deliveryService, steering.deliveryService)) {
+			return false;
+		}
+		if (!Objects.equals(targets, steering.targets)) {
+			return false;
+		}
+		return Objects.equals(filters, steering.filters);
 
 	}
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/SteeringRegistry.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/SteeringRegistry.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +29,7 @@ import java.util.Map;
 public class SteeringRegistry {
 	private static final Logger LOGGER = Logger.getLogger(SteeringRegistry.class);
 
-	private final Map<String, Steering> registry = new HashMap<String, Steering>();
+	private Map<String, Steering> registry = new HashMap<>();
 	private final ObjectMapper objectMapper = new ObjectMapper(new JsonFactory());
 
 	@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.AvoidDuplicateLiterals"})
@@ -53,25 +52,29 @@ public class SteeringRegistry {
 			newSteerings.put(steering.getDeliveryService(), steering);
 		}
 
-		registry.clear();
-		registry.putAll(newSteerings);
-		for (final Steering steering : steerings) {
-			for (final SteeringTarget target : steering.getTargets()) {
-				if (target.getGeolocation() != null && target.getGeoOrder() != 0) {
-					LOGGER.info("Steering " + steering.getDeliveryService() + " target " + target.getDeliveryService() + " now has geolocation [" + target.getLatitude() + ", "  + target.getLongitude() + "] and geoOrder " + target.getGeoOrder());
-				} else if (target.getGeolocation() != null && target.getWeight() > 0) {
-					LOGGER.info("Steering " + steering.getDeliveryService() + " target " + target.getDeliveryService() + " now has geolocation [" + target.getLatitude() + ", "  + target.getLongitude() + "] and weight " + target.getWeight());
-				} else if (target.getGeolocation() != null) {
-					LOGGER.info("Steering " + steering.getDeliveryService() + " target " + target.getDeliveryService() + " now has geolocation [" + target.getLatitude() + ", "  + target.getLongitude() + "]");
-				} else if (target.getWeight() > 0) {
-					LOGGER.info("Steering " + steering.getDeliveryService() + " target " + target.getDeliveryService() + " now has weight " + target.getWeight());
-				} else if (target.getOrder() != 0) { // this target has a specific order set
-					LOGGER.info("Steering " + steering.getDeliveryService() + " target " + target.getDeliveryService() + " now has order " + target.getOrder());
-				} else {
-					LOGGER.info("Steering " + steering.getDeliveryService() + " target " + target.getDeliveryService() + " now has weight " + target.getWeight() + " and order " + target.getOrder());
+		newSteerings.forEach((k, newSteering) -> {
+			final Steering old = registry.get(k);
+			if (old == null || !old.equals(newSteering)) {
+				for (final SteeringTarget target : newSteering.getTargets()) {
+					if (target.getGeolocation() != null && target.getGeoOrder() != 0) {
+						LOGGER.info("Steering " + newSteering.getDeliveryService() + " target " + target.getDeliveryService() + " now has geolocation [" + target.getLatitude() + ", "  + target.getLongitude() + "] and geoOrder " + target.getGeoOrder());
+					} else if (target.getGeolocation() != null && target.getWeight() > 0) {
+						LOGGER.info("Steering " + newSteering.getDeliveryService() + " target " + target.getDeliveryService() + " now has geolocation [" + target.getLatitude() + ", "  + target.getLongitude() + "] and weight " + target.getWeight());
+					} else if (target.getGeolocation() != null) {
+						LOGGER.info("Steering " + newSteering.getDeliveryService() + " target " + target.getDeliveryService() + " now has geolocation [" + target.getLatitude() + ", "  + target.getLongitude() + "]");
+					} else if (target.getWeight() > 0) {
+						LOGGER.info("Steering " + newSteering.getDeliveryService() + " target " + target.getDeliveryService() + " now has weight " + target.getWeight());
+					} else if (target.getOrder() != 0) { // this target has a specific order set
+						LOGGER.info("Steering " + newSteering.getDeliveryService() + " target " + target.getDeliveryService() + " now has order " + target.getOrder());
+					} else {
+						LOGGER.info("Steering " + newSteering.getDeliveryService() + " target " + target.getDeliveryService() + " now has weight " + target.getWeight() + " and order " + target.getOrder());
+					}
 				}
 			}
-		}
+		});
+
+		registry = newSteerings;
+		LOGGER.info("Finished updating steering registry");
 	}
 
 	public boolean verify(final String json) {
@@ -98,13 +101,4 @@ public class SteeringRegistry {
 		return registry.values();
 	}
 
-	public Collection<Steering> removeAll(final List<String> steeringIds) {
-		final List<Steering> removedEntries = new ArrayList<Steering>();
-
-		for (final String steeringId : steeringIds) {
-			removedEntries.add(registry.remove(steeringId));
-		}
-
-		return removedEntries;
-	}
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Clearing the existing map and putting all the new steerings into it can
potentially cause a race where the map is empty or partially empty when
doing steering lookups for incoming requests. Instead, swap the old map
with the new map (which is atomic).

Additionally, improve the steering registry logging so that only changes
are logged, rather than re-printing the entire registry when a single
entry is changed.

## Which Traffic Control components are affected by this PR?
- Traffic Router

## What is the best way to verify this PR?
1. Create a couple `CLIENT_STEERING` delivery services with a few targets each (preferably using `STEERING_ORDER`).
2. Snapshot the CDN.
3. Start up TR, wait for it to finish processing the snapshot.
4. Request one of the `CLIENT_STEERING` DSes from TR, ensure that the returned `locations` list is ordered as expected.
5. Change the `STEERING_ORDER` values of that DS's steering targets, observe the TR logs, ensure that it only logs the target configurations of the changed `CLIENT_STEERING` DS.
6. Repeat step 4.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.x
- 4.x

## The following criteria are ALL met by this PR
- [x] fairly trivial change, race condition is difficult to reproduce in a test
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
