### PR TITLE
TM init.d script: Append to traffic_monitor.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5405](https://github.com/apache/trafficcontrol/issues/5405) - Prevent Tenant update from choosing child as new parent
 - [#5384](https://github.com/apache/trafficcontrol/issues/5384) - New grids will now properly remember the current page number.
 - Fixed Invalid TS logrotate configuration permissions causing TS logs to be ignored by logrotate.
+- [#5604](https://github.com/apache/trafficcontrol/issues/5604) - traffic_monitor.log is no longer truncated when restarting Traffic Monitor
 
 ### Changed
 - Updated the Traffic Ops Python client to 3.0

--- a/traffic_monitor/build/traffic_monitor.init
+++ b/traffic_monitor/build/traffic_monitor.init
@@ -63,7 +63,7 @@ start() {
 
         # Start daemons.
         echo -n $"Starting $name: "
-        daemon nohup $prog $options < /dev/null 2>&1 &
+        daemon nohup $prog $options < /dev/null &
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && touch $lockfile

--- a/traffic_monitor/build/traffic_monitor.init
+++ b/traffic_monitor/build/traffic_monitor.init
@@ -63,7 +63,7 @@ start() {
 
         # Start daemons.
         echo -n $"Starting $name: "
-        daemon nohup $prog $options < /dev/null > /opt/traffic_monitor/var/log/traffic_monitor.log 2>&1 &
+        daemon nohup $prog $options < /dev/null >> /opt/traffic_monitor/var/log/traffic_monitor.log 2>&1 &
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && touch $lockfile

--- a/traffic_monitor/build/traffic_monitor.init
+++ b/traffic_monitor/build/traffic_monitor.init
@@ -63,7 +63,7 @@ start() {
 
         # Start daemons.
         echo -n $"Starting $name: "
-        daemon nohup $prog $options < /dev/null >> /opt/traffic_monitor/var/log/traffic_monitor.log 2>&1 &
+        daemon nohup $prog $options < /dev/null 2>&1 &
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && touch $lockfile


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5604<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. In `variables.env`, set the `TM_LOG` environment variables so that Traffic Monitor logs to /opt/traffic_monitor/var/log/traffic_monitor.log:
   ```diff
   diff --git a/infrastructure/cdn-in-a-box/variables.env b/infrastructure/cdn-in-a-box/variables.env
   index d61703116b..391f1688ae 100644
   --- a/infrastructure/cdn-in-a-box/variables.env
   +++ b/infrastructure/cdn-in-a-box/variables.env
   @@ -64,11 +64,11 @@ TM_PORT=80
   TM_EMAIL=tmonitor@cdn.example.com
   TM_PASSWORD=jhdslvhdfsuklvfhsuvlhs
   TM_USER=tmon
   -TM_LOG_EVENT=stdout
   -TM_LOG_ERROR=stdout
   -TM_LOG_WARNING=stdout
   -TM_LOG_INFO=stdout
   -TM_LOG_DEBUG=stdout
   +TM_LOG_EVENT=/opt/traffic_monitor/var/log/event.log
   +TM_LOG_ERROR=/opt/traffic_monitor/var/log/traffic_monitor.log
   +TM_LOG_WARNING=/opt/traffic_monitor/var/log/traffic_monitor.log
   +TM_LOG_INFO=null
   +TM_LOG_DEBUG=null
   TO_ADMIN_PASSWORD=twelve12
   TO_ADMIN_USER=admin
   TO_ADMIN_FULL_NAME=James Cole
   ```
2. Start CDN in a Box
3. Compare the log's line count before and after restarting Traffic Monitor using the `traffic_monitor` init.d script:
   ```shell
   <<BASH_COMMANDS docker-compose exec -T trafficmonitor bash
      wc -l /opt/traffic_monitor/var/log/traffic_monitor.log &&
      source /etc/rc.d/init.d/functions traffic_monitor &&
      service traffic_monitor restart &&
      wc -l /opt/traffic_monitor/var/log/traffic_monitor.log
   BASH_COMMANDS
   ```
The second line count should be greater or equal to the first line count. Example of successful output:
```
6 /opt/traffic_monitor/var/log/traffic_monitor.log
Shutting down traffic_monitor:                             [  OK  ]
Starting traffic_monitor:
6 /opt/traffic_monitor/var/log/traffic_monitor.log
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (2a9229ed3d)
- 5.1.0
- 4.1.1

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] Change is to init.d script, no tests necessary beyond the one mentioned above
- [x] Bugfix, documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
