### PR TITLE
Add t3c dns-local-bind

### DIFF
--- a/traffic_ops_ort/t3c/README.md
+++ b/traffic_ops_ort/t3c/README.md
@@ -32,6 +32,7 @@ long option                             | short | default | description
 --traffic-ops-url=[url]                 | -u    | ""      | TrafficOps URL. Required if not set with the environment variable TO_URL
 --traffic-ops-user=[username]           | -U    | ""      | TrafficOps username. Required if not set with the environment variable TO_USER
 --trafficserver-home=[directory]        | -R    | ""      | Used to specify an alternate install location for ATS, otherwise its set from the RPM.
+--dns-local-bind=['true' or 'false']    | -b    | false   | set the ATS config to bind to the Server's Service Address in Traffic Ops for DNS.
 --wait-for-parents=['true' or 'false']  | -W    | true    | do not update if parent_pending = 1 in the update json.
 
 # Modes

--- a/traffic_ops_ort/t3c/config/config.go
+++ b/traffic_ops_ort/t3c/config/config.go
@@ -108,6 +108,7 @@ type Cfg struct {
 	TOUser              string
 	TOPass              string
 	TOURL               string
+	DNSLocalBind        bool
 	WaitForParents      bool
 	YumOptions          string
 }
@@ -185,6 +186,7 @@ func GetCfg() (Cfg, error) {
 	toPassPtr := getopt.StringLong("traffic-ops-password", 'P', "", "Traffic Ops password. Required. May also be set with the environment variable TO_PASS")
 	tsHomePtr := getopt.StringLong("trafficserver-home", 'R', "", "Trafficserver Package directory. May also be set with the environment variable TS_HOME")
 	waitForParentsPtr := getopt.BoolLong("wait-for-parents", 'W', "[true | false] do not update if parent_pending = 1 in the update json. default is false, wait for parents")
+	dnsLocalBindPtr := getopt.BoolLong("dns-local-bind", 'b', "[true | false] whether to use the server's Service Addresses to set the ATS DNS local bind address")
 	helpPtr := getopt.BoolLong("help", 'h', "Print usage information and exit")
 	getopt.Parse()
 
@@ -215,6 +217,7 @@ func GetCfg() (Cfg, error) {
 	toUser := *toUserPtr
 	toPass := *toPassPtr
 	waitForParents := *waitForParentsPtr
+	dnsLocalBind := *dnsLocalBindPtr
 	help := *helpPtr
 
 	if help {
@@ -318,6 +321,7 @@ func GetCfg() (Cfg, error) {
 		TOUser:              toUser,
 		TOPass:              toPass,
 		TOURL:               toURL,
+		DNSLocalBind:        dnsLocalBind,
 		WaitForParents:      waitForParents,
 		YumOptions:          yumOptions,
 	}

--- a/traffic_ops_ort/t3c/torequest/torequest.go
+++ b/traffic_ops_ort/t3c/torequest/torequest.go
@@ -228,6 +228,10 @@ func (r *TrafficOpsReq) atsTcExecCommand(cmdstr string, queueState int, revalSta
 		args = append(args, "--traffic-ops-insecure")
 	}
 
+	if r.Cfg.DNSLocalBind {
+		args = append(args, "--dns-local-bind")
+	}
+
 	switch cmdstr {
 	case "chkconfig":
 		args = append(args, "--get-data=chkconfig")

--- a/traffic_ops_ort/testing/docker/ort_test/run.sh
+++ b/traffic_ops_ort/testing/docker/ort_test/run.sh
@@ -77,5 +77,4 @@ ping_to
 sleep 2
 
 (touch test.log && tail -f test.log)&
-go test -cfg=conf/docker-edge-cache.conf 2>&1 >> test.log
-
+go test -v -failfast -cfg=conf/docker-edge-cache.conf 2>&1 >> test.log

--- a/traffic_ops_ort/testing/ort-tests/t3c-dns-local-bind_test.go
+++ b/traffic_ops_ort/testing/ort-tests/t3c-dns-local-bind_test.go
@@ -1,0 +1,80 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"bytes"
+	"errors"
+	"github.com/apache/trafficcontrol/traffic_ops_ort/testing/ort-tests/tcdata"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestT3CDNSLocalBind(t *testing.T) {
+	t.Logf("------------- Starting TestT3CDNSLocalBind ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		err := t3cUpdateDNSLocalBind("atlanta-edge-03", "badass")
+		if err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+
+		recordsName := filepath.Join(test_config_dir, "records.config")
+		recordsDotConfig, err := ioutil.ReadFile(recordsName)
+		if err != nil {
+			t.Fatalf("reading %v: %v\n", recordsName, err)
+		}
+
+		if !bytes.Contains(recordsDotConfig, []byte("proxy.config.dns.local_ipv4")) {
+			t.Errorf("expected records.config to contain proxy.config.dns.local_ipv4, actual: '%v'\n", string(recordsDotConfig))
+		}
+	})
+	t.Logf("------------- End of TestT3CDNSLocalBind ---------------")
+}
+
+func t3cUpdateDNSLocalBind(host string, run_mode string) error {
+	args := []string{
+		"--traffic-ops-insecure=true",
+		"--dispersion=0",
+		"--login-dispersion=0",
+		"--traffic-ops-timeout-milliseconds=3000",
+		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,
+		"--traffic-ops-password=" + tcd.Config.TrafficOps.UserPassword,
+		"--traffic-ops-url=" + tcd.Config.TrafficOps.URL,
+		"--cache-host-name=" + host,
+		"--log-location-error=test.log",
+		"--log-location-info=test.log",
+		"--log-location-debug=test.log",
+		"--run-mode=" + run_mode,
+		"--dns-local-bind",
+	}
+	cmd := exec.Command("/opt/ort/t3c", args...)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	if err != nil {
+		return errors.New(err.Error() + ": " + "stdout: " + out.String() + " stderr: " + errOut.String())
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a t3c flag exposing the config gen dns-local-bind option, for setting the ATS DNS bind address to the server's Server Address in Traffic Ops. The option already existing in ort.pl, this adds it to t3c.

Includes tests.
Changelog already exists for the option.
Includes docs.

- [x] This PR is not related to any other Issue 

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT Integration Tests.
Run t3c with --dns-local-bind, verify dns.local_ipv* config is injected into records.config.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information