### PR TITLE
Fix broken reference in docs to removed section

### DIFF
--- a/docs/source/admin/traffic_ops.rst
+++ b/docs/source/admin/traffic_ops.rst
@@ -654,7 +654,9 @@ You will need to update `cdn.conf`_ with any necessary changes.
 
 Managing Traffic Ops Extensions
 ===============================
-Traffic Ops supports two types of extensions. `Check Extensions`_ are analytics scripts that collect and display information as columns in the table under :menuselection:`Monitor --> Cache Checks` in Traffic Portal. `Data Source Extensions`_ provide ways to add data to the graph views and usage APIs.
+Traffic Ops supports "`Check Extensions`_", which are analytics scripts that collect and display information as columns in the table under :menuselection:`Monitor --> Cache Checks` in Traffic Portal.
+
+.. seealso:: Traffic Ops also supports a more involved type of extension in the form of :ref:`to_go_plugins`.
 
 .. |checkmark| image:: images/good.png
 .. |X| image:: images/bad.png


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

Fixes a reference in the documentation to the removed "Data Source Extension" section. Data Source Extensions were only supported by the now-removed Perl implementation of Traffic Ops.


## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Build the documentation, verify no warnings or errors.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**