### PR TITLE
Python 2.7 support for Python postinstall script

### DIFF
--- a/docs/source/admin/traffic_ops.rst
+++ b/docs/source/admin/traffic_ops.rst
@@ -214,6 +214,8 @@ Guide
 		| Password for the admin user                        | The password for the administrative Traffic Ops user.                                          |
 		+----------------------------------------------------+------------------------------------------------------------------------------------------------+
 
+.. note:: A Python postinstall script also exists, and, unlike the Perl postinstall script, has no dependencies besides the interpreter itself. To use it, run ``/opt/traffic_ops/install/bin/postinstall.py`` with the same arguments you would have passed to ``/opt/traffic_ops/install/bin/postinstall`` (runs under either Python 3 or Python 2).
+
 .. _to-upgrading:
 
 Upgrading

--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -38,6 +38,7 @@ Requires:         openssl-devel, perl, perl-core, perl-DBD-Pg, perl-DBI, perl-Di
 Requires:         libidn-devel, libcurl-devel, libcap
 Requires:         postgresql96 >= 9.6.2 , postgresql96-devel >= 9.6.2
 Requires:         perl-JSON, perl-libwww-perl, perl-Test-CPAN-Meta, perl-WWW-Curl, perl-TermReadKey, perl-Crypt-ScryptKDF
+Requires:         python(abi)
 Requires(pre):    /usr/sbin/useradd, /usr/bin/getent
 Requires(postun): /usr/sbin/userdel
 

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -744,9 +744,9 @@ def setup_maxmind(maxmind_answer, root): # type: (str, str) -> None
 			universal_newlines=True
 		)
 	except subprocess.CalledProcessError as e:
-		failed_download(6)
+		failed_download(e, 6)
 	except subprocess.SubprocessError as e:
-		failed_download(6)
+		failed_download(e, 6)
 
 def exec_openssl(description, *cmd_args): # type: (str, ...) -> bool
 	"""

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -749,7 +749,9 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 		with open(cdn_conf_path) as conf_file:
 			cdn_conf = json.load(conf_file)
 	except (OSError, json.JSONDecodeError) as e:
-		raise OSError("reading {cdn_conf_path}: {e}".format(cdn_conf_path=cdn_conf_path, e=e)) from e
+		exception = OSError("reading {cdn_conf_path}: {e}".format(cdn_conf_path=cdn_conf_path, e=e))
+		exception.__cause__ = e
+		raise exception
 
 	if (
 		not isinstance(cdn_conf, dict) or
@@ -808,33 +810,49 @@ def generate_cdn_conf(questions, fname, automatic, root): # type: (list[Question
 	try:
 		num_secrets = int(cdn_conf["keepSecrets"])
 	except KeyError as e:
-		raise ValueError("missing 'keepSecrets' config_var") from e
+		exception = ValueError("missing 'keepSecrets' config_var")
+		exception.__cause__ = e
+		raise exception
 	except ValueError as e:
-		raise ValueError("invalid 'keepSecrets' config_var value: {e}".format(e=e)) from e
+		exception = ValueError("invalid 'keepSecrets' config_var value: {e}".format(e=e))
+		exception.__cause__ = e
+		raise exception
 
 	try:
 		port = int(cdn_conf["port"])
 	except KeyError as e:
-		raise ValueError("missing 'port' config_var") from e
+		exception = ValueError("missing 'port' config_var")
+		exception.__cause__ = e
+		raise exception
 	except ValueError as e:
-		raise ValueError("invalid 'port' config_var value: {e}".format(e=e)) from e
+		exception = ValueError("invalid 'port' config_var value: {e}".format(e=e))
+		exception.__cause__ = e
+		raise exception
 
 	try:
 		workers = int(cdn_conf["workers"])
 	except KeyError as e:
-		raise ValueError("missing 'workers' config_var") from e
+		exception = ValueError("missing 'workers' config_var")
+		exception.__cause__ = e
+		raise exception
 	except ValueError as e:
-		raise ValueError("invalid 'workers' config_var value: {e}".format(e=e)) from e
+		exception = ValueError("invalid 'workers' config_var value: {e}".format(e=e))
+		exception.__cause__ = e
+		raise exception
 
 	try:
 		url = cdn_conf["base_url"]
 	except KeyError as e:
-		raise ValueError("missing 'base_url' config_var") from e
+		exception = ValueError("missing 'base_url' config_var")
+		exception.__cause__ = e
+		raise exception
 
 	try:
 		ldap_loc = cdn_conf["ldap_conf_location"]
 	except KeyError as e:
-		raise ValueError("missing 'ldap_conf_location' config_var") from e
+		exception = ValueError("missing 'ldap_conf_location' config_var")
+		exception.__cause__ = e
+		raise exception
 
 	conf = CDNConfig(gen_secret, num_secrets, port, workers, url, ldap_loc)
 
@@ -845,7 +863,9 @@ def generate_cdn_conf(questions, fname, automatic, root): # type: (list[Question
 			try:
 				existing_conf = json.load(conf_file)
 			except json.JSONDecodeError as e:
-				raise ValueError("invalid existing cdn.config at {path}: {e}".format(path=path, e=e)) from e
+				exception = ValueError("invalid existing cdn.config at {path}: {e}".format(path=path, e=e))
+				exception.__cause__ = e
+				raise exception
 
 	if not isinstance(existing_conf, dict):
 		logging.warning("Existing cdn.conf (at '%s') is not an object - overwriting", path)

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1073,7 +1073,10 @@ def exec_psql(conn_str, query): # type: (str, str) -> str
 	if proc.returncode != 0:
 		logging.debug("psql exec failed; stderr: %s\n\tstdout: %s", proc.stderr, proc.stdout)
 		raise OSError("failed to execute database query")
-	return proc.stdout.strip()
+	if sys.version_info.major >= 3:
+		return proc.stdout.strip()
+	else:
+		return string.strip(proc.stdout)
 
 def invoke_db_admin_pl(action, root): # type: (str, str) -> None
 	"""

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -87,6 +87,9 @@ POST_INSTALL_CFG = "/opt/traffic_ops/install/data/json/post_install.json"
 # Python, instead, outputs to stdout. This is breaking, but more flexible. Change it?
 # OUTPUT_CONFIG_FILE = "/opt/traffic_ops/install/bin/configuration_file.json"
 
