### PR TITLE
Support testing PostgreSQL 9.6 dumps under PostgreSQL 13

### DIFF
--- a/traffic_ops_db/test/docker/Dockerfile-db
+++ b/traffic_ops_db/test/docker/Dockerfile-db
@@ -19,7 +19,10 @@
 # Dockerfile for trafficops db
 ############################################################
 
-FROM postgres:13.2
+ARG POSTGRES_VERSION=13.2
+FROM postgres:${POSTGRES_VERSION}
+ARG POSTGRES_VERSION=13.2
+ENV POSTGRES_VERSION=$POSTGRES_VERSION
 
 ENV POSTGRES_PASSWORD=twelve
 ENV POSTGRES_DB=traffic_ops

--- a/traffic_ops_db/test/docker/Dockerfile-db-admin
+++ b/traffic_ops_db/test/docker/Dockerfile-db-admin
@@ -19,8 +19,9 @@
 # Dockerfile to build Traffic Ops DB admin test environment
 ############################################################
 
-
 FROM centos:7
+ARG POSTGRES_VERSION=13.2
+ENV POSTGRES_VERSION=$POSTGRES_VERSION
 
 # NOTE: temporary workaround for removal of golang packages from CentOS 7 base repo
 RUN yum install -y \

--- a/traffic_ops_db/test/docker/docker-compose.yml
+++ b/traffic_ops_db/test/docker/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-db
+      args:
+        POSTGRES_VERSION: ${POSTGRES_VERSION:-13.2}
     ports:
       - 5432
 
@@ -40,7 +42,9 @@ services:
       context: .
       dockerfile: Dockerfile-db-admin
       args:
+        POSTGRES_VERSION: ${POSTGRES_VERSION:-13.2}
         TRAFFIC_OPS_RPM: traffic_ops.rpm
     depends_on:
       - db
+
     image: trafficops-db-admin

--- a/traffic_ops_db/test/docker/goose-config.sh
+++ b/traffic_ops_db/test/docker/goose-config.sh
@@ -22,7 +22,7 @@
 envvars=( DB_SERVER DB_PORT DB_USER DB_USER_PASS DB_NAME )
 for v in $envvars
 do
-	if [[ -z $$v ]]; then echo "$v is unset"; exit 1; fi
+	if [[ -z "${!v}" ]]; then echo "$v is unset"; exit 1; fi
 done
 
 cat <<-EOF >/opt/traffic_ops/app/db/dbconf.yml

