### PR TITLE
Take unmonitored interfaces into account while calculating bandwidth_kbps for caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added functionality to automatically renew ACME certificates.
 
 ### Fixed
+- [#5558](https://github.com/apache/trafficcontrol/issues/5558) - Fixed `TM UI` and `/api/cache-statuses` to report aggregate `bandwidth_kbps` correctly.
 - [#5288](https://github.com/apache/trafficcontrol/issues/5288) - Fixed the ability to create and update a server with MTU value >= 1280.
 - [#5445](https://github.com/apache/trafficcontrol/issues/5445) - When updating a registered user, ignore updates on registration_sent field.
 - [#5335](https://github.com/apache/trafficcontrol/issues/5335) - Don't create a change log entry if the delivery service primary origin hasn't changed

--- a/traffic_monitor/datareq/cachestate.go
+++ b/traffic_monitor/datareq/cachestate.go
@@ -177,9 +177,7 @@ func createCacheStatuses(
 				infStatus.Status, infStatus.Available = interfaceStatus(inf, health[0])
 				if infVit, ok := health[0].InterfaceVitals[inf.Name]; ok {
 					infStatus.BandwidthKbps = float64(infVit.KbpsOut)
-					if inf.Monitor {
-						totalKbps += infStatus.BandwidthKbps
-					}
+					totalKbps += infStatus.BandwidthKbps
 				} else {
 					log.Infof("Cache server '%s' interface '%s' not in last health measurement.", cacheName, inf.Name)
 				}

--- a/traffic_monitor/datareq/cachestate_test.go
+++ b/traffic_monitor/datareq/cachestate_test.go
@@ -1,0 +1,153 @@
+package datareq
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_monitor/cache"
+	"github.com/apache/trafficcontrol/traffic_monitor/dsdata"
+	"github.com/apache/trafficcontrol/traffic_monitor/threadsafe"
+)
+
+func TestCreateCacheStatusesForKbps(t *testing.T) {
+	var cacheTypes map[tc.CacheName]tc.CacheType
+	var statInfoHistory cache.ResultInfoHistory
+	statResultHistory := threadsafe.NewResultStatHistory()
+	healthHistory := make(map[tc.CacheName][]cache.Result, 0)
+	cacheResult := cache.Result{
+		Available:       true,
+		Error:           nil,
+		ID:              "1",
+		Miscellaneous:   nil,
+		PollFinished:    nil,
+		PollID:          0,
+		PrecomputedData: cache.PrecomputedData{},
+		RequestTime:     0,
+		Statistics:      cache.Statistics{},
+		Time:            time.Now(),
+		UsingIPv4:       true,
+		Vitals:          cache.Vitals{},
+		InterfaceVitals: map[string]cache.Vitals{"interface1": cache.Vitals{
+			LoadAvg:    23.2,
+			BytesOut:   200,
+			BytesIn:    140,
+			KbpsOut:    300,
+			MaxKbpsOut: 1000,
+		}},
+	}
+	healthHistory["edgeserver"] = []cache.Result{cacheResult}
+
+	var lastHealthDurations map[tc.CacheName]time.Duration
+	var cacheStates map[tc.CacheName]tc.IsAvailable
+	var lastStats dsdata.LastStats
+	localCacheStatusThreadsafe := threadsafe.NewCacheAvailableStatus()
+	statMaxKbpses := threadsafe.NewCacheKbpses()
+	servers := make(map[string]tc.TrafficServer, 0)
+	interfaces := make([]tc.ServerInterfaceInfo, 0)
+	ipAddresses := make([]tc.ServerIPAddress, 0)
+	ipAddresses = append(ipAddresses, tc.ServerIPAddress{
+		Address:        "123.24.25.26",
+		Gateway:        util.StrPtr("255.255.0.0"),
+		ServiceAddress: true,
+	})
+	i := tc.ServerInterfaceInfo{
+		IPAddresses:  ipAddresses,
+		MaxBandwidth: util.Uint64Ptr(1000),
+		Monitor:      false,
+		MTU:          util.Uint64Ptr(9000),
+		Name:         "interface1",
+	}
+	interfaces = append(interfaces, i)
+
+	s := tc.TrafficServer{
+		CacheGroup:       "cg",
+		DeliveryServices: nil,
+		FQDN:             "fqdn",
+		HashID:           "hashID",
+		HostName:         "hostName",
+		HTTPSPort:        443,
+		Interfaces:       interfaces,
+		Port:             8080,
+		Profile:          "profile",
+		ServerStatus:     "REPORTED",
+		Type:             "EDGE",
+	}
+	servers["edgeserver"] = s
+	result := createCacheStatuses(cacheTypes,
+		statInfoHistory,
+		statResultHistory,
+		healthHistory,
+		lastHealthDurations,
+		cacheStates,
+		lastStats,
+		localCacheStatusThreadsafe,
+		statMaxKbpses,
+		servers)
+
+	if len(result) != 1 {
+		t.Fatalf("expected only one cache in result, but got %d", len(result))
+	}
+	if status, ok := result["edgeserver"]; !ok {
+		t.Fatalf("result status did not contain the expected key 'edgeserver'")
+	} else {
+		if status.BandwidthKbps == nil {
+			t.Fatalf("expected a valid value in BandwidthKbps, but got nothing")
+		}
+		if *status.BandwidthKbps != 300 {
+			t.Errorf("expected BandwidthKbps to be equal to the sum of the values in the interfaces (300), but got %f", *status.BandwidthKbps)
+		}
+	}
+
+	// Add another interface to the server and test again
+	ipAddresses = append(ipAddresses, tc.ServerIPAddress{
+		Address:        "223.24.25.26",
+		Gateway:        util.StrPtr("255.255.0.0"),
+		ServiceAddress: true,
+	})
+
+	i = tc.ServerInterfaceInfo{
+		IPAddresses:  ipAddresses,
+		MaxBandwidth: util.Uint64Ptr(1000),
+		Monitor:      false,
+		MTU:          util.Uint64Ptr(9000),
+		Name:         "interface2",
+	}
+	interfaces = append(interfaces, i)
+	s.Interfaces = interfaces
+	servers["edgeserver"] = s
+	cacheResult.InterfaceVitals["interface2"] = cache.Vitals{
+		LoadAvg:    19.23,
+		BytesOut:   45,
+		BytesIn:    40,
+		KbpsOut:    500,
+		MaxKbpsOut: 1000,
+	}
+	healthHistory["edgeserver"] = []cache.Result{cacheResult}
+
+	result = createCacheStatuses(cacheTypes,
+		statInfoHistory,
+		statResultHistory,
+		healthHistory,
+		lastHealthDurations,
+		cacheStates,
+		lastStats,
+		localCacheStatusThreadsafe,
+		statMaxKbpses,
+		servers)
+
+	if len(result) != 1 {
+		t.Fatalf("expected only one cache in result, but got %d", len(result))
+	}
+	if status, ok := result["edgeserver"]; !ok {
+		t.Fatalf("result status did not contain the expected key 'edgeserver'")
+	} else {
+		if status.BandwidthKbps == nil {
+			t.Fatalf("expected a valid value in BandwidthKbps, but got nothing")
+		}
+		if *status.BandwidthKbps != 800 {
+			t.Errorf("expected BandwidthKbps to be equal to the sum of the values in the interfaces (800), but got %f", *status.BandwidthKbps)
+		}
+	}
+}

--- a/traffic_monitor/datareq/cachestate_test.go
+++ b/traffic_monitor/datareq/cachestate_test.go
@@ -1,5 +1,24 @@
 package datareq
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import (
 	"testing"
 	"time"


### PR DESCRIPTION

<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5558  <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Monitor
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Run TM and hit the `api/cache_statuses` endpoint.
Make sure the UI and /api/cache-statuses API should report the aggregate bandwidth of a server's interfaces, even if monitor = false.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests 
- [x] This PR does not include documentation
- [x] This PR includes an update to CHANGELOG.md 
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