+# Accepting a string for json.dump()'s `indent` keyword argument is a Python 3 feature
+indent = "\t" if sys.version_info.major >= 3 else 4 # type: int
+
 class Question(object):
 	"""
 	Question represents a single question to be asked of the user, to determine a configuration
@@ -318,7 +321,7 @@ def generate_db_conf(qstns, fname, automatic, root): # (list[Question], str, boo
 
 	path = os.path.join(root, fname.lstrip('/'))
 	with open(path, 'w+') as conf_file:
-		json.dump(db_conf, conf_file, indent="\t")
+		json.dump(db_conf, conf_file, indent=indent)
 		print(file=conf_file)
 
 	logging.info("Database configuration has been saved")
@@ -391,7 +394,7 @@ def generate_ldap_conf(questions, fname, automatic, root): # type: (list[Questio
 	path = os.path.join(root, fname.lstrip('/'))
 	os.makedirs(os.path.dirname(path), exist_ok=True)
 	with open(path, 'w+') as conf_file:
-		json.dump(ldap_conf, conf_file, indent="\t")
+		json.dump(ldap_conf, conf_file, indent=indent)
 		print(file=conf_file)
 
 def hash_pass(passwd): # type: (str) -> str
@@ -425,7 +428,7 @@ def generate_users_conf(qstns, fname, auto, root): # type: (list[Question], str,
 
 	path = os.path.join(root, fname.lstrip('/'))
 	with open(path, 'w+') as conf_file:
-		json.dump({"username": config["tmAdminUser"], "password": hashed_pass}, conf_file, indent="\t")
+		json.dump({"username": config["tmAdminUser"], "password": hashed_pass}, conf_file, indent=indent)
 		print(file=conf_file)
 
 	return User(config["tmAdminUser"], config["tmAdminPw"])
@@ -463,7 +466,7 @@ def generate_param_conf(qstns, fname, auto, root): # type: (list[Question], str,
 
 	path = os.path.join(root, fname.lstrip('/'))
 	with open(path, 'w+') as conf_file:
-		json.dump(conf, conf_file, indent="\t")
+		json.dump(conf, conf_file, indent=indent)
 		print(file=conf_file)
 
 	return conf
@@ -888,7 +891,7 @@ def generate_cdn_conf(questions, fname, automatic, root): # type: (list[Question
 		existing_conf["hypnotoad"]["workers"] = conf.num_workers
 
 	with open(path, "w+") as conf_file:
-		json.dump(existing_conf, conf_file, indent="\t")
+		json.dump(existing_conf, conf_file, indent=indent)
 		print(file=conf_file)
 	logging.info("CDN configuration has been saved")
 
@@ -1095,12 +1098,12 @@ no_database, # type: bool
 			if defaults:
 				try:
 					with open(defaults, "w") as dump_file:
-						json.dump(DEFAULTS, dump_file, indent="\t")
+						json.dump(DEFAULTS, dump_file, indent=indent)
 				except OSError as e:
 					logging.critical("Writing output: %s", e)
 					return 1
 			else:
-				json.dump(DEFAULTS, sys.stdout, cls=ConfigEncoder, indent="\t")
+				json.dump(DEFAULTS, sys.stdout, cls=ConfigEncoder, indent=indent)
 				print()
 		except ValueError as e:
 			logging.critical("Converting defaults to JSON: %s", e)

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # There's a bug in asteroid with Python 3.9's NamedTuple being
 # recognized for the dynamically generated class that it is. Should be fixed
 # with the next release, but 'til then...
@@ -30,20 +43,6 @@ testing.
 >>> [c for c in [[a for a in b if not a.config_var] for b in DEFAULTS.values()] if c]
 []
 """
-
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 import argparse
 import base64

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -387,7 +387,7 @@ def generate_ldap_conf(questions, fname, automatic, root): # type: (list[Questio
 		if key not in ldap_conf:
 			raise ValueError("{key} is a required key in {fname}".format(key=key, fname=fname))
 
-	if not re.fullmatch(r"\S+:\d+", ldap_conf["host"]):
+	if not re.match(r"^\S+:\d+$", ldap_conf["host"]):
 		raise ValueError("host in {fname} must be of form 'hostname:port'".format(fname=fname))
 
 	path = os.path.join(root, fname.lstrip('/'))

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -667,7 +667,7 @@ def unmarshal_config(dct): # type: (dict) -> dict[str, list[Question]]
 			if not isinstance(qstn, dict):
 				raise ValueError("file '{file}' has a malformed question ({qstn})".format(file=file, qstn=qstn))
 			try:
-				question = next(key for key in qstn.keys() if qstn not in ("hidden", "config_var"))
+				question = next(key for key in qstn.keys() if key not in ("hidden", "config_var"))
 			except StopIteration:
 				raise ValueError("question in '{file}' has no question/answer properties ({qstn})".format(file=file, qstn=qstn))
 

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -749,7 +749,7 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 	try:
 		with open(cdn_conf_path) as conf_file:
 			cdn_conf = json.load(conf_file)
-	except (OSError, json.JSONDecodeError) as e:
+	except (OSError, ValueError) as e:
 		exception = OSError("reading {cdn_conf_path}: {e}".format(cdn_conf_path=cdn_conf_path, e=e))
 		exception.__cause__ = e
 		raise exception
@@ -863,7 +863,7 @@ def generate_cdn_conf(questions, fname, automatic, root): # type: (list[Question
 		with open(path) as conf_file:
 			try:
 				existing_conf = json.load(conf_file)
-			except json.JSONDecodeError as e:
+			except ValueError as e:
 				exception = ValueError("invalid existing cdn.config at {path}: {e}".format(path=path, e=e))
 				exception.__cause__ = e
 				raise exception
@@ -1124,7 +1124,7 @@ no_database, # type: bool
 			diffs,
 			'' if diffs == 1 else 's'
 			)
-		except (OSError, ValueError, json.JSONDecodeError) as e:
+		except (OSError, ValueError) as e:
 			logging.critical("Reading in input file '%s': %s", cfile, e)
 			return 1
 

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1332,7 +1332,7 @@ no_database, # type: bool
 				"Use the script `/opt/traffic_ops/install/bin/todb_bootstrap.sh` " \
 				"on the db server to create it and run `postinstall` again."
 			)
-			return -1
+			return 1
 
 		if not os.path.isfile("/usr/bin/psql") or not os.access("/usr/bin/psql", os.X_OK):
 			logging.critical("psql is not installed, please install it to continue with database setup")
@@ -1350,10 +1350,10 @@ no_database, # type: bool
 			setup_database_data(conn_str, admin_conf, paramconf, root_dir)
 		except (OSError, subprocess.CalledProcessError)as e:
 			db_connect_failed()
-			return -1
+			return 1
 		except subprocess.SubprocessError as e:
 			db_connect_failed()
-			return -1
+			return 1
 
 
 	if not no_restart_to:

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -369,7 +369,7 @@ def generate_ldap_conf(questions, fname, automatic, root): # type: (list[Questio
 		return
 	use_ldap = use_ldap_question[0].default if automatic else use_ldap_question[0].ask()
 
-	if use_ldap.casefold() not in {'y', 'yes'}:
+	if use_ldap.lower() not in {'y', 'yes'}:
 		logging.info("Not setting up ldap")
 		return
 
@@ -451,7 +451,7 @@ def generate_openssl_conf(questions, fname, auto): # type: (list[Question], str,
 	if "genCert" not in cfg_map:
 		raise ValueError("missing 'genCert' key")
 
-	gen_cert = cfg_map["genCert"].casefold() in {"y", "yes"}
+	gen_cert = cfg_map["genCert"].lower() in {"y", "yes"}
 
 	return SSLConfig(gen_cert, cfg_map)
 
