### PR TITLE
Change lib/go-log to escape newlines

### DIFF
--- a/lib/go-log/log.go
+++ b/lib/go-log/log.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -76,14 +77,14 @@ func logf(logger *log.Logger, format string, v ...interface{}) {
 	if logger == nil {
 		return
 	}
-	logger.Output(stackFrame, time.Now().UTC().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
+	logger.Output(stackFrame, time.Now().UTC().Format(timeFormat)+": "+strings.Replace(strings.TrimSpace(fmt.Sprintf(format, v...)), "\n", `\n`, -1)+"\n")
 }
 
 func logln(logger *log.Logger, v ...interface{}) {
 	if logger == nil {
 		return
 	}
-	logger.Output(stackFrame, time.Now().UTC().Format(timeFormat)+": "+fmt.Sprintln(v...))
+	logger.Output(stackFrame, time.Now().UTC().Format(timeFormat)+": "+strings.Replace(strings.TrimSpace(fmt.Sprintln(v...)), "\n", `\n`, -1)+"\n")
 }
 
 const timeFormat = time.RFC3339Nano

--- a/lib/go-log/log_test.go
+++ b/lib/go-log/log_test.go
@@ -42,3 +42,15 @@ func TestUTC(t *testing.T) {
 		t.Errorf("expected UTC time, actual '" + actual + "'")
 	}
 }
+
+func TestNewlinesSingleLogLine(t *testing.T) {
+	buf := &bytes.Buffer{}
+	Init(nil, writeCloser{buf}, nil, nil, nil)
+	// Have to concatenate, because Go doesn't allow you to test multiple trailing newline behavior.
+	Errorln("foo\n\nbar\n" + "\n" + "\n")
+	actual := buf.String()
+
+	if !strings.HasSuffix(actual, `Z: foo\n\nbar`+"\n") {
+		t.Errorf("expected message with newlines to be a single log line, with interior newlines escaped and trailing newlines trimmed, actual '" + actual + "'")
+	}
+}


### PR DESCRIPTION
Changes lib/go-log to escape newlines in the message. 

This is intended to make log parsing easier. It's currently difficult or impossible for loggers to parse messages across multiple lines. Traffic Control logs should generally not be multiple lines, but this guarantees it for log parsers.

Includes tests.
No docs, the exact log format isn't documented.
No changelog, no interface change.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
This is a library. So theoretically everything. But nothing should be logging newlines anyway.

## What is the best way to verify this PR?
Run unit tests.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
