### PR TITLE
TR: Fix NullPointerException when given SNI hostname is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5382](https://github.com/apache/trafficcontrol/issues/5382) - Fixed API documentation and TP helptext for "Max DNS Answers" field with respect to DNS, HTTP, Steering Delivery Service
 - [#5396](https://github.com/apache/trafficcontrol/issues/5396) - Return the correct error type if user tries to update the root tenant
 - [#5378](https://github.com/apache/trafficcontrol/issues/5378) - Updating a non existent DS should return a 404, instead of a 500
+- Fixed a NullPointerException in TR when a client passes a null SNI hostname in a TLS request
 - Fixed a potential Traffic Router race condition that could cause erroneous 503s for CLIENT_STEERING delivery services when loading new steering changes
 - Fixed a logging bug in Traffic Monitor where it wouldn't log errors in certain cases where a backup file could be used instead. Also, Traffic Monitor now rejects monitoring snapshots that have no delivery services.
 - [#5195](https://github.com/apache/trafficcontrol/issues/5195) - Correctly show CDN ID in Changelog during Snap

--- a/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
+++ b/traffic_router/connector/src/main/java/com/comcast/cdn/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
@@ -124,7 +124,7 @@ public class RouterNioEndpoint extends NioEndpoint {
 
 	@Override
 	protected SSLHostConfig getSSLHostConfig(final String sniHostName){
-		return super.getSSLHostConfig(sniHostName.toLowerCase());
+		return super.getSSLHostConfig(sniHostName == null ? null : sniHostName.toLowerCase());
 	}
 
 	@Override


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Fixes the following NPE found in the Tomcat logs:
```
18-Feb-2021 01:05:43.142 SEVERE [https-openssl-nio-443-exec-9] org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun
        java.lang.NullPointerException
                at com.comcast.cdn.traffic_control.traffic_router.protocol.RouterNioEndpoint.getSSLHostConfig(RouterNioEndpoint.java:127)
                at org.apache.tomcat.util.net.AbstractJsseEndpoint.createSSLEngine(AbstractJsseEndpoint.java:110)
                at org.apache.tomcat.util.net.SecureNioChannel.processSNI(SecureNioChannel.java:333)
                at org.apache.tomcat.util.net.SecureNioChannel.handshake(SecureNioChannel.java:179)
                at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1606)
                at com.comcast.cdn.traffic_control.traffic_router.protocol.RouterNioEndpoint$RouterSocketProcessor.doRun(RouterNioEndpoint.java:156)
                at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
                at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
                at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
                at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
                at java.lang.Thread.run(Thread.java:748)
```
I believe this is mostly just log pollution, because if a given SNI hostname doesn't match a valid delivery service certificate (or is null), TR will return the default certificate. This should cause TR to return a default certificate instead of whatever Tomcat does when it encounters a `NullPointerException`. I'm not exactly sure what it does from a client perspective when encountering a `NullPointerException`, but not including an SNI in the ssl connection doesn't seem like a valid request anyways.


## Which Traffic Control components are affected by this PR?
- Traffic Router

## What is the best way to verify this PR?
Make an https request to an https-enabled delivery service URL, ensure that TR still accepts and handles the request.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.1.x
- 5.0.x
- 4.1.x

## The following criteria are ALL met by this PR

- [x] Adding a new test suite for this seems like overkill
- [x] Bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