@@ -565,7 +565,7 @@ def setup_maxmind(maxmind_answer, root): # type: (str, str) -> None
 	If 'maxmind_answer' is a truthy response ('y' or 'yes' (case-insensitive), sets up a Maxmind
 	database using `wget`.
 	"""
-	if maxmind_answer.casefold() not in {'y', 'yes'}:
+	if maxmind_answer.lower() not in {'y', 'yes'}:
 		logging.info("Not downloading Maxmind data")
 		return
 
@@ -626,9 +626,9 @@ def exec_openssl(description, *cmd_args): # type: (str, ...) -> bool
 		logging.debug("openssl exec failed with code %s; stderr: %s", proc.returncode, proc.stderr)
 		while True:
 			ans = input("{description} failed. Try again (y/n) [y]: ".format(description=description))
-			if not ans or ans.casefold().startswith('n'):
+			if not ans or ans.lower().startswith('n'):
 				return False
-			if ans.casefold().startswith('y'):
+			if ans.lower().startswith('y'):
 				break
 
 def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str, str, str) -> int
@@ -806,7 +806,7 @@ def generate_cdn_conf(questions, fname, automatic, root): # type: (list[Question
 	if "genSecret" not in cdn_conf:
 		raise ValueError("missing 'genSecret' config_var")
 
-	gen_secret = cdn_conf["genSecret"].casefold() in {'y', 'yes'}
+	gen_secret = cdn_conf["genSecret"].lower() in {'y', 'yes'}
 
 	try:
 		num_secrets = int(cdn_conf["keepSecrets"])

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env bash
+"exec" "bash" "-c" "PATH+=:/usr/libexec/; exec \$(type -p python38 python3.8 python36 python3.8 python3 python python27 python2.7 python2 platform-python | head -n1) \"$0\" $*"
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -59,7 +59,7 @@ import stat
 import string
 import subprocess
 import sys
-from typing import Dict, NamedTuple, List, Optional
+from typing import NamedTuple
 
 # Paths for output configuration files
 DATABASE_CONF_FILE = "/opt/traffic_ops/app/conf/production/database.conf"
@@ -96,25 +96,25 @@ class Question:
 	Question(question='question', default='answer', config_var='var', hidden=False)
 	"""
 
-	def __init__(self, question: str, default: str, config_var: str, hidden: bool = False):
+	def __init__(self, question, default, config_var, hidden = False): # type: (str, str, str, bool) -> None
 		self.question = question
 		self.default = default
 		self.config_var = config_var
 		self.hidden = hidden
 
-	def __str__(self) -> str:
+	def __str__(self): # type: () -> str
 		if self.default:
 			return f"{self.question} [{self.default}]: "
 		return f"{self.question}: "
 
-	def __repr__(self) -> str:
+	def __repr__(self): # type: () -> str
 		qstn = self.question
 		ans = self.default
 		cfgvr = self.config_var
 		hddn = self.hidden
 		return f"Question(question='{qstn}', default='{ans}', config_var='{cfgvr}', hidden={hddn})"
 
-	def ask(self) -> str:
+	def ask(self): # type: () -> str
 		"""
 		Asks the user the Question interactively.
 
@@ -131,7 +131,7 @@ class Question:
 		ipt = input(self)
 		return ipt if ipt else self.default
 
-	def to_json(self) -> str:
+	def to_json(self): # type: () -> str
 		"""
 		Converts a question to JSON encoding.
 
@@ -147,7 +147,7 @@ class Question:
 			return f'{{"{qstn}": "{ans}", "config_var": "{cfgvr}", "hidden": true}}'
 		return f'{{"{qstn}": "{ans}", "config_var": "{cfgvr}"}}'
 
-	def serialize(self) -> object:
+	def serialize(self): # type: () -> object
 		"""Returns a serializable dictionary, suitable for converting to JSON."""
 		return {self.question: self.default, "config_var": self.config_var, "hidden": self.hidden}
 
@@ -155,14 +155,14 @@ class User(NamedTuple):
 	"""Users represents a user that will be inserted into the Traffic Ops database."""
 
 	#: The user's username.
-	username: str
+	username = None # type: str
 	#: The user's password - IN PLAINTEXT.
-	password: str
+	password = None # type: str
 
 class SSLConfig:
 	"""SSLConfig bundles the options for generating new (self-signed) SSL certificates"""
 
-	def __init__(self, gen_cert: bool, cfg_map: Dict[str, str]):
+	def __init__(self, gen_cert, cfg_map): # type: (bool, dict[str, str]) -> None
 
 		self.gen_cert = gen_cert
 		self.rsa_password = cfg_map["rsaPassword"]
@@ -171,12 +171,12 @@ class SSLConfig:
 
 class CDNConfig(NamedTuple):
 	"""CDNConfig holds all of the options needed to format a cdn.conf file."""
-	gen_secret: bool
-	num_secrets: int
-	port: int
-	num_workers: int
-	url: str
-	ldap_conf_location: str
+	gen_secret = None # type: bool
+	num_secrets = None # type: int
+	port = None # type: int
+	num_workers = None # type: int
+	url = None # type: str
+	ldap_conf_location = None # type: str
 
 	def generate_secret(self, conf):
 		"""
@@ -279,7 +279,7 @@ class ConfigEncoder(json.JSONEncoder):
 	"""
 
 	# The linter is just wrong about this
-	def default(self, o) -> object:
+	def default(self, o): # type: (object) -> object
 		"""
 		Returns a serializable representation of 'o'.
 
@@ -292,7 +292,7 @@ class ConfigEncoder(json.JSONEncoder):
 
 		return json.JSONEncoder.default(self, o)
 
-def get_config(questions: List[Question], fname: str, automatic: bool = False) -> Dict[str, str]:
+def get_config(questions, fname, automatic = False): # type: (list[Question], str, bool) -> dict[str, str]
 	"""Asks all provided questions, or uses their defaults in automatic mode"""
 
 	logging.info("===========%s===========", fname)
@@ -306,7 +306,7 @@ def get_config(questions: List[Question], fname: str, automatic: bool = False) -
 
 	return config
 
-def generate_db_conf(qstns: List[Question], fname: str, automatic: bool, root: str) -> dict:
+def generate_db_conf(qstns, fname, automatic, root): # (list[Question], str, bool, str) -> dict
 	"""
 	Generates the database.conf file and returns a map of its configuration.
 
@@ -328,7 +328,7 @@ def generate_db_conf(qstns: List[Question], fname: str, automatic: bool, root: s
 
 	return db_conf
 
-def generate_todb_conf(qstns: list, fname: str, auto: bool, root: str, conf: dict) -> dict:
+def generate_todb_conf(qstns, fname, auto, root, conf): # (list, str, bool, str, dict) -> dict
 	"""
 	Generates the dbconf.yml file and returns a map of its configuration.
 
@@ -357,7 +357,7 @@ def generate_todb_conf(qstns: list, fname: str, auto: bool, root: str, conf: dic
 
 	return todbconf
 
-def generate_ldap_conf(questions: List[Question], fname: str, automatic: bool, root: str):
+def generate_ldap_conf(questions, fname, automatic, root): # type: (list[Question], str, bool, str) -> None
 	"""
 	Generates the ldap.conf file by asking the questions or using default answers in auto mode.
 
@@ -397,7 +397,7 @@ def generate_ldap_conf(questions: List[Question], fname: str, automatic: bool, r
 		json.dump(ldap_conf, conf_file, indent="\t")
 		print(file=conf_file)
 
-def hash_pass(passwd: str) -> str:
+def hash_pass(passwd): # type: (str) -> str
 	"""
 	Generates a Scrypt-based hash of the given password in a Perl-compatible format.
 	It's hard-coded - like the Perl - to use 64 random bytes for the salt, n=16384,
@@ -414,7 +414,7 @@ def hash_pass(passwd: str) -> str:
 
 	return f"SCRYPT:{n}:{r_val}:{p_val}:{salt_b64}:{hashed_b64}"
 
-def generate_users_conf(qstns: List[Question], fname: str, auto: bool, root: str) -> User:
+def generate_users_conf(qstns, fname, auto, root): # type: (list[Question], str, bool, str) -> User
 	"""
 	Generates a users.json file from the given questions and returns a User containing the same
 	information.
@@ -433,7 +433,7 @@ def generate_users_conf(qstns: List[Question], fname: str, auto: bool, root: str
 
 	return User(config["tmAdminUser"], config["tmAdminPw"])
 
-def generate_profiles_dir(questions: List[Question]):
+def generate_profiles_dir(questions): # type: (list[Question]) -> None
 	"""
 	I truly have no idea what's going on here. This is what the Perl did, so I
 	copied it. It does nothing. Literally nothing.
@@ -442,7 +442,7 @@ def generate_profiles_dir(questions: List[Question]):
 	user_in = questions
 	#pylint:enable=unused-variable
 
-def generate_openssl_conf(questions: List[Question], fname: str, auto: bool) -> SSLConfig:
+def generate_openssl_conf(questions, fname, auto): # type: (list[Question], str, bool) -> SSLConfig
 	"""
 	Constructs an SSLConfig by asking the passed questions, or using their default answers if in
 	auto mode.
@@ -455,7 +455,7 @@ def generate_openssl_conf(questions: List[Question], fname: str, auto: bool) -> 
 
 	return SSLConfig(gen_cert, cfg_map)
 
-def generate_param_conf(qstns: List[Question], fname: str, auto: bool, root: str) -> dict:
+def generate_param_conf(qstns, fname, auto, root): # type: (list[Question], str, bool, str) -> dict
 	"""
 	Generates a profiles.json by asking the passed questions, or using their default answers in auto
 	mode.
@@ -471,7 +471,7 @@ def generate_param_conf(qstns: List[Question], fname: str, auto: bool, root: str
 
 	return conf
 
-def sanity_check_config(cfg: Dict[str, List[Question]], automatic: bool) -> int:
+def sanity_check_config(cfg, automatic): # type: (dict[str, list[Question]], bool) -> int
 	"""
 	Checks a user-input configuration file, and outputs the number of files in the
 	default question set that did not appear in the input.
@@ -511,7 +511,7 @@ def sanity_check_config(cfg: Dict[str, List[Question]], automatic: bool) -> int:
 
 	return diffs
 
-def unmarshal_config(dct: dict) -> Dict[str, List[Question]]:
+def unmarshal_config(dct): # type: (dict) -> dict[str, list[Question]]
 	"""
 	Reads in a raw parsed configuration file and returns the resulting configuration.
 
@@ -560,7 +560,7 @@ def unmarshal_config(dct: dict) -> Dict[str, List[Question]]:
 
 	return ret
 
-def setup_maxmind(maxmind_answer: str, root: str):
+def setup_maxmind(maxmind_answer, root): # type: (str, str) -> None
 	"""
 	If 'maxmind_answer' is a truthy response ('y' or 'yes' (case-insensitive), sets up a Maxmind
 	database using `wget`.
@@ -601,7 +601,7 @@ def setup_maxmind(maxmind_answer: str, root: str):
 		logging.error("Failed to download MaxMind data")
 		logging.debug("(ipv6) Exception: %s", e)
 
-def exec_openssl(description: str, *cmd_args) -> bool:
+def exec_openssl(description, *cmd_args): # type: (str, ...) -> bool
 	"""
 	Executes openssl with the supplied command-line arguments.
 
@@ -631,7 +631,7 @@ def exec_openssl(description: str, *cmd_args) -> bool:
 			if ans.casefold().startswith('y'):
 				break
 
-def setup_certificates(conf: SSLConfig, root: str, ops_user: str, ops_group: str) -> int:
+def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str, str, str) -> int
 	"""
 	Generates self-signed SSL certificates from the given configuration.
 	:returns: For whatever reason this subroutine needs to dictate the return code of the script, so that's what it returns.
@@ -785,7 +785,7 @@ def setup_certificates(conf: SSLConfig, root: str, ops_user: str, ops_group: str
 
 	return 0
 
-def random_word(length: int = 12) -> str:
+def random_word(length = 12): # type: (int) -> str
 	"""
 	Returns a randomly generated string 'length' characters long containing only word
 	characters ([a-zA-Z0-9_]).
@@ -793,7 +793,7 @@ def random_word(length: int = 12) -> str:
 	word_chars = string.ascii_letters + string.digits + '_'
 	return ''.join(random.choice(word_chars) for _ in range(length))
 
-def generate_cdn_conf(questions: List[Question], fname: str, automatic: bool, root: str):
+def generate_cdn_conf(questions, fname, automatic, root): # type: (list[Question], str, bool, str) -> None
 	"""
 	Generates some properties of a cdn.conf file based on the passed questions.
 
@@ -875,7 +875,7 @@ def generate_cdn_conf(questions: List[Question], fname: str, automatic: bool, ro
 		print(file=conf_file)
 	logging.info("CDN configuration has been saved")
 
-def db_connection_string(dbconf: dict) -> str:
+def db_connection_string(dbconf): # type: (dict) -> str
 	"""
 	Constructs a database connection string from the passed configuration object.
 	"""
@@ -886,7 +886,7 @@ def db_connection_string(dbconf: dict) -> str:
 	port = dbconf["port"]
 	return f"postgresql://{user}:{password}@{hostname}:{port}/{db_name}"
 
-def exec_psql(conn_str: str, query: str) -> str:
+def exec_psql(conn_str, query): # type: (str, str) -> str
 	"""
 	Executes SQL queries by forking and exec-ing '/usr/bin/psql'.
 
@@ -908,7 +908,7 @@ def exec_psql(conn_str: str, query: str) -> str:
 		raise OSError("failed to execute database query")
 	return proc.stdout.strip()
 
-def invoke_db_admin_pl(action: str, root: str):
+def invoke_db_admin_pl(action, root): # type: (str, str) -> None
 	"""
 	Exectues admin with the given action, and looks for it from the given root directory.
 	"""
@@ -929,7 +929,7 @@ def invoke_db_admin_pl(action: str, root: str):
 		raise OSError(f"Database {action} failed")
 	logging.info("Database %s succeeded", action)
 
-def setup_database_data(conn_str: str, user: User, param_conf: dict, root: str):
+def setup_database_data(conn_str, user, param_conf, root): # type: (str, User, dict, str) -> None
 	"""
 	Sets up all necessary initial database data using `/usr/bin/sql`
 	"""
@@ -1044,18 +1044,19 @@ def setup_database_data(conn_str: str, user: User, param_conf: dict, root: str):
 	_ = exec_psql(conn_str, insert_cdn_query)
 
 def main(
-automatic: bool,
-debug: bool,
-defaults: Optional[str],
-cfile: Optional[str],
-root_dir: str,
-ops_user: str,
-ops_group: str,
-no_restart_to: bool,
-no_database: bool
-) -> int:
+automatic, # type: bool
+debug, # type: bool
+defaults, # type: str
+cfile, # type: str
+root_dir, # type: str
+ops_user, # type: str
+ops_group, # type: str
+no_restart_to, # type: bool
+no_database, # type: bool
+):
 	"""
 	Runs the main routine given the parsed arguments as input.
+	:rtype: int
 	"""
 	if debug:
 		logging.getLogger().setLevel(logging.DEBUG)

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -18,6 +18,7 @@
 # with the next release, but 'til then...
 #pylint:disable=inherit-non-class
 from __future__ import print_function
+
 """
 This script is meant as a drop-in replacement for the old _postinstall Perl script.
 
@@ -47,6 +48,7 @@ testing.
 """
 import argparse
 import base64
+import errno
 import getpass
 import hashlib
 import json
@@ -392,7 +394,11 @@ def generate_ldap_conf(questions, fname, automatic, root): # type: (list[Questio
 		raise ValueError("host in {fname} must be of form 'hostname:port'".format(fname=fname))
 
 	path = os.path.join(root, fname.lstrip('/'))
-	os.makedirs(os.path.dirname(path), exist_ok=True)
+	try:
+		os.makedirs(os.path.dirname(path))
+	except OSError as e:
+		if e.errno == errno.EEXIST:
+			pass
 	with open(path, 'w+') as conf_file:
 		json.dump(ldap_conf, conf_file, indent=indent)
 		print(file=conf_file)

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -104,15 +104,15 @@ class Question:
 
 	def __str__(self): # type: () -> str
 		if self.default:
-			return f"{self.question} [{self.default}]: "
-		return f"{self.question}: "
+			return "{question} [{default}]: ".format(question=self.question, default=self.default)
+		return "{question}: ".format(question=self.question)
 
 	def __repr__(self): # type: () -> str
 		qstn = self.question
 		ans = self.default
 		cfgvr = self.config_var
 		hddn = self.hidden
-		return f"Question(question='{qstn}', default='{ans}', config_var='{cfgvr}', hidden={hddn})"
+		return "Question(question='{qstn}', default='{ans}', config_var='{cfgvr}', hidden={hddn})".format(qstn=qstn, ans=ans, cfgvr=cfgvr, hddn=hddn)
 
 	def ask(self): # type: () -> str
 		"""
@@ -125,7 +125,7 @@ class Question:
 				passwd = getpass.getpass(str(self))
 				if not passwd:
 					continue
-				if passwd == getpass.getpass(f"Re-Enter {self.question}: "):
+				if passwd == getpass.getpass("Re-Enter {question}: ".format(question=self.question)):
 					return passwd
 				print("Error: passwords do not match, try again")
 		ipt = input(self)
@@ -144,8 +144,8 @@ class Question:
 		ans = self.default
 		cfgvr = self.config_var
 		if self.hidden:
-			return f'{{"{qstn}": "{ans}", "config_var": "{cfgvr}", "hidden": true}}'
-		return f'{{"{qstn}": "{ans}", "config_var": "{cfgvr}"}}'
+			return '{{"{qstn}": "{ans}", "config_var": "{cfgvr}", "hidden": true}}'.format(qstn=qstn, ans=ans, cfgvr=cfgvr)
+		return '{{"{qstn}": "{ans}", "config_var": "{cfgvr}"}}'.format(qstn=qstn, ans=ans, cfgvr=cfgvr)
 
 	def serialize(self): # type: () -> object
 		"""Returns a serializable dictionary, suitable for converting to JSON."""
@@ -317,7 +317,7 @@ def generate_db_conf(qstns, fname, automatic, root): # (list[Question], str, boo
 	hostname = db_conf.get("hostname", "UNKNOWN")
 	port = db_conf.get("port", "UNKNOWN")
 
-	db_conf["description"] = f"{typ} database on {hostname}:{port}"
+	db_conf["description"] = "{typ} database on {hostname}:{port}".format(typ=typ, hostname=hostname, port=port)
 
 	path = os.path.join(root, fname.lstrip('/'))
 	with open(path, 'w+') as conf_file:
@@ -349,11 +349,11 @@ def generate_todb_conf(qstns, fname, auto, root, conf): # (list, str, bool, str,
 	password = conf.get('password', 'UNKNOWN')
 	dbname = conf.get('dbname', 'UNKNOWN')
 
-	open_line = f"host={hostname} port={port} user={user} password={password} dbname={dbname}"
+	open_line = "host={hostname} port={port} user={user} password={password} dbname={dbname}".format(hostname=hostname, port=port, user=user, password=password, dbname=dbname)
 	with open(path, 'w+') as conf_file:
 		print("production:", file=conf_file)
 		print("    driver:", driver, file=conf_file)
-		print(f"    open: {open_line} sslmode=disable", file=conf_file)
+		print("    open: {open_line} sslmode=disable".format(open_line=open_line), file=conf_file)
 
 	return todbconf
 
@@ -386,10 +386,10 @@ def generate_ldap_conf(questions, fname, automatic, root): # type: (list[Questio
 
 	for key in keys:
 		if key not in ldap_conf:
-			raise ValueError(f"{key} is a required key in {fname}")
+			raise ValueError("{key} is a required key in {fname}".format(key=key, fname=fname))
 
 	if not re.fullmatch(r"\S+:\d+", ldap_conf["host"]):
-		raise ValueError(f"host in {fname} must be of form 'hostname:port'")
+		raise ValueError("host in {fname} must be of form 'hostname:port'".format(fname=fname))
 
 	path = os.path.join(root, fname.lstrip('/'))
 	os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -412,7 +412,7 @@ def hash_pass(passwd): # type: (str) -> str
 	hashed_b64 = base64.standard_b64encode(hashed).decode()
 	salt_b64 = base64.standard_b64encode(salt).decode()
 
-	return f"SCRYPT:{n}:{r_val}:{p_val}:{salt_b64}:{hashed_b64}"
+	return "SCRYPT:{n}:{r_val}:{p_val}:{salt_b64}:{hashed_b64}".format(n=n, r_val=r_val, p_val=p_val, salt_b64=salt_b64, hashed_b64=hashed_b64)
 
 def generate_users_conf(qstns, fname, auto, root): # type: (list[Question], str, bool, str) -> User
 	"""
@@ -422,7 +422,7 @@ def generate_users_conf(qstns, fname, auto, root): # type: (list[Question], str,
 	config = get_config(qstns, fname, auto)
 
 	if "tmAdminUser" not in config or "tmAdminPw" not in config:
-		raise ValueError(f"{fname} must include 'tmAdminUser' and 'tmAdminPw'")
+		raise ValueError("{fname} must include 'tmAdminUser' and 'tmAdminPw'".format(fname=fname))
 
 	hashed_pass = hash_pass(config["tmAdminPw"])
 
@@ -523,20 +523,20 @@ def unmarshal_config(dct): # type: (dict) -> dict[str, list[Question]]
 	ret = {}
 	for file, questions in dct.items():
 		if not isinstance(questions, list):
-			raise ValueError(f"file '{file}' has malformed questions")
+			raise ValueError("file '{file}' has malformed questions".format(file=file))
 
 		qstns = []
 		for qstn in questions:
 			if not isinstance(qstn, dict):
-				raise ValueError(f"file '{file}' has a malformed question ({qstn})")
+				raise ValueError("file '{file}' has a malformed question ({qstn})".format(file=file, qstn=qstn))
 			try:
 				question = next(key for key in qstn.keys() if qstn not in ("hidden", "config_var"))
 			except StopIteration:
-				raise ValueError(f"question in '{file}' has no question/answer properties ({qstn})")
+				raise ValueError("question in '{file}' has no question/answer properties ({qstn})".format(file=file, qstn=qstn))
 
 			answer = qstn[question]
 			if not isinstance(question, str) or not isinstance(answer, str):
-				errstr = f"question in '{file}' has malformed question/answer property ({question}: {answer})"
+				errstr = "question in '{file}' has malformed question/answer property ({question}: {answer})".format(file=file, question=question, answer=answer)
 				raise ValueError(errstr)
 
 			del qstn[question]
@@ -546,10 +546,10 @@ def unmarshal_config(dct): # type: (dict) -> dict[str, list[Question]]
 				del qstn["hidden"]
 
 			if "config_var" not in qstn:
-				raise ValueError(f"question in '{file}' has no 'config_var' property")
+				raise ValueError("question in '{file}' has no 'config_var' property".format(file=file))
 			cfg_var = qstn["config_var"]
 			if not isinstance(cfg_var, str):
-				raise ValueError(f"question in '{file}' has malformed 'config_var' property ({cfg_var})")
+				raise ValueError("question in '{file}' has malformed 'config_var' property ({cfg_var})".format(file=file, cfg_var=cfg_var))
 			del qstn["config_var"]
 
 			if qstn:
@@ -625,7 +625,7 @@ def exec_openssl(description, *cmd_args): # type: (str, ...) -> bool
 
 		logging.debug("openssl exec failed with code %s; stderr: %s", proc.returncode, proc.stderr)
 		while True:
-			ans = input(f"{description} failed. Try again (y/n) [y]: ")
+			ans = input("{description} failed. Try again (y/n) [y]: ".format(description=description))
 			if not ans or ans.casefold().startswith('n'):
 				return False
 			if ans.casefold().startswith('y'):
@@ -659,7 +659,7 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 		"-out",
 		"server.key",
 		"-passout",
-		f"pass:{conf.rsa_password}",
+		"pass:{rsa_password}".format(rsa_password=conf.rsa_password),
 		"1024"
 	)
 	if not exec_openssl("Generating an RSA Private Server Key", *args):
@@ -673,7 +673,7 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 		"-out",
 		"server.csr",
 		"-passin",
-		f"pass:{conf.rsa_password}",
+		"pass:{rsa_password}".format(rsa_password=conf.rsa_password),
 		"-subj",
 		conf.params
 	)
@@ -690,7 +690,7 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 		"-out",
 		"server.key",
 		"-passin",
-		f"pass:{conf.rsa_password}"
+		"pass:{rsa_password}".format(rsa_password=conf.rsa_password)
 	)
 	if not exec_openssl("Removing the pass phrase from the server key", *args):
 		return 1
@@ -750,7 +750,7 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 		with open(cdn_conf_path) as conf_file:
 			cdn_conf = json.load(conf_file)
 	except (OSError, json.JSONDecodeError) as e:
-		raise OSError(f"reading {cdn_conf_path}: {e}") from e
+		raise OSError("reading {cdn_conf_path}: {e}".format(cdn_conf_path=cdn_conf_path, e=e)) from e
 
 	if (
 		not isinstance(cdn_conf, dict) or
@@ -774,7 +774,7 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 
 	listen = hypnotoad["listen"][0]
 
-	if f"cert={certpath}" not in listen or f"key={keypath}" not in listen:
+	if "cert={certpath}".format(certpath=certpath) not in listen or "key={keypath}".format(keypath=keypath) not in listen:
 		log_msg = """	The "listen" portion of %s is:
 	%s
 	and does not reference the same "cert=" and "key=" values as are created here.
@@ -811,21 +811,21 @@ def generate_cdn_conf(questions, fname, automatic, root): # type: (list[Question
 	except KeyError as e:
 		raise ValueError("missing 'keepSecrets' config_var") from e
 	except ValueError as e:
-		raise ValueError(f"invalid 'keepSecrets' config_var value: {e}") from e
+		raise ValueError("invalid 'keepSecrets' config_var value: {e}".format(e=e)) from e
 
 	try:
 		port = int(cdn_conf["port"])
 	except KeyError as e:
 		raise ValueError("missing 'port' config_var") from e
 	except ValueError as e:
-		raise ValueError(f"invalid 'port' config_var value: {e}") from e
+		raise ValueError("invalid 'port' config_var value: {e}".format(e=e)) from e
 
 	try:
 		workers = int(cdn_conf["workers"])
 	except KeyError as e:
 		raise ValueError("missing 'workers' config_var") from e
 	except ValueError as e:
-		raise ValueError(f"invalid 'workers' config_var value: {e}") from e
+		raise ValueError("invalid 'workers' config_var value: {e}".format(e=e)) from e
 
 	try:
 		url = cdn_conf["base_url"]
@@ -846,7 +846,7 @@ def generate_cdn_conf(questions, fname, automatic, root): # type: (list[Question
 			try:
 				existing_conf = json.load(conf_file)
 			except json.JSONDecodeError as e:
-				raise ValueError(f"invalid existing cdn.config at {path}: {e}") from e
+				raise ValueError("invalid existing cdn.config at {path}: {e}".format(path=path, e=e)) from e
 
 	if not isinstance(existing_conf, dict):
 		logging.warning("Existing cdn.conf (at '%s') is not an object - overwriting", path)
@@ -884,7 +884,7 @@ def db_connection_string(dbconf): # type: (dict) -> str
 	db_name = "traffic_ops" if dbconf["type"] == "Pg" else dbconf["type"]
 	hostname = dbconf["hostname"]
 	port = dbconf["port"]
-	return f"postgresql://{user}:{password}@{hostname}:{port}/{db_name}"
+	return "postgresql://{user}:{password}@{hostname}:{port}/{db_name}".format(user=user, password=password, hostname=hostname, port=port, db_name=db_name)
 
 def exec_psql(conn_str, query): # type: (str, str) -> str
 	"""
@@ -926,7 +926,7 @@ def invoke_db_admin_pl(action, root): # type: (str, str) -> None
 	)
 	if proc.returncode != 0:
 		logging.debug("admin exec failed; stderr: %s\n\tstdout: %s", proc.stderr, proc.stdout)
-		raise OSError(f"Database {action} failed")
+		raise OSError("Database {action} failed".format(action=action))
 	logging.info("Database %s succeeded", action)
 
 def setup_database_data(conn_str, user, param_conf, root): # type: (str, User, dict, str) -> None

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -714,7 +714,7 @@ def setup_maxmind(maxmind_answer, root): # type: (str, str) -> None
 
 	os.chdir(os.path.join(root, 'opt/traffic_ops/app/public/routing'))
 
-	def failed_download(ip_version):  # type: (int) -> None
+	def failed_download(e, ip_version):  # type: (Exception, int) -> None
 		logging.error("Failed to download MaxMind data")
 		logging.debug("(ipv%d) Exception: %s", ip_version, e)
 
@@ -729,9 +729,9 @@ def setup_maxmind(maxmind_answer, root): # type: (str, str) -> None
 			universal_newlines=True
 		)
 	except subprocess.CalledProcessError as e:
-		failed_download(4)
+		failed_download(e, 4)
 	except subprocess.SubprocessError as e:
-		failed_download(4)
+		failed_download(e, 4)
 
 	cmd[1] = (
 		"https://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz"

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -50,10 +50,12 @@ import argparse
 import base64
 import errno
 import getpass
+import grp
 import hashlib
 import json
 import logging
 import os
+import pwd
 import random
 import re
 import shutil
@@ -863,7 +865,7 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 	keypath = os.path.join(root, 'etc/pki/tls/private/localhost.key')
 	shutil.copy("server.key", keypath)
 	os.chmod(keypath, stat.S_IRUSR | stat.S_IWUSR)
-	shutil.chown(keypath, user=ops_user, group=ops_group)
+	os.chown(keypath, pwd.getpwnam(ops_user).pw_uid, grp.getgrnam(ops_group).gr_gid)
 
 	logging.info("The private key has been installed")
 	logging.info("Installing self signed certificate")
@@ -871,14 +873,14 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 	certpath = os.path.join(root, 'etc/pki/tls/certs/localhost.crt')
 	shutil.copy("server.crt", certpath)
 	os.chmod(certpath, stat.S_IRUSR | stat.S_IWUSR)
-	shutil.chown(certpath, user=ops_user, group=ops_group)
+	os.chown(certpath, pwd.getpwnam(ops_user).pw_uid, grp.getgrnam(ops_group).gr_gid)
 
 	logging.info("Saving the self signed csr")
 
 	csrpath = os.path.join(root, 'etc/pki/tls/certs/localhost.csr')
 	shutil.copy("server.csr", csrpath)
 	os.chmod(csrpath, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH)
-	shutil.chown(csrpath, user=ops_user, group=ops_group)
+	os.chown(csrpath, pwd.getpwnam(ops_user).pw_uid, grp.getgrnam(ops_group).gr_gid)
 
 	log_msg = """
         The self signed certificate has now been installed.

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -58,7 +58,7 @@ import stat
 import string
 import subprocess
 import sys
-from typing import NamedTuple
+from collections import namedtuple
 
 # Paths for output configuration files
 DATABASE_CONF_FILE = "/opt/traffic_ops/app/conf/production/database.conf"
@@ -86,7 +86,7 @@ POST_INSTALL_CFG = "/opt/traffic_ops/install/data/json/post_install.json"
 # Python, instead, outputs to stdout. This is breaking, but more flexible. Change it?
 # OUTPUT_CONFIG_FILE = "/opt/traffic_ops/install/bin/configuration_file.json"
 
-class Question:
+class Question(object):
 	"""
 	Question represents a single question to be asked of the user, to determine a configuration
 	value.
@@ -150,13 +150,16 @@ class Question:
 		"""Returns a serializable dictionary, suitable for converting to JSON."""
 		return {self.question: self.default, "config_var": self.config_var, "hidden": self.hidden}
 
-class User(NamedTuple):
-	"""Users represents a user that will be inserted into the Traffic Ops database."""
+class User(namedtuple('User', ['username', 'password'])):
+	"""Users represents a user that will be inserted into the Traffic Ops database.
 
-	#: The user's username.
-	username = None # type: str
-	#: The user's password - IN PLAINTEXT.
-	password = None # type: str
+	Attributes
+	----------
+	self.username: str
+		The user's username.
+	self.password: str
+		The user's password - IN PLAINTEXT.
+	"""
 
 class SSLConfig:
 	"""SSLConfig bundles the options for generating new (self-signed) SSL certificates"""
@@ -168,14 +171,8 @@ class SSLConfig:
 		self.params = "/C={country}/ST={state}/L={locality}/O={company}/OU={org_unit}/CN={common_name}/"
 		self.params = self.params.format(**cfg_map)
 
-class CDNConfig(NamedTuple):
+class CDNConfig(namedtuple('CDNConfig', ['gen_secret', 'num_secrets', 'port', 'num_workers', 'url', 'ldap_conf_location'])):
 	"""CDNConfig holds all of the options needed to format a cdn.conf file."""
-	gen_secret = None # type: bool
-	num_secrets = None # type: int
-	port = None # type: int
-	num_workers = None # type: int
-	url = None # type: str
-	ldap_conf_location = None # type: str
 
 	def generate_secret(self, conf):
 		"""

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -609,7 +609,7 @@ def exec_openssl(description, *cmd_args): # type: (str, ...) -> bool
 	"""
 	logging.info(description)
 
-	cmd = ["/usr/bin/openssl", *cmd_args]
+	cmd = ("/usr/bin/openssl",) + cmd_args
 
 	while True:
 		proc = subprocess.run(

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -16,6 +16,7 @@
 # recognized for the dynamically generated class that it is. Should be fixed
 # with the next release, but 'til then...
 #pylint:disable=inherit-non-class
+from __future__ import print_function
 """
 This script is meant as a drop-in replacement for the old _postinstall Perl script.
 
@@ -43,7 +44,6 @@ testing.
 >>> [c for c in [[a for a in b if not a.config_var] for b in DEFAULTS.values()] if c]
 []
 """
-
 import argparse
 import base64
 import getpass

--- a/traffic_ops/install/bin/postinstall.py
+++ b/traffic_ops/install/bin/postinstall.py
@@ -91,8 +91,12 @@ POST_INSTALL_CFG = "/opt/traffic_ops/install/data/json/post_install.json"
 # Python, instead, outputs to stdout. This is breaking, but more flexible. Change it?
 # OUTPUT_CONFIG_FILE = "/opt/traffic_ops/install/bin/configuration_file.json"
 
-# Accepting a string for json.dump()'s `indent` keyword argument is a Python 3 feature
-indent = "\t" if sys.version_info.major >= 3 else 4 # type: int
+if sys.version_info.major >= 3:
+	# Accepting a string for json.dump()'s `indent` keyword argument is a Python 3 feature
+	indent = "\t"  # type: str
+else:
+	indent = 4 #  type: int
+	str = unicode  # type: type[unicode]
 
 class Question(object):
 	"""

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -309,6 +309,9 @@ from __future__ import print_function
 import json
 import sys
 
+if sys.version_info.major < 3:
+	str = unicode
+
 try:
 	with open('$USERS_JSON_FILE') as fd:
 		users_json = json.load(fd)
@@ -377,6 +380,9 @@ from __future__ import print_function
 import json
 import string
 import sys
+
+if sys.version_info.major < 3:
+	str = unicode
 
 try:
 	with(open('$ROOT_DIR/opt/traffic_ops/app/conf/cdn.conf')) as fd:

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -22,12 +22,11 @@ readonly MY_DIR="$(pwd)";
 
 while getopts :23sb: opt; do
 	case "$opt" in
-		2)	python_version=2;;
-		3)	python_version=3;;
-		s)	skip_python2=true;;
-		b)	python_bin="$OPTARG";;
-		*)	echo "Invalid flag received: ${OPTARG}" >&2
-			exit 1;;
+		2) python_version=2;;
+		3) python_version=3;;
+		b) python_bin="$OPTARG";;
+		s) skip_python2=true;;
+		*) echo "Invalid flag received: ${OPTARG}" >&2 && exit 1;;
 	esac;
 done;
 

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -24,20 +24,21 @@ help_string="$(<<-'HELP_STRING' cat
 	Usage: ./postinstall.test.h [
 	    -2        Set Python version to 2
 	    -3        Set Python version to 3
-	    -b <path> Explicitly set the path to the Python binary as this value
+	    -b        Explicitly set the path to the Python binary as this value
+	    -h, ?     Print this help text and exit
 	    -s        Do not test Python 2 after testing Python 3
 HELP_STRING
 )"
 
