### PR TITLE
Fixed GET api/3.1/cdns/routing endpoint to avoid incorrect success response (return all zeros) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - ORT config generation: Added a rule to ip_allow such that PURGE requests are allowed over localhost
 
 ### Fixed
+- Fixed the return error for GET api `cdns/routing` to avoid incorrect success response.
 - [#2471](https://github.com/apache/trafficcontrol/issues/2471) - A PR check to ensure added db migration file is the latest.
 - [#5609](https://github.com/apache/trafficcontrol/issues/5609) - Fixed GET /servercheck filter for an extra query param.
 - [#5565](https://github.com/apache/trafficcontrol/issues/5565) - TO GET /caches/stats panic converting string to uint64

--- a/traffic_ops/traffic_ops_golang/crstats/routing.go
+++ b/traffic_ops/traffic_ops_golang/crstats/routing.go
@@ -107,7 +107,6 @@ func getRoutersRouting(tx *sql.Tx, routers map[tc.CDNName][]string, statType *st
 			return tc.Routing{}, r.Error
 		}
 		dat = addCRSStats(dat, r.Stats, statType, hostRegex)
-
 	}
 	return sumRouterData(dat), nil
 }

--- a/traffic_ops/traffic_ops_golang/crstats/routing.go
+++ b/traffic_ops/traffic_ops_golang/crstats/routing.go
@@ -58,11 +58,13 @@ const (
 
 func getRoutersRouting(tx *sql.Tx, routers map[tc.CDNName][]string, statType *string, hostRegexs []string) (tc.Routing, error) {
 	forwardProxy, forwardProxyExists, err := dbhelpers.GetGlobalParam(tx, RouterProxyParameter)
+	fmt.Println(forwardProxy, forwardProxyExists, err)
 	if err != nil {
 		return tc.Routing{}, errors.New("getting global router proxy parameter: " + err.Error())
 	}
 	client := &http.Client{Timeout: RouterRequestTimeout}
 	if forwardProxyExists {
+		fmt.Println("Doubt you are here?")
 		proxyURI, err := url.Parse(forwardProxy)
 		if err != nil {
 			return tc.Routing{}, errors.New("router forward proxy '" + forwardProxy + "' in parameter '" + RouterProxyParameter + "' not a URI: " + err.Error())
@@ -75,6 +77,7 @@ func getRoutersRouting(tx *sql.Tx, routers map[tc.CDNName][]string, statType *st
 	}
 
 	var hostRegex *regexp.Regexp
+	fmt.Println("Host", hostRegex, "Client", client)
 	if len(hostRegexs) > 0 {
 		hostRegex, err = regexp.Compile(strings.Join(hostRegexs, "|"))
 		if err != nil {
@@ -84,15 +87,18 @@ func getRoutersRouting(tx *sql.Tx, routers map[tc.CDNName][]string, statType *st
 
 	count := 0
 	for _, routerFQDNs := range routers {
+		fmt.Println(routerFQDNs)
 		count += len(routerFQDNs)
 	}
 
 	resp := make(chan RouterResp, count)
 
 	wg := sync.WaitGroup{}
+	fmt.Println(count)
 	wg.Add(count)
 
 	for cdn, routerFQDNs := range routers {
+		fmt.Println(cdn, routerFQDNs)
 		for _, routerFQDN := range routerFQDNs {
 			go getCRSStats(resp, &wg, routerFQDN, string(cdn), client)
 		}
@@ -102,12 +108,58 @@ func getRoutersRouting(tx *sql.Tx, routers map[tc.CDNName][]string, statType *st
 	close(resp)
 
 	dat := RouterData{}
+	//testmap := map[string]tc.CRSStatsStat{
+	//	"video.demo1.mycdn.ciab.test": tc.CRSStatsStat {10, 20, 0, 0, 0, 0, 0, 0, 0, 0},
+	//}
+	//test := tc.CRSStats{
+	//	App:   tc.CRSStatsApp{
+	//		BuildTimestamp: "2021-03-24",
+	//		Name:           "traffic_router",
+	//		DeployDir:      "/opt/traffic_router",
+	//		GitRevision:    "36a47e9a3",
+	//		Version:        "5.1.0",
+	//	},
+	//	Stats: tc.CRSStatsStats{
+	//		DNSMap:           nil,
+	//		HTTPMap:          testmap,
+	//		TotalDNSCount:    0,
+	//		TotalHTTPCount:   2,
+	//		TotalDSMissCount: 0,
+	//		AppStartTime:     1616606046447,
+	//		AverageDnsTime:   0,
+	//		AverageHttpTime:  1616606088088,
+	//		UpdateTracker:    tc.CRSStatsUpdateTracker{
+	//			LastHttpsCertificatesCheck:           0,
+	//			LastGeolocationDatabaseUpdaterUpdate: 2,
+	//			LastCacheStateCheck:                  0,
+	//			LastCacheStateChange:                 1616606408121,
+	//			LastNetworkUpdaterUpdate:             0,
+	//			LastHTTPSCertificatesUpdate:          1616606543653,
+	//			LastConfigCheck:                      1616606069501,
+	//			LastConfigChange:                     0,
+	//			LastHTTPSCertificatesFetchFail:       1616606410547,
+	//			LastNetworkUpdaterCheck:              1616606544371,
+	//			NewDNSSECKeysFound:                   1616606109280,
+	//			LastGeolocationDatabaseUpdaterCheck:  0,
+	//			LastHTTPSCertificatesFetchSuccess:    0,
+	//			LastSteeringWatcherCheck:             0,
+	//			LastDNSSECKeysCheck:                  0,
+	//			LastFederationsWatcherCheck:          1616606408507,
+	//			LastHTTPSCertificatesFetchAttempt:    1616606487260,
+	//		},
+	//	},
+	//}
 
+	fmt.Println("Resp", &resp)
 	for r := range resp {
-		if r.Error != nil {
-			return tc.Routing{}, err
-		}
+		fmt.Println("Data", dat, "r", r.Stats)
+		//if r.Error != nil {
+		//	return tc.Routing{}, err
+		//}
+		fmt.Println("You here?")
+		//r.Stats = test
 		dat = addCRSStats(dat, r.Stats, statType, hostRegex)
+		fmt.Println("Data1", dat)
 	}
 	return sumRouterData(dat), nil
 }
@@ -140,7 +192,9 @@ func addCRSStats(d RouterData, stats tc.CRSStats, statType *string, hostRegex *r
 	// DNSMap
 	if statType == nil || *statType == "DNS" {
 		for host, stat := range stats.Stats.DNSMap {
+			fmt.Println("MH-dns", host, matchingHost(host))
 			if matchingHost(host) {
+				fmt.Println(d.StatTotal, stat)
 				d.StatTotal = sumCRSStat(d.StatTotal, stat)
 				d.Total += totalCRSStat(stat)
 			}
@@ -150,7 +204,9 @@ func addCRSStats(d RouterData, stats tc.CRSStats, statType *string, hostRegex *r
 	// HTTPMap
 	if statType == nil || *statType == "HTTP" {
 		for host, stat := range stats.Stats.HTTPMap {
+			fmt.Println("MH-http", host, matchingHost(host))
 			if matchingHost(host) {
+				fmt.Println(d.StatTotal, stat)
 				d.StatTotal = sumCRSStat(d.StatTotal, stat)
 				d.Total += totalCRSStat(stat)
 			}
@@ -197,12 +253,14 @@ func getCRSStats(respond chan<- RouterResp, wg *sync.WaitGroup, routerFQDN, cdn 
 		return
 	}
 	stats := tc.CRSStats{}
+	fmt.Println("Response", resp)
 	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
 		r.Error = fmt.Errorf("decoding stats from CDN %s router %s: %v", cdn, routerFQDN, err)
 		respond <- r
 		return
 	}
 	r.Stats = stats
+	fmt.Println(r.Stats)
 	respond <- r
 }
 
@@ -238,10 +296,15 @@ GROUP BY s.host_name, s.domain_name, c.name
 		if port.Valid {
 			fqdn += ":" + strconv.FormatInt(port.Int64, 10)
 		}
+		fmt.Println(fqdn)
+		//fqdn = "cdn-tr-atl-01.cdn.comcast.net:3333"
+		fqdn = "cdn-tr-oshob-02.nightly.cdnlab.comcast.net:3333"
+		fmt.Println(fqdn)
 		if requiredCDN != nil && *requiredCDN != cdn {
 			continue
 		}
 		routers[tc.CDNName(cdn)] = append(routers[tc.CDNName(cdn)], fqdn)
 	}
+	fmt.Println(routers)
 	return routers, nil
 }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/StatTracker.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/StatTracker.java
@@ -318,14 +318,14 @@ public class StatTracker {
 	public Map<String, Tallies> getHttpMap() {
 		return httpMap;
 	}
-	public int getTotalDnsCount() {
+	public long getTotalDnsCount() {
 		return totalDnsCount;
 	}
 	public long getAverageDnsTime() {
 		if(totalDnsCount==0) { return 0; }
 		return totalDnsTime/totalDnsCount;
 	}
-	public int getTotalHttpCount() {
+	public long getTotalHttpCount() {
 		return totalHttpCount;
 	}
 	public long getAverageHttpTime() {
@@ -339,9 +339,9 @@ public class StatTracker {
 		this.totalDsMissCount = totalDsMissCount;
 	}
 
-	private int totalDnsCount;
+	private long totalDnsCount;
 	private long totalDnsTime;
-	private int totalHttpCount;
+	private long totalHttpCount;
 	private long totalHttpTime;
 	private int totalDsMissCount = 0;
 	public Map<String,Long> getUpdateTracker() {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/StatTracker.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/StatTracker.java
@@ -332,10 +332,10 @@ public class StatTracker {
 		if(totalHttpCount==0) { return 0; }
 		return totalHttpTime/totalHttpCount;
 	}
-	public int getTotalDsMissCount() {
+	public long getTotalDsMissCount() {
 		return totalDsMissCount;
 	}
-	public void setTotalDsMissCount(final int totalDsMissCount) {
+	public void setTotalDsMissCount(final long totalDsMissCount) {
 		this.totalDsMissCount = totalDsMissCount;
 	}
 
@@ -343,7 +343,7 @@ public class StatTracker {
 	private long totalDnsTime;
 	private long totalHttpCount;
 	private long totalHttpTime;
-	private int totalDsMissCount = 0;
+	private long totalDsMissCount = 0;
 	public Map<String,Long> getUpdateTracker() {
 		return TrafficRouterManager.getTimeTracker();
 	}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes a bug found during ATC v5.1 Release Validation <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Test GET API endpoint: api/3.1/cdns/routing against CIAB or local TR and if TR is not up an running or has any other issue, one should see the right error response and http code.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- 5.1.1
- master (7f5c7be)


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR does not includes tests.
- [x] I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

Logic didn't change, hence there was no test or documentation added.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
