### PR TITLE
Fix TOclient topologies path (#5521)

### DIFF
--- a/traffic_ops/testing/api/v3/topologies_test.go
+++ b/traffic_ops/testing/api/v3/topologies_test.go
@@ -37,6 +37,7 @@ type topologyTestCase struct {
 
 func TestTopologies(t *testing.T) {
 	WithObjs(t, []TCObj{Types, CacheGroups, CDNs, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, Servers, ServerCapabilities, ServerServerCapabilitiesForTopologies, Topologies, Tenants, DeliveryServices, TopologyBasedDeliveryServiceRequiredCapabilities}, func() {
+		GetTestTopologies(t)
 		UpdateTestTopologies(t)
 		ValidationTestTopologies(t)
 		UpdateValidateTopologyORGServerCacheGroup(t)
@@ -58,6 +59,19 @@ func CreateTestTopologies(t *testing.T) {
 			t.Fatalf("Topology in response should be the same as the one POSTed. expected: %v\nactual: %v", topology, postResponse.Response)
 		}
 		t.Log("Response: ", postResponse)
+	}
+}
+
+func GetTestTopologies(t *testing.T) {
+	if len(testData.Topologies) < 1 {
+		t.Fatalf("test data has no topologies, can't test")
+	}
+	topos, _, err := TOSession.GetTopologiesWithHdr(nil)
+	if err != nil {
+		t.Fatalf("expected GET error to be nil, actual: %v", err)
+	}
+	if len(topos) != len(testData.Topologies) {
+		t.Errorf("expected topologies GET to return %v topologies, actual %v", len(testData.Topologies), len(topos))
 	}
 }
 

--- a/traffic_ops/v3-client/topology.go
+++ b/traffic_ops/v3-client/topology.go
@@ -37,7 +37,7 @@ func (to *Session) CreateTopology(top tc.Topology) (*tc.TopologyResponse, ReqInf
 
 func (to *Session) GetTopologiesWithHdr(header http.Header) ([]tc.Topology, ReqInf, error) {
 	var data tc.TopologiesResponse
-	reqInf, err := to.get(ApiTopologies, header, &data)
+	reqInf, err := to.get(APITopologies, header, &data)
 	return data.Response, reqInf, err
 }
 


### PR DESCRIPTION
This PR backports #5521 

* Fix TOclient topologies path

* Add TO test topologies to v4

(cherry picked from commit 3526335f2c1142a13bc12783aefa8faa2aac1aaa)