--- a/traffic_ops_db/test/docker/initdb.d/90-load-dumps.sh
+++ b/traffic_ops_db/test/docker/initdb.d/90-load-dumps.sh
@@ -22,10 +22,10 @@ set -ex
 
 d=/docker-entrypoint-initdb.d
 for dump in "$d"/*dump; do
-    [[ -f $dump ]] || break
+    [[ -f "$dump" ]] || break
     t=$(mktemp -p /tmp XXX.sql)
     # convert to sql -- can't load a dump until db initialized,  but sql works
     echo "Restoring from $dump"
-    pg_restore -f "$t" $dump
+    pg_restore -f "$t" "$dump"
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$DB_NAME" <"$t"
 done

--- a/traffic_ops_db/test/docker/initdb.d/90-load-dumps.sh
+++ b/traffic_ops_db/test/docker/initdb.d/90-load-dumps.sh
@@ -27,5 +27,6 @@ for dump in "$d"/*dump; do
     # convert to sql -- can't load a dump until db initialized,  but sql works
     echo "Restoring from $dump"
     pg_restore -f "$t" "$dump"
+    sed -i '/^CREATE SCHEMA public;$/d' "$t"
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$DB_NAME" <"$t"
 done

--- a/traffic_ops_db/test/docker/initdb.d/90-load-dumps.sh
+++ b/traffic_ops_db/test/docker/initdb.d/90-load-dumps.sh
@@ -27,6 +27,8 @@ for dump in "$d"/*dump; do
     # convert to sql -- can't load a dump until db initialized,  but sql works
     echo "Restoring from $dump"
     pg_restore -f "$t" "$dump"
-    sed -i '/^CREATE SCHEMA public;$/d' "$t"
+    if [[ "${POSTGRES_VERSION%%.*}" -gt 10 ]]; then
+      sed -i '/^CREATE SCHEMA public;$/d' "$t"
+    fi
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$DB_NAME" <"$t"
 done

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -128,6 +128,6 @@ for d in $(get_db_dumps); do
     echo "testing restoration of DB dump: $d"
     dropdb --echo --if-exists < "$d" > /dev/null || echo "Dropping DB ${DB_NAME} failed: $d"
     createdb --echo < "$d" > /dev/null || echo "Creating DB ${DB_NAME} failed: $d"
-    pg_restore --verbose --clean --if-exists -d "$DB_NAME" < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
+    pg_restore --verbose --clean --if-exists --exit-on-error -d "$DB_NAME" < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
 done
 

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -122,6 +122,8 @@ fi
 # test full restoration of the initial DB dump
 for d in $(get_db_dumps); do
     echo "testing restoration of DB dump: $d"
-    pg_restore --verbose --clean --if-exists --create -h "$DB_SERVER" -p "$DB_PORT" -U postgres -d traffic_ops < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
+    dropdb --echo --if-exists -h "$DB_SERVER" -p "$DB_PORT" -U postgres "$DB_NAME" < "$d" > /dev/null || echo "Dropping DB ${DB_NAME} failed: $d"
+    createdb --echo -h "$DB_SERVER" -p $DB_PORT -U postgres "$DB_NAME" < "$d" > /dev/null || echo "Creating DB ${DB_NAME} failed: $d"
+    pg_restore --verbose --clean --if-exists -h "$DB_SERVER" -p "$DB_PORT" -U postgres -d traffic_ops < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
 done
 

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -32,9 +32,12 @@ if [[ ! -r /goose-config.sh ]]; then
 fi
 . /goose-config.sh
 
-pg_isready=$(rpm -ql postgresql13 | grep bin/pg_isready)
+postgresql_package="$(<<<"postgresql${POSTGRES_VERSION}" sed 's/\.//g' |
+	sed -E 's/([0-9]{2})[0-9]+/\1/g'
+)"
+pg_isready=$(rpm -ql "$postgresql_package" | grep bin/pg_isready)
 if [[ ! -x "$pg_isready" ]] ; then
-    echo "Can't find pg_ready in postgresql13"
+    echo "Can't find pg_ready in ${postgresql_package}"
     exit 1
 fi
 

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -33,19 +33,19 @@ fi
 . /goose-config.sh
 
 pg_isready=$(rpm -ql postgresql13 | grep bin/pg_isready)
-if [[ ! -x $pg_isready ]] ; then
+if [[ ! -x "$pg_isready" ]] ; then
     echo "Can't find pg_ready in postgresql13"
     exit 1
 fi
 
-while ! $pg_isready -h$DB_SERVER -p$DB_PORT -d $DB_NAME; do
+while ! $pg_isready -h"$DB_SERVER" -p"$DB_PORT" -d "$DB_NAME"; do
         echo "waiting for db on $DB_SERVER $DB_PORT"
         sleep 3
 done
 
-echo "*:*:*:postgres:$DB_USER_PASS" > $HOME/.pgpass
-echo "*:*:*:traffic_ops:$DB_USER_PASS" >> $HOME/.pgpass
-chmod 0600 $HOME/.pgpass
+echo "*:*:*:postgres:$DB_USER_PASS" > "${HOME}/.pgpass"
+echo "*:*:*:traffic_ops:$DB_USER_PASS" >> "${HOME}/.pgpass"
+chmod 0600 "${HOME}/.pgpass"
 
 export TO_DIR=/opt/traffic_ops/app
 
@@ -76,7 +76,7 @@ for d in $(get_db_dumps); do
     pg_restore -l "$d" > /dev/null || { echo "invalid DB dump: $d. Unable to list contents"; exit 1; }
 done
 
-cd $TO_DIR
+cd "$TO_DIR"
 db_is_empty=false
 old_db_version=$(get_current_db_version)
 [[ "$old_db_version" =~ ^failed ]] && { echo "get_current_db_version failed: $old_db_version"; exit 1; }
@@ -122,6 +122,6 @@ fi
 # test full restoration of the initial DB dump
 for d in $(get_db_dumps); do
     echo "testing restoration of DB dump: $d"
-    pg_restore --verbose --clean --if-exists --create -h $DB_SERVER -p $DB_PORT -U postgres -d traffic_ops < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
+    pg_restore --verbose --clean --if-exists --create -h "$DB_SERVER" -p "$DB_PORT" -U postgres -d traffic_ops < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
 done
 

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -20,9 +20,10 @@
 #
 DB_SERVER=db
 DB_PORT=5432
-DB_USER=traffic_ops
+DB_USER=postgres
 DB_USER_PASS=twelve
 DB_NAME=traffic_ops
+export PGHOST="$DB_SERVER" PGPORT="$DB_PORT" PGUSER="$DB_USER" PGDATABASE="$DB_NAME"
 
 # Write config files
 set -x
@@ -125,8 +126,8 @@ fi
 # test full restoration of the initial DB dump
 for d in $(get_db_dumps); do
     echo "testing restoration of DB dump: $d"
-    dropdb --echo --if-exists -h "$DB_SERVER" -p "$DB_PORT" -U postgres "$DB_NAME" < "$d" > /dev/null || echo "Dropping DB ${DB_NAME} failed: $d"
-    createdb --echo -h "$DB_SERVER" -p $DB_PORT -U postgres "$DB_NAME" < "$d" > /dev/null || echo "Creating DB ${DB_NAME} failed: $d"
-    pg_restore --verbose --clean --if-exists -h "$DB_SERVER" -p "$DB_PORT" -U postgres -d traffic_ops < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
+    dropdb --echo --if-exists < "$d" > /dev/null || echo "Dropping DB ${DB_NAME} failed: $d"
+    createdb --echo < "$d" > /dev/null || echo "Creating DB ${DB_NAME} failed: $d"
+    pg_restore --verbose --clean --if-exists -d "$DB_NAME" < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
 done
 


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- Allows the Traffic Ops DB tests to run on an initial database dump provided from `pg_dump` 9.6, since the repo is at PostgreSQL 13 as of #5630
- Lets the TODB use a dump with spaces in its filename
- Adds the `POSTGRES_VERSION` build arg in case someone wants to test different PostgreSQL versions
- - [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->
- Traffic Ops DB tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Build CDN in a Box at [`36a47e9~`](https://github.com/apache/trafficcontrol/commit/36a47e9a39~) and start it
2. Dump the database using `GET /api/4.0/dbdump`, store the result in `traffic_ops_db/test/docker/initdb.d/`
3. Build and run `traffic_ops_db/test/docker/`

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
 - master (bd9e54eb4a)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] Fixes tests, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

