### PR TITLE
CiaB: Unset DIG_IP_RETRY for TO test and TP test

### DIFF
--- a/infrastructure/cdn-in-a-box/docker-compose.traffic-ops-test.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.traffic-ops-test.yml
@@ -20,8 +20,8 @@
 # make sure any container rpms you need are updated. Below is an
 # example of how to run the main compose with this file:
 #
-# docker-compose up --build db trafficops
-# docker-compose -f docker-compose.traffic-ops-test.yml up --build integration
+# docker-compose -f docker-compose.yml -f docker-compose.traffic-ops-test.yml up -d edge enroller dns db smtp trafficops trafficvault integration
+# docker-compose -f docker-compose.yml -f docker-compose.traffic-ops-test.yml logs -f integration
 
 ---
 version: '2.1'
@@ -38,6 +38,11 @@ services:
     volumes:
       - shared:/shared
       - ../../junit:/junit
+
+  trafficops:
+    environment:
+      DIG_IP_RETRY: ${DIG_IP_RETRY:-0}
+      LOAD_TRAFFIC_OPS_DATA: ${LOAD_TRAFFIC_OPS_DATA:-false}
 
 volumes:
   junit:

--- a/infrastructure/cdn-in-a-box/docker-compose.traffic-portal-test.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.traffic-portal-test.yml
@@ -20,8 +20,8 @@
 # make sure any container rpms you need are updated. Below is an
 # example of how to run the main compose with this file:
 #
-# docker-compose up --build db trafficops trafficportal
-# docker-compose -f docker-compose.traffic-portal-test.yml up --build
+# docker-compose -f docker-compose.yml -f docker-compose.traffic-portal-test.yml up -d db edge trafficportal trafficops trafficvault portal-integration-test
+# docker-compose -f docker-compose.yml -f docker-compose.traffic-portal-test.yml logs -f portal-integration-test
 
 ---
 version: '2.1'
@@ -42,6 +42,10 @@ services:
     volumes:
       - shared:/shared
       - ../../junit:/junit
+
+  trafficops:
+    environment:
+      DIG_IP_RETRY: ${DIG_IP_RETRY:-0}
 
 volumes:
   shared:


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #5556 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5556<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
* Start the TO API tests in CDN in a Box and 
  ```shell
  waiting for trafficops
  + to-ping
  + echo waiting for trafficops
  + sleep 3
  waiting for trafficops
  + to-ping
  {"ping":"pong"}
  + source config.sh
  ++ envvars=(DB_NAME DB_FQDN DB_USER DB_USER_PASS DB_PORT TO_HOST TO_PORT TO_ADMIN_PASSWORD)
  ++ unset_vars=
  ++ for v in "${envvars[@]}"
  ++ [[ -z traffic_ops ]]
  ++ for v in "${envvars[@]}"
  ++ [[ -z db.infra.ciab.test ]]
  ++ for v in "${envvars[@]}"
  ++ [[ -z traffic_ops ]]
  ++ for v in "${envvars[@]}"
  ++ [[ -z twelve ]]
  ++ for v in "${envvars[@]}"
  ++ [[ -z 5432 ]]
  ++ for v in "${envvars[@]}"
  ++ [[ -z trafficops ]]
  ++ for v in "${envvars[@]}"
  ++ [[ -z 443 ]]
  ++ for v in "${envvars[@]}"
  ++ [[ -z twelve12 ]]
  ++ [[ ! -z '' ]]
  ++ cat
  + exit_code=0
  + for api_version in v{1..4}
  + ./traffic_ops_v1_integration_test -test.v -cfg=traffic-ops-test.conf -fixtures=tc-fixtures-v1.json
  + ./go-junit-report --package-name=golang.test.toapi.v1 --set-exit-code
  ```

* Start the TP UI tests in CDN in a Box and verify that it gets to the point where the UI tests start
    ```shell
    waiting for Traffic Ops at 'https://trafficops.infra.ciab.test:443' fqdn 'trafficops.infra.ciab.test' host 'trafficops'
    waiting for Traffic Ops at 'https://trafficops.infra.ciab.test:443' fqdn 'trafficops.infra.ciab.test' host 'trafficops'
    {"ping":"pong"}
    Waiting for Traffic Ops to finish seeding the Traffic Ops data so Traffic Portal will start...
    Waiting for Traffic Ops to finish seeding the Traffic Ops data so Traffic Portal will start...
    Waiting for Traffic Ops to finish seeding the Traffic Ops data so Traffic Portal will start...
    waiting for Traffic Portal at 'https://trafficportal.infra.ciab.test:443' fqdn 'trafficportal.infra.ciab.test' host 'trafficportal'
    waiting for Traffic Portal at 'https://trafficportal.infra.ciab.test:443' fqdn 'trafficportal.infra.ciab.test' host 'trafficportal'
    {"ping":"pong"}
    waiting for selenium server to start on 'http://localhost:4444'
    [22:14:46] I/start - java -Djava.security.egd=file:///dev/./urandom -Dwebdriver.chrome.driver=/usr/local/lib/node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_88.0.4324.182 -Dwebdriver.gecko.driver=/usr/local/lib/node_modules/protractor/node_modules/webdriver-manager/selenium/geckodriver-v0.29.0 -jar /usr/local/lib/node_modules/protractor/node_modules/webdriver-manager/selenium/selenium-server-standalone-3.141.59.jar -port 4444
    [22:14:46] I/start - seleniumProcess.pid: 121
    ```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (092e9fb089)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] Bugfix, no documentation is necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
