### PR TITLE
Fix atscfg comparing pointers not values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5395](https://github.com/apache/trafficcontrol/issues/5395) - Added validation to prevent changing the Type any Cache Group that is in use by a Topology
 - [#5384](https://github.com/apache/trafficcontrol/issues/5384) - New grids will now properly remember the current page number.
 - Fix for public schema in 2020062923101648_add_deleted_tables.sql
+- Fix for config gen missing max_origin_connections on mids in certain scenarios
 - Fixed and issue with 2020082700000000_server_id_primary_key.sql trying to create multiple primary keys when there are multiple schemas.
 
 ### Changed

--- a/lib/go-atscfg/headerrewritemiddotconfig.go
+++ b/lib/go-atscfg/headerrewritemiddotconfig.go
@@ -94,7 +94,7 @@ func MakeHeaderRewriteMidDotConfig(
 			continue
 		}
 
-		if sv.CDNName != server.CDNName {
+		if *sv.CDNName != *server.CDNName {
 			continue
 		}
 		if _, ok := assignedServers[*sv.ID]; !ok && (tcDS.Topology == nil || *tcDS.Topology == "") {

--- a/lib/go-atscfg/headerrewritemiddotconfig_test.go
+++ b/lib/go-atscfg/headerrewritemiddotconfig_test.go
@@ -32,11 +32,19 @@ func TestMakeHeaderRewriteMidDotConfig(t *testing.T) {
 	hdr := "myHeaderComment"
 
 	server := makeGenericServer()
-	server.CDNName = &cdnName
+	server.CDNName = util.StrPtr(cdnName)
 	server.Cachegroup = util.StrPtr("edgeCG")
 	server.HostName = util.StrPtr("myserver")
 	serverStatus := string(tc.CacheStatusReported)
 	server.Status = &serverStatus
+
+	// server, as inserted in servers.
+	// needs to be different, so the pointers are different, like they will be with different API calls.
+	serverSvs := makeGenericServer()
+	serverSvs.CDNName = util.StrPtr(cdnName)
+	serverSvs.Cachegroup = util.StrPtr("edgeCG")
+	serverSvs.HostName = util.StrPtr("myserver")
+	serverSvs.Status = util.StrPtr(string(tc.CacheStatusReported))
 
 	ds := makeGenericDS()
 	ds.EdgeHeaderRewrite = util.StrPtr("edgerewrite")
@@ -44,27 +52,27 @@ func TestMakeHeaderRewriteMidDotConfig(t *testing.T) {
 	ds.XMLID = util.StrPtr("ds0")
 	ds.MaxOriginConnections = util.IntPtr(42)
 	ds.MidHeaderRewrite = util.StrPtr("midrewrite")
-	ds.CDNName = &cdnName
+	ds.CDNName = util.StrPtr(cdnName)
 	dsType := tc.DSTypeHTTP
 	ds.Type = &dsType
 	ds.ServiceCategory = util.StrPtr("servicecategory")
 
 	mid0 := makeGenericServer()
-	mid0.CDNName = &cdnName
+	mid0.CDNName = util.StrPtr(cdnName)
 	mid0.Cachegroup = util.StrPtr("midCG")
 	mid0.HostName = util.StrPtr("mymid0")
 	mid0Status := string(tc.CacheStatusReported)
 	mid0.Status = &mid0Status
 
 	mid1 := makeGenericServer()
-	mid1.CDNName = &cdnName
+	mid1.CDNName = util.StrPtr(cdnName)
 	mid1.Cachegroup = util.StrPtr("midCG")
 	mid1.HostName = util.StrPtr("mymid1")
 	mid1Status := string(tc.CacheStatusOnline)
 	mid1.Status = &mid1Status
 
 	mid2 := makeGenericServer()
-	mid2.CDNName = &cdnName
+	mid2.CDNName = util.StrPtr(cdnName)
 	mid2.Cachegroup = util.StrPtr("midCG")
 	mid2.HostName = util.StrPtr("mymid2")
 	mid2Status := string(tc.CacheStatusOffline)
@@ -85,7 +93,7 @@ func TestMakeHeaderRewriteMidDotConfig(t *testing.T) {
 	mCG.Type = &mCGType
 
 	cgs := []tc.CacheGroupNullable{*eCG, *mCG}
-	servers := []Server{*server, *mid0, *mid1, *mid2}
+	servers := []Server{*serverSvs, *mid0, *mid1, *mid2}
 	dses := []DeliveryService{*ds}
 	dss := makeDSS(servers, dses)
 


### PR DESCRIPTION
This causes the config gen to think CDNs are different when they aren't, causing it to think no servers on the same CDN are assigned, omitting a max_origin_connections entry.

Includes modifying the tests to have different pointers, so the tests will fail without this fix.
Includes changelog.
No docs, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Generate config on a Mid with MaxOriginConnetions on a DS, verify max_origin_connections is inserted in header rewrite file.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.0
- 5.1

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information