### PR TITLE
Fix migration due to different constraint naming across PGSQL versions

### DIFF
--- a/traffic_ops/app/db/migrations/2021010900000003_server_interface_ip_address_cascade.sql
+++ b/traffic_ops/app/db/migrations/2021010900000003_server_interface_ip_address_cascade.sql
@@ -19,6 +19,25 @@ ALTER TABLE interface
   DROP CONSTRAINT interface_server_fkey,
   ADD CONSTRAINT interface_server_fkey FOREIGN KEY (server) REFERENCES server(id) ON DELETE CASCADE ON UPDATE CASCADE;
 
+-- +goose StatementBegin
+DO $$
+BEGIN
+  IF EXISTS(
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = (
+      SELECT oid
+      FROM pg_class
+      WHERE relname LIKE 'ip_address'
+    ) AND conname = 'ip_address_interface_server_fkey'
+  ) THEN
+    ALTER TABLE ip_address
+      RENAME CONSTRAINT ip_address_interface_server_fkey TO ip_address_interface_fkey;
+  END IF;
+END
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
 ALTER TABLE ip_address
   DROP CONSTRAINT ip_address_interface_fkey,
   ADD CONSTRAINT ip_address_interface_fkey FOREIGN KEY (server) REFERENCES server(id) ON DELETE CASCADE ON UPDATE CASCADE,


### PR DESCRIPTION
## What does this PR (Pull Request) do?
In 13.1, the constraint appears to get named 'ip_address_interface_server_fkey' by default, but in 9.6 it appears to get named 'ip_address_interface_fkey' by default. This fixes the migration to change the name to the 9.6 version before altering the constraint in order for upgrades in 13.1 to work.

This issue was found when resetting the DB in 13.1.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
On postgres 9.6, run the DB migration (reset, upgrade, down, upgrade), ensure it is successful. Do the same with postgres 13.1.

## If this is a bug fix, what versions of Traffic Control are affected?
- basically just master because 13.1 support isn't official yet

## The following criteria are ALL met by this PR

- [x] DB migration fix, covered by DB tests
- [x] DB migration fix, no docs necessary
- [x] not including changelog because this just the start of adding 13.1 support (which will be coming later)
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)