### PR TITLE
Add t3c git flag to track config changes in git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `GET` request method for `/deliveryservices/{{ID}}/status`
 - Atscfg: Added a rule to ip_allow such that PURGE requests are allowed over localhost
 - [#5644](https://github.com/apache/trafficcontrol/issues/5644) ORT config generation: Added ATS9 ip_allow.yaml support, and automatic generation if the server's package Parameter is 9.*
+- t3c: Added option to track config changes in git.
 - ORT config generation: Added a rule to ip_allow such that PURGE requests are allowed over localhost
 
 ### Fixed

--- a/traffic_ops_ort/build/traffic_ops_ort.spec
+++ b/traffic_ops_ort/build/traffic_ops_ort.spec
@@ -26,9 +26,9 @@ Source0:  traffic_ops_ort-%{version}.tgz
 URL:      https://github.com/apache/trafficcontrol/
 Vendor:   Apache Software Foundation
 Packager: dev at trafficcontrol dot Apache dot org
-%{?el6:Requires: perl-JSON, perl-libwww-perl, perl-Crypt-SSLeay, perl-Digest-SHA}
-%{?el7:Requires: perl-JSON, perl-libwww-perl, perl-Crypt-SSLeay, perl-LWP-Protocol-https, perl-Digest-SHA}
-%{?el8:Requires: perl-JSON, perl-libwww-perl, perl-Net-SSLeay, perl-LWP-Protocol-https, perl-Digest-SHA}
+%{?el6:Requires: git, perl-JSON, perl-libwww-perl, perl-Crypt-SSLeay, perl-Digest-SHA}
+%{?el7:Requires: git, perl-JSON, perl-libwww-perl, perl-Crypt-SSLeay, perl-LWP-Protocol-https, perl-Digest-SHA}
+%{?el8:Requires: git, perl-JSON, perl-libwww-perl, perl-Net-SSLeay, perl-LWP-Protocol-https, perl-Digest-SHA}
 
 
 %description

--- a/traffic_ops_ort/t3c/README.md
+++ b/traffic_ops_ort/t3c/README.md
@@ -33,6 +33,7 @@ long option                             | short | default | description
 --traffic-ops-user=[username]           | -U    | ""      | TrafficOps username. Required if not set with the environment variable TO_USER
 --trafficserver-home=[directory]        | -R    | ""      | Used to specify an alternate install location for ATS, otherwise its set from the RPM.
 --wait-for-parents=['true' or 'false']  | -W    | true    | do not update if parent_pending = 1 in the update json.
+--git=['yes' or 'no' or 'auto']         | -g    | auto    | track changes in git. If yes, create and commit to a repo. If auto, commit if a repo exists.
 
 # Modes
 

--- a/traffic_ops_ort/t3c/config/config.go
+++ b/traffic_ops_ort/t3c/config/config.go
@@ -110,6 +110,33 @@ type Cfg struct {
 	TOURL               string
 	WaitForParents      bool
 	YumOptions          string
+	// UseGit is whether to create and maintain a git repo of config changes.
+	// Note this only applies to the ATS config directory inferred or set via the flag.
+	//      It does not do anything for config files generated outside that location.
+	UseGit UseGitFlag
+}
+
+type UseGitFlag string
+
+const (
+	UseGitAuto    = "auto"
+	UseGitYes     = "yes"
+	UseGitNo      = "no"
+	UseGitInvalid = ""
+)
+
+func StrToUseGitFlag(str string) UseGitFlag {
+	str = strings.ToLower(strings.TrimSpace(str))
+	switch str {
+	case UseGitAuto:
+		fallthrough
+	case UseGitYes:
+		fallthrough
+	case UseGitNo:
+		return UseGitFlag(str)
+	default:
+		return UseGitInvalid
+	}
 }
 
 func (cfg Cfg) ErrorLog() log.LogLocation   { return log.LogLocation(cfg.LogLocationErr) }
@@ -186,6 +213,7 @@ func GetCfg() (Cfg, error) {
 	tsHomePtr := getopt.StringLong("trafficserver-home", 'R', "", "Trafficserver Package directory. May also be set with the environment variable TS_HOME")
 	waitForParentsPtr := getopt.BoolLong("wait-for-parents", 'W', "[true | false] do not update if parent_pending = 1 in the update json. default is false, wait for parents")
 	helpPtr := getopt.BoolLong("help", 'h', "Print usage information and exit")
+	useGitStr := getopt.StringLong("git", 'g', "auto", "Create and use a git repo in the config directory. Options are yes, no, and auto. If yes, create and use. If auto, use if it exist. Default is auto.")
 	getopt.Parse()
 
 	dispersion := time.Second * time.Duration(*dispersionPtr)
@@ -203,6 +231,12 @@ func GetCfg() (Cfg, error) {
 		if err != nil {
 			return Cfg{}, errors.New("Could not get the hostname from the O.S., please supply a hostname: " + err.Error())
 		}
+	}
+
+	useGit := StrToUseGitFlag(*useGitStr)
+
+	if useGit == UseGitInvalid {
+		return Cfg{}, errors.New("Invalid git flag '" + *useGitStr + "'. Valid options are yes, no, auto.")
 	}
 
 	retries := *retriesPtr
@@ -320,6 +354,7 @@ func GetCfg() (Cfg, error) {
 		TOURL:               toURL,
 		WaitForParents:      waitForParents,
 		YumOptions:          yumOptions,
+		UseGit:              useGit,
 	}
 
 	if err = log.InitCfg(cfg); err != nil {

--- a/traffic_ops_ort/t3c/util/gitutil.go
+++ b/traffic_ops_ort/t3c/util/gitutil.go
@@ -1,0 +1,187 @@
+package util
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/apache/trafficcontrol/traffic_ops_ort/t3c/config"
+)
+
+func EnsureConfigDirIsGitRepo(atsConfigDir string) error {
+	cmd := exec.Command("git", "status")
+	cmd.Dir = atsConfigDir
+
+	errPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return errors.New("getting stderr pipe for command: " + err.Error())
+	}
+
+	if err := cmd.Start(); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			// this means Go failed to run the command, not that the command returned an error.
+			return errors.New("git status returned: " + err.Error())
+		}
+	}
+
+	errOutput, err := ioutil.ReadAll(errPipe)
+	if err != nil {
+		return errors.New("reading stderr: " + err.Error())
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			// this means Go failed to run the command, not that the command returned an error.
+			return errors.New("waiting for git command: " + err.Error())
+		}
+	}
+
+	const GitNotARepoMsgPrefix = `fatal: not a git repository`
+
+	errOutput = bytes.ToLower(errOutput)
+	if !bytes.Contains(errOutput, []byte(GitNotARepoMsgPrefix)) {
+		return nil // it's already a git repo
+	}
+
+	if err := makeConfigDirGitRepo(atsConfigDir); err != nil {
+		return errors.New("making config dir '" + atsConfigDir + "' a git repo: " + err.Error())
+	}
+
+	return nil
+}
+
+func makeConfigDirGitRepo(atsConfigDir string) error {
+	cmd := exec.Command("git", "init")
+	cmd.Dir = atsConfigDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git init in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+	}
+
+	if err := makeConfigDirGitUser(atsConfigDir); err != nil {
+		return fmt.Errorf("git creating user in config dir '%v': %v", atsConfigDir, err)
+	}
+
+	if err := makeInitialGitCommit(atsConfigDir); err != nil {
+		return errors.New("creating initial git commit: " + err.Error())
+	}
+
+	if err := MakeGitCommitAll(atsConfigDir, GitChangeIsSelf, config.BadAss, true); err != nil {
+		return errors.New("creating first files git commit: " + err.Error())
+	}
+
+	return nil
+}
+
+const gitEmail = "traffic-control-cache-config@apache-traffic-control.invalid"
+const gitUser = "t3c"
+
+func makeConfigDirGitUser(atsConfigDir string) error {
+	{
+		cmd := exec.Command("git", "config", "user.email", gitEmail)
+		cmd.Dir = atsConfigDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git config user.email in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+		}
+	}
+	{
+		cmd := exec.Command("git", "config", "user.name", gitUser)
+		cmd.Dir = atsConfigDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git config user.email in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+		}
+	}
+	return nil
+}
+
+// makeInitialGitCommit makes the initial commit for a new git repo.
+// An initial empty commit is desirable, because the first commit is difficult to manipulate.
+func makeInitialGitCommit(atsConfigDir string) error {
+	// TODO git config author?
+
+	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "Initial commit")
+	cmd.Dir = atsConfigDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git initial commit error: in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+	}
+	return nil
+}
+
+const GitChangeIsSelf = true
+const GitChangeNotSelf = false
+
+// makeGitCommitAll makes a git commit of all changes in atsConfigDir, including untracked files.
+func MakeGitCommitAll(atsConfigDir string, self bool, mode config.Mode, success bool) error {
+	{
+		// if there are no changes, don't do anything
+		cmd := exec.Command("git", "status", "--porcelain")
+		cmd.Dir = atsConfigDir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git status error: in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+		}
+		if len(output) == 0 {
+			// no error and no output means there were zero changes, so just return
+			return nil
+		}
+	}
+
+	{
+		cmd := exec.Command("git", "add", "-A")
+		cmd.Dir = atsConfigDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git add error: in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+		}
+	}
+
+	now := time.Now() // TODO get a single consistent time when ORT starts?
+	msg := makeGitCommitMsg(now, self, mode, success)
+
+	{
+		cmd := exec.Command("git", "commit", "--message", msg)
+		cmd.Dir = atsConfigDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git commit error: in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+		}
+	}
+
+	return nil
+}
+
+func makeGitCommitMsg(now time.Time, self bool, mode config.Mode, success bool) string {
+	const appStr = "t3c"
+	selfStr := "other"
+	if self {
+		selfStr = "self"
+	}
+	timeStr := now.UTC().Format(time.RFC3339)
+	modeStr := strings.ToLower(mode.String())
+	successStr := "fail"
+	if success {
+		successStr = "success"
+	}
+	const sep = " "
+	return strings.Join([]string{appStr, selfStr, modeStr, successStr, timeStr}, sep)
+}

