### PR TITLE
Add ORT ATS9 ip_allow.yaml generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Ops API version 4.0
 - `GET` request method for `/deliveryservices/{{ID}}/assign`
 - `GET` request method for `/deliveryservices/{{ID}}/status`
-- Atscfg: Added a rule to ip_allow such that PURGE requests are allowed over localhost 
+- [#5644](https://github.com/apache/trafficcontrol/issues/5644) ORT config generation: Added ATS9 ip_allow.yaml support, and automatic generation if the server's package Parameter is 9.*
+- ORT config generation: Added a rule to ip_allow such that PURGE requests are allowed over localhost
 
 ### Fixed
 - [#5609](https://github.com/apache/trafficcontrol/issues/5609) - Fixed GET /servercheck filter for an extra query param.

--- a/lib/go-atscfg/ipallowdotyaml.go
+++ b/lib/go-atscfg/ipallowdotyaml.go
@@ -1,0 +1,365 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+const IPAllowYamlFileName = `ip_allow.yaml`
+const ContentTypeIPAllowDotYAML = "application/yaml; charset=us-ascii" // Note YAML has no IANA standard mime type. This is one of several common usages, and is likely to be the standardized value. If you're reading this, please check IANA to see if YAML has been added, and change this to the IANA definition if so. Also note we include 'charset=us-ascii' because YAML is commonly UTF-8, but ATS is likely to be unable to handle UTF.
+const LineCommentIPAllowDotYAML = LineCommentHash
+
+// const ParamPurgeAllowIP = "purge_allow_ip"
+// const ParamCoalesceMaskLenV4 = "coalesce_masklen_v4"
+// const ParamCoalesceNumberV4 = "coalesce_number_v4"
+// const ParamCoalesceMaskLenV6 = "coalesce_masklen_v6"
+// const ParamCoalesceNumberV6 = "coalesce_number_v6"
+
+// const DefaultCoalesceMaskLenV4 = 24
+// const DefaultCoalesceNumberV4 = 5
+// const DefaultCoalesceMaskLenV6 = 48
+// const DefaultCoalesceNumberV6 = 5
+
+const MethodPush = `PUSH`
+const MethodPurge = `PURGE`
+
+// MakeIPAllowDotYAML creates the ip_allow.yaml ATS 9+ config file.
+func MakeIPAllowDotYAML(
+	serverParams []tc.Parameter,
+	server *Server,
+	servers []Server,
+	cacheGroups []tc.CacheGroupNullable,
+	topologies []tc.Topology,
+	hdrComment string,
+) (Cfg, error) {
+	warnings := []string{}
+
+	if server.Cachegroup == nil {
+		return Cfg{}, makeErr(warnings, "this server missing Cachegroup")
+	}
+	if server.HostName == nil {
+		return Cfg{}, makeErr(warnings, "this server missing HostName")
+	}
+
+	params := paramsToMultiMap(filterParams(serverParams, IPAllowConfigFileName, "", "", ""))
+
+	ipAllowDat := []ipAllowYAMLData{}
+	const ActionAllow = "allow"
+	const ActionDeny = "deny"
+	const MethodAll = "ALL"
+
+	// localhost is trusted.
+	ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+		Src:     `127.0.0.1`,
+		Action:  ActionAllow,
+		Methods: []string{MethodAll},
+	})
+	ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+		Src:     `::1`,
+		Action:  ActionAllow,
+		Methods: []string{MethodAll},
+	})
+
+	// default for coalesce_ipv4 = 24, 5 and for ipv6 48, 5; override with the parameters in the server profile.
+	coalesceMaskLenV4 := DefaultCoalesceMaskLenV4
+	coalesceNumberV4 := DefaultCoalesceNumberV4
+	coalesceMaskLenV6 := DefaultCoalesceMaskLenV6
+	coalesceNumberV6 := DefaultCoalesceNumberV6
+
+	for name, vals := range params {
+		for _, val := range vals {
+			switch name {
+			case "purge_allow_ip":
+				ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+					Src:     val,
+					Action:  ActionAllow,
+					Methods: []string{MethodAll},
+				})
+			case ParamCoalesceMaskLenV4:
+				if vi, err := strconv.Atoi(val); err != nil {
+					warnings = append(warnings, "got param '"+name+"' val '"+val+"' not a number, ignoring!")
+				} else if coalesceMaskLenV4 != DefaultCoalesceMaskLenV4 {
+					warnings = append(warnings, "got multiple param '"+name+"' - ignoring  val '"+val+"'!")
+				} else {
+					coalesceMaskLenV4 = vi
+				}
+			case ParamCoalesceNumberV4:
+				if vi, err := strconv.Atoi(val); err != nil {
+					warnings = append(warnings, "got param '"+name+"' val '"+val+"' not a number, ignoring!")
+				} else if coalesceNumberV4 != DefaultCoalesceNumberV4 {
+					warnings = append(warnings, "got multiple param '"+name+"' - ignoring  val '"+val+"'!")
+				} else {
+					coalesceNumberV4 = vi
+				}
+			case ParamCoalesceMaskLenV6:
+				if vi, err := strconv.Atoi(val); err != nil {
+					warnings = append(warnings, "got param '"+name+"' val '"+val+"' not a number, ignoring!")
+				} else if coalesceMaskLenV6 != DefaultCoalesceMaskLenV6 {
+					warnings = append(warnings, "got multiple param '"+name+"' - ignoring  val '"+val+"'!")
+				} else {
+					coalesceMaskLenV6 = vi
+				}
+			case ParamCoalesceNumberV6:
+				if vi, err := strconv.Atoi(val); err != nil {
+					warnings = append(warnings, "got param '"+name+"' val '"+val+"' not a number, ignoring!")
+				} else if coalesceNumberV6 != DefaultCoalesceNumberV6 {
+					warnings = append(warnings, "got multiple param '"+name+"' - ignoring  val '"+val+"'!")
+				} else {
+					coalesceNumberV6 = vi
+				}
+			}
+		}
+	}
+
+	// for edges deny "PUSH|PURGE|DELETE", allow everything else to everyone.
+	isMid := strings.HasPrefix(server.Type, tc.MidTypePrefix)
+	if !isMid {
+		ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+			Src:     `0.0.0.0/0`,
+			Action:  ActionDeny,
+			Methods: []string{MethodPush, MethodPurge, http.MethodDelete},
+		})
+		ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+			Src:     `::/0`,
+			Action:  ActionDeny,
+			Methods: []string{MethodPush, MethodPurge, http.MethodDelete},
+		})
+	} else {
+
+		ips := []*net.IPNet{}
+		ip6s := []*net.IPNet{}
+
+		cgMap := map[string]tc.CacheGroupNullable{}
+		for _, cg := range cacheGroups {
+			if cg.Name == nil {
+				return Cfg{}, makeErr(warnings, "got cachegroup with nil name!")
+			}
+			cgMap[*cg.Name] = cg
+		}
+
+		if server.Cachegroup == nil {
+			return Cfg{}, makeErr(warnings, "server had nil Cachegroup!")
+		}
+
+		serverCG, ok := cgMap[*server.Cachegroup]
+		if !ok {
+			return Cfg{}, makeErr(warnings, "server cachegroup not in cachegroups!")
+		}
+
+		childCGNames := getTopologyDirectChildren(tc.CacheGroupName(*server.Cachegroup), topologies)
+
+		childCGs := map[string]tc.CacheGroupNullable{}
+		for cgName, _ := range childCGNames {
+			childCGs[string(cgName)] = cgMap[string(cgName)]
+		}
+
+		for cgName, cg := range cgMap {
+			if (cg.ParentName != nil && *cg.ParentName == *serverCG.Name) || (cg.SecondaryParentName != nil && *cg.SecondaryParentName == *serverCG.Name) {
+				childCGs[cgName] = cg
+			}
+		}
+
+		// sort servers, to guarantee things like IP coalescing are deterministic
+		sort.Sort(serversSortByName(servers))
+		for _, childServer := range servers {
+			if childServer.Cachegroup == nil {
+				warnings = append(warnings, "Servers had server with nil Cachegroup, skipping!")
+				continue
+			} else if childServer.HostName == nil {
+				warnings = append(warnings, "Servers had server with nil HostName, skipping!")
+				continue
+			}
+
+			// We need to add IPs to the allow of
+			// - all children of this server
+			// - all monitors, if this server is a Mid
+			//
+			_, isChild := childCGs[*childServer.Cachegroup]
+			if !isChild && (!strings.HasPrefix(server.Type, tc.MidTypePrefix) || (string(childServer.Type) != tc.MonitorTypeName)) {
+				continue
+			}
+
+			for _, svInterface := range childServer.Interfaces {
+				for _, svAddr := range svInterface.IPAddresses {
+					if ip := net.ParseIP(svAddr.Address); ip != nil {
+						// got an IP - convert it to a CIDR and add it to the list
+						if ip4 := ip.To4(); ip4 != nil {
+							ips = append(ips, util.IPToCIDR(ip4))
+						} else {
+							ip6s = append(ip6s, util.IPToCIDR(ip))
+						}
+					} else {
+						// not an IP, try a CIDR
+						if ip, cidr, err := net.ParseCIDR(svAddr.Address); err != nil {
+							// not a CIDR or IP - error out
+							warnings = append(warnings, "server '"+*server.HostName+"' IP '"+svAddr.Address+" is not an IP address or CIDR - skipping!")
+						} else if ip == nil {
+							// not a CIDR or IP - error out
+							warnings = append(warnings, "server '"+*server.HostName+"' IP '"+svAddr.Address+" failed to parse as IP or CIDR - skipping!")
+						} else {
+							// got a valid CIDR - add it to the list
+							if ip4 := ip.To4(); ip4 != nil {
+								ips = append(ips, cidr)
+							} else {
+								ip6s = append(ip6s, cidr)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		cidrs := util.CoalesceCIDRs(ips, coalesceNumberV4, coalesceMaskLenV4)
+		cidr6s := util.CoalesceCIDRs(ip6s, coalesceNumberV6, coalesceMaskLenV6)
+
+		for _, cidr := range cidrs {
+			ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+				Src:     cidr.String(),
+				Action:  ActionAllow,
+				Methods: []string{MethodAll},
+			})
+		}
+		for _, cidr := range cidr6s {
+			ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+				Src:     cidr.String(),
+				Action:  ActionAllow,
+				Methods: []string{MethodAll},
+			})
+		}
+
+		// allow RFC 1918 server space - TODO JvD: parameterize
+		ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+			Src:     `10.0.0.0/8`,
+			Action:  ActionAllow,
+			Methods: []string{MethodAll},
+		})
+		ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+			Src:     `172.16.0.0/12`,
+			Action:  ActionAllow,
+			Methods: []string{MethodAll},
+		})
+		ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+			Src:     `192.168.0.0/16`,
+			Action:  ActionAllow,
+			Methods: []string{MethodAll},
+		})
+
+		// order matters, so sort before adding the denys
+		sort.Sort(ipAllowYAMLDatas(ipAllowDat))
+
+		// start with a deny for PUSH and PURGE - TODO CDL: parameterize
+		// but leave purge open through localhost
+		if isMid { // Edges already deny PUSH and PURGE
+			ipAllowDat = append([]ipAllowYAMLData{
+				{
+					Src:     `127.0.0.1`,
+					Action:  ActionAllow,
+					Methods: []string{MethodPurge},
+				},
+				{
+					Src:     `::1`,
+					Action:  ActionAllow,
+					Methods: []string{MethodPurge},
+				},
+				{
+					Src:     `0.0.0.0/0`,
+					Action:  ActionDeny,
+					Methods: []string{MethodPush, MethodPurge},
+				},
+				{
+					Src:     `::/0`,
+					Action:  ActionDeny,
+					Methods: []string{MethodPush, MethodPurge},
+				},
+			}, ipAllowDat...)
+		}
+
+		// end with a deny
+		ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+			Src:     `0.0.0.0/0`,
+			Action:  ActionDeny,
+			Methods: []string{MethodAll},
+		})
+		ipAllowDat = append(ipAllowDat, ipAllowYAMLData{
+			Src:     `::/0`,
+			Action:  ActionDeny,
+			Methods: []string{MethodAll},
+		})
+	}
+
+	text := makeHdrComment(hdrComment)
+	text += `
+ip_allow:`
+	for _, al := range ipAllowDat {
+		text += `
+  - apply: in
+    ip_addrs: ` + al.Src + `
+    action: ` + al.Action + `
+    methods:`
+		for _, method := range al.Methods {
+			text += `
+      - ` + method
+		}
+	}
+	text += "\n"
+
+	return Cfg{
+		Text:        text,
+		ContentType: ContentTypeHostingDotConfig,
+		LineComment: LineCommentHostingDotConfig,
+		Warnings:    warnings,
+	}, nil
+}
+
+type ipAllowYAMLData struct {
+	Src     string
+	Action  string
+	Methods []string
+}
+
+type ipAllowYAMLDatas []ipAllowYAMLData
+
+func (is ipAllowYAMLDatas) Len() int      { return len(is) }
+func (is ipAllowYAMLDatas) Swap(i, j int) { is[i], is[j] = is[j], is[i] }
+func (is ipAllowYAMLDatas) Less(i, j int) bool {
+	if is[i].Src != is[j].Src {
+		return is[i].Src < is[j].Src
+	}
+	if is[i].Action != is[j].Action {
+		return is[i].Action < is[j].Action
+	}
+	if len(is[i].Methods) < len(is[j].Methods) {
+		return true
+	}
+	for mi := 0; mi < len(is[i].Methods); mi++ {
+		if is[i].Methods[mi] != is[j].Methods[mi] {
+			return is[i].Methods[mi] < is[j].Methods[mi]
+		}
+	}
+	return false
+}

