### PR TITLE
Fixes the ORT Integration tests TO docker container.

### DIFF
--- a/traffic_ops_ort/testing/docker/docker-compose.yml
+++ b/traffic_ops_ort/testing/docker/docker-compose.yml
@@ -56,10 +56,8 @@ services:
     ports: 
       - "443:443"
     build:
-      context: .
-      dockerfile: traffic_ops/Dockerfile
-      args:
-        RPM: traffic_ops.rpm 
+      context: ../../..
+      dockerfile: traffic_ops_ort/testing/docker/traffic_ops/Dockerfile
     volumes:
       - ../../../GO_VERSION:/GO_VERSION
     depends_on:

--- a/traffic_ops_ort/testing/docker/traffic_ops/Dockerfile
+++ b/traffic_ops_ort/testing/docker/traffic_ops/Dockerfile
@@ -17,46 +17,70 @@
 
 ############################################################
 # Dockerfile to build Traffic Ops container images
-# Based on CentOS 7.2
+# Based on CentOS 8
 ############################################################
 
-# Example Build and Run:
-# docker network create cdnet
-# docker build --rm --tag traffic_ops:1.7.0 --build-arg=RPM=http://traffic-control-cdn.net/downloads/1.7.0/RELEASE-1.7.0/traffic_ops-1.7.0-3908.5b77f60f.x86_64.rpm traffic_ops
-#
-# docker run --name my-traffic-ops-mysql --hostname my-traffic-ops-mysql --net cdnet --env MYSQL_ROOT_PASSWORD=secretrootpass --detach mysql:5.5
-#
-# docker run --name my-traffic-ops --hostname my-traffic-ops --net cdnet --publish 443:443 --env MYSQL_IP=my-traffic-ops-mysql --env MYSQL_PORT=3306 --env MYSQL_ROOT_PASS=secretrootpass --env MYSQL_TRAFFIC_OPS_PASS=supersecretpassword --env ADMIN_USER=superroot --env ADMIN_PASS=supersecreterpassward --env CERT_COUNTRY=US --env CERT_STATE=Colorado --env CERT_CITY=Denver --env CERT_COMPANY=NotComcast --env TRAFFIC_VAULT_PASS=marginallylesssecret --env DOMAIN=cdnet --detach traffic_ops:1.5.1
+ARG RHEL_VERSION=8
+FROM centos:${RHEL_VERSION}
+ARG RHEL_VERSION=8
+# Makes RHEL_VERSION available in later layers without needing to specify it again
+ENV RHEL_VERSION=$RHEL_VERSION
 
-FROM centos/systemd
-MAINTAINER dev@trafficcontrol.apache.org
+RUN if [[ "${RHEL_VERSION%%.*}" -eq 7 ]]; then \
+		yum -y install dnf || exit 1; \
+	fi
 
-RUN yum install -y \
-  https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-  initscripts epel-release perl-Crypt-ScryptKDF perl cpanminus perl-Test-CPAN-Meta perl-DBIx-Connector
-
-RUN cpanm Carton
-
-# Override RPM arg to use a different one using --build-arg RPM=...  Can be local file or http://...
-ARG RPM=traffic_ops.rpm
-ADD traffic_ops/$RPM /
-RUN yum install -y /$(basename $RPM)
-
-# once installed, remove rpm to lower image size
-RUN rm /$(basename $RPM)
-
-RUN POSTGRES_HOME=/usr/pgsql-9.6 cd /opt/traffic_ops/app && carton
-
-RUN export PERL5LIB=/opt/traffic_ops/app/local/lib/perl5/:/opt/traffic_ops/install/lib/ \
-	&& export TERM=xterm \
-	&& export USER=root 
-
-# fixes an 'Invalid Argument' bug; TODO diagnose    , fix, & remove
-RUN cp /opt/traffic_ops/app/bin/traffic_ops_golang{,.new} && mv /opt/traffic_ops/app/bin/traffic_ops_golang{.new,} 
+RUN set -o nounset -o errexit && \
+	mkdir -p /etc/cron.d; \
+	if [[ "${RHEL_VERSION%%.*}" -eq 7 ]]; then \
+		use_repo=''; \
+		enable_repo=''; \
+	else \
+		use_repo='--repo=pgdg96'; \
+		enable_repo='--enablerepo=powertools'; \
+	fi; \
+	dnf -y install "https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION%%.*}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"; \
+	dnf -y $use_repo -- install postgresql96; \
+	dnf -y install epel-release; \
+	dnf -y $enable_repo install      \
+		bind-utils           \
+		gettext              \
+		git                  \
+		golang               \
+		# ip commands is used in set-to-ips-from-dns.sh
+		iproute              \
+		isomd5sum            \
+		jq                   \
+		libidn-devel         \
+		libpcap-devel        \
+		mkisofs              \
+		net-tools            \
+		nmap-ncat            \
+		openssl              \
+		perl-Crypt-ScryptKDF \
+		perl-Digest-SHA1     \
+		perl-JSON-PP         \
+		python3              \
+		# rsync is used to copy certs in "Shared SSL certificate generation" step
+		rsync;               \
+	dnf clean all
 
 EXPOSE 443