--- a/traffic_ops_ort/testing/ort-tests/t3c-git_test.go
+++ b/traffic_ops_ort/testing/ort-tests/t3c-git_test.go
@@ -1,0 +1,141 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/traffic_ops_ort/testing/ort-tests/tcdata"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/testing/ort-tests/util"
+)
+
+func TestT3cGit(t *testing.T) {
+	t.Logf("------------- Starting TestT3cGit ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		// run badass and check config files.
+		err := t3cUpdateGit("atlanta-edge-03", "badass")
+		if err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+		for _, v := range testFiles {
+			bfn := base_line_dir + "/" + v
+			if !util.FileExists(bfn) {
+				t.Fatalf("ERROR: missing baseline config file, %s,  needed for tests", bfn)
+			}
+			tfn := test_config_dir + "/" + v
+			if !util.FileExists(tfn) {
+				t.Fatalf("ERROR: missing the expected config file, %s", tfn)
+			}
+
+			result, err := util.DiffFiles(bfn, tfn)
+			if err != nil || !result {
+				t.Fatalf("ERROR: the contents of '%s' does not match those in %s",
+					tfn, bfn)
+			}
+		}
+
+		time.Sleep(time.Second * 5)
+
+		t.Logf("------------------------ running SYNCDS Test ------------------")
+		// remove the remap.config in preparation for running syncds
+		remap := test_config_dir + "/remap.config"
+		err = os.Remove(remap)
+		if err != nil {
+			t.Fatalf("ERROR: unable to remove %s\n", remap)
+		}
+		// prepare for running syncds.
+		err = setQueueUpdateStatus("atlanta-edge-03", "true")
+		if err != nil {
+			t.Fatalf("ERROR: queue updates failed: %v\n", err)
+		}
+
+		// remap.config is removed and atlanta-edge-03 should have
+		// queue updates enabled.  run t3c to verify a new remap.config
+		// is pulled down.
+		err = t3cUpdateGit("atlanta-edge-03", "syncds")
+		if err != nil {
+			t.Fatalf("ERROR: t3c syncds failed: %v\n", err)
+		}
+		if !util.FileExists(remap) {
+			t.Fatalf("ERROR: syncds failed to pull down %s\n", remap)
+		}
+		t.Logf("------------------------ end SYNCDS Test ------------------")
+
+		numCommits, err := gitNumCommits(test_config_dir)
+		if err != nil {
+			t.Errorf("ERROR: checking number of git commits: %v\n", err)
+		} else if numCommits != 3 { // expecting 3 commits: initial commit, startup commit of preexisting files, and the post-run commit
+			t.Errorf("ERROR: git commits expected %v actual %v\n", 3, numCommits)
+		}
+
+	})
+	t.Logf("------------- End of TestT3cGit ---------------")
+}
+
+func gitNumCommits(dir string) (int, error) {
+	cmd := exec.Command("git", "rev-list", "--count", "HEAD")
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("git error: in dir '%v' returned err %v msg '%v'", dir, err, string(output))
+	}
+	numChanges, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	if err != nil {
+		return 0, fmt.Errorf("git error: in dir '%v' expected number, but got '%v'", dir, string(output))
+	}
+	return numChanges, nil
+}
+
+func t3cUpdateGit(host string, run_mode string) error {
+	args := []string{
+		"--traffic-ops-insecure=true",
+		"--dispersion=0",
+		"--login-dispersion=0",
+		"--traffic-ops-timeout-milliseconds=3000",
+		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,
+		"--traffic-ops-password=" + tcd.Config.TrafficOps.UserPassword,
+		"--traffic-ops-url=" + tcd.Config.TrafficOps.URL,
+		"--cache-host-name=" + host,
+		"--log-location-error=test.log",
+		"--log-location-info=test.log",
+		"--log-location-debug=test.log",
+		"--run-mode=" + run_mode,
+		"--git=" + "yes",
+	}
+	cmd := exec.Command("/opt/ort/t3c", args...)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	if err != nil {
+		return errors.New(err.Error() + ": " + "stdout: " + out.String() + " stderr: " + errOut.String())
+	}
+	return nil
+}


### PR DESCRIPTION
Add t3c git flag to track config changes in git.

```
--git=['yes' or 'no' or 'auto']         | -g    | auto    | track changes in git. If yes, create and commit to a repo. If auto, commit if a repo exists.
```

Includes tests.
Includes docs.
Includes changelog.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT integration tests. 
Run t3c with `--git=yes`, observe git repo initialized and commited to. Run `t3c` few times with changes, observe changes being committed to repo.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information