### PR TITLE
Remove atscfg debug message

### DIFF
--- a/lib/go-atscfg/headerrewritedotconfig.go
+++ b/lib/go-atscfg/headerrewritedotconfig.go
@@ -21,7 +21,6 @@ package atscfg
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"net/url"
 	"regexp"
@@ -167,16 +166,6 @@ func MakeHeaderRewriteDotConfig(
 	}
 
 	text := makeHdrComment(hdrComment)
-
-	hdrRwTxtStr := ""
-	if headerRewriteTxt != nil {
-		hdrRwTxtStr = *headerRewriteTxt
-	}
-	maxConns := 0
-	if ds.MaxOriginConnections != nil {
-		maxConns = *ds.MaxOriginConnections
-	}
-	warnings = append(warnings, fmt.Sprintf("DEBUG ds '"+*ds.XMLID+"' headerRewriteTxt '''%v''' serverIsLastTier %v numLastTierServers %v atsMajorVersion %v maxConns %v", hdrRwTxtStr, serverIsLastTier, numLastTierServers, atsMajorVersion, maxConns))
 
 	// Add the TC directives (which may be empty).
 	// NOTE!! Custom TC injections MUST NOT EVER have a `[L]`. Doing so will break custom header rewrites!


### PR DESCRIPTION
Removes an atscfg debug message accidentally left in.

tests exist for config gen and log messages aren't tested.
No docs, no interface change.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT, verify debug message isn't printed.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
