### PR TITLE
Fix logrotate permissions for Traffic Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5363](https://github.com/apache/trafficcontrol/issues/5363) - Postgresql version changeable by env variable
 - [#5405](https://github.com/apache/trafficcontrol/issues/5405) - Prevent Tenant update from choosing child as new parent
 - [#5384](https://github.com/apache/trafficcontrol/issues/5384) - New grids will now properly remember the current page number.
+- Fixed Invalid TS logrotate configuration permissions causing TS logs to be ignored by logrotate.
 
 ### Changed
 - Updated the Traffic Ops Python client to 3.0

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -116,7 +116,7 @@ fi
 
 %config(noreplace) %attr(600, traffic_stats, traffic_stats) /opt/traffic_stats/conf/traffic_stats.cfg
 %config(noreplace) %attr(600, traffic_stats, traffic_stats) /opt/traffic_stats/conf/traffic_stats_seelog.xml
-%config(noreplace) /etc/logrotate.d/traffic_stats
+%config(noreplace) %attr(644, root, root) /etc/logrotate.d/traffic_stats
 
 %dir /opt/traffic_stats
 %dir /opt/traffic_stats/bin


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR is not related to any Issue 

## Which Traffic Control components are affected by this PR?

- Traffic Stats

## What is the best way to verify this PR?

Change the permissions for `/etc/logrotate.d/traffic_stats` and see if logrotate works correctly

## If this is a bug fix, what versions of Traffic Control are affected?

- master 
- 5.1.0

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [ ] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)



<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