-while getopts :23sb: opt; do
+while getopts :23hsb: opt; do
 	case "$opt" in
 		2) python_version=2;;
 		3) python_version=3;;
 		b) python_bin="$OPTARG";;
-		s) skip_python2=true;;
 		h) echo "$help_string" && exit;;
+		s) skip_python2=true;;
 		?) echo "$help_string" && exit;;
-		*) echo "Invalid flag received: ${OPTARG}" >&2 && exit 1;;
+		*) echo "Invalid flag received: ${OPTARG}" >&2 && echo "$help_string" && exit 1;;
 	esac;
 done;
 

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -351,12 +351,12 @@ if [[ "$(cat $POST_INSTALL_JSON)" != "{}" ]]; then
 fi
 
 readonly PROFILES_JSON_EXPECTED="{
-	\"tm.url\": \"https://localhost\",
 	\"cdn_name\": \"kabletown_cdn\",
-	\"dns_subdomain\": \"cdn1.kabletown.net\"
+	\"dns_subdomain\": \"cdn1.kabletown.net\",
+	\"tm.url\": \"https://localhost\"
 }";
 
-readonly PROFILES_JSON_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/install/data/json/profiles.json)";
+readonly PROFILES_JSON_ACTUAL="$(<"$ROOT_DIR/opt/traffic_ops/install/data/json/profiles.json" jq -S --tab .)";
 if [[ "$PROFILES_JSON_ACTUAL" != "$PROFILES_JSON_EXPECTED" ]]; then
 	echo "Incorrect profiles.json, expected: $PROFILES_JSON_EXPECTED, got: $PROFILES_JSON_ACTUAL" >&2;
 	exit 1;
