### PR TITLE
CDN in a Box Traffic Ops: Add iproute package for ip command

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -47,6 +47,8 @@ RUN set -o nounset -o errexit && \
 		gettext              \
 		git                  \
 		golang               \
+		# ip commands is used in set-to-ips-from-dns.sh
+		iproute              \
 		isomd5sum            \
 		jq                   \
 		libidn-devel         \

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -43,24 +43,24 @@ RUN set -o nounset -o errexit && \
 	dnf -y $use_repo -- install postgresql96; \
 	dnf -y install epel-release; \
 	dnf -y $enable_repo install      \
-		jq              \
-		bind-utils      \
-		net-tools       \
-		gettext         \
-		perl-JSON-PP    \
-		perl-Crypt-ScryptKDF  \
-		mkisofs         \
-		isomd5sum       \
-		nmap-ncat       \
-		openssl         \
-		python3         \
-		golang          \
-		git             \
-		libidn-devel    \
-		libpcap-devel   \
-		perl-Digest-SHA1\
-		# Used to copy certs in "Shared SSL certificate generation" step
-		rsync;          \
+		bind-utils           \
+		gettext              \
+		git                  \
+		golang               \
+		isomd5sum            \
+		jq                   \
+		libidn-devel         \
+		libpcap-devel        \
+		mkisofs              \
+		net-tools            \
+		nmap-ncat            \
+		openssl              \
+		perl-Crypt-ScryptKDF \
+		perl-Digest-SHA1     \
+		perl-JSON-PP         \
+		python3              \
+		# rsync is used to copy certs in "Shared SSL certificate generation" step
+		rsync;               \
 	dnf clean all
 
 EXPOSE 443


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.



^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Build CDN in a Box for CentOS 7, ensure it works
```shell
export RHEL_VERSION=7;
make native debug;
docker-compose build --parallel;
docker-compose up -d;
docker-compose logs -f trafficrouter;
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (3a5ff4181a)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR changes tests
- [x] 1 package added, I added a comment but no documentation is necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
