### PR TITLE
Fix TODB tests when providing initial DB dump to test with

### DIFF
--- a/traffic_ops_db/test/docker/initdb.d/90-load-dumps.sh
+++ b/traffic_ops_db/test/docker/initdb.d/90-load-dumps.sh
@@ -23,7 +23,7 @@ set -ex
 d=/docker-entrypoint-initdb.d
 for dump in "$d"/*dump; do
     [[ -f $dump ]] || break
-    t=$(mktemp XXX.sql)
+    t=$(mktemp -p /tmp XXX.sql)
     # convert to sql -- can't load a dump until db initialized,  but sql works
     echo "Restoring from $dump"
     pg_restore -f "$t" $dump

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -122,6 +122,6 @@ fi
 # test full restoration of the initial DB dump
 for d in $(get_db_dumps); do
     echo "testing restoration of DB dump: $d"
-    pg_restore --verbose --clean --if-exists --create -h $DB_SERVER -p $DB_PORT -U postgres < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
+    pg_restore --verbose --clean --if-exists --create -h $DB_SERVER -p $DB_PORT -U postgres -d traffic_ops < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
 done
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Fixes a new issue w/ the TODB tests when providing an initial database dump file. This test feature was accidentally broken in the conversion to postgres 13.2: https://github.com/apache/trafficcontrol/pull/5630

## Which Traffic Control components are affected by this PR?
- Traffic Ops DB tests

## What is the best way to verify this PR?
NOTE: the TODB postgres version that produces the TO DB dump should be 13.2. If it's 9.6, the test will fail because you can't restore a 9.6 DB dump into a 13.2 DB. If you use CIAB to get the TO dbdump, it should work, since CIAB now uses 13.2.
```
cd traffic_ops_db/test/docker
# get a DB dump from TO via /api/3.0/dbdump, put the dump file in ./initdb.d/
docker-compose build
docker-compose up --exit-code-from trafficops-db-admin
```

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] test fix, no docs necessary
- [x] unreleased bug, no changelog necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
