### PR TITLE
update service category header rewrite logic

### DIFF
--- a/lib/go-atscfg/headerrewritedotconfig.go
+++ b/lib/go-atscfg/headerrewritedotconfig.go
@@ -35,7 +35,7 @@ const HeaderRewritePrefix = "hdr_rw_"
 const ContentTypeHeaderRewriteDotConfig = ContentTypeTextASCII
 const LineCommentHeaderRewriteDotConfig = LineCommentHash
 
-const ServiceCategoryHeader = "X-CDN-SVC"
+const ServiceCategoryHeader = "CDN-SVC"
 
 const MaxOriginConnectionsNoMax = 0 // 0 indicates no limit on origin connections
 

--- a/lib/go-atscfg/headerrewritedotconfig.go
+++ b/lib/go-atscfg/headerrewritedotconfig.go
@@ -35,7 +35,7 @@ const HeaderRewritePrefix = "hdr_rw_"
 const ContentTypeHeaderRewriteDotConfig = ContentTypeTextASCII
 const LineCommentHeaderRewriteDotConfig = LineCommentHash
 
-const ServiceCategoryHeader = "CDN-SVC"
+const ServiceCategoryHeader = "X-CDN-SVC"
 
 const MaxOriginConnectionsNoMax = 0 // 0 indicates no limit on origin connections
 
@@ -147,7 +147,12 @@ func MakeHeaderRewriteDotConfig(
 	}
 
 	if !strings.Contains(text, ServiceCategoryHeader) && ds.ServiceCategory != "" {
-		text += fmt.Sprintf("\nset-header %s \"%s|%s\"", ServiceCategoryHeader, dsName, ds.ServiceCategory)
+		scHeaderVal := fmt.Sprintf("\nset-header %s \"%s|%s\" %s", ServiceCategoryHeader, dsName, ds.ServiceCategory, "[L]")
+		if strings.Contains(text, "[L]") {
+			text = strings.Replace(text, "[L]", scHeaderVal, 1)
+		} else {
+			text += scHeaderVal
+		}
 	}
 
 	text += "\n"


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- This PR correctly sets the ATS header when a service category is assigned to a delivery service
- Tests are not necessary for this pr because there are already tests in headerrewritedotconfig_test.go checking that this header gets added to the string

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT
- Documentation is not required because it fixes a bug with the existing implementation. Documentation is already in place for the functionality of the feature.

## What is the best way to verify this PR?
- Check the traffic server hdr_wr config file contains the correct headers/rewrite string

## If this is a bug fix, what versions of Traffic Control are affected?
- master 
- 5.x.x

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
