### PR TITLE
Ensure that 5.x TS is not logging all 0's for cache_stats, when linked with a 5.x TM/TO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a NullPointerException in TR when a client passes a null SNI hostname in a TLS request
 - Fixed a logging bug in Traffic Monitor where it wouldn't log errors in certain cases where a backup file could be used instead. Also, Traffic Monitor now rejects monitoring snapshots that have no delivery services.
 - [#5407](https://github.com/apache/trafficcontrol/issues/5407) - Make sure that you cannot add two servers with identical content
+- [#5712](https://github.com/apache/trafficcontrol/issues/5712) - Ensure that 5.x Traffic Stats is compatible with 5.x Traffic Monitor and 5.x Traffic Ops  
 - [#2881](https://github.com/apache/trafficcontrol/issues/2881) - Some API endpoints have incorrect Content-Types
 - [#5363](https://github.com/apache/trafficcontrol/issues/5363) - Postgresql version changeable by env variable
 - [#5405](https://github.com/apache/trafficcontrol/issues/5405) - Prevent Tenant update from choosing child as new parent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a NullPointerException in TR when a client passes a null SNI hostname in a TLS request
 - Fixed a logging bug in Traffic Monitor where it wouldn't log errors in certain cases where a backup file could be used instead. Also, Traffic Monitor now rejects monitoring snapshots that have no delivery services.
 - [#5407](https://github.com/apache/trafficcontrol/issues/5407) - Make sure that you cannot add two servers with identical content
-- [#5712](https://github.com/apache/trafficcontrol/issues/5712) - Ensure that 5.x Traffic Stats is compatible with 5.x Traffic Monitor and 5.x Traffic Ops  
+- [#5712](https://github.com/apache/trafficcontrol/issues/5712) - Ensure that 5.x Traffic Stats is compatible with 5.x Traffic Monitor and 5.x Traffic Ops, and that it doesn't log all 0's for `cache_stats`  
 - [#2881](https://github.com/apache/trafficcontrol/issues/2881) - Some API endpoints have incorrect Content-Types
 - [#5363](https://github.com/apache/trafficcontrol/issues/5363) - Postgresql version changeable by env variable
 - [#5405](https://github.com/apache/trafficcontrol/issues/5405) - Prevent Tenant update from choosing child as new parent

--- a/traffic_stats/traffic_stats_test.go
+++ b/traffic_stats/traffic_stats_test.go
@@ -1,0 +1,157 @@
+package main
+
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	influx "github.com/influxdata/influxdb/client/v2"
+)
+
+func TestCalcCacheValuesWithInvalidValue(t *testing.T) {
+	stats := make(map[string][]tc.ResultStatVal)
+	caches := make(map[tc.CacheName]map[string][]tc.ResultStatVal)
+	cacheMap := make(map[string]tc.Server)
+	resultSatsVal := []tc.ResultStatVal{
+		{
+			Span: 0,
+			Time: time.Now(),
+			Val:  "invalid stat",
+		},
+	}
+	stats["maxKbps"] = resultSatsVal
+	caches["cache1"] = stats
+	cacheMap["cache1"] = tc.Server{}
+	config := StartupConfig{
+		BpsChan: make(chan influx.BatchPoints),
+	}
+	legacyStats := tc.LegacyStats{
+		CommonAPIData: tc.CommonAPIData{},
+		Caches:        caches,
+	}
+	data, err := json.Marshal(legacyStats)
+	if err != nil {
+		t.Fatalf("couldn't marshal struct %v", caches)
+	}
+	go calcCacheValues(data, "cdn", 0, cacheMap, config)
+	result := <-config.BpsChan
+	if len(result.Points()) == 0 {
+		t.Fatalf("expected one point in the result, got none")
+	}
+	fields, err := result.Points()[0].Fields()
+	if err != nil {
+		t.Fatalf("couldn't read the fields of the result: %v", err.Error())
+	}
+	if val, ok := fields["value"]; !ok {
+		t.Fatalf("couldn't find a 'value' field")
+	} else {
+		if val.(float64) != 0.0 {
+			t.Errorf("expected invalid stat to result in a value of 0.0, but got %v instead", val.(float64))
+		}
+	}
+}
+
+func TestCalcCacheValuesWithEmptyInterface(t *testing.T) {
+	stats := make(map[string][]tc.ResultStatVal)
+	caches := make(map[tc.CacheName]map[string][]tc.ResultStatVal)
+	cacheMap := make(map[string]tc.Server)
+	resultSatsVal := []tc.ResultStatVal{
+		{
+			Span: 0,
+			Time: time.Now(),
+		},
+	}
+	stats["maxKbps"] = resultSatsVal
+	caches["cache1"] = stats
+	cacheMap["cache1"] = tc.Server{}
+	config := StartupConfig{
+		BpsChan: make(chan influx.BatchPoints),
+	}
+	legacyStats := tc.LegacyStats{
+		CommonAPIData: tc.CommonAPIData{},
+		Caches:        caches,
+	}
+	data, err := json.Marshal(legacyStats)
+	if err != nil {
+		t.Fatalf("couldn't marshal struct %v", caches)
+	}
+	go calcCacheValues(data, "cdn", 0, cacheMap, config)
+	result := <-config.BpsChan
+	if len(result.Points()) == 0 {
+		t.Fatalf("expected one point in the result, got none")
+	}
+	fields, err := result.Points()[0].Fields()
+	if err != nil {
+		t.Fatalf("couldn't read the fields of the result: %v", err.Error())
+	}
+	if val, ok := fields["value"]; !ok {
+		t.Fatalf("couldn't find a 'value' field")
+	} else {
+		if val.(float64) != 0.0 {
+			t.Errorf("expected invalid stat to result in a value of 0.0, but got %v instead", val.(float64))
+		}
+	}
+}
+
+func TestCalcCacheValues(t *testing.T) {
+	stats := make(map[string][]tc.ResultStatVal)
+	caches := make(map[tc.CacheName]map[string][]tc.ResultStatVal)
+	cacheMap := make(map[string]tc.Server)
+	resultSatsVal := []tc.ResultStatVal{
+		{
+			Span: 0,
+			Time: time.Now(),
+			Val:  "25.56",
+		},
+	}
+	stats["maxKbps"] = resultSatsVal
+	caches["cache1"] = stats
+	cacheMap["cache1"] = tc.Server{}
+	config := StartupConfig{
+		BpsChan: make(chan influx.BatchPoints),
+	}
+	legacyStats := tc.LegacyStats{
+		CommonAPIData: tc.CommonAPIData{},
+		Caches:        caches,
+	}
+	data, err := json.Marshal(legacyStats)
+	if err != nil {
+		t.Fatalf("couldn't marshal struct %v", caches)
+	}
+	go calcCacheValues(data, "cdn", 0, cacheMap, config)
+	result := <-config.BpsChan
+	if len(result.Points()) == 0 {
+		t.Fatalf("expected one point in the result, got none")
+	}
+	fields, err := result.Points()[0].Fields()
+	if err != nil {
+		t.Fatalf("couldn't read the fields of the result: %v", err.Error())
+	}
+	if val, ok := fields["value"]; !ok {
+		t.Fatalf("couldn't find a 'value' field")
+	} else {
+		if val.(float64) != 25.56 {
+			t.Errorf("expected invalid stat to result in a value of 0.0, but got %v instead", val.(float64))
+		}
+	}
+}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5712  <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Stats
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Start up a 5.x TS, and hook it up with a 5.x TO(prod/ staging/ nightly/ anything that has data in it). Make sure you dont see all 0's in the `cache_stats` database in influxdb. 
## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master
- 5.1.2
## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests 
- [x] Documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md 
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
