### PR TITLE
Removing Tomcat build lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Moved move_lets_encrypt_to_acme.sql, add_max_request_header_size_delivery_service.sql, and server_interface_ip_address_cascade.sql past last migration in 5.0.0
 
 ### Changed
+- [#5553](https://github.com/apache/trafficcontrol/pull/5553) - Removing Tomcat specific build requirement
 - Refactored the Traffic Ops Go client internals so that all public methods have a consistent behavior/implementation
 - Pinned external actions used by Documentation Build and TR Unit Tests workflows to commit SHA-1 and the Docker image used by the Weasel workflow to a SHA-256 digest
 - Updated Flot libraries to supported versions

--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -44,7 +44,7 @@ TOMCAT_VERSION := $(shell grep '^\s*TOMCAT_VERSION=' ../../traffic_router/build/
 TOMCAT_RELEASE := $(shell grep '^\s*TOMCAT_RELEASE=' ../../traffic_router/build/build_rpm.sh  | cut -d= -f2)
 
 SPECIAL_SAUCE := $(TC_VERSION)-$(BUILD_NUMBER).el$(RHEL_VERSION).x86_64.rpm
-SPECIAL_SEASONING := $(TOMCAT_VERSION).$(TOMCAT_RELEASE)-$(BUILD_NUMBER).el$(RHEL_VERSION).x86_64.rpm
+SPECIAL_SEASONING := $(TOMCAT_VERSION).$(TOMCAT_RELEASE)-1.el$(RHEL_VERSION).noarch.rpm
 
 TO_SOURCE := $(wildcard ../../traffic_ops/**/*)
 TO_SOURCE += $(wildcard ../../traffic_ops_db/**/*)

--- a/traffic_router/build/build_rpm.sh
+++ b/traffic_router/build/build_rpm.sh
@@ -65,11 +65,10 @@ buildRpmTrafficRouter () {
 adaptEnvironment() {
 	echo "Verifying the build configuration environment."
 	# get traffic_control src path -- relative to build_rpm.sh script
-	PACKAGE='' TC_VERSION='' BUILD_LOCK='' RPMBUILD='' DIST='' RPM='' TOMCAT_VERSION='' TOMCAT_RELEASE=''
+	PACKAGE='' TC_VERSION='' RPMBUILD='' DIST='' RPM='' TOMCAT_VERSION='' TOMCAT_RELEASE=''
 	PACKAGE="traffic_router"
 	TC_VERSION=$(getVersion "$TC_DIR")
 	BUILD_NUMBER=${BUILD_NUMBER:-$(getBuildNumber)}
-	BUILD_LOCK=$(getBuildNumber).${RHEL_VERSION}
 	WORKSPACE=${WORKSPACE:-$TC_DIR}
 	RPMBUILD="$WORKSPACE/rpmbuild"
 	DIST="$WORKSPACE/dist"
@@ -77,12 +76,11 @@ adaptEnvironment() {
 	RPM_TARGET_OS="${RPM_TARGET_OS:-linux}"
 	TOMCAT_VERSION=9.0
 	TOMCAT_RELEASE=43
-	export PACKAGE TC_VERSION BUILD_NUMBER BUILD_LOCK WORKSPACE RPMBUILD DIST RPM RPM_TARGET_OS TOMCAT_VERSION TOMCAT_RELEASE
+	export PACKAGE TC_VERSION BUILD_NUMBER WORKSPACE RPMBUILD DIST RPM RPM_TARGET_OS TOMCAT_VERSION TOMCAT_RELEASE
 
 	echo "=================================================="
 	echo "WORKSPACE: $WORKSPACE"
 	echo "BUILD_NUMBER: $BUILD_NUMBER"
-	echo "BUILD_LOCK: $BUILD_LOCK"
 	echo "TOMCAT_VERSION=$TOMCAT_VERSION"
 	echo "TOMCAT_RELEASE=$TOMCAT_RELEASE"
 	echo "TC_VERSION: $TC_VERSION"

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -88,7 +88,6 @@
 							<rules>
 								<requireEnvironmentVariable>
 									<variableName>BUILD_NUMBER</variableName>
-									<variableName>BUILD_LOCK</variableName>
 									<variableName>TOMCAT_VERSION</variableName>
 									<variableName>TOMCAT_RELEASE</variableName>
 									<variableName>RHEL_VERSION</variableName>
@@ -237,15 +236,11 @@
 								</mapping>
 							</mappings>
 							<requires>
-								<require>java &gt;= 1.8</require>
-								<require>tomcat = ${env.TOMCAT_VERSION}.${env.TOMCAT_RELEASE}-${env.BUILD_LOCK}</require>
-								<require>apr &gt;= 1.4.8</require>
+								<require>java >= 1.8</require>
+								<require>tomcat >= ${env.TOMCAT_VERSION}.${env.TOMCAT_RELEASE}</require>
+								<require>apr >= 1.4.8</require>
 								<require>tomcat-native >= 1.2.23</require>
 							</requires>
-							<obsoletes>
-								<obsolete>traffic_router &lt; 3.0.0</obsolete>
-							</obsoletes>
-
 							<pretransScriptlet>
 								 <scriptFile>../core/src/main/scripts/pretrans.sh</scriptFile>
 							</pretransScriptlet>

--- a/traffic_router/tomcat-rpm/build_rpm.sh
+++ b/traffic_router/tomcat-rpm/build_rpm.sh
@@ -39,7 +39,10 @@ checkEnvironment() {
 	export RPMBUILD="$WORKSPACE/rpmbuild"
 	export RPM_TARGET_OS="${RPM_TARGET_OS:-linux}"
 	export DIST="$WORKSPACE/dist"
-	export RPM="${PACKAGE}-${TOMCAT_VERSION}.${TOMCAT_RELEASE}-${BUILD_NUMBER}.${RHEL_VERSION}.x86_64.rpm"
+	# Forcing BUILD NUMBER to 1 since this is outside the tree and related to Tomcat Release
+	export BUILD_NUMBER=1
+	export RPM="${PACKAGE}-${TOMCAT_VERSION}.${TOMCAT_RELEASE}-${BUILD_NUMBER}.${RHEL_VERSION}.noarch.rpm"
+
 
 	echo "=================================================="
 	echo "WORKSPACE: $WORKSPACE"

--- a/traffic_router/tomcat-rpm/build_rpm.sh
+++ b/traffic_router/tomcat-rpm/build_rpm.sh
@@ -46,7 +46,6 @@ checkEnvironment() {
 	echo "TOMCAT_RELEASE: $TOMCAT_RELEASE"  #defined in traffic_router
 	echo "TOMCAT_VERSION: $TOMCAT_VERSION"  #defined in traffic_router
 	echo "BUILD_NUMBER: $BUILD_NUMBER"      #defined in traffic_router
-	echo "BUILD_LOCK: $BUILD_LOCK"          #defined in traffic_router
 	echo "RPM: $RPM"
 	echo "--------------------------------------------------"
 }

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -14,6 +14,7 @@
 
 Name:       tomcat
 Version:    %{tomcat_version}
+BuildArch:  noarch
 Release:    %{build_number}
 Summary:    Apache Tomcat Servlet/JSP Engine 9.0+, RI for Servlet 3.1/JSP 2.3 API
 License:    Apache Software License


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This removes the restrictions imposed in the past to "lock in" the Tomcat release for Traffic Router. This has been quite a bit of a problem in the past in production when downgrading/upgrading TR (rollback). We don't compile nor we change the Tomcat code. There shouldn't be a need for this except for having a required version installed.

There has been compatibility issues in the past. All code should be tested in the lab before going to production.

This will also allow to upgrade Tomcat in the field without recompiling Traffic Router.

- [x] This PR fixes is not related to any Issue

## Which Traffic Control components are affected by this PR?

- Traffic Router

## What is the best way to verify this PR?

Making sure Traffic Router install and starts properly

## If this is a bug fix, what versions of Traffic Control are affected?

This is not a bug

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information

None yet