+
 WORKDIR /opt/traffic_ops/app
-ENV MOJO_MODE production
-ADD traffic_ops/profile.origin.traffic_ops /
-ADD traffic_ops/run.sh /
+ADD traffic_ops/install/bin/install_goose.sh ./
+RUN ./install_goose.sh && rm ./install_goose.sh && dnf -y remove git && dnf clean all
+
+# Override TRAFFIC_OPS_RPM arg to use a different one using --build-arg TRAFFIC_OPS_RPM=...  Can be local file or http://...
+#
+ARG TRAFFIC_OPS_RPM=traffic_ops_ort/testing/docker/traffic_ops/traffic_ops.rpm
+
+COPY $TRAFFIC_OPS_RPM /traffic_ops.rpm
+RUN yum -y install /traffic_ops.rpm && \
+	rm /traffic_ops.rpm
+
+ADD traffic_ops_ort/testing/docker/traffic_ops/run.sh /
+ADD traffic_ops_ort/testing/ort-tests /ort-tests 
+
+EXPOSE 443
 CMD /run.sh

--- a/traffic_ops_ort/testing/docker/traffic_ops/run.sh
+++ b/traffic_ops_ort/testing/docker/traffic_ops/run.sh
@@ -36,6 +36,9 @@
 # TO_DOMAIN
 # TRAFFIC_VAULT_PASS
 
+# make sure 'goose' is available 
+PATH=$PATH:/opt/traffic_ops/go/bin; export PATH
+
 # Check that env vars are set
 envvars=( DB_SERVER DB_PORT DB_ROOT_PASS DB_USER DB_USER_PASS TO_ADMIN_USER TO_ADMIN_PASS CERT_COUNTRY CERT_STATE CERT_CITY CERT_COMPANY TO_DOMAIN)
 for v in $envvars
@@ -44,203 +47,46 @@ do
 done
 
 start() {
-	service traffic_ops start
-	exec tail -f /var/log/traffic_ops/traffic_ops.log
+  traffic_ops_golang_command=(./bin/traffic_ops_golang -cfg "$CDNCONF" -dbcfg "$DATABASECONF" -riakcfg "$RIAKCONF");
+  "${traffic_ops_golang_command[@]}" &
+	exec tail -f $TO_LOG
 }
 