--- a/lib/go-atscfg/ipallowdotyaml_test.go
+++ b/lib/go-atscfg/ipallowdotyaml_test.go
@@ -1,0 +1,431 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+func TestMakeIPAllowDotYAML(t *testing.T) {
+	hdr := "myHeaderComment"
+
+	params := makeParamsFromMapArr("serverProfile", IPAllowConfigFileName, map[string][]string{
+		"purge_allow_ip":       []string{"192.168.2.99"},
+		ParamCoalesceMaskLenV4: []string{"24"},
+		ParamCoalesceNumberV4:  []string{"3"},
+		ParamCoalesceMaskLenV6: []string{"48"},
+		ParamCoalesceNumberV6:  []string{"4"},
+	})
+
+	svs := []Server{
+		*makeIPAllowChild("child0", "192.168.2.1", "2001:DB8:1::1/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child1", "192.168.2.100/30", "2001:DB8:2::1/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child2", "192.168.2.150", "", tc.MonitorTypeName),
+		*makeIPAllowChild("child3", "", "2001:DB8:2::2/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child4", "", "192.168.2.155/32", tc.MonitorTypeName),
+		*makeIPAllowChild("child5", "", "2001:DB8:3::1", tc.MonitorTypeName),
+		*makeIPAllowChild("child6", "", "2001:DB8:2::3", tc.MonitorTypeName),
+		*makeIPAllowChild("child7", "", "2001:DB8:2::4", tc.MonitorTypeName),
+		*makeIPAllowChild("child8", "", "2001:DB8:2::5/64", tc.MonitorTypeName),
+	}
+
+	expecteds := []string{
+		"127.0.0.1",
+		"::1",
+		"0.0.0.0/0",
+		"::/0",
+		"172.16.0.0/12",
+		"10.0.0.0/8",
+		"2001:db8:3::1",
+		"192.168.2.0/24",
+		"192.168.2.99",
+		"2001:db8:1::/64",
+		"2001:db8:2::/48",
+	}
+
+	cgs := []tc.CacheGroupNullable{
+		tc.CacheGroupNullable{
+			Name: util.StrPtr("cg0"),
+		},
+	}
+
+	sv := &Server{}
+	sv.HostName = util.StrPtr("server0")
+	sv.Type = string(tc.CacheTypeMid)
+	sv.Cachegroup = cgs[0].Name
+	svs = append(svs, *sv)
+
+	topologies := []tc.Topology{}
+
+	cfg, err := MakeIPAllowDotYAML(params, sv, svs, cgs, topologies, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	lines := strings.Split(txt, "\n")
+
+	if len(lines) == 0 {
+		t.Fatalf("expected: lines actual: no lines\n")
+	}
+
+	commentLine := lines[0]
+	commentLine = strings.TrimSpace(commentLine)
+	if !strings.HasPrefix(commentLine, "#") {
+		t.Errorf("expected: comment line starting with '#', actual: '%v'\n", commentLine)
+	}
+	if !strings.Contains(commentLine, hdr) {
+		t.Errorf("expected: comment line containing header comment '%v', actual: '%v'\n", hdr, commentLine)
+	}
+
+	lines = lines[1:] // remove comment line
+
+	/* Test that PUSH and PURGE are denied ere the allowance of anything else. */
+	{
+		ip4deny := false
+		ip6deny := false
+	eachLine:
+		for i, line := range lines {
+			if strings.Contains(line, `0.0.0.0/0`) && strings.Contains(lines[i+1], `deny`) && strings.Contains(lines[i+3], `PUSH`) && strings.Contains(lines[i+4], `PURGE`) {
+				ip4deny = true
+				continue
+			}
+
+			if strings.Contains(line, `::/0`) && strings.Contains(lines[i+1], `deny`) && strings.Contains(lines[i+3], `PUSH`) && strings.Contains(lines[i+4], `PURGE`) {
+				ip6deny = true
+				continue
+			}
+
+			if strings.Contains(line, `: allow`) && !(strings.Contains(lines[i-1], `127.0.0.1`) || strings.Contains(lines[i-1], `::1`)) {
+				if !(ip4deny && ip6deny) {
+					t.Errorf("Expected denies for PUSH and PURGE before any ips are allowed; pre-denial allowance on line %d: '%v' v4 %v v6 %v text %v", i+1, line, ip4deny, ip6deny, txt)
+				}
+				break eachLine
+			}
+
+		}
+	}
+
+	for _, expected := range expecteds {
+		if !strings.Contains(txt, expected) {
+			t.Errorf("expected %+v actual '%v'\n", expected, txt)
+		}
+	}
+}
+
+func TestMakeIPAllowDotYAMLEdge(t *testing.T) {
+	hdr := "myHeaderComment"
+
+	params := makeParamsFromMapArr("serverProfile", IPAllowConfigFileName, map[string][]string{
+		ParamCoalesceMaskLenV4: []string{"24"},
+		ParamCoalesceNumberV4:  []string{"3"},
+		ParamCoalesceMaskLenV6: []string{"48"},
+		ParamCoalesceNumberV6:  []string{"4"},
+	})
+
+	svs := []Server{
+		*makeIPAllowChild("child0", "192.168.2.1", "2001:DB8:1::1/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child1", "192.168.2.100/30", "2001:DB8:2::1/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child2", "192.168.2.150", "", tc.MonitorTypeName),
+		*makeIPAllowChild("child3", "", "2001:DB8:2::2/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child4", "", "192.168.2.155/32", tc.MonitorTypeName),
+		*makeIPAllowChild("child5", "", "2001:DB8:3::1", tc.MonitorTypeName),
+		*makeIPAllowChild("child6", "", "2001:DB8:2::3", tc.MonitorTypeName),
+		*makeIPAllowChild("child7", "", "2001:DB8:2::4", tc.MonitorTypeName),
+		*makeIPAllowChild("child8", "", "2001:DB8:2::5/64", tc.MonitorTypeName),
+	}
+
+	expecteds := []string{
+		"127.0.0.1",
+		"::1",
+		"0.0.0.0/0",
+		"::/0",
+	}
+
+	notExpecteds := []string{
+		"2001:db8",
+		"192.168.2",
+	}
+
+	cgs := []tc.CacheGroupNullable{
+		tc.CacheGroupNullable{
+			Name: util.StrPtr("cg0"),
+		},
+	}
+
+	sv := &Server{}
+	sv.HostName = util.StrPtr("server0")
+	sv.Type = string(tc.CacheTypeEdge)
+	sv.Cachegroup = cgs[0].Name
+	svs = append(svs, *sv)
+
+	topologies := []tc.Topology{}
+
+	cfg, err := MakeIPAllowDotYAML(params, sv, svs, cgs, topologies, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	lines := strings.Split(txt, "\n")
+
+	if len(lines) == 0 {
+		t.Fatalf("expected: lines actual: no lines\n")
+	}
+
+	commentLine := lines[0]
+	commentLine = strings.TrimSpace(commentLine)
+	if !strings.HasPrefix(commentLine, "#") {
+		t.Errorf("expected: comment line starting with '#', actual: '%v'\n", commentLine)
+	}
+	if !strings.Contains(commentLine, hdr) {
+		t.Errorf("expected: comment line containing header comment '%v', actual: '%v'\n", hdr, commentLine)
+	}
+
+	lines = lines[1:] // remove comment line
+
+	for _, expected := range expecteds {
+		if !strings.Contains(txt, expected) {
+			t.Errorf("expected %+v actual '%v'\n", expected, txt)
+		}
+	}
+
+	for _, notExpected := range notExpecteds {
+		if strings.Contains(txt, notExpected) {
+			t.Errorf("expected NOT %+v actual '%v'\n", notExpected, txt)
+		}
+	}
+}
+
+func TestMakeIPAllowDotYAMLNonDefaultV6Number(t *testing.T) {
+	hdr := "myHeaderComment"
+	params := makeParamsFromMapArr("serverProfile", IPAllowConfigFileName, map[string][]string{
+		"purge_allow_ip":       []string{"192.168.2.99"},
+		ParamCoalesceMaskLenV4: []string{"24"},
+		ParamCoalesceNumberV4:  []string{"3"},
+		ParamCoalesceMaskLenV6: []string{"48"},
+		ParamCoalesceNumberV6:  []string{"100"},
+	})
+
+	svs := []Server{
+		*makeIPAllowChild("child0", "192.168.2.1", "2001:DB8:1::1/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child1", "192.168.2.100/30", "2001:DB8:2::1/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child2", "192.168.2.150", "", tc.MonitorTypeName),
+		*makeIPAllowChild("child3", "", "2001:DB8:2::2/64", tc.MonitorTypeName),
+		*makeIPAllowChild("child4", "", "192.168.2.155/32", tc.MonitorTypeName),
+		*makeIPAllowChild("child5", "", "2001:DB8:3::1", tc.MonitorTypeName),
+		*makeIPAllowChild("child6", "", "2001:DB8:2::3", tc.MonitorTypeName),
+		*makeIPAllowChild("child7", "", "2001:DB8:2::4", tc.MonitorTypeName),
+		*makeIPAllowChild("child8", "", "2001:DB8:2::5/64", tc.MonitorTypeName),
+	}
+
+	expecteds := []string{
+		"127.0.0.1",
+		"::1",
+		"0.0.0.0/0",
+		"::/0",
+		"172.16.0.0/12",
+		"10.0.0.0/8",
+		"2001:db8:3::1",
+		"192.168.2.0/24",
+		"192.168.2.99",
+		"2001:db8:2::3",
+		"2001:db8:2::4",
+	}
+
+	cgs := []tc.CacheGroupNullable{
+		tc.CacheGroupNullable{
+			Name: util.StrPtr("cg0"),
+		},
+	}
+
+	sv := &Server{}
+	sv.HostName = util.StrPtr("server0")
+	sv.Type = string(tc.CacheTypeMid)
+	sv.Cachegroup = cgs[0].Name
+	svs = append(svs, *sv)
+
+	topologies := []tc.Topology{}
+
+	cfg, err := MakeIPAllowDotYAML(params, sv, svs, cgs, topologies, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	lines := strings.Split(txt, "\n")
+
+	if len(lines) == 0 {
+		t.Fatalf("expected: lines actual: no lines\n")
+	}
+
+	commentLine := lines[0]
+	commentLine = strings.TrimSpace(commentLine)
+	if !strings.HasPrefix(commentLine, "#") {
+		t.Errorf("expected: comment line starting with '#', actual: '%v'\n", commentLine)
+	}
+	if !strings.Contains(commentLine, hdr) {
+		t.Errorf("expected: comment line containing header comment '%v', actual: '%v'\n", hdr, commentLine)
+	}
+
+	lines = lines[1:] // remove comment line
+
+	for _, expected := range expecteds {
+		if !strings.Contains(txt, expected) {
+			t.Errorf("expected %+v actual '%v'\n", expected, txt)
+		}
+	}
+}
+
+func TestMakeIPAllowDotYAMLTopologies(t *testing.T) {
+	hdr := "myHeaderComment"
+
+	params := makeParamsFromMapArr("serverProfile", IPAllowConfigFileName, map[string][]string{
+		"purge_allow_ip":       []string{"192.168.2.99"},
+		ParamCoalesceMaskLenV4: []string{"24"},
+		ParamCoalesceNumberV4:  []string{"3"},
+		ParamCoalesceMaskLenV6: []string{"48"},
+		ParamCoalesceNumberV6:  []string{"4"},
+	})
+
+	// make children all MID types, because MIDs would never normally be parented to MIDs with pre-topologies
+	svs := []Server{
+		*makeIPAllowChild("child0", "192.168.2.1", "2001:DB8:1::1/64", tc.MidTypePrefix),
+		*makeIPAllowChild("child1", "192.168.2.100/30", "2001:DB8:2::1/64", tc.MidTypePrefix),
+		*makeIPAllowChild("child2", "192.168.2.150", "", tc.MidTypePrefix),
+		*makeIPAllowChild("child3", "", "2001:DB8:2::2/64", tc.MidTypePrefix),
+		*makeIPAllowChild("child4", "", "192.168.2.155/32", tc.MidTypePrefix),
+		*makeIPAllowChild("child5", "", "2001:DB8:3::1", tc.MidTypePrefix),
+		*makeIPAllowChild("child6", "", "2001:DB8:2::3", tc.MidTypePrefix),
+		*makeIPAllowChild("child7", "", "2001:DB8:2::4", tc.MidTypePrefix),
+		*makeIPAllowChild("child8", "", "2001:DB8:2::5/64", tc.MidTypePrefix),
+	}
+
+	expecteds := []string{
+		"127.0.0.1",
+		"::1",
+		"0.0.0.0/0",
+		"::/0",
+		"172.16.0.0/12",
+		"10.0.0.0/8",
+		"2001:db8:3::1",
+		"192.168.2.0/24",
+		"192.168.2.99",
+		"2001:db8:1::/64",
+		"2001:db8:2::/48",
+	}
+
+	cgs := []tc.CacheGroupNullable{
+		tc.CacheGroupNullable{
+			Name: util.StrPtr("midcg"),
+		},
+		tc.CacheGroupNullable{
+			Name: util.StrPtr("midcg2"),
+		},
+		tc.CacheGroupNullable{
+			Name: util.StrPtr("childcg"),
+		},
+	}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "childcg",
+					Parents:    []int{1, 2},
+				},
+				tc.TopologyNode{
+					Cachegroup: "midcg",
+				},
+				tc.TopologyNode{
+					Cachegroup: "midcg2",
+				},
+			},
+		},
+	}
+
+	sv := &Server{}
+	sv.HostName = util.StrPtr("server0")
+	sv.Type = string(tc.CacheTypeMid)
+	sv.Cachegroup = cgs[1].Name
+	svs = append(svs, *sv)
+
+	//	topologies := []tc.Topology{}
+
+	cfg, err := MakeIPAllowDotYAML(params, sv, svs, cgs, topologies, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	lines := strings.Split(txt, "\n")
+
+	if len(lines) == 0 {
+		t.Fatalf("expected: lines actual: no lines\n")
+	}
+
+	commentLine := lines[0]
+	commentLine = strings.TrimSpace(commentLine)
+	if !strings.HasPrefix(commentLine, "#") {
+		t.Errorf("expected: comment line starting with '#', actual: '%v'\n", commentLine)
+	}
+	if !strings.Contains(commentLine, hdr) {
+		t.Errorf("expected: comment line containing header comment '%v', actual: '%v'\n", hdr, commentLine)
+	}
+
+	lines = lines[1:] // remove comment line
+
+	/* Test that PUSH and PURGE are denied ere the allowance of anything else. */
+	{
+		ip4deny := false
+		ip6deny := false
+	eachLine:
+		for i, line := range lines {
+			if strings.Contains(line, `0.0.0.0/0`) && strings.Contains(lines[i+1], `deny`) && strings.Contains(lines[i+3], `PUSH`) && strings.Contains(lines[i+4], `PURGE`) {
+				ip4deny = true
+				continue
+			}
+
+			if strings.Contains(line, `::/0`) && strings.Contains(lines[i+1], `deny`) && strings.Contains(lines[i+3], `PUSH`) && strings.Contains(lines[i+4], `PURGE`) {
+				ip6deny = true
+				continue
+			}
+
+			if strings.Contains(line, `: allow`) && !(strings.Contains(lines[i-1], `127.0.0.1`) || strings.Contains(lines[i-1], `::1`)) {
+				if !(ip4deny && ip6deny) {
+					t.Errorf("Expected denies for PUSH and PURGE before any ips are allowed; pre-denial allowance on line %d: '%v' v4 %v v6 %v text %v", i+1, line, ip4deny, ip6deny, txt)
+				}
+				break eachLine
+			}
+
+		}
+	}
+
+	for _, expected := range expecteds {
+		if !strings.Contains(txt, expected) {
+			t.Errorf("expected %+v actual '%v'\n", expected, txt)
+		}
+	}
+}

