### PR TITLE
Add API v4 integration tests to those run on PRs

### DIFF
--- a/.github/workflows/traffic ops.yml
+++ b/.github/workflows/traffic ops.yml
@@ -94,3 +94,9 @@ jobs:
       with:
         version: 3
         smtp_address: 172.17.0.1
+    - name: Run API v4 tests
+      if: ${{ steps.todb.outcome == 'success' && always() }}
+      uses: ./.github/actions/to-integration-tests
+      with:
+        version: 4
+        smtp_address: 172.17.0.1


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR makes the TO/Go client integration tests run against APIv4 in the CI workflows - most importantly on PRs, but also on push to master and release branches.

## Which Traffic Control components are affected by this PR?
- CI tests

## What is the best way to verify this PR?
Notice the tests running include the APIv4 tests.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**