### PR TITLE
Fix TO client urlsig path

### DIFF
--- a/traffic_ops/testing/api/v2/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v2/deliveryservices_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +33,9 @@ import (
 func TestDeliveryServices(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Tenants, Users, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, CacheGroups, Servers, DeliveryServices}, func() {
 		GetAccessibleToTest(t)
+		if includeSystemTests {
+			GetTestDeliveryServicesURLSigKeys(t)
+		}
 		UpdateTestDeliveryServices(t)
 		UpdateNullableTestDeliveryServices(t)
 		UpdateDeliveryServiceWithInvalidRemapText(t)
@@ -548,4 +552,22 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 		t.Error("expected tenant4user to be unable to create a deliveryservice outside of its tenant")
 	}
 
+}
+
+func GetTestDeliveryServicesURLSigKeys(t *testing.T) {
+	if len(testData.DeliveryServices) == 0 {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+	firstDS := testData.DeliveryServices[0]
+	if firstDS.XMLID == nil {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+
+	_, _, err := TOSession.GetDeliveryServiceURLSigKeys(*firstDS.XMLID)
+	if err != nil {
+		// The v2 tests don't support Riak, so the only thing we can test is that the endpoint exists.
+		if errStr := strings.ToLower(err.Error()); strings.Contains(errStr, "not found") || strings.Contains(errStr, "404") {
+			t.Error("Expected URL Sig path to exist, actual: " + err.Error())
+		}
+	}
 }

--- a/traffic_ops/testing/api/v3/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/deliveryservices_test.go
@@ -43,6 +43,7 @@ func TestDeliveryServices(t *testing.T) {
 
 		if includeSystemTests {
 			SSLDeliveryServiceCDNUpdateTest(t)
+			GetTestDeliveryServicesURLSigKeys(t)
 		}
 		GetTestDeliveryServicesIMS(t)
 		GetAccessibleToTest(t)
@@ -1169,5 +1170,20 @@ func DeliveryServiceTenancyTest(t *testing.T) {
 	tenant3DS.DisplayName = util.StrPtr("deliveryservicetenancytest")
 	if _, _, err = tenant4TOClient.CreateDeliveryServiceV30(tenant3DS); err == nil {
 		t.Error("expected tenant4user to be unable to create a deliveryservice outside of its tenant")
+	}
+}
+
+func GetTestDeliveryServicesURLSigKeys(t *testing.T) {
+	if len(testData.DeliveryServices) == 0 {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+	firstDS := testData.DeliveryServices[0]
+	if firstDS.XMLID == nil {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+
+	_, _, err := TOSession.GetDeliveryServiceURLSigKeysWithHdr(*firstDS.XMLID, nil)
+	if err != nil {
+		t.Error("failed to get url sig keys: " + err.Error())
 	}
 }

--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -43,6 +43,7 @@ func TestDeliveryServices(t *testing.T) {
 
 		if includeSystemTests {
 			SSLDeliveryServiceCDNUpdateTest(t)
+			GetTestDeliveryServicesURLSigKeys(t)
 		}
 		GetTestDeliveryServicesIMS(t)
 		GetAccessibleToTest(t)
@@ -1234,5 +1235,20 @@ func VerifyPaginationSupportDS(t *testing.T) {
 		t.Error("expected GET deliveryservice to return an error when page is not a positive integer")
 	} else if !strings.Contains(err.Error(), "must be a positive integer") {
 		t.Errorf("expected GET deliveryservice to return an error for page is not a positive integer, actual error: " + err.Error())
+	}
+}
+
+func GetTestDeliveryServicesURLSigKeys(t *testing.T) {
+	if len(testData.DeliveryServices) == 0 {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+	firstDS := testData.DeliveryServices[0]
+	if firstDS.XMLID == nil {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+
+	_, _, err := TOSession.GetDeliveryServiceURLSigKeysWithHdr(*firstDS.XMLID, nil)
+	if err != nil {
+		t.Error("failed to get url sig keys: " + err.Error())
 	}
 }

--- a/traffic_ops/v2-client/deliveryservice.go
+++ b/traffic_ops/v2-client/deliveryservice.go
@@ -85,7 +85,7 @@ const (
 	// by its XMLID. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the XMLID of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v2/deliveryservices_xmlid_xmlid_urlkeys.html
-	API_DELIVERY_SERVICES_URL_SIGNING_KEYS = API_DELIVERY_SERVICES + "/xmlid/%s/urlkeys"
+	API_DELIVERY_SERVICES_URL_SIGNING_KEYS = API_DELIVERY_SERVICES + "/xmlId/%s/urlkeys"
 
 	// API_DELIVERY_SERVICES_REGEXES is the API path on which Traffic Ops serves Delivery Service
 	// 'regex' (Regular Expression) information.

--- a/traffic_ops/v3-client/deliveryservice.go
+++ b/traffic_ops/v3-client/deliveryservice.go
@@ -154,7 +154,7 @@ const (
 	APIDeliveryServiceXmlidSslKeys    = APIDeliveryServices + "/xmlId/%s/sslkeys"
 	APIDeliveryServiceGenerateSslKeys = APIDeliveryServices + "/sslkeys/generate"
 	APIDeliveryServicesUriSigningKeys = APIDeliveryServices + "/%s/urisignkeys"
-	APIDeliveryServicesUrlSigningKeys = APIDeliveryServices + "/xmlid/%s/urlkeys"
+	APIDeliveryServicesUrlSigningKeys = APIDeliveryServices + "/xmlId/%s/urlkeys"
 	APIDeliveryServicesRegexes        = "/deliveryservices_regexes"
 	APIServerDeliveryServices         = "/servers/%d/deliveryservices"
 	APIDeliveryServiceServer          = "/deliveryserviceserver"

--- a/traffic_ops/v4-client/deliveryservice.go
+++ b/traffic_ops/v4-client/deliveryservice.go
@@ -93,7 +93,7 @@ const (
 	// by its XMLID. It is intended to be used with fmt.Sprintf to insert its required path parameter
 	// (namely the XMLID of the Delivery Service of interest).
 	// See Also: https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/deliveryservices_xmlid_xmlid_urlkeys.html
-	APIDeliveryServicesURLSigKeys = APIDeliveryServices + "/xmlid/%s/urlkeys"
+	APIDeliveryServicesURLSigKeys = APIDeliveryServices + "/xmlId/%s/urlkeys"
 
 	// APIDeliveryServicesRegexes is the API path on which Traffic Ops serves Delivery Service
 	// 'regex' (Regular Expression) information.


### PR DESCRIPTION
Fixes the TO client urlsig path being wrong.

This is critical, because ORT uses this client function now, causing ORT url_sig keys to break.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops Client
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Run ORT, and verify url_sig files are generated correctly. Write an app to use the TO client urlsig function, verify it returns the keys successfully.

## If this is a bug fix, what versions of Traffic Control are affected?
ORT is critically broken in `master and 5.1. Client v2-client and v3-client functions have been broken since inception (but nothing inside ATS used the function, as far as I know).

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information