--- a/traffic_ops_ort/atstccfg/cfgfile/routing.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/routing.go
@@ -85,6 +85,7 @@ var configFileLiteralFuncs = []ConfigFileLiteralFunc{
 	{"drop_qstring.config", MakeDropQStringDotConfig},
 	{"hosting.config", MakeHostingDotConfig},
 	{"ip_allow.config", MakeIPAllowDotConfig},
+	{"ip_allow.yaml", MakeIPAllowDotYAML},
 	{"logging.config", MakeLoggingDotConfig},
 	{"logging.yaml", MakeLoggingDotYAML},
 	{"logs_xml.config", MakeLogsXMLDotConfig},

--- a/traffic_ops_ort/atstccfg/cfgfile/wrappers.go
+++ b/traffic_ops_ort/atstccfg/cfgfile/wrappers.go
@@ -90,6 +90,17 @@ func MakeIPAllowDotConfig(toData *config.TOData, fileName string, hdrCommentTxt 
 	)
 }
 
+func MakeIPAllowDotYAML(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
+	return atscfg.MakeIPAllowDotYAML(
+		toData.ServerParams,
+		toData.Server,
+		toData.Servers,
+		toData.CacheGroups,
+		toData.Topologies,
+		hdrCommentTxt,
+	)
+}
+
 func MakeLoggingDotConfig(toData *config.TOData, fileName string, hdrCommentTxt string, cfg config.TCCfg) (atscfg.Cfg, error) {
 	return atscfg.MakeLoggingDotConfig(toData.Server, toData.ServerParams, hdrCommentTxt)
 }


### PR DESCRIPTION
This is required for ATS9 support. ATS 9 drops support for ip_allow.config.

Includes tests.
Includes changelog.
No docs, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests.
Change a server's package Parameter to `9.*` and run ORT. Verify ip_allow.yaml is generated correctly.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information