### PR TITLE
Fix ORT TO minor fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue with 2020082700000000_server_id_primary_key.sql trying to create multiple primary keys when there are multiple schemas.
 - Fix for public schema in 2020062923101648_add_deleted_tables.sql
 - Fix for config gen missing max_origin_connections on mids in certain scenarios
+- [#5642](https://github.com/apache/trafficcontrol/issues/5642) - Fixed ORT to fall back to previous minor Traffic Ops versions, allowing ORT to be upgraded before Traffic Ops when the minor has changed.
 - Moved move_lets_encrypt_to_acme.sql, add_max_request_header_size_delivery_service.sql, and server_interface_ip_address_cascade.sql past last migration in 5.0.0
 - [#5505](https://github.com/apache/trafficcontrol/issues/5505) - Make `parent_reval_pending` for servers in a Flexible Topology CDN-specific on `GET /servers/{name}/update_status`
 - [#5317](https://github.com/apache/trafficcontrol/issues/5317) - Clicking IP addresses in the servers table no longer navigates to server details page.

--- a/traffic_ops_ort/atstccfg/toreqold/client.go
+++ b/traffic_ops_ort/atstccfg/toreqold/client.go
@@ -47,13 +47,17 @@ const isFallback = true
 func New(url *url.URL, user string, pass string, insecure bool, timeout time.Duration, userAgent string) (*TOClient, error) {
 	log.Infoln("URL: '" + url.String() + "' User: '" + user + "' Pass len: '" + strconv.Itoa(len(pass)) + "'")
 
-	toFQDN := url.Scheme + "://" + url.Host
-	log.Infoln("TO FQDN: '" + toFQDN + "'")
+	toURLStr := url.Scheme + "://" + url.Host
+	log.Infoln("TO URL string: '" + toURLStr + "'")
 	log.Infoln("TO URL: '" + url.String() + "'")
 
-	toClient, toIP, err := toclient.LoginWithAgent(toFQDN, user, pass, insecure, userAgent, false, timeout)
+	opts := toclient.ClientOpts{}
+	opts.Insecure = insecure
+	opts.UserAgent = userAgent
+	opts.RequestTimeout = timeout
+	toClient, inf, err := toclient.Login(toURLStr, user, pass, opts)
 	if err != nil {
-		return nil, errors.New("Logging in to Traffic Ops '" + torequtil.MaybeIPStr(toIP) + "': " + err.Error())
+		return nil, errors.New("Logging in to Traffic Ops '" + torequtil.MaybeIPStr(inf.RemoteAddr) + "': " + err.Error())
 	}
 
 	return &TOClient{C: toClient}, nil


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Fixes ORT to fall back to previous Traffic Ops minor versions. This is necessary to make it possible to upgrade ORT before Traffic Ops.

We don't have a test framework capable of testing multiple TO versions yet. But the existing tests test the current version and validate it still works correctly.
Includes changelog.
No docs, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit and integration tests, to verify the latest version still works.
Run ORT against the previous TO which doesn't have the latest minor, verify it still has features in the current major.

## If this is a bug fix, what versions of Traffic Control are affected?
This has been a bug since ORT started using the TO client, around 3.0.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information