@@ -440,16 +440,16 @@ exit(0)
 EOF
 
 readonly DATABASE_CONF_EXPECTED='{
-	"type": "Pg",
 	"dbname": "traffic_ops",
+	"description": "Pg database on localhost:5432",
 	"hostname": "localhost",
-	"port": "5432",
-	"user": "traffic_ops",
 	"password": "twelve",
-	"description": "Pg database on localhost:5432"
+	"port": "5432",
+	"type": "Pg",
+	"user": "traffic_ops"
 }';
 
-readonly DATABASE_CONF_ACTUAL="$(cat $ROOT_DIR/opt/traffic_ops/app/conf/production/database.conf)";
+readonly DATABASE_CONF_ACTUAL="$(<"$ROOT_DIR/opt/traffic_ops/app/conf/production/database.conf" jq -S --tab .)";
 if [[ "$DATABASE_CONF_ACTUAL" != "$DATABASE_CONF_EXPECTED" ]]; then
 	echo "Incorrect database.conf, expected: $DATABASE_CONF_EXPECTED, got $DATABASE_CONF_ACTUAL" >&2;
 	exit 1;

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -20,12 +20,23 @@ set -e;
 cd "$(dirname "${BASH_SOURCE[0]}")";
 readonly MY_DIR="$(pwd)";
 
