### PR TITLE
Add ORT header rewrite check tool

### DIFF
--- a/traffic_ops_ort/tools/check-header-rewrite-files/README.md
+++ b/traffic_ops_ort/tools/check-header-rewrite-files/README.md
@@ -1,0 +1,35 @@
+# check-header-rewrite-files
+
+check-header-rewrite-files is a utility to verify all header rewrite directives in remap.config point to files that exist.
+
+The config generation around creating and injecting header rewrites is complex, and it's difficult to verify that all scenarios which result in a header rewrite directive on a remap line also result in a header rewrite file being generated.
+
+It's also possible there may be valid scenarios where it's possible to create data resulting in a header rewrite remap line without a corresponding file (such as with Profiles and Parameters), but which isn't a code bug. So it may not be possible to detect in the generation itself. Moreover, any detection would have to be after creating remap.config (or else we would have prevented it there), and thus it isn't obvious what ORT should do if it did detect it.
+
+It's also possible a user may have a header rewrite file not managed by Traffic Control, and thus ORT can't safely simply create an empty file if one doesn't exist.
+
+Therefore, this tool gives users and developers a way to detect code and data bugs resulting in malformed config, so the bugs can then be fixed.
+
+# Usage
+
+check-header-rewrite-files takes the output of atstccfg as input. If no missing files were found, it outputs nothing and returns exit code 0. If any files are missing, their names are printed and a nonzero exit code is returned.
+
+# Examples
+
+```sh
+./atstccfg --traffic-ops-url="trafficops.example.net" --cache-host-name="my-cache" > allfiles.txt
+go run check-header-rewrite-files < allfiles.txt
+```
+
+```sh
+atstccfg -u "trafficops.example.net" -n "my-cache" > check-header-rewrite-files
+```
+
+```sh
+go run check-header-rewrite-files < allfiles.txt
+```
+
+```sh
+go build;
+./check-header-rewrite-files allfiles.txt
+```

--- a/traffic_ops_ort/tools/check-header-rewrite-files/check-header-rewrite-files.go
+++ b/traffic_ops_ort/tools/check-header-rewrite-files/check-header-rewrite-files.go
@@ -1,0 +1,62 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var remapHeaderRewriteRegex = regexp.MustCompile(`\@plugin=header_rewrite\.so @pparam=([^\s]+)\s+.*\n`)
+
+func main() {
+	bts, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Println("Error reading input: " + err.Error())
+		os.Exit(1)
+	}
+
+	matches := remapHeaderRewriteRegex.FindAllSubmatch(bts, -1)
+
+	headerRewriteFiles := []string{}
+
+	for _, match := range matches {
+		fileName := string(match[1])
+		headerRewriteFiles = append(headerRewriteFiles, fileName)
+	}
+
+	anyFileMissing := false
+	for _, fileName := range headerRewriteFiles {
+		reStr := `\r\nPath\: .*\/` + strings.Replace(fileName, `.`, `\.`, -1) + "\r"
+		re := regexp.MustCompile(reStr)
+		if re.FindIndex(bts) == nil {
+			fmt.Println(fileName)
+			anyFileMissing = true
+		}
+	}
+
+	if anyFileMissing {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}


### PR DESCRIPTION
Adds a helper utility for checking that all remap.config header
rewrite directives have a matching file.

The header rewrite directive and file generation has a lot of conditions, so it's difficult to ensure they match identically. This provides users and developers a tool for checking code and data generate matching directives and files correctly.

Includes documentation in the tool directory.
No tests, is a standalone tool that doesn't affect production code paths.
Includes changelog.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
Tool is useful to ORT, but does not affect ORT or any other production code path.

## What is the best way to verify this PR?
See readme, run tool according to instructions.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information