+install_go() {
+  if [ -f /GO_VERSION ]; then
+    go_version=$(cat /GO_VERSION) && \
+      curl -Lo go.tar.gz https://dl.google.com/go/go${go_version}.linux-amd64.tar.gz && \
+      tar -C /usr/local -xvzf go.tar.gz && rm go.tar.gz
+  else
+    echo "no GO_VERSION file, unable to install go"
+    exit 1
+  fi
+}
+
+# generates and saves SSL certificates, database and RIAK config files.
 init() {
-	local postinstall_input_file="postinstall-input.json"
-	cat > "$postinstall_input_file" <<- ENDOFMESSAGE
-{
-  "/opt/traffic_ops/app/conf/production/database.conf":[
-    {
-      "Database type":"Pg",
-      "config_var":"type"
-    },
-    {
-      "Database name":"$DB_NAME",
-      "config_var":"dbname"
-    },
-    {
-      "Database server hostname IP or FQDN":"$DB_SERVER",
-      "config_var":"hostname"
-    },
-    {
-      "Database port number":"$DB_PORT",
-      "config_var":"port"
-    },
-    {
-      "Traffic Ops database user":"$DB_USER",
-      "config_var":"user"
-    },
-    {
-      "Traffic Ops database password":"$DB_USER_PASS",
-      "config_var":"password",
-      "hidden":"1"
-    }
-  ],
-  "/opt/traffic_ops/app/db/dbconf.yml":[
-    {
-      "Database server root (admin) user":"postgres",
-      "config_var":"pgUser"
-    },
-    {
-      "Database server admin password":"$DB_ROOT_PASS",
-      "config_var":"pgPassword",
-      "hidden":"1"
-    },
-    {
-      "Download Maxmind Database?":"yes",
-      "config_var":"maxmind"
-    }
-  ],
-  "/opt/traffic_ops/app/conf/cdn.conf":[
-    {
-      "Generate a new secret?":"yes",
-      "config_var":"genSecret"
-    },
-    {
-      "Port to serve on?": "443",
-      "config_var": "port"
-    },
-    {
-      "Number of workers?": "12",
-      "config_var":"workers"
-    },
-    {
-      "Traffic Ops url?": "https://$TO_HOSTNAME",
-      "config_var": "base_url"
-    },
-    {
-      "Number of secrets to keep?":"1",
-      "config_var":"keepSecrets"
-    }
-  ],
-  "/opt/traffic_ops/app/conf/ldap.conf":[
-    {
-      "Do you want to set up LDAP?":"no",
-      "config_var":"setupLdap"
-    },
-    {
-      "LDAP server hostname":"",
-      "config_var":"host"
-    },
-    {
-      "LDAP Admin DN":"",
-      "config_var":"admin_dn"
-    },
-    {
-      "LDAP Admin Password":"",
-      "config_var":"admin_pass",
-      "hidden":"1"
-    },
-    {
-      "LDAP Search Base":"",
-      "config_var":"search_base"
-    }
-  ],
-  "/opt/traffic_ops/install/data/json/users.json":[
-    {
-      "Administration username for Traffic Ops":"$TO_ADMIN_USER",
-      "config_var":"tmAdminUser"
-    },
-    {
-      "Password for the admin user":"$TO_ADMIN_PASS",
-      "config_var":"tmAdminPw",
-      "hidden":"1"
-    }
-  ],
-  "/opt/traffic_ops/install/data/profiles/":[
-    {
-      "Add custom profiles?":"no",
-      "config_var":"custom_profiles"
-    }
-  ],
-  "/opt/traffic_ops/install/data/json/openssl_configuration.json":[
-    {
-      "Do you want to generate a certificate?":"yes",
-      "config_var":"genCert"
-    },
-    {
-      "Country Name (2 letter code)":"$CERT_COUNTRY",
-      "config_var":"country"
-    },
-    {
-      "State or Province Name (full name)":"$CERT_STATE",
-      "config_var":"state"
-    },
-    {
-      "Locality Name (eg, city)":"$CERT_CITY",
-      "config_var":"locality"
-    },
-    {
-      "Organization Name (eg, company)":"$CERT_COMPANY",
-      "config_var":"company"
-    },
-    {
-      "Organizational Unit Name (eg, section)":"",
-      "config_var":"org_unit"
-    },
-    {
-      "Common Name (eg, your name or your server's hostname)":"$TO_HOSTNAME",
-      "config_var":"common_name"
-    },
-    {
-      "RSA Passphrase":"passphrase",
-      "config_var":"rsaPassword",
-      "hidden":"1"
-    }
-  ],
-  "/opt/traffic_ops/install/data/json/profiles.json":[
-    {
-      "Traffic Ops url":"https://$TO_HOSTNAME",
-      "config_var":"tm.url"
-    },
-    {
-      "Human-readable CDN Name.  (No whitespace, please)":"cdn",
-      "config_var":"cdn_name"
-    },
-    {
-      "Health Polling Interval (milliseconds)":"8000",
-      "config_var":"health_polling_int"
-    },
-    {
-      "DNS sub-domain for which your CDN is authoritative":"$TO_HOSTNAME.$TO_DOMAIN",
-      "config_var":"dns_subdomain"
-    },
-    {
-      "TLD SOA admin":"traffic_ops",
-      "config_var":"soa_admin"
-    },
-    {
-      "TrafficServer Drive Prefix":"/dev/ram",
-      "config_var":"driver_prefix"
-    },
-    {
-      "TrafficServer RAM Drive Prefix":"/dev/ram",
-      "config_var":"ram_drive_prefix"
-    },
-    {
-      "TrafficServer RAM Drive Letters (comma separated)":"1",
-      "config_var":"ram_drive_letters"
-    },
-    {
-      "Health Threshold Load Average":"25",
-      "config_var":"health_thresh_load_avg"
-    },
-    {
-      "Health Threshold Available Bandwidth in Kbps":"1750000",
-      "config_var":"health_thresh_kbps"
-    },
-    {
-      "Traffic Server Health Connection Timeout (milliseconds)":"2000",
-      "config_var":"health_connect_timeout"
-    }
-  ]
-}
-ENDOFMESSAGE
+  # install certificates for TO
+  openssl req -newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key -x509 -days 365 \
+    -out /etc/pki/tls/certs/localhost.crt -subj "/C=$CERT_COUNTRY/ST=$CERT_STATE/L=$CERT_CITY/O=$CERT_COMPANY"
+  cp /etc/pki/tls/certs/localhost.crt /etc/pki/tls/certs/ca-bundle.crt
 
-cat > /opt/traffic_ops/app/conf/production/riak.conf << EOM
+  # update the base_url in cdn.conf
+  sed -i -e "s#http://localhost\:3000#http://${TO_HOSTNAME}\:443#" $CDNCONF
+	sed -i -e 's#https://\[::\]#https://127\.0\.0\.1#' $CDNCONF
+  #
+  cat > $DATABASECONF << EOM
+{
+  "type" : "Pg",
+  "description" : "Pg database on localhost:5432",
+  "port" : "$DB_PORT",
+  "dbname" : "$DB_NAME",
+  "password" : "$DB_USER_PASS",
+  "hostname" : "$DB_SERVER",
+  "user" : "$DB_USER"
+}
+EOM
+
+  cat > $RIAKCONF << EOM
 {
   "user": "riakuser",
   "password": "$RIAK_USER_PASS",
@@ -251,28 +97,42 @@ cat > /opt/traffic_ops/app/conf/production/riak.conf << EOM
 }
 EOM
 
-	# TODO determine if term, user are necessary
-	export TERM=xterm && export USER=root && /opt/traffic_ops/install/bin/postinstall -cfile "$postinstall_input_file"
+  cat > $DBCONF << EOM
+version: "1.0"
+name: dbconf.yml
 
-	# Only listen on IPv4, not IPv6, because Docker doesn't provide a v6 interface by default. See http://mojolicious.org/perldoc/Mojo/Server/Daemon#listen
-	sed -i -e 's#https://\[::\]#https://127\.0\.0\.1#' /opt/traffic_ops/app/conf/cdn.conf
-	service traffic_ops restart
+development:
+  driver: postgres
+  open: host=$DB_SERVER port=5432 user=traffic_ops password=$DB_USER_PASS dbname=to_development sslmode=disable
 
+test:
+  driver: postgres
+  open: host=$DB_SERVER port=5432 user=traffic_ops password=$DB_USER_PASS dbname=to_test sslmode=disable
+
+integration:
+  driver: postgres
+  open: host=$DB_SERVER port=5432 user=traffic_ops password=$DB_USER_PASS dbname=to_integration sslmode=disable
+
+production:
+  driver: postgres
+  open: host=$DB_SERVER port=5432 user=traffic_ops password=$DB_USER_PASS dbname=traffic_ops sslmode=disable
+EOM
+
+  touch $LOG_DEBUG $LOG_ERROR $LOG_EVENT $LOG_INFO $LOG_WARN $TO_LOG
 }
 
