### PR TITLE
Fixed GET /servercheck filtering for unknown and extra query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added an endpoint for statuses on asynchronous jobs and applied it to the ACME renewal endpoint.
 
 ### Fixed
+- [#5609](https://github.com/apache/trafficcontrol/issues/5609) - Fixed GET /servercheck filter for an extra query param.
 - [#5558](https://github.com/apache/trafficcontrol/issues/5558) - Fixed `TM UI` and `/api/cache-statuses` to report aggregate `bandwidth_kbps` correctly.
 - [#5288](https://github.com/apache/trafficcontrol/issues/5288) - Fixed the ability to create and update a server with MTU value >= 1280.
 - [#5445](https://github.com/apache/trafficcontrol/issues/5445) - When updating a registered user, ignore updates on registration_sent field.

--- a/traffic_ops/testing/api/v4/serverchecks_test.go
+++ b/traffic_ops/testing/api/v4/serverchecks_test.go
@@ -154,6 +154,21 @@ func GetTestServerChecksWithName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not GET serverchecks by name (%v): %v (alerts: %+v)", scResp[0].HostName, err, alerts)
 	}
+
+	//Add unknown param key
+	params.Add("foo", "car")
+	// Get server checks
+	resp, alerts, _, err := TOSession.GetServersChecks(params, nil)
+	if len(resp) == 0 {
+		t.Fatal("no server checks in response, quitting")
+	}
+	if err != nil {
+		t.Fatalf("could not GET serverchecks by name (%v): %v (alerts: %+v)", resp[0].HostName, err, alerts)
+	}
+
+	if len(scResp) != len(resp) {
+		t.Fatalf("expected: Both response lengths should be equal, got: first resp:%v-second resp:%v", len(scResp), len(resp))
+	}
 }
 
 func GetTestServerChecksWithID(t *testing.T) {
@@ -175,6 +190,21 @@ func GetTestServerChecksWithID(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("could not GET serverchecks by id (%v): %v (alerts: %+v)", scResp[0].ID, err, alerts)
+	}
+
+	//Add unknown param key
+	params.Add("foo", "car")
+	// Get server checks
+	resp, alerts, _, err := TOSession.GetServersChecks(params, nil)
+	if len(resp) == 0 {
+		t.Fatal("no server checks in response, quitting")
+	}
+	if err != nil {
+		t.Fatalf("could not GET serverchecks by name (%v): %v (alerts: %+v)", resp[0].HostName, err, alerts)
+	}
+
+	if len(scResp) != len(resp) {
+		t.Fatalf("expected: Both response lengths should be equal, got: first resp:%v-second resp:%v", len(scResp), len(resp))
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -270,6 +270,12 @@ func handleReadServerCheck(inf *api.APIInfo, tx *sql.Tx) ([]tc.GenericServerChec
 		if ok && ok1 {
 			whereSI = "WHERE (type.name LIKE 'MID%' OR type.name LIKE 'EDGE%') AND (server.host_name=:hostName AND server.id=:id)"
 			whereSC = "WHERE servercheck.server=:id"
+		} else if ok && !ok1 {
+			whereSI = "WHERE (type.name LIKE 'MID%' OR type.name LIKE 'EDGE%') AND server.id=:id "
+			whereSC = "WHERE servercheck.server=:id"
+		} else if ok1 && !ok {
+			whereSI = "WHERE (type.name LIKE 'MID%' OR type.name LIKE 'EDGE%') AND server.host_name=:hostName "
+			whereSC = ""
 		} else {
 			whereSI = "WHERE type.name LIKE 'MID%' OR type.name LIKE 'EDGE%' "
 			whereSC = ""


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5609 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run API tests or curl for GET /servercheck for different query (known and unknown) param (like id, hostName, foo, blah, cdn etc)

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master (038a439)
- 5.0.0


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->
No documentation change required since no new query params were added.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
