### PR TITLE
TR: fix server.xml protocols list to use '+' instead of ','

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Pinned external actions used by Documentation Build and TR Unit Tests workflows to commit SHA-1 and the Docker image used by the Weasel workflow to a SHA-256 digest
 - Updated Flot libraries to supported versions
 - [apache/trafficcontrol](https://github.com/apache/trafficcontrol) is now a Go module
-- Set Traffic Router to only accept TLSv1.1 and TLSv1.2 protocols in server.xml
+- Set Traffic Router to only accept TLSv1.1, TLSv1.2, and TLSv1.3 protocols by default in server.xml
 - Updated Apache Tomcat from 8.5.57 to 9.0.43
 - Updated Apache Tomcat Native from 1.2.16 to 1.2.23
 

--- a/traffic_router/core/src/main/conf/server.xml
+++ b/traffic_router/core/src/main/conf/server.xml
@@ -40,11 +40,11 @@
 		<Connector port="3333" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
 				   connectionTimeout="10000" mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="ApiPort"/>
 		<Connector port="3443" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
-				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" protocols="TLSv1.1,TLSv1.2" connectionTimeout="10000"
+				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" protocols="+TLSv1.1+TLSv1.2+TLSv1.3" connectionTimeout="10000"
 				   mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="SecureApiPort" sendReasonPhrase="true"
 				   sslImplementationName="com.comcast.cdn.traffic_control.traffic_router.protocol.RouterSslImplementation"> </Connector>
 		<Connector port="443" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
-				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" protocols="TLSv1.1,TLSv1.2" connectionTimeout="10000"
+				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" protocols="+TLSv1.1+TLSv1.2+TLSv1.3" connectionTimeout="10000"
 				   mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="SecurePort" sendReasonPhrase="true"
 				   sslImplementationName="com.comcast.cdn.traffic_control.traffic_router.protocol.RouterSslImplementation">
 		</Connector>

--- a/traffic_router/core/src/main/conf/server.xml
+++ b/traffic_router/core/src/main/conf/server.xml
@@ -40,11 +40,11 @@
 		<Connector port="3333" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
 				   connectionTimeout="10000" mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="ApiPort"/>
 		<Connector port="3443" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
-				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" protocols="+TLSv1.1+TLSv1.2+TLSv1.3" connectionTimeout="10000"
+				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" protocols="+TLSv1.1,+TLSv1.2,+TLSv1.3" connectionTimeout="10000"
 				   mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="SecureApiPort" sendReasonPhrase="true"
 				   sslImplementationName="com.comcast.cdn.traffic_control.traffic_router.protocol.RouterSslImplementation"> </Connector>
 		<Connector port="443" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
-				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" protocols="+TLSv1.1+TLSv1.2+TLSv1.3" connectionTimeout="10000"
+				   scheme="https" secure="true" SSLEnabled="true" clientAuth="false" sslProtocol="TLS" protocols="+TLSv1.1,+TLSv1.2,+TLSv1.3" connectionTimeout="10000"
 				   mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="SecurePort" sendReasonPhrase="true"
 				   sslImplementationName="com.comcast.cdn.traffic_control.traffic_router.protocol.RouterSslImplementation">
 		</Connector>


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Follow-up to https://github.com/apache/trafficcontrol/pull/5547: TR seems to support commas but prints the following warning when using them:
```
  The protocol [TLSv1.2] was added to the list of protocols on the
  SSLHostConfig named [example.org]. Check if a +/- prefix is missing.
```
Also, TR ignores TLSv1.3 being in the list if the backend doesn't support it, so it is safe to include by default. On systems that don't support it, the following warning is printed in the tomcat logs:
```
org.apache.tomcat.util.net.SSLUtilBase.getEnabled Some of the specified [protocols] are not supported by the SSL engine and have been skipped: [[TLSv1.3]]
```

For reference: https://tomcat.apache.org/tomcat-8.5-doc/config/http.html#SSL_Support_-_SSLHostConfig

## Which Traffic Control components are affected by this PR?
- Traffic Router

## What is the best way to verify this PR?
```
docker run --rm -it drwetter/testssl.sh:latest -p <some_traffic_router>
```
Sample output:
```
  Testing protocols via sockets except NPN+ALPN

 SSLv2      not offered (OK)
 SSLv3      not offered (OK)
 TLS 1      not offered
 TLS 1.1    offered (deprecated)
 TLS 1.2    offered (OK)
 TLS 1.3    not offered and downgraded to a weaker protocol
 NPN/SPDY   not offered
 ALPN/HTTP2 not offered
```

## The following criteria are ALL met by this PR

- [x] default config change, tests unnecessary
- [x] default config change, docs unnecessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
