### PR TITLE
Log when getting errors from TO but backup configs exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5396](https://github.com/apache/trafficcontrol/issues/5396) - Return the correct error type if user tries to update the root tenant
 - [#5378](https://github.com/apache/trafficcontrol/issues/5378) - Updating a non existent DS should return a 404, instead of a 500
 - Fixed a potential Traffic Router race condition that could cause erroneous 503s for CLIENT_STEERING delivery services when loading new steering changes
+- Fixed a logging bug in Traffic Monitor where it wouldn't log errors in certain cases where a backup file could be used instead. Also, Traffic Monitor now rejects monitoring snapshots that have no delivery services.
 - [#5195](https://github.com/apache/trafficcontrol/issues/5195) - Correctly show CDN ID in Changelog during Snap
 - [#5438](https://github.com/apache/trafficcontrol/issues/5438) - Correctly specify nodejs version requirements in traffic_portal.spec
 - Fixed Traffic Router logging unnecessary warnings for IPv6-only caches

--- a/lib/go-tc/traffic_monitor.go
+++ b/lib/go-tc/traffic_monitor.go
@@ -303,11 +303,9 @@ func (cfg *TrafficMonitorConfigMap) Valid() error {
 	if len(cfg.TrafficMonitor) == 0 {
 		return errors.New("MonitorConfig.TrafficMonitor empty")
 	}
-	// TODO uncomment this, when TO is fixed to include DeliveryServices.
-	// See https://github.com/apache/trafficcontrol/issues/3528
-	// if len(cfg.DeliveryService) == 0 {
-	// 	return errors.New("MonitorConfig.DeliveryService empty")
-	// }
+	if len(cfg.DeliveryService) == 0 {
+		return errors.New("MonitorConfig.DeliveryService empty")
+	}
 	if len(cfg.Profile) == 0 {
 		return errors.New("MonitorConfig.Profile empty")
 	}

--- a/lib/go-tc/traffic_monitor_test.go
+++ b/lib/go-tc/traffic_monitor_test.go
@@ -473,24 +473,23 @@ func TestTrafficMonitorConfigMap_Valid(t *testing.T) {
 	}
 
 	mc.Config["peers.polling.interval"] = 42.0
-	// TODO: uncomment these tests when #3528 is resolved
-	// mc.DeliveryService = nil
-	// err = mc.Valid()
-	// if err == nil {
-	// 	t.Error("Didn't get expected error checking validity of config map with nil DeliveryService")
-	// } else {
-	// 	t.Logf("Got expected error: checking validity of config map with nil DeliveryService: %v", err)
-	// }
+	mc.DeliveryService = nil
+	err = mc.Valid()
+	if err == nil {
+		t.Error("Didn't get expected error checking validity of config map with nil DeliveryService")
+	} else {
+		t.Logf("Got expected error: checking validity of config map with nil DeliveryService: %v", err)
+	}
 
-	// mc.DeliveryService = map[string]TMDeliveryService{}
-	// err = mc.Valid()
-	// if err == nil {
-	// 	t.Error("Didn't get expected error checking validity of config map with no DeliveryServices")
-	// } else {
-	// 	t.Logf("Got expected error: checking validity of config map with no DeliveryServices: %v", err)
-	// }
+	mc.DeliveryService = map[string]TMDeliveryService{}
+	err = mc.Valid()
+	if err == nil {
+		t.Error("Didn't get expected error checking validity of config map with no DeliveryServices")
+	} else {
+		t.Logf("Got expected error: checking validity of config map with no DeliveryServices: %v", err)
+	}
 
-	// mc.DeliveryService["a"] = TMDeliveryService{}
+	mc.DeliveryService["a"] = TMDeliveryService{}
 	mc.Profile = nil
 	err = mc.Valid()
 	if err == nil {
@@ -570,7 +569,7 @@ func TestTrafficMonitorTransformToMap(t *testing.T) {
 		TrafficMonitors: []TrafficMonitor{
 			TrafficMonitor{},
 		},
-		DeliveryServices: []TMDeliveryService{},
+		DeliveryServices: []TMDeliveryService{{XMLID: "foo"}},
 		Profiles: []TMProfile{
 			{
 				Name: "test",
@@ -596,6 +595,13 @@ func TestTrafficMonitorTransformToMap(t *testing.T) {
 
 	if len(converted.TrafficServer) != 1 {
 		t.Errorf("Incorrect number of traffic servers after conversion; expected: 1, got: %d", len(converted.TrafficServer))
+	}
+
+	if len(converted.DeliveryService) != 1 {
+		t.Errorf("Incorrect number of deliveryServices after conversion; expected: 1, got: %d", len(converted.DeliveryService))
+	}
+	if _, ok := converted.DeliveryService["foo"]; !ok {
+		t.Error("Expected delivery service 'foo' to exist in map after conversion, but it didn't")
 	}
 
 	if _, ok := converted.TrafficServer["testHostname"]; !ok {

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -363,12 +363,12 @@ func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 		ioutil.WriteFile(s.CRConfigBackupFile, data, 0644)
 	} else {
 		if s.BackupFileExists() {
+			log.Errorln("using backup file for CRConfig snapshot due to error fetching CRConfig snapshot from Traffic Ops: " + err.Error())
 			data, err = ioutil.ReadFile(s.CRConfigBackupFile)
 			if err != nil {
 				return nil, fmt.Errorf("file Read Error: %v", err)
 			}
 			remoteAddr = localHostIP
-			log.Errorln("Error getting CRConfig from traffic_ops, backup file exists, reading from file")
 			err = nil
 		} else {
 			return nil, fmt.Errorf("Failed to get CRConfig from Traffic Ops (%v), and there is no backup file", err)
@@ -473,17 +473,17 @@ func (s TrafficOpsSessionThreadsafe) trafficMonitorConfigMapRaw(cdn string) (*tc
 		if !s.BackupFileExists() {
 			return nil, err
 		}
+		log.Errorln("using backup file for monitoring config snapshot due to invalid monitoring config snapshot from Traffic Ops: " + err.Error())
 
 		b, err := ioutil.ReadFile(s.TMConfigBackupFile)
 		if err != nil {
 			return nil, errors.New("reading TMConfigBackupFile: " + err.Error())
 		}
 
-		log.Errorln("Error getting configMap from traffic_ops, backup file exists, reading from file")
 		json := jsoniter.ConfigFastest
 		var tmConfig tc.TrafficMonitorConfig
 		if err := json.Unmarshal(b, &tmConfig); err != nil {
-			return nil, errors.New("unmarhsalling backup file monitoring.json: " + err.Error())
+			return nil, errors.New("unmarshalling backup file monitoring.json: " + err.Error())
 		}
 		return tc.TrafficMonitorTransformToMap(&tmConfig)
 	}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Currently, TM doesn't log an error if it got an invalid monitoring snapshot from TO and a backup file exists. Also TM doesn't log an error if it gets an error fetching a CRConfig snapshot from TO and a backup file exists. This PR makes TM log errors in those cases, because we would need to know the cause of these errors if they were to occur.

Also, this PR makes TM consider a monitoring snapshot invalid if there are no delivery services.

## Which Traffic Control components are affected by this PR?
- Traffic Monitor

## What is the best way to verify this PR?
1. Starting with a valid crconfig so that TM will create a backup of it, shut down TO so that TM fails to fetch it. TM should log an informative error in this case.
2. Starting with a valid monitoring snapshot so that TM will create a backup of it, delete all delivery services from TO, then snapshot the CDN. This should produce an invalid monitoring snapshot, upon which TM should log an informative error (even though it has a valid backup).

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 4.1.x
- 5.0.x

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
