### PR TITLE
Convert deprecated LDAP key `hostname` to `host`

### DIFF
--- a/infrastructure/ansible/roles/traffic_ops/templates/postinstall.input.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/postinstall.input.j2
@@ -37,7 +37,7 @@
     },
     {
       "LDAP server hostname": "{{ to_ldap_hostname }}",
-      "config_var": "hostname"
+      "config_var": "host"
     },
     {
       "LDAP Admin DN": "{{ to_ldap_admin_dn }}",

--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -398,6 +398,11 @@ def generate_ldap_conf(questions, fname, automatic, root): # type: (list[Questio
 		if key not in ldap_conf:
 			raise ValueError("{key} is a required key in {fname}".format(key=key, fname=fname))
 
+	keys_converted = {'password': 'admin_pass', 'hostname': 'host'}
+	for deprecated, key in keys_converted.items():
+		if deprecated in ldap_conf and ldap_conf[key] == '':
+			ldap_conf[key] = ldap_conf[deprecated]
+
 	if not re.match(r"^\S+:\d+$", ldap_conf["host"]):
 		raise ValueError("host in {fname} must be of form 'hostname:port'".format(fname=fname))
 

--- a/traffic_ops/install/bin/postinstall.test.sh
+++ b/traffic_ops/install/bin/postinstall.test.sh
@@ -205,42 +205,42 @@ cat <<- EOF > "$ROOT_DIR/defaults.json"
 	],
 	"/opt/traffic_ops/app/conf/ldap.conf": [
 		{
-			"Do you want to set up LDAP?": "no",
+			"Do you want to set up LDAP?": "yes",
 			"config_var": "setupLdap",
 			"hidden": false
 		},
 		{
-			"LDAP server hostname": "",
+			"LDAP server hostname": "ldaps://ad.cdn.site:3269",
 			"config_var": "host",
 			"hidden": false
 		},
 		{
-			"LDAP Admin DN": "",
+			"LDAP Admin DN": "contact@cdn.site",
 			"config_var": "admin_dn",
 			"hidden": false
 		},
 		{
-			"LDAP Admin Password": "",
+			"LDAP Admin Password": "${TO_PASSWORD}",
 			"config_var": "admin_pass",
 			"hidden": true
 		},
 		{
-			"LDAP Search Base": "",
+			"LDAP Search Base": "dc=cdn,dc=site",
 			"config_var": "search_base",
 			"hidden": false
 		},
 		{
-			"LDAP Search Query": "",
+			"LDAP Search Query": "(&(objectCategory=person)(objectClass=user)(sAMAccountName=%s))",
 			"config_var": "search_query",
 			"hidden": false
 		},
 		{
-			"LDAP Skip TLS verify": "",
+			"LDAP Skip TLS verify": "True",
 			"config_var": "insecure",
 			"hidden": false
 		},
 		{
-			"LDAP Timeout Seconds": "",
+			"LDAP Timeout Seconds": "120",
 			"config_var": "ldap_timeout_secs",
 			"hidden": false
 		}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
This PR
- Changes the name of the `hostname` ldap.conf Postinstall input file config var to `host`
- Supports deprecated ldap.conf Postinstall input file config var names (No other config files have deprecated keys)
  This is necessary because the Perl Postinstall script did it:
  https://github.com/apache/trafficcontrol/blob/9eda0980a46de78f9b7aceb20f0870c95e821dd5/traffic_ops/install/bin/_postinstall.pl#L257-L258

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops - Postinstall script
- Ansible roles

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
- Run the Postinstall unit tests
- Ensure that the *CDN-in-a-Box CI* workflow exits successfully, which indicates that Postinstall succeeded

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (9eda0980a4)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] Bugfix, no documentation necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