-if [ -f /GO_VERSION ]; then
-  go_version=$(cat /GO_VERSION) && \
-      curl -Lo go.tar.gz https://dl.google.com/go/go${go_version}.linux-amd64.tar.gz && \
-        tar -C /usr/local -xvzf go.tar.gz && \
-        ln -s /usr/local/go/bin/go /usr/bin/go && \
-        rm go.tar.gz
-else
-  echo "no GO_VERSION file, unable to install go"
-  exit 0
-fi
+# install the golang version indicated in '/GO_VERSION'
+# exits on error.
+install_go
+
+# installs goose, exits on error
 /opt/traffic_ops/install/bin/install_goose.sh
 
-(cd /opt/traffic_ops/app && db/admin --env=production reset)
 source /etc/environment
 if [ -z "$INITIALIZED" ]; then init; fi
+
+# create the 'traffic_ops' database, tables and runs migrations
+(cd /opt/traffic_ops/app && db/admin --env=production reset > /admin.log 2>&1)
+
+# start traffic_ops
 start

--- a/traffic_ops_ort/testing/docker/variables.env
+++ b/traffic_ops_ort/testing/docker/variables.env
@@ -15,10 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+CDNCONF=/opt/traffic_ops/app/conf/cdn.conf
 CERT_COUNTRY=US
 CERT_STATE=Colorado
 CERT_CITY=Denver
 CERT_COMPANY=NotComcast
