### PR TITLE
Fix TOclient topologies path

### DIFF
--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -37,6 +37,7 @@ type topologyTestCase struct {
 
 func TestTopologies(t *testing.T) {
 	WithObjs(t, []TCObj{Types, CacheGroups, CDNs, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, Servers, ServerCapabilities, ServerServerCapabilitiesForTopologies, Topologies, Tenants, DeliveryServices, TopologyBasedDeliveryServiceRequiredCapabilities}, func() {
+		GetTestTopologies(t)
 		UpdateTestTopologies(t)
 		ValidationTestTopologies(t)
 		UpdateValidateTopologyORGServerCacheGroup(t)
@@ -58,6 +59,19 @@ func CreateTestTopologies(t *testing.T) {
 			t.Fatalf("Topology in response should be the same as the one POSTed. expected: %v\nactual: %v", topology, postResponse.Response)
 		}
 		t.Log("Response: ", postResponse)
+	}
+}
+
+func GetTestTopologies(t *testing.T) {
+	if len(testData.Topologies) < 1 {
+		t.Fatalf("test data has no topologies, can't test")
+	}
+	topos, _, err := TOSession.GetTopologiesWithHdr(nil)
+	if err != nil {
+		t.Fatalf("expected GET error to be nil, actual: %v", err)
+	}
+	if len(topos) != len(testData.Topologies) {
+		t.Errorf("expected topologies GET to return %v topologies, actual %v", len(testData.Topologies), len(topos))
 	}
 }
 

--- a/traffic_ops/testing/api/v4/topologies_test.go
+++ b/traffic_ops/testing/api/v4/topologies_test.go
@@ -37,6 +37,7 @@ type topologyTestCase struct {
 
 func TestTopologies(t *testing.T) {
 	WithObjs(t, []TCObj{Types, CacheGroups, CDNs, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, Servers, ServerCapabilities, ServerServerCapabilitiesForTopologies, Topologies, Tenants, DeliveryServices, TopologyBasedDeliveryServiceRequiredCapabilities}, func() {
+		GetTestTopologies(t)
 		UpdateTestTopologies(t)
 		ValidationTestTopologies(t)
 		UpdateValidateTopologyORGServerCacheGroup(t)
@@ -59,6 +60,19 @@ func CreateTestTopologies(t *testing.T) {
 			t.Fatalf("Topology in response should be the same as the one POSTed. expected: %v\nactual: %v", topology, postResponse.Response)
 		}
 		t.Log("Response: ", postResponse)
+	}
+}
+
+func GetTestTopologies(t *testing.T) {
+	if len(testData.Topologies) < 1 {
+		t.Fatalf("test data has no topologies, can't test")
+	}
+	topos, _, err := TOSession.GetTopologiesWithHdr(nil)
+	if err != nil {
+		t.Fatalf("expected GET error to be nil, actual: %v", err)
+	}
+	if len(topos) != len(testData.Topologies) {
+		t.Errorf("expected topologies GET to return %v topologies, actual %v", len(testData.Topologies), len(topos))
 	}
 }
 

--- a/traffic_ops/v3-client/topology.go
+++ b/traffic_ops/v3-client/topology.go
@@ -37,7 +37,7 @@ func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf
 
 func (to *Session) GetTopologiesWithHdr(header http.Header) ([]tc.Topology, ReqInf, error) {
 	var data tc.TopologiesResponse
-	reqInf, err := to.get(ApiTopologies, header, &data)
+	reqInf, err := to.get(APITopologies, header, &data)
 	return data.Response, reqInf, err
 }
 


### PR DESCRIPTION
Fixes the TO cilent's topologies GetTopologiesWithHdr path, which got missed in the `/api/` removal.

Incidentally, this was discovered with the new ORT Integration Test Framework.

Includes a test for GetTopologiesWithHdr (one didn't exist before, which is how it got missed).
No docs, no interface change.
No changelog, no interface change and bug isn't in a release.

## What does this PR (Pull Request) do?

Fixes `traffic_ops/v3-client.GetTopologiesWithHdr`.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?

- Traffic Control Client Go

## What is the best way to verify this PR?

Run TO API Tests. Run ORT Integration tests.. Run ORT against a TO with Topologies. Write an app calling `traffic_ops/v3-client.GetTopologiesWithHdr`.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 
## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
