### PR TITLE
Add TO client v4 fallback

### DIFF
--- a/infrastructure/cdn-in-a-box/enroller/Dockerfile
+++ b/infrastructure/cdn-in-a-box/enroller/Dockerfile
@@ -36,6 +36,7 @@ ENV GOPATH=/go
 COPY ./lib/ /go/src/github.com/apache/trafficcontrol/lib/
 COPY ./go.mod ./go.sum /go/src/github.com/apache/trafficcontrol/
 COPY ./vendor/ /go/src/github.com/apache/trafficcontrol/vendor/
+COPY ./traffic_ops/toclientlib/ /go/src/github.com/apache/trafficcontrol/traffic_ops/toclientlib/
 COPY ./traffic_ops/v4-client/ /go/src/github.com/apache/trafficcontrol/traffic_ops/v4-client/
 COPY ./infrastructure/cdn-in-a-box/ /go/src/github.com/apache/trafficcontrol/infrastructure/cdn-in-a-box/
 

--- a/infrastructure/cdn-in-a-box/traffic_ops_integration_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops_integration_test/Dockerfile
@@ -44,6 +44,7 @@ COPY ./vendor/ /go/src/github.com/apache/trafficcontrol/vendor/
 # integration source and dependencies
 COPY ./infrastructure/cdn-in-a-box/ /go/src/github.com/apache/trafficcontrol/infrastructure/cdn-in-a-box/
 COPY ./lib/ /go/src/github.com/apache/trafficcontrol/lib/
+COPY ./traffic_ops/toclientlib/ /go/src/github.com/apache/trafficcontrol/traffic_ops/toclientlib/
 COPY ./traffic_ops/v1-client/ /go/src/github.com/apache/trafficcontrol/traffic_ops/v1-client/
 COPY ./traffic_ops/v2-client/ /go/src/github.com/apache/trafficcontrol/traffic_ops/v2-client/
 COPY ./traffic_ops/v3-client/ /go/src/github.com/apache/trafficcontrol/traffic_ops/v3-client/

--- a/traffic_ops/toclientlib/endpoints.go
+++ b/traffic_ops/toclientlib/endpoints.go
@@ -1,0 +1,39 @@
+package toclientlib
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+const apiBaseStr = "/api/"
+
+// APIBase returns the base API string for HTTP requests, such as /api/3.1.
+func (sn *TOClient) APIBase() string {
+	return apiBaseStr + sn.APIVersion()
+}
+
+// APIVersion is the version of the Traffic Ops API this client will use for requests.
+// If the client was created with any function except Login, or with UseLatestSupportedAPI false,
+// this will be LatestAPIVersion().
+// Otherwise, it will be the version dynamically determined to be the latest the Traffic Ops Server supports.
+func (sn *TOClient) APIVersion() string {
+	if sn.latestSupportedAPI != "" {
+		return sn.latestSupportedAPI
+	}
+	return sn.LatestAPIVersion()
+}
+
+// LatestAPIVersion returns the latest Traffic Ops API version this client supports.
+func (sn *TOClient) LatestAPIVersion() string {
+	return sn.apiVersions[0]
+}

--- a/traffic_ops/toclientlib/toclientlib.go
+++ b/traffic_ops/toclientlib/toclientlib.go
@@ -1,0 +1,735 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package toclientlib provides shared symbols for Traffic Ops Go clients.
+package toclientlib
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptrace"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// Login authenticates with Traffic Ops and returns the client object.
+//
+// Returns the logged in client, the remote address of Traffic Ops which was translated and used to log in, and any error. If the error is not nil, the remote address may or may not be nil, depending whether the error occurred before the login request.
+//
+// apiVersions is the list of API versions to be supported. This should generally be provided by the specific client version wrapping this library.
+//
+// See ClientOpts for details about options, which options are required, and how they behave.
+//
+func Login(url, user, pass string, opts ClientOpts, apiVersions []string) (*TOClient, ReqInf, error) {
+	if strings.TrimSpace(opts.UserAgent) == "" {
+		return nil, ReqInf{}, errors.New("opts.UserAgent is required")
+	}
+	if opts.RequestTimeout == 0 {
+		opts.RequestTimeout = DefaultTimeout
+	}
+	if opts.APIVersionCheckInterval == 0 {
+		opts.APIVersionCheckInterval = DefaultAPIVersionCheckInterval
+	}
+
+	jar, err := cookiejar.New(&cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	})
+	if err != nil {
+		return nil, ReqInf{}, errors.New("creating cookie jar: " + err.Error())
+	}
+
+	to := NewClient(user, pass, url, opts.UserAgent, &http.Client{
+		Timeout: opts.RequestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: opts.Insecure},
+		},
+		Jar: jar,
+	}, apiVersions)
+
+	if !opts.ForceLatestAPI {
+		to.latestSupportedAPI = apiVersions[0]
+	}
+
+	to.forceLatestAPI = opts.ForceLatestAPI
+	to.apiVerCheckInterval = opts.APIVersionCheckInterval
+
+	remoteAddr, err := to.login()
+	if err != nil {
+		return nil, ReqInf{RemoteAddr: remoteAddr}, errors.New("logging in: " + err.Error())
+	}
+	return to, ReqInf{RemoteAddr: remoteAddr}, nil
+}
+
+// ClientOpts is the options to configure the creation of the Client.
+//
+// This exists to allow adding new features without a breaking change to the Login function.
+// Users should understand this, and understand that upgrading their library may result in new options that their application doesn't know to use.
+// New fields should always behave as-before if their value is the default.
+type ClientOpts struct {
+	// ForceLatestAPI will cause Login to return an error if the latest minor API in the client
+	// is not supported by the Traffic Ops Server.
+	//
+	// Note this was the behavior of all Traffic Ops client functions prior to the Login function.
+	//
+	// If this is false or unset, login will determine the latest minor version supported, and use that for all requests.
+	//
+	// Be aware, this means client fields unknown to the server will always be default-initialized.
+	// For example, suppose the field Foo was added in API 3.1, the client code is 3.1, and the server is 3.0.
+	// Then, the field Foo will always be nil or the default value.
+	// Client applications must understand this, and code processing the new feature Foo must be able to
+	// process default or nil values, understanding they may indicate a server version before the feature was added.
+	//
+	ForceLatestAPI bool
+
+	// Insecure is whether to ignore HTTPS certificate errors with Traffic Ops.
+	// Setting this on production systems is strongly discouraged.
+	Insecure bool
+
+	// RequestTimeout is the HTTP timeout for Traffic Ops requests.
+	// If 0 or not explicitly set, DefaultTimeout will be used.
+	RequestTimeout time.Duration
+
+	// UserAgent is the HTTP User Agent to use set when communicating with Traffic Ops.
+	// This field is required, and Login will fail if it is unset or the empty string.
+	UserAgent string
+
+	// APIVersionCheckInterval is how often to try a newer Traffic Ops API Version.
+	// This allows clients to get new Traffic Ops features after Traffic Ops is upgraded
+	// without requiring a restart or new client.
+	//
+	// If 0 or not explicitly set, DefaultAPIVersionCheckInterval will be used.
+	// To disable, set to a very high value (like 100 years).
+	//
+	// This has no effect if ForceLatestAPI is true.
+	APIVersionCheckInterval time.Duration
+}
+
+// Client is a Traffic Ops client, with generic functions to be used by any specific client.
+type TOClient struct {
+	UserName     string
+	Password     string
+	URL          string
+	Client       *http.Client
+	UserAgentStr string
+
+	latestSupportedAPI string
+	// forceLatestAPI is whether to forcibly always use the latest API version known to this client.
+	// This should only ever be set by ClientOpts.ForceLatestAPI.
+	forceLatestAPI bool
+	// lastAPIVerCheck is the last time the Client tried to get a newer API version from TO.
+	// Used internally to decide whether to try again.
+	lastAPIVerCheck time.Time
+	// apiVerCheckInterval is how often to try a newer Traffic Ops API, in case Traffic Ops was upgraded.
+	// This should only ever be set by ClientOpts.APIVersionCheckInterval.
+	apiVerCheckInterval time.Duration
+
+	// apiVersions is the list of support Traffic Ops versions.
+	// This must be provided on construction, typically by the client wrapping this lib.
+	apiVersions []string
+}
+
+func NewClient(user, password, url, userAgent string, client *http.Client, apiVersions []string) *TOClient {
+	return &TOClient{
+		UserName:     user,
+		Password:     password,
+		URL:          url,
+		Client:       client,
+		UserAgentStr: userAgent,
+		apiVersions:  apiVersions,
+	}
+}
+
+const DefaultTimeout = time.Second * 30
+const DefaultAPIVersionCheckInterval = time.Second * 60
+
+// HTTPError is returned on Update Client failure.
+type HTTPError struct {
+	HTTPStatusCode int
+	HTTPStatus     string
+	URL            string
+	Body           string
+}
+
+// Error implements the error interface for our customer error type.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("%s[%d] - Error requesting Traffic Ops %s %s", e.HTTPStatus, e.HTTPStatusCode, e.URL, e.Body)
+}
+
+// loginCreds gathers login credentials for Traffic Ops.
+func loginCreds(toUser string, toPasswd string) ([]byte, error) {
+	credentials := tc.UserCredentials{
+		Username: toUser,
+		Password: toPasswd,
+	}
+
+	js, err := json.Marshal(credentials)
+	if err != nil {
+		err := fmt.Errorf("Error creating login json: %v", err)
+		return nil, err
+	}
+	return js, nil
+}
+
+// loginToken gathers token login credentials for Traffic Ops.
+func loginToken(token string) ([]byte, error) {
+	form := tc.UserToken{
+		Token: token,
+	}
+
+	j, e := json.Marshal(form)
+	if e != nil {
+		e := fmt.Errorf("Error creating token login json: %v", e)
+		return nil, e
+	}
+	return j, nil
+}
+
+// login tries to log in to Traffic Ops, and set the auth cookie in the Client. Returns the IP address of the remote Traffic Ops.
+func (to *TOClient) login() (net.Addr, error) {
+	path := "/user/login"
+	body := tc.UserCredentials{Username: to.UserName, Password: to.Password}
+	alerts := tc.Alerts{}
+
+	// Can't use req() because it retries login failures, which would be an infinite loop.
+	reqF := composeReqFuncs(makeRequestWithHeader, []MidReqF{reqTryLatest, reqFallback, reqAPI})
+
+	reqInf, err := reqF(to, http.MethodPost, path, body, nil, &alerts)
+	if err != nil {
+		return reqInf.RemoteAddr, fmt.Errorf("Login error %v, alerts string: %+v", err, alerts)
+	}
+
+	success := false
+	for _, alert := range alerts.Alerts {
+		if alert.Level == "success" && alert.Text == "Successfully logged in." {
+			success = true
+			break
+		}
+	}
+
+	if !success {
+		return reqInf.RemoteAddr, fmt.Errorf("Login failed, alerts string: %+v", alerts)
+	}
+
+	return reqInf.RemoteAddr, nil
+}
+
+func (to *TOClient) loginWithToken(token []byte) (net.Addr, error) {
+	path := to.APIBase() + "/user/login/token"
+	resp, remoteAddr, err := to.RawRequestWithHdr(http.MethodPost, path, token, nil)
+	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
+	if err != nil {
+		return remoteAddr, fmt.Errorf("requesting: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var alerts tc.Alerts
+	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+		return remoteAddr, fmt.Errorf("decoding response JSON: %v", err)
+	}
+
+	for _, alert := range alerts.Alerts {
+		if alert.Level == tc.SuccessLevel.String() && alert.Text == "Successfully logged in." {
+			return remoteAddr, nil
+		}
+	}
+
+	return remoteAddr, fmt.Errorf("Login failed, alerts string: %+v", alerts)
+}
+
+// logout of Traffic Ops
+func (to *TOClient) logout() (net.Addr, error) {
+	credentials, err := loginCreds(to.UserName, to.Password)
+	if err != nil {
+		return nil, errors.New("creating login credentials: " + err.Error())
+	}
+
+	path := to.APIBase() + "/user/logout"
+	resp, remoteAddr, err := to.RawRequestWithHdr("POST", path, credentials, nil)
+	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
+	if err != nil {
+		return remoteAddr, errors.New("requesting: " + err.Error())
+	}
+	defer resp.Body.Close()
+
+	var alerts tc.Alerts
+	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
+		return remoteAddr, errors.New("decoding response JSON: " + err.Error())
+	}
+
+	success := false
+	for _, alert := range alerts.Alerts {
+		if alert.Level == "success" && alert.Text == "Successfully logged in." {
+			success = true
+			break
+		}
+	}
+
+	if !success {
+		return remoteAddr, fmt.Errorf("Logout failed, alerts string: %+v", alerts)
+	}
+
+	return remoteAddr, nil
+}
+
+// Login to traffic_ops, the response should set the cookie for this client
+// automatically. Start with
+//     to := traffic_ops.Login("user", "passwd", true)
+// subsequent calls like to.GetData("datadeliveryservice") will be authenticated.
+// Returns the logged in client, the remote address of Traffic Ops which was translated and used to log in, and any error. If the error is not nil, the remote address may or may not be nil, depending whether the error occurred before the login request.
+//
+// The apiVersions is the list of API versions supported in this client. This should generally be provided by the client package wrapping this package.
+func LoginWithAgent(
+	toURL string,
+	toUser string,
+	toPasswd string,
+	insecure bool,
+	userAgent string,
+	requestTimeout time.Duration,
+	apiVersions []string,
+) (*TOClient, net.Addr, error) {
+	options := cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	}
+
+	jar, err := cookiejar.New(&options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	to := NewClient(toUser, toPasswd, toURL, userAgent, &http.Client{
+		Timeout: requestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		},
+		Jar: jar,
+	}, apiVersions)
+
+	remoteAddr, err := to.login()
+	if err != nil {
+		return nil, remoteAddr, errors.New("logging in: " + err.Error())
+	}
+	return to, remoteAddr, nil
+}
+
+// The apiVersions is the list of API versions supported in this client. This should generally be provided by the client package wrapping this package.
+func LoginWithToken(
+	toURL string,
+	token string,
+	insecure bool,
+	userAgent string,
+	requestTimeout time.Duration,
+	apiVersions []string,
+) (*TOClient, net.Addr, error) {
+	options := cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	}
+
+	jar, err := cookiejar.New(&options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client := http.Client{
+		Timeout: requestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		},
+		Jar: jar,
+	}
+
+	to := NewClient("", "", toURL, userAgent, &client, apiVersions)
+	tBts, err := loginToken(token)
+	if err != nil {
+		return nil, nil, fmt.Errorf("logging in: %v", err)
+	}
+
+	remoteAddr, err := to.loginWithToken(tBts)
+	if err != nil {
+		return nil, remoteAddr, fmt.Errorf("logging in: %v", err)
+	}
+	return to, remoteAddr, nil
+}
+
+// Logout of Traffic Ops.
+//
+// The apiVersions is the list of API versions supported in this client. This should generally be provided by the client package wrapping this package.
+//
+func LogoutWithAgent(
+	toURL string,
+	toUser string,
+	toPasswd string,
+	insecure bool,
+	userAgent string,
+	requestTimeout time.Duration,
+	apiVersions []string,
+) (*TOClient, net.Addr, error) {
+	options := cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	}
+
+	jar, err := cookiejar.New(&options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	to := NewClient(toUser, toPasswd, toURL, userAgent, &http.Client{
+		Timeout: requestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		},
+		Jar: jar,
+	}, apiVersions)
+
+	remoteAddr, err := to.logout()
+	if err != nil {
+		return nil, remoteAddr, errors.New("logging out: " + err.Error())
+	}
+	return to, remoteAddr, nil
+}
+
+// NewNoAuthClient returns a new Client without logging in
+// this can be used for querying unauthenticated endpoints without requiring a login
+// The apiVersions is the list of API versions supported in this client. This should generally be provided by the client package wrapping this package.
+func NewNoAuthClient(
+	toURL string,
+	insecure bool,
+	userAgent string,
+	requestTimeout time.Duration,
+	apiVersions []string,
+) *TOClient {
+	return NewClient("", "", toURL, userAgent, &http.Client{
+		Timeout: requestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		},
+	}, apiVersions)
+}
+
+func ErrIsNotImplemented(err error) bool {
+	return err != nil && strings.Contains(err.Error(), ErrNotImplemented.Error()) // use string.Contains in case context was added to the error
+}
+
+// ErrNotImplemented is returned when Traffic Ops returns a 501 Not Implemented
+// Users should check ErrIsNotImplemented rather than comparing directly, in case context was added.
+var ErrNotImplemented = errors.New("Traffic Ops Server returned 'Not Implemented', this client is probably newer than Traffic Ops, and you probably need to either upgrade Traffic Ops, or use a client whose version matches your Traffic Ops version.")
+
+// errUnlessOKOrNotModified returns the response, the remote address, and an error if the given Response's status code is anything
+// but 200 OK/ 304 Not Modified. This includes reading the Response.Body and Closing it. Otherwise, the given response, the remote
+// address, and a nil error are returned.
+func (to *TOClient) errUnlessOKOrNotModified(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
+	if err != nil {
+		return resp, remoteAddr, err
+	}
+	if resp.StatusCode < 300 || resp.StatusCode == 304 {
+		return resp, remoteAddr, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotImplemented {
+		return resp, remoteAddr, ErrNotImplemented
+	}
+
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		return resp, remoteAddr, readErr
+	}
+	return resp, remoteAddr, errors.New(resp.Status + "[" + strconv.Itoa(resp.StatusCode) + "] - Error requesting Traffic Ops " + to.getURL(path) + " " + string(body))
+}
+
+func (to *TOClient) getURL(path string) string { return to.URL + path }
+
+type ReqF func(to *TOClient, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error)
+
+type MidReqF func(ReqF) ReqF
+
+// composeReqFuncs takes an initial request func and middleware, and
+// returns a single ReqFunc to be called,
+func composeReqFuncs(reqF ReqF, middleware []MidReqF) ReqF {
+	// compose in reverse-order, which causes them to be applied in forward-order.
+	for i := len(middleware) - 1; i >= 0; i-- {
+		reqF = middleware[i](reqF)
+	}
+	return reqF
+}
+
+// reqTryLatest will re-set to.latestSupportedAPI to the latest, if it's less than the latest and to.apiVerCheckInterval has passed.
+// This does not fallback, so it should generally be composed with reqFallback.
+func reqTryLatest(reqF ReqF) ReqF {
+	return func(to *TOClient, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+		if to.apiVerCheckInterval == 0 {
+			// Client could have been default-initialized rather than created with a func, so we need to check here, not just in login funcs.
+			to.apiVerCheckInterval = DefaultAPIVersionCheckInterval
+		}
+
+		if !to.forceLatestAPI && time.Since(to.lastAPIVerCheck) >= to.apiVerCheckInterval {
+			// if it's been apiVerCheckInterval since the last version check,
+			// set the version to the latest (and fall back again, if necessary)
+			to.latestSupportedAPI = to.apiVersions[0]
+
+			// Set the last version check to far in the future, and then
+			// defer setting the last check until this function returns,
+			// so that if fallback takes longer than the interval,
+			// the recursive calls to this function don't end up forever retrying the latest.
+			to.lastAPIVerCheck = time.Now().Add(time.Hour * 24 * 365)
+			defer func() { to.lastAPIVerCheck = time.Now() }()
+		}
+		return reqF(to, method, path, body, header, response)
+	}
+}
+
+// reqLogin makes the request, and if it fails, tries to log in again then makes the request again.
+// If the login fails, the original response is returned.
+// If the second request fails, it's returned. Login is only tried once.
+// This is designed to handle expired sessions, when the time between requests is longer than the session expiration;
+// it does not do perpetual retry.
+func reqLogin(reqF ReqF) ReqF {
+	return func(to *TOClient, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+		inf, err := reqF(to, method, path, body, header, response)
+		if inf.StatusCode != http.StatusUnauthorized && inf.StatusCode != http.StatusForbidden {
+			return inf, err
+		}
+		if _, lerr := to.login(); lerr != nil {
+			return inf, err
+		}
+		return reqF(to, method, path, body, header, response)
+	}
+}
+
+// reqFallback calls reqF, and if Traffic Ops doesn't support the latest version,
+// falls back to the previous and retries, recursively.
+// If all supported versions fail, the last response error is returned.
+func reqFallback(reqF ReqF) ReqF {
+	var fallbackFunc func(to *TOClient, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error)
+	fallbackFunc = func(to *TOClient, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+		inf, err := reqF(to, method, path, body, header, response)
+		if err == nil {
+			return inf, err
+		}
+		if !ErrIsNotImplemented(err) ||
+			to.forceLatestAPI {
+			return inf, err
+		}
+
+		apiVersions := to.apiVersions
+
+		nextAPIVerI := int(math.MaxInt32) - 1
+		for verI, ver := range apiVersions {
+			if to.latestSupportedAPI == ver {
+				nextAPIVerI = verI
+				break
+			}
+		}
+		nextAPIVerI = nextAPIVerI + 1
+		if nextAPIVerI >= len(apiVersions) {
+			return inf, err // we're already on the oldest minor supported, and the server doesn't support it.
+		}
+		to.latestSupportedAPI = apiVersions[nextAPIVerI]
+
+		return fallbackFunc(to, method, path, body, header, response)
+	}
+	return fallbackFunc
+}
+
+// reqAPI calls reqF with a path not including the /api/x prefix,
+// and adds the API version from the Client.
+//
+// For example, path should be like '/deliveryservices'
+// and this will request '/api/3.1/deliveryservices'.
+//
+func reqAPI(reqF ReqF) ReqF {
+	return func(to *TOClient, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+		path = to.APIBase() + path
+		return reqF(to, method, path, body, header, response)
+	}
+}
+
+// makeRequestWithHeader marshals the response body (if non-nil), performs the HTTP request,
+// and decodes the response into the given response pointer.
+//
+// Note processing on the following codes:
+// 304 http.StatusNotModified  - Will return the 304 in ReqInf, a nil error, and a nil response.
+//
+// 401 http.StatusUnauthorized - Via to.request(), Same as 403 Forbidden.
+// 403 http.StatusForbidden    - Via to.request()
+//                               Will try to log in again, and try the request again.
+//                               The second request is returned, even if it fails.
+//
+// To request the bytes without deserializing, pass a *[]byte response.
+//
+func makeRequestWithHeader(to *TOClient, method, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+	var remoteAddr net.Addr
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	var reqBody []byte
+	var err error
+	if body != nil {
+		reqBody, err = json.Marshal(body)
+		if err != nil {
+			return reqInf, errors.New("marshalling request body: " + err.Error())
+		}
+	}
+	resp, remoteAddr, err := to.request(method, path, reqBody, header)
+	reqInf.RemoteAddr = remoteAddr
+	if resp != nil {
+		reqInf.StatusCode = resp.StatusCode
+		if reqInf.StatusCode == http.StatusNotModified {
+			return reqInf, nil
+		}
+		defer log.Close(resp.Body, "unable to close response body")
+	}
+	if err != nil {
+		return reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
+	}
+
+	if btsPtr, isBytes := response.(*[]byte); isBytes {
+		bts, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return reqInf, errors.New("reading response body: " + err.Error())
+		}
+		*btsPtr = bts
+		return reqInf, nil
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
+		return reqInf, errors.New("decoding response body: " + err.Error())
+	}
+	return reqInf, nil
+}
+
+func (to *TOClient) Req(method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
+	reqF := composeReqFuncs(makeRequestWithHeader, []MidReqF{reqTryLatest, reqFallback, reqAPI, reqLogin})
+	return reqF(to, method, path, body, header, response)
+}
+
+// request performs the HTTP request to Traffic Ops, trying to refresh the cookie if an Unauthorized or Forbidden code is received. It only tries once. If the login fails, the original Unauthorized/Forbidden response is returned. If the login succeeds and the subsequent re-request fails, the re-request's response is returned even if it's another Unauthorized/Forbidden.
+// Returns the response, the remote address of the Traffic Ops instance used, and any error.
+// The returned net.Addr is guaranteed to be either nil or valid, even if the returned error is not nil. Callers are encouraged to check and use the net.Addr if an error is returned, and use the remote address in their own error messages. This violates the Go idiom that a non-nil error implies all other values are undefined, but it's more straightforward than alternatives like typecasting.
+func (to *TOClient) request(method, path string, body []byte, header http.Header) (*http.Response, net.Addr, error) {
+	r, remoteAddr, err := to.RawRequestWithHdr(method, path, body, header)
+	if err != nil {
+		return r, remoteAddr, err
+	}
+	if r.StatusCode != http.StatusUnauthorized && r.StatusCode != http.StatusForbidden {
+		return to.errUnlessOKOrNotModified(r, remoteAddr, err, path)
+	}
+	if _, lerr := to.login(); lerr != nil {
+		return to.errUnlessOKOrNotModified(r, remoteAddr, err, path) // if re-logging-in fails, return the original request's response
+	}
+
+	// return second request, even if it's another Unauthorized or Forbidden.
+	r, remoteAddr, err = to.RawRequestWithHdr(method, path, body, header)
+	return to.errUnlessOKOrNotModified(r, remoteAddr, err, path)
+}
+
+func (to *TOClient) RawRequestWithHdr(method, path string, body []byte, header http.Header) (*http.Response, net.Addr, error) {
+	url := to.getURL(path)
+
+	var req *http.Request
+	var err error
+	remoteAddr := net.Addr(nil)
+
+	if body != nil {
+		req, err = http.NewRequest(method, url, bytes.NewBuffer(body))
+		if err != nil {
+			return nil, remoteAddr, err
+		}
+		if header != nil {
+			req.Header = header.Clone()
+		}
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+		if err != nil {
+			return nil, remoteAddr, err
+		}
+		if header != nil {
+			req.Header = header.Clone()
+		}
+	}
+
+	trace := &httptrace.ClientTrace{
+		GotConn: func(connInfo httptrace.GotConnInfo) {
+			remoteAddr = connInfo.Conn.RemoteAddr()
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	req.Header.Set("User-Agent", to.UserAgentStr)
+	resp, err := to.Client.Do(req)
+	return resp, remoteAddr, err
+}
+
+// RawRequest performs the actual HTTP request to Traffic Ops, simply, without trying to refresh the cookie if an Unauthorized code is returned.
+// Returns the response, the remote address of the Traffic Ops instance used, and any error.
+// The returned net.Addr is guaranteed to be either nil or valid, even if the returned error is not nil. Callers are encouraged to check and use the net.Addr if an error is returned, and use the remote address in their own error messages. This violates the Go idiom that a non-nil error implies all other values are undefined, but it's more straightforward than alternatives like typecasting.
+// Deprecated: RawRequest will be removed in 6.0. Use RawRequestWithHdr.
+func (to *TOClient) RawRequest(method, path string, body []byte) (*http.Response, net.Addr, error) {
+	return to.RawRequestWithHdr(method, path, body, nil)
+}
+
+type ReqInf struct {
+	// CacheHitStatus is deprecated and will be removed in the next major version.
+	CacheHitStatus CacheHitStatus
+	RemoteAddr     net.Addr
+	StatusCode     int
+}
+
+// CacheHitStatus is deprecated and will be removed in the next major version.
+type CacheHitStatus string
+
+// CacheHitStatusHit is deprecated and will be removed in the next major version.
+const CacheHitStatusHit = CacheHitStatus("hit")
+
+// CacheHitStatusExpired is deprecated and will be removed in the next major version.
+const CacheHitStatusExpired = CacheHitStatus("expired")
+
+// CacheHitStatusMiss is deprecated and will be removed in the next major version.
+const CacheHitStatusMiss = CacheHitStatus("miss")
+
+// CacheHitStatusInvalid is deprecated and will be removed in the next major version.
+const CacheHitStatusInvalid = CacheHitStatus("")
+
+// String is deprecated and will be removed in the next major version.
+func (s CacheHitStatus) String() string {
+	return string(s)
+}
+
+// StringToCacheHitStatus is deprecated and will be removed in the next major version.
+func StringToCacheHitStatus(s string) CacheHitStatus {
+	s = strings.ToLower(s)
+	switch s {
+	case "hit":
+		return CacheHitStatusHit
+	case "expired":
+		return CacheHitStatusExpired
+	case "miss":
+		return CacheHitStatusMiss
+	default:
+		return CacheHitStatusInvalid
+	}
+}

--- a/traffic_ops/v3-client/about.go
+++ b/traffic_ops/v3-client/about.go
@@ -20,6 +20,10 @@ package client
    limitations under the License.
 */
 
+import (
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+)
+
 const (
 	// API_ABOUT is Deprecated: will be removed in the next major version. Be aware this may not be the URI being requested, for clients created with Login and ClientOps.ForceLatestAPI false.
 	API_ABOUT = apiBase + "/about"
@@ -28,7 +32,7 @@ const (
 )
 
 // GetAbout gets data about the TO instance.
-func (to *Session) GetAbout() (map[string]string, ReqInf, error) {
+func (to *Session) GetAbout() (map[string]string, toclientlib.ReqInf, error) {
 	var data map[string]string
 	reqInf, err := to.get(APIAbout, nil, &data)
 	return data, reqInf, err

--- a/traffic_ops/v3-client/api_capability.go
+++ b/traffic_ops/v3-client/api_capability.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 /*
@@ -24,11 +25,11 @@ import (
 // GetAPICapabilities will retrieve API Capabilities. In the event that no capability parameter
 // is supplied, it will return all existing. If a capability is supplied, it will return only
 // those with an exact match. Order may be specified to change the default sort order.
-func (to *Session) GetAPICapabilities(capability string, order string) (tc.APICapabilityResponse, ReqInf, error) {
+func (to *Session) GetAPICapabilities(capability string, order string) (tc.APICapabilityResponse, toclientlib.ReqInf, error) {
 	var (
 		vals   = url.Values{}
 		path   = "/api_capabilities"
-		reqInf = ReqInf{CacheHitStatus: CacheHitStatusMiss}
+		reqInf = toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}
 		resp   tc.APICapabilityResponse
 	)
 

--- a/traffic_ops/v3-client/asn.go
+++ b/traffic_ops/v3-client/asn.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,14 +32,14 @@ const (
 )
 
 // CreateASN creates a ASN
-func (to *Session) CreateASN(entity tc.ASN) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateASN(entity tc.ASN) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIASNs, entity, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // UpdateASNByID updates a ASN by ID
-func (to *Session) UpdateASNByID(id int, entity tc.ASN) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateASNByID(id int, entity tc.ASN) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIASNs, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, entity, nil, &alerts)
@@ -46,7 +47,7 @@ func (to *Session) UpdateASNByID(id int, entity tc.ASN) (tc.Alerts, ReqInf, erro
 }
 
 // GetASNsWithHeader Returns a list of ASNs matching query params
-func (to *Session) GetASNsWithHeader(params *url.Values, header http.Header) ([]tc.ASN, ReqInf, error) {
+func (to *Session) GetASNsWithHeader(params *url.Values, header http.Header) ([]tc.ASN, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?%s", APIASNs, params.Encode())
 	var data tc.ASNsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -54,7 +55,7 @@ func (to *Session) GetASNsWithHeader(params *url.Values, header http.Header) ([]
 }
 
 // DeleteASNByASN deletes an ASN by asn number
-func (to *Session) DeleteASNByASN(asn int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteASNByASN(asn int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIASNs, asn)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/cachegroup.go
+++ b/traffic_ops/v3-client/cachegroup.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -33,14 +34,14 @@ const (
 )
 
 // Create a CacheGroup.
-func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, ReqInf, error) {
+func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, toclientlib.ReqInf, error) {
 	if cachegroup.TypeID == nil && cachegroup.Type != nil {
 		ty, _, err := to.GetTypeByNameWithHdr(*cachegroup.Type, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if len(ty) == 0 {
-			return nil, ReqInf{}, errors.New("no type named " + *cachegroup.Type)
+			return nil, toclientlib.ReqInf{}, errors.New("no type named " + *cachegroup.Type)
 		}
 		cachegroup.TypeID = &ty[0].ID
 	}
@@ -48,10 +49,10 @@ func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*
 	if cachegroup.ParentCachegroupID == nil && cachegroup.ParentName != nil {
 		p, _, err := to.GetCacheGroupNullableByNameWithHdr(*cachegroup.ParentName, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if len(p) == 0 {
-			return nil, ReqInf{}, errors.New("no cachegroup named " + *cachegroup.ParentName)
+			return nil, toclientlib.ReqInf{}, errors.New("no cachegroup named " + *cachegroup.ParentName)
 		}
 		cachegroup.ParentCachegroupID = p[0].ID
 	}
@@ -59,10 +60,10 @@ func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*
 	if cachegroup.SecondaryParentCachegroupID == nil && cachegroup.SecondaryParentName != nil {
 		p, _, err := to.GetCacheGroupNullableByNameWithHdr(*cachegroup.SecondaryParentName, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if len(p) == 0 {
-			return nil, ReqInf{}, errors.New("no cachegroup named " + *cachegroup.ParentName)
+			return nil, toclientlib.ReqInf{}, errors.New("no cachegroup named " + *cachegroup.ParentName)
 		}
 		cachegroup.SecondaryParentCachegroupID = p[0].ID
 	}
@@ -72,7 +73,7 @@ func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*
 	return &cachegroupResp, reqInf, err
 }
 
-func (to *Session) UpdateCacheGroupNullableByIDWithHdr(id int, cachegroup tc.CacheGroupNullable, h http.Header) (*tc.CacheGroupDetailResponse, ReqInf, error) {
+func (to *Session) UpdateCacheGroupNullableByIDWithHdr(id int, cachegroup tc.CacheGroupNullable, h http.Header) (*tc.CacheGroupDetailResponse, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APICachegroups, id)
 	var cachegroupResp tc.CacheGroupDetailResponse
 	reqInf, err := to.put(route, cachegroup, h, &cachegroupResp)
@@ -81,11 +82,11 @@ func (to *Session) UpdateCacheGroupNullableByIDWithHdr(id int, cachegroup tc.Cac
 
 // Update a CacheGroup by ID.
 // Deprecated: UpdateCacheGroupNullableByID will be removed in 6.0. Use UpdateCacheGroupNullableByIDWithHdr.
-func (to *Session) UpdateCacheGroupNullableByID(id int, cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, ReqInf, error) {
+func (to *Session) UpdateCacheGroupNullableByID(id int, cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, toclientlib.ReqInf, error) {
 	return to.UpdateCacheGroupNullableByIDWithHdr(id, cachegroup, nil)
 }
 
-func (to *Session) GetCacheGroupsNullableWithHdr(header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupsNullableWithHdr(header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	var data tc.CacheGroupsNullableResponse
 	reqInf, err := to.get(APICachegroups, header, &data)
 	return data.Response, reqInf, err
@@ -93,11 +94,11 @@ func (to *Session) GetCacheGroupsNullableWithHdr(header http.Header) ([]tc.Cache
 
 // Returns a list of CacheGroups.
 // Deprecated: GetCacheGroupsNullable will be removed in 6.0. Use GetCacheGroupsNullableWithHdr.
-func (to *Session) GetCacheGroupsNullable() ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupsNullable() ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupsNullableWithHdr(nil)
 }
 
-func (to *Session) GetCacheGroupNullableByIDWithHdr(id int, header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByIDWithHdr(id int, header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%v", APICachegroups, id)
 	var data tc.CacheGroupsNullableResponse
 	reqInf, err := to.get(route, header, &data)
@@ -106,11 +107,11 @@ func (to *Session) GetCacheGroupNullableByIDWithHdr(id int, header http.Header) 
 
 // GET a CacheGroup by the CacheGroup ID.
 // Deprecated: GetCacheGroupNullableByID will be removed in 6.0. Use GetCacheGroupNullableByIDWithHdr.
-func (to *Session) GetCacheGroupNullableByID(id int) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByID(id int) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupNullableByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetCacheGroupNullableByNameWithHdr(name string, header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByNameWithHdr(name string, header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APICachegroups, url.QueryEscape(name))
 	var data tc.CacheGroupsNullableResponse
 	reqInf, err := to.get(route, header, &data)
@@ -119,11 +120,11 @@ func (to *Session) GetCacheGroupNullableByNameWithHdr(name string, header http.H
 
 // GET a CacheGroup by the CacheGroup name.
 // Deprecated: GetCacheGroupNullableByName will be removed in 6.0. Use GetCacheGroupNullableByNameWithHdr.
-func (to *Session) GetCacheGroupNullableByName(name string) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByName(name string) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupNullableByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetCacheGroupNullableByShortNameWithHdr(shortName string, header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByShortNameWithHdr(shortName string, header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?shortName=%s", APICachegroups, url.QueryEscape(shortName))
 	var data tc.CacheGroupsNullableResponse
 	reqInf, err := to.get(route, header, &data)
@@ -132,12 +133,12 @@ func (to *Session) GetCacheGroupNullableByShortNameWithHdr(shortName string, hea
 
 // GET a CacheGroup by the CacheGroup short name.
 // Deprecated: GetCacheGroupNullableByShortName will be removed in 6.0. Use GetCacheGroupNullableByShortNameWithHdr.
-func (to *Session) GetCacheGroupNullableByShortName(shortName string) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByShortName(shortName string) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupNullableByShortNameWithHdr(shortName, nil)
 }
 
 // DELETE a CacheGroup by ID.
-func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APICachegroups, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
@@ -146,11 +147,11 @@ func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, ReqInf, error) {
 
 // GetCacheGroupsByQueryParams gets cache groups by the given query parameters.
 // Deprecated: GetCacheGroupsByQueryParams will be removed in 6.0. Use GetCacheGroupsByQueryParamsWithHdr.
-func (to *Session) GetCacheGroupsByQueryParams(qparams url.Values) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupsByQueryParams(qparams url.Values) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupsByQueryParamsWithHdr(qparams, nil)
 }
 
-func (to *Session) GetCacheGroupsByQueryParamsWithHdr(qparams url.Values, header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupsByQueryParamsWithHdr(qparams url.Values, header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	route := APICachegroups
 	if len(qparams) > 0 {
 		route += "?" + qparams.Encode()
@@ -160,7 +161,7 @@ func (to *Session) GetCacheGroupsByQueryParamsWithHdr(qparams url.Values, header
 	return data.Response, reqInf, err
 }
 
-func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
+func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int) (tc.CacheGroupPostDSRespResponse, toclientlib.ReqInf, error) {
 	uri := `/cachegroups/` + strconv.Itoa(cgID) + `/deliveryservices`
 	req := tc.CachegroupPostDSReq{DeliveryServices: dsIDs}
 	resp := tc.CacheGroupPostDSRespResponse{}

--- a/traffic_ops/v3-client/cachegroup_parameters.go
+++ b/traffic_ops/v3-client/cachegroup_parameters.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -29,36 +30,36 @@ const (
 	APICachegroupParameters = "/cachegroupparameters"
 )
 
-func (to *Session) GetCacheGroupParametersWithHdr(cacheGroupID int, header http.Header) ([]tc.CacheGroupParameter, ReqInf, error) {
+func (to *Session) GetCacheGroupParametersWithHdr(cacheGroupID int, header http.Header) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d/parameters", APICachegroups, cacheGroupID)
 	return to.getCacheGroupParameters(route, "", header)
 }
 
 // GetCacheGroupParameters Gets a Cache Group's Parameters
 // Deprecated: GetCacheGroupParameters will be removed in 6.0. Use GetCacheGroupParametersWithHdr.
-func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.CacheGroupParameter, ReqInf, error) {
+func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupParametersWithHdr(cacheGroupID, nil)
 }
 
-func (to *Session) GetCacheGroupParametersByQueryParamsWithHdr(cacheGroupID int, queryParams string, header http.Header) ([]tc.CacheGroupParameter, ReqInf, error) {
+func (to *Session) GetCacheGroupParametersByQueryParamsWithHdr(cacheGroupID int, queryParams string, header http.Header) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d/parameters", APICachegroups, cacheGroupID)
 	return to.getCacheGroupParameters(route, queryParams, header)
 }
 
 // GetCacheGroupParametersByQueryParams Gets a Cache Group's Parameters with query parameters
 // Deprecated: GetCacheGroupParametersByQueryParams will be removed in 6.0. Use GetCacheGroupParametersByQueryParamsWithHdr.
-func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.CacheGroupParameter, ReqInf, error) {
+func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupParametersByQueryParamsWithHdr(cacheGroupID, queryParams, nil)
 }
 
-func (to *Session) getCacheGroupParameters(route, queryParams string, header http.Header) ([]tc.CacheGroupParameter, ReqInf, error) {
+func (to *Session) getCacheGroupParameters(route, queryParams string, header http.Header) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
 	r := fmt.Sprintf("%s%s", route, queryParams)
 	var data tc.CacheGroupParametersResponse
 	reqInf, err := to.get(r, header, &data)
 	return data.Response, reqInf, err
 }
 
-func (to *Session) GetAllCacheGroupParametersWithHdr(header http.Header) ([]tc.CacheGroupParametersResponseNullable, ReqInf, error) {
+func (to *Session) GetAllCacheGroupParametersWithHdr(header http.Header) ([]tc.CacheGroupParametersResponseNullable, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/", APICachegroupParameters)
 	var data tc.AllCacheGroupParametersResponse
 	reqInf, err := to.get(route, header, &data)
@@ -67,12 +68,12 @@ func (to *Session) GetAllCacheGroupParametersWithHdr(header http.Header) ([]tc.C
 
 // GetAllCacheGroupParameters Gets all Cachegroup Parameter associations
 // Deprecated: GetAllCacheGroupParameters will be removed in 6.0. Use GetAllCacheGroupParametersWithHdr.
-func (to *Session) GetAllCacheGroupParameters() ([]tc.CacheGroupParametersResponseNullable, ReqInf, error) {
+func (to *Session) GetAllCacheGroupParameters() ([]tc.CacheGroupParametersResponseNullable, toclientlib.ReqInf, error) {
 	return to.GetAllCacheGroupParametersWithHdr(nil)
 }
 
 // DeleteCacheGroupParameter Deassociates a Parameter with a Cache Group
-func (to *Session) DeleteCacheGroupParameter(cacheGroupID, parameterID int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteCacheGroupParameter(cacheGroupID, parameterID int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d/%d", APICachegroupParameters, cacheGroupID, parameterID)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
@@ -80,7 +81,7 @@ func (to *Session) DeleteCacheGroupParameter(cacheGroupID, parameterID int) (tc.
 }
 
 // CreateCacheGroupParameter Associates a Parameter with a Cache Group
-func (to *Session) CreateCacheGroupParameter(cacheGroupID, parameterID int) (*tc.CacheGroupParametersPostResponse, ReqInf, error) {
+func (to *Session) CreateCacheGroupParameter(cacheGroupID, parameterID int) (*tc.CacheGroupParametersPostResponse, toclientlib.ReqInf, error) {
 	cacheGroupParameterReq := tc.CacheGroupParameterRequest{
 		CacheGroupID: cacheGroupID,
 		ParameterID:  parameterID,

--- a/traffic_ops/v3-client/capability.go
+++ b/traffic_ops/v3-client/capability.go
@@ -19,13 +19,14 @@ import "net/http"
 import "net/url"
 
 import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 
 // API_CAPABILITIES is Deprecated: will be removed in the next major version. Be aware this may not be the URI being requested, for clients created with Login and ClientOps.ForceLatestAPI false.
 const API_CAPABILITIES = apiBase + "/capabilities"
 
 const APICapabilities = "/capabilities"
 
-func (to *Session) GetCapabilitiesWithHdr(header http.Header) ([]tc.Capability, ReqInf, error) {
+func (to *Session) GetCapabilitiesWithHdr(header http.Header) ([]tc.Capability, toclientlib.ReqInf, error) {
 	var data tc.CapabilitiesResponse
 	reqInf, err := to.get(APICapabilities, header, &data)
 	return data.Response, reqInf, err
@@ -33,11 +34,11 @@ func (to *Session) GetCapabilitiesWithHdr(header http.Header) ([]tc.Capability, 
 
 // GetCapabilities retrieves all capabilities.
 // Deprecated: GetCapabilities will be removed in 6.0. Use GetCapabilitiesWithHdr.
-func (to *Session) GetCapabilities() ([]tc.Capability, ReqInf, error) {
+func (to *Session) GetCapabilities() ([]tc.Capability, toclientlib.ReqInf, error) {
 	return to.GetCapabilitiesWithHdr(nil)
 }
 
-func (to *Session) GetCapabilityWithHdr(c string, header http.Header) (tc.Capability, ReqInf, error) {
+func (to *Session) GetCapabilityWithHdr(c string, header http.Header) (tc.Capability, toclientlib.ReqInf, error) {
 	v := url.Values{}
 	v.Add("name", c)
 	endpoint := APICapabilities + "?" + v.Encode()
@@ -54,6 +55,6 @@ func (to *Session) GetCapabilityWithHdr(c string, header http.Header) (tc.Capabi
 
 // GetCapability retrieves only the capability named 'c'.
 // Deprecated: GetCapability will be removed in 6.0. Use GetCapabilityWithHdr.
-func (to *Session) GetCapability(c string) (tc.Capability, ReqInf, error) {
+func (to *Session) GetCapability(c string) (tc.Capability, toclientlib.ReqInf, error) {
 	return to.GetCapabilityWithHdr(c, nil)
 }

--- a/traffic_ops/v3-client/cdn.go
+++ b/traffic_ops/v3-client/cdn.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,13 +32,13 @@ const (
 )
 
 // CreateCDN creates a CDN.
-func (to *Session) CreateCDN(cdn tc.CDN) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateCDN(cdn tc.CDN) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APICDNs, cdn, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateCDNByIDWithHdr(id int, cdn tc.CDN, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateCDNByIDWithHdr(id int, cdn tc.CDN, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APICDNs, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, cdn, header, &alerts)
@@ -46,11 +47,11 @@ func (to *Session) UpdateCDNByIDWithHdr(id int, cdn tc.CDN, header http.Header) 
 
 // UpdateCDNByID updates a CDN by ID.
 // Deprecated: UpdateCDNByID will be removed in 6.0. Use UpdateCDNByIDWithHdr.
-func (to *Session) UpdateCDNByID(id int, cdn tc.CDN) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateCDNByID(id int, cdn tc.CDN) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateCDNByIDWithHdr(id, cdn, nil)
 }
 
-func (to *Session) GetCDNsWithHdr(header http.Header) ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNsWithHdr(header http.Header) ([]tc.CDN, toclientlib.ReqInf, error) {
 	var data tc.CDNsResponse
 	reqInf, err := to.get(APICDNs, header, &data)
 	return data.Response, reqInf, err
@@ -58,11 +59,11 @@ func (to *Session) GetCDNsWithHdr(header http.Header) ([]tc.CDN, ReqInf, error) 
 
 // GetCDNs eturns a list of CDNs.
 // Deprecated: GetCDNs will be removed in 6.0. Use GetCDNsWithHdr.
-func (to *Session) GetCDNs() ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNs() ([]tc.CDN, toclientlib.ReqInf, error) {
 	return to.GetCDNsWithHdr(nil)
 }
 
-func (to *Session) GetCDNByIDWithHdr(id int, header http.Header) ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNByIDWithHdr(id int, header http.Header) ([]tc.CDN, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%v", APICDNs, id)
 	var data tc.CDNsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -71,11 +72,11 @@ func (to *Session) GetCDNByIDWithHdr(id int, header http.Header) ([]tc.CDN, ReqI
 
 // GetCDNByID a CDN by the CDN ID.
 // Deprecated: GetCDNByID will be removed in 6.0. Use GetCDNByIDWithHdr.
-func (to *Session) GetCDNByID(id int) ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNByID(id int) ([]tc.CDN, toclientlib.ReqInf, error) {
 	return to.GetCDNByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetCDNByNameWithHdr(name string, header http.Header) ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNByNameWithHdr(name string, header http.Header) ([]tc.CDN, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APICDNs, url.QueryEscape(name))
 	var data tc.CDNsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -84,19 +85,19 @@ func (to *Session) GetCDNByNameWithHdr(name string, header http.Header) ([]tc.CD
 
 // GetCDNByName gets a CDN by the CDN name.
 // Deprecated: GetCDNByName will be removed in 6.0. Use GetCDNByNameWithHdr.
-func (to *Session) GetCDNByName(name string) ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNByName(name string) ([]tc.CDN, toclientlib.ReqInf, error) {
 	return to.GetCDNByNameWithHdr(name, nil)
 }
 
 // DeleteCDNByID deletes a CDN by ID.
-func (to *Session) DeleteCDNByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteCDNByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APICDNs, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetCDNSSLKeysWithHdr(name string, header http.Header) ([]tc.CDNSSLKeys, ReqInf, error) {
+func (to *Session) GetCDNSSLKeysWithHdr(name string, header http.Header) ([]tc.CDNSSLKeys, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/name/%s/sslkeys", APICDNs, name)
 	var data tc.CDNSSLKeysResponse
 	reqInf, err := to.get(route, header, &data)
@@ -104,6 +105,6 @@ func (to *Session) GetCDNSSLKeysWithHdr(name string, header http.Header) ([]tc.C
 }
 
 // Deprecated: GetCDNSSLKeys will be removed in 6.0. Use GetCDNSSLKeysWithHdr.
-func (to *Session) GetCDNSSLKeys(name string) ([]tc.CDNSSLKeys, ReqInf, error) {
+func (to *Session) GetCDNSSLKeys(name string) ([]tc.CDNSSLKeys, toclientlib.ReqInf, error) {
 	return to.GetCDNSSLKeysWithHdr(name, nil)
 }

--- a/traffic_ops/v3-client/cdn_domains.go
+++ b/traffic_ops/v3-client/cdn_domains.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 /*
@@ -21,13 +22,13 @@ import (
    limitations under the License.
 */
 
-func (to *Session) GetDomainsWithHdr(header http.Header) ([]tc.Domain, ReqInf, error) {
+func (to *Session) GetDomainsWithHdr(header http.Header) ([]tc.Domain, toclientlib.ReqInf, error) {
 	var data tc.DomainsResponse
 	inf, err := to.get("/cdns/domains", header, &data)
 	return data.Response, inf, err
 }
 
 // Deprecated: GetDomains will be removed in 6.0. Use GetDomainsWithHdr.
-func (to *Session) GetDomains() ([]tc.Domain, ReqInf, error) {
+func (to *Session) GetDomains() ([]tc.Domain, toclientlib.ReqInf, error) {
 	return to.GetDomainsWithHdr(nil)
 }

--- a/traffic_ops/v3-client/cdnfederations.go
+++ b/traffic_ops/v3-client/cdnfederations.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 /* Internally, the CDNName is only used in the GET method. The CDNName
@@ -28,14 +29,14 @@ import (
  * `/cdns/:name/federations`. Although the behavior is odd, it is kept to
  * keep the same behavior from perl. */
 
-func (to *Session) CreateCDNFederationByName(f tc.CDNFederation, CDNName string) (*tc.CreateCDNFederationResponse, ReqInf, error) {
+func (to *Session) CreateCDNFederationByName(f tc.CDNFederation, CDNName string) (*tc.CreateCDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.CreateCDNFederationResponse{}
 	route := fmt.Sprintf("/cdns/%s/federations", url.QueryEscape(CDNName))
 	inf, err := to.post(route, f, nil, &data)
 	return &data, inf, err
 }
 
-func (to *Session) GetCDNFederationsByNameWithHdr(CDNName string, header http.Header) (*tc.CDNFederationResponse, ReqInf, error) {
+func (to *Session) GetCDNFederationsByNameWithHdr(CDNName string, header http.Header) (*tc.CDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.CDNFederationResponse{}
 	route := fmt.Sprintf("/cdns/%s/federations", url.QueryEscape(CDNName))
 	inf, err := to.get(route, header, &data)
@@ -43,11 +44,11 @@ func (to *Session) GetCDNFederationsByNameWithHdr(CDNName string, header http.He
 }
 
 // Deprecated: GetCDNFederationsByName will be removed in 6.0. Use GetCDNFederationsByNameWithHdr.
-func (to *Session) GetCDNFederationsByName(CDNName string) (*tc.CDNFederationResponse, ReqInf, error) {
+func (to *Session) GetCDNFederationsByName(CDNName string) (*tc.CDNFederationResponse, toclientlib.ReqInf, error) {
 	return to.GetCDNFederationsByNameWithHdr(CDNName, nil)
 }
 
-func (to *Session) GetCDNFederationsByNameWithHdrReturnList(CDNName string, header http.Header) ([]tc.CDNFederation, ReqInf, error) {
+func (to *Session) GetCDNFederationsByNameWithHdrReturnList(CDNName string, header http.Header) ([]tc.CDNFederation, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("/cdns/%s/federations", url.QueryEscape(CDNName))
 	resp := struct {
 		Response []tc.CDNFederation `json:"response"`
@@ -56,7 +57,7 @@ func (to *Session) GetCDNFederationsByNameWithHdrReturnList(CDNName string, head
 	return resp.Response, inf, err
 }
 
-func (to *Session) GetCDNFederationsByIDWithHdr(CDNName string, ID int, header http.Header) (*tc.CDNFederationResponse, ReqInf, error) {
+func (to *Session) GetCDNFederationsByIDWithHdr(CDNName string, ID int, header http.Header) (*tc.CDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.CDNFederationResponse{}
 	route := fmt.Sprintf("/cdns/%s/federations?id=%v", url.QueryEscape(CDNName), ID)
 	inf, err := to.get(route, header, &data)
@@ -64,11 +65,11 @@ func (to *Session) GetCDNFederationsByIDWithHdr(CDNName string, ID int, header h
 }
 
 // Deprecated: GetCDNFederationsByID will be removed in 6.0. Use GetCDNFederationsByIDWithHdr.
-func (to *Session) GetCDNFederationsByID(CDNName string, ID int) (*tc.CDNFederationResponse, ReqInf, error) {
+func (to *Session) GetCDNFederationsByID(CDNName string, ID int) (*tc.CDNFederationResponse, toclientlib.ReqInf, error) {
 	return to.GetCDNFederationsByIDWithHdr(CDNName, ID, nil)
 }
 
-func (to *Session) UpdateCDNFederationsByIDWithHdr(f tc.CDNFederation, CDNName string, ID int, h http.Header) (*tc.UpdateCDNFederationResponse, ReqInf, error) {
+func (to *Session) UpdateCDNFederationsByIDWithHdr(f tc.CDNFederation, CDNName string, ID int, h http.Header) (*tc.UpdateCDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.UpdateCDNFederationResponse{}
 	route := fmt.Sprintf("/cdns/%s/federations/%d", url.QueryEscape(CDNName), ID)
 	inf, err := to.put(route, f, h, &data)
@@ -76,11 +77,11 @@ func (to *Session) UpdateCDNFederationsByIDWithHdr(f tc.CDNFederation, CDNName s
 }
 
 // Deprecated: UpdateCDNFederationsByID will be removed in 6.0. Use UpdateCDNFederationsByIDWithHdr.
-func (to *Session) UpdateCDNFederationsByID(f tc.CDNFederation, CDNName string, ID int) (*tc.UpdateCDNFederationResponse, ReqInf, error) {
+func (to *Session) UpdateCDNFederationsByID(f tc.CDNFederation, CDNName string, ID int) (*tc.UpdateCDNFederationResponse, toclientlib.ReqInf, error) {
 	return to.UpdateCDNFederationsByIDWithHdr(f, CDNName, ID, nil)
 }
 
-func (to *Session) DeleteCDNFederationByID(CDNName string, ID int) (*tc.DeleteCDNFederationResponse, ReqInf, error) {
+func (to *Session) DeleteCDNFederationByID(CDNName string, ID int) (*tc.DeleteCDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.DeleteCDNFederationResponse{}
 	route := fmt.Sprintf("/cdns/%s/federations/%d", url.QueryEscape(CDNName), ID)
 	inf, err := to.del(route, nil, &data)

--- a/traffic_ops/v3-client/coordinate.go
+++ b/traffic_ops/v3-client/coordinate.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -30,13 +31,13 @@ const (
 )
 
 // Create a Coordinate
-func (to *Session) CreateCoordinate(coordinate tc.Coordinate) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateCoordinate(coordinate tc.Coordinate) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APICoordinates, coordinate, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateCoordinateByIDWithHdr(id int, coordinate tc.Coordinate, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateCoordinateByIDWithHdr(id int, coordinate tc.Coordinate, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APICoordinates, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, coordinate, header, &alerts)
@@ -45,11 +46,11 @@ func (to *Session) UpdateCoordinateByIDWithHdr(id int, coordinate tc.Coordinate,
 
 // Update a Coordinate by ID
 // Deprecated: UpdateCoordinateByID will be removed in 6.0. Use UpdateCoordinateByIDWithHdr.
-func (to *Session) UpdateCoordinateByID(id int, coordinate tc.Coordinate) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateCoordinateByID(id int, coordinate tc.Coordinate) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateCoordinateByIDWithHdr(id, coordinate, nil)
 }
 
-func (to *Session) GetCoordinatesWithHdr(header http.Header) ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinatesWithHdr(header http.Header) ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	var data tc.CoordinatesResponse
 	reqInf, err := to.get(APICoordinates, header, &data)
 	return data.Response, reqInf, err
@@ -57,11 +58,11 @@ func (to *Session) GetCoordinatesWithHdr(header http.Header) ([]tc.Coordinate, R
 
 // Returns a list of Coordinates
 // Deprecated: GetCoordinates will be removed in 6.0. Use GetCoordinatesWithHdr.
-func (to *Session) GetCoordinates() ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinates() ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	return to.GetCoordinatesWithHdr(nil)
 }
 
-func (to *Session) GetCoordinateByIDWithHdr(id int, header http.Header) ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinateByIDWithHdr(id int, header http.Header) ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APICoordinates, id)
 	var data tc.CoordinatesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -70,17 +71,17 @@ func (to *Session) GetCoordinateByIDWithHdr(id int, header http.Header) ([]tc.Co
 
 // GET a Coordinate by the Coordinate id
 // Deprecated: GetCoordinateByID will be removed in 6.0. Use GetCoordinateByIDWithHdr.
-func (to *Session) GetCoordinateByID(id int) ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinateByID(id int) ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	return to.GetCoordinateByIDWithHdr(id, nil)
 }
 
 // GET a Coordinate by the Coordinate name
 // Deprecated: GetCoordinateByName will be removed in 6.0. Use GetCoordinateByNameWithHdr.
-func (to *Session) GetCoordinateByName(name string) ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinateByName(name string) ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	return to.GetCoordinateByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetCoordinateByNameWithHdr(name string, header http.Header) ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinateByNameWithHdr(name string, header http.Header) ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APICoordinates, name)
 	var data tc.CoordinatesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -88,7 +89,7 @@ func (to *Session) GetCoordinateByNameWithHdr(name string, header http.Header) (
 }
 
 // DELETE a Coordinate by ID
-func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APICoordinates, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/crconfig.go
+++ b/traffic_ops/v3-client/crconfig.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -36,7 +37,7 @@ type OuterResponse struct {
 }
 
 // GetCRConfig returns the raw JSON bytes of the CRConfig from Traffic Ops, and whether the bytes were from the client's internal cache.
-func (to *Session) GetCRConfig(cdn string) ([]byte, ReqInf, error) {
+func (to *Session) GetCRConfig(cdn string) ([]byte, toclientlib.ReqInf, error) {
 	uri := `/cdns/` + cdn + `/snapshot`
 	bts := []byte{}
 	reqInf, err := to.get(uri, nil, &bts)
@@ -51,7 +52,7 @@ func (to *Session) GetCRConfig(cdn string) ([]byte, ReqInf, error) {
 	return resp.Response, reqInf, nil
 }
 
-func (to *Session) SnapshotCRConfigWithHdr(cdn string, header http.Header) (ReqInf, error) {
+func (to *Session) SnapshotCRConfigWithHdr(cdn string, header http.Header) (toclientlib.ReqInf, error) {
 	uri := fmt.Sprintf("%s?cdn=%s", APISnapshot, url.QueryEscape(cdn))
 	resp := OuterResponse{}
 	reqInf, err := to.put(uri, nil, header, &resp)
@@ -59,7 +60,7 @@ func (to *Session) SnapshotCRConfigWithHdr(cdn string, header http.Header) (ReqI
 }
 
 // GetCRConfigNew returns the raw JSON bytes of the latest CRConfig from Traffic Ops, and whether the bytes were from the client's internal cache.
-func (to *Session) GetCRConfigNew(cdn string) ([]byte, ReqInf, error) {
+func (to *Session) GetCRConfigNew(cdn string) ([]byte, toclientlib.ReqInf, error) {
 	uri := `/cdns/` + cdn + `/snapshot/new`
 	bts := []byte{}
 	reqInf, err := to.get(uri, nil, &bts)
@@ -76,12 +77,12 @@ func (to *Session) GetCRConfigNew(cdn string) ([]byte, ReqInf, error) {
 
 // SnapshotCRConfig snapshots a CDN by name.
 // Deprecated: SnapshotCRConfig will be removed in 6.0. Use SnapshotCRConfigWithHdr.
-func (to *Session) SnapshotCRConfig(cdn string) (ReqInf, error) {
+func (to *Session) SnapshotCRConfig(cdn string) (toclientlib.ReqInf, error) {
 	return to.SnapshotCRConfigWithHdr(cdn, nil)
 }
 
 // SnapshotCDNByID snapshots a CDN by ID.
-func (to *Session) SnapshotCRConfigByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) SnapshotCRConfigByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	url := fmt.Sprintf("%s?cdnID=%d", APISnapshot, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(url, nil, nil, &alerts)

--- a/traffic_ops/v3-client/deliveryservice.go
+++ b/traffic_ops/v3-client/deliveryservice.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // These are the API endpoints used by the various Delivery Service-related client methods.
@@ -160,7 +161,7 @@ const (
 	APIDeliveryServicesServers        = "/deliveryservices/%s/servers"
 )
 
-func (to *Session) GetDeliveryServicesByServerV30WithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByServerV30WithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServicesResponseV30
 	reqInf, err := to.get(fmt.Sprintf(APIServerDeliveryServices, id), header, &data)
 	return data.Response, reqInf, err
@@ -174,11 +175,11 @@ func (to *Session) GetDeliveryServicesByServerV30WithHdr(id int, header http.Hea
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesByServerV30WithHdr.
-func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesByServerWithHdr(id, nil)
 }
 
-func (to *Session) GetDeliveryServicesByServerWithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByServerWithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServicesNullableResponse
 
 	reqInf, err := to.get(fmt.Sprintf(APIServerDeliveryServices, id), header, &data)
@@ -188,7 +189,7 @@ func (to *Session) GetDeliveryServicesByServerWithHdr(id int, header http.Header
 // GetDeliveryServicesV30WithHdr returns all (tenant-visible) Delivery Services that
 // satisfy the passed query string parameters. See the API documentation for
 // information on the available parameters.
-func (to *Session) GetDeliveryServicesV30WithHdr(header http.Header, params url.Values) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) GetDeliveryServicesV30WithHdr(header http.Header, params url.Values) ([]tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	uri := APIDeliveryServices
 	if params != nil {
 		uri += "?" + params.Encode()
@@ -198,7 +199,7 @@ func (to *Session) GetDeliveryServicesV30WithHdr(header http.Header, params url.
 	return data.Response, reqInf, err
 }
 
-func (to *Session) GetDeliveryServicesNullableWithHdr(header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesNullableWithHdr(header http.Header) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
@@ -213,11 +214,11 @@ func (to *Session) GetDeliveryServicesNullableWithHdr(header http.Header) ([]tc.
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetDeliveryServicesNullable() ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesNullable() ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesNullableWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServicesByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
@@ -233,12 +234,12 @@ func (to *Session) GetDeliveryServicesByCDNIDWithHdr(cdnID int, header http.Head
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetDeliveryServicesByCDNID(cdnID int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByCDNID(cdnID int) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesByCDNIDWithHdr(cdnID, nil)
 }
 
 // GetDeliveryServiceNullableWithHdr fetches the Delivery Service with the given ID.
-func (to *Session) GetDeliveryServiceNullableWithHdr(id string, header http.Header) (*tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) GetDeliveryServiceNullableWithHdr(id string, header http.Header) (*tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullableV30 `json:"response"`
 	}{}
@@ -261,7 +262,7 @@ func (to *Session) GetDeliveryServiceNullableWithHdr(id string, header http.Head
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetDeliveryServiceNullable(id string) (*tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServiceNullable(id string) (*tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
@@ -277,7 +278,7 @@ func (to *Session) GetDeliveryServiceNullable(id string) (*tc.DeliveryServiceNul
 
 // GetDeliveryServiceByXMLIDNullableWithHdr fetches all Delivery Services with
 // the given XMLID.
-func (to *Session) GetDeliveryServiceByXMLIDNullableWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) GetDeliveryServiceByXMLIDNullableWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServicesResponseV30
 	reqInf, err := to.get(APIDeliveryServices+"?xmlId="+url.QueryEscape(XMLID), header, &data)
 	return data.Response, reqInf, err
@@ -292,7 +293,7 @@ func (to *Session) GetDeliveryServiceByXMLIDNullableWithHdr(XMLID string, header
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	var ret []tc.DeliveryServiceNullable
 	resp, reqInf, err := to.GetDeliveryServiceByXMLIDNullableWithHdr(XMLID, nil)
 	if len(resp) > 0 {
@@ -305,8 +306,8 @@ func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string) ([]tc.Deliver
 }
 
 // CreateDeliveryServiceV30 creates the Delivery Service it's passed.
-func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (tc.DeliveryServiceNullableV30, ReqInf, error) {
-	var reqInf ReqInf
+func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
+	var reqInf toclientlib.ReqInf
 	if ds.TypeID == nil && ds.Type != nil {
 		ty, _, err := to.GetTypeByNameWithHdr(ds.Type.String(), nil)
 		if err != nil {
@@ -421,7 +422,7 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 
 // UpdateDeliveryServiceV30WithHdr replaces the Delivery Service identified by the
 // integral, unique identifier 'id' with the one it's passed.
-func (to *Session) UpdateDeliveryServiceV30WithHdr(id int, ds tc.DeliveryServiceNullableV30, header http.Header) (tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceV30WithHdr(id int, ds tc.DeliveryServiceNullableV30, header http.Header) (tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServicesResponseV30
 	reqInf, err := to.put(fmt.Sprintf(APIDeliveryServiceId, id), ds, header, &data)
 	if err != nil {
@@ -466,7 +467,7 @@ func (to *Session) DeleteDeliveryService(id string) (*tc.DeleteDeliveryServiceRe
 	return &data, nil
 }
 
-func (to *Session) GetDeliveryServiceHealthWithHdr(id string, header http.Header) (*tc.DeliveryServiceHealth, ReqInf, error) {
+func (to *Session) GetDeliveryServiceHealthWithHdr(id string, header http.Header) (*tc.DeliveryServiceHealth, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceHealthResponse
 	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServiceHealth, id), nil, &data)
 	if err != nil {
@@ -479,11 +480,11 @@ func (to *Session) GetDeliveryServiceHealthWithHdr(id string, header http.Header
 // GetDeliveryServiceHealth gets the 'health' of the Delivery Service identified by the
 // integral, unique identifier 'id' (which must be passed as a string).
 // Deprecated: GetDeliveryServiceHealth will be removed in 6.0. Use GetDeliveryServiceHealthWithHdr.
-func (to *Session) GetDeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, ReqInf, error) {
+func (to *Session) GetDeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceHealthWithHdr(id, nil)
 }
 
-func (to *Session) GetDeliveryServiceCapacityWithHdr(id string, header http.Header) (*tc.DeliveryServiceCapacity, ReqInf, error) {
+func (to *Session) GetDeliveryServiceCapacityWithHdr(id string, header http.Header) (*tc.DeliveryServiceCapacity, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceCapacityResponse
 	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServiceCapacity, id), header, &data)
 	if err != nil {
@@ -495,12 +496,12 @@ func (to *Session) GetDeliveryServiceCapacityWithHdr(id string, header http.Head
 // GetDeliveryServiceCapacity gets the 'capacity' of the Delivery Service identified by the
 // integral, unique identifier 'id' (which must be passed as a string).
 // Deprecated: GetDeliveryServiceCapacity will be removed in 6.0. Use GetDeliveryServiceCapacityWithHdr.
-func (to *Session) GetDeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, ReqInf, error) {
+func (to *Session) GetDeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceCapacityWithHdr(id, nil)
 }
 
 // GenerateSSLKeysForDS generates ssl keys for a given cdn
-func (to *Session) GenerateSSLKeysForDS(XMLID string, CDNName string, sslFields tc.SSLKeyRequestFields) (string, ReqInf, error) {
+func (to *Session) GenerateSSLKeysForDS(XMLID string, CDNName string, sslFields tc.SSLKeyRequestFields) (string, toclientlib.ReqInf, error) {
 	version := util.JSONIntStr(1)
 	request := tc.DeliveryServiceSSLKeysReq{
 		BusinessUnit:    sslFields.BusinessUnit,
@@ -524,7 +525,7 @@ func (to *Session) GenerateSSLKeysForDS(XMLID string, CDNName string, sslFields 
 	return response.Response, reqInf, nil
 }
 
-func (to *Session) DeleteDeliveryServiceSSLKeysByID(XMLID string) (string, ReqInf, error) {
+func (to *Session) DeleteDeliveryServiceSSLKeysByID(XMLID string) (string, toclientlib.ReqInf, error) {
 	resp := struct {
 		Response string `json:"response"`
 	}{}
@@ -535,11 +536,11 @@ func (to *Session) DeleteDeliveryServiceSSLKeysByID(XMLID string) (string, ReqIn
 // GetDeliveryServiceSSLKeysByID returns information about the SSL Keys used by the Delivery
 // Service identified by the passed XMLID.
 // Deprecated: GetDeliveryServiceSSLKeysByID will be removed in 6.0. Use GetDeliveryServiceSSLKeysByIDWithHdr.
-func (to *Session) GetDeliveryServiceSSLKeysByID(XMLID string) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
+func (to *Session) GetDeliveryServiceSSLKeysByID(XMLID string) (*tc.DeliveryServiceSSLKeys, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceSSLKeysByIDWithHdr(XMLID, nil)
 }
 
-func (to *Session) GetDeliveryServiceSSLKeysByIDWithHdr(XMLID string, header http.Header) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
+func (to *Session) GetDeliveryServiceSSLKeysByIDWithHdr(XMLID string, header http.Header) (*tc.DeliveryServiceSSLKeys, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceSSLKeysResponse
 	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServiceXmlidSslKeys, url.QueryEscape(XMLID)), header, &data)
 	if err != nil {
@@ -548,7 +549,7 @@ func (to *Session) GetDeliveryServiceSSLKeysByIDWithHdr(XMLID string, header htt
 	return &data.Response, reqInf, nil
 }
 
-func (to *Session) GetDeliveryServicesEligibleWithHdr(dsID int, header http.Header) ([]tc.DSServer, ReqInf, error) {
+func (to *Session) GetDeliveryServicesEligibleWithHdr(dsID int, header http.Header) ([]tc.DSServer, toclientlib.ReqInf, error) {
 	resp := struct {
 		Response []tc.DSServer `json:"response"`
 	}{Response: []tc.DSServer{}}
@@ -560,18 +561,18 @@ func (to *Session) GetDeliveryServicesEligibleWithHdr(dsID int, header http.Head
 // GetDeliveryServicesEligible returns the servers eligible for assignment to the Delivery
 // Service identified by the integral, unique identifier 'dsID'.
 // Deprecated: GetDeliveryServicesEligible will be removed in 6.0. Use GetDeliveryServicesEligibleWithHdr.
-func (to *Session) GetDeliveryServicesEligible(dsID int) ([]tc.DSServer, ReqInf, error) {
+func (to *Session) GetDeliveryServicesEligible(dsID int) ([]tc.DSServer, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesEligibleWithHdr(dsID, nil)
 }
 
 // GetDeliveryServiceURLSigKeys returns the URL-signing keys used by the Delivery Service
 // identified by the XMLID 'dsName'.
 // Deprecated: GetDeliveryServiceURLSigKeys will be removed in 6.0. Use GetDeliveryServiceURLSigKeysWithHdr.
-func (to *Session) GetDeliveryServiceURLSigKeys(dsName string) (tc.URLSigKeys, ReqInf, error) {
+func (to *Session) GetDeliveryServiceURLSigKeys(dsName string) (tc.URLSigKeys, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceURLSigKeysWithHdr(dsName, nil)
 }
 
-func (to *Session) GetDeliveryServiceURLSigKeysWithHdr(dsName string, header http.Header) (tc.URLSigKeys, ReqInf, error) {
+func (to *Session) GetDeliveryServiceURLSigKeysWithHdr(dsName string, header http.Header) (tc.URLSigKeys, toclientlib.ReqInf, error) {
 	data := struct {
 		Response tc.URLSigKeys `json:"response"`
 	}{}
@@ -584,13 +585,13 @@ func (to *Session) GetDeliveryServiceURLSigKeysWithHdr(dsName string, header htt
 }
 
 // Deprecated: GetDeliveryServiceURISigningKeys will be removed in 6.0. Use GetDeliveryServiceURISigningKeysWithHdr.
-func (to *Session) GetDeliveryServiceURISigningKeys(dsName string) ([]byte, ReqInf, error) {
+func (to *Session) GetDeliveryServiceURISigningKeys(dsName string) ([]byte, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceURISigningKeysWithHdr(dsName, nil)
 }
 
 // GetDeliveryServiceURISigningKeys returns the URI-signing keys used by the Delivery Service
 // identified by the XMLID 'dsName'. The result is not parsed.
-func (to *Session) GetDeliveryServiceURISigningKeysWithHdr(dsName string, header http.Header) ([]byte, ReqInf, error) {
+func (to *Session) GetDeliveryServiceURISigningKeysWithHdr(dsName string, header http.Header) ([]byte, toclientlib.ReqInf, error) {
 	data := json.RawMessage{}
 	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServicesUriSigningKeys, url.QueryEscape(dsName)), header, &data)
 	if err != nil {
@@ -601,7 +602,7 @@ func (to *Session) GetDeliveryServiceURISigningKeysWithHdr(dsName string, header
 
 // SafeDeliveryServiceUpdateV30WithHdr updates the "safe" fields of the Delivery
 // Service identified by the integral, unique identifier 'id'.
-func (to *Session) SafeDeliveryServiceUpdateV30WithHdr(id int, r tc.DeliveryServiceSafeUpdateRequest, header http.Header) (tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) SafeDeliveryServiceUpdateV30WithHdr(id int, r tc.DeliveryServiceSafeUpdateRequest, header http.Header) (tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceSafeUpdateResponseV30
 	reqInf, err := to.put(fmt.Sprintf(APIDeliveryServicesSafeUpdate, id), r, header, &data)
 	if err != nil {
@@ -620,7 +621,7 @@ func (to *Session) SafeDeliveryServiceUpdateV30WithHdr(id int, r tc.DeliveryServ
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // SafeDeliveryServiceUpdateV30WithHdr.
-func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUpdateRequest) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUpdateRequest) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	var resp tc.DeliveryServiceSafeUpdateResponse
 	reqInf, err := to.put(fmt.Sprintf(APIDeliveryServicesSafeUpdate, id), ds, nil, &resp)
 	if err != nil {
@@ -641,7 +642,7 @@ func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUp
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetAccessibleDeliveryServicesByTenant(tenantId int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetAccessibleDeliveryServicesByTenant(tenantId int) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	data := tc.DeliveryServicesNullableResponse{}
 	reqInf, err := to.get(fmt.Sprintf("%s?accessibleTo=%d", APIDeliveryServices, tenantId), nil, &data)
 	return data.Response, reqInf, err

--- a/traffic_ops/v3-client/deliveryservice_regexes.go
+++ b/traffic_ops/v3-client/deliveryservice_regexes.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -32,7 +33,7 @@ const (
 
 // GetDeliveryServiceRegexesByDSID gets DeliveryServiceRegexes by a DS id
 // also accepts an optional map of query parameters
-func (to *Session) GetDeliveryServiceRegexesByDSID(dsID int, params map[string]string) ([]tc.DeliveryServiceIDRegex, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRegexesByDSID(dsID int, params map[string]string) ([]tc.DeliveryServiceIDRegex, toclientlib.ReqInf, error) {
 	response := struct {
 		Response []tc.DeliveryServiceIDRegex `json:"response"`
 	}{}
@@ -43,17 +44,17 @@ func (to *Session) GetDeliveryServiceRegexesByDSID(dsID int, params map[string]s
 // GetDeliveryServiceRegexes returns the "Regexes" (Regular Expressions) used by all (tenant-visible)
 // Delivery Services.
 // Deprecated: GetDeliveryServiceRegexes will be removed in 6.0. Use GetDeliveryServiceRegexesWithHdr.
-func (to *Session) GetDeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRegexesWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServiceRegexesWithHdr(header http.Header) ([]tc.DeliveryServiceRegexes, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRegexesWithHdr(header http.Header) ([]tc.DeliveryServiceRegexes, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceRegexResponse
 	reqInf, err := to.get(APIDeliveryServicesRegexes, header, &data)
 	return data.Response, reqInf, err
 }
 
-func (to *Session) PostDeliveryServiceRegexesByDSID(dsID int, regex tc.DeliveryServiceRegexPost) (tc.Alerts, ReqInf, error) {
+func (to *Session) PostDeliveryServiceRegexesByDSID(dsID int, regex tc.DeliveryServiceRegexPost) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	route := fmt.Sprintf(APIDSRegexes, dsID)
 	reqInf, err := to.post(route, regex, nil, &alerts)

--- a/traffic_ops/v3-client/deliveryservice_request_comments.go
+++ b/traffic_ops/v3-client/deliveryservice_request_comments.go
@@ -16,11 +16,11 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
-
-	"fmt"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,13 +31,13 @@ const (
 )
 
 // Create a delivery service request comment
-func (to *Session) CreateDeliveryServiceRequestComment(comment tc.DeliveryServiceRequestComment) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateDeliveryServiceRequestComment(comment tc.DeliveryServiceRequestComment) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIDeliveryServiceRequestComments, comment, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateDeliveryServiceRequestCommentByIDWithHdr(id int, comment tc.DeliveryServiceRequestComment, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceRequestCommentByIDWithHdr(id int, comment tc.DeliveryServiceRequestComment, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIDeliveryServiceRequestComments, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, comment, header, &alerts)
@@ -46,11 +46,11 @@ func (to *Session) UpdateDeliveryServiceRequestCommentByIDWithHdr(id int, commen
 
 // Update a delivery service request by ID
 // Deprecated: UpdateDeliveryServiceRequestCommentByID will be removed in 6.0. Use UpdateDeliveryServiceRequestCommentByIDWithHdr.
-func (to *Session) UpdateDeliveryServiceRequestCommentByID(id int, comment tc.DeliveryServiceRequestComment) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceRequestCommentByID(id int, comment tc.DeliveryServiceRequestComment) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateDeliveryServiceRequestCommentByIDWithHdr(id, comment, nil)
 }
 
-func (to *Session) GetDeliveryServiceRequestCommentsWithHdr(header http.Header) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestCommentsWithHdr(header http.Header) ([]tc.DeliveryServiceRequestComment, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceRequestCommentsResponse
 	reqInf, err := to.get(APIDeliveryServiceRequestComments, header, &data)
 	return data.Response, reqInf, err
@@ -58,11 +58,11 @@ func (to *Session) GetDeliveryServiceRequestCommentsWithHdr(header http.Header) 
 
 // Returns a list of delivery service request comments
 // Deprecated: GetDeliveryServiceRequestComments will be removed in 6.0. Use GetDeliveryServiceRequestCommentsWithHdr.
-func (to *Session) GetDeliveryServiceRequestComments() ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestComments() ([]tc.DeliveryServiceRequestComment, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestCommentsWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServiceRequestCommentByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestCommentByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequestComment, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIDeliveryServiceRequestComments, id)
 	var data tc.DeliveryServiceRequestCommentsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -71,12 +71,12 @@ func (to *Session) GetDeliveryServiceRequestCommentByIDWithHdr(id int, header ht
 
 // GET a delivery service request comment by ID
 // Deprecated: GetDeliveryServiceRequestCommentByID will be removed in 6.0. Use GetDeliveryServiceRequestCommentByIDWithHdr.
-func (to *Session) GetDeliveryServiceRequestCommentByID(id int) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestCommentByID(id int) ([]tc.DeliveryServiceRequestComment, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestCommentByIDWithHdr(id, nil)
 }
 
 // DELETE a delivery service request comment by ID
-func (to *Session) DeleteDeliveryServiceRequestCommentByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteDeliveryServiceRequestCommentByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIDeliveryServiceRequestComments, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/deliveryservice_requests.go
+++ b/traffic_ops/v3-client/deliveryservice_requests.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -32,7 +33,7 @@ const (
 )
 
 // CreateDeliveryServiceRequest creates a Delivery Service Request.
-func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequest) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequest) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	if dsr.AssigneeID == 0 && dsr.Assignee != "" {
 		res, reqInf, err := to.GetUserByUsernameWithHdr(dsr.Assignee, nil)
@@ -92,7 +93,7 @@ func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequest) (
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetDeliveryServiceRequestsWithHdr(header http.Header) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestsWithHdr(header http.Header) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceRequest `json:"response"`
 	}{}
@@ -102,11 +103,11 @@ func (to *Session) GetDeliveryServiceRequestsWithHdr(header http.Header) ([]tc.D
 
 // GetDeliveryServiceRequests retrieves all deliveryservices available to session user.
 // Deprecated: GetDeliveryServiceRequests will be removed in 6.0. Use GetDeliveryServiceRequestsWithHdr.
-func (to *Session) GetDeliveryServiceRequests() ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequests() ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestsWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServiceRequestByXMLIDWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestByXMLIDWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?xmlId=%s", APIDSRequests, url.QueryEscape(XMLID))
 	data := struct {
 		Response []tc.DeliveryServiceRequest `json:"response"`
@@ -117,11 +118,11 @@ func (to *Session) GetDeliveryServiceRequestByXMLIDWithHdr(XMLID string, header 
 
 // GET a DeliveryServiceRequest by the DeliveryServiceRequest XMLID
 // Deprecated: GetDeliveryServiceRequestByXMLID will be removed in 6.0. Use GetDeliveryServiceRequestByXMLIDWithHdr.
-func (to *Session) GetDeliveryServiceRequestByXMLID(XMLID string) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestByXMLID(XMLID string) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestByXMLIDWithHdr(XMLID, nil)
 }
 
-func (to *Session) GetDeliveryServiceRequestByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIDSRequests, id)
 	data := struct {
 		Response []tc.DeliveryServiceRequest `json:"response"`
@@ -132,11 +133,11 @@ func (to *Session) GetDeliveryServiceRequestByIDWithHdr(id int, header http.Head
 
 // GET a DeliveryServiceRequest by the DeliveryServiceRequest id
 // Deprecated: GetDeliveryServiceRequestByID will be removed in 6.0. Use GetDeliveryServiceRequestByIDWithHdr.
-func (to *Session) GetDeliveryServiceRequestByID(id int) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestByID(id int) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestByIDWithHdr(id, nil)
 }
 
-func (to *Session) UpdateDeliveryServiceRequestByIDWithHdr(id int, dsr tc.DeliveryServiceRequest, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceRequestByIDWithHdr(id int, dsr tc.DeliveryServiceRequest, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIDSRequests, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, dsr, header, &alerts)
@@ -145,12 +146,12 @@ func (to *Session) UpdateDeliveryServiceRequestByIDWithHdr(id int, dsr tc.Delive
 
 // Update a DeliveryServiceRequest by ID
 // Deprecated: UpdateDeliveryServiceRequestByID will be removed in 6.0. Use UpdateDeliveryServiceRequestByIDWithHdr.
-func (to *Session) UpdateDeliveryServiceRequestByID(id int, dsr tc.DeliveryServiceRequest) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceRequestByID(id int, dsr tc.DeliveryServiceRequest) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateDeliveryServiceRequestByIDWithHdr(id, dsr, nil)
 }
 
 // DELETE a DeliveryServiceRequest by DeliveryServiceRequest assignee
-func (to *Session) DeleteDeliveryServiceRequestByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteDeliveryServiceRequestByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIDSRequests, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/deliveryservices_required_capabilities.go
+++ b/traffic_ops/v3-client/deliveryservices_required_capabilities.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -32,14 +33,14 @@ const (
 )
 
 // CreateDeliveryServicesRequiredCapability assigns a Required Capability to a Delivery Service
-func (to *Session) CreateDeliveryServicesRequiredCapability(capability tc.DeliveryServicesRequiredCapability) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateDeliveryServicesRequiredCapability(capability tc.DeliveryServicesRequiredCapability) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIDeliveryServicesRequiredCapabilities, capability, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteDeliveryServicesRequiredCapability unassigns a Required Capability from a Delivery Service
-func (to *Session) DeleteDeliveryServicesRequiredCapability(deliveryserviceID int, capability string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteDeliveryServicesRequiredCapability(deliveryserviceID int, capability string) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	param := url.Values{}
 	param.Add("deliveryServiceID", strconv.Itoa(deliveryserviceID))
@@ -49,7 +50,7 @@ func (to *Session) DeleteDeliveryServicesRequiredCapability(deliveryserviceID in
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServiceID *int, xmlID, capability *string, header http.Header) ([]tc.DeliveryServicesRequiredCapability, ReqInf, error) {
+func (to *Session) GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServiceID *int, xmlID, capability *string, header http.Header) ([]tc.DeliveryServicesRequiredCapability, toclientlib.ReqInf, error) {
 	param := url.Values{}
 	if deliveryServiceID != nil {
 		param.Add("deliveryServiceID", strconv.Itoa(*deliveryServiceID))
@@ -76,6 +77,6 @@ func (to *Session) GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServic
 // GetDeliveryServicesRequiredCapabilities retrieves a list of Required Capabilities that are assigned to a Delivery Service
 // Callers can filter the results by delivery service id, xml id and/or required capability via the optional parameters
 // Deprecated: GetDeliveryServicesRequiredCapabilities will be removed in 6.0. Use GetDeliveryServicesRequiredCapabilitiesWithHdr.
-func (to *Session) GetDeliveryServicesRequiredCapabilities(deliveryServiceID *int, xmlID, capability *string) ([]tc.DeliveryServicesRequiredCapability, ReqInf, error) {
+func (to *Session) GetDeliveryServicesRequiredCapabilities(deliveryServiceID *int, xmlID, capability *string) ([]tc.DeliveryServicesRequiredCapability, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServiceID, xmlID, capability, nil)
 }

--- a/traffic_ops/v3-client/deliveryserviceserver.go
+++ b/traffic_ops/v3-client/deliveryserviceserver.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // CreateDeliveryServiceServers associates the given servers with the given delivery services. If replace is true, it deletes any existing associations for the given delivery service.
-func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, replace bool) (*tc.DSServerIDs, ReqInf, error) {
+func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, replace bool) (*tc.DSServerIDs, toclientlib.ReqInf, error) {
 	req := tc.DSServerIDs{
 		DeliveryServiceID: util.IntPtr(dsID),
 		ServerIDs:         serverIDs,
@@ -43,7 +44,7 @@ func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, repla
 	return &resp.Response, reqInf, nil
 }
 
-func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := `/deliveryserviceserver/` + strconv.Itoa(dsID) + "/" + strconv.Itoa(serverID)
 	resp := tc.Alerts{}
 	reqInf, err := to.del(route, nil, &resp)
@@ -51,7 +52,7 @@ func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alert
 }
 
 // AssignServersToDeliveryService assigns the given list of servers to the delivery service with the given xmlId.
-func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string) (tc.Alerts, ReqInf, error) {
+func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf(APIDeliveryServicesServers, url.QueryEscape(xmlId))
 	dss := tc.DeliveryServiceServers{ServerNames: servers, XmlId: xmlId}
 	resp := tc.Alerts{}
@@ -62,38 +63,38 @@ func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string
 // GetDeliveryServiceServer returns associations between Delivery Services and servers using the
 // provided pagination controls.
 // Deprecated: GetDeliveryServiceServer will be removed in 6.0. Use GetDeliveryServiceServerWithHdr.
-func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceServerWithHdr(page, limit, nil)
 }
 
-func (to *Session) GetDeliveryServiceServerWithHdr(page, limit string, header http.Header) ([]tc.DeliveryServiceServer, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServerWithHdr(page, limit string, header http.Header) ([]tc.DeliveryServiceServer, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceServerResponse
 	// TODO: page and limit should be integers not strings
 	reqInf, err := to.get(APIDeliveryServiceServer+"?page="+url.QueryEscape(page)+"&limit="+url.QueryEscape(limit), header, &data)
 	return data.Response, reqInf, err
 }
 
-func (to *Session) GetDeliveryServiceServersWithHdr(h http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersWithHdr(h http.Header) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.getDeliveryServiceServers(url.Values{}, h)
 }
 
 // GetDeliveryServiceServers gets all delivery service servers, with the default API limit.
 // Deprecated: GetDeliveryServiceServers will be removed in 6.0. Use GetDeliveryServiceServersWithHdr.
-func (to *Session) GetDeliveryServiceServers() (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServers() (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceServersWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServiceServersNWithHdr(n int, header http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersNWithHdr(n int, header http.Header) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.getDeliveryServiceServers(url.Values{"limit": []string{strconv.Itoa(n)}}, header)
 }
 
 // GetDeliveryServiceServersN gets all delivery service servers, with a limit of n.
 // Deprecated: GetDeliveryServiceServersN will be removed in 6.0. Use GetDeliveryServiceServersNWithHdr.
-func (to *Session) GetDeliveryServiceServersN(n int) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersN(n int) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceServersNWithHdr(n, nil)
 }
 
-func (to *Session) GetDeliveryServiceServersWithLimitsWithHdr(limit int, deliveryServiceIDs []int, serverIDs []int, header http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersWithLimitsWithHdr(limit int, deliveryServiceIDs []int, serverIDs []int, header http.Header) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	vals := url.Values{}
 	if limit != 0 {
 		vals.Set("limit", strconv.Itoa(limit))
@@ -121,11 +122,11 @@ func (to *Session) GetDeliveryServiceServersWithLimitsWithHdr(limit int, deliver
 // GetDeliveryServiceServersWithLimits gets all delivery service servers, allowing specifying the limit of mappings to return, the delivery services to return, and the servers to return.
 // The limit may be 0, in which case the default limit will be applied. The deliveryServiceIDs and serverIDs may be nil or empty, in which case all delivery services and/or servers will be returned.
 // Deprecated: GetDeliveryServiceServersWithLimits will be removed in 6.0. Use GetDeliveryServiceServersWithLimitsWithHdr.
-func (to *Session) GetDeliveryServiceServersWithLimits(limit int, deliveryServiceIDs []int, serverIDs []int) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersWithLimits(limit int, deliveryServiceIDs []int, serverIDs []int) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceServersWithLimitsWithHdr(limit, deliveryServiceIDs, serverIDs, nil)
 }
 
-func (to *Session) getDeliveryServiceServers(urlQuery url.Values, h http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) getDeliveryServiceServers(urlQuery url.Values, h http.Header) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	route := APIDeliveryServiceServer
 	if qry := urlQuery.Encode(); qry != "" {
 		route += `?` + qry

--- a/traffic_ops/v3-client/division.go
+++ b/traffic_ops/v3-client/division.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,13 +32,13 @@ const (
 )
 
 // Create a Division
-func (to *Session) CreateDivision(division tc.Division) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateDivision(division tc.Division) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIDivisions, division, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateDivisionByIDWithHdr(id int, division tc.Division, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDivisionByIDWithHdr(id int, division tc.Division, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIDivisions, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, division, header, &alerts)
@@ -46,11 +47,11 @@ func (to *Session) UpdateDivisionByIDWithHdr(id int, division tc.Division, heade
 
 // Update a Division by ID
 // Deprecated: UpdateDivisionByID will be removed in 6.0. Use UpdateDivisionByIDWithHdr.
-func (to *Session) UpdateDivisionByID(id int, division tc.Division) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDivisionByID(id int, division tc.Division) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateDivisionByIDWithHdr(id, division, nil)
 }
 
-func (to *Session) GetDivisionsWithHdr(header http.Header) ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisionsWithHdr(header http.Header) ([]tc.Division, toclientlib.ReqInf, error) {
 	var data tc.DivisionsResponse
 	reqInf, err := to.get(APIDivisions, header, &data)
 	return data.Response, reqInf, err
@@ -58,11 +59,11 @@ func (to *Session) GetDivisionsWithHdr(header http.Header) ([]tc.Division, ReqIn
 
 // Returns a list of Divisions
 // Deprecated: GetDivisions will be removed in 6.0. Use GetDivisionsWithHdr.
-func (to *Session) GetDivisions() ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisions() ([]tc.Division, toclientlib.ReqInf, error) {
 	return to.GetDivisionsWithHdr(nil)
 }
 
-func (to *Session) GetDivisionByIDWithHdr(id int, header http.Header) ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisionByIDWithHdr(id int, header http.Header) ([]tc.Division, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIDivisions, id)
 	var data tc.DivisionsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -71,11 +72,11 @@ func (to *Session) GetDivisionByIDWithHdr(id int, header http.Header) ([]tc.Divi
 
 // GET a Division by the Division id
 // Deprecated: GetDivisionByID will be removed in 6.0. Use GetDivisionByIDWithHdr.
-func (to *Session) GetDivisionByID(id int) ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisionByID(id int) ([]tc.Division, toclientlib.ReqInf, error) {
 	return to.GetDivisionByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetDivisionByNameWithHdr(name string, header http.Header) ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisionByNameWithHdr(name string, header http.Header) ([]tc.Division, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APIDivisions, url.QueryEscape(name))
 	var data tc.DivisionsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -84,12 +85,12 @@ func (to *Session) GetDivisionByNameWithHdr(name string, header http.Header) ([]
 
 // GET a Division by the Division name
 // Deprecated: GetDivisionByName will be removed in 6.0. Use GetDivisionByNameWithHdr.
-func (to *Session) GetDivisionByName(name string) ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisionByName(name string) ([]tc.Division, toclientlib.ReqInf, error) {
 	return to.GetDivisionByNameWithHdr(name, nil)
 }
 
 // DELETE a Division by Division id
-func (to *Session) DeleteDivisionByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteDivisionByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIDivisions, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/dsuser.go
+++ b/traffic_ops/v3-client/dsuser.go
@@ -18,7 +18,7 @@ package client
 import (
 	"strconv"
 
-	tc "github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 // SetUserDeliveryService associates the given delivery services with the given user.

--- a/traffic_ops/v3-client/endpoints.go
+++ b/traffic_ops/v3-client/endpoints.go
@@ -19,8 +19,6 @@ package client
 // This isn't public, but only exists for deprecated public constants. It should be removed when they are.
 const apiBase = "/api/3.1"
 
-const apiBaseStr = "/api/"
-
 // apiVersions is the list of minor API versions in this client's major version.
 // This should be all minor versions from 0 up to the latest minor in Traffic Control
 // as of this client code.
@@ -31,25 +29,4 @@ func apiVersions() []string {
 		"3.1",
 		"3.0",
 	}
-}
-
-// APIBase returns the base API string for HTTP requests, such as /api/3.1.
-func (sn *Session) APIBase() string {
-	return apiBaseStr + sn.APIVersion()
-}
-
-// APIVersion is the version of the Traffic Ops API this client will use for requests.
-// If the client was created with any function except Login, or with UseLatestSupportedAPI false,
-// this will be LatestAPIVersion().
-// Otherwise, it will be the version dynamically determined to be the latest the Traffic Ops Server supports.
-func (sn *Session) APIVersion() string {
-	if sn.latestSupportedAPI != "" {
-		return sn.latestSupportedAPI
-	}
-	return sn.LatestAPIVersion()
-}
-
-// LatestAPIVersion returns the latest Traffic Ops API version this client supports.
-func (sn *Session) LatestAPIVersion() string {
-	return apiVersions()[0]
 }

--- a/traffic_ops/v3-client/federation.go
+++ b/traffic_ops/v3-client/federation.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // APIFederations is Deprecated: will be removed in the next major version. Be aware this may not be the URI being requested, for clients created with Login and ClientOps.ForceLatestAPI false.
@@ -31,7 +32,7 @@ const APIFederations = apiBase + "/federations"
 
 const APIFederationsPath = "/federations"
 
-func (to *Session) FederationsWithHdr(header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) FederationsWithHdr(header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	type FederationResponse struct {
 		Response []tc.AllDeliveryServiceFederationsMapping `json:"response"`
 	}
@@ -41,11 +42,11 @@ func (to *Session) FederationsWithHdr(header http.Header) ([]tc.AllDeliveryServi
 }
 
 // Deprecated: Federations will be removed in 6.0. Use FederationsWithHdr.
-func (to *Session) Federations() ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) Federations() ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	return to.FederationsWithHdr(nil)
 }
 
-func (to *Session) AllFederationsWithHdr(header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) AllFederationsWithHdr(header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	type FederationResponse struct {
 		Response []tc.AllDeliveryServiceFederationsMapping `json:"response"`
 	}
@@ -55,11 +56,11 @@ func (to *Session) AllFederationsWithHdr(header http.Header) ([]tc.AllDeliverySe
 }
 
 // Deprecated: AllFederations will be removed in 6.0. Use AllFederationsWithHdr.
-func (to *Session) AllFederations() ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) AllFederations() ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	return to.AllFederationsWithHdr(nil)
 }
 
-func (to *Session) AllFederationsForCDNWithHdr(cdnName string, header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) AllFederationsForCDNWithHdr(cdnName string, header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	// because the Federations JSON array is heterogeneous (array members may be a AllFederation or AllFederationCDN), we have to try decoding each separately.
 	type FederationResponse struct {
 		Response []json.RawMessage `json:"response"`
@@ -86,18 +87,18 @@ func (to *Session) AllFederationsForCDNWithHdr(cdnName string, header http.Heade
 }
 
 // Deprecated: AllFederationsForCDN will be removed in 6.0. Use AllFederationsForCDNWithHdr.
-func (to *Session) AllFederationsForCDN(cdnName string) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) AllFederationsForCDN(cdnName string) ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	return to.AllFederationsForCDNWithHdr(cdnName, nil)
 }
 
-func (to *Session) CreateFederationDeliveryServices(federationID int, deliveryServiceIDs []int, replace bool) (ReqInf, error) {
+func (to *Session) CreateFederationDeliveryServices(federationID int, deliveryServiceIDs []int, replace bool) (toclientlib.ReqInf, error) {
 	req := tc.FederationDSPost{DSIDs: deliveryServiceIDs, Replace: &replace}
 	resp := map[string]interface{}{}
 	inf, err := to.post(`/federations/`+strconv.Itoa(federationID)+`/deliveryservices`, req, nil, &resp)
 	return inf, err
 }
 
-func (to *Session) GetFederationDeliveryServicesWithHdr(federationID int, header http.Header) ([]tc.FederationDeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetFederationDeliveryServicesWithHdr(federationID int, header http.Header) ([]tc.FederationDeliveryServiceNullable, toclientlib.ReqInf, error) {
 	type FederationDSesResponse struct {
 		Response []tc.FederationDeliveryServiceNullable `json:"response"`
 	}
@@ -108,12 +109,12 @@ func (to *Session) GetFederationDeliveryServicesWithHdr(federationID int, header
 
 // GetFederationDeliveryServices Returns a given Federation's Delivery Services
 // Deprecated: GetFederationDeliveryServices will be removed in 6.0. Use GetFederationDeliveryServicesWithHdr.
-func (to *Session) GetFederationDeliveryServices(federationID int) ([]tc.FederationDeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetFederationDeliveryServices(federationID int) ([]tc.FederationDeliveryServiceNullable, toclientlib.ReqInf, error) {
 	return to.GetFederationDeliveryServicesWithHdr(federationID, nil)
 }
 
 // DeleteFederationDeliveryService Deletes a given Delivery Service from a Federation
-func (to *Session) DeleteFederationDeliveryService(federationID, deliveryServiceID int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteFederationDeliveryService(federationID, deliveryServiceID int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("/federations/%d/deliveryservices/%d", federationID, deliveryServiceID)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
@@ -121,14 +122,14 @@ func (to *Session) DeleteFederationDeliveryService(federationID, deliveryService
 }
 
 // GetFederationUsers Associates the given Users' IDs to a Federation
-func (to *Session) CreateFederationUsers(federationID int, userIDs []int, replace bool) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateFederationUsers(federationID int, userIDs []int, replace bool) (tc.Alerts, toclientlib.ReqInf, error) {
 	req := tc.FederationUserPost{IDs: userIDs, Replace: &replace}
 	var alerts tc.Alerts
 	inf, err := to.post(fmt.Sprintf("/federations/%d/users", federationID), req, nil, &alerts)
 	return alerts, inf, err
 }
 
-func (to *Session) GetFederationUsersWithHdr(federationID int, header http.Header) ([]tc.FederationUser, ReqInf, error) {
+func (to *Session) GetFederationUsersWithHdr(federationID int, header http.Header) ([]tc.FederationUser, toclientlib.ReqInf, error) {
 	type FederationUsersResponse struct {
 		Response []tc.FederationUser `json:"response"`
 	}
@@ -139,12 +140,12 @@ func (to *Session) GetFederationUsersWithHdr(federationID int, header http.Heade
 
 // GetFederationUsers Returns a given Federation's Users
 // Deprecated: GetFederationUsers will be removed in 6.0. Use GetFederationUsersWithHdr.
-func (to *Session) GetFederationUsers(federationID int) ([]tc.FederationUser, ReqInf, error) {
+func (to *Session) GetFederationUsers(federationID int) ([]tc.FederationUser, toclientlib.ReqInf, error) {
 	return to.GetFederationUsersWithHdr(federationID, nil)
 }
 
 // DeleteFederationUser Deletes a given User from a Federation
-func (to *Session) DeleteFederationUser(federationID, userID int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteFederationUser(federationID, userID int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("/federations/%d/users/%d", federationID, userID)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
@@ -153,7 +154,7 @@ func (to *Session) DeleteFederationUser(federationID, userID int) (tc.Alerts, Re
 
 // AddFederationResolverMappingsForCurrentUser adds Federation Resolver mappings to one or more
 // Delivery Services for the current user.
-func (to *Session) AddFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, ReqInf, error) {
+func (to *Session) AddFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIFederationsPath, mappings, nil, &alerts)
 	return alerts, reqInf, err
@@ -162,7 +163,7 @@ func (to *Session) AddFederationResolverMappingsForCurrentUser(mappings tc.Deliv
 // DeleteFederationResolverMappingsForCurrentUser removes ALL Federation Resolver mappings for ALL
 // Federations assigned to the currently authenticated user, as well as deleting ALL of the
 // Federation Resolvers themselves.
-func (to *Session) DeleteFederationResolverMappingsForCurrentUser() (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteFederationResolverMappingsForCurrentUser() (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.del(APIFederationsPath, nil, &alerts)
 	return alerts, reqInf, err
@@ -174,7 +175,7 @@ func (to *Session) DeleteFederationResolverMappingsForCurrentUser() (tc.Alerts, 
 // well as deleting ALL of the Federation Resolvers themselves. In other words, calling this is
 // equivalent to a call to DeleteFederationResolverMappingsForCurrentUser followed by a call to
 // AddFederationResolverMappingsForCurrentUser .
-func (to *Session) ReplaceFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, ReqInf, error) {
+func (to *Session) ReplaceFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.put(APIFederationsPath, mappings, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v3-client/federation_federation_resolver.go
+++ b/traffic_ops/v3-client/federation_federation_resolver.go
@@ -17,10 +17,11 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // GetFederationFederationResolversByID retrieves all Federation Resolvers belonging to Federation of ID.
-func (to *Session) GetFederationFederationResolversByID(id int) (tc.FederationFederationResolversResponse, ReqInf, error) {
+func (to *Session) GetFederationFederationResolversByID(id int) (tc.FederationFederationResolversResponse, toclientlib.ReqInf, error) {
 	path := fmt.Sprintf("/federations/%d/federation_resolvers", id)
 	resp := tc.FederationFederationResolversResponse{}
 	reqInf, err := to.get(path, nil, &resp)
@@ -28,7 +29,7 @@ func (to *Session) GetFederationFederationResolversByID(id int) (tc.FederationFe
 }
 
 // AssignFederationFederationResolver creates the Federation Resolver 'fr'.
-func (to *Session) AssignFederationFederationResolver(fedID int, resolverIDs []int, replace bool) (tc.AssignFederationFederationResolversResponse, ReqInf, error) {
+func (to *Session) AssignFederationFederationResolver(fedID int, resolverIDs []int, replace bool) (tc.AssignFederationFederationResolversResponse, toclientlib.ReqInf, error) {
 	path := fmt.Sprintf("/federations/%d/federation_resolvers", fedID)
 	req := tc.AssignFederationResolversRequest{
 		Replace:        replace,

--- a/traffic_ops/v3-client/federation_resolver.go
+++ b/traffic_ops/v3-client/federation_resolver.go
@@ -20,8 +20,9 @@ import "net/url"
 import "strconv"
 
 import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 
-func (to *Session) getFederationResolvers(id *uint, ip *string, t *string, header http.Header) ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) getFederationResolvers(id *uint, ip *string, t *string, header http.Header) ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	var vals = url.Values{}
 	if id != nil {
 		vals.Set("id", strconv.FormatUint(uint64(*id), 10))
@@ -45,17 +46,17 @@ func (to *Session) getFederationResolvers(id *uint, ip *string, t *string, heade
 	return data.Response, inf, err
 }
 
-func (to *Session) GetFederationResolversWithHdr(header http.Header) ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolversWithHdr(header http.Header) ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.getFederationResolvers(nil, nil, nil, header)
 }
 
 // GetFederationResolvers retrieves all Federation Resolvers from Traffic Ops
 // Deprecated: GetFederationResolvers will be removed in 6.0. Use GetFederationResolversWithHdr.
-func (to *Session) GetFederationResolvers() ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolvers() ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.GetFederationResolversWithHdr(nil)
 }
 
-func (to *Session) GetFederationResolverByIDWithHdr(ID uint, header http.Header) (tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolverByIDWithHdr(ID uint, header http.Header) (tc.FederationResolver, toclientlib.ReqInf, error) {
 	var fr tc.FederationResolver
 	frs, inf, err := to.getFederationResolvers(&ID, nil, nil, header)
 	if len(frs) > 0 {
@@ -66,11 +67,11 @@ func (to *Session) GetFederationResolverByIDWithHdr(ID uint, header http.Header)
 
 // GetFederationResolverByID retrieves a single Federation Resolver identified by ID.
 // Deprecated: GetFederationResolverByID will be removed in 6.0. Use GetFederationResolverByIDWithHdr.
-func (to *Session) GetFederationResolverByID(ID uint) (tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolverByID(ID uint) (tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.GetFederationResolverByIDWithHdr(ID, nil)
 }
 
-func (to *Session) GetFederationResolverByIPAddressWithHdr(ip string, header http.Header) (tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolverByIPAddressWithHdr(ip string, header http.Header) (tc.FederationResolver, toclientlib.ReqInf, error) {
 	var fr tc.FederationResolver
 	frs, inf, err := to.getFederationResolvers(nil, &ip, nil, header)
 	if len(frs) > 0 {
@@ -82,29 +83,29 @@ func (to *Session) GetFederationResolverByIPAddressWithHdr(ip string, header htt
 // GetFederationResolverByIPAddress retrieves the Federation Resolver that uses the IP address or
 // CIDR-notation subnet 'ip'.
 // Deprecated: GetFederationResolverByIPAddress will be removed in 6.0. Use GetFederationResolverByIPAddressWithHdr.
-func (to *Session) GetFederationResolverByIPAddress(ip string) (tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolverByIPAddress(ip string) (tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.GetFederationResolverByIPAddressWithHdr(ip, nil)
 }
 
-func (to *Session) GetFederationResolversByTypeWithHdr(t string, header http.Header) ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolversByTypeWithHdr(t string, header http.Header) ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.getFederationResolvers(nil, nil, &t, header)
 }
 
 // GetFederationResolversByType gets all Federation Resolvers that are of the Type named 't'.
 // Deprecated: GetFederationResolversByType will be removed in 6.0. Use GetFederationResolversByTypeWithHdr.
-func (to *Session) GetFederationResolversByType(t string) ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolversByType(t string) ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.GetFederationResolversByTypeWithHdr(t, nil)
 }
 
 // CreateFederationResolver creates the Federation Resolver 'fr'.
-func (to *Session) CreateFederationResolver(fr tc.FederationResolver) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateFederationResolver(fr tc.FederationResolver) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post("/federation_resolvers", fr, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteFederationResolver deletes the Federation Resolver identified by 'id'.
-func (to *Session) DeleteFederationResolver(id uint) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteFederationResolver(id uint) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	path := fmt.Sprintf("/federation_resolvers?id=%d", id)
 	reqInf, err := to.del(path, nil, &alerts)

--- a/traffic_ops/v3-client/iso.go
+++ b/traffic_ops/v3-client/iso.go
@@ -21,6 +21,7 @@ package client
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -35,7 +36,7 @@ const (
 // Structure of returned map:
 //  key:   Name of OS
 //  value: Directory where the ISO source can be found
-func (to *Session) GetOSVersions() (map[string]string, ReqInf, error) {
+func (to *Session) GetOSVersions() (map[string]string, toclientlib.ReqInf, error) {
 	var data struct {
 		Versions tc.OSVersionsResponse `json:"response"`
 	}

--- a/traffic_ops/v3-client/job.go
+++ b/traffic_ops/v3-client/job.go
@@ -22,17 +22,18 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // Creates a new Content Invalidation Job
-func (to *Session) CreateInvalidationJob(job tc.InvalidationJobInput) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateInvalidationJob(job tc.InvalidationJobInput) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(`/jobs`, job, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // Deletes a Content Invalidation Job
-func (to *Session) DeleteInvalidationJob(jobID uint64) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteInvalidationJob(jobID uint64) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.del(fmt.Sprintf("/jobs?id=%d", jobID), nil, &alerts)
 	return alerts, reqInf, err
@@ -40,7 +41,7 @@ func (to *Session) DeleteInvalidationJob(jobID uint64) (tc.Alerts, ReqInf, error
 }
 
 // Updates a Content Invalidation Job
-func (to *Session) UpdateInvalidationJob(job tc.InvalidationJob) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateInvalidationJob(job tc.InvalidationJob) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.put(fmt.Sprintf(`/jobs?id=%d`, *job.ID), job, nil, &alerts)
 	return alerts, reqInf, err
@@ -51,7 +52,7 @@ func (to *Session) UpdateInvalidationJob(job tc.InvalidationJob) (tc.Alerts, Req
 // that user are returned. Both deliveryServiceID and userID may be nil.
 //
 // Deprecated, use GetInvalidationJobs instead
-func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, ReqInf, error) {
+func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, toclientlib.ReqInf, error) {
 	params := url.Values{}
 	if deliveryServiceID != nil {
 		params.Add("dsId", strconv.Itoa(*deliveryServiceID))
@@ -82,7 +83,7 @@ func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, ReqIn
 // desired user (in the case of a float64 the fractional part is dropped, e.g. 3.45 -> 3), or it may
 // be a string, in which case it should be the username of the desired user, or it may be an actual
 // tc.User or tc.UserCurrent structure.
-func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc.InvalidationJob, ReqInf, error) {
+func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc.InvalidationJob, toclientlib.ReqInf, error) {
 	const DSIDKey = "dsId"
 	const DSKey = "deliveryService"
 	const UserKey = "userId"
@@ -106,10 +107,10 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 			} else if d.(tc.DeliveryServiceNullable).ID != nil {
 				params.Add(DSIDKey, strconv.FormatInt(int64(*d.(tc.DeliveryServiceNullable).ID), 10))
 			} else {
-				return nil, ReqInf{}, errors.New("no non-nil identifier on passed Delivery Service")
+				return nil, toclientlib.ReqInf{}, errors.New("no non-nil identifier on passed Delivery Service")
 			}
 		default:
-			return nil, ReqInf{}, fmt.Errorf("invalid type for argument 'ds': %T*", t)
+			return nil, toclientlib.ReqInf{}, fmt.Errorf("invalid type for argument 'ds': %T*", t)
 		}
 	}
 	if user != nil {
@@ -129,7 +130,7 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 			} else if u.(tc.User).ID != nil {
 				params.Add(UserKey, strconv.FormatInt(int64(*u.(tc.User).ID), 10))
 			} else {
-				return nil, ReqInf{}, errors.New("no non-nil identifier on passed User")
+				return nil, toclientlib.ReqInf{}, errors.New("no non-nil identifier on passed User")
 			}
 		case tc.UserCurrent:
 			if u.(tc.UserCurrent).UserName != nil {
@@ -137,10 +138,10 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 			} else if u.(tc.UserCurrent).ID != nil {
 				params.Add(UserKey, strconv.FormatInt(int64(*u.(tc.UserCurrent).ID), 10))
 			} else {
-				return nil, ReqInf{}, errors.New("no non-nil identifier on passed UserCurrent")
+				return nil, toclientlib.ReqInf{}, errors.New("no non-nil identifier on passed UserCurrent")
 			}
 		default:
-			return nil, ReqInf{}, fmt.Errorf("invalid type for argument 'user': %T*", t)
+			return nil, toclientlib.ReqInf{}, fmt.Errorf("invalid type for argument 'user': %T*", t)
 		}
 	}
 	path := "/jobs"

--- a/traffic_ops/v3-client/log.go
+++ b/traffic_ops/v3-client/log.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -29,7 +30,7 @@ const (
 )
 
 // GetLogsByQueryParams gets a list of logs filtered by query params.
-func (to *Session) GetLogsByQueryParams(queryParams string) ([]tc.Log, ReqInf, error) {
+func (to *Session) GetLogsByQueryParams(queryParams string) ([]tc.Log, toclientlib.ReqInf, error) {
 	uri := APILogs + queryParams
 	var data tc.LogsResponse
 	reqInf, err := to.get(uri, nil, &data)
@@ -37,16 +38,16 @@ func (to *Session) GetLogsByQueryParams(queryParams string) ([]tc.Log, ReqInf, e
 }
 
 // GetLogs gets a list of logs.
-func (to *Session) GetLogs() ([]tc.Log, ReqInf, error) {
+func (to *Session) GetLogs() ([]tc.Log, toclientlib.ReqInf, error) {
 	return to.GetLogsByQueryParams("")
 }
 
 // GetLogsByLimit gets a list of logs limited to a certain number of logs.
-func (to *Session) GetLogsByLimit(limit int) ([]tc.Log, ReqInf, error) {
+func (to *Session) GetLogsByLimit(limit int) ([]tc.Log, toclientlib.ReqInf, error) {
 	return to.GetLogsByQueryParams(fmt.Sprintf("?limit=%d", limit))
 }
 
 // GetLogsByDays gets a list of logs limited to a certain number of days.
-func (to *Session) GetLogsByDays(days int) ([]tc.Log, ReqInf, error) {
+func (to *Session) GetLogsByDays(days int) ([]tc.Log, toclientlib.ReqInf, error) {
 	return to.GetLogsByQueryParams(fmt.Sprintf("?days=%d", days))
 }

--- a/traffic_ops/v3-client/origin.go
+++ b/traffic_ops/v3-client/origin.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -89,9 +90,9 @@ func originIDs(to *Session, origin *tc.Origin) error {
 }
 
 // Create an Origin
-func (to *Session) CreateOrigin(origin tc.Origin) (*tc.OriginDetailResponse, ReqInf, error) {
+func (to *Session) CreateOrigin(origin tc.Origin) (*tc.OriginDetailResponse, toclientlib.ReqInf, error) {
 	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	reqInf := toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss, RemoteAddr: remoteAddr}
 
 	err := originIDs(to, &origin)
 	if err != nil {
@@ -102,9 +103,9 @@ func (to *Session) CreateOrigin(origin tc.Origin) (*tc.OriginDetailResponse, Req
 	return &originResp, reqInf, err
 }
 
-func (to *Session) UpdateOriginByIDWithHdr(id int, origin tc.Origin, header http.Header) (*tc.OriginDetailResponse, ReqInf, error) {
+func (to *Session) UpdateOriginByIDWithHdr(id int, origin tc.Origin, header http.Header) (*tc.OriginDetailResponse, toclientlib.ReqInf, error) {
 	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	reqInf := toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss, RemoteAddr: remoteAddr}
 
 	err := originIDs(to, &origin)
 	if err != nil {
@@ -118,12 +119,12 @@ func (to *Session) UpdateOriginByIDWithHdr(id int, origin tc.Origin, header http
 
 // Update an Origin by ID
 // Deprecated: UpdateOriginByID will be removed in 6.0. Use UpdateOriginByIDWithHdr.
-func (to *Session) UpdateOriginByID(id int, origin tc.Origin) (*tc.OriginDetailResponse, ReqInf, error) {
+func (to *Session) UpdateOriginByID(id int, origin tc.Origin) (*tc.OriginDetailResponse, toclientlib.ReqInf, error) {
 	return to.UpdateOriginByIDWithHdr(id, origin, nil)
 }
 
 // GET a list of Origins by a query parameter string
-func (to *Session) GetOriginsByQueryParams(queryParams string) ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOriginsByQueryParams(queryParams string) ([]tc.Origin, toclientlib.ReqInf, error) {
 	uri := APIOrigins + queryParams
 	var data tc.OriginsResponse
 	reqInf, err := to.get(uri, nil, &data)
@@ -131,27 +132,27 @@ func (to *Session) GetOriginsByQueryParams(queryParams string) ([]tc.Origin, Req
 }
 
 // Returns a list of Origins
-func (to *Session) GetOrigins() ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOrigins() ([]tc.Origin, toclientlib.ReqInf, error) {
 	return to.GetOriginsByQueryParams("")
 }
 
 // GET an Origin by the Origin ID
-func (to *Session) GetOriginByID(id int) ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOriginByID(id int) ([]tc.Origin, toclientlib.ReqInf, error) {
 	return to.GetOriginsByQueryParams(fmt.Sprintf("?id=%d", id))
 }
 
 // GET an Origin by the Origin name
-func (to *Session) GetOriginByName(name string) ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOriginByName(name string) ([]tc.Origin, toclientlib.ReqInf, error) {
 	return to.GetOriginsByQueryParams(fmt.Sprintf("?name=%s", url.QueryEscape(name)))
 }
 
 // GET a list of Origins by Delivery Service ID
-func (to *Session) GetOriginsByDeliveryServiceID(id int) ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOriginsByDeliveryServiceID(id int) ([]tc.Origin, toclientlib.ReqInf, error) {
 	return to.GetOriginsByQueryParams(fmt.Sprintf("?deliveryservice=%d", id))
 }
 
 // DELETE an Origin by ID
-func (to *Session) DeleteOriginByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteOriginByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIOrigins, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/parameter.go
+++ b/traffic_ops/v3-client/parameter.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,20 +32,20 @@ const (
 )
 
 // CreateParameter performs a POST to create a Parameter.
-func (to *Session) CreateParameter(pl tc.Parameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateParameter(pl tc.Parameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIParameters, pl, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // CreateMultipleParameters performs a POST to create multiple Parameters at once.
-func (to *Session) CreateMultipleParameters(pls []tc.Parameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateMultipleParameters(pls []tc.Parameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIParameters, pls, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateParameterByIDWithHdr(id int, pl tc.Parameter, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateParameterByIDWithHdr(id int, pl tc.Parameter, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIParameters, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, pl, header, &alerts)
@@ -53,11 +54,11 @@ func (to *Session) UpdateParameterByIDWithHdr(id int, pl tc.Parameter, header ht
 
 // UpdateParameterByID performs a PUT to update a Parameter by ID.
 // Deprecated: UpdateParameterByID will be removed in 6.0. Use UpdateParameterByIDWithHdr.
-func (to *Session) UpdateParameterByID(id int, pl tc.Parameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateParameterByID(id int, pl tc.Parameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateParameterByIDWithHdr(id, pl, nil)
 }
 
-func (to *Session) GetParametersWithHdr(header http.Header) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParametersWithHdr(header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	var data tc.ParametersResponse
 	reqInf, err := to.get(APIParameters, header, &data)
 	return data.Response, reqInf, err
@@ -65,11 +66,11 @@ func (to *Session) GetParametersWithHdr(header http.Header) ([]tc.Parameter, Req
 
 // GetParameters returns a list of Parameters.
 // Deprecated: GetParameters will be removed in 6.0. Use GetParametersWithHdr.
-func (to *Session) GetParameters() ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameters() ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParametersWithHdr(nil)
 }
 
-func (to *Session) GetParameterByIDWithHdr(id int, header http.Header) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByIDWithHdr(id int, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIParameters, id)
 	var data tc.ParametersResponse
 	reqInf, err := to.get(route, header, &data)
@@ -78,11 +79,11 @@ func (to *Session) GetParameterByIDWithHdr(id int, header http.Header) ([]tc.Par
 
 // GetParameterByID GETs a Parameter by the Parameter ID.
 // Deprecated: GetParameterByID will be removed in 6.0. Use GetParameterByIDWithHdr.
-func (to *Session) GetParameterByID(id int) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByID(id int) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetParameterByNameWithHdr(name string, header http.Header) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByNameWithHdr(name string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	uri := APIParameters + "?name=" + url.QueryEscape(name)
 	var data tc.ParametersResponse
 	reqInf, err := to.get(uri, header, &data)
@@ -91,11 +92,11 @@ func (to *Session) GetParameterByNameWithHdr(name string, header http.Header) ([
 
 // GetParameterByName GETs a Parameter by the Parameter name.
 // Deprecated: GetParameterByName will be removed in 6.0. Use GetParameterByNameWithHdr.
-func (to *Session) GetParameterByName(name string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByName(name string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetParameterByConfigFileWithHdr(configFile string, header http.Header) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByConfigFileWithHdr(configFile string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	uri := APIParameters + "?configFile=" + url.QueryEscape(configFile)
 	var data tc.ParametersResponse
 	reqInf, err := to.get(uri, header, &data)
@@ -104,11 +105,11 @@ func (to *Session) GetParameterByConfigFileWithHdr(configFile string, header htt
 
 // GetParameterByConfigFile GETs a Parameter by the Parameter ConfigFile.
 // Deprecated: GetParameterByConfigFile will be removed in 6.0. Use GetParameterByConfigFileWithHdr.
-func (to *Session) GetParameterByConfigFile(configFile string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByConfigFile(configFile string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByConfigFileWithHdr(configFile, nil)
 }
 
-func (to *Session) GetParameterByNameAndConfigFileWithHdr(name string, configFile string, header http.Header) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByNameAndConfigFileWithHdr(name string, configFile string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	uri := fmt.Sprintf("%s?name=%s&configFile=%s", APIParameters, url.QueryEscape(name), url.QueryEscape(configFile))
 	var data tc.ParametersResponse
 	reqInf, err := to.get(uri, header, &data)
@@ -117,11 +118,11 @@ func (to *Session) GetParameterByNameAndConfigFileWithHdr(name string, configFil
 
 // GetParameterByNameAndConfigFile GETs a Parameter by the Parameter Name and ConfigFile.
 // Deprecated: GetParameterByNameAndConfigFile will be removed in 6.0. Use GetParameterByNameAndConfigFileWithHdr.
-func (to *Session) GetParameterByNameAndConfigFile(name string, configFile string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByNameAndConfigFile(name string, configFile string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByNameAndConfigFileWithHdr(name, configFile, nil)
 }
 
-func (to *Session) GetParameterByNameAndConfigFileAndValueWithHdr(name, configFile, value string, header http.Header) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByNameAndConfigFileAndValueWithHdr(name, configFile, value string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	params, reqInf, err := to.GetParameterByNameAndConfigFileWithHdr(name, configFile, header)
 	if reqInf.StatusCode == http.StatusNotModified {
 		return []tc.Parameter{}, reqInf, nil
@@ -141,12 +142,12 @@ func (to *Session) GetParameterByNameAndConfigFileAndValueWithHdr(name, configFi
 // TODO: API should support all 3, but does not support filter by value
 // currently. Until then, loop through hits until you find one with that value.
 // Deprecated: GetParameterByNameAndConfigFileAndValue will be removed in 6.0. Use GetParameterByNameAndConfigFileAndValueWithHdr.
-func (to *Session) GetParameterByNameAndConfigFileAndValue(name, configFile, value string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByNameAndConfigFileAndValue(name, configFile, value string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByNameAndConfigFileAndValueWithHdr(name, configFile, value, nil)
 }
 
 // DeleteParameterByID DELETEs a Parameter by ID.
-func (to *Session) DeleteParameterByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteParameterByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	uri := fmt.Sprintf("%s/%d", APIParameters, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(uri, nil, &alerts)

--- a/traffic_ops/v3-client/phys_location.go
+++ b/traffic_ops/v3-client/phys_location.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -32,14 +33,14 @@ const (
 )
 
 // CreatePhysLocation creates a PhysLocation.
-func (to *Session) CreatePhysLocation(pl tc.PhysLocation) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreatePhysLocation(pl tc.PhysLocation) (tc.Alerts, toclientlib.ReqInf, error) {
 	if pl.RegionID == 0 && pl.RegionName != "" {
 		regions, _, err := to.GetRegionByNameWithHdr(pl.RegionName, nil)
 		if err != nil {
-			return tc.Alerts{}, ReqInf{}, err
+			return tc.Alerts{}, toclientlib.ReqInf{}, err
 		}
 		if len(regions) == 0 {
-			return tc.Alerts{}, ReqInf{}, errors.New("no region with name " + pl.RegionName)
+			return tc.Alerts{}, toclientlib.ReqInf{}, errors.New("no region with name " + pl.RegionName)
 		}
 		pl.RegionID = regions[0].ID
 	}
@@ -48,7 +49,7 @@ func (to *Session) CreatePhysLocation(pl tc.PhysLocation) (tc.Alerts, ReqInf, er
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdatePhysLocationByIDWithHdr(id int, pl tc.PhysLocation, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdatePhysLocationByIDWithHdr(id int, pl tc.PhysLocation, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIPhysLocations, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, pl, header, &alerts)
@@ -57,11 +58,11 @@ func (to *Session) UpdatePhysLocationByIDWithHdr(id int, pl tc.PhysLocation, hea
 
 // Update a PhysLocation by ID
 // Deprecated: UpdatePhysLocationByID will be removed in 6.0. Use UpdatePhysLocationByIDWithHdr.
-func (to *Session) UpdatePhysLocationByID(id int, pl tc.PhysLocation) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdatePhysLocationByID(id int, pl tc.PhysLocation) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdatePhysLocationByIDWithHdr(id, pl, nil)
 }
 
-func (to *Session) GetPhysLocationsWithHdr(params map[string]string, header http.Header) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocationsWithHdr(params map[string]string, header http.Header) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	path := APIPhysLocations + mapToQueryParameters(params)
 	var data tc.PhysLocationsResponse
 	reqInf, err := to.get(path, header, &data)
@@ -70,11 +71,11 @@ func (to *Session) GetPhysLocationsWithHdr(params map[string]string, header http
 
 // Returns a list of PhysLocations with optional query parameters applied
 // Deprecated: GetPhysLocations will be removed in 6.0. Use GetPhysLocationsWithHdr.
-func (to *Session) GetPhysLocations(params map[string]string) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocations(params map[string]string) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	return to.GetPhysLocationsWithHdr(params, nil)
 }
 
-func (to *Session) GetPhysLocationByIDWithHdr(id int, header http.Header) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocationByIDWithHdr(id int, header http.Header) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIPhysLocations, id)
 	var data tc.PhysLocationsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -83,11 +84,11 @@ func (to *Session) GetPhysLocationByIDWithHdr(id int, header http.Header) ([]tc.
 
 // GET a PhysLocation by the PhysLocation ID
 // Deprecated: GetPhysLocationByID will be removed in 6.0. Use GetPhysLocationByIDWithHdr.
-func (to *Session) GetPhysLocationByID(id int) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocationByID(id int) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	return to.GetPhysLocationByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetPhysLocationByNameWithHdr(name string, header http.Header) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocationByNameWithHdr(name string, header http.Header) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APIPhysLocations, url.QueryEscape(name))
 	var data tc.PhysLocationsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -96,12 +97,12 @@ func (to *Session) GetPhysLocationByNameWithHdr(name string, header http.Header)
 
 // GET a PhysLocation by the PhysLocation name
 // Deprecated: GetPhysLocationByName will be removed in 6.0. Use GetPhysLocationByNameWithHdr.
-func (to *Session) GetPhysLocationByName(name string) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocationByName(name string) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	return to.GetPhysLocationByNameWithHdr(name, nil)
 }
 
 // DELETE a PhysLocation by ID
-func (to *Session) DeletePhysLocationByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeletePhysLocationByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIPhysLocations, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/ping.go
+++ b/traffic_ops/v3-client/ping.go
@@ -15,6 +15,10 @@
 
 package client
 
+import (
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+)
+
 const (
 	// API_PING is Deprecated: will be removed in the next major version. Be aware this may not be the URI being requested, for clients created with Login and ClientOps.ForceLatestAPI false.
 	API_PING = apiBase + "/ping"
@@ -23,7 +27,7 @@ const (
 )
 
 // Ping returns a static json object to show that traffic_ops is responsive
-func (to *Session) Ping() (map[string]string, ReqInf, error) {
+func (to *Session) Ping() (map[string]string, toclientlib.ReqInf, error) {
 	var data map[string]string
 	reqInf, err := to.get(APIPing, nil, &data)
 	return data, reqInf, err

--- a/traffic_ops/v3-client/profile.go
+++ b/traffic_ops/v3-client/profile.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -35,11 +36,11 @@ const (
 )
 
 // CreateProfile creates a Profile.
-func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, toclientlib.ReqInf, error) {
 	if pl.CDNID == 0 && pl.CDNName != "" {
 		cdns, _, err := to.GetCDNByNameWithHdr(pl.CDNName, nil)
 		if err != nil {
-			return tc.Alerts{}, ReqInf{}, err
+			return tc.Alerts{}, toclientlib.ReqInf{}, err
 		}
 		if len(cdns) == 0 {
 			return tc.Alerts{
@@ -50,7 +51,7 @@ func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, ReqInf, error) {
 						},
 					},
 				},
-				ReqInf{},
+				toclientlib.ReqInf{},
 				fmt.Errorf("no CDN with name %s", pl.CDNName)
 		}
 		pl.CDNID = cdns[0].ID
@@ -61,7 +62,7 @@ func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateProfileByIDWithHdr(id int, pl tc.Profile, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateProfileByIDWithHdr(id int, pl tc.Profile, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIProfiles, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, pl, header, &alerts)
@@ -70,11 +71,11 @@ func (to *Session) UpdateProfileByIDWithHdr(id int, pl tc.Profile, header http.H
 
 // UpdateProfileByID updates a Profile by ID.
 // Deprecated: UpdateProfileByID will be removed in 6.0. Use UpdateProfileByIDWithHdr.
-func (to *Session) UpdateProfileByID(id int, pl tc.Profile) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateProfileByID(id int, pl tc.Profile) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateProfileByIDWithHdr(id, pl, nil)
 }
 
-func (to *Session) GetParametersByProfileNameWithHdr(profileName string, header http.Header) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParametersByProfileNameWithHdr(profileName string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf(APIProfilesNameParameters, profileName)
 	var data tc.ParametersResponse
 	reqInf, err := to.get(route, header, &data)
@@ -83,11 +84,11 @@ func (to *Session) GetParametersByProfileNameWithHdr(profileName string, header 
 
 // GetParametersByProfileName gets all of the Parameters assigned to the Profile named 'profileName'.
 // Deprecated: GetParametersByProfileName will be removed in 6.0. Use GetParametersByProfileNameWithHdr.
-func (to *Session) GetParametersByProfileName(profileName string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParametersByProfileName(profileName string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParametersByProfileNameWithHdr(profileName, nil)
 }
 
-func (to *Session) GetProfilesWithHdr(header http.Header) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfilesWithHdr(header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(APIProfiles, header, &data)
 	return data.Response, reqInf, err
@@ -95,11 +96,11 @@ func (to *Session) GetProfilesWithHdr(header http.Header) ([]tc.Profile, ReqInf,
 
 // GetProfiles returns a list of Profiles.
 // Deprecated: GetProfiles will be removed in 6.0. Use GetProfilesWithHdr.
-func (to *Session) GetProfiles() ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfiles() ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfilesWithHdr(nil)
 }
 
-func (to *Session) GetProfileByIDWithHdr(id int, header http.Header) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByIDWithHdr(id int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIProfiles, id)
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -108,11 +109,11 @@ func (to *Session) GetProfileByIDWithHdr(id int, header http.Header) ([]tc.Profi
 
 // GetProfileByID GETs a Profile by the Profile ID.
 // Deprecated: GetProfileByID will be removed in 6.0. Use GetProfileByIDWithHdr.
-func (to *Session) GetProfileByID(id int) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByID(id int) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetProfileByNameWithHdr(name string, header http.Header) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByNameWithHdr(name string, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
 	URI := fmt.Sprintf("%s?name=%s", APIProfiles, url.QueryEscape(name))
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
@@ -121,11 +122,11 @@ func (to *Session) GetProfileByNameWithHdr(name string, header http.Header) ([]t
 
 // GetProfileByName GETs a Profile by the Profile name.
 // Deprecated: GetProfileByName will be removed in 6.0. Use GetProfileByNameWithHdr.
-func (to *Session) GetProfileByName(name string) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByName(name string) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
 	URI := fmt.Sprintf("%s?param=%s", APIProfiles, url.QueryEscape(param))
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
@@ -134,11 +135,11 @@ func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header
 
 // GetProfileByParameter GETs a Profile by the Profile "param".
 // Deprecated: GetProfileByParameter will be removed in 6.0. Use GetProfileByParameterWithHdr.
-func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByParameterWithHdr(param, nil)
 }
 
-func (to *Session) GetProfileByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
 	uri := fmt.Sprintf("%s?cdn=%d", APIProfiles, cdnID)
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(uri, header, &data)
@@ -147,12 +148,12 @@ func (to *Session) GetProfileByCDNIDWithHdr(cdnID int, header http.Header) ([]tc
 
 // GetProfileByCDNID GETs a Profile by the Profile CDN ID.
 // Deprecated: GetProfileByCDNID will be removed in 6.0. Use GetProfileByCDNIDWithHdr.
-func (to *Session) GetProfileByCDNID(cdnID int) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByCDNID(cdnID int) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByCDNIDWithHdr(cdnID, nil)
 }
 
 // DeleteProfileByID DELETEs a Profile by ID.
-func (to *Session) DeleteProfileByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteProfileByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	uri := fmt.Sprintf("%s/%d", APIProfiles, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(uri, nil, &alerts)
@@ -160,7 +161,7 @@ func (to *Session) DeleteProfileByID(id int) (tc.Alerts, ReqInf, error) {
 }
 
 // ExportProfile Returns an exported Profile.
-func (to *Session) ExportProfile(id int) (*tc.ProfileExportResponse, ReqInf, error) {
+func (to *Session) ExportProfile(id int) (*tc.ProfileExportResponse, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d/export", APIProfiles, id)
 	var data tc.ProfileExportResponse
 	reqInf, err := to.get(route, nil, &data)
@@ -168,7 +169,7 @@ func (to *Session) ExportProfile(id int) (*tc.ProfileExportResponse, ReqInf, err
 }
 
 // ImportProfile imports an exported Profile.
-func (to *Session) ImportProfile(importRequest *tc.ProfileImportRequest) (*tc.ProfileImportResponse, ReqInf, error) {
+func (to *Session) ImportProfile(importRequest *tc.ProfileImportRequest) (*tc.ProfileImportResponse, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/import", APIProfiles)
 	var data tc.ProfileImportResponse
 	reqInf, err := to.post(route, importRequest, nil, &data)
@@ -176,7 +177,7 @@ func (to *Session) ImportProfile(importRequest *tc.ProfileImportRequest) (*tc.Pr
 }
 
 // CopyProfile creates a new profile from an existing profile.
-func (to *Session) CopyProfile(p tc.ProfileCopy) (tc.ProfileCopyResponse, ReqInf, error) {
+func (to *Session) CopyProfile(p tc.ProfileCopy) (tc.ProfileCopyResponse, toclientlib.ReqInf, error) {
 	path := fmt.Sprintf("%s/name/%s/copy/%s", APIProfiles, p.Name, p.ExistingName)
 	resp := tc.ProfileCopyResponse{}
 	reqInf, err := to.post(path, p, nil, &resp)

--- a/traffic_ops/v3-client/profile_parameter.go
+++ b/traffic_ops/v3-client/profile_parameter.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -32,30 +33,30 @@ const (
 )
 
 // Create a ProfileParameter
-func (to *Session) CreateProfileParameter(pp tc.ProfileParameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateProfileParameter(pp tc.ProfileParameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIProfileParameters, pp, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // CreateMultipleProfileParameters creates multiple ProfileParameters at once.
-func (to *Session) CreateMultipleProfileParameters(pps []tc.ProfileParameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateMultipleProfileParameters(pps []tc.ProfileParameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIProfileParameters, pps, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetProfileParametersWithHdr(header http.Header) ([]tc.ProfileParameter, ReqInf, error) {
+func (to *Session) GetProfileParametersWithHdr(header http.Header) ([]tc.ProfileParameter, toclientlib.ReqInf, error) {
 	return to.GetProfileParameterByQueryParamsWithHdr("", header)
 }
 
 // Returns a list of Profile Parameters
 // Deprecated: GetProfileParameters will be removed in 6.0. Use GetProfileParametersWithHdr.
-func (to *Session) GetProfileParameters() ([]tc.ProfileParameter, ReqInf, error) {
+func (to *Session) GetProfileParameters() ([]tc.ProfileParameter, toclientlib.ReqInf, error) {
 	return to.GetProfileParametersWithHdr(nil)
 }
 
-func (to *Session) GetProfileParameterByQueryParamsWithHdr(queryParams string, header http.Header) ([]tc.ProfileParameter, ReqInf, error) {
+func (to *Session) GetProfileParameterByQueryParamsWithHdr(queryParams string, header http.Header) ([]tc.ProfileParameter, toclientlib.ReqInf, error) {
 	uri := APIProfileParameters + queryParams
 	var data tc.ProfileParametersNullableResponse
 	reqInf, err := to.get(uri, header, &data)
@@ -77,12 +78,12 @@ func (to *Session) GetProfileParameterByQueryParamsWithHdr(queryParams string, h
 
 // GET a Profile Parameter by the Parameter
 // Deprecated: GetProfileParameterByQueryParams will be removed in 6.0. Use GetProfileParameterByQueryParamsWithHdr.
-func (to *Session) GetProfileParameterByQueryParams(queryParams string) ([]tc.ProfileParameter, ReqInf, error) {
+func (to *Session) GetProfileParameterByQueryParams(queryParams string) ([]tc.ProfileParameter, toclientlib.ReqInf, error) {
 	return to.GetProfileParameterByQueryParamsWithHdr(queryParams, nil)
 }
 
 // DELETE a Parameter by Parameter
-func (to *Session) DeleteParameterByProfileParameter(profile int, parameter int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteParameterByProfileParameter(profile int, parameter int) (tc.Alerts, toclientlib.ReqInf, error) {
 	uri := fmt.Sprintf("%s/%d/%d", APIProfileParameters, profile, parameter)
 	var alerts tc.Alerts
 	reqInf, err := to.del(uri, nil, &alerts)

--- a/traffic_ops/v3-client/region.go
+++ b/traffic_ops/v3-client/region.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -33,14 +34,14 @@ const (
 )
 
 // CreateRegion creates a Region.
-func (to *Session) CreateRegion(region tc.Region) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateRegion(region tc.Region) (tc.Alerts, toclientlib.ReqInf, error) {
 	if region.Division == 0 && region.DivisionName != "" {
 		divisions, _, err := to.GetDivisionByNameWithHdr(region.DivisionName, nil)
 		if err != nil {
-			return tc.Alerts{}, ReqInf{}, err
+			return tc.Alerts{}, toclientlib.ReqInf{}, err
 		}
 		if len(divisions) == 0 {
-			return tc.Alerts{}, ReqInf{}, errors.New("no division with name " + region.DivisionName)
+			return tc.Alerts{}, toclientlib.ReqInf{}, errors.New("no division with name " + region.DivisionName)
 		}
 		region.Division = divisions[0].ID
 	}
@@ -49,7 +50,7 @@ func (to *Session) CreateRegion(region tc.Region) (tc.Alerts, ReqInf, error) {
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateRegionByIDWithHdr(id int, region tc.Region, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateRegionByIDWithHdr(id int, region tc.Region, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIRegions, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, region, header, &alerts)
@@ -58,11 +59,11 @@ func (to *Session) UpdateRegionByIDWithHdr(id int, region tc.Region, header http
 
 // UpdateRegionByID updates a Region by ID.
 // Deprecated: UpdateRegionByID will be removed in 6.0. Use UpdateRegionByIDWithHdr.
-func (to *Session) UpdateRegionByID(id int, region tc.Region) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateRegionByID(id int, region tc.Region) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateRegionByIDWithHdr(id, region, nil)
 }
 
-func (to *Session) GetRegionsWithHdr(header http.Header) ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegionsWithHdr(header http.Header) ([]tc.Region, toclientlib.ReqInf, error) {
 	var data tc.RegionsResponse
 	reqInf, err := to.get(APIRegions, header, &data)
 	return data.Response, reqInf, err
@@ -70,11 +71,11 @@ func (to *Session) GetRegionsWithHdr(header http.Header) ([]tc.Region, ReqInf, e
 
 // GetRegions returns a list of regions.
 // Deprecated: GetRegions will be removed in 6.0. Use GetRegionsWithHdr.
-func (to *Session) GetRegions() ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegions() ([]tc.Region, toclientlib.ReqInf, error) {
 	return to.GetRegionsWithHdr(nil)
 }
 
-func (to *Session) GetRegionByIDWithHdr(id int, header http.Header) ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegionByIDWithHdr(id int, header http.Header) ([]tc.Region, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIRegions, id)
 	var data tc.RegionsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -83,11 +84,11 @@ func (to *Session) GetRegionByIDWithHdr(id int, header http.Header) ([]tc.Region
 
 // GetRegionByID GETs a Region by the Region ID.
 // Deprecated: GetRegionByID will be removed in 6.0. Use GetRegionByIDWithHdr.
-func (to *Session) GetRegionByID(id int) ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegionByID(id int) ([]tc.Region, toclientlib.ReqInf, error) {
 	return to.GetRegionByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetRegionByNameWithHdr(name string, header http.Header) ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegionByNameWithHdr(name string, header http.Header) ([]tc.Region, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APIRegions, url.QueryEscape(name))
 	var data tc.RegionsResponse
 	reqInf, err := to.get(route, header, &data)
@@ -96,12 +97,12 @@ func (to *Session) GetRegionByNameWithHdr(name string, header http.Header) ([]tc
 
 // GetRegionByName GETs a Region by the Region name.
 // Deprecated: GetRegionByName will be removed in 6.0. Use GetRegionByNameHdr.
-func (to *Session) GetRegionByName(name string) ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegionByName(name string) ([]tc.Region, toclientlib.ReqInf, error) {
 	return to.GetRegionByNameWithHdr(name, nil)
 }
 
 // DeleteRegionByID DELETEs a Region by ID.
-func (to *Session) DeleteRegionByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteRegionByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIRegions, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
@@ -109,7 +110,7 @@ func (to *Session) DeleteRegionByID(id int) (tc.Alerts, ReqInf, error) {
 }
 
 // DeleteRegion lets you DELETE a Region. Only 1 parameter is required, not both.
-func (to *Session) DeleteRegion(id *int, name *string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteRegion(id *int, name *string) (tc.Alerts, toclientlib.ReqInf, error) {
 	v := url.Values{}
 	if id != nil {
 		v.Add("id", strconv.Itoa(*id))

--- a/traffic_ops/v3-client/role.go
+++ b/traffic_ops/v3-client/role.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,13 +32,13 @@ const (
 )
 
 // CreateRole creates a Role.
-func (to *Session) CreateRole(role tc.Role) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) CreateRole(role tc.Role) (tc.Alerts, toclientlib.ReqInf, int, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIRoles, role, nil, &alerts)
 	return alerts, reqInf, reqInf.StatusCode, err
 }
 
-func (to *Session) UpdateRoleByIDWithHdr(id int, role tc.Role, header http.Header) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) UpdateRoleByIDWithHdr(id int, role tc.Role, header http.Header) (tc.Alerts, toclientlib.ReqInf, int, error) {
 	route := fmt.Sprintf("%s/?id=%d", APIRoles, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, role, header, &alerts)
@@ -46,12 +47,12 @@ func (to *Session) UpdateRoleByIDWithHdr(id int, role tc.Role, header http.Heade
 
 // UpdateRoleByID updates a Role by ID.
 // Deprecated: UpdateRoleByID will be removed in 6.0. Use UpdateRoleByIDWithHdr.
-func (to *Session) UpdateRoleByID(id int, role tc.Role) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) UpdateRoleByID(id int, role tc.Role) (tc.Alerts, toclientlib.ReqInf, int, error) {
 
 	return to.UpdateRoleByIDWithHdr(id, role, nil)
 }
 
-func (to *Session) GetRolesWithHdr(header http.Header) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRolesWithHdr(header http.Header) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	var data tc.RolesResponse
 	reqInf, err := to.get(APIRoles, header, &data)
 	return data.Response, reqInf, reqInf.StatusCode, err
@@ -59,11 +60,11 @@ func (to *Session) GetRolesWithHdr(header http.Header) ([]tc.Role, ReqInf, int, 
 
 // GetRoles returns a list of roles.
 // Deprecated: GetRoles will be removed in 6.0. Use GetRolesWithHdr.
-func (to *Session) GetRoles() ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoles() ([]tc.Role, toclientlib.ReqInf, int, error) {
 	return to.GetRolesWithHdr(nil)
 }
 
-func (to *Session) GetRoleByIDWithHdr(id int, header http.Header) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByIDWithHdr(id int, header http.Header) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	route := fmt.Sprintf("%s/?id=%d", APIRoles, id)
 	var data tc.RolesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -72,11 +73,11 @@ func (to *Session) GetRoleByIDWithHdr(id int, header http.Header) ([]tc.Role, Re
 
 // GetRoleByID GETs a Role by the Role ID.
 // Deprecated: GetRoleByID will be removed in 6.0. Use GetRoleByIDWithHdr.
-func (to *Session) GetRoleByID(id int) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByID(id int) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	return to.GetRoleByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetRoleByNameWithHdr(name string, header http.Header) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByNameWithHdr(name string, header http.Header) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	route := fmt.Sprintf("%s?name=%s", APIRoles, url.QueryEscape(name))
 	var data tc.RolesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -85,11 +86,11 @@ func (to *Session) GetRoleByNameWithHdr(name string, header http.Header) ([]tc.R
 
 // GetRoleByName GETs a Role by the Role name.
 // Deprecated: GetRoleByName will be removed in 6.0. Use GetRoleByNameWithHdr.
-func (to *Session) GetRoleByName(name string) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByName(name string) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	return to.GetRoleByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetRoleByQueryParamsWithHdr(queryParams map[string]string, header http.Header) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByQueryParamsWithHdr(queryParams map[string]string, header http.Header) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	route := fmt.Sprintf("%s%s", APIRoles, mapToQueryParameters(queryParams))
 	var data tc.RolesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -98,12 +99,12 @@ func (to *Session) GetRoleByQueryParamsWithHdr(queryParams map[string]string, he
 
 // GetRoleByQueryParams gets a Role by the Role query parameters.
 // Deprecated: GetRoleByQueryParams will be removed in 6.0. Use GetRoleByQueryParamsWithHdr.
-func (to *Session) GetRoleByQueryParams(queryParams map[string]string) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByQueryParams(queryParams map[string]string) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	return to.GetRoleByQueryParamsWithHdr(queryParams, nil)
 }
 
 // DeleteRoleByID DELETEs a Role by ID.
-func (to *Session) DeleteRoleByID(id int) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) DeleteRoleByID(id int) (tc.Alerts, toclientlib.ReqInf, int, error) {
 	route := fmt.Sprintf("%s/?id=%d", APIRoles, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/server_server_capabilities.go
+++ b/traffic_ops/v3-client/server_server_capabilities.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -32,14 +33,14 @@ const (
 )
 
 // CreateServerServerCapability assigns a Server Capability to a Server
-func (to *Session) CreateServerServerCapability(ssc tc.ServerServerCapability) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateServerServerCapability(ssc tc.ServerServerCapability) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIServerServerCapabilities, ssc, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteServerServerCapability unassigns a Server Capability from a Server
-func (to *Session) DeleteServerServerCapability(serverID int, serverCapability string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteServerServerCapability(serverID int, serverCapability string) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	v := url.Values{}
 	v.Add("serverId", strconv.Itoa(serverID))
@@ -50,7 +51,7 @@ func (to *Session) DeleteServerServerCapability(serverID int, serverCapability s
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetServerServerCapabilitiesWithHdr(serverID *int, serverHostName, serverCapability *string, header http.Header) ([]tc.ServerServerCapability, ReqInf, error) {
+func (to *Session) GetServerServerCapabilitiesWithHdr(serverID *int, serverHostName, serverCapability *string, header http.Header) ([]tc.ServerServerCapability, toclientlib.ReqInf, error) {
 	v := url.Values{}
 	if serverID != nil {
 		v.Add("serverId", strconv.Itoa(*serverID))
@@ -76,6 +77,6 @@ func (to *Session) GetServerServerCapabilitiesWithHdr(serverID *int, serverHostN
 // GetServerServerCapabilities retrieves a list of Server Capabilities that are assigned to a Server
 // Callers can filter the results by server id, server host name and/or server capability via the optional parameters
 // Deprecated: GetServerServerCapabilities will be removed in 6.0. Use GetServerServerCapabilitiesWithHdr.
-func (to *Session) GetServerServerCapabilities(serverID *int, serverHostName, serverCapability *string) ([]tc.ServerServerCapability, ReqInf, error) {
+func (to *Session) GetServerServerCapabilities(serverID *int, serverHostName, serverCapability *string) ([]tc.ServerServerCapability, toclientlib.ReqInf, error) {
 	return to.GetServerServerCapabilitiesWithHdr(serverID, serverHostName, serverCapability, nil)
 }

--- a/traffic_ops/v3-client/server_update_status.go
+++ b/traffic_ops/v3-client/server_update_status.go
@@ -22,10 +22,11 @@ import (
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // UpdateServerStatus updates a server's status and returns the response.
-func (to *Session) UpdateServerStatus(serverID int, req tc.ServerPutStatus) (*tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateServerStatus(serverID int, req tc.ServerPutStatus) (*tc.Alerts, toclientlib.ReqInf, error) {
 	path := fmt.Sprintf("/servers/%d/status", serverID)
 	alerts := tc.Alerts{}
 	reqInf, err := to.put(path, req, nil, &alerts)
@@ -41,7 +42,7 @@ var queueUpdateActions = map[bool]string{
 }
 
 // SetServerQueueUpdate updates a server's status and returns the response.
-func (to *Session) SetServerQueueUpdate(serverID int, queueUpdate bool) (tc.ServerQueueUpdateResponse, ReqInf, error) {
+func (to *Session) SetServerQueueUpdate(serverID int, queueUpdate bool) (tc.ServerQueueUpdateResponse, toclientlib.ReqInf, error) {
 	req := tc.ServerQueueUpdateRequest{Action: queueUpdateActions[queueUpdate]}
 	resp := tc.ServerQueueUpdateResponse{}
 	path := fmt.Sprintf("/servers/%d/queue_update", serverID)
@@ -51,8 +52,8 @@ func (to *Session) SetServerQueueUpdate(serverID int, queueUpdate bool) (tc.Serv
 
 // UpdateServerStatus updates a server's queue status and/or reval status.
 // Either updateStatus or revalStatus may be nil, in which case that status isn't updated (but not both, because that wouldn't do anything).
-func (to *Session) SetUpdateServerStatuses(serverName string, updateStatus *bool, revalStatus *bool) (ReqInf, error) {
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+func (to *Session) SetUpdateServerStatuses(serverName string, updateStatus *bool, revalStatus *bool) (toclientlib.ReqInf, error) {
+	reqInf := toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}
 	if updateStatus == nil && revalStatus == nil {
 		return reqInf, errors.New("either updateStatus or revalStatus must be non-nil; nothing to do")
 	}

--- a/traffic_ops/v3-client/servercapability.go
+++ b/traffic_ops/v3-client/servercapability.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,7 +32,7 @@ const (
 )
 
 // CreateServerCapability creates a server capability and returns the response.
-func (to *Session) CreateServerCapability(sc tc.ServerCapability) (*tc.ServerCapabilityDetailResponse, ReqInf, error) {
+func (to *Session) CreateServerCapability(sc tc.ServerCapability) (*tc.ServerCapabilityDetailResponse, toclientlib.ReqInf, error) {
 	var scResp tc.ServerCapabilityDetailResponse
 	reqInf, err := to.post(APIServerCapabilities, sc, nil, &scResp)
 	if err != nil {
@@ -40,7 +41,7 @@ func (to *Session) CreateServerCapability(sc tc.ServerCapability) (*tc.ServerCap
 	return &scResp, reqInf, nil
 }
 
-func (to *Session) GetServerCapabilitiesWithHdr(header http.Header) ([]tc.ServerCapability, ReqInf, error) {
+func (to *Session) GetServerCapabilitiesWithHdr(header http.Header) ([]tc.ServerCapability, toclientlib.ReqInf, error) {
 	var data tc.ServerCapabilitiesResponse
 	reqInf, err := to.get(APIServerCapabilities, header, &data)
 	return data.Response, reqInf, err
@@ -48,11 +49,11 @@ func (to *Session) GetServerCapabilitiesWithHdr(header http.Header) ([]tc.Server
 
 // GetServerCapabilities returns all the server capabilities.
 // Deprecated: GetServerCapabilities will be removed in 6.0. Use GetServerCapabilitiesWithHdr.
-func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, ReqInf, error) {
+func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, toclientlib.ReqInf, error) {
 	return to.GetServerCapabilitiesWithHdr(nil)
 }
 
-func (to *Session) GetServerCapabilityWithHdr(name string, header http.Header) (*tc.ServerCapability, ReqInf, error) {
+func (to *Session) GetServerCapabilityWithHdr(name string, header http.Header) (*tc.ServerCapability, toclientlib.ReqInf, error) {
 	reqUrl := fmt.Sprintf("%s?name=%s", APIServerCapabilities, url.QueryEscape(name))
 	var data tc.ServerCapabilitiesResponse
 	reqInf, err := to.get(reqUrl, header, &data)
@@ -67,12 +68,12 @@ func (to *Session) GetServerCapabilityWithHdr(name string, header http.Header) (
 
 // GetServerCapability returns the given server capability by name.
 // Deprecated: GetServerCapability will be removed in 6.0. Use GetServerCapabilityWithHdr.
-func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, ReqInf, error) {
+func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, toclientlib.ReqInf, error) {
 	return to.GetServerCapabilityWithHdr(name, nil)
 }
 
 // DeleteServerCapability deletes the given server capability by name.
-func (to *Session) DeleteServerCapability(name string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteServerCapability(name string) (tc.Alerts, toclientlib.ReqInf, error) {
 	reqUrl := fmt.Sprintf("%s?name=%s", APIServerCapabilities, url.QueryEscape(name))
 	var alerts tc.Alerts
 	reqInf, err := to.del(reqUrl, nil, &alerts)

--- a/traffic_ops/v3-client/servercheck.go
+++ b/traffic_ops/v3-client/servercheck.go
@@ -17,6 +17,7 @@ package client
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // API_SERVERCHECK is Deprecated: will be removed in the next major version. Be aware this may not be the URI being requested, for clients created with Login and ClientOps.ForceLatestAPI false.
@@ -25,7 +26,7 @@ const API_SERVERCHECK = apiBase + "/servercheck"
 const APIServercheck = "/servercheck"
 
 // InsertServerCheckStatus Will insert/update the servercheck value based on if it already exists or not.
-func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable) (*tc.ServercheckPostResponse, ReqInf, error) {
+func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable) (*tc.ServercheckPostResponse, toclientlib.ReqInf, error) {
 	resp := tc.ServercheckPostResponse{}
 	reqInf, err := to.post(APIServercheck, status, nil, &resp)
 	if err != nil {
@@ -35,7 +36,7 @@ func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable)
 }
 
 // GetServersChecks fetches check and meta information about servers from /servercheck.
-func (to *Session) GetServersChecks() ([]tc.GenericServerCheck, tc.Alerts, ReqInf, error) {
+func (to *Session) GetServersChecks() ([]tc.GenericServerCheck, tc.Alerts, toclientlib.ReqInf, error) {
 	var response struct {
 		tc.Alerts
 		Response []tc.GenericServerCheck `json:"response"`

--- a/traffic_ops/v3-client/servercheckextensions.go
+++ b/traffic_ops/v3-client/servercheckextensions.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // API_TO_EXTENSION is Deprecated: will be removed in the next major version. Be aware this may not be the URI being requested, for clients created with Login and ClientOps.ForceLatestAPI false.
@@ -24,14 +25,14 @@ const API_TO_EXTENSION = apiBase + "/servercheck/extensions"
 const APITOExtension = "/servercheck/extensions"
 
 // CreateServerCheckExtension creates a servercheck extension.
-func (to *Session) CreateServerCheckExtension(ServerCheckExtension tc.ServerCheckExtensionNullable) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateServerCheckExtension(ServerCheckExtension tc.ServerCheckExtensionNullable) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APITOExtension, ServerCheckExtension, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteServerCheckExtension deletes a servercheck extension.
-func (to *Session) DeleteServerCheckExtension(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteServerCheckExtension(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	URI := fmt.Sprintf("%s/%d", APITOExtension, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(URI, nil, &alerts)
@@ -39,7 +40,7 @@ func (to *Session) DeleteServerCheckExtension(id int) (tc.Alerts, ReqInf, error)
 }
 
 // GetServerCheckExtensions gets all servercheck extensions.
-func (to *Session) GetServerCheckExtensions() (tc.ServerCheckExtensionResponse, ReqInf, error) {
+func (to *Session) GetServerCheckExtensions() (tc.ServerCheckExtensionResponse, toclientlib.ReqInf, error) {
 	var toExtResp tc.ServerCheckExtensionResponse
 	reqInf, err := to.get(APITOExtension, nil, &toExtResp)
 	return toExtResp, reqInf, err

--- a/traffic_ops/v3-client/serviceCategory.go
+++ b/traffic_ops/v3-client/serviceCategory.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,14 +32,14 @@ const (
 )
 
 // CreateServiceCategory performs a post to create a service category.
-func (to *Session) CreateServiceCategory(serviceCategory tc.ServiceCategory) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateServiceCategory(serviceCategory tc.ServiceCategory) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIServiceCategories, serviceCategory, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // UpdateServiceCategoryByName updates a service category by its unique name.
-func (to *Session) UpdateServiceCategoryByName(name string, serviceCategory tc.ServiceCategory, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateServiceCategoryByName(name string, serviceCategory tc.ServiceCategory, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%s", APIServiceCategories, name)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, serviceCategory, header, &alerts)
@@ -46,7 +47,7 @@ func (to *Session) UpdateServiceCategoryByName(name string, serviceCategory tc.S
 }
 
 // GetServiceCategoriesWithHdr gets a list of service categories by the passed in url values and http headers.
-func (to *Session) GetServiceCategoriesWithHdr(values *url.Values, header http.Header) ([]tc.ServiceCategory, ReqInf, error) {
+func (to *Session) GetServiceCategoriesWithHdr(values *url.Values, header http.Header) ([]tc.ServiceCategory, toclientlib.ReqInf, error) {
 	path := fmt.Sprintf("%s?%s", APIServiceCategories, values.Encode())
 	var data tc.ServiceCategoriesResponse
 	reqInf, err := to.get(path, header, &data)
@@ -54,13 +55,13 @@ func (to *Session) GetServiceCategoriesWithHdr(values *url.Values, header http.H
 }
 
 // GetServiceCategories gets a list of service categories by the passed in url values.
-func (to *Session) GetServiceCategories(values *url.Values) ([]tc.ServiceCategory, ReqInf, error) {
+func (to *Session) GetServiceCategories(values *url.Values) ([]tc.ServiceCategory, toclientlib.ReqInf, error) {
 	return to.GetServiceCategoriesWithHdr(values, nil)
 }
 
 // DeleteServiceCategoryByName deletes a service category by the service
 // category's unique name.
-func (to *Session) DeleteServiceCategoryByName(name string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteServiceCategoryByName(name string) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%s", APIServiceCategories, name)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/session.go
+++ b/traffic_ops/v3-client/session.go
@@ -17,25 +17,11 @@
 package client
 
 import (
-	"bytes"
-	"crypto/tls"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"math"
 	"net"
 	"net/http"
-	"net/http/cookiejar"
-	"net/http/httptrace"
-	"strconv"
-	"strings"
 	"time"
 
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/lib/go-tc"
-
-	"golang.org/x/net/publicsuffix"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // Login authenticates with Traffic Ops and returns the client object.
@@ -44,250 +30,27 @@ import (
 //
 // See ClientOpts for details about options, which options are required, and how they behave.
 //
-func Login(url, user, pass string, opts ClientOpts) (*Session, ReqInf, error) {
-	if strings.TrimSpace(opts.UserAgent) == "" {
-		return nil, ReqInf{}, errors.New("opts.UserAgent is required")
-	}
-	if opts.RequestTimeout == 0 {
-		opts.RequestTimeout = DefaultTimeout
-	}
-	if opts.APIVersionCheckInterval == 0 {
-		opts.APIVersionCheckInterval = DefaultAPIVersionCheckInterval
-	}
-
-	jar, err := cookiejar.New(&cookiejar.Options{
-		PublicSuffixList: publicsuffix.List,
-	})
+func Login(url, user, pass string, opts ClientOpts) (*Session, toclientlib.ReqInf, error) {
+	cl, ip, err := toclientlib.Login(url, user, pass, opts.ClientOpts, apiVersions())
 	if err != nil {
-		return nil, ReqInf{}, errors.New("creating cookie jar: " + err.Error())
+		return nil, toclientlib.ReqInf{}, err
 	}
-
-	to := NewSession(user, pass, url, opts.UserAgent, &http.Client{
-		Timeout: opts.RequestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: opts.Insecure},
-		},
-		Jar: jar,
-	}, false)
-
-	if !opts.ForceLatestAPI {
-		to.latestSupportedAPI = apiVersions()[0]
-	}
-
-	to.forceLatestAPI = opts.ForceLatestAPI
-	to.apiVerCheckInterval = opts.APIVersionCheckInterval
-
-	remoteAddr, err := to.login()
-	if err != nil {
-		return nil, ReqInf{RemoteAddr: remoteAddr}, errors.New("logging in: " + err.Error())
-	}
-	return to, ReqInf{RemoteAddr: remoteAddr}, nil
+	return &Session{TOClient: *cl}, ip, err
 }
 
-// ClientOpts is the options to configure the creation of the Client.
-//
-// This exists to allow adding new features without a breaking change to the Login function.
-// Users should understand this, and understand that upgrading their library may result in new options that their application doesn't know to use.
-// New fields should always behave as-before if their value is the default.
 type ClientOpts struct {
-	// ForceLatestAPI will cause Login to return an error if the latest minor API in the client
-	// is not supported by the Traffic Ops Server.
-	//
-	// Note this was the behavior of all Traffic Ops client functions prior to the Login function.
-	//
-	// If this is false or unset, login will determine the latest minor version supported, and use that for all requests.
-	//
-	// Be aware, this means client fields unknown to the server will always be default-initialized.
-	// For example, suppose the field Foo was added in API 3.1, the client code is 3.1, and the server is 3.0.
-	// Then, the field Foo will always be nil or the default value.
-	// Client applications must understand this, and code processing the new feature Foo must be able to
-	// process default or nil values, understanding they may indicate a server version before the feature was added.
-	//
-	ForceLatestAPI bool
-
-	// Insecure is whether to ignore HTTPS certificate errors with Traffic Ops.
-	// Setting this on production systems is strongly discouraged.
-	Insecure bool
-
-	// RequestTimeout is the HTTP timeout for Traffic Ops requests.
-	// If 0 or not explicitly set, DefaultTimeout will be used.
-	RequestTimeout time.Duration
-
-	// UserAgent is the HTTP User Agent to use set when communicating with Traffic Ops.
-	// This field is required, and Login will fail if it is unset or the empty string.
-	UserAgent string
-
-	// APIVersionCheckInterval is how often to try a newer Traffic Ops API Version.
-	// This allows clients to get new Traffic Ops features after Traffic Ops is upgraded
-	// without requiring a restart or new client.
-	//
-	// If 0 or not explicitly set, DefaultAPIVersionCheckInterval will be used.
-	// To disable, set to a very high value (like 100 years).
-	//
-	// This has no effect if ForceLatestAPI is true.
-	APIVersionCheckInterval time.Duration
+	toclientlib.ClientOpts
 }
 
-// Session ...
+// Session is a Traffic Ops client.
 type Session struct {
-	UserName     string
-	Password     string
-	URL          string
-	Client       *http.Client
-	UserAgentStr string
-
-	latestSupportedAPI string
-	// forceLatestAPI is whether to forcibly always use the latest API version known to this client.
-	// This should only ever be set by ClientOpts.ForceLatestAPI.
-	forceLatestAPI bool
-	// lastAPIVerCheck is the last time the Session tried to get a newer API version from TO.
-	// Used internally to decide whether to try again.
-	lastAPIVerCheck time.Time
-	// apiVerCheckInterval is how often to try a newer Traffic Ops API, in case Traffic Ops was upgraded.
-	// This should only ever be set by ClientOpts.APIVersionCheckInterval.
-	apiVerCheckInterval time.Duration
+	toclientlib.TOClient
 }
 
 func NewSession(user, password, url, userAgent string, client *http.Client, useCache bool) *Session {
 	return &Session{
-		UserName:     user,
-		Password:     password,
-		URL:          url,
-		Client:       client,
-		UserAgentStr: userAgent,
+		TOClient: *toclientlib.NewClient(user, password, url, userAgent, client, apiVersions()),
 	}
-}
-
-const DefaultTimeout = time.Second * 30
-const DefaultAPIVersionCheckInterval = time.Second * 60
-
-// HTTPError is returned on Update Session failure.
-type HTTPError struct {
-	HTTPStatusCode int
-	HTTPStatus     string
-	URL            string
-	Body           string
-}
-
-// Error implements the error interface for our customer error type.
-func (e *HTTPError) Error() string {
-	return fmt.Sprintf("%s[%d] - Error requesting Traffic Ops %s %s", e.HTTPStatus, e.HTTPStatusCode, e.URL, e.Body)
-}
-
-// loginCreds gathers login credentials for Traffic Ops.
-func loginCreds(toUser string, toPasswd string) ([]byte, error) {
-	credentials := tc.UserCredentials{
-		Username: toUser,
-		Password: toPasswd,
-	}
-
-	js, err := json.Marshal(credentials)
-	if err != nil {
-		err := fmt.Errorf("Error creating login json: %v", err)
-		return nil, err
-	}
-	return js, nil
-}
-
-// loginToken gathers token login credentials for Traffic Ops.
-func loginToken(token string) ([]byte, error) {
-	form := tc.UserToken{
-		Token: token,
-	}
-
-	j, e := json.Marshal(form)
-	if e != nil {
-		e := fmt.Errorf("Error creating token login json: %v", e)
-		return nil, e
-	}
-	return j, nil
-}
-
-// login tries to log in to Traffic Ops, and set the auth cookie in the Session. Returns the IP address of the remote Traffic Ops.
-func (to *Session) login() (net.Addr, error) {
-	path := "/user/login"
-	body := tc.UserCredentials{Username: to.UserName, Password: to.Password}
-	alerts := tc.Alerts{}
-
-	// Can't use req() because it retries login failures, which would be an infinite loop.
-	reqF := composeReqFuncs(makeRequestWithHeader, []MidReqF{reqTryLatest, reqFallback, reqAPI})
-
-	reqInf, err := reqF(to, http.MethodPost, path, body, nil, &alerts)
-	if err != nil {
-		return reqInf.RemoteAddr, fmt.Errorf("Login error %v, alerts string: %+v", err, alerts)
-	}
-
-	success := false
-	for _, alert := range alerts.Alerts {
-		if alert.Level == "success" && alert.Text == "Successfully logged in." {
-			success = true
-			break
-		}
-	}
-
-	if !success {
-		return reqInf.RemoteAddr, fmt.Errorf("Login failed, alerts string: %+v", alerts)
-	}
-
-	return reqInf.RemoteAddr, nil
-}
-
-func (to *Session) loginWithToken(token []byte) (net.Addr, error) {
-	path := to.APIBase() + "/user/login/token"
-	resp, remoteAddr, err := to.RawRequestWithHdr(http.MethodPost, path, token, nil)
-	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
-	if err != nil {
-		return remoteAddr, fmt.Errorf("requesting: %v", err)
-	}
-	defer resp.Body.Close()
-
-	var alerts tc.Alerts
-	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
-		return remoteAddr, fmt.Errorf("decoding response JSON: %v", err)
-	}
-
-	for _, alert := range alerts.Alerts {
-		if alert.Level == tc.SuccessLevel.String() && alert.Text == "Successfully logged in." {
-			return remoteAddr, nil
-		}
-	}
-
-	return remoteAddr, fmt.Errorf("Login failed, alerts string: %+v", alerts)
-}
-
-// logout of Traffic Ops
-func (to *Session) logout() (net.Addr, error) {
-	credentials, err := loginCreds(to.UserName, to.Password)
-	if err != nil {
-		return nil, errors.New("creating login credentials: " + err.Error())
-	}
-
-	path := to.APIBase() + "/user/logout"
-	resp, remoteAddr, err := to.RawRequestWithHdr("POST", path, credentials, nil)
-	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
-	if err != nil {
-		return remoteAddr, errors.New("requesting: " + err.Error())
-	}
-	defer resp.Body.Close()
-
-	var alerts tc.Alerts
-	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
-		return remoteAddr, errors.New("decoding response JSON: " + err.Error())
-	}
-
-	success := false
-	for _, alert := range alerts.Alerts {
-		if alert.Level == "success" && alert.Text == "Successfully logged in." {
-			success = true
-			break
-		}
-	}
-
-	if !success {
-		return remoteAddr, fmt.Errorf("Logout failed, alerts string: %+v", alerts)
-	}
-
-	return remoteAddr, nil
 }
 
 // Login to traffic_ops, the response should set the cookie for this session
@@ -297,415 +60,50 @@ func (to *Session) logout() (net.Addr, error) {
 // Returns the logged in client, the remote address of Traffic Ops which was translated and used to log in, and any error. If the error is not nil, the remote address may or may not be nil, depending whether the error occurred before the login request.
 // The useCache argument is ignored. It exists to avoid breaking compatibility, and does not exist in newer functions.
 func LoginWithAgent(toURL string, toUser string, toPasswd string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) (*Session, net.Addr, error) {
-	options := cookiejar.Options{
-		PublicSuffixList: publicsuffix.List,
-	}
-
-	jar, err := cookiejar.New(&options)
+	cl, ip, err := toclientlib.LoginWithAgent(toURL, toUser, toPasswd, insecure, userAgent, requestTimeout, apiVersions())
 	if err != nil {
 		return nil, nil, err
 	}
-
-	to := NewSession(toUser, toPasswd, toURL, userAgent, &http.Client{
-		Timeout: requestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		},
-		Jar: jar,
-	}, useCache)
-
-	remoteAddr, err := to.login()
-	if err != nil {
-		return nil, remoteAddr, errors.New("logging in: " + err.Error())
-	}
-	return to, remoteAddr, nil
+	return &Session{TOClient: *cl}, ip, err
 }
 
 func LoginWithToken(toURL string, token string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) (*Session, net.Addr, error) {
-	options := cookiejar.Options{
-		PublicSuffixList: publicsuffix.List,
-	}
-
-	jar, err := cookiejar.New(&options)
+	cl, ip, err := toclientlib.LoginWithToken(toURL, token, insecure, userAgent, requestTimeout, apiVersions())
 	if err != nil {
 		return nil, nil, err
 	}
-
-	client := http.Client{
-		Timeout: requestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		},
-		Jar: jar,
-	}
-
-	to := NewSession("", "", toURL, userAgent, &client, useCache)
-	tBts, err := loginToken(token)
-	if err != nil {
-		return nil, nil, fmt.Errorf("logging in: %v", err)
-	}
-
-	remoteAddr, err := to.loginWithToken(tBts)
-	if err != nil {
-		return nil, remoteAddr, fmt.Errorf("logging in: %v", err)
-	}
-	return to, remoteAddr, nil
+	return &Session{TOClient: *cl}, ip, err
 }
 
 // Logout of Traffic Ops.
 // The useCache argument is ignored. It exists to avoid breaking compatibility, and does not exist in newer functions.
 func LogoutWithAgent(toURL string, toUser string, toPasswd string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) (*Session, net.Addr, error) {
-	options := cookiejar.Options{
-		PublicSuffixList: publicsuffix.List,
-	}
-
-	jar, err := cookiejar.New(&options)
+	cl, ip, err := toclientlib.LogoutWithAgent(toURL, toUser, toPasswd, insecure, userAgent, requestTimeout, apiVersions())
 	if err != nil {
 		return nil, nil, err
 	}
-
-	to := NewSession(toUser, toPasswd, toURL, userAgent, &http.Client{
-		Timeout: requestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		},
-		Jar: jar,
-	}, useCache)
-
-	remoteAddr, err := to.logout()
-	if err != nil {
-		return nil, remoteAddr, errors.New("logging out: " + err.Error())
-	}
-	return to, remoteAddr, nil
+	return &Session{TOClient: *cl}, ip, err
 }
 
 // NewNoAuthSession returns a new Session without logging in
 // this can be used for querying unauthenticated endpoints without requiring a login
 // The useCache argument is ignored. It exists to avoid breaking compatibility, and does not exist in newer functions.
 func NewNoAuthSession(toURL string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) *Session {
-	return NewSession("", "", toURL, userAgent, &http.Client{
-		Timeout: requestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		},
-	}, useCache)
+	return &Session{TOClient: *toclientlib.NewNoAuthClient(toURL, insecure, userAgent, requestTimeout, apiVersions())}
 }
 
-func ErrIsNotImplemented(err error) bool {
-	return err != nil && strings.Contains(err.Error(), ErrNotImplemented.Error()) // use string.Contains in case context was added to the error
+func (to *Session) get(path string, header http.Header, response interface{}) (toclientlib.ReqInf, error) {
+	return to.TOClient.Req(http.MethodGet, path, nil, header, response)
 }
 
-// ErrNotImplemented is returned when Traffic Ops returns a 501 Not Implemented
-// Users should check ErrIsNotImplemented rather than comparing directly, in case context was added.
-var ErrNotImplemented = errors.New("Traffic Ops Server returned 'Not Implemented', this client is probably newer than Traffic Ops, and you probably need to either upgrade Traffic Ops, or use a client whose version matches your Traffic Ops version.")
-
-// errUnlessOKOrNotModified returns the response, the remote address, and an error if the given Response's status code is anything
-// but 200 OK/ 304 Not Modified. This includes reading the Response.Body and Closing it. Otherwise, the given response, the remote
-// address, and a nil error are returned.
-func (to *Session) errUnlessOKOrNotModified(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
-	if err != nil {
-		return resp, remoteAddr, err
-	}
-	if resp.StatusCode < 300 || resp.StatusCode == 304 {
-		return resp, remoteAddr, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotImplemented {
-		return resp, remoteAddr, ErrNotImplemented
-	}
-
-	body, readErr := ioutil.ReadAll(resp.Body)
-	if readErr != nil {
-		return resp, remoteAddr, readErr
-	}
-	return resp, remoteAddr, errors.New(resp.Status + "[" + strconv.Itoa(resp.StatusCode) + "] - Error requesting Traffic Ops " + to.getURL(path) + " " + string(body))
+func (to *Session) post(path string, body interface{}, header http.Header, response interface{}) (toclientlib.ReqInf, error) {
+	return to.TOClient.Req(http.MethodPost, path, body, header, response)
 }
 
-func (to *Session) getURL(path string) string { return to.URL + path }
-
-type ReqF func(to *Session, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error)
-
-type MidReqF func(ReqF) ReqF
-
-// composeReqFuncs takes an initial request func and middleware, and
-// returns a single ReqFunc to be called,
-func composeReqFuncs(reqF ReqF, middleware []MidReqF) ReqF {
-	// compose in reverse-order, which causes them to be applied in forward-order.
-	for i := len(middleware) - 1; i >= 0; i-- {
-		reqF = middleware[i](reqF)
-	}
-	return reqF
+func (to *Session) put(path string, body interface{}, header http.Header, response interface{}) (toclientlib.ReqInf, error) {
+	return to.TOClient.Req(http.MethodPut, path, body, header, response)
 }
 
-// reqTryLatest will re-set to.latestSupportedAPI to the latest, if it's less than the latest and to.apiVerCheckInterval has passed.
-// This does not fallback, so it should generally be composed with reqFallback.
-func reqTryLatest(reqF ReqF) ReqF {
-	return func(to *Session, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-		if to.apiVerCheckInterval == 0 {
-			// Session could have been default-initialized rather than created with a func, so we need to check here, not just in login funcs.
-			to.apiVerCheckInterval = DefaultAPIVersionCheckInterval
-		}
-
-		if !to.forceLatestAPI && time.Since(to.lastAPIVerCheck) >= to.apiVerCheckInterval {
-			// if it's been apiVerCheckInterval since the last version check,
-			// set the version to the latest (and fall back again, if necessary)
-			to.latestSupportedAPI = apiVersions()[0]
-
-			// Set the last version check to far in the future, and then
-			// defer setting the last check until this function returns,
-			// so that if fallback takes longer than the interval,
-			// the recursive calls to this function don't end up forever retrying the latest.
-			to.lastAPIVerCheck = time.Now().Add(time.Hour * 24 * 365)
-			defer func() { to.lastAPIVerCheck = time.Now() }()
-		}
-		return reqF(to, method, path, body, header, response)
-	}
-}
-
-// reqLogin makes the request, and if it fails, tries to log in again then makes the request again.
-// If the login fails, the original response is returned.
-// If the second request fails, it's returned. Login is only tried once.
-// This is designed to handle expired sessions, when the time between requests is longer than the session expiration;
-// it does not do perpetual retry.
-func reqLogin(reqF ReqF) ReqF {
-	return func(to *Session, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-		inf, err := reqF(to, method, path, body, header, response)
-		if inf.StatusCode != http.StatusUnauthorized && inf.StatusCode != http.StatusForbidden {
-			return inf, err
-		}
-		if _, lerr := to.login(); lerr != nil {
-			return inf, err
-		}
-		return reqF(to, method, path, body, header, response)
-	}
-}
-
-// reqFallback calls reqF, and if Traffic Ops doesn't support the latest version,
-// falls back to the previous and retries, recursively.
-// If all supported versions fail, the last response error is returned.
-func reqFallback(reqF ReqF) ReqF {
-	var fallbackFunc func(to *Session, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error)
-	fallbackFunc = func(to *Session, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-		inf, err := reqF(to, method, path, body, header, response)
-		if err == nil {
-			return inf, err
-		}
-		if !ErrIsNotImplemented(err) ||
-			to.forceLatestAPI {
-			return inf, err
-		}
-
-		apiVersions := apiVersions()
-
-		nextAPIVerI := int(math.MaxInt32) - 1
-		for verI, ver := range apiVersions {
-			if to.latestSupportedAPI == ver {
-				nextAPIVerI = verI
-				break
-			}
-		}
-		nextAPIVerI = nextAPIVerI + 1
-		if nextAPIVerI >= len(apiVersions) {
-			return inf, err // we're already on the oldest minor supported, and the server doesn't support it.
-		}
-		to.latestSupportedAPI = apiVersions[nextAPIVerI]
-
-		return fallbackFunc(to, method, path, body, header, response)
-	}
-	return fallbackFunc
-}
-
-// reqAPI calls reqF with a path not including the /api/x prefix,
-// and adds the API version from the Session.
-//
-// For example, path should be like '/deliveryservices'
-// and this will request '/api/3.1/deliveryservices'.
-//
-func reqAPI(reqF ReqF) ReqF {
-	return func(to *Session, method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-		path = to.APIBase() + path
-		return reqF(to, method, path, body, header, response)
-	}
-}
-
-// makeRequestWithHeader marshals the response body (if non-nil), performs the HTTP request,
-// and decodes the response into the given response pointer.
-//
-// Note processing on the following codes:
-// 304 http.StatusNotModified  - Will return the 304 in ReqInf, a nil error, and a nil response.
-//
-// 401 http.StatusUnauthorized - Via to.request(), Same as 403 Forbidden.
-// 403 http.StatusForbidden    - Via to.request()
-//                               Will try to log in again, and try the request again.
-//                               The second request is returned, even if it fails.
-//
-// To request the bytes without deserializing, pass a *[]byte response.
-//
-func makeRequestWithHeader(to *Session, method, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	var reqBody []byte
-	var err error
-	if body != nil {
-		reqBody, err = json.Marshal(body)
-		if err != nil {
-			return reqInf, errors.New("marshalling request body: " + err.Error())
-		}
-	}
-	resp, remoteAddr, err := to.request(method, path, reqBody, header)
-	reqInf.RemoteAddr = remoteAddr
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return reqInf, nil
-		}
-		defer log.Close(resp.Body, "unable to close response body")
-	}
-	if err != nil {
-		return reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
-	}
-
-	if btsPtr, isBytes := response.(*[]byte); isBytes {
-		bts, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return reqInf, errors.New("reading response body: " + err.Error())
-		}
-		*btsPtr = bts
-		return reqInf, nil
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
-		return reqInf, errors.New("decoding response body: " + err.Error())
-	}
-	return reqInf, nil
-}
-
-func (to *Session) get(path string, header http.Header, response interface{}) (ReqInf, error) {
-	return to.req(http.MethodGet, path, nil, header, response)
-}
-
-func (to *Session) post(path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-	return to.req(http.MethodPost, path, body, header, response)
-}
-
-func (to *Session) put(path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-	return to.req(http.MethodPut, path, body, header, response)
-}
-
-func (to *Session) del(path string, header http.Header, response interface{}) (ReqInf, error) {
-	return to.req(http.MethodDelete, path, nil, header, response)
-}
-
-func (to *Session) req(method string, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-	reqF := composeReqFuncs(makeRequestWithHeader, []MidReqF{reqTryLatest, reqFallback, reqAPI, reqLogin})
-	return reqF(to, method, path, body, header, response)
-}
-
-// request performs the HTTP request to Traffic Ops, trying to refresh the cookie if an Unauthorized or Forbidden code is received. It only tries once. If the login fails, the original Unauthorized/Forbidden response is returned. If the login succeeds and the subsequent re-request fails, the re-request's response is returned even if it's another Unauthorized/Forbidden.
-// Returns the response, the remote address of the Traffic Ops instance used, and any error.
-// The returned net.Addr is guaranteed to be either nil or valid, even if the returned error is not nil. Callers are encouraged to check and use the net.Addr if an error is returned, and use the remote address in their own error messages. This violates the Go idiom that a non-nil error implies all other values are undefined, but it's more straightforward than alternatives like typecasting.
-func (to *Session) request(method, path string, body []byte, header http.Header) (*http.Response, net.Addr, error) {
-	r, remoteAddr, err := to.RawRequestWithHdr(method, path, body, header)
-	if err != nil {
-		return r, remoteAddr, err
-	}
-	if r.StatusCode != http.StatusUnauthorized && r.StatusCode != http.StatusForbidden {
-		return to.errUnlessOKOrNotModified(r, remoteAddr, err, path)
-	}
-	if _, lerr := to.login(); lerr != nil {
-		return to.errUnlessOKOrNotModified(r, remoteAddr, err, path) // if re-logging-in fails, return the original request's response
-	}
-
-	// return second request, even if it's another Unauthorized or Forbidden.
-	r, remoteAddr, err = to.RawRequestWithHdr(method, path, body, header)
-	return to.errUnlessOKOrNotModified(r, remoteAddr, err, path)
-}
-
-func (to *Session) RawRequestWithHdr(method, path string, body []byte, header http.Header) (*http.Response, net.Addr, error) {
-	url := to.getURL(path)
-
-	var req *http.Request
-	var err error
-	remoteAddr := net.Addr(nil)
-
-	if body != nil {
-		req, err = http.NewRequest(method, url, bytes.NewBuffer(body))
-		if err != nil {
-			return nil, remoteAddr, err
-		}
-		if header != nil {
-			req.Header = header.Clone()
-		}
-		req.Header.Set("Content-Type", "application/json")
-	} else {
-		req, err = http.NewRequest(method, url, nil)
-		if err != nil {
-			return nil, remoteAddr, err
-		}
-		if header != nil {
-			req.Header = header.Clone()
-		}
-	}
-
-	trace := &httptrace.ClientTrace{
-		GotConn: func(connInfo httptrace.GotConnInfo) {
-			remoteAddr = connInfo.Conn.RemoteAddr()
-		},
-	}
-	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
-	req.Header.Set("User-Agent", to.UserAgentStr)
-	resp, err := to.Client.Do(req)
-	return resp, remoteAddr, err
-}
-
-// RawRequest performs the actual HTTP request to Traffic Ops, simply, without trying to refresh the cookie if an Unauthorized code is returned.
-// Returns the response, the remote address of the Traffic Ops instance used, and any error.
-// The returned net.Addr is guaranteed to be either nil or valid, even if the returned error is not nil. Callers are encouraged to check and use the net.Addr if an error is returned, and use the remote address in their own error messages. This violates the Go idiom that a non-nil error implies all other values are undefined, but it's more straightforward than alternatives like typecasting.
-// Deprecated: RawRequest will be removed in 6.0. Use RawRequestWithHdr.
-func (to *Session) RawRequest(method, path string, body []byte) (*http.Response, net.Addr, error) {
-	return to.RawRequestWithHdr(method, path, body, nil)
-}
-
-type ReqInf struct {
-	// CacheHitStatus is deprecated and will be removed in the next major version.
-	CacheHitStatus CacheHitStatus
-	RemoteAddr     net.Addr
-	StatusCode     int
-}
-
-// CacheHitStatus is deprecated and will be removed in the next major version.
-type CacheHitStatus string
-
-// CacheHitStatusHit is deprecated and will be removed in the next major version.
-const CacheHitStatusHit = CacheHitStatus("hit")
-
-// CacheHitStatusExpired is deprecated and will be removed in the next major version.
-const CacheHitStatusExpired = CacheHitStatus("expired")
-
-// CacheHitStatusMiss is deprecated and will be removed in the next major version.
-const CacheHitStatusMiss = CacheHitStatus("miss")
-
-// CacheHitStatusInvalid is deprecated and will be removed in the next major version.
-const CacheHitStatusInvalid = CacheHitStatus("")
-
-// String is deprecated and will be removed in the next major version.
-func (s CacheHitStatus) String() string {
-	return string(s)
-}
-
-// StringToCacheHitStatus is deprecated and will be removed in the next major version.
-func StringToCacheHitStatus(s string) CacheHitStatus {
-	s = strings.ToLower(s)
-	switch s {
-	case "hit":
-		return CacheHitStatusHit
-	case "expired":
-		return CacheHitStatusExpired
-	case "miss":
-		return CacheHitStatusMiss
-	default:
-		return CacheHitStatusInvalid
-	}
+func (to *Session) del(path string, header http.Header, response interface{}) (toclientlib.ReqInf, error) {
+	return to.TOClient.Req(http.MethodDelete, path, nil, header, response)
 }

--- a/traffic_ops/v3-client/staticdnsentry.go
+++ b/traffic_ops/v3-client/staticdnsentry.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -75,23 +76,23 @@ func staticDNSEntryIDs(to *Session, sdns *tc.StaticDNSEntry) error {
 }
 
 // CreateStaticDNSEntry creates a Static DNS Entry.
-func (to *Session) CreateStaticDNSEntry(sdns tc.StaticDNSEntry) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateStaticDNSEntry(sdns tc.StaticDNSEntry) (tc.Alerts, toclientlib.ReqInf, error) {
 	// fill in missing IDs from names
 	var alerts tc.Alerts
 	err := staticDNSEntryIDs(to, &sdns)
 	if err != nil {
-		return alerts, ReqInf{CacheHitStatus: CacheHitStatusMiss}, err
+		return alerts, toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}, err
 	}
 	reqInf, err := to.post(APIStaticDNSEntries, sdns, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateStaticDNSEntryByIDWithHdr(id int, sdns tc.StaticDNSEntry, header http.Header) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) UpdateStaticDNSEntryByIDWithHdr(id int, sdns tc.StaticDNSEntry, header http.Header) (tc.Alerts, toclientlib.ReqInf, int, error) {
 	// fill in missing IDs from names
 	var alerts tc.Alerts
 	err := staticDNSEntryIDs(to, &sdns)
 	if err != nil {
-		return alerts, ReqInf{CacheHitStatus: CacheHitStatusMiss}, 0, err
+		return alerts, toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}, 0, err
 	}
 	route := fmt.Sprintf("%s?id=%d", APIStaticDNSEntries, id)
 	reqInf, err := to.put(route, sdns, header, &alerts)
@@ -100,11 +101,11 @@ func (to *Session) UpdateStaticDNSEntryByIDWithHdr(id int, sdns tc.StaticDNSEntr
 
 // UpdateStaticDNSEntryByID updates a Static DNS Entry by ID.
 // Deprecated: UpdateStaticDNSEntryByID will be removed in 6.0. Use UpdateStaticDNSEntryByIDWithHdr.
-func (to *Session) UpdateStaticDNSEntryByID(id int, sdns tc.StaticDNSEntry) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) UpdateStaticDNSEntryByID(id int, sdns tc.StaticDNSEntry) (tc.Alerts, toclientlib.ReqInf, int, error) {
 	return to.UpdateStaticDNSEntryByIDWithHdr(id, sdns, nil)
 }
 
-func (to *Session) GetStaticDNSEntriesWithHdr(header http.Header) ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntriesWithHdr(header http.Header) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	var data tc.StaticDNSEntriesResponse
 	reqInf, err := to.get(APIStaticDNSEntries, header, &data)
 	return data.Response, reqInf, err
@@ -112,11 +113,11 @@ func (to *Session) GetStaticDNSEntriesWithHdr(header http.Header) ([]tc.StaticDN
 
 // GetStaticDNSEntries returns a list of Static DNS Entrys.
 // Deprecated: GetStaticDNSEntries will be removed in 6.0. Use GetStaticDNSEntriesWithHdr.
-func (to *Session) GetStaticDNSEntries() ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntries() ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	return to.GetStaticDNSEntriesWithHdr(nil)
 }
 
-func (to *Session) GetStaticDNSEntryByIDWithHdr(id int, header http.Header) ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntryByIDWithHdr(id int, header http.Header) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIStaticDNSEntries, id)
 	var data tc.StaticDNSEntriesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -125,11 +126,11 @@ func (to *Session) GetStaticDNSEntryByIDWithHdr(id int, header http.Header) ([]t
 
 // GetStaticDNSEntryByID GETs a Static DNS Entry by the Static DNS Entry's ID.
 // Deprecated: GetStaticDNSEntryByID will be removed in 6.0. Use GetStaticDNSEntryByIDWithHdr.
-func (to *Session) GetStaticDNSEntryByID(id int) ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntryByID(id int) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	return to.GetStaticDNSEntryByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetStaticDNSEntriesByHostWithHdr(host string, header http.Header) ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntriesByHostWithHdr(host string, header http.Header) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?host=%s", APIStaticDNSEntries, url.QueryEscape(host))
 	var data tc.StaticDNSEntriesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -138,12 +139,12 @@ func (to *Session) GetStaticDNSEntriesByHostWithHdr(host string, header http.Hea
 
 // GetStaticDNSEntriesByHost GETs a Static DNS Entry by the Static DNS Entry's host.
 // Deprecated: GetStaticDNSEntriesByHost will be removed in 6.0. Use GetStaticDNSEntriesByHostWithHdr.
-func (to *Session) GetStaticDNSEntriesByHost(host string) ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntriesByHost(host string) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	return to.GetStaticDNSEntriesByHostWithHdr(host, nil)
 }
 
 // DeleteStaticDNSEntryByID DELETEs a Static DNS Entry by ID.
-func (to *Session) DeleteStaticDNSEntryByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteStaticDNSEntryByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIStaticDNSEntries, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/stats_summary.go
+++ b/traffic_ops/v3-client/stats_summary.go
@@ -16,7 +16,8 @@ import (
 	"fmt"
 	"net/url"
 
-	tc "github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -27,7 +28,7 @@ const (
 )
 
 // GetSummaryStats gets a list of summary stats with the ability to filter on cdn,deliveryService and/or stat
-func (to *Session) GetSummaryStats(cdn, deliveryService, statName *string) (tc.StatsSummaryResponse, ReqInf, error) {
+func (to *Session) GetSummaryStats(cdn, deliveryService, statName *string) (tc.StatsSummaryResponse, toclientlib.ReqInf, error) {
 	resp := tc.StatsSummaryResponse{}
 
 	param := url.Values{}
@@ -50,7 +51,7 @@ func (to *Session) GetSummaryStats(cdn, deliveryService, statName *string) (tc.S
 }
 
 // GetSummaryStatsLastUpdated time of the last summary for a given stat
-func (to *Session) GetSummaryStatsLastUpdated(statName *string) (tc.StatsSummaryLastUpdatedResponse, ReqInf, error) {
+func (to *Session) GetSummaryStatsLastUpdated(statName *string) (tc.StatsSummaryLastUpdatedResponse, toclientlib.ReqInf, error) {
 	resp := tc.StatsSummaryLastUpdatedResponse{}
 
 	param := url.Values{}
@@ -64,7 +65,7 @@ func (to *Session) GetSummaryStatsLastUpdated(statName *string) (tc.StatsSummary
 }
 
 // CreateSummaryStats creates a stats summary
-func (to *Session) CreateSummaryStats(statsSummary tc.StatsSummary) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateSummaryStats(statsSummary tc.StatsSummary) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIStatsSummary, statsSummary, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v3-client/status.go
+++ b/traffic_ops/v3-client/status.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,13 +32,13 @@ const (
 )
 
 // CreateStatusNullable creates a new status, using the tc.StatusNullable structure.
-func (to *Session) CreateStatusNullable(status tc.StatusNullable) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateStatusNullable(status tc.StatusNullable) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIStatuses, status, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateStatusByIDWithHdr(id int, status tc.Status, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateStatusByIDWithHdr(id int, status tc.Status, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIStatuses, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, status, header, &alerts)
@@ -46,11 +47,11 @@ func (to *Session) UpdateStatusByIDWithHdr(id int, status tc.Status, header http
 
 // UpdateStatusByID updates a Status by ID.
 // Deprecated: UpdateStatusByID will be removed in 6.0. Use UpdateStatusByIDWithHdr.
-func (to *Session) UpdateStatusByID(id int, status tc.Status) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateStatusByID(id int, status tc.Status) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateStatusByIDWithHdr(id, status, nil)
 }
 
-func (to *Session) GetStatusesWithHdr(header http.Header) ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatusesWithHdr(header http.Header) ([]tc.Status, toclientlib.ReqInf, error) {
 	var data tc.StatusesResponse
 	reqInf, err := to.get(APIStatuses, header, &data)
 	return data.Response, reqInf, err
@@ -58,11 +59,11 @@ func (to *Session) GetStatusesWithHdr(header http.Header) ([]tc.Status, ReqInf, 
 
 // GetStatuses returns a list of Statuses.
 // Deprecated: GetStatuses will be removed in 6.0. Use GetStatusesWithHdr.
-func (to *Session) GetStatuses() ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatuses() ([]tc.Status, toclientlib.ReqInf, error) {
 	return to.GetStatusesWithHdr(nil)
 }
 
-func (to *Session) GetStatusByIDWithHdr(id int, header http.Header) ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatusByIDWithHdr(id int, header http.Header) ([]tc.Status, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APIStatuses, id)
 	var data tc.StatusesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -71,11 +72,11 @@ func (to *Session) GetStatusByIDWithHdr(id int, header http.Header) ([]tc.Status
 
 // GetStatusByID GETs a Status by the Status ID.
 // Deprecated: GetStatusByID will be removed in 6.0. Use GetStatusByIDWithHdr.
-func (to *Session) GetStatusByID(id int) ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatusByID(id int) ([]tc.Status, toclientlib.ReqInf, error) {
 	return to.GetStatusByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetStatusByNameWithHdr(name string, header http.Header) ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatusByNameWithHdr(name string, header http.Header) ([]tc.Status, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APIStatuses, url.QueryEscape(name))
 	var data tc.StatusesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -84,12 +85,12 @@ func (to *Session) GetStatusByNameWithHdr(name string, header http.Header) ([]tc
 
 // GetStatusByName GETs a Status by the Status name.
 // Deprecated: GetStatusByName will be removed in 6.0. Use GetStatusByNameWithHdr.
-func (to *Session) GetStatusByName(name string) ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatusByName(name string) ([]tc.Status, toclientlib.ReqInf, error) {
 	return to.GetStatusByNameWithHdr(name, nil)
 }
 
 // DeleteStatusByID DELETEs a Status by ID.
-func (to *Session) DeleteStatusByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteStatusByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APIStatuses, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/steering.go
+++ b/traffic_ops/v3-client/steering.go
@@ -19,9 +19,10 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-func (to *Session) SteeringWithHdr(header http.Header) ([]tc.Steering, ReqInf, error) {
+func (to *Session) SteeringWithHdr(header http.Header) ([]tc.Steering, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.Steering `json:"response"`
 	}{}
@@ -30,6 +31,6 @@ func (to *Session) SteeringWithHdr(header http.Header) ([]tc.Steering, ReqInf, e
 }
 
 // Deprecated: Steering will be removed in 6.0. Use SteeringWithHdr.
-func (to *Session) Steering() ([]tc.Steering, ReqInf, error) {
+func (to *Session) Steering() ([]tc.Steering, toclientlib.ReqInf, error) {
 	return to.SteeringWithHdr(nil)
 }

--- a/traffic_ops/v3-client/steeringtarget.go
+++ b/traffic_ops/v3-client/steeringtarget.go
@@ -21,11 +21,12 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-func (to *Session) CreateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, toclientlib.ReqInf, error) {
 	if st.DeliveryServiceID == nil {
-		return tc.Alerts{}, ReqInf{CacheHitStatus: CacheHitStatusMiss}, errors.New("missing delivery service id")
+		return tc.Alerts{}, toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}, errors.New("missing delivery service id")
 	}
 	alerts := tc.Alerts{}
 	route := fmt.Sprintf("/steering/%d/targets", *st.DeliveryServiceID)
@@ -33,8 +34,8 @@ func (to *Session) CreateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateSteeringTargetWithHdr(st tc.SteeringTargetNullable, header http.Header) (tc.Alerts, ReqInf, error) {
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+func (to *Session) UpdateSteeringTargetWithHdr(st tc.SteeringTargetNullable, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	reqInf := toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}
 	if st.DeliveryServiceID == nil {
 		return tc.Alerts{}, reqInf, errors.New("missing delivery service id")
 	}
@@ -48,11 +49,11 @@ func (to *Session) UpdateSteeringTargetWithHdr(st tc.SteeringTargetNullable, hea
 }
 
 // Deprecated: UpdateSteeringTarget will be removed in 6.0. Use UpdateSteeringTargetWithHdr.
-func (to *Session) UpdateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateSteeringTargetWithHdr(st, nil)
 }
 
-func (to *Session) GetSteeringTargets(dsID int) ([]tc.SteeringTargetNullable, ReqInf, error) {
+func (to *Session) GetSteeringTargets(dsID int) ([]tc.SteeringTargetNullable, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("/steering/%d/targets", dsID)
 	data := struct {
 		Response []tc.SteeringTargetNullable `json:"response"`
@@ -61,7 +62,7 @@ func (to *Session) GetSteeringTargets(dsID int) ([]tc.SteeringTargetNullable, Re
 	return data.Response, reqInf, err
 }
 
-func (to *Session) DeleteSteeringTarget(dsID int, targetID int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteSteeringTarget(dsID int, targetID int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("/steering/%d/targets/%d", dsID, targetID)
 	alerts := tc.Alerts{}
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/tenant.go
+++ b/traffic_ops/v3-client/tenant.go
@@ -21,7 +21,8 @@ import (
 	"net/http"
 	"net/url"
 
-	tc "github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // API_TENANTS is Deprecated: will be removed in the next major version. Be aware this may not be the URI being requested, for clients created with Login and ClientOps.ForceLatestAPI false.
@@ -34,7 +35,7 @@ const APITenants = "/tenants"
 
 const APITenantID = APITenants + "/%v"
 
-func (to *Session) TenantsWithHdr(header http.Header) ([]tc.Tenant, ReqInf, error) {
+func (to *Session) TenantsWithHdr(header http.Header) ([]tc.Tenant, toclientlib.ReqInf, error) {
 	var data tc.GetTenantsResponse
 	reqInf, err := to.get(APITenants, header, &data)
 	return data.Response, reqInf, err
@@ -42,11 +43,11 @@ func (to *Session) TenantsWithHdr(header http.Header) ([]tc.Tenant, ReqInf, erro
 
 // Tenants gets an array of Tenants.
 // Deprecated: Tenants will be removed in 6.0. Use TenantsWithHdr.
-func (to *Session) Tenants() ([]tc.Tenant, ReqInf, error) {
+func (to *Session) Tenants() ([]tc.Tenant, toclientlib.ReqInf, error) {
 	return to.TenantsWithHdr(nil)
 }
 
-func (to *Session) TenantWithHdr(id string, header http.Header) (*tc.Tenant, ReqInf, error) {
+func (to *Session) TenantWithHdr(id string, header http.Header) (*tc.Tenant, toclientlib.ReqInf, error) {
 	var data tc.GetTenantsResponse
 	reqInf, err := to.get(fmt.Sprintf("%s?id=%v", APITenants, id), header, &data)
 	if err != nil {
@@ -61,11 +62,11 @@ func (to *Session) TenantWithHdr(id string, header http.Header) (*tc.Tenant, Req
 // Tenant gets the Tenant identified by the passed integral, unique identifer - which
 // must be passed as a string.
 // Deprecated: Tenant will be removed in 6.0. Use TenantWithHdr.
-func (to *Session) Tenant(id string) (*tc.Tenant, ReqInf, error) {
+func (to *Session) Tenant(id string) (*tc.Tenant, toclientlib.ReqInf, error) {
 	return to.TenantWithHdr(id, nil)
 }
 
-func (to *Session) TenantByNameWithHdr(name string, header http.Header) (*tc.Tenant, ReqInf, error) {
+func (to *Session) TenantByNameWithHdr(name string, header http.Header) (*tc.Tenant, toclientlib.ReqInf, error) {
 	var data tc.GetTenantsResponse
 	query := APITenants + "?name=" + url.QueryEscape(name)
 	reqInf, err := to.get(query, header, &data)
@@ -84,7 +85,7 @@ func (to *Session) TenantByNameWithHdr(name string, header http.Header) (*tc.Ten
 
 // TenantByName gets the Tenant with the name it's passed.
 // Deprecated: TenantByName will be removed in 6.0. Use TenantByNameWithHdr.
-func (to *Session) TenantByName(name string) (*tc.Tenant, ReqInf, error) {
+func (to *Session) TenantByName(name string) (*tc.Tenant, toclientlib.ReqInf, error) {
 	return to.TenantByNameWithHdr(name, nil)
 }
 
@@ -109,7 +110,7 @@ func (to *Session) CreateTenant(t *tc.Tenant) (*tc.TenantResponse, error) {
 	return &data, nil
 }
 
-func (to *Session) UpdateTenantWithHdr(id string, t *tc.Tenant, header http.Header) (*tc.TenantResponse, ReqInf, error) {
+func (to *Session) UpdateTenantWithHdr(id string, t *tc.Tenant, header http.Header) (*tc.TenantResponse, toclientlib.ReqInf, error) {
 	var data tc.TenantResponse
 	reqInf, err := to.put(fmt.Sprintf(APITenantID, id), t, header, &data)
 	if err != nil {

--- a/traffic_ops/v3-client/topology.go
+++ b/traffic_ops/v3-client/topology.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // ApiTopologies is Deprecated: will be removed in the next major version. Be aware this may not be the URI being requested, for clients created with Login and ClientOps.ForceLatestAPI false.
@@ -29,13 +30,13 @@ const ApiTopologies = apiBase + "/topologies"
 const APITopologies = "/topologies"
 
 // CreateTopology creates a topology and returns the response.
-func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf, error) {
+func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, toclientlib.ReqInf, error) {
 	resp := new(tc.TopologyResponse)
 	reqInf, err := to.post(APITopologies, top, nil, resp)
 	return resp, reqInf, err
 }
 
-func (to *Session) GetTopologiesWithHdr(header http.Header) ([]tc.Topology, ReqInf, error) {
+func (to *Session) GetTopologiesWithHdr(header http.Header) ([]tc.Topology, toclientlib.ReqInf, error) {
 	var data tc.TopologiesResponse
 	reqInf, err := to.get(ApiTopologies, header, &data)
 	return data.Response, reqInf, err
@@ -43,11 +44,11 @@ func (to *Session) GetTopologiesWithHdr(header http.Header) ([]tc.Topology, ReqI
 
 // GetTopologies returns all topologies.
 // Deprecated: GetTopologies will be removed in 6.0. Use GetTopologiesWithHdr.
-func (to *Session) GetTopologies() ([]tc.Topology, ReqInf, error) {
+func (to *Session) GetTopologies() ([]tc.Topology, toclientlib.ReqInf, error) {
 	return to.GetTopologiesWithHdr(nil)
 }
 
-func (to *Session) GetTopologyWithHdr(name string, header http.Header) (*tc.Topology, ReqInf, error) {
+func (to *Session) GetTopologyWithHdr(name string, header http.Header) (*tc.Topology, toclientlib.ReqInf, error) {
 	reqUrl := fmt.Sprintf("%s?name=%s", APITopologies, url.QueryEscape(name))
 	var data tc.TopologiesResponse
 	reqInf, err := to.get(reqUrl, header, &data)
@@ -62,12 +63,12 @@ func (to *Session) GetTopologyWithHdr(name string, header http.Header) (*tc.Topo
 
 // GetTopology returns the given topology by name.
 // Deprecated: GetTopology will be removed in 6.0. Use GetTopologyWithHdr.
-func (to *Session) GetTopology(name string) (*tc.Topology, ReqInf, error) {
+func (to *Session) GetTopology(name string) (*tc.Topology, toclientlib.ReqInf, error) {
 	return to.GetTopologyWithHdr(name, nil)
 }
 
 // UpdateTopology updates a Topology by name.
-func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyResponse, ReqInf, error) {
+func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyResponse, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APITopologies, name)
 	var response = new(tc.TopologyResponse)
 	reqInf, err := to.put(route, t, nil, &response)
@@ -75,7 +76,7 @@ func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyRespo
 }
 
 // DeleteTopology deletes the given topology by name.
-func (to *Session) DeleteTopology(name string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteTopology(name string) (tc.Alerts, toclientlib.ReqInf, error) {
 	reqUrl := fmt.Sprintf("%s?name=%s", APITopologies, url.QueryEscape(name))
 	var alerts tc.Alerts
 	reqInf, err := to.del(reqUrl, nil, &alerts)

--- a/traffic_ops/v3-client/topology_queue_updates.go
+++ b/traffic_ops/v3-client/topology_queue_updates.go
@@ -23,9 +23,10 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-func (to *Session) TopologiesQueueUpdate(topologyName tc.TopologyName, req tc.TopologiesQueueUpdateRequest) (tc.TopologiesQueueUpdateResponse, ReqInf, error) {
+func (to *Session) TopologiesQueueUpdate(topologyName tc.TopologyName, req tc.TopologiesQueueUpdateRequest) (tc.TopologiesQueueUpdateResponse, toclientlib.ReqInf, error) {
 	path := fmt.Sprintf("%s/%s/queue_update", APITopologies, topologyName)
 	var resp tc.TopologiesQueueUpdateResponse
 	reqInf, err := to.post(path, req, nil, &resp)

--- a/traffic_ops/v3-client/traffic_monitor.go
+++ b/traffic_ops/v3-client/traffic_monitor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 /*
@@ -37,7 +38,7 @@ const APICDNMonitoringConfig = "/cdns/%s/configs/monitoring"
 
 // GetTrafficMonitorConfigMap is functionally identical to GetTrafficMonitorConfig, except that it
 // coerces the value returned by the API to the tc.TrafficMonitorConfigMap structure.
-func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, ReqInf, error) {
+func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, toclientlib.ReqInf, error) {
 	tmConfig, reqInf, err := to.GetTrafficMonitorConfig(cdn)
 	if err != nil {
 		return nil, reqInf, err
@@ -50,7 +51,7 @@ func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorCon
 }
 
 // GetTrafficMonitorConfig returns the monitoring configuration for the CDN named by 'cdn'.
-func (to *Session) GetTrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, ReqInf, error) {
+func (to *Session) GetTrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf(APICDNMonitoringConfig, cdn)
 	var data tc.TMConfigResponse
 	reqInf, err := to.get(route, nil, &data)

--- a/traffic_ops/v3-client/traffic_stats.go
+++ b/traffic_ops/v3-client/traffic_stats.go
@@ -16,10 +16,11 @@ package client
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // GetCurrentStats gets current stats for each CDNs and a total across them
-func (to *Session) GetCurrentStats() (tc.TrafficStatsCDNStatsResponse, ReqInf, error) {
+func (to *Session) GetCurrentStats() (tc.TrafficStatsCDNStatsResponse, toclientlib.ReqInf, error) {
 	resp := tc.TrafficStatsCDNStatsResponse{}
 	reqInf, err := to.get("/current_stats", nil, &resp)
 	return resp, reqInf, err

--- a/traffic_ops/v3-client/type.go
+++ b/traffic_ops/v3-client/type.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
@@ -31,13 +32,13 @@ const (
 )
 
 // CreateType creates a Type. There should be a very good reason for doing this.
-func (to *Session) CreateType(typ tc.Type) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateType(typ tc.Type) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APITypes, typ, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateTypeByIDWithHdr(id int, typ tc.Type, header http.Header) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateTypeByIDWithHdr(id int, typ tc.Type, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APITypes, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, typ, header, &alerts)
@@ -46,7 +47,7 @@ func (to *Session) UpdateTypeByIDWithHdr(id int, typ tc.Type, header http.Header
 
 // UpdateTypeByID updates a Type by ID.
 // Deprecated: UpdateTypeByID will be removed in 6.0. Use UpdateTypeByIDWithHdr.
-func (to *Session) UpdateTypeByID(id int, typ tc.Type) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateTypeByID(id int, typ tc.Type) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateTypeByIDWithHdr(id, typ, nil)
 }
 
@@ -54,9 +55,9 @@ func (to *Session) UpdateTypeByID(id int, typ tc.Type) (tc.Alerts, ReqInf, error
 // If a 'useInTable' parameter is passed, the returned Types are restricted to those with
 // that exact 'useInTable' property. Only exactly 1 or exactly 0 'useInTable' parameters may
 // be passed; passing more will result in an error being returned.
-func (to *Session) GetTypesWithHdr(header http.Header, useInTable ...string) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypesWithHdr(header http.Header, useInTable ...string) ([]tc.Type, toclientlib.ReqInf, error) {
 	if len(useInTable) > 1 {
-		return nil, ReqInf{}, errors.New("please pass in a single value for the 'useInTable' parameter")
+		return nil, toclientlib.ReqInf{}, errors.New("please pass in a single value for the 'useInTable' parameter")
 	}
 	var data tc.TypesResponse
 	reqInf, err := to.get(APITypes, header, &data)
@@ -82,12 +83,12 @@ func (to *Session) GetTypesWithHdr(header http.Header, useInTable ...string) ([]
 // are restricted to those with that exact 'useInTable' property. Only exactly 1 or exactly 0
 // 'useInTable' parameters may be passed; passing more will result in an error being returned.
 // Deprecated: GetTypes will be removed in 6.0. Use GetTypesWithHdr.
-func (to *Session) GetTypes(useInTable ...string) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypes(useInTable ...string) ([]tc.Type, toclientlib.ReqInf, error) {
 	return to.GetTypesWithHdr(nil, useInTable...)
 }
 
 // GetTypeByID GETs a Type by the Type ID, and filters by http header params in the request.
-func (to *Session) GetTypeByIDWithHdr(id int, header http.Header) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypeByIDWithHdr(id int, header http.Header) ([]tc.Type, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?id=%d", APITypes, id)
 	var data tc.TypesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -96,11 +97,11 @@ func (to *Session) GetTypeByIDWithHdr(id int, header http.Header) ([]tc.Type, Re
 
 // GetTypeByID GETs a Type by the Type ID.
 // Deprecated: GetTypeByID will be removed in 6.0. Use GetTypeByIDWithHdr.
-func (to *Session) GetTypeByID(id int) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypeByID(id int) ([]tc.Type, toclientlib.ReqInf, error) {
 	return to.GetTypeByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetTypeByNameWithHdr(name string, header http.Header) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypeByNameWithHdr(name string, header http.Header) ([]tc.Type, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s?name=%s", APITypes, name)
 	var data tc.TypesResponse
 	reqInf, err := to.get(route, header, &data)
@@ -109,12 +110,12 @@ func (to *Session) GetTypeByNameWithHdr(name string, header http.Header) ([]tc.T
 
 // GetTypeByName GETs a Type by the Type name.
 // Deprecated: GetTypeByName will be removed in 6.0. Use GetTypeByNameWithHdr.
-func (to *Session) GetTypeByName(name string) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypeByName(name string) ([]tc.Type, toclientlib.ReqInf, error) {
 	return to.GetTypeByNameWithHdr(name, nil)
 }
 
 // DeleteTypeByID DELETEs a Type by ID.
-func (to *Session) DeleteTypeByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteTypeByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := fmt.Sprintf("%s/%d", APITypes, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)

--- a/traffic_ops/v3-client/user.go
+++ b/traffic_ops/v3-client/user.go
@@ -24,9 +24,10 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-func (to *Session) GetUsersWithHdr(header http.Header) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUsersWithHdr(header http.Header) ([]tc.User, toclientlib.ReqInf, error) {
 	data := tc.UsersResponse{}
 	route := "/users"
 	inf, err := to.get(route, header, &data)
@@ -35,11 +36,11 @@ func (to *Session) GetUsersWithHdr(header http.Header) ([]tc.User, ReqInf, error
 
 // GetUsers returns all users accessible from current user
 // Deprecated: GetUsers will be removed in 6.0. Use GetUsersWithHdr.
-func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
+func (to *Session) GetUsers() ([]tc.User, toclientlib.ReqInf, error) {
 	return to.GetUsersWithHdr(nil)
 }
 
-func (to *Session) GetUsersByRoleWithHdr(roleName string, header http.Header) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUsersByRoleWithHdr(roleName string, header http.Header) ([]tc.User, toclientlib.ReqInf, error) {
 	data := tc.UsersResponse{}
 	route := fmt.Sprintf("/users?role=%s", url.QueryEscape(roleName))
 	inf, err := to.get(route, header, &data)
@@ -48,11 +49,11 @@ func (to *Session) GetUsersByRoleWithHdr(roleName string, header http.Header) ([
 
 // GetUsersByRole returns all users accessible from current user for a given role
 // Deprecated: GetUsersByRole will be removed in 6.0. Use GetUsersByRoleWithHdr.
-func (to *Session) GetUsersByRole(roleName string) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUsersByRole(roleName string) ([]tc.User, toclientlib.ReqInf, error) {
 	return to.GetUsersByRoleWithHdr(roleName, nil)
 }
 
-func (to *Session) GetUserByIDWithHdr(id int, header http.Header) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUserByIDWithHdr(id int, header http.Header) ([]tc.User, toclientlib.ReqInf, error) {
 	data := tc.UsersResponse{}
 	route := fmt.Sprintf("/users/%d", id)
 	inf, err := to.get(route, header, &data)
@@ -60,11 +61,11 @@ func (to *Session) GetUserByIDWithHdr(id int, header http.Header) ([]tc.User, Re
 }
 
 // Deprecated: GetUserByID will be removed in 6.0. Use GetUserByIDWithHdr.
-func (to *Session) GetUserByID(id int) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUserByID(id int) ([]tc.User, toclientlib.ReqInf, error) {
 	return to.GetUserByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetUserByUsernameWithHdr(username string, header http.Header) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUserByUsernameWithHdr(username string, header http.Header) ([]tc.User, toclientlib.ReqInf, error) {
 	data := tc.UsersResponse{}
 	route := fmt.Sprintf("/users?username=%s", url.QueryEscape(username))
 	inf, err := to.get(route, header, &data)
@@ -72,11 +73,11 @@ func (to *Session) GetUserByUsernameWithHdr(username string, header http.Header)
 }
 
 // Deprecated: GetUserByUsername will be removed in 6.0. Use GetUserByUsernameWithHdr.
-func (to *Session) GetUserByUsername(username string) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUserByUsername(username string) ([]tc.User, toclientlib.ReqInf, error) {
 	return to.GetUserByUsernameWithHdr(username, nil)
 }
 
-func (to *Session) GetUserCurrentWithHdr(header http.Header) (*tc.UserCurrent, ReqInf, error) {
+func (to *Session) GetUserCurrentWithHdr(header http.Header) (*tc.UserCurrent, toclientlib.ReqInf, error) {
 	route := `/user/current`
 	resp := tc.UserCurrentResponse{}
 	reqInf, err := to.get(route, header, &resp)
@@ -88,12 +89,12 @@ func (to *Session) GetUserCurrentWithHdr(header http.Header) (*tc.UserCurrent, R
 
 // GetUserCurrent gets information about the current user
 // Deprecated: GetUserCurrent will be removed in 6.0. Use GetUserCurrentWithHdr.
-func (to *Session) GetUserCurrent() (*tc.UserCurrent, ReqInf, error) {
+func (to *Session) GetUserCurrent() (*tc.UserCurrent, toclientlib.ReqInf, error) {
 	return to.GetUserCurrentWithHdr(nil)
 }
 
 // UpdateCurrentUser replaces the current user data with the provided tc.User structure.
-func (to *Session) UpdateCurrentUser(u tc.User) (*tc.UpdateUserResponse, ReqInf, error) {
+func (to *Session) UpdateCurrentUser(u tc.User) (*tc.UpdateUserResponse, toclientlib.ReqInf, error) {
 	user := struct {
 		User tc.User `json:"user"`
 	}{u}
@@ -104,14 +105,14 @@ func (to *Session) UpdateCurrentUser(u tc.User) (*tc.UpdateUserResponse, ReqInf,
 }
 
 // CreateUser creates a user
-func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, error) {
+func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, toclientlib.ReqInf, error) {
 	if user.TenantID == nil && user.Tenant != nil {
 		tenant, _, err := to.TenantByNameWithHdr(*user.Tenant, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if tenant == nil {
-			return nil, ReqInf{}, errors.New("no tenant with name " + *user.Tenant)
+			return nil, toclientlib.ReqInf{}, errors.New("no tenant with name " + *user.Tenant)
 		}
 		user.TenantID = &tenant.ID
 	}
@@ -119,10 +120,10 @@ func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, er
 	if user.RoleName != nil && *user.RoleName != "" {
 		roles, _, _, err := to.GetRoleByNameWithHdr(*user.RoleName, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if len(roles) == 0 || roles[0].ID == nil {
-			return nil, ReqInf{}, errors.New("no role with name " + *user.RoleName)
+			return nil, toclientlib.ReqInf{}, errors.New("no role with name " + *user.RoleName)
 		}
 		user.Role = roles[0].ID
 	}
@@ -134,7 +135,7 @@ func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, er
 }
 
 // UpdateUserByID updates user with the given id
-func (to *Session) UpdateUserByID(id int, u *tc.User) (*tc.UpdateUserResponse, ReqInf, error) {
+func (to *Session) UpdateUserByID(id int, u *tc.User) (*tc.UpdateUserResponse, toclientlib.ReqInf, error) {
 	route := "/users/" + strconv.Itoa(id)
 	var clientResp tc.UpdateUserResponse
 	reqInf, err := to.put(route, u, nil, &clientResp)
@@ -142,7 +143,7 @@ func (to *Session) UpdateUserByID(id int, u *tc.User) (*tc.UpdateUserResponse, R
 }
 
 // DeleteUserByID updates user with the given id
-func (to *Session) DeleteUserByID(id int) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteUserByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
 	route := "/users/" + strconv.Itoa(id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
@@ -151,7 +152,7 @@ func (to *Session) DeleteUserByID(id int) (tc.Alerts, ReqInf, error) {
 
 // RegisterNewUser requests the registration of a new user with the given tenant ID and role ID,
 // through their email.
-func (to *Session) RegisterNewUser(tenantID uint, roleID uint, email rfc.EmailAddress) (tc.Alerts, ReqInf, error) {
+func (to *Session) RegisterNewUser(tenantID uint, roleID uint, email rfc.EmailAddress) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqBody := tc.UserRegistrationRequest{
 		Email:    email,

--- a/traffic_ops/v4-client/about.go
+++ b/traffic_ops/v4-client/about.go
@@ -20,13 +20,17 @@ package client
    limitations under the License.
 */
 
+import (
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+)
+
 const (
-	API_ABOUT = apiBase + "/about"
+	APIAbout = "/about"
 )
 
 // GetAbout gets data about the TO instance.
-func (to *Session) GetAbout() (map[string]string, ReqInf, error) {
-	route := API_ABOUT
+func (to *Session) GetAbout() (map[string]string, toclientlib.ReqInf, error) {
+	route := APIAbout
 	var data map[string]string
 	reqInf, err := to.get(route, nil, &data)
 	return data, reqInf, err

--- a/traffic_ops/v4-client/api_capability.go
+++ b/traffic_ops/v4-client/api_capability.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 /*
@@ -24,11 +25,11 @@ import (
 // GetAPICapabilities will retrieve API Capabilities. In the event that no capability parameter
 // is supplied, it will return all existing. If a capability is supplied, it will return only
 // those with an exact match. Order may be specified to change the default sort order.
-func (to *Session) GetAPICapabilities(capability string, order string) (tc.APICapabilityResponse, ReqInf, error) {
+func (to *Session) GetAPICapabilities(capability string, order string) (tc.APICapabilityResponse, toclientlib.ReqInf, error) {
 	var (
 		vals   = url.Values{}
-		path   = fmt.Sprintf("%s/api_capabilities", apiBase)
-		reqInf = ReqInf{CacheHitStatus: CacheHitStatusMiss}
+		path   = "/api_capabilities"
+		reqInf = toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}
 		resp   tc.APICapabilityResponse
 	)
 

--- a/traffic_ops/v4-client/asn.go
+++ b/traffic_ops/v4-client/asn.go
@@ -21,38 +21,39 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_ASNS = apiBase + "/asns"
+	APIASNs = "/asns"
 )
 
 // CreateASN creates a ASN
-func (to *Session) CreateASN(entity tc.ASN) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateASN(entity tc.ASN) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_ASNS, entity, nil, &alerts)
+	reqInf, err := to.post(APIASNs, entity, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // UpdateASNByID updates a ASN by ID
-func (to *Session) UpdateASNByID(id int, entity tc.ASN) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_ASNS, id)
+func (to *Session) UpdateASNByID(id int, entity tc.ASN) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIASNs, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, entity, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // GetASNsWithHeader Returns a list of ASNs matching query params
-func (to *Session) GetASNsWithHeader(params *url.Values, header http.Header) ([]tc.ASN, ReqInf, error) {
-	route := fmt.Sprintf("%s?%s", API_ASNS, params.Encode())
+func (to *Session) GetASNsWithHeader(params *url.Values, header http.Header) ([]tc.ASN, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?%s", APIASNs, params.Encode())
 	var data tc.ASNsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
 }
 
 // DeleteASNByASN deletes an ASN by asn number
-func (to *Session) DeleteASNByASN(asn int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_ASNS, asn)
+func (to *Session) DeleteASNByASN(asn int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIASNs, asn)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/cachegroup.go
+++ b/traffic_ops/v4-client/cachegroup.go
@@ -23,21 +23,22 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_CACHEGROUPS = apiBase + "/cachegroups"
+	APICachegroups = "/cachegroups"
 )
 
 // Create a CacheGroup.
-func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, ReqInf, error) {
+func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, toclientlib.ReqInf, error) {
 	if cachegroup.TypeID == nil && cachegroup.Type != nil {
 		ty, _, err := to.GetTypeByNameWithHdr(*cachegroup.Type, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if len(ty) == 0 {
-			return nil, ReqInf{}, errors.New("no type named " + *cachegroup.Type)
+			return nil, toclientlib.ReqInf{}, errors.New("no type named " + *cachegroup.Type)
 		}
 		cachegroup.TypeID = &ty[0].ID
 	}
@@ -45,10 +46,10 @@ func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*
 	if cachegroup.ParentCachegroupID == nil && cachegroup.ParentName != nil {
 		p, _, err := to.GetCacheGroupNullableByNameWithHdr(*cachegroup.ParentName, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if len(p) == 0 {
-			return nil, ReqInf{}, errors.New("no cachegroup named " + *cachegroup.ParentName)
+			return nil, toclientlib.ReqInf{}, errors.New("no cachegroup named " + *cachegroup.ParentName)
 		}
 		cachegroup.ParentCachegroupID = p[0].ID
 	}
@@ -56,21 +57,21 @@ func (to *Session) CreateCacheGroupNullable(cachegroup tc.CacheGroupNullable) (*
 	if cachegroup.SecondaryParentCachegroupID == nil && cachegroup.SecondaryParentName != nil {
 		p, _, err := to.GetCacheGroupNullableByNameWithHdr(*cachegroup.SecondaryParentName, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if len(p) == 0 {
-			return nil, ReqInf{}, errors.New("no cachegroup named " + *cachegroup.ParentName)
+			return nil, toclientlib.ReqInf{}, errors.New("no cachegroup named " + *cachegroup.ParentName)
 		}
 		cachegroup.SecondaryParentCachegroupID = p[0].ID
 	}
 
 	var cachegroupResp tc.CacheGroupDetailResponse
-	reqInf, err := to.post(API_CACHEGROUPS, cachegroup, nil, &cachegroupResp)
+	reqInf, err := to.post(APICachegroups, cachegroup, nil, &cachegroupResp)
 	return &cachegroupResp, reqInf, err
 }
 
-func (to *Session) UpdateCacheGroupNullableByIDWithHdr(id int, cachegroup tc.CacheGroupNullable, h http.Header) (*tc.CacheGroupDetailResponse, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_CACHEGROUPS, id)
+func (to *Session) UpdateCacheGroupNullableByIDWithHdr(id int, cachegroup tc.CacheGroupNullable, h http.Header) (*tc.CacheGroupDetailResponse, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APICachegroups, id)
 	var cachegroupResp tc.CacheGroupDetailResponse
 	reqInf, err := to.put(route, cachegroup, h, &cachegroupResp)
 	return &cachegroupResp, reqInf, err
@@ -78,24 +79,24 @@ func (to *Session) UpdateCacheGroupNullableByIDWithHdr(id int, cachegroup tc.Cac
 
 // Update a CacheGroup by ID.
 // Deprecated: UpdateCacheGroupNullableByID will be removed in 6.0. Use UpdateCacheGroupNullableByIDWithHdr.
-func (to *Session) UpdateCacheGroupNullableByID(id int, cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, ReqInf, error) {
+func (to *Session) UpdateCacheGroupNullableByID(id int, cachegroup tc.CacheGroupNullable) (*tc.CacheGroupDetailResponse, toclientlib.ReqInf, error) {
 	return to.UpdateCacheGroupNullableByIDWithHdr(id, cachegroup, nil)
 }
 
-func (to *Session) GetCacheGroupsNullableWithHdr(header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupsNullableWithHdr(header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	var data tc.CacheGroupsNullableResponse
-	reqInf, err := to.get(API_CACHEGROUPS, header, &data)
+	reqInf, err := to.get(APICachegroups, header, &data)
 	return data.Response, reqInf, err
 }
 
 // Returns a list of CacheGroups.
 // Deprecated: GetCacheGroupsNullable will be removed in 6.0. Use GetCacheGroupsNullableWithHdr.
-func (to *Session) GetCacheGroupsNullable() ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupsNullable() ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupsNullableWithHdr(nil)
 }
 
-func (to *Session) GetCacheGroupNullableByIDWithHdr(id int, header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%v", API_CACHEGROUPS, id)
+func (to *Session) GetCacheGroupNullableByIDWithHdr(id int, header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%v", APICachegroups, id)
 	var data tc.CacheGroupsNullableResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -103,12 +104,12 @@ func (to *Session) GetCacheGroupNullableByIDWithHdr(id int, header http.Header) 
 
 // GET a CacheGroup by the CacheGroup ID.
 // Deprecated: GetCacheGroupNullableByID will be removed in 6.0. Use GetCacheGroupNullableByIDWithHdr.
-func (to *Session) GetCacheGroupNullableByID(id int) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByID(id int) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupNullableByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetCacheGroupNullableByNameWithHdr(name string, header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", API_CACHEGROUPS, url.QueryEscape(name))
+func (to *Session) GetCacheGroupNullableByNameWithHdr(name string, header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APICachegroups, url.QueryEscape(name))
 	var data tc.CacheGroupsNullableResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -116,12 +117,12 @@ func (to *Session) GetCacheGroupNullableByNameWithHdr(name string, header http.H
 
 // GET a CacheGroup by the CacheGroup name.
 // Deprecated: GetCacheGroupNullableByName will be removed in 6.0. Use GetCacheGroupNullableByNameWithHdr.
-func (to *Session) GetCacheGroupNullableByName(name string) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByName(name string) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupNullableByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetCacheGroupNullableByShortNameWithHdr(shortName string, header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
-	route := fmt.Sprintf("%s?shortName=%s", API_CACHEGROUPS, url.QueryEscape(shortName))
+func (to *Session) GetCacheGroupNullableByShortNameWithHdr(shortName string, header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?shortName=%s", APICachegroups, url.QueryEscape(shortName))
 	var data tc.CacheGroupsNullableResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -129,13 +130,13 @@ func (to *Session) GetCacheGroupNullableByShortNameWithHdr(shortName string, hea
 
 // GET a CacheGroup by the CacheGroup short name.
 // Deprecated: GetCacheGroupNullableByShortName will be removed in 6.0. Use GetCacheGroupNullableByShortNameWithHdr.
-func (to *Session) GetCacheGroupNullableByShortName(shortName string) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupNullableByShortName(shortName string) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupNullableByShortNameWithHdr(shortName, nil)
 }
 
 // DELETE a CacheGroup by ID.
-func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_CACHEGROUPS, id)
+func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APICachegroups, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
@@ -143,12 +144,12 @@ func (to *Session) DeleteCacheGroupByID(id int) (tc.Alerts, ReqInf, error) {
 
 // GetCacheGroupsByQueryParams gets cache groups by the given query parameters.
 // Deprecated: GetCacheGroupsByQueryParams will be removed in 6.0. Use GetCacheGroupsByQueryParamsWithHdr.
-func (to *Session) GetCacheGroupsByQueryParams(qparams url.Values) ([]tc.CacheGroupNullable, ReqInf, error) {
+func (to *Session) GetCacheGroupsByQueryParams(qparams url.Values) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupsByQueryParamsWithHdr(qparams, nil)
 }
 
-func (to *Session) GetCacheGroupsByQueryParamsWithHdr(qparams url.Values, header http.Header) ([]tc.CacheGroupNullable, ReqInf, error) {
-	route := API_CACHEGROUPS
+func (to *Session) GetCacheGroupsByQueryParamsWithHdr(qparams url.Values, header http.Header) ([]tc.CacheGroupNullable, toclientlib.ReqInf, error) {
+	route := APICachegroups
 	if len(qparams) > 0 {
 		route += "?" + qparams.Encode()
 	}
@@ -157,8 +158,8 @@ func (to *Session) GetCacheGroupsByQueryParamsWithHdr(qparams url.Values, header
 	return data.Response, reqInf, err
 }
 
-func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int) (tc.CacheGroupPostDSRespResponse, ReqInf, error) {
-	uri := apiBase + `/cachegroups/` + strconv.Itoa(cgID) + `/deliveryservices`
+func (to *Session) SetCachegroupDeliveryServices(cgID int, dsIDs []int) (tc.CacheGroupPostDSRespResponse, toclientlib.ReqInf, error) {
+	uri := `/cachegroups/` + strconv.Itoa(cgID) + `/deliveryservices`
 	req := tc.CachegroupPostDSReq{DeliveryServices: dsIDs}
 	resp := tc.CacheGroupPostDSRespResponse{}
 	reqInf, err := to.post(uri, req, nil, &resp)

--- a/traffic_ops/v4-client/cachegroup_parameters.go
+++ b/traffic_ops/v4-client/cachegroup_parameters.go
@@ -20,43 +20,44 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_CACHEGROUPPARAMETERS = apiBase + "/cachegroupparameters"
+	APICachegroupParameters = "/cachegroupparameters"
 )
 
-func (to *Session) GetCacheGroupParametersWithHdr(cacheGroupID int, header http.Header) ([]tc.CacheGroupParameter, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d/parameters", API_CACHEGROUPS, cacheGroupID)
+func (to *Session) GetCacheGroupParametersWithHdr(cacheGroupID int, header http.Header) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/parameters", APICachegroups, cacheGroupID)
 	return to.getCacheGroupParameters(route, "", header)
 }
 
 // GetCacheGroupParameters Gets a Cache Group's Parameters
 // Deprecated: GetCacheGroupParameters will be removed in 6.0. Use GetCacheGroupParametersWithHdr.
-func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.CacheGroupParameter, ReqInf, error) {
+func (to *Session) GetCacheGroupParameters(cacheGroupID int) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupParametersWithHdr(cacheGroupID, nil)
 }
 
-func (to *Session) GetCacheGroupParametersByQueryParamsWithHdr(cacheGroupID int, queryParams string, header http.Header) ([]tc.CacheGroupParameter, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d/parameters", API_CACHEGROUPS, cacheGroupID)
+func (to *Session) GetCacheGroupParametersByQueryParamsWithHdr(cacheGroupID int, queryParams string, header http.Header) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/parameters", APICachegroups, cacheGroupID)
 	return to.getCacheGroupParameters(route, queryParams, header)
 }
 
 // GetCacheGroupParametersByQueryParams Gets a Cache Group's Parameters with query parameters
 // Deprecated: GetCacheGroupParametersByQueryParams will be removed in 6.0. Use GetCacheGroupParametersByQueryParamsWithHdr.
-func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.CacheGroupParameter, ReqInf, error) {
+func (to *Session) GetCacheGroupParametersByQueryParams(cacheGroupID int, queryParams string) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
 	return to.GetCacheGroupParametersByQueryParamsWithHdr(cacheGroupID, queryParams, nil)
 }
 
-func (to *Session) getCacheGroupParameters(route, queryParams string, header http.Header) ([]tc.CacheGroupParameter, ReqInf, error) {
+func (to *Session) getCacheGroupParameters(route, queryParams string, header http.Header) ([]tc.CacheGroupParameter, toclientlib.ReqInf, error) {
 	r := fmt.Sprintf("%s%s", route, queryParams)
 	var data tc.CacheGroupParametersResponse
 	reqInf, err := to.get(r, header, &data)
 	return data.Response, reqInf, err
 }
 
-func (to *Session) GetAllCacheGroupParametersWithHdr(header http.Header) ([]tc.CacheGroupParametersResponseNullable, ReqInf, error) {
-	route := fmt.Sprintf("%s/", API_CACHEGROUPPARAMETERS)
+func (to *Session) GetAllCacheGroupParametersWithHdr(header http.Header) ([]tc.CacheGroupParametersResponseNullable, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/", APICachegroupParameters)
 	var data tc.AllCacheGroupParametersResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response.CacheGroupParameters, reqInf, err
@@ -64,25 +65,25 @@ func (to *Session) GetAllCacheGroupParametersWithHdr(header http.Header) ([]tc.C
 
 // GetAllCacheGroupParameters Gets all Cachegroup Parameter associations
 // Deprecated: GetAllCacheGroupParameters will be removed in 6.0. Use GetAllCacheGroupParametersWithHdr.
-func (to *Session) GetAllCacheGroupParameters() ([]tc.CacheGroupParametersResponseNullable, ReqInf, error) {
+func (to *Session) GetAllCacheGroupParameters() ([]tc.CacheGroupParametersResponseNullable, toclientlib.ReqInf, error) {
 	return to.GetAllCacheGroupParametersWithHdr(nil)
 }
 
 // DeleteCacheGroupParameter Deassociates a Parameter with a Cache Group
-func (to *Session) DeleteCacheGroupParameter(cacheGroupID, parameterID int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d/%d", API_CACHEGROUPPARAMETERS, cacheGroupID, parameterID)
+func (to *Session) DeleteCacheGroupParameter(cacheGroupID, parameterID int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/%d", APICachegroupParameters, cacheGroupID, parameterID)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // CreateCacheGroupParameter Associates a Parameter with a Cache Group
-func (to *Session) CreateCacheGroupParameter(cacheGroupID, parameterID int) (*tc.CacheGroupParametersPostResponse, ReqInf, error) {
+func (to *Session) CreateCacheGroupParameter(cacheGroupID, parameterID int) (*tc.CacheGroupParametersPostResponse, toclientlib.ReqInf, error) {
 	cacheGroupParameterReq := tc.CacheGroupParameterRequest{
 		CacheGroupID: cacheGroupID,
 		ParameterID:  parameterID,
 	}
 	var data tc.CacheGroupParametersPostResponse
-	reqInf, err := to.post(API_CACHEGROUPPARAMETERS, cacheGroupParameterReq, nil, &data)
+	reqInf, err := to.post(APICachegroupParameters, cacheGroupParameterReq, nil, &data)
 	return &data, reqInf, err
 }

--- a/traffic_ops/v4-client/capability.go
+++ b/traffic_ops/v4-client/capability.go
@@ -19,25 +19,26 @@ import "net/http"
 import "net/url"
 
 import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 
-const API_CAPABILITIES = apiBase + "/capabilities"
+const APICapabilities = "/capabilities"
 
-func (to *Session) GetCapabilitiesWithHdr(header http.Header) ([]tc.Capability, ReqInf, error) {
+func (to *Session) GetCapabilitiesWithHdr(header http.Header) ([]tc.Capability, toclientlib.ReqInf, error) {
 	var data tc.CapabilitiesResponse
-	reqInf, err := to.get(API_CAPABILITIES, header, &data)
+	reqInf, err := to.get(APICapabilities, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetCapabilities retrieves all capabilities.
 // Deprecated: GetCapabilities will be removed in 6.0. Use GetCapabilitiesWithHdr.
-func (to *Session) GetCapabilities() ([]tc.Capability, ReqInf, error) {
+func (to *Session) GetCapabilities() ([]tc.Capability, toclientlib.ReqInf, error) {
 	return to.GetCapabilitiesWithHdr(nil)
 }
 
-func (to *Session) GetCapabilityWithHdr(c string, header http.Header) (tc.Capability, ReqInf, error) {
+func (to *Session) GetCapabilityWithHdr(c string, header http.Header) (tc.Capability, toclientlib.ReqInf, error) {
 	v := url.Values{}
 	v.Add("name", c)
-	endpoint := API_CAPABILITIES + "?" + v.Encode()
+	endpoint := APICapabilities + "?" + v.Encode()
 	var data tc.CapabilitiesResponse
 	reqInf, err := to.get(endpoint, header, &data)
 	if err != nil {
@@ -51,6 +52,6 @@ func (to *Session) GetCapabilityWithHdr(c string, header http.Header) (tc.Capabi
 
 // GetCapability retrieves only the capability named 'c'.
 // Deprecated: GetCapability will be removed in 6.0. Use GetCapabilityWithHdr.
-func (to *Session) GetCapability(c string) (tc.Capability, ReqInf, error) {
+func (to *Session) GetCapability(c string) (tc.Capability, toclientlib.ReqInf, error) {
 	return to.GetCapabilityWithHdr(c, nil)
 }

--- a/traffic_ops/v4-client/cdn.go
+++ b/traffic_ops/v4-client/cdn.go
@@ -21,21 +21,22 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_CDNS = apiBase + "/cdns"
+	APICDNs = "/cdns"
 )
 
 // CreateCDN creates a CDN.
-func (to *Session) CreateCDN(cdn tc.CDN) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateCDN(cdn tc.CDN) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_CDNS, cdn, nil, &alerts)
+	reqInf, err := to.post(APICDNs, cdn, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateCDNByIDWithHdr(id int, cdn tc.CDN, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_CDNS, id)
+func (to *Session) UpdateCDNByIDWithHdr(id int, cdn tc.CDN, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APICDNs, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, cdn, header, &alerts)
 	return alerts, reqInf, err
@@ -43,24 +44,24 @@ func (to *Session) UpdateCDNByIDWithHdr(id int, cdn tc.CDN, header http.Header) 
 
 // UpdateCDNByID updates a CDN by ID.
 // Deprecated: UpdateCDNByID will be removed in 6.0. Use UpdateCDNByIDWithHdr.
-func (to *Session) UpdateCDNByID(id int, cdn tc.CDN) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateCDNByID(id int, cdn tc.CDN) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateCDNByIDWithHdr(id, cdn, nil)
 }
 
-func (to *Session) GetCDNsWithHdr(header http.Header) ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNsWithHdr(header http.Header) ([]tc.CDN, toclientlib.ReqInf, error) {
 	var data tc.CDNsResponse
-	reqInf, err := to.get(API_CDNS, header, &data)
+	reqInf, err := to.get(APICDNs, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetCDNs eturns a list of CDNs.
 // Deprecated: GetCDNs will be removed in 6.0. Use GetCDNsWithHdr.
-func (to *Session) GetCDNs() ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNs() ([]tc.CDN, toclientlib.ReqInf, error) {
 	return to.GetCDNsWithHdr(nil)
 }
 
-func (to *Session) GetCDNByIDWithHdr(id int, header http.Header) ([]tc.CDN, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%v", API_CDNS, id)
+func (to *Session) GetCDNByIDWithHdr(id int, header http.Header) ([]tc.CDN, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%v", APICDNs, id)
 	var data tc.CDNsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -68,12 +69,12 @@ func (to *Session) GetCDNByIDWithHdr(id int, header http.Header) ([]tc.CDN, ReqI
 
 // GetCDNByID a CDN by the CDN ID.
 // Deprecated: GetCDNByID will be removed in 6.0. Use GetCDNByIDWithHdr.
-func (to *Session) GetCDNByID(id int) ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNByID(id int) ([]tc.CDN, toclientlib.ReqInf, error) {
 	return to.GetCDNByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetCDNByNameWithHdr(name string, header http.Header) ([]tc.CDN, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", API_CDNS, url.QueryEscape(name))
+func (to *Session) GetCDNByNameWithHdr(name string, header http.Header) ([]tc.CDN, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APICDNs, url.QueryEscape(name))
 	var data tc.CDNsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -81,26 +82,26 @@ func (to *Session) GetCDNByNameWithHdr(name string, header http.Header) ([]tc.CD
 
 // GetCDNByName gets a CDN by the CDN name.
 // Deprecated: GetCDNByName will be removed in 6.0. Use GetCDNByNameWithHdr.
-func (to *Session) GetCDNByName(name string) ([]tc.CDN, ReqInf, error) {
+func (to *Session) GetCDNByName(name string) ([]tc.CDN, toclientlib.ReqInf, error) {
 	return to.GetCDNByNameWithHdr(name, nil)
 }
 
 // DeleteCDNByID deletes a CDN by ID.
-func (to *Session) DeleteCDNByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_CDNS, id)
+func (to *Session) DeleteCDNByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APICDNs, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetCDNSSLKeysWithHdr(name string, header http.Header) ([]tc.CDNSSLKeys, ReqInf, error) {
-	route := fmt.Sprintf("%s/name/%s/sslkeys", API_CDNS, name)
+func (to *Session) GetCDNSSLKeysWithHdr(name string, header http.Header) ([]tc.CDNSSLKeys, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/name/%s/sslkeys", APICDNs, name)
 	var data tc.CDNSSLKeysResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
 }
 
 // Deprecated: GetCDNSSLKeys will be removed in 6.0. Use GetCDNSSLKeysWithHdr.
-func (to *Session) GetCDNSSLKeys(name string) ([]tc.CDNSSLKeys, ReqInf, error) {
+func (to *Session) GetCDNSSLKeys(name string) ([]tc.CDNSSLKeys, toclientlib.ReqInf, error) {
 	return to.GetCDNSSLKeysWithHdr(name, nil)
 }

--- a/traffic_ops/v4-client/cdn_domains.go
+++ b/traffic_ops/v4-client/cdn_domains.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 /*
@@ -21,13 +22,13 @@ import (
    limitations under the License.
 */
 
-func (to *Session) GetDomainsWithHdr(header http.Header) ([]tc.Domain, ReqInf, error) {
+func (to *Session) GetDomainsWithHdr(header http.Header) ([]tc.Domain, toclientlib.ReqInf, error) {
 	var data tc.DomainsResponse
-	inf, err := to.get(apiBase+"/cdns/domains", header, &data)
+	inf, err := to.get("/cdns/domains", header, &data)
 	return data.Response, inf, err
 }
 
 // Deprecated: GetDomains will be removed in 6.0. Use GetDomainsWithHdr.
-func (to *Session) GetDomains() ([]tc.Domain, ReqInf, error) {
+func (to *Session) GetDomains() ([]tc.Domain, toclientlib.ReqInf, error) {
 	return to.GetDomainsWithHdr(nil)
 }

--- a/traffic_ops/v4-client/cdnfederations.go
+++ b/traffic_ops/v4-client/cdnfederations.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 /* Internally, the CDNName is only used in the GET method. The CDNName
@@ -28,27 +29,27 @@ import (
  * `/cdns/:name/federations`. Although the behavior is odd, it is kept to
  * keep the same behavior from perl. */
 
-func (to *Session) CreateCDNFederationByName(f tc.CDNFederation, CDNName string) (*tc.CreateCDNFederationResponse, ReqInf, error) {
+func (to *Session) CreateCDNFederationByName(f tc.CDNFederation, CDNName string) (*tc.CreateCDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.CreateCDNFederationResponse{}
-	route := fmt.Sprintf("%s/cdns/%s/federations", apiBase, url.QueryEscape(CDNName))
+	route := "/cdns/" + url.QueryEscape(CDNName) + "/federations"
 	inf, err := to.post(route, f, nil, &data)
 	return &data, inf, err
 }
 
-func (to *Session) GetCDNFederationsByNameWithHdr(CDNName string, header http.Header) (*tc.CDNFederationResponse, ReqInf, error) {
+func (to *Session) GetCDNFederationsByNameWithHdr(CDNName string, header http.Header) (*tc.CDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.CDNFederationResponse{}
-	route := fmt.Sprintf("%s/cdns/%s/federations", apiBase, url.QueryEscape(CDNName))
+	route := "/cdns/" + url.QueryEscape(CDNName) + "/federations"
 	inf, err := to.get(route, header, &data)
 	return &data, inf, err
 }
 
 // Deprecated: GetCDNFederationsByName will be removed in 6.0. Use GetCDNFederationsByNameWithHdr.
-func (to *Session) GetCDNFederationsByName(CDNName string) (*tc.CDNFederationResponse, ReqInf, error) {
+func (to *Session) GetCDNFederationsByName(CDNName string) (*tc.CDNFederationResponse, toclientlib.ReqInf, error) {
 	return to.GetCDNFederationsByNameWithHdr(CDNName, nil)
 }
 
-func (to *Session) GetCDNFederationsByNameWithHdrReturnList(CDNName string, header http.Header) ([]tc.CDNFederation, ReqInf, error) {
-	route := fmt.Sprintf("%s/cdns/%s/federations", apiBase, url.QueryEscape(CDNName))
+func (to *Session) GetCDNFederationsByNameWithHdrReturnList(CDNName string, header http.Header) ([]tc.CDNFederation, toclientlib.ReqInf, error) {
+	route := "/cdns/" + url.QueryEscape(CDNName) + "/federations"
 	resp := struct {
 		Response []tc.CDNFederation `json:"response"`
 	}{}
@@ -56,33 +57,33 @@ func (to *Session) GetCDNFederationsByNameWithHdrReturnList(CDNName string, head
 	return resp.Response, inf, err
 }
 
-func (to *Session) GetCDNFederationsByIDWithHdr(CDNName string, ID int, header http.Header) (*tc.CDNFederationResponse, ReqInf, error) {
+func (to *Session) GetCDNFederationsByIDWithHdr(CDNName string, ID int, header http.Header) (*tc.CDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.CDNFederationResponse{}
-	route := fmt.Sprintf("%s/cdns/%s/federations?id=%v", apiBase, url.QueryEscape(CDNName), ID)
+	route := fmt.Sprintf("/cdns/%s/federations?id=%v", url.QueryEscape(CDNName), ID)
 	inf, err := to.get(route, header, &data)
 	return &data, inf, err
 }
 
 // Deprecated: GetCDNFederationsByID will be removed in 6.0. Use GetCDNFederationsByIDWithHdr.
-func (to *Session) GetCDNFederationsByID(CDNName string, ID int) (*tc.CDNFederationResponse, ReqInf, error) {
+func (to *Session) GetCDNFederationsByID(CDNName string, ID int) (*tc.CDNFederationResponse, toclientlib.ReqInf, error) {
 	return to.GetCDNFederationsByIDWithHdr(CDNName, ID, nil)
 }
 
-func (to *Session) UpdateCDNFederationsByIDWithHdr(f tc.CDNFederation, CDNName string, ID int, h http.Header) (*tc.UpdateCDNFederationResponse, ReqInf, error) {
+func (to *Session) UpdateCDNFederationsByIDWithHdr(f tc.CDNFederation, CDNName string, ID int, h http.Header) (*tc.UpdateCDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.UpdateCDNFederationResponse{}
-	route := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, url.QueryEscape(CDNName), ID)
+	route := fmt.Sprintf("/cdns/%s/federations/%d", url.QueryEscape(CDNName), ID)
 	inf, err := to.put(route, f, h, &data)
 	return &data, inf, err
 }
 
 // Deprecated: UpdateCDNFederationsByID will be removed in 6.0. Use UpdateCDNFederationsByIDWithHdr.
-func (to *Session) UpdateCDNFederationsByID(f tc.CDNFederation, CDNName string, ID int) (*tc.UpdateCDNFederationResponse, ReqInf, error) {
+func (to *Session) UpdateCDNFederationsByID(f tc.CDNFederation, CDNName string, ID int) (*tc.UpdateCDNFederationResponse, toclientlib.ReqInf, error) {
 	return to.UpdateCDNFederationsByIDWithHdr(f, CDNName, ID, nil)
 }
 
-func (to *Session) DeleteCDNFederationByID(CDNName string, ID int) (*tc.DeleteCDNFederationResponse, ReqInf, error) {
+func (to *Session) DeleteCDNFederationByID(CDNName string, ID int) (*tc.DeleteCDNFederationResponse, toclientlib.ReqInf, error) {
 	data := tc.DeleteCDNFederationResponse{}
-	route := fmt.Sprintf("%s/cdns/%s/federations/%d", apiBase, url.QueryEscape(CDNName), ID)
+	route := fmt.Sprintf("/cdns/%s/federations/%d", url.QueryEscape(CDNName), ID)
 	inf, err := to.del(route, nil, &data)
 	return &data, inf, err
 }

--- a/traffic_ops/v4-client/coordinate.go
+++ b/traffic_ops/v4-client/coordinate.go
@@ -20,21 +20,22 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_COORDINATES = apiBase + "/coordinates"
+	APICoordinates = "/coordinates"
 )
 
 // Create a Coordinate
-func (to *Session) CreateCoordinate(coordinate tc.Coordinate) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateCoordinate(coordinate tc.Coordinate) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_COORDINATES, coordinate, nil, &alerts)
+	reqInf, err := to.post(APICoordinates, coordinate, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateCoordinateByIDWithHdr(id int, coordinate tc.Coordinate, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_COORDINATES, id)
+func (to *Session) UpdateCoordinateByIDWithHdr(id int, coordinate tc.Coordinate, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APICoordinates, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, coordinate, header, &alerts)
 	return alerts, reqInf, err
@@ -42,24 +43,24 @@ func (to *Session) UpdateCoordinateByIDWithHdr(id int, coordinate tc.Coordinate,
 
 // Update a Coordinate by ID
 // Deprecated: UpdateCoordinateByID will be removed in 6.0. Use UpdateCoordinateByIDWithHdr.
-func (to *Session) UpdateCoordinateByID(id int, coordinate tc.Coordinate) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateCoordinateByID(id int, coordinate tc.Coordinate) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateCoordinateByIDWithHdr(id, coordinate, nil)
 }
 
-func (to *Session) GetCoordinatesWithHdr(header http.Header) ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinatesWithHdr(header http.Header) ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	var data tc.CoordinatesResponse
-	reqInf, err := to.get(API_COORDINATES, header, &data)
+	reqInf, err := to.get(APICoordinates, header, &data)
 	return data.Response, reqInf, err
 }
 
 // Returns a list of Coordinates
 // Deprecated: GetCoordinates will be removed in 6.0. Use GetCoordinatesWithHdr.
-func (to *Session) GetCoordinates() ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinates() ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	return to.GetCoordinatesWithHdr(nil)
 }
 
-func (to *Session) GetCoordinateByIDWithHdr(id int, header http.Header) ([]tc.Coordinate, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_COORDINATES, id)
+func (to *Session) GetCoordinateByIDWithHdr(id int, header http.Header) ([]tc.Coordinate, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APICoordinates, id)
 	var data tc.CoordinatesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -67,26 +68,26 @@ func (to *Session) GetCoordinateByIDWithHdr(id int, header http.Header) ([]tc.Co
 
 // GET a Coordinate by the Coordinate id
 // Deprecated: GetCoordinateByID will be removed in 6.0. Use GetCoordinateByIDWithHdr.
-func (to *Session) GetCoordinateByID(id int) ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinateByID(id int) ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	return to.GetCoordinateByIDWithHdr(id, nil)
 }
 
 // GET a Coordinate by the Coordinate name
 // Deprecated: GetCoordinateByName will be removed in 6.0. Use GetCoordinateByNameWithHdr.
-func (to *Session) GetCoordinateByName(name string) ([]tc.Coordinate, ReqInf, error) {
+func (to *Session) GetCoordinateByName(name string) ([]tc.Coordinate, toclientlib.ReqInf, error) {
 	return to.GetCoordinateByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetCoordinateByNameWithHdr(name string, header http.Header) ([]tc.Coordinate, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", API_COORDINATES, name)
+func (to *Session) GetCoordinateByNameWithHdr(name string, header http.Header) ([]tc.Coordinate, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APICoordinates, name)
 	var data tc.CoordinatesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
 }
 
 // DELETE a Coordinate by ID
-func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_COORDINATES, id)
+func (to *Session) DeleteCoordinateByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APICoordinates, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/crconfig.go
+++ b/traffic_ops/v4-client/crconfig.go
@@ -22,10 +22,11 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_SNAPSHOT = apiBase + "/snapshot"
+	APISnapshot = "/snapshot"
 )
 
 type OuterResponse struct {
@@ -33,9 +34,10 @@ type OuterResponse struct {
 }
 
 // GetCRConfig returns the raw JSON bytes of the CRConfig from Traffic Ops, and whether the bytes were from the client's internal cache.
-func (to *Session) GetCRConfig(cdn string) ([]byte, ReqInf, error) {
-	uri := apiBase + `/cdns/` + cdn + `/snapshot`
-	bts, reqInf, err := to.getBytesWithTTL(uri, tmPollingInterval)
+func (to *Session) GetCRConfig(cdn string) ([]byte, toclientlib.ReqInf, error) {
+	uri := `/cdns/` + cdn + `/snapshot`
+	bts := []byte{}
+	reqInf, err := to.get(uri, nil, &bts)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -47,17 +49,18 @@ func (to *Session) GetCRConfig(cdn string) ([]byte, ReqInf, error) {
 	return resp.Response, reqInf, nil
 }
 
-func (to *Session) SnapshotCRConfigWithHdr(cdn string, header http.Header) (ReqInf, error) {
-	uri := fmt.Sprintf("%s?cdn=%s", API_SNAPSHOT, url.QueryEscape(cdn))
+func (to *Session) SnapshotCRConfigWithHdr(cdn string, header http.Header) (toclientlib.ReqInf, error) {
+	uri := fmt.Sprintf("%s?cdn=%s", APISnapshot, url.QueryEscape(cdn))
 	resp := OuterResponse{}
 	reqInf, err := to.put(uri, nil, header, &resp)
 	return reqInf, err
 }
 
 // GetCRConfigNew returns the raw JSON bytes of the latest CRConfig from Traffic Ops, and whether the bytes were from the client's internal cache.
-func (to *Session) GetCRConfigNew(cdn string) ([]byte, ReqInf, error) {
-	uri := apiBase + `/cdns/` + cdn + `/snapshot/new`
-	bts, reqInf, err := to.getBytesWithTTL(uri, tmPollingInterval)
+func (to *Session) GetCRConfigNew(cdn string) ([]byte, toclientlib.ReqInf, error) {
+	uri := `/cdns/` + cdn + `/snapshot/new`
+	bts := []byte{}
+	reqInf, err := to.get(uri, nil, &bts)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -71,13 +74,13 @@ func (to *Session) GetCRConfigNew(cdn string) ([]byte, ReqInf, error) {
 
 // SnapshotCRConfig snapshots a CDN by name.
 // Deprecated: SnapshotCRConfig will be removed in 6.0. Use SnapshotCRConfigWithHdr.
-func (to *Session) SnapshotCRConfig(cdn string) (ReqInf, error) {
+func (to *Session) SnapshotCRConfig(cdn string) (toclientlib.ReqInf, error) {
 	return to.SnapshotCRConfigWithHdr(cdn, nil)
 }
 
 // SnapshotCDNByID snapshots a CDN by ID.
-func (to *Session) SnapshotCRConfigByID(id int) (tc.Alerts, ReqInf, error) {
-	url := fmt.Sprintf("%s?cdnID=%d", API_SNAPSHOT, id)
+func (to *Session) SnapshotCRConfigByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	url := fmt.Sprintf("%s?cdnID=%d", APISnapshot, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(url, nil, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/deliveryservice.go
+++ b/traffic_ops/v4-client/deliveryservice.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // These are the API endpoints used by the various Delivery Service-related client methods.
@@ -32,94 +33,94 @@ const (
 	// API_DELIVERY_SERVICES is the API path on which Traffic Ops serves Delivery Service
 	// information. More specific information is typically found on sub-paths of this.
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices.html
-	API_DELIVERY_SERVICES = apiBase + "/deliveryservices"
+	APIDeliveryServices = "/deliveryservices"
 
-	// API_DELIVERY_SERVICE_ID is the API path on which Traffic Ops serves information about
+	// APIDeliveryServiceId is the API path on which Traffic Ops serves information about
 	// a specific Delivery Service identified by an integral, unique identifier. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the ID
 	// of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id.html
-	API_DELIVERY_SERVICE_ID = API_DELIVERY_SERVICES + "/%v"
+	APIDeliveryServiceID = APIDeliveryServices + "/%v"
 
-	// API_DELIVERY_SERVICE_HEALTH is the API path on which Traffic Ops serves information about
+	// APIDeliveryServiceHealth is the API path on which Traffic Ops serves information about
 	// the 'health' of a specific Delivery Service identified by an integral, unique identifier. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the ID
 	// of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_health.html
-	API_DELIVERY_SERVICE_HEALTH = API_DELIVERY_SERVICE_ID + "/health"
+	APIDeliveryServiceHealth = APIDeliveryServiceID + "/health"
 
-	// API_DELIVERY_SERVICE_CAPACITY is the API path on which Traffic Ops serves information about
+	// APIDeliveryServiceCapacity is the API path on which Traffic Ops serves information about
 	// the 'capacity' of a specific Delivery Service identified by an integral, unique identifier. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the ID
 	// of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_capacity.html
-	API_DELIVERY_SERVICE_CAPACITY = API_DELIVERY_SERVICE_ID + "/capacity"
+	APIDeliveryServiceCapacity = APIDeliveryServiceID + "/capacity"
 
-	// API_DELIVERY_SERVICE_ELIGIBLE_SERVERS is the API path on which Traffic Ops serves information about
+	// APIDeliveryServiceEligibleServers is the API path on which Traffic Ops serves information about
 	// the servers which are eligible to be assigned to a specific Delivery Service identified by an integral,
 	// unique identifier. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the ID of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_servers_eligible.html
-	API_DELIVERY_SERVICE_ELIGIBLE_SERVERS = API_DELIVERY_SERVICE_ID + "/servers/eligible"
+	APIDeliveryServiceEligibleServers = APIDeliveryServiceID + "/servers/eligible"
 
-	// API_DELIVERY_SERVICES_SAFE_UPDATE is the API path on which Traffic Ops provides the functionality to
+	// APIDeliveryServicesSafeUpdate is the API path on which Traffic Ops provides the functionality to
 	// update the "safe" subset of properties of a Delivery Service identified by an integral, unique
 	// identifer. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the ID of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_safe.html
-	API_DELIVERY_SERVICES_SAFE_UPDATE = API_DELIVERY_SERVICE_ID + "/safe"
+	APIDeliveryServicesSafeUpdate = APIDeliveryServiceID + "/safe"
 
-	// API_DELIVERY_SERVICE_XMLID_SSL_KEYS is the API path on which Traffic Ops serves information about
+	// APIDeliveryServiceXMLIDSSLKeys is the API path on which Traffic Ops serves information about
 	// and functionality relating to the SSL keys used by a Delivery Service identified by its XMLID. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the XMLID
 	// of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_xmlid_sslkeys.html
-	API_DELIVERY_SERVICE_XMLID_SSL_KEYS = API_DELIVERY_SERVICES + "/xmlId/%s/sslkeys"
+	APIDeliveryServiceXMLIDSSLKeys = APIDeliveryServices + "/xmlId/%s/sslkeys"
 
-	// API_DELIVERY_SERVICE_GENERATE_SSL_KEYS is the API path on which Traffic Ops will generate new SSL keys
+	// APIDeliveryServiceGenerateSSLKeys is the API path on which Traffic Ops will generate new SSL keys
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_sslkeys_generate.html
-	API_DELIVERY_SERVICE_GENERATE_SSL_KEYS = API_DELIVERY_SERVICES + "/sslkeys/generate"
+	APIDeliveryServiceGenerateSSLKeys = APIDeliveryServices + "/sslkeys/generate"
 
-	// API_DELIVERY_SERVICE_URI_SIGNING_KEYS is the API path on which Traffic Ops serves information
+	// APIDeliveryServiceURISigningKeys is the API path on which Traffic Ops serves information
 	// about and functionality relating to the URI-signing keys used by a Delivery Service identified
 	// by its XMLID. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the XMLID of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_urisignkeys.html
-	API_DELIVERY_SERVICES_URI_SIGNING_KEYS = API_DELIVERY_SERVICES + "/%s/urisignkeys"
+	APIDeliveryServicesURISigningKeys = APIDeliveryServices + "/%s/urisignkeys"
 
-	// API_DELIVERY_SERVICES_URL_SIGNING_KEYS is the API path on which Traffic Ops serves information
+	// APIDeliveryServicesURLSigKeys is the API path on which Traffic Ops serves information
 	// about and functionality relating to the URL-signing keys used by a Delivery Service identified
 	// by its XMLID. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the XMLID of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_xmlid_urlkeys.html
-	API_DELIVERY_SERVICES_URL_SIGNING_KEYS = API_DELIVERY_SERVICES + "/xmlid/%s/urlkeys"
+	APIDeliveryServicesURLSigKeys = APIDeliveryServices + "/xmlid/%s/urlkeys"
 
-	// API_DELIVERY_SERVICES_REGEXES is the API path on which Traffic Ops serves Delivery Service
+	// APIDeliveryServicesRegexes is the API path on which Traffic Ops serves Delivery Service
 	// 'regex' (Regular Expression) information.
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_regexes.html
-	API_DELIVERY_SERVICES_REGEXES = apiBase + "/deliveryservices_regexes"
+	APIDeliveryServicesRegexes = "/deliveryservices_regexes"
 
-	// API_SERVER_DELIVERY_SERVICES is the API path on which Traffic Ops serves functionality
+	// APIServerDeliveryServices is the API path on which Traffic Ops serves functionality
 	// related to the associations a specific server and its assigned Delivery Services. It is
 	// intended to be used with fmt.Sprintf to insert its required path parameter (namely the ID
 	// of the server of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/servers_id_deliveryservices.html
-	API_SERVER_DELIVERY_SERVICES = apiBase + "/servers/%d/deliveryservices"
+	APIServerDeliveryServices = "/servers/%d/deliveryservices"
 
-	// API_DELIVERY_SERVICE_SERVER is the API path on which Traffic Ops serves functionality related
+	// APIDeliveryServiceServer is the API path on which Traffic Ops serves functionality related
 	// to the associations between Delivery Services and their assigned Server(s).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryserviceserver.html
-	API_DELIVERY_SERVICE_SERVER = apiBase + "/deliveryserviceserver"
+	APIDeliveryServiceServer = "/deliveryserviceserver"
 
-	// API_DELIVERY_SERVICES_SERVERS is the API path on which Traffic Ops serves functionality related
+	// APIDeliveryServicesServers is the API path on which Traffic Ops serves functionality related
 	// to the associations between a Delivery Service and its assigned Server(s).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_servers.html
-	API_DELIVERY_SERVICES_SERVERS = apiBase + "/deliveryservices/%s/servers"
+	APIDeliveryServicesServers = "/deliveryservices/%s/servers"
 )
 
-func (to *Session) GetDeliveryServicesByServerV30WithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByServerV30WithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServicesResponseV30
-	reqInf, err := to.get(fmt.Sprintf(API_SERVER_DELIVERY_SERVICES, id), header, &data)
+	reqInf, err := to.get(fmt.Sprintf(APIServerDeliveryServices, id), header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -131,22 +132,22 @@ func (to *Session) GetDeliveryServicesByServerV30WithHdr(id int, header http.Hea
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesByServerV30WithHdr.
-func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesByServerWithHdr(id, nil)
 }
 
-func (to *Session) GetDeliveryServicesByServerWithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByServerWithHdr(id int, header http.Header) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServicesNullableResponse
 
-	reqInf, err := to.get(fmt.Sprintf(API_SERVER_DELIVERY_SERVICES, id), header, &data)
+	reqInf, err := to.get(fmt.Sprintf(APIServerDeliveryServices, id), header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetDeliveryServicesV30WithHdr returns all (tenant-visible) Delivery Services that
 // satisfy the passed query string parameters. See the API documentation for
 // information on the available parameters.
-func (to *Session) GetDeliveryServicesV30WithHdr(header http.Header, params url.Values) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
-	uri := API_DELIVERY_SERVICES
+func (to *Session) GetDeliveryServicesV30WithHdr(header http.Header, params url.Values) ([]tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
+	uri := APIDeliveryServices
 	if params != nil {
 		uri += "?" + params.Encode()
 	}
@@ -158,8 +159,8 @@ func (to *Session) GetDeliveryServicesV30WithHdr(header http.Header, params url.
 // GetDeliveryServicesV4 returns all (tenant-visible) Delivery Services that
 // satisfy the passed query string parameters. See the API documentation for
 // information on the available parameters.
-func (to *Session) GetDeliveryServicesV4(header http.Header, params url.Values) ([]tc.DeliveryServiceV4, ReqInf, error) {
-	uri := API_DELIVERY_SERVICES
+func (to *Session) GetDeliveryServicesV4(header http.Header, params url.Values) ([]tc.DeliveryServiceV4, toclientlib.ReqInf, error) {
+	uri := APIDeliveryServices
 	if params != nil {
 		uri += "?" + params.Encode()
 	}
@@ -168,11 +169,11 @@ func (to *Session) GetDeliveryServicesV4(header http.Header, params url.Values) 
 	return data.Response, reqInf, err
 }
 
-func (to *Session) GetDeliveryServicesNullableWithHdr(header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesNullableWithHdr(header http.Header) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
-	reqInf, err := to.get(API_DELIVERY_SERVICES, header, &data)
+	reqInf, err := to.get(APIDeliveryServices, header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -183,15 +184,15 @@ func (to *Session) GetDeliveryServicesNullableWithHdr(header http.Header) ([]tc.
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetDeliveryServicesNullable() ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesNullable() ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesNullableWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServicesByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
-	reqInf, err := to.get(API_DELIVERY_SERVICES+"?cdn="+strconv.Itoa(cdnID), header, &data)
+	reqInf, err := to.get(APIDeliveryServices+"?cdn="+strconv.Itoa(cdnID), header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -203,16 +204,16 @@ func (to *Session) GetDeliveryServicesByCDNIDWithHdr(cdnID int, header http.Head
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetDeliveryServicesByCDNID(cdnID int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServicesByCDNID(cdnID int) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesByCDNIDWithHdr(cdnID, nil)
 }
 
 // GetDeliveryServiceNullableWithHdr fetches the Delivery Service with the given ID.
-func (to *Session) GetDeliveryServiceNullableWithHdr(id string, header http.Header) (*tc.DeliveryServiceV4, ReqInf, error) {
+func (to *Session) GetDeliveryServiceNullableWithHdr(id string, header http.Header) (*tc.DeliveryServiceV4, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceV4 `json:"response"`
 	}{}
-	route := fmt.Sprintf("%s?id=%s", API_DELIVERY_SERVICES, id)
+	route := fmt.Sprintf("%s?id=%s", APIDeliveryServices, id)
 	reqInf, err := to.get(route, header, &data)
 	if err != nil {
 		return nil, reqInf, err
@@ -231,11 +232,11 @@ func (to *Session) GetDeliveryServiceNullableWithHdr(id string, header http.Head
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetDeliveryServiceNullable(id string) (*tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServiceNullable(id string) (*tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceNullable `json:"response"`
 	}{}
-	reqInf, err := to.get(API_DELIVERY_SERVICES+"?id="+url.QueryEscape(id), nil, &data)
+	reqInf, err := to.get(APIDeliveryServices+"?id="+url.QueryEscape(id), nil, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -247,9 +248,9 @@ func (to *Session) GetDeliveryServiceNullable(id string) (*tc.DeliveryServiceNul
 
 // GetDeliveryServiceByXMLIDNullableWithHdr fetches all Delivery Services with
 // the given XMLID.
-func (to *Session) GetDeliveryServiceByXMLIDNullableWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) GetDeliveryServiceByXMLIDNullableWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServicesResponseV30
-	reqInf, err := to.get(API_DELIVERY_SERVICES+"?xmlId="+url.QueryEscape(XMLID), header, &data)
+	reqInf, err := to.get(APIDeliveryServices+"?xmlId="+url.QueryEscape(XMLID), header, &data)
 	return data.Response, reqInf, err
 }
 
@@ -262,7 +263,7 @@ func (to *Session) GetDeliveryServiceByXMLIDNullableWithHdr(XMLID string, header
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	var ret []tc.DeliveryServiceNullable
 	resp, reqInf, err := to.GetDeliveryServiceByXMLIDNullableWithHdr(XMLID, nil)
 	if len(resp) > 0 {
@@ -274,8 +275,8 @@ func (to *Session) GetDeliveryServiceByXMLIDNullable(XMLID string) ([]tc.Deliver
 	return ret, reqInf, err
 }
 
-func (to *Session) CreateDeliveryServiceV4(ds tc.DeliveryServiceV4) (tc.DeliveryServiceV4, ReqInf, error) {
-	var reqInf ReqInf
+func (to *Session) CreateDeliveryServiceV4(ds tc.DeliveryServiceV4) (tc.DeliveryServiceV4, toclientlib.ReqInf, error) {
+	var reqInf toclientlib.ReqInf
 	if ds.TypeID == nil && ds.Type != nil {
 		ty, _, err := to.GetTypeByNameWithHdr(ds.Type.String(), nil)
 		if err != nil {
@@ -318,7 +319,7 @@ func (to *Session) CreateDeliveryServiceV4(ds tc.DeliveryServiceV4) (tc.Delivery
 	}
 
 	var data tc.DeliveryServicesResponseV4
-	reqInf, err := to.post(API_DELIVERY_SERVICES, ds, nil, &data)
+	reqInf, err := to.post(APIDeliveryServices, ds, nil, &data)
 	if err != nil {
 		return tc.DeliveryServiceV4{}, reqInf, err
 	}
@@ -330,8 +331,8 @@ func (to *Session) CreateDeliveryServiceV4(ds tc.DeliveryServiceV4) (tc.Delivery
 }
 
 // CreateDeliveryServiceV30 creates the Delivery Service it's passed.
-func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (tc.DeliveryServiceNullableV30, ReqInf, error) {
-	var reqInf ReqInf
+func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
+	var reqInf toclientlib.ReqInf
 	if ds.TypeID == nil && ds.Type != nil {
 		ty, _, err := to.GetTypeByNameWithHdr(ds.Type.String(), nil)
 		if err != nil {
@@ -374,7 +375,7 @@ func (to *Session) CreateDeliveryServiceV30(ds tc.DeliveryServiceNullableV30) (t
 	}
 
 	var data tc.DeliveryServicesResponseV30
-	reqInf, err := to.post(API_DELIVERY_SERVICES, ds, nil, &data)
+	reqInf, err := to.post(APIDeliveryServices, ds, nil, &data)
 	if err != nil {
 		return tc.DeliveryServiceNullableV30{}, reqInf, err
 	}
@@ -436,7 +437,7 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 	}
 
 	var data tc.CreateDeliveryServiceNullableResponse
-	_, err := to.post(API_DELIVERY_SERVICES, ds, nil, &data)
+	_, err := to.post(APIDeliveryServices, ds, nil, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -446,9 +447,9 @@ func (to *Session) CreateDeliveryServiceNullable(ds *tc.DeliveryServiceNullable)
 
 // UpdateDeliveryServiceV4 replaces the Delivery Service identified by the
 // integral, unique identifier 'id' with the one it's passed.
-func (to *Session) UpdateDeliveryServiceV4(id int, ds tc.DeliveryServiceV4, header http.Header) (tc.DeliveryServiceV4, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceV4(id int, ds tc.DeliveryServiceV4, header http.Header) (tc.DeliveryServiceV4, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServicesResponseV4
-	reqInf, err := to.put(fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), ds, header, &data)
+	reqInf, err := to.put(fmt.Sprintf(APIDeliveryServiceID, id), ds, header, &data)
 	if err != nil {
 		return tc.DeliveryServiceV4{}, reqInf, err
 	}
@@ -473,7 +474,7 @@ func (to *Session) UpdateDeliveryServiceNullable(id string, ds *tc.DeliveryServi
 
 func (to *Session) UpdateDeliveryServiceNullableWithHdr(id string, ds *tc.DeliveryServiceNullable, header http.Header) (*tc.UpdateDeliveryServiceNullableResponse, error) {
 	var data tc.UpdateDeliveryServiceNullableResponse
-	_, err := to.put(fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), ds, header, &data)
+	_, err := to.put(fmt.Sprintf(APIDeliveryServiceID, id), ds, header, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -483,16 +484,16 @@ func (to *Session) UpdateDeliveryServiceNullableWithHdr(id string, ds *tc.Delive
 // DeleteDeliveryService deletes the DeliveryService matching the ID it's passed.
 func (to *Session) DeleteDeliveryService(id string) (*tc.DeleteDeliveryServiceResponse, error) {
 	var data tc.DeleteDeliveryServiceResponse
-	_, err := to.del(fmt.Sprintf(API_DELIVERY_SERVICE_ID, id), nil, &data)
+	_, err := to.del(fmt.Sprintf(APIDeliveryServiceID, id), nil, &data)
 	if err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (to *Session) GetDeliveryServiceHealthWithHdr(id string, header http.Header) (*tc.DeliveryServiceHealth, ReqInf, error) {
+func (to *Session) GetDeliveryServiceHealthWithHdr(id string, header http.Header) (*tc.DeliveryServiceHealth, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceHealthResponse
-	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICE_HEALTH, id), nil, &data)
+	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServiceHealth, id), nil, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -503,13 +504,13 @@ func (to *Session) GetDeliveryServiceHealthWithHdr(id string, header http.Header
 // GetDeliveryServiceHealth gets the 'health' of the Delivery Service identified by the
 // integral, unique identifier 'id' (which must be passed as a string).
 // Deprecated: GetDeliveryServiceHealth will be removed in 6.0. Use GetDeliveryServiceHealthWithHdr.
-func (to *Session) GetDeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, ReqInf, error) {
+func (to *Session) GetDeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceHealthWithHdr(id, nil)
 }
 
-func (to *Session) GetDeliveryServiceCapacityWithHdr(id string, header http.Header) (*tc.DeliveryServiceCapacity, ReqInf, error) {
+func (to *Session) GetDeliveryServiceCapacityWithHdr(id string, header http.Header) (*tc.DeliveryServiceCapacity, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceCapacityResponse
-	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICE_CAPACITY, id), header, &data)
+	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServiceCapacity, id), header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -519,12 +520,12 @@ func (to *Session) GetDeliveryServiceCapacityWithHdr(id string, header http.Head
 // GetDeliveryServiceCapacity gets the 'capacity' of the Delivery Service identified by the
 // integral, unique identifier 'id' (which must be passed as a string).
 // Deprecated: GetDeliveryServiceCapacity will be removed in 6.0. Use GetDeliveryServiceCapacityWithHdr.
-func (to *Session) GetDeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, ReqInf, error) {
+func (to *Session) GetDeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceCapacityWithHdr(id, nil)
 }
 
 // GenerateSSLKeysForDS generates ssl keys for a given cdn
-func (to *Session) GenerateSSLKeysForDS(XMLID string, CDNName string, sslFields tc.SSLKeyRequestFields) (string, ReqInf, error) {
+func (to *Session) GenerateSSLKeysForDS(XMLID string, CDNName string, sslFields tc.SSLKeyRequestFields) (string, toclientlib.ReqInf, error) {
 	version := util.JSONIntStr(1)
 	request := tc.DeliveryServiceSSLKeysReq{
 		BusinessUnit:    sslFields.BusinessUnit,
@@ -541,66 +542,66 @@ func (to *Session) GenerateSSLKeysForDS(XMLID string, CDNName string, sslFields 
 	response := struct {
 		Response string `json:"response"`
 	}{}
-	reqInf, err := to.post(API_DELIVERY_SERVICE_GENERATE_SSL_KEYS, request, nil, &response)
+	reqInf, err := to.post(APIDeliveryServiceGenerateSSLKeys, request, nil, &response)
 	if err != nil {
 		return "", reqInf, err
 	}
 	return response.Response, reqInf, nil
 }
 
-func (to *Session) DeleteDeliveryServiceSSLKeysByID(XMLID string) (string, ReqInf, error) {
+func (to *Session) DeleteDeliveryServiceSSLKeysByID(XMLID string) (string, toclientlib.ReqInf, error) {
 	resp := struct {
 		Response string `json:"response"`
 	}{}
-	reqInf, err := to.del(fmt.Sprintf(API_DELIVERY_SERVICE_XMLID_SSL_KEYS, url.QueryEscape(XMLID)), nil, &resp)
+	reqInf, err := to.del(fmt.Sprintf(APIDeliveryServiceXMLIDSSLKeys, url.QueryEscape(XMLID)), nil, &resp)
 	return resp.Response, reqInf, err
 }
 
 // GetDeliveryServiceSSLKeysByID returns information about the SSL Keys used by the Delivery
 // Service identified by the passed XMLID.
 // Deprecated: GetDeliveryServiceSSLKeysByID will be removed in 6.0. Use GetDeliveryServiceSSLKeysByIDWithHdr.
-func (to *Session) GetDeliveryServiceSSLKeysByID(XMLID string) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
+func (to *Session) GetDeliveryServiceSSLKeysByID(XMLID string) (*tc.DeliveryServiceSSLKeys, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceSSLKeysByIDWithHdr(XMLID, nil)
 }
 
-func (to *Session) GetDeliveryServiceSSLKeysByIDWithHdr(XMLID string, header http.Header) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
+func (to *Session) GetDeliveryServiceSSLKeysByIDWithHdr(XMLID string, header http.Header) (*tc.DeliveryServiceSSLKeys, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceSSLKeysResponse
-	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICE_XMLID_SSL_KEYS, url.QueryEscape(XMLID)), header, &data)
+	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServiceXMLIDSSLKeys, url.QueryEscape(XMLID)), header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
 	return &data.Response, reqInf, nil
 }
 
-func (to *Session) GetDeliveryServicesEligibleWithHdr(dsID int, header http.Header) ([]tc.DSServer, ReqInf, error) {
+func (to *Session) GetDeliveryServicesEligibleWithHdr(dsID int, header http.Header) ([]tc.DSServer, toclientlib.ReqInf, error) {
 	resp := struct {
 		Response []tc.DSServer `json:"response"`
 	}{Response: []tc.DSServer{}}
 
-	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICE_ELIGIBLE_SERVERS, dsID), header, &resp)
+	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServiceEligibleServers, dsID), header, &resp)
 	return resp.Response, reqInf, err
 }
 
 // GetDeliveryServicesEligible returns the servers eligible for assignment to the Delivery
 // Service identified by the integral, unique identifier 'dsID'.
 // Deprecated: GetDeliveryServicesEligible will be removed in 6.0. Use GetDeliveryServicesEligibleWithHdr.
-func (to *Session) GetDeliveryServicesEligible(dsID int) ([]tc.DSServer, ReqInf, error) {
+func (to *Session) GetDeliveryServicesEligible(dsID int) ([]tc.DSServer, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesEligibleWithHdr(dsID, nil)
 }
 
 // GetDeliveryServiceURLSigKeys returns the URL-signing keys used by the Delivery Service
 // identified by the XMLID 'dsName'.
 // Deprecated: GetDeliveryServiceURLSigKeys will be removed in 6.0. Use GetDeliveryServiceURLSigKeysWithHdr.
-func (to *Session) GetDeliveryServiceURLSigKeys(dsName string) (tc.URLSigKeys, ReqInf, error) {
+func (to *Session) GetDeliveryServiceURLSigKeys(dsName string) (tc.URLSigKeys, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceURLSigKeysWithHdr(dsName, nil)
 }
 
-func (to *Session) GetDeliveryServiceURLSigKeysWithHdr(dsName string, header http.Header) (tc.URLSigKeys, ReqInf, error) {
+func (to *Session) GetDeliveryServiceURLSigKeysWithHdr(dsName string, header http.Header) (tc.URLSigKeys, toclientlib.ReqInf, error) {
 	data := struct {
 		Response tc.URLSigKeys `json:"response"`
 	}{}
 
-	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICES_URL_SIGNING_KEYS, dsName), header, &data)
+	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServicesURLSigKeys, dsName), header, &data)
 	if err != nil {
 		return tc.URLSigKeys{}, reqInf, err
 	}
@@ -608,15 +609,15 @@ func (to *Session) GetDeliveryServiceURLSigKeysWithHdr(dsName string, header htt
 }
 
 // Deprecated: GetDeliveryServiceURISigningKeys will be removed in 6.0. Use GetDeliveryServiceURISigningKeysWithHdr.
-func (to *Session) GetDeliveryServiceURISigningKeys(dsName string) ([]byte, ReqInf, error) {
+func (to *Session) GetDeliveryServiceURISigningKeys(dsName string) ([]byte, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceURISigningKeysWithHdr(dsName, nil)
 }
 
 // GetDeliveryServiceURISigningKeys returns the URI-signing keys used by the Delivery Service
 // identified by the XMLID 'dsName'. The result is not parsed.
-func (to *Session) GetDeliveryServiceURISigningKeysWithHdr(dsName string, header http.Header) ([]byte, ReqInf, error) {
+func (to *Session) GetDeliveryServiceURISigningKeysWithHdr(dsName string, header http.Header) ([]byte, toclientlib.ReqInf, error) {
 	data := json.RawMessage{}
-	reqInf, err := to.get(fmt.Sprintf(API_DELIVERY_SERVICES_URI_SIGNING_KEYS, url.QueryEscape(dsName)), header, &data)
+	reqInf, err := to.get(fmt.Sprintf(APIDeliveryServicesURISigningKeys, url.QueryEscape(dsName)), header, &data)
 	if err != nil {
 		return []byte{}, reqInf, err
 	}
@@ -625,9 +626,9 @@ func (to *Session) GetDeliveryServiceURISigningKeysWithHdr(dsName string, header
 
 // SafeDeliveryServiceUpdateV30WithHdr updates the "safe" fields of the Delivery
 // Service identified by the integral, unique identifier 'id'.
-func (to *Session) SafeDeliveryServiceUpdateV30WithHdr(id int, r tc.DeliveryServiceSafeUpdateRequest, header http.Header) (tc.DeliveryServiceNullableV30, ReqInf, error) {
+func (to *Session) SafeDeliveryServiceUpdateV30WithHdr(id int, r tc.DeliveryServiceSafeUpdateRequest, header http.Header) (tc.DeliveryServiceNullableV30, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceSafeUpdateResponseV30
-	reqInf, err := to.put(fmt.Sprintf(API_DELIVERY_SERVICES_SAFE_UPDATE, id), r, header, &data)
+	reqInf, err := to.put(fmt.Sprintf(APIDeliveryServicesSafeUpdate, id), r, header, &data)
 	if err != nil {
 		return tc.DeliveryServiceNullableV30{}, reqInf, err
 	}
@@ -644,9 +645,9 @@ func (to *Session) SafeDeliveryServiceUpdateV30WithHdr(id int, r tc.DeliveryServ
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // SafeDeliveryServiceUpdateV30WithHdr.
-func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUpdateRequest) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUpdateRequest) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	var resp tc.DeliveryServiceSafeUpdateResponse
-	reqInf, err := to.put(fmt.Sprintf(API_DELIVERY_SERVICES_SAFE_UPDATE, id), ds, nil, &resp)
+	reqInf, err := to.put(fmt.Sprintf(APIDeliveryServicesSafeUpdate, id), ds, nil, &resp)
 	if err != nil {
 		return resp.Response, reqInf, err
 	}
@@ -665,8 +666,8 @@ func (to *Session) UpdateDeliveryServiceSafe(id int, ds tc.DeliveryServiceSafeUp
 // Deprecated: Please used versioned library imports in the future, and
 // versioned methods, specifically, for API v3.0 - in this case,
 // GetDeliveryServicesV30WithHdr.
-func (to *Session) GetAccessibleDeliveryServicesByTenant(tenantId int) ([]tc.DeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetAccessibleDeliveryServicesByTenant(tenantId int) ([]tc.DeliveryServiceNullable, toclientlib.ReqInf, error) {
 	data := tc.DeliveryServicesNullableResponse{}
-	reqInf, err := to.get(fmt.Sprintf("%s?accessibleTo=%d", API_DELIVERY_SERVICES, tenantId), nil, &data)
+	reqInf, err := to.get(fmt.Sprintf("%s?accessibleTo=%d", APIDeliveryServices, tenantId), nil, &data)
 	return data.Response, reqInf, err
 }

--- a/traffic_ops/v4-client/deliveryservice_regexes.go
+++ b/traffic_ops/v4-client/deliveryservice_regexes.go
@@ -20,39 +20,40 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
 	// See: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_id_regexes.html
-	API_DS_REGEXES = apiBase + "/deliveryservices/%d/regexes"
+	APIDSRegexes = "/deliveryservices/%d/regexes"
 )
 
 // GetDeliveryServiceRegexesByDSID gets DeliveryServiceRegexes by a DS id
 // also accepts an optional map of query parameters
-func (to *Session) GetDeliveryServiceRegexesByDSID(dsID int, params map[string]string) ([]tc.DeliveryServiceIDRegex, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRegexesByDSID(dsID int, params map[string]string) ([]tc.DeliveryServiceIDRegex, toclientlib.ReqInf, error) {
 	response := struct {
 		Response []tc.DeliveryServiceIDRegex `json:"response"`
 	}{}
-	reqInf, err := to.get(fmt.Sprintf(API_DS_REGEXES, dsID)+mapToQueryParameters(params), nil, &response)
+	reqInf, err := to.get(fmt.Sprintf(APIDSRegexes, dsID)+mapToQueryParameters(params), nil, &response)
 	return response.Response, reqInf, err
 }
 
 // GetDeliveryServiceRegexes returns the "Regexes" (Regular Expressions) used by all (tenant-visible)
 // Delivery Services.
 // Deprecated: GetDeliveryServiceRegexes will be removed in 6.0. Use GetDeliveryServiceRegexesWithHdr.
-func (to *Session) GetDeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRegexesWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServiceRegexesWithHdr(header http.Header) ([]tc.DeliveryServiceRegexes, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRegexesWithHdr(header http.Header) ([]tc.DeliveryServiceRegexes, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceRegexResponse
-	reqInf, err := to.get(API_DELIVERY_SERVICES_REGEXES, header, &data)
+	reqInf, err := to.get(APIDeliveryServicesRegexes, header, &data)
 	return data.Response, reqInf, err
 }
 
-func (to *Session) PostDeliveryServiceRegexesByDSID(dsID int, regex tc.DeliveryServiceRegexPost) (tc.Alerts, ReqInf, error) {
+func (to *Session) PostDeliveryServiceRegexesByDSID(dsID int, regex tc.DeliveryServiceRegexPost) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	route := fmt.Sprintf(API_DS_REGEXES, dsID)
+	route := fmt.Sprintf(APIDSRegexes, dsID)
 	reqInf, err := to.post(route, regex, nil, &alerts)
 	return alerts, reqInf, err
 }

--- a/traffic_ops/v4-client/deliveryservice_request_comments.go
+++ b/traffic_ops/v4-client/deliveryservice_request_comments.go
@@ -16,26 +16,26 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
-
-	"fmt"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_DELIVERY_SERVICE_REQUEST_COMMENTS = apiBase + "/deliveryservice_request_comments"
+	APIDeliveryServiceRequestComments = "/deliveryservice_request_comments"
 )
 
 // Create a delivery service request comment
-func (to *Session) CreateDeliveryServiceRequestComment(comment tc.DeliveryServiceRequestComment) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateDeliveryServiceRequestComment(comment tc.DeliveryServiceRequestComment) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_DELIVERY_SERVICE_REQUEST_COMMENTS, comment, nil, &alerts)
+	reqInf, err := to.post(APIDeliveryServiceRequestComments, comment, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateDeliveryServiceRequestCommentByIDWithHdr(id int, comment tc.DeliveryServiceRequestComment, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_DELIVERY_SERVICE_REQUEST_COMMENTS, id)
+func (to *Session) UpdateDeliveryServiceRequestCommentByIDWithHdr(id int, comment tc.DeliveryServiceRequestComment, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIDeliveryServiceRequestComments, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, comment, header, &alerts)
 	return alerts, reqInf, err
@@ -43,24 +43,24 @@ func (to *Session) UpdateDeliveryServiceRequestCommentByIDWithHdr(id int, commen
 
 // Update a delivery service request by ID
 // Deprecated: UpdateDeliveryServiceRequestCommentByID will be removed in 6.0. Use UpdateDeliveryServiceRequestCommentByIDWithHdr.
-func (to *Session) UpdateDeliveryServiceRequestCommentByID(id int, comment tc.DeliveryServiceRequestComment) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceRequestCommentByID(id int, comment tc.DeliveryServiceRequestComment) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateDeliveryServiceRequestCommentByIDWithHdr(id, comment, nil)
 }
 
-func (to *Session) GetDeliveryServiceRequestCommentsWithHdr(header http.Header) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestCommentsWithHdr(header http.Header) ([]tc.DeliveryServiceRequestComment, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceRequestCommentsResponse
-	reqInf, err := to.get(API_DELIVERY_SERVICE_REQUEST_COMMENTS, header, &data)
+	reqInf, err := to.get(APIDeliveryServiceRequestComments, header, &data)
 	return data.Response, reqInf, err
 }
 
 // Returns a list of delivery service request comments
 // Deprecated: GetDeliveryServiceRequestComments will be removed in 6.0. Use GetDeliveryServiceRequestCommentsWithHdr.
-func (to *Session) GetDeliveryServiceRequestComments() ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestComments() ([]tc.DeliveryServiceRequestComment, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestCommentsWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServiceRequestCommentByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_DELIVERY_SERVICE_REQUEST_COMMENTS, id)
+func (to *Session) GetDeliveryServiceRequestCommentByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequestComment, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIDeliveryServiceRequestComments, id)
 	var data tc.DeliveryServiceRequestCommentsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -68,13 +68,13 @@ func (to *Session) GetDeliveryServiceRequestCommentByIDWithHdr(id int, header ht
 
 // GET a delivery service request comment by ID
 // Deprecated: GetDeliveryServiceRequestCommentByID will be removed in 6.0. Use GetDeliveryServiceRequestCommentByIDWithHdr.
-func (to *Session) GetDeliveryServiceRequestCommentByID(id int) ([]tc.DeliveryServiceRequestComment, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestCommentByID(id int) ([]tc.DeliveryServiceRequestComment, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestCommentByIDWithHdr(id, nil)
 }
 
 // DELETE a delivery service request comment by ID
-func (to *Session) DeleteDeliveryServiceRequestCommentByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_DELIVERY_SERVICE_REQUEST_COMMENTS, id)
+func (to *Session) DeleteDeliveryServiceRequestCommentByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIDeliveryServiceRequestComments, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/deliveryservice_requests.go
+++ b/traffic_ops/v4-client/deliveryservice_requests.go
@@ -22,14 +22,15 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_DS_REQUESTS = apiBase + "/deliveryservice_requests"
+	APIDSRequests = "/deliveryservice_requests"
 )
 
 // CreateDeliveryServiceRequest creates a Delivery Service Request.
-func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequest) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequest) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	if dsr.AssigneeID == 0 && dsr.Assignee != "" {
 		res, reqInf, err := to.GetUserByUsernameWithHdr(dsr.Assignee, nil)
@@ -85,26 +86,26 @@ func (to *Session) CreateDeliveryServiceRequest(dsr tc.DeliveryServiceRequest) (
 		dsr.DeliveryService.TenantID = ten.ID
 	}
 
-	reqInf, err := to.post(API_DS_REQUESTS, dsr, nil, &alerts)
+	reqInf, err := to.post(APIDSRequests, dsr, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetDeliveryServiceRequestsWithHdr(header http.Header) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestsWithHdr(header http.Header) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.DeliveryServiceRequest `json:"response"`
 	}{}
-	reqInf, err := to.get(API_DS_REQUESTS, header, &data)
+	reqInf, err := to.get(APIDSRequests, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetDeliveryServiceRequests retrieves all deliveryservices available to session user.
 // Deprecated: GetDeliveryServiceRequests will be removed in 6.0. Use GetDeliveryServiceRequestsWithHdr.
-func (to *Session) GetDeliveryServiceRequests() ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequests() ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestsWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServiceRequestByXMLIDWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceRequest, ReqInf, error) {
-	route := fmt.Sprintf("%s?xmlId=%s", API_DS_REQUESTS, url.QueryEscape(XMLID))
+func (to *Session) GetDeliveryServiceRequestByXMLIDWithHdr(XMLID string, header http.Header) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?xmlId=%s", APIDSRequests, url.QueryEscape(XMLID))
 	data := struct {
 		Response []tc.DeliveryServiceRequest `json:"response"`
 	}{}
@@ -114,12 +115,12 @@ func (to *Session) GetDeliveryServiceRequestByXMLIDWithHdr(XMLID string, header 
 
 // GET a DeliveryServiceRequest by the DeliveryServiceRequest XMLID
 // Deprecated: GetDeliveryServiceRequestByXMLID will be removed in 6.0. Use GetDeliveryServiceRequestByXMLIDWithHdr.
-func (to *Session) GetDeliveryServiceRequestByXMLID(XMLID string) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestByXMLID(XMLID string) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestByXMLIDWithHdr(XMLID, nil)
 }
 
-func (to *Session) GetDeliveryServiceRequestByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequest, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_DS_REQUESTS, id)
+func (to *Session) GetDeliveryServiceRequestByIDWithHdr(id int, header http.Header) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIDSRequests, id)
 	data := struct {
 		Response []tc.DeliveryServiceRequest `json:"response"`
 	}{}
@@ -129,12 +130,12 @@ func (to *Session) GetDeliveryServiceRequestByIDWithHdr(id int, header http.Head
 
 // GET a DeliveryServiceRequest by the DeliveryServiceRequest id
 // Deprecated: GetDeliveryServiceRequestByID will be removed in 6.0. Use GetDeliveryServiceRequestByIDWithHdr.
-func (to *Session) GetDeliveryServiceRequestByID(id int) ([]tc.DeliveryServiceRequest, ReqInf, error) {
+func (to *Session) GetDeliveryServiceRequestByID(id int) ([]tc.DeliveryServiceRequest, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceRequestByIDWithHdr(id, nil)
 }
 
-func (to *Session) UpdateDeliveryServiceRequestByIDWithHdr(id int, dsr tc.DeliveryServiceRequest, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_DS_REQUESTS, id)
+func (to *Session) UpdateDeliveryServiceRequestByIDWithHdr(id int, dsr tc.DeliveryServiceRequest, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIDSRequests, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, dsr, header, &alerts)
 	return alerts, reqInf, err
@@ -142,13 +143,13 @@ func (to *Session) UpdateDeliveryServiceRequestByIDWithHdr(id int, dsr tc.Delive
 
 // Update a DeliveryServiceRequest by ID
 // Deprecated: UpdateDeliveryServiceRequestByID will be removed in 6.0. Use UpdateDeliveryServiceRequestByIDWithHdr.
-func (to *Session) UpdateDeliveryServiceRequestByID(id int, dsr tc.DeliveryServiceRequest) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDeliveryServiceRequestByID(id int, dsr tc.DeliveryServiceRequest) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateDeliveryServiceRequestByIDWithHdr(id, dsr, nil)
 }
 
 // DELETE a DeliveryServiceRequest by DeliveryServiceRequest assignee
-func (to *Session) DeleteDeliveryServiceRequestByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_DS_REQUESTS, id)
+func (to *Session) DeleteDeliveryServiceRequestByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIDSRequests, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/deliveryservices_required_capabilities.go
+++ b/traffic_ops/v4-client/deliveryservices_required_capabilities.go
@@ -22,31 +22,32 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES = apiBase + "/deliveryservices_required_capabilities"
+	APIDeliveryServicesRequiredCapabilities = "/deliveryservices_required_capabilities"
 )
 
 // CreateDeliveryServicesRequiredCapability assigns a Required Capability to a Delivery Service
-func (to *Session) CreateDeliveryServicesRequiredCapability(capability tc.DeliveryServicesRequiredCapability) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateDeliveryServicesRequiredCapability(capability tc.DeliveryServicesRequiredCapability) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES, capability, nil, &alerts)
+	reqInf, err := to.post(APIDeliveryServicesRequiredCapabilities, capability, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteDeliveryServicesRequiredCapability unassigns a Required Capability from a Delivery Service
-func (to *Session) DeleteDeliveryServicesRequiredCapability(deliveryserviceID int, capability string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteDeliveryServicesRequiredCapability(deliveryserviceID int, capability string) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	param := url.Values{}
 	param.Add("deliveryServiceID", strconv.Itoa(deliveryserviceID))
 	param.Add("requiredCapability", capability)
-	route := fmt.Sprintf("%s?%s", API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES, param.Encode())
+	route := fmt.Sprintf("%s?%s", APIDeliveryServicesRequiredCapabilities, param.Encode())
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServiceID *int, xmlID, capability *string, header http.Header) ([]tc.DeliveryServicesRequiredCapability, ReqInf, error) {
+func (to *Session) GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServiceID *int, xmlID, capability *string, header http.Header) ([]tc.DeliveryServicesRequiredCapability, toclientlib.ReqInf, error) {
 	param := url.Values{}
 	if deliveryServiceID != nil {
 		param.Add("deliveryServiceID", strconv.Itoa(*deliveryServiceID))
@@ -58,7 +59,7 @@ func (to *Session) GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServic
 		param.Add("requiredCapability", *capability)
 	}
 
-	route := API_DELIVERY_SERVICES_REQUIRED_CAPABILITIES
+	route := APIDeliveryServicesRequiredCapabilities
 	if len(param) > 0 {
 		route = fmt.Sprintf("%s?%s", route, param.Encode())
 	}
@@ -73,6 +74,6 @@ func (to *Session) GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServic
 // GetDeliveryServicesRequiredCapabilities retrieves a list of Required Capabilities that are assigned to a Delivery Service
 // Callers can filter the results by delivery service id, xml id and/or required capability via the optional parameters
 // Deprecated: GetDeliveryServicesRequiredCapabilities will be removed in 6.0. Use GetDeliveryServicesRequiredCapabilitiesWithHdr.
-func (to *Session) GetDeliveryServicesRequiredCapabilities(deliveryServiceID *int, xmlID, capability *string) ([]tc.DeliveryServicesRequiredCapability, ReqInf, error) {
+func (to *Session) GetDeliveryServicesRequiredCapabilities(deliveryServiceID *int, xmlID, capability *string) ([]tc.DeliveryServicesRequiredCapability, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServicesRequiredCapabilitiesWithHdr(deliveryServiceID, xmlID, capability, nil)
 }

--- a/traffic_ops/v4-client/deliveryserviceserver.go
+++ b/traffic_ops/v4-client/deliveryserviceserver.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // CreateDeliveryServiceServers associates the given servers with the given delivery services. If replace is true, it deletes any existing associations for the given delivery service.
-func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, replace bool) (*tc.DSServerIDs, ReqInf, error) {
-	path := API_DELIVERY_SERVICE_SERVER
+func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, replace bool) (*tc.DSServerIDs, toclientlib.ReqInf, error) {
+	path := APIDeliveryServiceServer
 	req := tc.DSServerIDs{
 		DeliveryServiceID: util.IntPtr(dsID),
 		ServerIDs:         serverIDs,
@@ -44,16 +45,16 @@ func (to *Session) CreateDeliveryServiceServers(dsID int, serverIDs []int, repla
 	return &resp.Response, reqInf, nil
 }
 
-func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alerts, ReqInf, error) {
-	route := apiBase + `/deliveryserviceserver/` + strconv.Itoa(dsID) + "/" + strconv.Itoa(serverID)
+func (to *Session) DeleteDeliveryServiceServer(dsID int, serverID int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := `/deliveryserviceserver/` + strconv.Itoa(dsID) + "/" + strconv.Itoa(serverID)
 	resp := tc.Alerts{}
 	reqInf, err := to.del(route, nil, &resp)
 	return resp, reqInf, err
 }
 
 // AssignServersToDeliveryService assigns the given list of servers to the delivery service with the given xmlId.
-func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf(API_DELIVERY_SERVICES_SERVERS, url.QueryEscape(xmlId))
+func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf(APIDeliveryServicesServers, url.QueryEscape(xmlId))
 	dss := tc.DeliveryServiceServers{ServerNames: servers, XmlId: xmlId}
 	resp := tc.Alerts{}
 	reqInf, err := to.post(route, dss, nil, &resp)
@@ -63,38 +64,38 @@ func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string
 // GetDeliveryServiceServer returns associations between Delivery Services and servers using the
 // provided pagination controls.
 // Deprecated: GetDeliveryServiceServer will be removed in 6.0. Use GetDeliveryServiceServerWithHdr.
-func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceServerWithHdr(page, limit, nil)
 }
 
-func (to *Session) GetDeliveryServiceServerWithHdr(page, limit string, header http.Header) ([]tc.DeliveryServiceServer, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServerWithHdr(page, limit string, header http.Header) ([]tc.DeliveryServiceServer, toclientlib.ReqInf, error) {
 	var data tc.DeliveryServiceServerResponse
 	// TODO: page and limit should be integers not strings
-	reqInf, err := to.get(API_DELIVERY_SERVICE_SERVER+"?page="+url.QueryEscape(page)+"&limit="+url.QueryEscape(limit), header, &data)
+	reqInf, err := to.get(APIDeliveryServiceServer+"?page="+url.QueryEscape(page)+"&limit="+url.QueryEscape(limit), header, &data)
 	return data.Response, reqInf, err
 }
 
-func (to *Session) GetDeliveryServiceServersWithHdr(h http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersWithHdr(h http.Header) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.getDeliveryServiceServers(url.Values{}, h)
 }
 
 // GetDeliveryServiceServers gets all delivery service servers, with the default API limit.
 // Deprecated: GetDeliveryServiceServers will be removed in 6.0. Use GetDeliveryServiceServersWithHdr.
-func (to *Session) GetDeliveryServiceServers() (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServers() (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceServersWithHdr(nil)
 }
 
-func (to *Session) GetDeliveryServiceServersNWithHdr(n int, header http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersNWithHdr(n int, header http.Header) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.getDeliveryServiceServers(url.Values{"limit": []string{strconv.Itoa(n)}}, header)
 }
 
 // GetDeliveryServiceServersN gets all delivery service servers, with a limit of n.
 // Deprecated: GetDeliveryServiceServersN will be removed in 6.0. Use GetDeliveryServiceServersNWithHdr.
-func (to *Session) GetDeliveryServiceServersN(n int) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersN(n int) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceServersNWithHdr(n, nil)
 }
 
-func (to *Session) GetDeliveryServiceServersWithLimitsWithHdr(limit int, deliveryServiceIDs []int, serverIDs []int, header http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersWithLimitsWithHdr(limit int, deliveryServiceIDs []int, serverIDs []int, header http.Header) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	vals := url.Values{}
 	if limit != 0 {
 		vals.Set("limit", strconv.Itoa(limit))
@@ -122,12 +123,12 @@ func (to *Session) GetDeliveryServiceServersWithLimitsWithHdr(limit int, deliver
 // GetDeliveryServiceServersWithLimits gets all delivery service servers, allowing specifying the limit of mappings to return, the delivery services to return, and the servers to return.
 // The limit may be 0, in which case the default limit will be applied. The deliveryServiceIDs and serverIDs may be nil or empty, in which case all delivery services and/or servers will be returned.
 // Deprecated: GetDeliveryServiceServersWithLimits will be removed in 6.0. Use GetDeliveryServiceServersWithLimitsWithHdr.
-func (to *Session) GetDeliveryServiceServersWithLimits(limit int, deliveryServiceIDs []int, serverIDs []int) (tc.DeliveryServiceServerResponse, ReqInf, error) {
+func (to *Session) GetDeliveryServiceServersWithLimits(limit int, deliveryServiceIDs []int, serverIDs []int) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
 	return to.GetDeliveryServiceServersWithLimitsWithHdr(limit, deliveryServiceIDs, serverIDs, nil)
 }
 
-func (to *Session) getDeliveryServiceServers(urlQuery url.Values, h http.Header) (tc.DeliveryServiceServerResponse, ReqInf, error) {
-	route := API_DELIVERY_SERVICE_SERVER
+func (to *Session) getDeliveryServiceServers(urlQuery url.Values, h http.Header) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
+	route := APIDeliveryServiceServer
 	if qry := urlQuery.Encode(); qry != "" {
 		route += `?` + qry
 	}

--- a/traffic_ops/v4-client/division.go
+++ b/traffic_ops/v4-client/division.go
@@ -21,21 +21,22 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_DIVISIONS = apiBase + "/divisions"
+	APIDivisions = "/divisions"
 )
 
 // Create a Division
-func (to *Session) CreateDivision(division tc.Division) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateDivision(division tc.Division) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_DIVISIONS, division, nil, &alerts)
+	reqInf, err := to.post(APIDivisions, division, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateDivisionByIDWithHdr(id int, division tc.Division, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_DIVISIONS, id)
+func (to *Session) UpdateDivisionByIDWithHdr(id int, division tc.Division, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIDivisions, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, division, header, &alerts)
 	return alerts, reqInf, err
@@ -43,24 +44,24 @@ func (to *Session) UpdateDivisionByIDWithHdr(id int, division tc.Division, heade
 
 // Update a Division by ID
 // Deprecated: UpdateDivisionByID will be removed in 6.0. Use UpdateDivisionByIDWithHdr.
-func (to *Session) UpdateDivisionByID(id int, division tc.Division) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateDivisionByID(id int, division tc.Division) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateDivisionByIDWithHdr(id, division, nil)
 }
 
-func (to *Session) GetDivisionsWithHdr(header http.Header) ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisionsWithHdr(header http.Header) ([]tc.Division, toclientlib.ReqInf, error) {
 	var data tc.DivisionsResponse
-	reqInf, err := to.get(API_DIVISIONS, header, &data)
+	reqInf, err := to.get(APIDivisions, header, &data)
 	return data.Response, reqInf, err
 }
 
 // Returns a list of Divisions
 // Deprecated: GetDivisions will be removed in 6.0. Use GetDivisionsWithHdr.
-func (to *Session) GetDivisions() ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisions() ([]tc.Division, toclientlib.ReqInf, error) {
 	return to.GetDivisionsWithHdr(nil)
 }
 
-func (to *Session) GetDivisionByIDWithHdr(id int, header http.Header) ([]tc.Division, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_DIVISIONS, id)
+func (to *Session) GetDivisionByIDWithHdr(id int, header http.Header) ([]tc.Division, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIDivisions, id)
 	var data tc.DivisionsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -68,12 +69,12 @@ func (to *Session) GetDivisionByIDWithHdr(id int, header http.Header) ([]tc.Divi
 
 // GET a Division by the Division id
 // Deprecated: GetDivisionByID will be removed in 6.0. Use GetDivisionByIDWithHdr.
-func (to *Session) GetDivisionByID(id int) ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisionByID(id int) ([]tc.Division, toclientlib.ReqInf, error) {
 	return to.GetDivisionByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetDivisionByNameWithHdr(name string, header http.Header) ([]tc.Division, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", API_DIVISIONS, url.QueryEscape(name))
+func (to *Session) GetDivisionByNameWithHdr(name string, header http.Header) ([]tc.Division, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APIDivisions, url.QueryEscape(name))
 	var data tc.DivisionsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -81,13 +82,13 @@ func (to *Session) GetDivisionByNameWithHdr(name string, header http.Header) ([]
 
 // GET a Division by the Division name
 // Deprecated: GetDivisionByName will be removed in 6.0. Use GetDivisionByNameWithHdr.
-func (to *Session) GetDivisionByName(name string) ([]tc.Division, ReqInf, error) {
+func (to *Session) GetDivisionByName(name string) ([]tc.Division, toclientlib.ReqInf, error) {
 	return to.GetDivisionByNameWithHdr(name, nil)
 }
 
 // DELETE a Division by Division id
-func (to *Session) DeleteDivisionByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_DIVISIONS, id)
+func (to *Session) DeleteDivisionByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIDivisions, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/dsuser.go
+++ b/traffic_ops/v4-client/dsuser.go
@@ -18,12 +18,12 @@ package client
 import (
 	"strconv"
 
-	tc "github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
 // SetUserDeliveryService associates the given delivery services with the given user.
 func (to *Session) SetDeliveryServiceUser(userID int, dses []int, replace bool) (*tc.UserDeliveryServicePostResponse, error) {
-	uri := apiBase + `/deliveryservice_user`
+	uri := `/deliveryservice_user`
 	ds := tc.DeliveryServiceUserPost{UserID: &userID, DeliveryServices: &dses, Replace: &replace}
 	resp := tc.UserDeliveryServicePostResponse{}
 	_, err := to.post(uri, ds, nil, &resp)
@@ -35,7 +35,7 @@ func (to *Session) SetDeliveryServiceUser(userID int, dses []int, replace bool) 
 
 // DeleteDeliveryServiceUser deletes the association between the given delivery service and user
 func (to *Session) DeleteDeliveryServiceUser(userID int, dsID int) (*tc.UserDeliveryServiceDeleteResponse, error) {
-	uri := apiBase + `/deliveryservice_user/` + strconv.Itoa(dsID) + `/` + strconv.Itoa(userID)
+	uri := `/deliveryservice_user/` + strconv.Itoa(dsID) + `/` + strconv.Itoa(userID)
 	resp := tc.UserDeliveryServiceDeleteResponse{}
 	if _, err := to.del(uri, nil, &resp); err != nil {
 		return nil, err

--- a/traffic_ops/v4-client/endpoints.go
+++ b/traffic_ops/v4-client/endpoints.go
@@ -15,4 +15,15 @@
 
 package client
 
-const apiBase = "/api/4.0"
+const apiBaseStr = "/api/"
+
+// apiVersions is the list of minor API versions in this client's major version.
+// This should be all minor versions from 0 up to the latest minor in Traffic Control
+// as of this client code.
+//
+// Versions are ordered latest-first.
+func apiVersions() []string {
+	return []string{
+		"4.0",
+	}
+}

--- a/traffic_ops/v4-client/federation.go
+++ b/traffic_ops/v4-client/federation.go
@@ -24,11 +24,12 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-const APIFederations = apiBase + "/federations"
+const APIFederations = "/federations"
 
-func (to *Session) FederationsWithHdr(header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) FederationsWithHdr(header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	type FederationResponse struct {
 		Response []tc.AllDeliveryServiceFederationsMapping `json:"response"`
 	}
@@ -38,31 +39,31 @@ func (to *Session) FederationsWithHdr(header http.Header) ([]tc.AllDeliveryServi
 }
 
 // Deprecated: Federations will be removed in 6.0. Use FederationsWithHdr.
-func (to *Session) Federations() ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) Federations() ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	return to.FederationsWithHdr(nil)
 }
 
-func (to *Session) AllFederationsWithHdr(header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) AllFederationsWithHdr(header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	type FederationResponse struct {
 		Response []tc.AllDeliveryServiceFederationsMapping `json:"response"`
 	}
 	data := FederationResponse{}
-	inf, err := to.get(apiBase+"/federations/all", header, &data)
+	inf, err := to.get("/federations/all", header, &data)
 	return data.Response, inf, err
 }
 
 // Deprecated: AllFederations will be removed in 6.0. Use AllFederationsWithHdr.
-func (to *Session) AllFederations() ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) AllFederations() ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	return to.AllFederationsWithHdr(nil)
 }
 
-func (to *Session) AllFederationsForCDNWithHdr(cdnName string, header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) AllFederationsForCDNWithHdr(cdnName string, header http.Header) ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	// because the Federations JSON array is heterogeneous (array members may be a AllFederation or AllFederationCDN), we have to try decoding each separately.
 	type FederationResponse struct {
 		Response []json.RawMessage `json:"response"`
 	}
 	data := FederationResponse{}
-	inf, err := to.get(apiBase+"/federations/all?cdnName="+url.QueryEscape(cdnName), header, &data)
+	inf, err := to.get("/federations/all?cdnName="+url.QueryEscape(cdnName), header, &data)
 	if err != nil {
 		return nil, inf, err
 	}
@@ -83,66 +84,66 @@ func (to *Session) AllFederationsForCDNWithHdr(cdnName string, header http.Heade
 }
 
 // Deprecated: AllFederationsForCDN will be removed in 6.0. Use AllFederationsForCDNWithHdr.
-func (to *Session) AllFederationsForCDN(cdnName string) ([]tc.AllDeliveryServiceFederationsMapping, ReqInf, error) {
+func (to *Session) AllFederationsForCDN(cdnName string) ([]tc.AllDeliveryServiceFederationsMapping, toclientlib.ReqInf, error) {
 	return to.AllFederationsForCDNWithHdr(cdnName, nil)
 }
 
-func (to *Session) CreateFederationDeliveryServices(federationID int, deliveryServiceIDs []int, replace bool) (ReqInf, error) {
+func (to *Session) CreateFederationDeliveryServices(federationID int, deliveryServiceIDs []int, replace bool) (toclientlib.ReqInf, error) {
 	req := tc.FederationDSPost{DSIDs: deliveryServiceIDs, Replace: &replace}
 	resp := map[string]interface{}{}
-	inf, err := to.post(apiBase+`/federations/`+strconv.Itoa(federationID)+`/deliveryservices`, req, nil, &resp)
+	inf, err := to.post(`/federations/`+strconv.Itoa(federationID)+`/deliveryservices`, req, nil, &resp)
 	return inf, err
 }
 
-func (to *Session) GetFederationDeliveryServicesWithHdr(federationID int, header http.Header) ([]tc.FederationDeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetFederationDeliveryServicesWithHdr(federationID int, header http.Header) ([]tc.FederationDeliveryServiceNullable, toclientlib.ReqInf, error) {
 	type FederationDSesResponse struct {
 		Response []tc.FederationDeliveryServiceNullable `json:"response"`
 	}
 	data := FederationDSesResponse{}
-	inf, err := to.get(fmt.Sprintf("%s/federations/%d/deliveryservices", apiBase, federationID), header, &data)
+	inf, err := to.get(fmt.Sprintf("/federations/%d/deliveryservices", federationID), header, &data)
 	return data.Response, inf, err
 }
 
 // GetFederationDeliveryServices Returns a given Federation's Delivery Services
 // Deprecated: GetFederationDeliveryServices will be removed in 6.0. Use GetFederationDeliveryServicesWithHdr.
-func (to *Session) GetFederationDeliveryServices(federationID int) ([]tc.FederationDeliveryServiceNullable, ReqInf, error) {
+func (to *Session) GetFederationDeliveryServices(federationID int) ([]tc.FederationDeliveryServiceNullable, toclientlib.ReqInf, error) {
 	return to.GetFederationDeliveryServicesWithHdr(federationID, nil)
 }
 
 // DeleteFederationDeliveryService Deletes a given Delivery Service from a Federation
-func (to *Session) DeleteFederationDeliveryService(federationID, deliveryServiceID int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/federations/%d/deliveryservices/%d", apiBase, federationID, deliveryServiceID)
+func (to *Session) DeleteFederationDeliveryService(federationID, deliveryServiceID int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("/federations/%d/deliveryservices/%d", federationID, deliveryServiceID)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // GetFederationUsers Associates the given Users' IDs to a Federation
-func (to *Session) CreateFederationUsers(federationID int, userIDs []int, replace bool) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateFederationUsers(federationID int, userIDs []int, replace bool) (tc.Alerts, toclientlib.ReqInf, error) {
 	req := tc.FederationUserPost{IDs: userIDs, Replace: &replace}
 	var alerts tc.Alerts
-	inf, err := to.post(fmt.Sprintf("%s/federations/%d/users", apiBase, federationID), req, nil, &alerts)
+	inf, err := to.post(fmt.Sprintf("/federations/%d/users", federationID), req, nil, &alerts)
 	return alerts, inf, err
 }
 
-func (to *Session) GetFederationUsersWithHdr(federationID int, header http.Header) ([]tc.FederationUser, ReqInf, error) {
+func (to *Session) GetFederationUsersWithHdr(federationID int, header http.Header) ([]tc.FederationUser, toclientlib.ReqInf, error) {
 	type FederationUsersResponse struct {
 		Response []tc.FederationUser `json:"response"`
 	}
 	data := FederationUsersResponse{}
-	inf, err := to.get(fmt.Sprintf("%s/federations/%d/users", apiBase, federationID), header, &data)
+	inf, err := to.get(fmt.Sprintf("/federations/%d/users", federationID), header, &data)
 	return data.Response, inf, err
 }
 
 // GetFederationUsers Returns a given Federation's Users
 // Deprecated: GetFederationUsers will be removed in 6.0. Use GetFederationUsersWithHdr.
-func (to *Session) GetFederationUsers(federationID int) ([]tc.FederationUser, ReqInf, error) {
+func (to *Session) GetFederationUsers(federationID int) ([]tc.FederationUser, toclientlib.ReqInf, error) {
 	return to.GetFederationUsersWithHdr(federationID, nil)
 }
 
 // DeleteFederationUser Deletes a given User from a Federation
-func (to *Session) DeleteFederationUser(federationID, userID int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/federations/%d/users/%d", apiBase, federationID, userID)
+func (to *Session) DeleteFederationUser(federationID, userID int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("/federations/%d/users/%d", federationID, userID)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
@@ -150,7 +151,7 @@ func (to *Session) DeleteFederationUser(federationID, userID int) (tc.Alerts, Re
 
 // AddFederationResolverMappingsForCurrentUser adds Federation Resolver mappings to one or more
 // Delivery Services for the current user.
-func (to *Session) AddFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, ReqInf, error) {
+func (to *Session) AddFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(APIFederations, mappings, nil, &alerts)
 	return alerts, reqInf, err
@@ -159,7 +160,7 @@ func (to *Session) AddFederationResolverMappingsForCurrentUser(mappings tc.Deliv
 // DeleteFederationResolverMappingsForCurrentUser removes ALL Federation Resolver mappings for ALL
 // Federations assigned to the currently authenticated user, as well as deleting ALL of the
 // Federation Resolvers themselves.
-func (to *Session) DeleteFederationResolverMappingsForCurrentUser() (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteFederationResolverMappingsForCurrentUser() (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.del(APIFederations, nil, &alerts)
 	return alerts, reqInf, err
@@ -171,7 +172,7 @@ func (to *Session) DeleteFederationResolverMappingsForCurrentUser() (tc.Alerts, 
 // well as deleting ALL of the Federation Resolvers themselves. In other words, calling this is
 // equivalent to a call to DeleteFederationResolverMappingsForCurrentUser followed by a call to
 // AddFederationResolverMappingsForCurrentUser .
-func (to *Session) ReplaceFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, ReqInf, error) {
+func (to *Session) ReplaceFederationResolverMappingsForCurrentUser(mappings tc.DeliveryServiceFederationResolverMappingRequest) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.put(APIFederations, mappings, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/federation_federation_resolver.go
+++ b/traffic_ops/v4-client/federation_federation_resolver.go
@@ -17,19 +17,20 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // GetFederationFederationResolversByID retrieves all Federation Resolvers belonging to Federation of ID.
-func (to *Session) GetFederationFederationResolversByID(id int) (tc.FederationFederationResolversResponse, ReqInf, error) {
-	path := fmt.Sprintf("%s/federations/%d/federation_resolvers", apiBase, id)
+func (to *Session) GetFederationFederationResolversByID(id int) (tc.FederationFederationResolversResponse, toclientlib.ReqInf, error) {
+	path := fmt.Sprintf("/federations/%d/federation_resolvers", id)
 	resp := tc.FederationFederationResolversResponse{}
 	reqInf, err := to.get(path, nil, &resp)
 	return resp, reqInf, err
 }
 
 // AssignFederationFederationResolver creates the Federation Resolver 'fr'.
-func (to *Session) AssignFederationFederationResolver(fedID int, resolverIDs []int, replace bool) (tc.AssignFederationFederationResolversResponse, ReqInf, error) {
-	path := fmt.Sprintf("%s/federations/%d/federation_resolvers", apiBase, fedID)
+func (to *Session) AssignFederationFederationResolver(fedID int, resolverIDs []int, replace bool) (tc.AssignFederationFederationResolversResponse, toclientlib.ReqInf, error) {
+	path := fmt.Sprintf("/federations/%d/federation_resolvers", fedID)
 	req := tc.AssignFederationResolversRequest{
 		Replace:        replace,
 		FedResolverIDs: resolverIDs,

--- a/traffic_ops/v4-client/federation_resolver.go
+++ b/traffic_ops/v4-client/federation_resolver.go
@@ -20,8 +20,9 @@ import "net/url"
 import "strconv"
 
 import "github.com/apache/trafficcontrol/lib/go-tc"
+import "github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 
-func (to *Session) getFederationResolvers(id *uint, ip *string, t *string, header http.Header) ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) getFederationResolvers(id *uint, ip *string, t *string, header http.Header) ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	var vals = url.Values{}
 	if id != nil {
 		vals.Set("id", strconv.FormatUint(uint64(*id), 10))
@@ -33,7 +34,7 @@ func (to *Session) getFederationResolvers(id *uint, ip *string, t *string, heade
 		vals.Set("type", *t)
 	}
 
-	var path = apiBase + "/federation_resolvers"
+	path := "/federation_resolvers"
 	if len(vals) > 0 {
 		path = fmt.Sprintf("%s?%s", path, vals.Encode())
 	}
@@ -45,17 +46,17 @@ func (to *Session) getFederationResolvers(id *uint, ip *string, t *string, heade
 	return data.Response, inf, err
 }
 
-func (to *Session) GetFederationResolversWithHdr(header http.Header) ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolversWithHdr(header http.Header) ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.getFederationResolvers(nil, nil, nil, header)
 }
 
 // GetFederationResolvers retrieves all Federation Resolvers from Traffic Ops
 // Deprecated: GetFederationResolvers will be removed in 6.0. Use GetFederationResolversWithHdr.
-func (to *Session) GetFederationResolvers() ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolvers() ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.GetFederationResolversWithHdr(nil)
 }
 
-func (to *Session) GetFederationResolverByIDWithHdr(ID uint, header http.Header) (tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolverByIDWithHdr(ID uint, header http.Header) (tc.FederationResolver, toclientlib.ReqInf, error) {
 	var fr tc.FederationResolver
 	frs, inf, err := to.getFederationResolvers(&ID, nil, nil, header)
 	if len(frs) > 0 {
@@ -66,11 +67,11 @@ func (to *Session) GetFederationResolverByIDWithHdr(ID uint, header http.Header)
 
 // GetFederationResolverByID retrieves a single Federation Resolver identified by ID.
 // Deprecated: GetFederationResolverByID will be removed in 6.0. Use GetFederationResolverByIDWithHdr.
-func (to *Session) GetFederationResolverByID(ID uint) (tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolverByID(ID uint) (tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.GetFederationResolverByIDWithHdr(ID, nil)
 }
 
-func (to *Session) GetFederationResolverByIPAddressWithHdr(ip string, header http.Header) (tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolverByIPAddressWithHdr(ip string, header http.Header) (tc.FederationResolver, toclientlib.ReqInf, error) {
 	var fr tc.FederationResolver
 	frs, inf, err := to.getFederationResolvers(nil, &ip, nil, header)
 	if len(frs) > 0 {
@@ -82,31 +83,31 @@ func (to *Session) GetFederationResolverByIPAddressWithHdr(ip string, header htt
 // GetFederationResolverByIPAddress retrieves the Federation Resolver that uses the IP address or
 // CIDR-notation subnet 'ip'.
 // Deprecated: GetFederationResolverByIPAddress will be removed in 6.0. Use GetFederationResolverByIPAddressWithHdr.
-func (to *Session) GetFederationResolverByIPAddress(ip string) (tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolverByIPAddress(ip string) (tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.GetFederationResolverByIPAddressWithHdr(ip, nil)
 }
 
-func (to *Session) GetFederationResolversByTypeWithHdr(t string, header http.Header) ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolversByTypeWithHdr(t string, header http.Header) ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.getFederationResolvers(nil, nil, &t, header)
 }
 
 // GetFederationResolversByType gets all Federation Resolvers that are of the Type named 't'.
 // Deprecated: GetFederationResolversByType will be removed in 6.0. Use GetFederationResolversByTypeWithHdr.
-func (to *Session) GetFederationResolversByType(t string) ([]tc.FederationResolver, ReqInf, error) {
+func (to *Session) GetFederationResolversByType(t string) ([]tc.FederationResolver, toclientlib.ReqInf, error) {
 	return to.GetFederationResolversByTypeWithHdr(t, nil)
 }
 
 // CreateFederationResolver creates the Federation Resolver 'fr'.
-func (to *Session) CreateFederationResolver(fr tc.FederationResolver) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateFederationResolver(fr tc.FederationResolver) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(apiBase+"/federation_resolvers", fr, nil, &alerts)
+	reqInf, err := to.post("/federation_resolvers", fr, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteFederationResolver deletes the Federation Resolver identified by 'id'.
-func (to *Session) DeleteFederationResolver(id uint) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteFederationResolver(id uint) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	path := fmt.Sprintf("%s/federation_resolvers?id=%d", apiBase, id)
+	path := fmt.Sprintf("/federation_resolvers?id=%d", id)
 	reqInf, err := to.del(path, nil, &alerts)
 	return alerts, reqInf, err
 }

--- a/traffic_ops/v4-client/iso.go
+++ b/traffic_ops/v4-client/iso.go
@@ -21,10 +21,11 @@ package client
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_OSVERSIONS = apiBase + "/osversions"
+	APIOSVersions = "/osversions"
 )
 
 // GetOSVersions GETs all available Operating System (OS) versions for ISO generation,
@@ -32,10 +33,10 @@ const (
 // Structure of returned map:
 //  key:   Name of OS
 //  value: Directory where the ISO source can be found
-func (to *Session) GetOSVersions() (map[string]string, ReqInf, error) {
+func (to *Session) GetOSVersions() (map[string]string, toclientlib.ReqInf, error) {
 	var data struct {
 		Versions tc.OSVersionsResponse `json:"response"`
 	}
-	reqInf, err := to.get(API_OSVERSIONS, nil, &data)
+	reqInf, err := to.get(APIOSVersions, nil, &data)
 	return data.Versions, reqInf, err
 }

--- a/traffic_ops/v4-client/job.go
+++ b/traffic_ops/v4-client/job.go
@@ -22,27 +22,28 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // Creates a new Content Invalidation Job
-func (to *Session) CreateInvalidationJob(job tc.InvalidationJobInput) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateInvalidationJob(job tc.InvalidationJobInput) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(apiBase+`/jobs`, job, nil, &alerts)
+	reqInf, err := to.post(`/jobs`, job, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // Deletes a Content Invalidation Job
-func (to *Session) DeleteInvalidationJob(jobID uint64) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteInvalidationJob(jobID uint64) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.del(fmt.Sprintf("%s/jobs?id=%d", apiBase, jobID), nil, &alerts)
+	reqInf, err := to.del(fmt.Sprintf("/jobs?id=%d", jobID), nil, &alerts)
 	return alerts, reqInf, err
 
 }
 
 // Updates a Content Invalidation Job
-func (to *Session) UpdateInvalidationJob(job tc.InvalidationJob) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateInvalidationJob(job tc.InvalidationJob) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.put(fmt.Sprintf(`%s/jobs?id=%d`, apiBase, *job.ID), job, nil, &alerts)
+	reqInf, err := to.put(fmt.Sprintf(`/jobs?id=%d`, *job.ID), job, nil, &alerts)
 	return alerts, reqInf, err
 }
 
@@ -51,7 +52,7 @@ func (to *Session) UpdateInvalidationJob(job tc.InvalidationJob) (tc.Alerts, Req
 // that user are returned. Both deliveryServiceID and userID may be nil.
 //
 // Deprecated, use GetInvalidationJobs instead
-func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, ReqInf, error) {
+func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, toclientlib.ReqInf, error) {
 	params := url.Values{}
 	if deliveryServiceID != nil {
 		params.Add("dsId", strconv.Itoa(*deliveryServiceID))
@@ -59,7 +60,7 @@ func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, ReqIn
 	if userID != nil {
 		params.Add("userId", strconv.Itoa(*userID))
 	}
-	path := apiBase + "/jobs?" + params.Encode()
+	path := "/jobs?" + params.Encode()
 	data := struct {
 		Response []tc.Job `json:"response"`
 	}{}
@@ -82,7 +83,7 @@ func (to *Session) GetJobs(deliveryServiceID *int, userID *int) ([]tc.Job, ReqIn
 // desired user (in the case of a float64 the fractional part is dropped, e.g. 3.45 -> 3), or it may
 // be a string, in which case it should be the username of the desired user, or it may be an actual
 // tc.User or tc.UserCurrent structure.
-func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc.InvalidationJob, ReqInf, error) {
+func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc.InvalidationJob, toclientlib.ReqInf, error) {
 	const DSIDKey = "dsId"
 	const DSKey = "deliveryService"
 	const UserKey = "userId"
@@ -106,10 +107,10 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 			} else if d.(tc.DeliveryServiceNullable).ID != nil {
 				params.Add(DSIDKey, strconv.FormatInt(int64(*d.(tc.DeliveryServiceNullable).ID), 10))
 			} else {
-				return nil, ReqInf{}, errors.New("no non-nil identifier on passed Delivery Service")
+				return nil, toclientlib.ReqInf{}, errors.New("no non-nil identifier on passed Delivery Service")
 			}
 		default:
-			return nil, ReqInf{}, fmt.Errorf("invalid type for argument 'ds': %T*", t)
+			return nil, toclientlib.ReqInf{}, fmt.Errorf("invalid type for argument 'ds': %T*", t)
 		}
 	}
 	if user != nil {
@@ -129,7 +130,7 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 			} else if u.(tc.User).ID != nil {
 				params.Add(UserKey, strconv.FormatInt(int64(*u.(tc.User).ID), 10))
 			} else {
-				return nil, ReqInf{}, errors.New("no non-nil identifier on passed User")
+				return nil, toclientlib.ReqInf{}, errors.New("no non-nil identifier on passed User")
 			}
 		case tc.UserCurrent:
 			if u.(tc.UserCurrent).UserName != nil {
@@ -137,13 +138,13 @@ func (to *Session) GetInvalidationJobs(ds *interface{}, user *interface{}) ([]tc
 			} else if u.(tc.UserCurrent).ID != nil {
 				params.Add(UserKey, strconv.FormatInt(int64(*u.(tc.UserCurrent).ID), 10))
 			} else {
-				return nil, ReqInf{}, errors.New("no non-nil identifier on passed UserCurrent")
+				return nil, toclientlib.ReqInf{}, errors.New("no non-nil identifier on passed UserCurrent")
 			}
 		default:
-			return nil, ReqInf{}, fmt.Errorf("invalid type for argument 'user': %T*", t)
+			return nil, toclientlib.ReqInf{}, fmt.Errorf("invalid type for argument 'user': %T*", t)
 		}
 	}
-	path := apiBase + "/jobs"
+	path := "/jobs"
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}

--- a/traffic_ops/v4-client/log.go
+++ b/traffic_ops/v4-client/log.go
@@ -19,31 +19,32 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_LOGS = apiBase + "/logs"
+	APILogs = "/logs"
 )
 
 // GetLogsByQueryParams gets a list of logs filtered by query params.
-func (to *Session) GetLogsByQueryParams(queryParams string) ([]tc.Log, ReqInf, error) {
-	URI := API_LOGS + queryParams
+func (to *Session) GetLogsByQueryParams(queryParams string) ([]tc.Log, toclientlib.ReqInf, error) {
+	uri := APILogs + queryParams
 	var data tc.LogsResponse
-	reqInf, err := to.get(URI, nil, &data)
+	reqInf, err := to.get(uri, nil, &data)
 	return data.Response, reqInf, err
 }
 
 // GetLogs gets a list of logs.
-func (to *Session) GetLogs() ([]tc.Log, ReqInf, error) {
+func (to *Session) GetLogs() ([]tc.Log, toclientlib.ReqInf, error) {
 	return to.GetLogsByQueryParams("")
 }
 
 // GetLogsByLimit gets a list of logs limited to a certain number of logs.
-func (to *Session) GetLogsByLimit(limit int) ([]tc.Log, ReqInf, error) {
+func (to *Session) GetLogsByLimit(limit int) ([]tc.Log, toclientlib.ReqInf, error) {
 	return to.GetLogsByQueryParams(fmt.Sprintf("?limit=%d", limit))
 }
 
 // GetLogsByDays gets a list of logs limited to a certain number of days.
-func (to *Session) GetLogsByDays(days int) ([]tc.Log, ReqInf, error) {
+func (to *Session) GetLogsByDays(days int) ([]tc.Log, toclientlib.ReqInf, error) {
 	return to.GetLogsByQueryParams(fmt.Sprintf("?days=%d", days))
 }

--- a/traffic_ops/v4-client/origin.go
+++ b/traffic_ops/v4-client/origin.go
@@ -23,10 +23,11 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_ORIGINS = apiBase + "/origins"
+	APIOrigins = "/origins"
 )
 
 func originIDs(to *Session, origin *tc.Origin) error {
@@ -86,28 +87,28 @@ func originIDs(to *Session, origin *tc.Origin) error {
 }
 
 // Create an Origin
-func (to *Session) CreateOrigin(origin tc.Origin) (*tc.OriginDetailResponse, ReqInf, error) {
+func (to *Session) CreateOrigin(origin tc.Origin) (*tc.OriginDetailResponse, toclientlib.ReqInf, error) {
 	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	reqInf := toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss, RemoteAddr: remoteAddr}
 
 	err := originIDs(to, &origin)
 	if err != nil {
 		return nil, reqInf, err
 	}
 	var originResp tc.OriginDetailResponse
-	reqInf, err = to.post(API_ORIGINS, origin, nil, &originResp)
+	reqInf, err = to.post(APIOrigins, origin, nil, &originResp)
 	return &originResp, reqInf, err
 }
 
-func (to *Session) UpdateOriginByIDWithHdr(id int, origin tc.Origin, header http.Header) (*tc.OriginDetailResponse, ReqInf, error) {
+func (to *Session) UpdateOriginByIDWithHdr(id int, origin tc.Origin, header http.Header) (*tc.OriginDetailResponse, toclientlib.ReqInf, error) {
 	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	reqInf := toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss, RemoteAddr: remoteAddr}
 
 	err := originIDs(to, &origin)
 	if err != nil {
 		return nil, reqInf, err
 	}
-	route := fmt.Sprintf("%s?id=%d", API_ORIGINS, id)
+	route := fmt.Sprintf("%s?id=%d", APIOrigins, id)
 	var originResp tc.OriginDetailResponse
 	reqInf, err = to.put(route, origin, header, &originResp)
 	return &originResp, reqInf, err
@@ -115,41 +116,41 @@ func (to *Session) UpdateOriginByIDWithHdr(id int, origin tc.Origin, header http
 
 // Update an Origin by ID
 // Deprecated: UpdateOriginByID will be removed in 6.0. Use UpdateOriginByIDWithHdr.
-func (to *Session) UpdateOriginByID(id int, origin tc.Origin) (*tc.OriginDetailResponse, ReqInf, error) {
+func (to *Session) UpdateOriginByID(id int, origin tc.Origin) (*tc.OriginDetailResponse, toclientlib.ReqInf, error) {
 	return to.UpdateOriginByIDWithHdr(id, origin, nil)
 }
 
 // GET a list of Origins by a query parameter string
-func (to *Session) GetOriginsByQueryParams(queryParams string) ([]tc.Origin, ReqInf, error) {
-	URI := API_ORIGINS + queryParams
+func (to *Session) GetOriginsByQueryParams(queryParams string) ([]tc.Origin, toclientlib.ReqInf, error) {
+	URI := APIOrigins + queryParams
 	var data tc.OriginsResponse
 	reqInf, err := to.get(URI, nil, &data)
 	return data.Response, reqInf, err
 }
 
 // Returns a list of Origins
-func (to *Session) GetOrigins() ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOrigins() ([]tc.Origin, toclientlib.ReqInf, error) {
 	return to.GetOriginsByQueryParams("")
 }
 
 // GET an Origin by the Origin ID
-func (to *Session) GetOriginByID(id int) ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOriginByID(id int) ([]tc.Origin, toclientlib.ReqInf, error) {
 	return to.GetOriginsByQueryParams(fmt.Sprintf("?id=%d", id))
 }
 
 // GET an Origin by the Origin name
-func (to *Session) GetOriginByName(name string) ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOriginByName(name string) ([]tc.Origin, toclientlib.ReqInf, error) {
 	return to.GetOriginsByQueryParams(fmt.Sprintf("?name=%s", url.QueryEscape(name)))
 }
 
 // GET a list of Origins by Delivery Service ID
-func (to *Session) GetOriginsByDeliveryServiceID(id int) ([]tc.Origin, ReqInf, error) {
+func (to *Session) GetOriginsByDeliveryServiceID(id int) ([]tc.Origin, toclientlib.ReqInf, error) {
 	return to.GetOriginsByQueryParams(fmt.Sprintf("?deliveryservice=%d", id))
 }
 
 // DELETE an Origin by ID
-func (to *Session) DeleteOriginByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_ORIGINS, id)
+func (to *Session) DeleteOriginByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIOrigins, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/parameter.go
+++ b/traffic_ops/v4-client/parameter.go
@@ -21,28 +21,29 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_PARAMETERS = apiBase + "/parameters"
+	APIParameters = "/parameters"
 )
 
 // CreateParameter performs a POST to create a Parameter.
-func (to *Session) CreateParameter(pl tc.Parameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateParameter(pl tc.Parameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_PARAMETERS, pl, nil, &alerts)
+	reqInf, err := to.post(APIParameters, pl, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // CreateMultipleParameters performs a POST to create multiple Parameters at once.
-func (to *Session) CreateMultipleParameters(pls []tc.Parameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateMultipleParameters(pls []tc.Parameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_PARAMETERS, pls, nil, &alerts)
+	reqInf, err := to.post(APIParameters, pls, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateParameterByIDWithHdr(id int, pl tc.Parameter, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_PARAMETERS, id)
+func (to *Session) UpdateParameterByIDWithHdr(id int, pl tc.Parameter, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIParameters, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, pl, header, &alerts)
 	return alerts, reqInf, err
@@ -50,24 +51,24 @@ func (to *Session) UpdateParameterByIDWithHdr(id int, pl tc.Parameter, header ht
 
 // UpdateParameterByID performs a PUT to update a Parameter by ID.
 // Deprecated: UpdateParameterByID will be removed in 6.0. Use UpdateParameterByIDWithHdr.
-func (to *Session) UpdateParameterByID(id int, pl tc.Parameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateParameterByID(id int, pl tc.Parameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateParameterByIDWithHdr(id, pl, nil)
 }
 
-func (to *Session) GetParametersWithHdr(header http.Header) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParametersWithHdr(header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	var data tc.ParametersResponse
-	reqInf, err := to.get(API_PARAMETERS, header, &data)
+	reqInf, err := to.get(APIParameters, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetParameters returns a list of Parameters.
 // Deprecated: GetParameters will be removed in 6.0. Use GetParametersWithHdr.
-func (to *Session) GetParameters() ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameters() ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParametersWithHdr(nil)
 }
 
-func (to *Session) GetParameterByIDWithHdr(id int, header http.Header) ([]tc.Parameter, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_PARAMETERS, id)
+func (to *Session) GetParameterByIDWithHdr(id int, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIParameters, id)
 	var data tc.ParametersResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -75,12 +76,12 @@ func (to *Session) GetParameterByIDWithHdr(id int, header http.Header) ([]tc.Par
 
 // GetParameterByID GETs a Parameter by the Parameter ID.
 // Deprecated: GetParameterByID will be removed in 6.0. Use GetParameterByIDWithHdr.
-func (to *Session) GetParameterByID(id int) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByID(id int) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetParameterByNameWithHdr(name string, header http.Header) ([]tc.Parameter, ReqInf, error) {
-	URI := API_PARAMETERS + "?name=" + url.QueryEscape(name)
+func (to *Session) GetParameterByNameWithHdr(name string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
+	URI := APIParameters + "?name=" + url.QueryEscape(name)
 	var data tc.ParametersResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -88,12 +89,12 @@ func (to *Session) GetParameterByNameWithHdr(name string, header http.Header) ([
 
 // GetParameterByName GETs a Parameter by the Parameter name.
 // Deprecated: GetParameterByName will be removed in 6.0. Use GetParameterByNameWithHdr.
-func (to *Session) GetParameterByName(name string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByName(name string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetParameterByConfigFileWithHdr(configFile string, header http.Header) ([]tc.Parameter, ReqInf, error) {
-	URI := API_PARAMETERS + "?configFile=" + url.QueryEscape(configFile)
+func (to *Session) GetParameterByConfigFileWithHdr(configFile string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
+	URI := APIParameters + "?configFile=" + url.QueryEscape(configFile)
 	var data tc.ParametersResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -101,12 +102,12 @@ func (to *Session) GetParameterByConfigFileWithHdr(configFile string, header htt
 
 // GetParameterByConfigFile GETs a Parameter by the Parameter ConfigFile.
 // Deprecated: GetParameterByConfigFile will be removed in 6.0. Use GetParameterByConfigFileWithHdr.
-func (to *Session) GetParameterByConfigFile(configFile string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByConfigFile(configFile string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByConfigFileWithHdr(configFile, nil)
 }
 
-func (to *Session) GetParameterByNameAndConfigFileWithHdr(name string, configFile string, header http.Header) ([]tc.Parameter, ReqInf, error) {
-	URI := fmt.Sprintf("%s?name=%s&configFile=%s", API_PARAMETERS, url.QueryEscape(name), url.QueryEscape(configFile))
+func (to *Session) GetParameterByNameAndConfigFileWithHdr(name string, configFile string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s?name=%s&configFile=%s", APIParameters, url.QueryEscape(name), url.QueryEscape(configFile))
 	var data tc.ParametersResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -114,12 +115,12 @@ func (to *Session) GetParameterByNameAndConfigFileWithHdr(name string, configFil
 
 // GetParameterByNameAndConfigFile GETs a Parameter by the Parameter Name and ConfigFile.
 // Deprecated: GetParameterByNameAndConfigFile will be removed in 6.0. Use GetParameterByNameAndConfigFileWithHdr.
-func (to *Session) GetParameterByNameAndConfigFile(name string, configFile string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByNameAndConfigFile(name string, configFile string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByNameAndConfigFileWithHdr(name, configFile, nil)
 }
 
-func (to *Session) GetParameterByNameAndConfigFileAndValueWithHdr(name, configFile, value string, header http.Header) ([]tc.Parameter, ReqInf, error) {
-	URI := fmt.Sprintf("%s?name=%s&configFile=%s&value=%s", API_PARAMETERS, url.QueryEscape(name), url.QueryEscape(configFile), url.QueryEscape(value))
+func (to *Session) GetParameterByNameAndConfigFileAndValueWithHdr(name, configFile, value string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s?name=%s&configFile=%s&value=%s", APIParameters, url.QueryEscape(name), url.QueryEscape(configFile), url.QueryEscape(value))
 	var data tc.ParametersResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -129,13 +130,13 @@ func (to *Session) GetParameterByNameAndConfigFileAndValueWithHdr(name, configFi
 // TODO: API should support all 3, but does not support filter by value
 // currently. Until then, loop through hits until you find one with that value.
 // Deprecated: GetParameterByNameAndConfigFileAndValue will be removed in 6.0. Use GetParameterByNameAndConfigFileAndValueWithHdr.
-func (to *Session) GetParameterByNameAndConfigFileAndValue(name, configFile, value string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParameterByNameAndConfigFileAndValue(name, configFile, value string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParameterByNameAndConfigFileAndValueWithHdr(name, configFile, value, nil)
 }
 
 // DeleteParameterByID DELETEs a Parameter by ID.
-func (to *Session) DeleteParameterByID(id int) (tc.Alerts, ReqInf, error) {
-	URI := fmt.Sprintf("%s/%d", API_PARAMETERS, id)
+func (to *Session) DeleteParameterByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s/%d", APIParameters, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(URI, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/phys_location.go
+++ b/traffic_ops/v4-client/phys_location.go
@@ -22,31 +22,32 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_PHYS_LOCATIONS = apiBase + "/phys_locations"
+	APIPhysLocations = "/phys_locations"
 )
 
 // CreatePhysLocation creates a PhysLocation.
-func (to *Session) CreatePhysLocation(pl tc.PhysLocation) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreatePhysLocation(pl tc.PhysLocation) (tc.Alerts, toclientlib.ReqInf, error) {
 	if pl.RegionID == 0 && pl.RegionName != "" {
 		regions, _, err := to.GetRegionByNameWithHdr(pl.RegionName, nil)
 		if err != nil {
-			return tc.Alerts{}, ReqInf{}, err
+			return tc.Alerts{}, toclientlib.ReqInf{}, err
 		}
 		if len(regions) == 0 {
-			return tc.Alerts{}, ReqInf{}, errors.New("no region with name " + pl.RegionName)
+			return tc.Alerts{}, toclientlib.ReqInf{}, errors.New("no region with name " + pl.RegionName)
 		}
 		pl.RegionID = regions[0].ID
 	}
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_PHYS_LOCATIONS, pl, nil, &alerts)
+	reqInf, err := to.post(APIPhysLocations, pl, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdatePhysLocationByIDWithHdr(id int, pl tc.PhysLocation, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_PHYS_LOCATIONS, id)
+func (to *Session) UpdatePhysLocationByIDWithHdr(id int, pl tc.PhysLocation, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIPhysLocations, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, pl, header, &alerts)
 	return alerts, reqInf, err
@@ -54,12 +55,12 @@ func (to *Session) UpdatePhysLocationByIDWithHdr(id int, pl tc.PhysLocation, hea
 
 // Update a PhysLocation by ID
 // Deprecated: UpdatePhysLocationByID will be removed in 6.0. Use UpdatePhysLocationByIDWithHdr.
-func (to *Session) UpdatePhysLocationByID(id int, pl tc.PhysLocation) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdatePhysLocationByID(id int, pl tc.PhysLocation) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdatePhysLocationByIDWithHdr(id, pl, nil)
 }
 
-func (to *Session) GetPhysLocationsWithHdr(params map[string]string, header http.Header) ([]tc.PhysLocation, ReqInf, error) {
-	path := API_PHYS_LOCATIONS + mapToQueryParameters(params)
+func (to *Session) GetPhysLocationsWithHdr(params map[string]string, header http.Header) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
+	path := APIPhysLocations + mapToQueryParameters(params)
 	var data tc.PhysLocationsResponse
 	reqInf, err := to.get(path, header, &data)
 	return data.Response, reqInf, err
@@ -67,12 +68,12 @@ func (to *Session) GetPhysLocationsWithHdr(params map[string]string, header http
 
 // Returns a list of PhysLocations with optional query parameters applied
 // Deprecated: GetPhysLocations will be removed in 6.0. Use GetPhysLocationsWithHdr.
-func (to *Session) GetPhysLocations(params map[string]string) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocations(params map[string]string) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	return to.GetPhysLocationsWithHdr(params, nil)
 }
 
-func (to *Session) GetPhysLocationByIDWithHdr(id int, header http.Header) ([]tc.PhysLocation, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_PHYS_LOCATIONS, id)
+func (to *Session) GetPhysLocationByIDWithHdr(id int, header http.Header) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIPhysLocations, id)
 	var data tc.PhysLocationsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -80,12 +81,12 @@ func (to *Session) GetPhysLocationByIDWithHdr(id int, header http.Header) ([]tc.
 
 // GET a PhysLocation by the PhysLocation ID
 // Deprecated: GetPhysLocationByID will be removed in 6.0. Use GetPhysLocationByIDWithHdr.
-func (to *Session) GetPhysLocationByID(id int) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocationByID(id int) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	return to.GetPhysLocationByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetPhysLocationByNameWithHdr(name string, header http.Header) ([]tc.PhysLocation, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", API_PHYS_LOCATIONS, url.QueryEscape(name))
+func (to *Session) GetPhysLocationByNameWithHdr(name string, header http.Header) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APIPhysLocations, url.QueryEscape(name))
 	var data tc.PhysLocationsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -93,13 +94,13 @@ func (to *Session) GetPhysLocationByNameWithHdr(name string, header http.Header)
 
 // GET a PhysLocation by the PhysLocation name
 // Deprecated: GetPhysLocationByName will be removed in 6.0. Use GetPhysLocationByNameWithHdr.
-func (to *Session) GetPhysLocationByName(name string) ([]tc.PhysLocation, ReqInf, error) {
+func (to *Session) GetPhysLocationByName(name string) ([]tc.PhysLocation, toclientlib.ReqInf, error) {
 	return to.GetPhysLocationByNameWithHdr(name, nil)
 }
 
 // DELETE a PhysLocation by ID
-func (to *Session) DeletePhysLocationByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_PHYS_LOCATIONS, id)
+func (to *Session) DeletePhysLocationByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIPhysLocations, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/ping.go
+++ b/traffic_ops/v4-client/ping.go
@@ -15,13 +15,17 @@
 
 package client
 
+import (
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+)
+
 const (
-	API_PING = apiBase + "/ping"
+	APIPing = "/ping"
 )
 
 // Ping returns a static json object to show that traffic_ops is responsive
-func (to *Session) Ping() (map[string]string, ReqInf, error) {
+func (to *Session) Ping() (map[string]string, toclientlib.ReqInf, error) {
 	var data map[string]string
-	reqInf, err := to.get(API_PING, nil, &data)
+	reqInf, err := to.get(APIPing, nil, &data)
 	return data, reqInf, err
 }

--- a/traffic_ops/v4-client/profile.go
+++ b/traffic_ops/v4-client/profile.go
@@ -21,19 +21,20 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_PROFILES                 = apiBase + "/profiles"
-	API_PROFILES_NAME_PARAMETERS = API_PROFILES + "/name/%s/parameters"
+	APIProfiles               = "/profiles"
+	APIProfilesNameParameters = APIProfiles + "/name/%s/parameters"
 )
 
 // CreateProfile creates a Profile.
-func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, toclientlib.ReqInf, error) {
 	if pl.CDNID == 0 && pl.CDNName != "" {
 		cdns, _, err := to.GetCDNByNameWithHdr(pl.CDNName, nil)
 		if err != nil {
-			return tc.Alerts{}, ReqInf{}, err
+			return tc.Alerts{}, toclientlib.ReqInf{}, err
 		}
 		if len(cdns) == 0 {
 			return tc.Alerts{
@@ -44,19 +45,19 @@ func (to *Session) CreateProfile(pl tc.Profile) (tc.Alerts, ReqInf, error) {
 						},
 					},
 				},
-				ReqInf{},
+				toclientlib.ReqInf{},
 				fmt.Errorf("no CDN with name %s", pl.CDNName)
 		}
 		pl.CDNID = cdns[0].ID
 	}
 
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_PROFILES, pl, nil, &alerts)
+	reqInf, err := to.post(APIProfiles, pl, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateProfileByIDWithHdr(id int, pl tc.Profile, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_PROFILES, id)
+func (to *Session) UpdateProfileByIDWithHdr(id int, pl tc.Profile, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIProfiles, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, pl, header, &alerts)
 	return alerts, reqInf, err
@@ -64,12 +65,12 @@ func (to *Session) UpdateProfileByIDWithHdr(id int, pl tc.Profile, header http.H
 
 // UpdateProfileByID updates a Profile by ID.
 // Deprecated: UpdateProfileByID will be removed in 6.0. Use UpdateProfileByIDWithHdr.
-func (to *Session) UpdateProfileByID(id int, pl tc.Profile) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateProfileByID(id int, pl tc.Profile) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateProfileByIDWithHdr(id, pl, nil)
 }
 
-func (to *Session) GetParametersByProfileNameWithHdr(profileName string, header http.Header) ([]tc.Parameter, ReqInf, error) {
-	route := fmt.Sprintf(API_PROFILES_NAME_PARAMETERS, profileName)
+func (to *Session) GetParametersByProfileNameWithHdr(profileName string, header http.Header) ([]tc.Parameter, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf(APIProfilesNameParameters, profileName)
 	var data tc.ParametersResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -77,24 +78,24 @@ func (to *Session) GetParametersByProfileNameWithHdr(profileName string, header 
 
 // GetParametersByProfileName gets all of the Parameters assigned to the Profile named 'profileName'.
 // Deprecated: GetParametersByProfileName will be removed in 6.0. Use GetParametersByProfileNameWithHdr.
-func (to *Session) GetParametersByProfileName(profileName string) ([]tc.Parameter, ReqInf, error) {
+func (to *Session) GetParametersByProfileName(profileName string) ([]tc.Parameter, toclientlib.ReqInf, error) {
 	return to.GetParametersByProfileNameWithHdr(profileName, nil)
 }
 
-func (to *Session) GetProfilesWithHdr(header http.Header) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfilesWithHdr(header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
 	var data tc.ProfilesResponse
-	reqInf, err := to.get(API_PROFILES, header, &data)
+	reqInf, err := to.get(APIProfiles, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetProfiles returns a list of Profiles.
 // Deprecated: GetProfiles will be removed in 6.0. Use GetProfilesWithHdr.
-func (to *Session) GetProfiles() ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfiles() ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfilesWithHdr(nil)
 }
 
-func (to *Session) GetProfileByIDWithHdr(id int, header http.Header) ([]tc.Profile, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_PROFILES, id)
+func (to *Session) GetProfileByIDWithHdr(id int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIProfiles, id)
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -102,12 +103,12 @@ func (to *Session) GetProfileByIDWithHdr(id int, header http.Header) ([]tc.Profi
 
 // GetProfileByID GETs a Profile by the Profile ID.
 // Deprecated: GetProfileByID will be removed in 6.0. Use GetProfileByIDWithHdr.
-func (to *Session) GetProfileByID(id int) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByID(id int) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetProfileByNameWithHdr(name string, header http.Header) ([]tc.Profile, ReqInf, error) {
-	URI := fmt.Sprintf("%s?name=%s", API_PROFILES, url.QueryEscape(name))
+func (to *Session) GetProfileByNameWithHdr(name string, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s?name=%s", APIProfiles, url.QueryEscape(name))
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -115,12 +116,12 @@ func (to *Session) GetProfileByNameWithHdr(name string, header http.Header) ([]t
 
 // GetProfileByName GETs a Profile by the Profile name.
 // Deprecated: GetProfileByName will be removed in 6.0. Use GetProfileByNameWithHdr.
-func (to *Session) GetProfileByName(name string) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByName(name string) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, ReqInf, error) {
-	URI := fmt.Sprintf("%s?param=%s", API_PROFILES, url.QueryEscape(param))
+func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s?param=%s", APIProfiles, url.QueryEscape(param))
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -128,12 +129,12 @@ func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header
 
 // GetProfileByParameter GETs a Profile by the Profile "param".
 // Deprecated: GetProfileByParameter will be removed in 6.0. Use GetProfileByParameterWithHdr.
-func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByParameterWithHdr(param, nil)
 }
 
-func (to *Session) GetProfileByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.Profile, ReqInf, error) {
-	URI := fmt.Sprintf("%s?cdn=%d", API_PROFILES, cdnID)
+func (to *Session) GetProfileByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s?cdn=%d", APIProfiles, cdnID)
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -141,37 +142,37 @@ func (to *Session) GetProfileByCDNIDWithHdr(cdnID int, header http.Header) ([]tc
 
 // GetProfileByCDNID GETs a Profile by the Profile CDN ID.
 // Deprecated: GetProfileByCDNID will be removed in 6.0. Use GetProfileByCDNIDWithHdr.
-func (to *Session) GetProfileByCDNID(cdnID int) ([]tc.Profile, ReqInf, error) {
+func (to *Session) GetProfileByCDNID(cdnID int) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByCDNIDWithHdr(cdnID, nil)
 }
 
 // DeleteProfileByID DELETEs a Profile by ID.
-func (to *Session) DeleteProfileByID(id int) (tc.Alerts, ReqInf, error) {
-	URI := fmt.Sprintf("%s/%d", API_PROFILES, id)
+func (to *Session) DeleteProfileByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s/%d", APIProfiles, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(URI, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // ExportProfile Returns an exported Profile.
-func (to *Session) ExportProfile(id int) (*tc.ProfileExportResponse, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d/export", API_PROFILES, id)
+func (to *Session) ExportProfile(id int) (*tc.ProfileExportResponse, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d/export", APIProfiles, id)
 	var data tc.ProfileExportResponse
 	reqInf, err := to.get(route, nil, &data)
 	return &data, reqInf, err
 }
 
 // ImportProfile imports an exported Profile.
-func (to *Session) ImportProfile(importRequest *tc.ProfileImportRequest) (*tc.ProfileImportResponse, ReqInf, error) {
-	route := fmt.Sprintf("%s/import", API_PROFILES)
+func (to *Session) ImportProfile(importRequest *tc.ProfileImportRequest) (*tc.ProfileImportResponse, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/import", APIProfiles)
 	var data tc.ProfileImportResponse
 	reqInf, err := to.post(route, importRequest, nil, &data)
 	return &data, reqInf, err
 }
 
 // CopyProfile creates a new profile from an existing profile.
-func (to *Session) CopyProfile(p tc.ProfileCopy) (tc.ProfileCopyResponse, ReqInf, error) {
-	path := fmt.Sprintf("%s/name/%s/copy/%s", API_PROFILES, p.Name, p.ExistingName)
+func (to *Session) CopyProfile(p tc.ProfileCopy) (tc.ProfileCopyResponse, toclientlib.ReqInf, error) {
+	path := fmt.Sprintf("%s/name/%s/copy/%s", APIProfiles, p.Name, p.ExistingName)
 	resp := tc.ProfileCopyResponse{}
 	reqInf, err := to.post(path, p, nil, &resp)
 	return resp, reqInf, err

--- a/traffic_ops/v4-client/profile_parameter.go
+++ b/traffic_ops/v4-client/profile_parameter.go
@@ -20,40 +20,41 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_PROFILE_PARAMETERS = apiBase + "/profileparameters"
-	ProfileIdQueryParam    = "profileId"
-	ParameterIdQueryParam  = "parameterId"
+	APIProfileParameters  = "/profileparameters"
+	ProfileIdQueryParam   = "profileId"
+	ParameterIdQueryParam = "parameterId"
 )
 
 // Create a ProfileParameter
-func (to *Session) CreateProfileParameter(pp tc.ProfileParameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateProfileParameter(pp tc.ProfileParameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_PROFILE_PARAMETERS, pp, nil, &alerts)
+	reqInf, err := to.post(APIProfileParameters, pp, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // CreateMultipleProfileParameters creates multiple ProfileParameters at once.
-func (to *Session) CreateMultipleProfileParameters(pps []tc.ProfileParameter) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateMultipleProfileParameters(pps []tc.ProfileParameter) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_PROFILE_PARAMETERS, pps, nil, &alerts)
+	reqInf, err := to.post(APIProfileParameters, pps, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetProfileParametersWithHdr(header http.Header) ([]tc.ProfileParameter, ReqInf, error) {
+func (to *Session) GetProfileParametersWithHdr(header http.Header) ([]tc.ProfileParameter, toclientlib.ReqInf, error) {
 	return to.GetProfileParameterByQueryParamsWithHdr("", header)
 }
 
 // Returns a list of Profile Parameters
 // Deprecated: GetProfileParameters will be removed in 6.0. Use GetProfileParametersWithHdr.
-func (to *Session) GetProfileParameters() ([]tc.ProfileParameter, ReqInf, error) {
+func (to *Session) GetProfileParameters() ([]tc.ProfileParameter, toclientlib.ReqInf, error) {
 	return to.GetProfileParametersWithHdr(nil)
 }
 
-func (to *Session) GetProfileParameterByQueryParamsWithHdr(queryParams string, header http.Header) ([]tc.ProfileParameter, ReqInf, error) {
-	URI := API_PROFILE_PARAMETERS + queryParams
+func (to *Session) GetProfileParameterByQueryParamsWithHdr(queryParams string, header http.Header) ([]tc.ProfileParameter, toclientlib.ReqInf, error) {
+	URI := APIProfileParameters + queryParams
 	var data tc.ProfileParametersNullableResponse
 	reqInf, err := to.get(URI, header, &data)
 	if err != nil {
@@ -74,13 +75,13 @@ func (to *Session) GetProfileParameterByQueryParamsWithHdr(queryParams string, h
 
 // GET a Profile Parameter by the Parameter
 // Deprecated: GetProfileParameterByQueryParams will be removed in 6.0. Use GetProfileParameterByQueryParamsWithHdr.
-func (to *Session) GetProfileParameterByQueryParams(queryParams string) ([]tc.ProfileParameter, ReqInf, error) {
+func (to *Session) GetProfileParameterByQueryParams(queryParams string) ([]tc.ProfileParameter, toclientlib.ReqInf, error) {
 	return to.GetProfileParameterByQueryParamsWithHdr(queryParams, nil)
 }
 
 // DELETE a Parameter by Parameter
-func (to *Session) DeleteParameterByProfileParameter(profile int, parameter int) (tc.Alerts, ReqInf, error) {
-	URI := fmt.Sprintf("%s/%d/%d", API_PROFILE_PARAMETERS, profile, parameter)
+func (to *Session) DeleteParameterByProfileParameter(profile int, parameter int) (tc.Alerts, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s/%d/%d", APIProfileParameters, profile, parameter)
 	var alerts tc.Alerts
 	reqInf, err := to.del(URI, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/region.go
+++ b/traffic_ops/v4-client/region.go
@@ -23,31 +23,32 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_REGIONS = apiBase + "/regions"
+	APIRegions = "/regions"
 )
 
 // CreateRegion creates a Region.
-func (to *Session) CreateRegion(region tc.Region) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateRegion(region tc.Region) (tc.Alerts, toclientlib.ReqInf, error) {
 	if region.Division == 0 && region.DivisionName != "" {
 		divisions, _, err := to.GetDivisionByNameWithHdr(region.DivisionName, nil)
 		if err != nil {
-			return tc.Alerts{}, ReqInf{}, err
+			return tc.Alerts{}, toclientlib.ReqInf{}, err
 		}
 		if len(divisions) == 0 {
-			return tc.Alerts{}, ReqInf{}, errors.New("no division with name " + region.DivisionName)
+			return tc.Alerts{}, toclientlib.ReqInf{}, errors.New("no division with name " + region.DivisionName)
 		}
 		region.Division = divisions[0].ID
 	}
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_REGIONS, region, nil, &alerts)
+	reqInf, err := to.post(APIRegions, region, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateRegionByIDWithHdr(id int, region tc.Region, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_REGIONS, id)
+func (to *Session) UpdateRegionByIDWithHdr(id int, region tc.Region, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIRegions, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, region, header, &alerts)
 	return alerts, reqInf, err
@@ -55,24 +56,24 @@ func (to *Session) UpdateRegionByIDWithHdr(id int, region tc.Region, header http
 
 // UpdateRegionByID updates a Region by ID.
 // Deprecated: UpdateRegionByID will be removed in 6.0. Use UpdateRegionByIDWithHdr.
-func (to *Session) UpdateRegionByID(id int, region tc.Region) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateRegionByID(id int, region tc.Region) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateRegionByIDWithHdr(id, region, nil)
 }
 
-func (to *Session) GetRegionsWithHdr(header http.Header) ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegionsWithHdr(header http.Header) ([]tc.Region, toclientlib.ReqInf, error) {
 	var data tc.RegionsResponse
-	reqInf, err := to.get(API_REGIONS, header, &data)
+	reqInf, err := to.get(APIRegions, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetRegions returns a list of regions.
 // Deprecated: GetRegions will be removed in 6.0. Use GetRegionsWithHdr.
-func (to *Session) GetRegions() ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegions() ([]tc.Region, toclientlib.ReqInf, error) {
 	return to.GetRegionsWithHdr(nil)
 }
 
-func (to *Session) GetRegionByIDWithHdr(id int, header http.Header) ([]tc.Region, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_REGIONS, id)
+func (to *Session) GetRegionByIDWithHdr(id int, header http.Header) ([]tc.Region, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIRegions, id)
 	var data tc.RegionsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -80,12 +81,12 @@ func (to *Session) GetRegionByIDWithHdr(id int, header http.Header) ([]tc.Region
 
 // GetRegionByID GETs a Region by the Region ID.
 // Deprecated: GetRegionByID will be removed in 6.0. Use GetRegionByIDWithHdr.
-func (to *Session) GetRegionByID(id int) ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegionByID(id int) ([]tc.Region, toclientlib.ReqInf, error) {
 	return to.GetRegionByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetRegionByNameWithHdr(name string, header http.Header) ([]tc.Region, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", API_REGIONS, url.QueryEscape(name))
+func (to *Session) GetRegionByNameWithHdr(name string, header http.Header) ([]tc.Region, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APIRegions, url.QueryEscape(name))
 	var data tc.RegionsResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -93,20 +94,20 @@ func (to *Session) GetRegionByNameWithHdr(name string, header http.Header) ([]tc
 
 // GetRegionByName GETs a Region by the Region name.
 // Deprecated: GetRegionByName will be removed in 6.0. Use GetRegionByNameHdr.
-func (to *Session) GetRegionByName(name string) ([]tc.Region, ReqInf, error) {
+func (to *Session) GetRegionByName(name string) ([]tc.Region, toclientlib.ReqInf, error) {
 	return to.GetRegionByNameWithHdr(name, nil)
 }
 
 // DeleteRegionByID DELETEs a Region by ID.
-func (to *Session) DeleteRegionByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_REGIONS, id)
+func (to *Session) DeleteRegionByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIRegions, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteRegion lets you DELETE a Region. Only 1 parameter is required, not both.
-func (to *Session) DeleteRegion(id *int, name *string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteRegion(id *int, name *string) (tc.Alerts, toclientlib.ReqInf, error) {
 	v := url.Values{}
 	if id != nil {
 		v.Add("id", strconv.Itoa(*id))
@@ -114,7 +115,7 @@ func (to *Session) DeleteRegion(id *int, name *string) (tc.Alerts, ReqInf, error
 	if name != nil {
 		v.Add("name", *name)
 	}
-	URI := apiBase + "/regions"
+	URI := "/regions"
 	if qStr := v.Encode(); len(qStr) > 0 {
 		URI = fmt.Sprintf("%s?%s", URI, qStr)
 	}

--- a/traffic_ops/v4-client/role.go
+++ b/traffic_ops/v4-client/role.go
@@ -21,21 +21,22 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_ROLES = apiBase + "/roles"
+	APIRoles = "/roles"
 )
 
 // CreateRole creates a Role.
-func (to *Session) CreateRole(role tc.Role) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) CreateRole(role tc.Role) (tc.Alerts, toclientlib.ReqInf, int, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_ROLES, role, nil, &alerts)
+	reqInf, err := to.post(APIRoles, role, nil, &alerts)
 	return alerts, reqInf, reqInf.StatusCode, err
 }
 
-func (to *Session) UpdateRoleByIDWithHdr(id int, role tc.Role, header http.Header) (tc.Alerts, ReqInf, int, error) {
-	route := fmt.Sprintf("%s/?id=%d", API_ROLES, id)
+func (to *Session) UpdateRoleByIDWithHdr(id int, role tc.Role, header http.Header) (tc.Alerts, toclientlib.ReqInf, int, error) {
+	route := fmt.Sprintf("%s/?id=%d", APIRoles, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, role, header, &alerts)
 	return alerts, reqInf, reqInf.StatusCode, err
@@ -43,25 +44,25 @@ func (to *Session) UpdateRoleByIDWithHdr(id int, role tc.Role, header http.Heade
 
 // UpdateRoleByID updates a Role by ID.
 // Deprecated: UpdateRoleByID will be removed in 6.0. Use UpdateRoleByIDWithHdr.
-func (to *Session) UpdateRoleByID(id int, role tc.Role) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) UpdateRoleByID(id int, role tc.Role) (tc.Alerts, toclientlib.ReqInf, int, error) {
 
 	return to.UpdateRoleByIDWithHdr(id, role, nil)
 }
 
-func (to *Session) GetRolesWithHdr(header http.Header) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRolesWithHdr(header http.Header) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	var data tc.RolesResponse
-	reqInf, err := to.get(API_ROLES, header, &data)
+	reqInf, err := to.get(APIRoles, header, &data)
 	return data.Response, reqInf, reqInf.StatusCode, err
 }
 
 // GetRoles returns a list of roles.
 // Deprecated: GetRoles will be removed in 6.0. Use GetRolesWithHdr.
-func (to *Session) GetRoles() ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoles() ([]tc.Role, toclientlib.ReqInf, int, error) {
 	return to.GetRolesWithHdr(nil)
 }
 
-func (to *Session) GetRoleByIDWithHdr(id int, header http.Header) ([]tc.Role, ReqInf, int, error) {
-	route := fmt.Sprintf("%s/?id=%d", API_ROLES, id)
+func (to *Session) GetRoleByIDWithHdr(id int, header http.Header) ([]tc.Role, toclientlib.ReqInf, int, error) {
+	route := fmt.Sprintf("%s/?id=%d", APIRoles, id)
 	var data tc.RolesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, reqInf.StatusCode, err
@@ -69,12 +70,12 @@ func (to *Session) GetRoleByIDWithHdr(id int, header http.Header) ([]tc.Role, Re
 
 // GetRoleByID GETs a Role by the Role ID.
 // Deprecated: GetRoleByID will be removed in 6.0. Use GetRoleByIDWithHdr.
-func (to *Session) GetRoleByID(id int) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByID(id int) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	return to.GetRoleByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetRoleByNameWithHdr(name string, header http.Header) ([]tc.Role, ReqInf, int, error) {
-	route := fmt.Sprintf("%s?name=%s", API_ROLES, url.QueryEscape(name))
+func (to *Session) GetRoleByNameWithHdr(name string, header http.Header) ([]tc.Role, toclientlib.ReqInf, int, error) {
+	route := fmt.Sprintf("%s?name=%s", APIRoles, url.QueryEscape(name))
 	var data tc.RolesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, reqInf.StatusCode, err
@@ -82,12 +83,12 @@ func (to *Session) GetRoleByNameWithHdr(name string, header http.Header) ([]tc.R
 
 // GetRoleByName GETs a Role by the Role name.
 // Deprecated: GetRoleByName will be removed in 6.0. Use GetRoleByNameWithHdr.
-func (to *Session) GetRoleByName(name string) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByName(name string) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	return to.GetRoleByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetRoleByQueryParamsWithHdr(queryParams map[string]string, header http.Header) ([]tc.Role, ReqInf, int, error) {
-	route := fmt.Sprintf("%s%s", API_ROLES, mapToQueryParameters(queryParams))
+func (to *Session) GetRoleByQueryParamsWithHdr(queryParams map[string]string, header http.Header) ([]tc.Role, toclientlib.ReqInf, int, error) {
+	route := fmt.Sprintf("%s%s", APIRoles, mapToQueryParameters(queryParams))
 	var data tc.RolesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, reqInf.StatusCode, err
@@ -95,13 +96,13 @@ func (to *Session) GetRoleByQueryParamsWithHdr(queryParams map[string]string, he
 
 // GetRoleByQueryParams gets a Role by the Role query parameters.
 // Deprecated: GetRoleByQueryParams will be removed in 6.0. Use GetRoleByQueryParamsWithHdr.
-func (to *Session) GetRoleByQueryParams(queryParams map[string]string) ([]tc.Role, ReqInf, int, error) {
+func (to *Session) GetRoleByQueryParams(queryParams map[string]string) ([]tc.Role, toclientlib.ReqInf, int, error) {
 	return to.GetRoleByQueryParamsWithHdr(queryParams, nil)
 }
 
 // DeleteRoleByID DELETEs a Role by ID.
-func (to *Session) DeleteRoleByID(id int) (tc.Alerts, ReqInf, int, error) {
-	route := fmt.Sprintf("%s/?id=%d", API_ROLES, id)
+func (to *Session) DeleteRoleByID(id int) (tc.Alerts, toclientlib.ReqInf, int, error) {
+	route := fmt.Sprintf("%s/?id=%d", APIRoles, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, reqInf.StatusCode, err

--- a/traffic_ops/v4-client/server_server_capabilities.go
+++ b/traffic_ops/v4-client/server_server_capabilities.go
@@ -22,32 +22,33 @@ import (
 	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_SERVER_SERVER_CAPABILITIES = apiBase + "/server_server_capabilities"
+	APIServerServerCapabilities = "/server_server_capabilities"
 )
 
 // CreateServerServerCapability assigns a Server Capability to a Server
-func (to *Session) CreateServerServerCapability(ssc tc.ServerServerCapability) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateServerServerCapability(ssc tc.ServerServerCapability) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_SERVER_SERVER_CAPABILITIES, ssc, nil, &alerts)
+	reqInf, err := to.post(APIServerServerCapabilities, ssc, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteServerServerCapability unassigns a Server Capability from a Server
-func (to *Session) DeleteServerServerCapability(serverID int, serverCapability string) (tc.Alerts, ReqInf, error) {
+func (to *Session) DeleteServerServerCapability(serverID int, serverCapability string) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	v := url.Values{}
 	v.Add("serverId", strconv.Itoa(serverID))
 	v.Add("serverCapability", serverCapability)
 	qStr := v.Encode()
-	queryURL := fmt.Sprintf("%s?%s", API_SERVER_SERVER_CAPABILITIES, qStr)
+	queryURL := fmt.Sprintf("%s?%s", APIServerServerCapabilities, qStr)
 	reqInf, err := to.del(queryURL, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) GetServerServerCapabilitiesWithHdr(serverID *int, serverHostName, serverCapability *string, header http.Header) ([]tc.ServerServerCapability, ReqInf, error) {
+func (to *Session) GetServerServerCapabilitiesWithHdr(serverID *int, serverHostName, serverCapability *string, header http.Header) ([]tc.ServerServerCapability, toclientlib.ReqInf, error) {
 	v := url.Values{}
 	if serverID != nil {
 		v.Add("serverId", strconv.Itoa(*serverID))
@@ -58,7 +59,7 @@ func (to *Session) GetServerServerCapabilitiesWithHdr(serverID *int, serverHostN
 	if serverCapability != nil {
 		v.Add("serverCapability", *serverCapability)
 	}
-	queryURL := API_SERVER_SERVER_CAPABILITIES
+	queryURL := APIServerServerCapabilities
 	if qStr := v.Encode(); len(qStr) > 0 {
 		queryURL = fmt.Sprintf("%s?%s", queryURL, qStr)
 	}
@@ -73,6 +74,6 @@ func (to *Session) GetServerServerCapabilitiesWithHdr(serverID *int, serverHostN
 // GetServerServerCapabilities retrieves a list of Server Capabilities that are assigned to a Server
 // Callers can filter the results by server id, server host name and/or server capability via the optional parameters
 // Deprecated: GetServerServerCapabilities will be removed in 6.0. Use GetServerServerCapabilitiesWithHdr.
-func (to *Session) GetServerServerCapabilities(serverID *int, serverHostName, serverCapability *string) ([]tc.ServerServerCapability, ReqInf, error) {
+func (to *Session) GetServerServerCapabilities(serverID *int, serverHostName, serverCapability *string) ([]tc.ServerServerCapability, toclientlib.ReqInf, error) {
 	return to.GetServerServerCapabilitiesWithHdr(serverID, serverHostName, serverCapability, nil)
 }

--- a/traffic_ops/v4-client/server_update_status.go
+++ b/traffic_ops/v4-client/server_update_status.go
@@ -22,11 +22,12 @@ import (
 	"strings"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // UpdateServerStatus updates a server's status and returns the response.
-func (to *Session) UpdateServerStatus(serverID int, req tc.ServerPutStatus) (*tc.Alerts, ReqInf, error) {
-	path := fmt.Sprintf("%s/servers/%d/status", apiBase, serverID)
+func (to *Session) UpdateServerStatus(serverID int, req tc.ServerPutStatus) (*tc.Alerts, toclientlib.ReqInf, error) {
+	path := fmt.Sprintf("/servers/%d/status", serverID)
 	alerts := tc.Alerts{}
 	reqInf, err := to.put(path, req, nil, &alerts)
 	if err != nil {
@@ -41,23 +42,23 @@ var queueUpdateActions = map[bool]string{
 }
 
 // SetServerQueueUpdate updates a server's status and returns the response.
-func (to *Session) SetServerQueueUpdate(serverID int, queueUpdate bool) (tc.ServerQueueUpdateResponse, ReqInf, error) {
+func (to *Session) SetServerQueueUpdate(serverID int, queueUpdate bool) (tc.ServerQueueUpdateResponse, toclientlib.ReqInf, error) {
 	req := tc.ServerQueueUpdateRequest{Action: queueUpdateActions[queueUpdate]}
 	resp := tc.ServerQueueUpdateResponse{}
-	path := fmt.Sprintf("%s/servers/%d/queue_update", apiBase, serverID)
+	path := fmt.Sprintf("/servers/%d/queue_update", serverID)
 	reqInf, err := to.post(path, req, nil, &resp)
 	return resp, reqInf, err
 }
 
 // UpdateServerStatus updates a server's queue status and/or reval status.
 // Either updateStatus or revalStatus may be nil, in which case that status isn't updated (but not both, because that wouldn't do anything).
-func (to *Session) SetUpdateServerStatuses(serverName string, updateStatus *bool, revalStatus *bool) (ReqInf, error) {
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+func (to *Session) SetUpdateServerStatuses(serverName string, updateStatus *bool, revalStatus *bool) (toclientlib.ReqInf, error) {
+	reqInf := toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}
 	if updateStatus == nil && revalStatus == nil {
 		return reqInf, errors.New("either updateStatus or revalStatus must be non-nil; nothing to do")
 	}
 
-	path := apiBase + `/servers/` + serverName + `/update?`
+	path := `/servers/` + serverName + `/update?`
 	queryParams := []string{}
 	if updateStatus != nil {
 		queryParams = append(queryParams, `updated=`+strconv.FormatBool(*updateStatus))

--- a/traffic_ops/v4-client/servercapability.go
+++ b/traffic_ops/v4-client/servercapability.go
@@ -21,36 +21,37 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_SERVER_CAPABILITIES = apiBase + "/server_capabilities"
+	APIServerCapabilities = "/server_capabilities"
 )
 
 // CreateServerCapability creates a server capability and returns the response.
-func (to *Session) CreateServerCapability(sc tc.ServerCapability) (*tc.ServerCapabilityDetailResponse, ReqInf, error) {
+func (to *Session) CreateServerCapability(sc tc.ServerCapability) (*tc.ServerCapabilityDetailResponse, toclientlib.ReqInf, error) {
 	var scResp tc.ServerCapabilityDetailResponse
-	reqInf, err := to.post(API_SERVER_CAPABILITIES, sc, nil, &scResp)
+	reqInf, err := to.post(APIServerCapabilities, sc, nil, &scResp)
 	if err != nil {
 		return nil, reqInf, err
 	}
 	return &scResp, reqInf, nil
 }
 
-func (to *Session) GetServerCapabilitiesWithHdr(header http.Header) ([]tc.ServerCapability, ReqInf, error) {
+func (to *Session) GetServerCapabilitiesWithHdr(header http.Header) ([]tc.ServerCapability, toclientlib.ReqInf, error) {
 	var data tc.ServerCapabilitiesResponse
-	reqInf, err := to.get(API_SERVER_CAPABILITIES, header, &data)
+	reqInf, err := to.get(APIServerCapabilities, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetServerCapabilities returns all the server capabilities.
 // Deprecated: GetServerCapabilities will be removed in 6.0. Use GetServerCapabilitiesWithHdr.
-func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, ReqInf, error) {
+func (to *Session) GetServerCapabilities() ([]tc.ServerCapability, toclientlib.ReqInf, error) {
 	return to.GetServerCapabilitiesWithHdr(nil)
 }
 
-func (to *Session) GetServerCapabilityWithHdr(name string, header http.Header) (*tc.ServerCapability, ReqInf, error) {
-	reqUrl := fmt.Sprintf("%s?name=%s", API_SERVER_CAPABILITIES, url.QueryEscape(name))
+func (to *Session) GetServerCapabilityWithHdr(name string, header http.Header) (*tc.ServerCapability, toclientlib.ReqInf, error) {
+	reqUrl := fmt.Sprintf("%s?name=%s", APIServerCapabilities, url.QueryEscape(name))
 	var data tc.ServerCapabilitiesResponse
 	reqInf, err := to.get(reqUrl, header, &data)
 	if err != nil {
@@ -64,13 +65,13 @@ func (to *Session) GetServerCapabilityWithHdr(name string, header http.Header) (
 
 // GetServerCapability returns the given server capability by name.
 // Deprecated: GetServerCapability will be removed in 6.0. Use GetServerCapabilityWithHdr.
-func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, ReqInf, error) {
+func (to *Session) GetServerCapability(name string) (*tc.ServerCapability, toclientlib.ReqInf, error) {
 	return to.GetServerCapabilityWithHdr(name, nil)
 }
 
 // DeleteServerCapability deletes the given server capability by name.
-func (to *Session) DeleteServerCapability(name string) (tc.Alerts, ReqInf, error) {
-	reqUrl := fmt.Sprintf("%s?name=%s", API_SERVER_CAPABILITIES, url.QueryEscape(name))
+func (to *Session) DeleteServerCapability(name string) (tc.Alerts, toclientlib.ReqInf, error) {
+	reqUrl := fmt.Sprintf("%s?name=%s", APIServerCapabilities, url.QueryEscape(name))
 	var alerts tc.Alerts
 	reqInf, err := to.del(reqUrl, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/servercheck.go
+++ b/traffic_ops/v4-client/servercheck.go
@@ -17,13 +17,14 @@ package client
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-const API_SERVERCHECK = apiBase + "/servercheck"
+const APIServercheck = "/servercheck"
 
 // InsertServerCheckStatus Will insert/update the servercheck value based on if it already exists or not.
-func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable) (*tc.ServercheckPostResponse, ReqInf, error) {
-	uri := API_SERVERCHECK
+func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable) (*tc.ServercheckPostResponse, toclientlib.ReqInf, error) {
+	uri := APIServercheck
 	resp := tc.ServercheckPostResponse{}
 	reqInf, err := to.post(uri, status, nil, &resp)
 	if err != nil {
@@ -33,11 +34,11 @@ func (to *Session) InsertServerCheckStatus(status tc.ServercheckRequestNullable)
 }
 
 // GetServersChecks fetches check and meta information about servers from /servercheck.
-func (to *Session) GetServersChecks() ([]tc.GenericServerCheck, tc.Alerts, ReqInf, error) {
+func (to *Session) GetServersChecks() ([]tc.GenericServerCheck, tc.Alerts, toclientlib.ReqInf, error) {
 	var response struct {
 		tc.Alerts
 		Response []tc.GenericServerCheck `json:"response"`
 	}
-	reqInf, err := to.get(API_SERVERCHECK, nil, &response)
+	reqInf, err := to.get(APIServercheck, nil, &response)
 	return response.Response, response.Alerts, reqInf, err
 }

--- a/traffic_ops/v4-client/servercheckextensions.go
+++ b/traffic_ops/v4-client/servercheckextensions.go
@@ -16,28 +16,29 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-const API_TO_EXTENSION = apiBase + "/servercheck/extensions"
+const APITOExtension = "/servercheck/extensions"
 
 // CreateServerCheckExtension creates a servercheck extension.
-func (to *Session) CreateServerCheckExtension(ServerCheckExtension tc.ServerCheckExtensionNullable) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateServerCheckExtension(ServerCheckExtension tc.ServerCheckExtensionNullable) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_TO_EXTENSION, ServerCheckExtension, nil, &alerts)
+	reqInf, err := to.post(APITOExtension, ServerCheckExtension, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // DeleteServerCheckExtension deletes a servercheck extension.
-func (to *Session) DeleteServerCheckExtension(id int) (tc.Alerts, ReqInf, error) {
-	URI := fmt.Sprintf("%s/%d", API_TO_EXTENSION, id)
+func (to *Session) DeleteServerCheckExtension(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s/%d", APITOExtension, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(URI, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // GetServerCheckExtensions gets all servercheck extensions.
-func (to *Session) GetServerCheckExtensions() (tc.ServerCheckExtensionResponse, ReqInf, error) {
+func (to *Session) GetServerCheckExtensions() (tc.ServerCheckExtensionResponse, toclientlib.ReqInf, error) {
 	var toExtResp tc.ServerCheckExtensionResponse
-	reqInf, err := to.get(API_TO_EXTENSION, nil, &toExtResp)
+	reqInf, err := to.get(APITOExtension, nil, &toExtResp)
 	return toExtResp, reqInf, err
 }

--- a/traffic_ops/v4-client/serviceCategory.go
+++ b/traffic_ops/v4-client/serviceCategory.go
@@ -21,44 +21,45 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_SERVICE_CATEGORIES = apiBase + "/service_categories"
+	APIServiceCategories = "/service_categories"
 )
 
 // CreateServiceCategory performs a post to create a service category.
-func (to *Session) CreateServiceCategory(serviceCategory tc.ServiceCategory) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateServiceCategory(serviceCategory tc.ServiceCategory) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_SERVICE_CATEGORIES, serviceCategory, nil, &alerts)
+	reqInf, err := to.post(APIServiceCategories, serviceCategory, nil, &alerts)
 	return alerts, reqInf, err
 }
 
 // UpdateServiceCategoryByName updates a service category by its unique name.
-func (to *Session) UpdateServiceCategoryByName(name string, serviceCategory tc.ServiceCategory, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%s", API_SERVICE_CATEGORIES, name)
+func (to *Session) UpdateServiceCategoryByName(name string, serviceCategory tc.ServiceCategory, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%s", APIServiceCategories, name)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, serviceCategory, header, &alerts)
 	return alerts, reqInf, err
 }
 
 // GetServiceCategoriesWithHdr gets a list of service categories by the passed in url values and http headers.
-func (to *Session) GetServiceCategoriesWithHdr(values *url.Values, header http.Header) ([]tc.ServiceCategory, ReqInf, error) {
-	path := fmt.Sprintf("%s?%s", API_SERVICE_CATEGORIES, values.Encode())
+func (to *Session) GetServiceCategoriesWithHdr(values *url.Values, header http.Header) ([]tc.ServiceCategory, toclientlib.ReqInf, error) {
+	path := fmt.Sprintf("%s?%s", APIServiceCategories, values.Encode())
 	var data tc.ServiceCategoriesResponse
 	reqInf, err := to.get(path, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetServiceCategories gets a list of service categories by the passed in url values.
-func (to *Session) GetServiceCategories(values *url.Values) ([]tc.ServiceCategory, ReqInf, error) {
+func (to *Session) GetServiceCategories(values *url.Values) ([]tc.ServiceCategory, toclientlib.ReqInf, error) {
 	return to.GetServiceCategoriesWithHdr(values, nil)
 }
 
 // DeleteServiceCategoryByName deletes a service category by the service
 // category's unique name.
-func (to *Session) DeleteServiceCategoryByName(name string) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%s", API_SERVICE_CATEGORIES, name)
+func (to *Session) DeleteServiceCategoryByName(name string) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%s", APIServiceCategories, name)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/session.go
+++ b/traffic_ops/v4-client/session.go
@@ -17,197 +17,40 @@
 package client
 
 import (
-	"bytes"
-	"crypto/tls"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
-	"net/http/cookiejar"
-	"net/http/httptrace"
-	"strconv"
-	"strings"
-	"sync"
 	"time"
 
-	log "github.com/apache/trafficcontrol/lib/go-log"
-	tc "github.com/apache/trafficcontrol/lib/go-tc"
-
-	"golang.org/x/net/publicsuffix"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-// Session ...
+// Login authenticates with Traffic Ops and returns the client object.
+//
+// Returns the logged in client, the remote address of Traffic Ops which was translated and used to log in, and any error. If the error is not nil, the remote address may or may not be nil, depending whether the error occurred before the login request.
+//
+// See ClientOpts for details about options, which options are required, and how they behave.
+//
+func Login(url, user, pass string, opts ClientOpts) (*Session, toclientlib.ReqInf, error) {
+	cl, ip, err := toclientlib.Login(url, user, pass, opts.ClientOpts, apiVersions())
+	if err != nil {
+		return nil, toclientlib.ReqInf{}, err
+	}
+	return &Session{TOClient: *cl}, ip, err
+}
+
+type ClientOpts struct {
+	toclientlib.ClientOpts
+}
+
+// Session is a Traffic Ops client.
 type Session struct {
-	UserName     string
-	Password     string
-	URL          string
-	Client       *http.Client
-	cache        map[string]CacheEntry
-	cacheMutex   *sync.RWMutex
-	useCache     bool
-	UserAgentStr string
+	toclientlib.TOClient
 }
 
 func NewSession(user, password, url, userAgent string, client *http.Client, useCache bool) *Session {
 	return &Session{
-		UserName:     user,
-		Password:     password,
-		URL:          url,
-		Client:       client,
-		cache:        map[string]CacheEntry{},
-		cacheMutex:   &sync.RWMutex{},
-		useCache:     useCache,
-		UserAgentStr: userAgent,
+		TOClient: *toclientlib.NewClient(user, password, url, userAgent, client, apiVersions()),
 	}
-}
-
-const DefaultTimeout = time.Second * time.Duration(30)
-
-// HTTPError is returned on Update Session failure.
-type HTTPError struct {
-	HTTPStatusCode int
-	HTTPStatus     string
-	URL            string
-	Body           string
-}
-
-// Error implements the error interface for our customer error type.
-func (e *HTTPError) Error() string {
-	return fmt.Sprintf("%s[%d] - Error requesting Traffic Ops %s %s", e.HTTPStatus, e.HTTPStatusCode, e.URL, e.Body)
-}
-
-// CacheEntry ...
-type CacheEntry struct {
-	Entered    int64
-	Bytes      []byte
-	RemoteAddr net.Addr
-}
-
-// TODO JvD
-const tmPollingInterval = 60
-
-// loginCreds gathers login credentials for Traffic Ops.
-func loginCreds(toUser string, toPasswd string) ([]byte, error) {
-	credentials := tc.UserCredentials{
-		Username: toUser,
-		Password: toPasswd,
-	}
-
-	js, err := json.Marshal(credentials)
-	if err != nil {
-		err := fmt.Errorf("Error creating login json: %v", err)
-		return nil, err
-	}
-	return js, nil
-}
-
-// loginToken gathers token login credentials for Traffic Ops.
-func loginToken(token string) ([]byte, error) {
-	form := tc.UserToken{
-		Token: token,
-	}
-
-	j, e := json.Marshal(form)
-	if e != nil {
-		e := fmt.Errorf("Error creating token login json: %v", e)
-		return nil, e
-	}
-	return j, nil
-}
-
-// login tries to log in to Traffic Ops, and set the auth cookie in the Session. Returns the IP address of the remote Traffic Ops.
-func (to *Session) login() (net.Addr, error) {
-	credentials, err := loginCreds(to.UserName, to.Password)
-	if err != nil {
-		return nil, errors.New("creating login credentials: " + err.Error())
-	}
-
-	path := apiBase + "/user/login"
-	resp, remoteAddr, err := to.RawRequestWithHdr("POST", path, credentials, nil)
-	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
-	if err != nil {
-		return remoteAddr, errors.New("requesting: " + err.Error())
-	}
-	defer resp.Body.Close()
-
-	var alerts tc.Alerts
-	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
-		return remoteAddr, errors.New("decoding response JSON: " + err.Error())
-	}
-
-	success := false
-	for _, alert := range alerts.Alerts {
-		if alert.Level == "success" && alert.Text == "Successfully logged in." {
-			success = true
-			break
-		}
-	}
-
-	if !success {
-		return remoteAddr, fmt.Errorf("Login failed, alerts string: %+v", alerts)
-	}
-
-	return remoteAddr, nil
-}
-
-func (to *Session) loginWithToken(token []byte) (net.Addr, error) {
-	path := apiBase + "/user/login/token"
-	resp, remoteAddr, err := to.RawRequestWithHdr(http.MethodPost, path, token, nil)
-	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
-	if err != nil {
-		return remoteAddr, fmt.Errorf("requesting: %v", err)
-	}
-	defer resp.Body.Close()
-
-	var alerts tc.Alerts
-	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
-		return remoteAddr, fmt.Errorf("decoding response JSON: %v", err)
-	}
-
-	for _, alert := range alerts.Alerts {
-		if alert.Level == tc.SuccessLevel.String() && alert.Text == "Successfully logged in." {
-			return remoteAddr, nil
-		}
-	}
-
-	return remoteAddr, fmt.Errorf("Login failed, alerts string: %+v", alerts)
-}
-
-// logout of Traffic Ops
-func (to *Session) logout() (net.Addr, error) {
-	credentials, err := loginCreds(to.UserName, to.Password)
-	if err != nil {
-		return nil, errors.New("creating login credentials: " + err.Error())
-	}
-
-	path := apiBase + "/user/logout"
-	resp, remoteAddr, err := to.RawRequestWithHdr("POST", path, credentials, nil)
-	resp, remoteAddr, err = to.errUnlessOKOrNotModified(resp, remoteAddr, err, path)
-	if err != nil {
-		return remoteAddr, errors.New("requesting: " + err.Error())
-	}
-	defer resp.Body.Close()
-
-	var alerts tc.Alerts
-	if err := json.NewDecoder(resp.Body).Decode(&alerts); err != nil {
-		return remoteAddr, errors.New("decoding response JSON: " + err.Error())
-	}
-
-	success := false
-	for _, alert := range alerts.Alerts {
-		if alert.Level == "success" && alert.Text == "Successfully logged in." {
-			success = true
-			break
-		}
-	}
-
-	if !success {
-		return remoteAddr, fmt.Errorf("Logout failed, alerts string: %+v", alerts)
-	}
-
-	return remoteAddr, nil
 }
 
 // Login to traffic_ops, the response should set the cookie for this session
@@ -216,339 +59,48 @@ func (to *Session) logout() (net.Addr, error) {
 // subsequent calls like to.GetData("datadeliveryservice") will be authenticated.
 // Returns the logged in client, the remote address of Traffic Ops which was translated and used to log in, and any error. If the error is not nil, the remote address may or may not be nil, depending whether the error occurred before the login request.
 func LoginWithAgent(toURL string, toUser string, toPasswd string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) (*Session, net.Addr, error) {
-	options := cookiejar.Options{
-		PublicSuffixList: publicsuffix.List,
-	}
-
-	jar, err := cookiejar.New(&options)
+	cl, ip, err := toclientlib.LoginWithAgent(toURL, toUser, toPasswd, insecure, userAgent, requestTimeout, apiVersions())
 	if err != nil {
 		return nil, nil, err
 	}
-
-	to := NewSession(toUser, toPasswd, toURL, userAgent, &http.Client{
-		Timeout: requestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		},
-		Jar: jar,
-	}, useCache)
-
-	remoteAddr, err := to.login()
-	if err != nil {
-		return nil, remoteAddr, errors.New("logging in: " + err.Error())
-	}
-	return to, remoteAddr, nil
+	return &Session{TOClient: *cl}, ip, err
 }
 
 func LoginWithToken(toURL string, token string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) (*Session, net.Addr, error) {
-	options := cookiejar.Options{
-		PublicSuffixList: publicsuffix.List,
-	}
-
-	jar, err := cookiejar.New(&options)
+	cl, ip, err := toclientlib.LoginWithToken(toURL, token, insecure, userAgent, requestTimeout, apiVersions())
 	if err != nil {
 		return nil, nil, err
 	}
-
-	client := http.Client{
-		Timeout: requestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		},
-		Jar: jar,
-	}
-
-	to := NewSession("", "", toURL, userAgent, &client, useCache)
-	tBts, err := loginToken(token)
-	if err != nil {
-		return nil, nil, fmt.Errorf("logging in: %v", err)
-	}
-
-	remoteAddr, err := to.loginWithToken(tBts)
-	if err != nil {
-		return nil, remoteAddr, fmt.Errorf("logging in: %v", err)
-	}
-	return to, remoteAddr, nil
+	return &Session{TOClient: *cl}, ip, err
 }
 
 // Logout of traffic_ops
 func LogoutWithAgent(toURL string, toUser string, toPasswd string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) (*Session, net.Addr, error) {
-	options := cookiejar.Options{
-		PublicSuffixList: publicsuffix.List,
-	}
-
-	jar, err := cookiejar.New(&options)
+	cl, ip, err := toclientlib.LogoutWithAgent(toURL, toUser, toPasswd, insecure, userAgent, requestTimeout, apiVersions())
 	if err != nil {
 		return nil, nil, err
 	}
-
-	to := NewSession(toUser, toPasswd, toURL, userAgent, &http.Client{
-		Timeout: requestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		},
-		Jar: jar,
-	}, useCache)
-
-	remoteAddr, err := to.logout()
-	if err != nil {
-		return nil, remoteAddr, errors.New("logging out: " + err.Error())
-	}
-	return to, remoteAddr, nil
+	return &Session{TOClient: *cl}, ip, err
 }
 
 // NewNoAuthSession returns a new Session without logging in
 // this can be used for querying unauthenticated endpoints without requiring a login
 func NewNoAuthSession(toURL string, insecure bool, userAgent string, useCache bool, requestTimeout time.Duration) *Session {
-	return NewSession("", "", toURL, userAgent, &http.Client{
-		Timeout: requestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		},
-	}, useCache)
+	return &Session{TOClient: *toclientlib.NewNoAuthClient(toURL, insecure, userAgent, requestTimeout, apiVersions())}
 }
 
-// errUnlessOKOrNotModified returns the response, the remote address, and an error if the given Response's status code is anything
-// but 200 OK/ 304 Not Modified. This includes reading the Response.Body and Closing it. Otherwise, the given response, the remote
-// address, and a nil error are returned.
-func (to *Session) errUnlessOKOrNotModified(resp *http.Response, remoteAddr net.Addr, err error, path string) (*http.Response, net.Addr, error) {
-	if err != nil {
-		return resp, remoteAddr, err
-	}
-	if resp.StatusCode < 300 || resp.StatusCode == 304 {
-		return resp, remoteAddr, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotImplemented {
-		return resp, remoteAddr, errors.New("Traffic Ops Server returned 'Not Implemented', this client is probably newer than Traffic Ops, and you probably need to either upgrade Traffic Ops, or use a client whose version matches your Traffic Ops version.")
-	}
-
-	body, readErr := ioutil.ReadAll(resp.Body)
-	if readErr != nil {
-		return resp, remoteAddr, readErr
-	}
-	return resp, remoteAddr, errors.New(resp.Status + "[" + strconv.Itoa(resp.StatusCode) + "] - Error requesting Traffic Ops " + to.getURL(path) + " " + string(body))
+func (to *Session) get(path string, header http.Header, response interface{}) (toclientlib.ReqInf, error) {
+	return to.TOClient.Req(http.MethodGet, path, nil, header, response)
 }
 
-func (to *Session) getURL(path string) string { return to.URL + path }
-
-// makeRequestWithHeader marshals the response body (if non-nil), performs the HTTP request,
-// and decodes the response into the given response pointer.
-func (to *Session) makeRequestWithHeader(method, path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-	var remoteAddr net.Addr
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
-	var reqBody []byte
-	var err error
-	if body != nil {
-		reqBody, err = json.Marshal(body)
-		if err != nil {
-			return reqInf, errors.New("marshalling request body: " + err.Error())
-		}
-	}
-	resp, remoteAddr, err := to.request(method, path, reqBody, header)
-	reqInf.RemoteAddr = remoteAddr
-	if resp != nil {
-		reqInf.StatusCode = resp.StatusCode
-		if reqInf.StatusCode == http.StatusNotModified {
-			return reqInf, nil
-		}
-		defer log.Close(resp.Body, "unable to close response body")
-	}
-	if err != nil {
-		return reqInf, errors.New("requesting from Traffic Ops: " + err.Error())
-	}
-	if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
-		return reqInf, errors.New("decoding response body: " + err.Error())
-	}
-	return reqInf, nil
+func (to *Session) post(path string, body interface{}, header http.Header, response interface{}) (toclientlib.ReqInf, error) {
+	return to.TOClient.Req(http.MethodPost, path, body, header, response)
 }
 
-func (to *Session) get(path string, header http.Header, response interface{}) (ReqInf, error) {
-	return to.makeRequestWithHeader(http.MethodGet, path, nil, header, response)
+func (to *Session) put(path string, body interface{}, header http.Header, response interface{}) (toclientlib.ReqInf, error) {
+	return to.TOClient.Req(http.MethodPut, path, body, header, response)
 }
 
-func (to *Session) post(path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-	return to.makeRequestWithHeader(http.MethodPost, path, body, header, response)
-}
-
-func (to *Session) put(path string, body interface{}, header http.Header, response interface{}) (ReqInf, error) {
-	return to.makeRequestWithHeader(http.MethodPut, path, body, header, response)
-}
-
-func (to *Session) del(path string, header http.Header, response interface{}) (ReqInf, error) {
-	return to.makeRequestWithHeader(http.MethodDelete, path, nil, header, response)
-}
-
-// request performs the HTTP request to Traffic Ops, trying to refresh the cookie if an Unauthorized or Forbidden code is received. It only tries once. If the login fails, the original Unauthorized/Forbidden response is returned. If the login succeeds and the subsequent re-request fails, the re-request's response is returned even if it's another Unauthorized/Forbidden.
-// Returns the response, the remote address of the Traffic Ops instance used, and any error.
-// The returned net.Addr is guaranteed to be either nil or valid, even if the returned error is not nil. Callers are encouraged to check and use the net.Addr if an error is returned, and use the remote address in their own error messages. This violates the Go idiom that a non-nil error implies all other values are undefined, but it's more straightforward than alternatives like typecasting.
-func (to *Session) request(method, path string, body []byte, header http.Header) (*http.Response, net.Addr, error) {
-	r, remoteAddr, err := to.RawRequestWithHdr(method, path, body, header)
-	if err != nil {
-		return r, remoteAddr, err
-	}
-	if r.StatusCode != http.StatusUnauthorized && r.StatusCode != http.StatusForbidden {
-		return to.errUnlessOKOrNotModified(r, remoteAddr, err, path)
-	}
-	if _, lerr := to.login(); lerr != nil {
-		return to.errUnlessOKOrNotModified(r, remoteAddr, err, path) // if re-logging-in fails, return the original request's response
-	}
-
-	// return second request, even if it's another Unauthorized or Forbidden.
-	r, remoteAddr, err = to.RawRequestWithHdr(method, path, body, header)
-	return to.errUnlessOKOrNotModified(r, remoteAddr, err, path)
-}
-
-func (to *Session) RawRequestWithHdr(method, path string, body []byte, header http.Header) (*http.Response, net.Addr, error) {
-	url := to.getURL(path)
-
-	var req *http.Request
-	var err error
-	remoteAddr := net.Addr(nil)
-
-	if body != nil {
-		req, err = http.NewRequest(method, url, bytes.NewBuffer(body))
-		if err != nil {
-			return nil, remoteAddr, err
-		}
-		if header != nil {
-			req.Header = header.Clone()
-		}
-		req.Header.Set("Content-Type", "application/json")
-	} else {
-		req, err = http.NewRequest(method, url, nil)
-		if err != nil {
-			return nil, remoteAddr, err
-		}
-		if header != nil {
-			req.Header = header.Clone()
-		}
-	}
-
-	trace := &httptrace.ClientTrace{
-		GotConn: func(connInfo httptrace.GotConnInfo) {
-			remoteAddr = connInfo.Conn.RemoteAddr()
-		},
-	}
-	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
-	req.Header.Set("User-Agent", to.UserAgentStr)
-	resp, err := to.Client.Do(req)
-	return resp, remoteAddr, err
-}
-
-// RawRequest performs the actual HTTP request to Traffic Ops, simply, without trying to refresh the cookie if an Unauthorized code is returned.
-// Returns the response, the remote address of the Traffic Ops instance used, and any error.
-// The returned net.Addr is guaranteed to be either nil or valid, even if the returned error is not nil. Callers are encouraged to check and use the net.Addr if an error is returned, and use the remote address in their own error messages. This violates the Go idiom that a non-nil error implies all other values are undefined, but it's more straightforward than alternatives like typecasting.
-// Deprecated: RawRequest will be removed in 6.0. Use RawRequestWithHdr.
-func (to *Session) RawRequest(method, path string, body []byte) (*http.Response, net.Addr, error) {
-	return to.RawRequestWithHdr(method, path, body, nil)
-}
-
-type ReqInf struct {
-	CacheHitStatus CacheHitStatus
-	RemoteAddr     net.Addr
-	StatusCode     int
-}
-
-type CacheHitStatus string
-
-const CacheHitStatusHit = CacheHitStatus("hit")
-const CacheHitStatusExpired = CacheHitStatus("expired")
-const CacheHitStatusMiss = CacheHitStatus("miss")
-const CacheHitStatusInvalid = CacheHitStatus("")
-
-func (s CacheHitStatus) String() string {
-	return string(s)
-}
-
-func StringToCacheHitStatus(s string) CacheHitStatus {
-	s = strings.ToLower(s)
-	switch s {
-	case "hit":
-		return CacheHitStatusHit
-	case "expired":
-		return CacheHitStatusExpired
-	case "miss":
-		return CacheHitStatusMiss
-	default:
-		return CacheHitStatusInvalid
-	}
-}
-
-// setCache Sets the given cache key and value. This is threadsafe for multiple goroutines.
-func (to *Session) setCache(path string, entry CacheEntry) {
-	if !to.useCache {
-		return
-	}
-	to.cacheMutex.Lock()
-	defer to.cacheMutex.Unlock()
-	to.cache[path] = entry
-}
-
-// getCache gets the cache value at the given key, or false if it doesn't exist. This is threadsafe for multiple goroutines.
-func (to *Session) getCache(path string) (CacheEntry, bool) {
-	to.cacheMutex.RLock()
-	defer to.cacheMutex.RUnlock()
-	cacheEntry, ok := to.cache[path]
-	return cacheEntry, ok
-}
-
-//if cacheEntry, ok := to.Cache[path]; ok {
-
-// getBytesWithTTL gets the path, and caches in the session. Returns bytes from the cache, if found and the TTL isn't expired. Otherwise, gets it and store it in cache
-func (to *Session) getBytesWithTTL(path string, ttl int64) ([]byte, ReqInf, error) {
-	var body []byte
-	var err error
-	var cacheHitStatus CacheHitStatus
-	var remoteAddr net.Addr
-
-	getFresh := false
-	if cacheEntry, ok := to.getCache(path); ok {
-		if cacheEntry.Entered > time.Now().Unix()-ttl {
-			cacheHitStatus = CacheHitStatusHit
-			body = cacheEntry.Bytes
-			remoteAddr = cacheEntry.RemoteAddr
-		} else {
-			cacheHitStatus = CacheHitStatusExpired
-			getFresh = true
-		}
-	} else {
-		cacheHitStatus = CacheHitStatusMiss
-		getFresh = true
-	}
-
-	if getFresh {
-		body, remoteAddr, err = to.getBytes(path)
-		if err != nil {
-			return nil, ReqInf{CacheHitStatus: CacheHitStatusInvalid, RemoteAddr: remoteAddr}, err
-		}
-
-		newEntry := CacheEntry{
-			Entered:    time.Now().Unix(),
-			Bytes:      body,
-			RemoteAddr: remoteAddr,
-		}
-		to.setCache(path, newEntry)
-	}
-
-	return body, ReqInf{CacheHitStatus: cacheHitStatus, RemoteAddr: remoteAddr}, nil
-}
-
-// GetBytes - get []bytes array for a certain path on the to session.
-// returns the raw body, the remote address the Traffic Ops URL resolved to, or any error. If the error is not nil, the RemoteAddr may or may not be nil, depending whether the error occurred before the request was executed.
-func (to *Session) getBytes(path string) ([]byte, net.Addr, error) {
-	resp, remoteAddr, err := to.request("GET", path, nil, nil)
-	if err != nil {
-		return nil, remoteAddr, err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, remoteAddr, err
-	}
-
-	return body, remoteAddr, nil
+func (to *Session) del(path string, header http.Header, response interface{}) (toclientlib.ReqInf, error) {
+	return to.TOClient.Req(http.MethodDelete, path, nil, header, response)
 }

--- a/traffic_ops/v4-client/staticdnsentry.go
+++ b/traffic_ops/v4-client/staticdnsentry.go
@@ -22,10 +22,11 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_STATIC_DNS_ENTRIES = apiBase + "/staticdnsentries"
+	APIStaticDNSEntries = "/staticdnsentries"
 )
 
 func staticDNSEntryIDs(to *Session, sdns *tc.StaticDNSEntry) error {
@@ -72,49 +73,49 @@ func staticDNSEntryIDs(to *Session, sdns *tc.StaticDNSEntry) error {
 }
 
 // CreateStaticDNSEntry creates a Static DNS Entry.
-func (to *Session) CreateStaticDNSEntry(sdns tc.StaticDNSEntry) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateStaticDNSEntry(sdns tc.StaticDNSEntry) (tc.Alerts, toclientlib.ReqInf, error) {
 	// fill in missing IDs from names
 	var alerts tc.Alerts
 	err := staticDNSEntryIDs(to, &sdns)
 	if err != nil {
-		return alerts, ReqInf{CacheHitStatus: CacheHitStatusMiss}, err
+		return alerts, toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}, err
 	}
-	reqInf, err := to.post(API_STATIC_DNS_ENTRIES, sdns, nil, &alerts)
+	reqInf, err := to.post(APIStaticDNSEntries, sdns, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateStaticDNSEntryByIDWithHdr(id int, sdns tc.StaticDNSEntry, header http.Header) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) UpdateStaticDNSEntryByIDWithHdr(id int, sdns tc.StaticDNSEntry, header http.Header) (tc.Alerts, toclientlib.ReqInf, int, error) {
 	// fill in missing IDs from names
 	var alerts tc.Alerts
 	err := staticDNSEntryIDs(to, &sdns)
 	if err != nil {
-		return alerts, ReqInf{CacheHitStatus: CacheHitStatusMiss}, 0, err
+		return alerts, toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}, 0, err
 	}
-	route := fmt.Sprintf("%s?id=%d", API_STATIC_DNS_ENTRIES, id)
+	route := fmt.Sprintf("%s?id=%d", APIStaticDNSEntries, id)
 	reqInf, err := to.put(route, sdns, header, &alerts)
 	return tc.Alerts{}, reqInf, reqInf.StatusCode, err
 }
 
 // UpdateStaticDNSEntryByID updates a Static DNS Entry by ID.
 // Deprecated: UpdateStaticDNSEntryByID will be removed in 6.0. Use UpdateStaticDNSEntryByIDWithHdr.
-func (to *Session) UpdateStaticDNSEntryByID(id int, sdns tc.StaticDNSEntry) (tc.Alerts, ReqInf, int, error) {
+func (to *Session) UpdateStaticDNSEntryByID(id int, sdns tc.StaticDNSEntry) (tc.Alerts, toclientlib.ReqInf, int, error) {
 	return to.UpdateStaticDNSEntryByIDWithHdr(id, sdns, nil)
 }
 
-func (to *Session) GetStaticDNSEntriesWithHdr(header http.Header) ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntriesWithHdr(header http.Header) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	var data tc.StaticDNSEntriesResponse
-	reqInf, err := to.get(API_STATIC_DNS_ENTRIES, header, &data)
+	reqInf, err := to.get(APIStaticDNSEntries, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetStaticDNSEntries returns a list of Static DNS Entrys.
 // Deprecated: GetStaticDNSEntries will be removed in 6.0. Use GetStaticDNSEntriesWithHdr.
-func (to *Session) GetStaticDNSEntries() ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntries() ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	return to.GetStaticDNSEntriesWithHdr(nil)
 }
 
-func (to *Session) GetStaticDNSEntryByIDWithHdr(id int, header http.Header) ([]tc.StaticDNSEntry, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_STATIC_DNS_ENTRIES, id)
+func (to *Session) GetStaticDNSEntryByIDWithHdr(id int, header http.Header) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIStaticDNSEntries, id)
 	var data tc.StaticDNSEntriesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -122,12 +123,12 @@ func (to *Session) GetStaticDNSEntryByIDWithHdr(id int, header http.Header) ([]t
 
 // GetStaticDNSEntryByID GETs a Static DNS Entry by the Static DNS Entry's ID.
 // Deprecated: GetStaticDNSEntryByID will be removed in 6.0. Use GetStaticDNSEntryByIDWithHdr.
-func (to *Session) GetStaticDNSEntryByID(id int) ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntryByID(id int) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	return to.GetStaticDNSEntryByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetStaticDNSEntriesByHostWithHdr(host string, header http.Header) ([]tc.StaticDNSEntry, ReqInf, error) {
-	route := fmt.Sprintf("%s?host=%s", API_STATIC_DNS_ENTRIES, url.QueryEscape(host))
+func (to *Session) GetStaticDNSEntriesByHostWithHdr(host string, header http.Header) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?host=%s", APIStaticDNSEntries, url.QueryEscape(host))
 	var data tc.StaticDNSEntriesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -135,13 +136,13 @@ func (to *Session) GetStaticDNSEntriesByHostWithHdr(host string, header http.Hea
 
 // GetStaticDNSEntriesByHost GETs a Static DNS Entry by the Static DNS Entry's host.
 // Deprecated: GetStaticDNSEntriesByHost will be removed in 6.0. Use GetStaticDNSEntriesByHostWithHdr.
-func (to *Session) GetStaticDNSEntriesByHost(host string) ([]tc.StaticDNSEntry, ReqInf, error) {
+func (to *Session) GetStaticDNSEntriesByHost(host string) ([]tc.StaticDNSEntry, toclientlib.ReqInf, error) {
 	return to.GetStaticDNSEntriesByHostWithHdr(host, nil)
 }
 
 // DeleteStaticDNSEntryByID DELETEs a Static DNS Entry by ID.
-func (to *Session) DeleteStaticDNSEntryByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_STATIC_DNS_ENTRIES, id)
+func (to *Session) DeleteStaticDNSEntryByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIStaticDNSEntries, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/stats_summary.go
+++ b/traffic_ops/v4-client/stats_summary.go
@@ -16,15 +16,16 @@ import (
 	"fmt"
 	"net/url"
 
-	tc "github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_STATS_SUMMARY = apiBase + "/stats_summary"
+	APIStatsSummary = "/stats_summary"
 )
 
 // GetSummaryStats gets a list of summary stats with the ability to filter on cdn,deliveryService and/or stat
-func (to *Session) GetSummaryStats(cdn, deliveryService, statName *string) (tc.StatsSummaryResponse, ReqInf, error) {
+func (to *Session) GetSummaryStats(cdn, deliveryService, statName *string) (tc.StatsSummaryResponse, toclientlib.ReqInf, error) {
 	resp := tc.StatsSummaryResponse{}
 
 	param := url.Values{}
@@ -38,16 +39,16 @@ func (to *Session) GetSummaryStats(cdn, deliveryService, statName *string) (tc.S
 		param.Add("statName", *statName)
 	}
 
-	route := API_STATS_SUMMARY
+	route := APIStatsSummary
 	if len(param) > 0 {
-		route = fmt.Sprintf("%s?%s", API_STATS_SUMMARY, param.Encode())
+		route = fmt.Sprintf("%s?%s", APIStatsSummary, param.Encode())
 	}
 	reqInf, err := to.get(route, nil, &resp)
 	return resp, reqInf, err
 }
 
 // GetSummaryStatsLastUpdated time of the last summary for a given stat
-func (to *Session) GetSummaryStatsLastUpdated(statName *string) (tc.StatsSummaryLastUpdatedResponse, ReqInf, error) {
+func (to *Session) GetSummaryStatsLastUpdated(statName *string) (tc.StatsSummaryLastUpdatedResponse, toclientlib.ReqInf, error) {
 	resp := tc.StatsSummaryLastUpdatedResponse{}
 
 	param := url.Values{}
@@ -55,15 +56,15 @@ func (to *Session) GetSummaryStatsLastUpdated(statName *string) (tc.StatsSummary
 	if statName != nil {
 		param.Add("statName", *statName)
 	}
-	route := fmt.Sprintf("%s?%s", API_STATS_SUMMARY, param.Encode())
+	route := fmt.Sprintf("%s?%s", APIStatsSummary, param.Encode())
 
 	reqInf, err := to.get(route, nil, &resp)
 	return resp, reqInf, err
 }
 
 // CreateSummaryStats creates a stats summary
-func (to *Session) CreateSummaryStats(statsSummary tc.StatsSummary) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateSummaryStats(statsSummary tc.StatsSummary) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_STATS_SUMMARY, statsSummary, nil, &alerts)
+	reqInf, err := to.post(APIStatsSummary, statsSummary, nil, &alerts)
 	return alerts, reqInf, err
 }

--- a/traffic_ops/v4-client/status.go
+++ b/traffic_ops/v4-client/status.go
@@ -21,21 +21,22 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_STATUSES = apiBase + "/statuses"
+	APIStatuses = "/statuses"
 )
 
 // CreateStatusNullable creates a new status, using the tc.StatusNullable structure.
-func (to *Session) CreateStatusNullable(status tc.StatusNullable) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateStatusNullable(status tc.StatusNullable) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_STATUSES, status, nil, &alerts)
+	reqInf, err := to.post(APIStatuses, status, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateStatusByIDWithHdr(id int, status tc.Status, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_STATUSES, id)
+func (to *Session) UpdateStatusByIDWithHdr(id int, status tc.Status, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIStatuses, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, status, header, &alerts)
 	return alerts, reqInf, err
@@ -43,24 +44,24 @@ func (to *Session) UpdateStatusByIDWithHdr(id int, status tc.Status, header http
 
 // UpdateStatusByID updates a Status by ID.
 // Deprecated: UpdateStatusByID will be removed in 6.0. Use UpdateStatusByIDWithHdr.
-func (to *Session) UpdateStatusByID(id int, status tc.Status) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateStatusByID(id int, status tc.Status) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateStatusByIDWithHdr(id, status, nil)
 }
 
-func (to *Session) GetStatusesWithHdr(header http.Header) ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatusesWithHdr(header http.Header) ([]tc.Status, toclientlib.ReqInf, error) {
 	var data tc.StatusesResponse
-	reqInf, err := to.get(API_STATUSES, header, &data)
+	reqInf, err := to.get(APIStatuses, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetStatuses returns a list of Statuses.
 // Deprecated: GetStatuses will be removed in 6.0. Use GetStatusesWithHdr.
-func (to *Session) GetStatuses() ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatuses() ([]tc.Status, toclientlib.ReqInf, error) {
 	return to.GetStatusesWithHdr(nil)
 }
 
-func (to *Session) GetStatusByIDWithHdr(id int, header http.Header) ([]tc.Status, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_STATUSES, id)
+func (to *Session) GetStatusByIDWithHdr(id int, header http.Header) ([]tc.Status, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APIStatuses, id)
 	var data tc.StatusesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -68,12 +69,12 @@ func (to *Session) GetStatusByIDWithHdr(id int, header http.Header) ([]tc.Status
 
 // GetStatusByID GETs a Status by the Status ID.
 // Deprecated: GetStatusByID will be removed in 6.0. Use GetStatusByIDWithHdr.
-func (to *Session) GetStatusByID(id int) ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatusByID(id int) ([]tc.Status, toclientlib.ReqInf, error) {
 	return to.GetStatusByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetStatusByNameWithHdr(name string, header http.Header) ([]tc.Status, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", API_STATUSES, url.QueryEscape(name))
+func (to *Session) GetStatusByNameWithHdr(name string, header http.Header) ([]tc.Status, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APIStatuses, url.QueryEscape(name))
 	var data tc.StatusesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -81,13 +82,13 @@ func (to *Session) GetStatusByNameWithHdr(name string, header http.Header) ([]tc
 
 // GetStatusByName GETs a Status by the Status name.
 // Deprecated: GetStatusByName will be removed in 6.0. Use GetStatusByNameWithHdr.
-func (to *Session) GetStatusByName(name string) ([]tc.Status, ReqInf, error) {
+func (to *Session) GetStatusByName(name string) ([]tc.Status, toclientlib.ReqInf, error) {
 	return to.GetStatusByNameWithHdr(name, nil)
 }
 
 // DeleteStatusByID DELETEs a Status by ID.
-func (to *Session) DeleteStatusByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_STATUSES, id)
+func (to *Session) DeleteStatusByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APIStatuses, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/steering.go
+++ b/traffic_ops/v4-client/steering.go
@@ -19,17 +19,18 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-func (to *Session) SteeringWithHdr(header http.Header) ([]tc.Steering, ReqInf, error) {
+func (to *Session) SteeringWithHdr(header http.Header) ([]tc.Steering, toclientlib.ReqInf, error) {
 	data := struct {
 		Response []tc.Steering `json:"response"`
 	}{}
-	reqInf, err := to.get(apiBase+`/steering`, header, &data)
+	reqInf, err := to.get(`/steering`, header, &data)
 	return data.Response, reqInf, err
 }
 
 // Deprecated: Steering will be removed in 6.0. Use SteeringWithHdr.
-func (to *Session) Steering() ([]tc.Steering, ReqInf, error) {
+func (to *Session) Steering() ([]tc.Steering, toclientlib.ReqInf, error) {
 	return to.SteeringWithHdr(nil)
 }

--- a/traffic_ops/v4-client/steeringtarget.go
+++ b/traffic_ops/v4-client/steeringtarget.go
@@ -21,39 +21,40 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-func (to *Session) CreateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, toclientlib.ReqInf, error) {
 	if st.DeliveryServiceID == nil {
-		return tc.Alerts{}, ReqInf{CacheHitStatus: CacheHitStatusMiss}, errors.New("missing delivery service id")
+		return tc.Alerts{}, toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}, errors.New("missing delivery service id")
 	}
 	alerts := tc.Alerts{}
-	route := fmt.Sprintf("%s/steering/%d/targets", apiBase, *st.DeliveryServiceID)
+	route := fmt.Sprintf("/steering/%d/targets", *st.DeliveryServiceID)
 	reqInf, err := to.post(route, st, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateSteeringTargetWithHdr(st tc.SteeringTargetNullable, header http.Header) (tc.Alerts, ReqInf, error) {
-	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss}
+func (to *Session) UpdateSteeringTargetWithHdr(st tc.SteeringTargetNullable, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	reqInf := toclientlib.ReqInf{CacheHitStatus: toclientlib.CacheHitStatusMiss}
 	if st.DeliveryServiceID == nil {
 		return tc.Alerts{}, reqInf, errors.New("missing delivery service id")
 	}
 	if st.TargetID == nil {
 		return tc.Alerts{}, reqInf, errors.New("missing target id")
 	}
-	route := fmt.Sprintf("%s/steering/%d/targets/%d", apiBase, *st.DeliveryServiceID, *st.TargetID)
+	route := fmt.Sprintf("/steering/%d/targets/%d", *st.DeliveryServiceID, *st.TargetID)
 	alerts := tc.Alerts{}
 	reqInf, err := to.put(route, st, header, &alerts)
 	return alerts, reqInf, err
 }
 
 // Deprecated: UpdateSteeringTarget will be removed in 6.0. Use UpdateSteeringTargetWithHdr.
-func (to *Session) UpdateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateSteeringTarget(st tc.SteeringTargetNullable) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateSteeringTargetWithHdr(st, nil)
 }
 
-func (to *Session) GetSteeringTargets(dsID int) ([]tc.SteeringTargetNullable, ReqInf, error) {
-	route := fmt.Sprintf("%s/steering/%d/targets", apiBase, dsID)
+func (to *Session) GetSteeringTargets(dsID int) ([]tc.SteeringTargetNullable, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("/steering/%d/targets", dsID)
 	data := struct {
 		Response []tc.SteeringTargetNullable `json:"response"`
 	}{}
@@ -61,8 +62,8 @@ func (to *Session) GetSteeringTargets(dsID int) ([]tc.SteeringTargetNullable, Re
 	return data.Response, reqInf, err
 }
 
-func (to *Session) DeleteSteeringTarget(dsID int, targetID int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/steering/%d/targets/%d", apiBase, dsID, targetID)
+func (to *Session) DeleteSteeringTarget(dsID int, targetID int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("/steering/%d/targets/%d", dsID, targetID)
 	alerts := tc.Alerts{}
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/tenant.go
+++ b/traffic_ops/v4-client/tenant.go
@@ -21,27 +21,28 @@ import (
 	"net/http"
 	"net/url"
 
-	tc "github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-const API_TENANTS = apiBase + "/tenants"
-const API_TENANT_ID = API_TENANTS + "/%s"
+const APITenants = "/tenants"
+const APITenantID = APITenants + "/%s"
 
-func (to *Session) TenantsWithHdr(header http.Header) ([]tc.Tenant, ReqInf, error) {
+func (to *Session) TenantsWithHdr(header http.Header) ([]tc.Tenant, toclientlib.ReqInf, error) {
 	var data tc.GetTenantsResponse
-	reqInf, err := to.get(API_TENANTS, header, &data)
+	reqInf, err := to.get(APITenants, header, &data)
 	return data.Response, reqInf, err
 }
 
 // Tenants gets an array of Tenants.
 // Deprecated: Tenants will be removed in 6.0. Use TenantsWithHdr.
-func (to *Session) Tenants() ([]tc.Tenant, ReqInf, error) {
+func (to *Session) Tenants() ([]tc.Tenant, toclientlib.ReqInf, error) {
 	return to.TenantsWithHdr(nil)
 }
 
-func (to *Session) TenantWithHdr(id string, header http.Header) (*tc.Tenant, ReqInf, error) {
+func (to *Session) TenantWithHdr(id string, header http.Header) (*tc.Tenant, toclientlib.ReqInf, error) {
 	var data tc.GetTenantsResponse
-	reqInf, err := to.get(fmt.Sprintf("%s?id=%v", API_TENANTS, id), header, &data)
+	reqInf, err := to.get(fmt.Sprintf("%s?id=%v", APITenants, id), header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -54,13 +55,13 @@ func (to *Session) TenantWithHdr(id string, header http.Header) (*tc.Tenant, Req
 // Tenant gets the Tenant identified by the passed integral, unique identifer - which
 // must be passed as a string.
 // Deprecated: Tenant will be removed in 6.0. Use TenantWithHdr.
-func (to *Session) Tenant(id string) (*tc.Tenant, ReqInf, error) {
+func (to *Session) Tenant(id string) (*tc.Tenant, toclientlib.ReqInf, error) {
 	return to.TenantWithHdr(id, nil)
 }
 
-func (to *Session) TenantByNameWithHdr(name string, header http.Header) (*tc.Tenant, ReqInf, error) {
+func (to *Session) TenantByNameWithHdr(name string, header http.Header) (*tc.Tenant, toclientlib.ReqInf, error) {
 	var data tc.GetTenantsResponse
-	query := API_TENANTS + "?name=" + url.QueryEscape(name)
+	query := APITenants + "?name=" + url.QueryEscape(name)
 	reqInf, err := to.get(query, header, &data)
 	if err != nil {
 		return nil, reqInf, err
@@ -77,7 +78,7 @@ func (to *Session) TenantByNameWithHdr(name string, header http.Header) (*tc.Ten
 
 // TenantByName gets the Tenant with the name it's passed.
 // Deprecated: TenantByName will be removed in 6.0. Use TenantByNameWithHdr.
-func (to *Session) TenantByName(name string) (*tc.Tenant, ReqInf, error) {
+func (to *Session) TenantByName(name string) (*tc.Tenant, toclientlib.ReqInf, error) {
 	return to.TenantByNameWithHdr(name, nil)
 }
 
@@ -95,16 +96,16 @@ func (to *Session) CreateTenant(t *tc.Tenant) (*tc.TenantResponse, error) {
 	}
 
 	var data tc.TenantResponse
-	_, err := to.post(API_TENANTS, t, nil, &data)
+	_, err := to.post(APITenants, t, nil, &data)
 	if err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (to *Session) UpdateTenantWithHdr(id string, t *tc.Tenant, header http.Header) (*tc.TenantResponse, ReqInf, error) {
+func (to *Session) UpdateTenantWithHdr(id string, t *tc.Tenant, header http.Header) (*tc.TenantResponse, toclientlib.ReqInf, error) {
 	var data tc.TenantResponse
-	reqInf, err := to.put(fmt.Sprintf(API_TENANT_ID, id), t, header, &data)
+	reqInf, err := to.put(fmt.Sprintf(APITenantID, id), t, header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -122,7 +123,7 @@ func (to *Session) UpdateTenant(id string, t *tc.Tenant) (*tc.TenantResponse, er
 // DeleteTenant deletes the Tenant matching the ID it's passed.
 func (to *Session) DeleteTenant(id string) (*tc.DeleteTenantResponse, error) {
 	var data tc.DeleteTenantResponse
-	_, err := to.del(fmt.Sprintf(API_TENANT_ID, id), nil, &data)
+	_, err := to.del(fmt.Sprintf(APITenantID, id), nil, &data)
 	if err != nil {
 		return nil, err
 	}

--- a/traffic_ops/v4-client/topology.go
+++ b/traffic_ops/v4-client/topology.go
@@ -21,31 +21,32 @@ import (
 	"net/url"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-const ApiTopologies = apiBase + "/topologies"
+const APITopologies = "/topologies"
 
 // CreateTopology creates a topology and returns the response.
-func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf, error) {
+func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, toclientlib.ReqInf, error) {
 	resp := new(tc.TopologyResponse)
-	reqInf, err := to.post(ApiTopologies, top, nil, resp)
+	reqInf, err := to.post(APITopologies, top, nil, resp)
 	return resp, reqInf, err
 }
 
-func (to *Session) GetTopologiesWithHdr(header http.Header) ([]tc.Topology, ReqInf, error) {
+func (to *Session) GetTopologiesWithHdr(header http.Header) ([]tc.Topology, toclientlib.ReqInf, error) {
 	var data tc.TopologiesResponse
-	reqInf, err := to.get(ApiTopologies, header, &data)
+	reqInf, err := to.get(APITopologies, header, &data)
 	return data.Response, reqInf, err
 }
 
 // GetTopologies returns all topologies.
 // Deprecated: GetTopologies will be removed in 6.0. Use GetTopologiesWithHdr.
-func (to *Session) GetTopologies() ([]tc.Topology, ReqInf, error) {
+func (to *Session) GetTopologies() ([]tc.Topology, toclientlib.ReqInf, error) {
 	return to.GetTopologiesWithHdr(nil)
 }
 
-func (to *Session) GetTopologyWithHdr(name string, header http.Header) (*tc.Topology, ReqInf, error) {
-	reqUrl := fmt.Sprintf("%s?name=%s", ApiTopologies, url.QueryEscape(name))
+func (to *Session) GetTopologyWithHdr(name string, header http.Header) (*tc.Topology, toclientlib.ReqInf, error) {
+	reqUrl := fmt.Sprintf("%s?name=%s", APITopologies, url.QueryEscape(name))
 	var data tc.TopologiesResponse
 	reqInf, err := to.get(reqUrl, header, &data)
 	if err != nil {
@@ -59,21 +60,21 @@ func (to *Session) GetTopologyWithHdr(name string, header http.Header) (*tc.Topo
 
 // GetTopology returns the given topology by name.
 // Deprecated: GetTopology will be removed in 6.0. Use GetTopologyWithHdr.
-func (to *Session) GetTopology(name string) (*tc.Topology, ReqInf, error) {
+func (to *Session) GetTopology(name string) (*tc.Topology, toclientlib.ReqInf, error) {
 	return to.GetTopologyWithHdr(name, nil)
 }
 
 // UpdateTopology updates a Topology by name.
-func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyResponse, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", ApiTopologies, name)
+func (to *Session) UpdateTopology(name string, t tc.Topology) (*tc.TopologyResponse, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APITopologies, name)
 	var response = new(tc.TopologyResponse)
 	reqInf, err := to.put(route, t, nil, &response)
 	return response, reqInf, err
 }
 
 // DeleteTopology deletes the given topology by name.
-func (to *Session) DeleteTopology(name string) (tc.Alerts, ReqInf, error) {
-	reqUrl := fmt.Sprintf("%s?name=%s", ApiTopologies, url.QueryEscape(name))
+func (to *Session) DeleteTopology(name string) (tc.Alerts, toclientlib.ReqInf, error) {
+	reqUrl := fmt.Sprintf("%s?name=%s", APITopologies, url.QueryEscape(name))
 	var alerts tc.Alerts
 	reqInf, err := to.del(reqUrl, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/topology_queue_updates.go
+++ b/traffic_ops/v4-client/topology_queue_updates.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-func (to *Session) TopologiesQueueUpdate(topologyName tc.TopologyName, req tc.TopologiesQueueUpdateRequest) (tc.TopologiesQueueUpdateResponse, ReqInf, error) {
-	path := fmt.Sprintf(ApiTopologies+"/%s/queue_update", topologyName)
+func (to *Session) TopologiesQueueUpdate(topologyName tc.TopologyName, req tc.TopologiesQueueUpdateRequest) (tc.TopologiesQueueUpdateResponse, toclientlib.ReqInf, error) {
+	path := fmt.Sprintf(APITopologies+"/%s/queue_update", topologyName)
 	var resp tc.TopologiesQueueUpdateResponse
 	reqInf, err := to.post(path, req, nil, &resp)
 	return resp, reqInf, err

--- a/traffic_ops/v4-client/traffic_monitor.go
+++ b/traffic_ops/v4-client/traffic_monitor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 /*
@@ -25,15 +26,15 @@ import (
  * under the License.
  */
 
-// API_CDN_MONITORING_CONFIG is the API path on which Traffic Ops serves the CDN monitoring
+// APICDNMonitoringConfig is the API path on which Traffic Ops serves the CDN monitoring
 // configuration information. It is meant to be used with fmt.Sprintf to insert the necessary
 // path parameters (namely the Name of the CDN of interest).
 // See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/cdns_name_configs_monitoring.html
-const API_CDN_MONITORING_CONFIG = apiBase + "/cdns/%s/configs/monitoring"
+const APICDNMonitoringConfig = "/cdns/%s/configs/monitoring"
 
 // GetTrafficMonitorConfigMap is functionally identical to GetTrafficMonitorConfig, except that it
 // coerces the value returned by the API to the tc.TrafficMonitorConfigMap structure.
-func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, ReqInf, error) {
+func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, toclientlib.ReqInf, error) {
 	tmConfig, reqInf, err := to.GetTrafficMonitorConfig(cdn)
 	if err != nil {
 		return nil, reqInf, err
@@ -46,8 +47,8 @@ func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorCon
 }
 
 // GetTrafficMonitorConfig returns the monitoring configuration for the CDN named by 'cdn'.
-func (to *Session) GetTrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, ReqInf, error) {
-	route := fmt.Sprintf(API_CDN_MONITORING_CONFIG, cdn)
+func (to *Session) GetTrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf(APICDNMonitoringConfig, cdn)
 	var data tc.TMConfigResponse
 	reqInf, err := to.get(route, nil, &data)
 	return &data.Response, reqInf, err

--- a/traffic_ops/v4-client/traffic_stats.go
+++ b/traffic_ops/v4-client/traffic_stats.go
@@ -16,11 +16,12 @@ package client
 
 import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 // GetCurrentStats gets current stats for each CDNs and a total across them
-func (to *Session) GetCurrentStats() (tc.TrafficStatsCDNStatsResponse, ReqInf, error) {
+func (to *Session) GetCurrentStats() (tc.TrafficStatsCDNStatsResponse, toclientlib.ReqInf, error) {
 	resp := tc.TrafficStatsCDNStatsResponse{}
-	reqInf, err := to.get(apiBase+"/current_stats", nil, &resp)
+	reqInf, err := to.get("/current_stats", nil, &resp)
 	return resp, reqInf, err
 }

--- a/traffic_ops/v4-client/type.go
+++ b/traffic_ops/v4-client/type.go
@@ -21,21 +21,22 @@ import (
 	"net/http"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
 const (
-	API_TYPES = apiBase + "/types"
+	APITypes = "/types"
 )
 
 // CreateType creates a Type. There should be a very good reason for doing this.
-func (to *Session) CreateType(typ tc.Type) (tc.Alerts, ReqInf, error) {
+func (to *Session) CreateType(typ tc.Type) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
-	reqInf, err := to.post(API_TYPES, typ, nil, &alerts)
+	reqInf, err := to.post(APITypes, typ, nil, &alerts)
 	return alerts, reqInf, err
 }
 
-func (to *Session) UpdateTypeByIDWithHdr(id int, typ tc.Type, header http.Header) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_TYPES, id)
+func (to *Session) UpdateTypeByIDWithHdr(id int, typ tc.Type, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APITypes, id)
 	var alerts tc.Alerts
 	reqInf, err := to.put(route, typ, header, &alerts)
 	return alerts, reqInf, err
@@ -43,7 +44,7 @@ func (to *Session) UpdateTypeByIDWithHdr(id int, typ tc.Type, header http.Header
 
 // UpdateTypeByID updates a Type by ID.
 // Deprecated: UpdateTypeByID will be removed in 6.0. Use UpdateTypeByIDWithHdr.
-func (to *Session) UpdateTypeByID(id int, typ tc.Type) (tc.Alerts, ReqInf, error) {
+func (to *Session) UpdateTypeByID(id int, typ tc.Type) (tc.Alerts, toclientlib.ReqInf, error) {
 	return to.UpdateTypeByIDWithHdr(id, typ, nil)
 }
 
@@ -51,12 +52,12 @@ func (to *Session) UpdateTypeByID(id int, typ tc.Type) (tc.Alerts, ReqInf, error
 // If a 'useInTable' parameter is passed, the returned Types are restricted to those with
 // that exact 'useInTable' property. Only exactly 1 or exactly 0 'useInTable' parameters may
 // be passed; passing more will result in an error being returned.
-func (to *Session) GetTypesWithHdr(header http.Header, useInTable ...string) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypesWithHdr(header http.Header, useInTable ...string) ([]tc.Type, toclientlib.ReqInf, error) {
 	if len(useInTable) > 1 {
-		return nil, ReqInf{}, errors.New("please pass in a single value for the 'useInTable' parameter")
+		return nil, toclientlib.ReqInf{}, errors.New("please pass in a single value for the 'useInTable' parameter")
 	}
 	var data tc.TypesResponse
-	reqInf, err := to.get(API_TYPES, header, &data)
+	reqInf, err := to.get(APITypes, header, &data)
 	if err != nil {
 		return nil, reqInf, err
 	}
@@ -79,13 +80,13 @@ func (to *Session) GetTypesWithHdr(header http.Header, useInTable ...string) ([]
 // are restricted to those with that exact 'useInTable' property. Only exactly 1 or exactly 0
 // 'useInTable' parameters may be passed; passing more will result in an error being returned.
 // Deprecated: GetTypes will be removed in 6.0. Use GetTypesWithHdr.
-func (to *Session) GetTypes(useInTable ...string) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypes(useInTable ...string) ([]tc.Type, toclientlib.ReqInf, error) {
 	return to.GetTypesWithHdr(nil, useInTable...)
 }
 
 // GetTypeByID GETs a Type by the Type ID, and filters by http header params in the request.
-func (to *Session) GetTypeByIDWithHdr(id int, header http.Header) ([]tc.Type, ReqInf, error) {
-	route := fmt.Sprintf("%s?id=%d", API_TYPES, id)
+func (to *Session) GetTypeByIDWithHdr(id int, header http.Header) ([]tc.Type, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?id=%d", APITypes, id)
 	var data tc.TypesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -93,12 +94,12 @@ func (to *Session) GetTypeByIDWithHdr(id int, header http.Header) ([]tc.Type, Re
 
 // GetTypeByID GETs a Type by the Type ID.
 // Deprecated: GetTypeByID will be removed in 6.0. Use GetTypeByIDWithHdr.
-func (to *Session) GetTypeByID(id int) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypeByID(id int) ([]tc.Type, toclientlib.ReqInf, error) {
 	return to.GetTypeByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetTypeByNameWithHdr(name string, header http.Header) ([]tc.Type, ReqInf, error) {
-	route := fmt.Sprintf("%s?name=%s", API_TYPES, name)
+func (to *Session) GetTypeByNameWithHdr(name string, header http.Header) ([]tc.Type, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s?name=%s", APITypes, name)
 	var data tc.TypesResponse
 	reqInf, err := to.get(route, header, &data)
 	return data.Response, reqInf, err
@@ -106,13 +107,13 @@ func (to *Session) GetTypeByNameWithHdr(name string, header http.Header) ([]tc.T
 
 // GetTypeByName GETs a Type by the Type name.
 // Deprecated: GetTypeByName will be removed in 6.0. Use GetTypeByNameWithHdr.
-func (to *Session) GetTypeByName(name string) ([]tc.Type, ReqInf, error) {
+func (to *Session) GetTypeByName(name string) ([]tc.Type, toclientlib.ReqInf, error) {
 	return to.GetTypeByNameWithHdr(name, nil)
 }
 
 // DeleteTypeByID DELETEs a Type by ID.
-func (to *Session) DeleteTypeByID(id int) (tc.Alerts, ReqInf, error) {
-	route := fmt.Sprintf("%s/%d", API_TYPES, id)
+func (to *Session) DeleteTypeByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf("%s/%d", APITypes, id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err

--- a/traffic_ops/v4-client/user.go
+++ b/traffic_ops/v4-client/user.go
@@ -24,60 +24,61 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
-func (to *Session) GetUsersWithHdr(header http.Header) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUsersWithHdr(header http.Header) ([]tc.User, toclientlib.ReqInf, error) {
 	data := tc.UsersResponse{}
-	route := fmt.Sprintf("%s/users", apiBase)
+	route := "/users"
 	inf, err := to.get(route, header, &data)
 	return data.Response, inf, err
 }
 
 // GetUsers returns all users accessible from current user
 // Deprecated: GetUsers will be removed in 6.0. Use GetUsersWithHdr.
-func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
+func (to *Session) GetUsers() ([]tc.User, toclientlib.ReqInf, error) {
 	return to.GetUsersWithHdr(nil)
 }
 
-func (to *Session) GetUsersByRoleWithHdr(roleName string, header http.Header) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUsersByRoleWithHdr(roleName string, header http.Header) ([]tc.User, toclientlib.ReqInf, error) {
 	data := tc.UsersResponse{}
-	route := fmt.Sprintf("%s/users?role=%s", apiBase, url.QueryEscape(roleName))
+	route := "/users?role=" + url.QueryEscape(roleName)
 	inf, err := to.get(route, header, &data)
 	return data.Response, inf, err
 }
 
 // GetUsersByRole returns all users accessible from current user for a given role
 // Deprecated: GetUsersByRole will be removed in 6.0. Use GetUsersByRoleWithHdr.
-func (to *Session) GetUsersByRole(roleName string) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUsersByRole(roleName string) ([]tc.User, toclientlib.ReqInf, error) {
 	return to.GetUsersByRoleWithHdr(roleName, nil)
 }
 
-func (to *Session) GetUserByIDWithHdr(id int, header http.Header) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUserByIDWithHdr(id int, header http.Header) ([]tc.User, toclientlib.ReqInf, error) {
 	data := tc.UsersResponse{}
-	route := fmt.Sprintf("%s/users/%d", apiBase, id)
+	route := fmt.Sprintf("/users/%d", id)
 	inf, err := to.get(route, header, &data)
 	return data.Response, inf, err
 }
 
 // Deprecated: GetUserByID will be removed in 6.0. Use GetUserByIDWithHdr.
-func (to *Session) GetUserByID(id int) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUserByID(id int) ([]tc.User, toclientlib.ReqInf, error) {
 	return to.GetUserByIDWithHdr(id, nil)
 }
 
-func (to *Session) GetUserByUsernameWithHdr(username string, header http.Header) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUserByUsernameWithHdr(username string, header http.Header) ([]tc.User, toclientlib.ReqInf, error) {
 	data := tc.UsersResponse{}
-	route := fmt.Sprintf("%s/users?username=%s", apiBase, url.QueryEscape(username))
+	route := "/users?username=" + url.QueryEscape(username)
 	inf, err := to.get(route, header, &data)
 	return data.Response, inf, err
 }
 
 // Deprecated: GetUserByUsername will be removed in 6.0. Use GetUserByUsernameWithHdr.
-func (to *Session) GetUserByUsername(username string) ([]tc.User, ReqInf, error) {
+func (to *Session) GetUserByUsername(username string) ([]tc.User, toclientlib.ReqInf, error) {
 	return to.GetUserByUsernameWithHdr(username, nil)
 }
 
-func (to *Session) GetUserCurrentWithHdr(header http.Header) (*tc.UserCurrent, ReqInf, error) {
-	route := apiBase + `/user/current`
+func (to *Session) GetUserCurrentWithHdr(header http.Header) (*tc.UserCurrent, toclientlib.ReqInf, error) {
+	route := `/user/current`
 	resp := tc.UserCurrentResponse{}
 	reqInf, err := to.get(route, header, &resp)
 	if err != nil {
@@ -88,29 +89,29 @@ func (to *Session) GetUserCurrentWithHdr(header http.Header) (*tc.UserCurrent, R
 
 // GetUserCurrent gets information about the current user
 // Deprecated: GetUserCurrent will be removed in 6.0. Use GetUserCurrentWithHdr.
-func (to *Session) GetUserCurrent() (*tc.UserCurrent, ReqInf, error) {
+func (to *Session) GetUserCurrent() (*tc.UserCurrent, toclientlib.ReqInf, error) {
 	return to.GetUserCurrentWithHdr(nil)
 }
 
 // UpdateCurrentUser replaces the current user data with the provided tc.User structure.
-func (to *Session) UpdateCurrentUser(u tc.User) (*tc.UpdateUserResponse, ReqInf, error) {
+func (to *Session) UpdateCurrentUser(u tc.User) (*tc.UpdateUserResponse, toclientlib.ReqInf, error) {
 	user := struct {
 		User tc.User `json:"user"`
 	}{u}
 	var clientResp tc.UpdateUserResponse
-	reqInf, err := to.put(apiBase+"/user/current", user, nil, &clientResp)
+	reqInf, err := to.put("/user/current", user, nil, &clientResp)
 	return &clientResp, reqInf, err
 }
 
 // CreateUser creates a user
-func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, error) {
+func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, toclientlib.ReqInf, error) {
 	if user.TenantID == nil && user.Tenant != nil {
 		tenant, _, err := to.TenantByNameWithHdr(*user.Tenant, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if tenant == nil {
-			return nil, ReqInf{}, errors.New("no tenant with name " + *user.Tenant)
+			return nil, toclientlib.ReqInf{}, errors.New("no tenant with name " + *user.Tenant)
 		}
 		user.TenantID = &tenant.ID
 	}
@@ -118,31 +119,31 @@ func (to *Session) CreateUser(user *tc.User) (*tc.CreateUserResponse, ReqInf, er
 	if user.RoleName != nil && *user.RoleName != "" {
 		roles, _, _, err := to.GetRoleByNameWithHdr(*user.RoleName, nil)
 		if err != nil {
-			return nil, ReqInf{}, err
+			return nil, toclientlib.ReqInf{}, err
 		}
 		if len(roles) == 0 || roles[0].ID == nil {
-			return nil, ReqInf{}, errors.New("no role with name " + *user.RoleName)
+			return nil, toclientlib.ReqInf{}, errors.New("no role with name " + *user.RoleName)
 		}
 		user.Role = roles[0].ID
 	}
 
-	route := apiBase + "/users"
+	route := "/users"
 	var clientResp tc.CreateUserResponse
 	reqInf, err := to.post(route, user, nil, &clientResp)
 	return &clientResp, reqInf, err
 }
 
 // UpdateUserByID updates user with the given id
-func (to *Session) UpdateUserByID(id int, u *tc.User) (*tc.UpdateUserResponse, ReqInf, error) {
-	route := apiBase + "/users/" + strconv.Itoa(id)
+func (to *Session) UpdateUserByID(id int, u *tc.User) (*tc.UpdateUserResponse, toclientlib.ReqInf, error) {
+	route := "/users/" + strconv.Itoa(id)
 	var clientResp tc.UpdateUserResponse
 	reqInf, err := to.put(route, u, nil, &clientResp)
 	return &clientResp, reqInf, err
 }
 
 // DeleteUserByID updates user with the given id
-func (to *Session) DeleteUserByID(id int) (tc.Alerts, ReqInf, error) {
-	route := apiBase + "/users/" + strconv.Itoa(id)
+func (to *Session) DeleteUserByID(id int) (tc.Alerts, toclientlib.ReqInf, error) {
+	route := "/users/" + strconv.Itoa(id)
 	var alerts tc.Alerts
 	reqInf, err := to.del(route, nil, &alerts)
 	return alerts, reqInf, err
@@ -150,13 +151,13 @@ func (to *Session) DeleteUserByID(id int) (tc.Alerts, ReqInf, error) {
 
 // RegisterNewUser requests the registration of a new user with the given tenant ID and role ID,
 // through their email.
-func (to *Session) RegisterNewUser(tenantID uint, roleID uint, email rfc.EmailAddress) (tc.Alerts, ReqInf, error) {
+func (to *Session) RegisterNewUser(tenantID uint, roleID uint, email rfc.EmailAddress) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqBody := tc.UserRegistrationRequest{
 		Email:    email,
 		TenantID: tenantID,
 		Role:     roleID,
 	}
-	reqInf, err := to.post(apiBase+"/users/register", reqBody, nil, &alerts)
+	reqInf, err := to.post("/users/register", reqBody, nil, &alerts)
 	return alerts, reqInf, err
 }


### PR DESCRIPTION
Also moves duplicate fallback and other duplicate client code
to a shared lib.

No new tests, existing TO API Tests cover these changes.
No docs, no interface change.
No changelog, client fallback already has a changelog entry.

- [x] This PR fixes #5518 OR is not related to any Issue

## Which Traffic Control components are affected by this PR?
- Traffic Control Client Go

## What is the best way to verify this PR?
Run tests. Make requests with the client, verify they work as expected.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information