+help_string="$(<<-'HELP_STRING' cat
+	Usage: ./postinstall.test.h [
+	    -2        Set Python version to 2
+	    -3        Set Python version to 3
+	    -b <path> Explicitly set the path to the Python binary as this value
+	    -s        Do not test Python 2 after testing Python 3
+HELP_STRING
+)"
+
 while getopts :23sb: opt; do
 	case "$opt" in
 		2) python_version=2;;
 		3) python_version=3;;
 		b) python_bin="$OPTARG";;
 		s) skip_python2=true;;
+		h) echo "$help_string" && exit;;
+		?) echo "$help_string" && exit;;
 		*) echo "Invalid flag received: ${OPTARG}" >&2 && exit 1;;
 	esac;
 done;

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -267,6 +267,7 @@ fi
 readonly USERS_JSON_FILE="$ROOT_DIR/opt/traffic_ops/install/data/json/users.json";
 
 /usr/bin/python3 <<EOF
+from __future__ import print_function
 import json
 import sys
 
@@ -334,6 +335,7 @@ if [[ "$DB_CONF_ACTUAL" != "$DB_CONF_EXPECTED" ]]; then
 fi
 
 /usr/bin/python3 <<EOF
+from __future__ import print_function
 import json
 import string
 import sys


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
* This PR makes the Python postinstall script added in #4763 compatible with Python 2.7.
* This PR also makes the Python postinstall script compatible with `/usr/lib/platform-python` (Python 3.6) on CentOS 8, which does not have the `typing` module.

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
* Run the postinstall end-to-end tests against Python 2.7 on CentOS 7 after installing the test dependencies:
  ```shell
  <<'COMMANDS' docker run --rm -i -v $(pwd):/trafficcontrol -w /trafficcontrol centos:7 bash
      yum -y install epel-release file openssl &&
      yum -y install jq &&
      time traffic_ops/install/bin/postinstall.test.sh -2 &&
      echo Tests succeeded for CentOS 7
  COMMANDS
  ```

* Run the postinstall end-to-end tests against Python 3.6 on CentOS 8 after installing the test dependencies:
  ```shell
  <<'COMMANDS' docker run --rm -i -v $(pwd):/trafficcontrol -w /trafficcontrol centos:8 bash
  yum -y install epel-release file openssl &&
  yum -y install jq &&
  time traffic_ops/install/bin/postinstall.test.sh -3 -s -b /usr/libexec/platform-python &&
  echo Tests succeeded for CentOS 8
  COMMANDS
  ```

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