+DBCONF=/opt/traffic_ops/app/db/dbconf.yml
+DATABASECONF=/opt/traffic_ops/app/conf/production/database.conf
 POSTGRES_HOME=/usr/pgsql-9.6
 PGPASSWORD=secretrootpass
 DB_NAME=traffic_ops
@@ -27,15 +30,24 @@ DB_ROOT_PASS=null
 DB_USER=traffic_ops
 DB_USER_PASS=twelve
 DB_SERVER=db
+LOG_DEBUG=/var/log/traffic_ops/debug.log
+LOG_ERROR=/var/log/traffic_ops/error.log
+LOG_EVENT=/var/log/traffic_ops/event.log
+LOG_INFO=/var/log/traffic_ops/info.log
+LOG_WARN=/var/log/traffic_ops/warn
 RIAK_USER_PASS=tvsecret
+RIAKCONF=/opt/traffic_ops/app/conf/production/riak.conf
 TO_ADMIN_USER=admin
 TO_ADMIN_PASS=twelve
 TO_HOSTNAME=to_server
+TO_LOG=/var/log/traffic_ops/traffic_ops.log
 TO_DOMAIN=trafficops_default
 TO_URI=https://to_server:443
 TV_ADMIN_USER=admin
 TV_ADMIN_PASSWORD=tvsecret
 TV_FQDN=localhost
+X509_CA_PERSIST_DIR=/ca
+X509_CA_PERSIST_ENV_FILE=/ca/environment
 TV_HTTPS_PORT=8088
 TV_RIAK_USER=riakuser
 TV_RIAK_PASSWORD=tvsecret


### PR DESCRIPTION
Fixes the ORT Integration tests TO docker container following the PERL codebase removals in traffic ops.

- [x] This PR fixes #9001 OR is not related to any Issue

Fixes an issue with the ORT integration testing Traffic Ops docker container.
No issue was created but I ran into the problem after rebasing and picking
up #5209 which removes the PERL codebase to traffic ops.

- Traffic Ops ORT
- CI tests

## What is the best way to verify this PR?

Run the ORT integration tests as outlined in traffic_ops_ort/testing/README.md

- master (1df853c8)

- [X] This PR includes tests OR I have explained why tests are unnecessary
- [X] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)



