### PR TITLE
Separate Makefile targets for relative and absolute RPM paths

### DIFF
--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -27,8 +27,9 @@ else
 	RHEL_VERSION := $(shell echo $(RHEL_VERSION) | cut -f1 -d.)
 endif
 
-CIAB_DIR := $(realpath $(dir $(MAKEFILE_LIST)))
-TC_DIR := $(shell cd "$(CIAB_DIR)/../.." && pwd -P)
+CIAB_DIR_RELATIVE := $(dir $(MAKEFILE_LIST))
+CIAB_DIR_ABSOLUTE := $(shell cd $(CIAB_DIR_RELATIVE) && pwd)
+TC_DIR := $(CIAB_DIR_RELATIVE)../..
 
 PKG_COMMAND := $(TC_DIR)/pkg
 PKG_FLAGS := -v -$(RHEL_VERSION)
@@ -50,13 +51,29 @@ TP_SOURCE := $(wildcard $(TC_DIR)/traffic_portal/**)
 TR_SOURCE := $(wildcard $(TC_DIR)/traffic_router/**)
 TS_SOURCE := $(wildcard $(TC_DIR)/traffic_stats/**)
 
-TM_RPM := $(CIAB_DIR)/traffic_monitor/traffic_monitor.rpm
-TO_RPM := $(CIAB_DIR)/traffic_ops/traffic_ops.rpm
-TP_RPM := $(CIAB_DIR)/traffic_portal/traffic_portal.rpm
-TR_RPM := $(CIAB_DIR)/traffic_router/traffic_router.rpm
-TOMCAT_RPM := $(CIAB_DIR)/traffic_router/tomcat.rpm
-TS_RPM := $(CIAB_DIR)/traffic_stats/traffic_stats.rpm
-ORT_RPM := $(CIAB_DIR)/cache/traffic_ops_ort.rpm
+TM_RPM := traffic_monitor/traffic_monitor.rpm
+TO_RPM := traffic_ops/traffic_ops.rpm
+TP_RPM := traffic_portal/traffic_portal.rpm
+TR_RPM := traffic_router/traffic_router.rpm
+TOMCAT_RPM := traffic_router/tomcat.rpm
+TS_RPM := traffic_stats/traffic_stats.rpm
+ORT_RPM := cache/traffic_ops_ort.rpm
+
+TM_RPM_RELATIVE := $(CIAB_DIR_RELATIVE)$(TM_RPM)
+TO_RPM_RELATIVE := $(CIAB_DIR_RELATIVE)$(TO_RPM)
+TP_RPM_RELATIVE := $(CIAB_DIR_RELATIVE)$(TP_RPM)
+TR_RPM_RELATIVE := $(CIAB_DIR_RELATIVE)$(TR_RPM)
+TOMCAT_RPM_RELATIVE := $(CIAB_DIR_RELATIVE)$(TOMCAT_RPM)
+TS_RPM_RELATIVE := $(CIAB_DIR_RELATIVE)$(TS_RPM)
+ORT_RPM_RELATIVE := $(CIAB_DIR_RELATIVE)$(ORT_RPM)
+
+TM_RPM_ABSOLUTE := $(CIAB_DIR_ABSOLUTE)/$(TM_RPM)
+TO_RPM_ABSOLUTE := $(CIAB_DIR_ABSOLUTE)/$(TO_RPM)
+TP_RPM_ABSOLUTE := $(CIAB_DIR_ABSOLUTE)/$(TP_RPM)
+TR_RPM_ABSOLUTE := $(CIAB_DIR_ABSOLUTE)/$(TR_RPM)
+TOMCAT_RPM_ABSOLUTE := $(CIAB_DIR_ABSOLUTE)/$(TOMCAT_RPM)
+TS_RPM_ABSOLUTE := $(CIAB_DIR_ABSOLUTE)/$(TS_RPM)
+ORT_RPM_ABSOLUTE := $(CIAB_DIR_ABSOLUTE)/$(ORT_RPM)
 
 TM_DIST_RPM := $(TC_DIR)/dist/traffic_monitor-$(SPECIAL_SAUCE)
 TO_DIST_RPM := $(TC_DIR)/dist/traffic_ops-$(SPECIAL_SAUCE)
@@ -69,7 +86,7 @@ ORT_DIST_RPM := $(TC_DIR)/dist/traffic_ops_ort-$(SPECIAL_SAUCE)
 .PHONY: all build-builders clean debug native nearly-all pull-builders very-clean
 
 # Default target; builds all pre-requisite rpms from source trees
-all: $(ORT_RPM) $(TM_RPM) $(TP_RPM) $(TO_RPM) $(TR_RPM) $(TOMCAT_RPM) $(TS_RPM)
+all: $(ORT_RPM_RELATIVE) $(TM_RPM_RELATIVE) $(TP_RPM_RELATIVE) $(TO_RPM_RELATIVE) $(TR_RPM_RELATIVE) $(TOMCAT_RPM_RELATIVE) $(TS_RPM_RELATIVE)
 
 ifneq ($(filter build-builders,$(MAKECMDGOALS)),)
 PKG_FLAGS += -b
@@ -114,30 +131,37 @@ pull-builders: all
 endif
 endif
 
-# Actual output rpm recipies
-$(TM_RPM): $(TM_DIST_RPM)
+# Relative path output RPM recipies
+$(TM_RPM_RELATIVE): $(TM_DIST_RPM)
 	cp -f "$?" "$@"
-$(TO_RPM): $(TO_DIST_RPM)
+$(TO_RPM_RELATIVE): $(TO_DIST_RPM)
 	cp -f "$?" "$@"
-$(TP_RPM): $(TP_DIST_RPM)
+$(TP_RPM_RELATIVE): $(TP_DIST_RPM)
 	cp -f "$?" "$@"
-$(TR_RPM): $(TR_DIST_RPM)
+$(TR_RPM_RELATIVE): $(TR_DIST_RPM)
 	cp -f "$?" "$@"
-$(TOMCAT_RPM): $(TOMCAT_DIST_RPM)
+$(TOMCAT_RPM_RELATIVE): $(TOMCAT_DIST_RPM)
 	cp -f "$?" "$@"
-$(TS_RPM): $(TS_DIST_RPM)
+$(TS_RPM_RELATIVE): $(TS_DIST_RPM)
 	cp -f "$?" "$@"
-$(ORT_RPM): $(ORT_DIST_RPM)
+$(ORT_RPM_RELATIVE): $(ORT_DIST_RPM)
 	cp -f "$?" "$@"
 
-# RPM target aliases
-traffic_monitor/traffic_monitor.rpm: $(TM_RPM)
-traffic_ops/traffic_ops.rpm: $(TO_RPM)
-traffic_portal/traffic_portal.rpm: $(TP_RPM)
-traffic_router/traffic_router.rpm: $(TR_RPM)
-traffic_router/tomcat.rpm: $(TOMCAT_RPM)
-traffic_stats/traffic_stats.rpm: $(TS_RPM)
-cache/traffic_ops_ort.rpm: $(ORT_RPM)
+# Absolute path output RPM recipies
+$(TM_RPM_ABSOLUTE): $(TM_DIST_RPM)
+	cp -f "$?" "$@"
+$(TO_RPM_ABSOLUTE): $(TO_DIST_RPM)
+	cp -f "$?" "$@"
+$(TP_RPM_ABSOLUTE): $(TP_DIST_RPM)
+	cp -f "$?" "$@"
+$(TR_RPM_ABSOLUTE): $(TR_DIST_RPM)
+	cp -f "$?" "$@"
+$(TOMCAT_RPM_ABSOLUTE): $(TOMCAT_DIST_RPM)
+	cp -f "$?" "$@"
+$(TS_RPM_ABSOLUTE): $(TS_DIST_RPM)
+	cp -f "$?" "$@"
+$(ORT_RPM_ABSOLUTE): $(ORT_DIST_RPM)
+	cp -f "$?" "$@"
 
 # Dist rpms
 $(TM_DIST_RPM): $(TM_SOURCE)
@@ -159,8 +183,8 @@ $(ORT_DIST_RPM): $(ORT_SOURCE)
 	"$(PKG_COMMAND)" $(PKG_FLAGS) traffic_ops_ort$(BUILD_SUFFIX)
 
 clean:
-	cd "$(CIAB_DIR)"
-	$(RM) $(TM_RPM) $(TO_RPM) $(TP_RPM) $(TR_RPM) $(TOMCAT_RPM) $(ORT_RPM) $(TS_RPM)
+	cd "$(CIAB_DIR_RELATIVE)"
+	$(RM) $(TM_RPM_RELATIVE) $(TO_RPM_RELATIVE) $(TP_RPM_RELATIVE) $(TR_RPM_RELATIVE) $(TOMCAT_RPM_RELATIVE) $(ORT_RPM_RELATIVE) $(TS_RPM_RELATIVE)
 
 very-clean: clean
 	$(warning This will destroy ALL OUTPUT RPMS IN 'dist'. Please be sure this is what you want)

--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -130,6 +130,15 @@ $(TS_RPM): $(TS_DIST_RPM)
 $(ORT_RPM): $(ORT_DIST_RPM)
 	cp -f "$?" "$@"
 
+# RPM target aliases
+traffic_monitor/traffic_monitor.rpm: $(TM_RPM)
+traffic_ops/traffic_ops.rpm: $(TO_RPM)
+traffic_portal/traffic_portal.rpm: $(TP_RPM)
+traffic_router/traffic_router.rpm: $(TR_RPM)
+traffic_router/tomcat.rpm: $(TOMCAT_RPM)
+traffic_stats/traffic_stats.rpm: $(TS_RPM)
+cache/traffic_ops_ort.rpm: $(ORT_RPM)
+
 # Dist rpms
 $(TM_DIST_RPM): $(TM_SOURCE)
 	"$(PKG_COMMAND)" $(PKG_FLAGS) traffic_monitor$(BUILD_SUFFIX)


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
Before #5653, you could build a single RPM by running `make cache/traffic_ops_ort.rpm` or `make traffic_monitor/traffic_monitor.rpm`, etc. and these Makefile targets were available to shell completion.
As of #5653, no RPM targets are completable in the shell and the only completable targets are the phony ones: `all`, `build-builders`, `clean`, `debug`, `native`, `nearly-all`, `pull-builders`, and `very-clean`.
This PR re-adds completion for those relative RPM targets but does *not* add them to the `all` target.
- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
In the CDN in a Box directory:
* Run `make` to verify that the `all` target still works
* Run `make traffic_ops/traffic_ops.rpm` and verify that the RPM ends up at `infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm`

In the main project directory:
* Run `make -f infrastructure/cdn-in-a-box/Makefile traffic_ops/traffic_ops.rpm` and verify that the RPM ends up at `infrastructure/cdn-in-a-box/traffic_ops/traffic_ops.rpm` and not `traffic_ops/traffic_ops.rpm`

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
 - master (c928be0441)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] Building RPMs for CDN in a Box and building/running CDN in a Box itself is a sufficient test for the CiaB Makefile
- [x] Bugfix, documentation is unnecessary
- [x] An update to CHANGELOG.md is unnecessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

