### PR TITLE
Fix atscfg Service Category Header to be Internal

### DIFF
--- a/lib/go-atscfg/headerrewritedotconfig.go
+++ b/lib/go-atscfg/headerrewritedotconfig.go
@@ -36,7 +36,9 @@ const HeaderRewriteMidPrefix = "hdr_rw_mid_"
 const ContentTypeHeaderRewriteDotConfig = ContentTypeTextASCII
 const LineCommentHeaderRewriteDotConfig = LineCommentHash
 
-const ServiceCategoryHeader = "CDN-SVC"
+// ServiceCategoryHeader is the internal service category header for logging the service category.
+// Note this is internal, and will never be set in an HTTP Request or Response by ATS.
+const ServiceCategoryHeader = "@CDN-SVC"
 
 const MaxOriginConnectionsNoMax = 0 // 0 indicates no limit on origin connections
 

--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -219,7 +219,7 @@ func addMetaObjConfigDir(
 				return nil, warnings, errors.New("getting topology placement: " + err.Error())
 			}
 			if placement.IsFirstCacheTier {
-				if ds.FirstHeaderRewrite != nil && *ds.FirstHeaderRewrite != "" || ds.MaxOriginConnections != nil {
+				if (ds.FirstHeaderRewrite != nil && *ds.FirstHeaderRewrite != "") || ds.MaxOriginConnections != nil || ds.ServiceCategory != nil {
 					fileName := FirstHeaderRewriteConfigFileName(*ds.XMLID)
 					if configFilesM, err = ensureConfigFile(configFilesM, fileName, configDir); err != nil {
 						warnings = append(warnings, "ensuring config file '"+fileName+"': "+err.Error())
@@ -227,7 +227,7 @@ func addMetaObjConfigDir(
 				}
 			}
 			if placement.IsInnerCacheTier {
-				if ds.InnerHeaderRewrite != nil && *ds.InnerHeaderRewrite != "" || ds.MaxOriginConnections != nil {
+				if (ds.InnerHeaderRewrite != nil && *ds.InnerHeaderRewrite != "") || ds.MaxOriginConnections != nil || ds.ServiceCategory != nil {
 					fileName := InnerHeaderRewriteConfigFileName(*ds.XMLID)
 					if configFilesM, err = ensureConfigFile(configFilesM, fileName, configDir); err != nil {
 						warnings = append(warnings, "ensuring config file '"+fileName+"': "+err.Error())
@@ -235,7 +235,7 @@ func addMetaObjConfigDir(
 				}
 			}
 			if placement.IsLastCacheTier {
-				if ds.LastHeaderRewrite != nil && *ds.LastHeaderRewrite != "" || ds.MaxOriginConnections != nil {
+				if (ds.LastHeaderRewrite != nil && *ds.LastHeaderRewrite != "") || ds.MaxOriginConnections != nil || ds.ServiceCategory != nil {
 					fileName := LastHeaderRewriteConfigFileName(*ds.XMLID)
 					if configFilesM, err = ensureConfigFile(configFilesM, fileName, configDir); err != nil {
 						warnings = append(warnings, "ensuring config file '"+fileName+"': "+err.Error())
@@ -243,7 +243,7 @@ func addMetaObjConfigDir(
 				}
 			}
 		} else if strings.HasPrefix(server.Type, tc.EdgeTypePrefix) {
-			if (ds.EdgeHeaderRewrite != nil || ds.MaxOriginConnections != nil) &&
+			if (ds.EdgeHeaderRewrite != nil || ds.MaxOriginConnections != nil || ds.ServiceCategory != nil) &&
 				strings.HasPrefix(server.Type, tc.EdgeTypePrefix) {
 				fileName := "hdr_rw_" + *ds.XMLID + ".config"
 				if configFilesM, err = ensureConfigFile(configFilesM, fileName, configDir); err != nil {
@@ -251,7 +251,7 @@ func addMetaObjConfigDir(
 				}
 			}
 		} else if strings.HasPrefix(server.Type, tc.MidTypePrefix) {
-			if (ds.MidHeaderRewrite != nil || ds.MaxOriginConnections != nil) &&
+			if (ds.MidHeaderRewrite != nil || ds.MaxOriginConnections != nil || ds.ServiceCategory != nil) &&
 				ds.Type != nil && ds.Type.UsesMidCache() &&
 				strings.HasPrefix(server.Type, tc.MidTypePrefix) {
 				fileName := "hdr_rw_mid_" + *ds.XMLID + ".config"

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -163,7 +163,7 @@ func getServerConfigRemapDotConfigForMid(
 				return "", warnings, err
 			}
 			midRemap += topoTxt
-		} else if ds.MidHeaderRewrite != nil && *ds.MidHeaderRewrite != "" {
+		} else if (ds.MidHeaderRewrite != nil && *ds.MidHeaderRewrite != "") || ds.MaxOriginConnections != nil || ds.ServiceCategory != nil {
 			midRemap += ` @plugin=header_rewrite.so @pparam=` + midHeaderRewriteConfigFileName(*ds.XMLID)
 		}
 
@@ -323,7 +323,7 @@ func buildEdgeRemapLine(
 			return "", warnings, err
 		}
 		text += topoTxt
-	} else if ds.EdgeHeaderRewrite != nil && *ds.EdgeHeaderRewrite != "" {
+	} else if (ds.EdgeHeaderRewrite != nil && *ds.EdgeHeaderRewrite != "") || ds.ServiceCategory != nil || ds.MaxOriginConnections != nil {
 		text += ` @plugin=header_rewrite.so @pparam=` + edgeHeaderRewriteConfigFileName(*ds.XMLID)
 	}
 
@@ -419,13 +419,13 @@ func makeDSTopologyHeaderRewriteTxt(ds DeliveryService, cg tc.CacheGroupName, to
 	}
 	txt := ""
 	const pluginTxt = ` @plugin=header_rewrite.so @pparam=`
-	if placement.IsFirstCacheTier && ds.FirstHeaderRewrite != nil && *ds.FirstHeaderRewrite != "" {
+	if placement.IsFirstCacheTier && ((ds.FirstHeaderRewrite != nil && *ds.FirstHeaderRewrite != "") || ds.ServiceCategory != nil) {
 		txt += pluginTxt + FirstHeaderRewriteConfigFileName(*ds.XMLID) + ` `
 	}
-	if placement.IsInnerCacheTier && ds.InnerHeaderRewrite != nil && *ds.InnerHeaderRewrite != "" {
+	if placement.IsInnerCacheTier && ((ds.InnerHeaderRewrite != nil && *ds.InnerHeaderRewrite != "") || ds.ServiceCategory != nil) {
 		txt += pluginTxt + InnerHeaderRewriteConfigFileName(*ds.XMLID) + ` `
 	}
-	if placement.IsLastCacheTier && ds.LastHeaderRewrite != nil && *ds.LastHeaderRewrite != "" {
+	if placement.IsLastCacheTier && ((ds.LastHeaderRewrite != nil && *ds.LastHeaderRewrite != "") || ds.ServiceCategory != nil || ds.MaxOriginConnections != nil) {
 		txt += pluginTxt + LastHeaderRewriteConfigFileName(*ds.XMLID) + ` `
 	}
 	return txt, nil


### PR DESCRIPTION
Fixes the TC Service Category header to be internal to ATS, and not sent by ATS in HTTP requests or responses.

Docs already exist for Service Category.
No changelog, no interface change.
Tested by existing Service Category Header Rewrite tests. I also manually tested, verified the `@` header is not sent by ATS, and verified the header rewrite is created for both Edges and Mids.

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests.
Generate config, verify header rewrites are prefixed with `@` to make them internal to ATS. Run ATS, verify header writes are not passed upstream or downstream and are logged if an appropriate `svc=%<{@CDN_SVC}cqh>` log field exists.

## If this is a bug fix, what versions of Traffic Control are affected?
`master`

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information