### PR TITLE
Update add_deleted_tables.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5461](https://github.com/apache/trafficcontrol/issues/5461) - Fixed steering endpoint to be ordered consistently
 - [#5395](https://github.com/apache/trafficcontrol/issues/5395) - Added validation to prevent changing the Type any Cache Group that is in use by a Topology
 - [#5384](https://github.com/apache/trafficcontrol/issues/5384) - New grids will now properly remember the current page number.
+- Fix for public schema in 2020062923101648_add_deleted_tables.sql
 
 ### Changed
 - Refactored the Traffic Ops Go client internals so that all public methods have a consistent behavior/implementation

--- a/traffic_ops/app/db/migrations/2020062923101648_add_deleted_tables.sql
+++ b/traffic_ops/app/db/migrations/2020062923101648_add_deleted_tables.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS last_deleted (
 --
 -- Name: on_delete_current_timestamp_last_updated(); Type: FUNCTION; Schema: public; Owner: traffic_ops
 --
-CREATE OR REPLACE FUNCTION on_delete_current_timestamp_last_updated()
+CREATE OR REPLACE FUNCTION public.on_delete_current_timestamp_last_updated()
     RETURNS trigger
     AS $$
 BEGIN


### PR DESCRIPTION
## What does this PR (Pull Request) do?

The create function call was not adding the function to the public schema
which was causing the subsequent "ALTER FUNCTION" call to fail.

- [x] This PR is not related to any issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops

## What is the best way to verify this PR?

I'm not sure how to test this. My DB has been around since the 1.x days. It has 2 schemas (traffic_ops and public).

## If this is a bug fix, what versions of Traffic Control are affected?

- 4.1.1 -> 5.0.0 upgrade

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)



<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
