### PR TITLE
Disable TLS 1.1 in TR Ansible role by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [apache/trafficcontrol](https://github.com/apache/trafficcontrol) is now a Go module
 - Updated Traffic Ops supported database version from PostgreSQL 9.6 to 13.2
 - Set Traffic Router to also accept TLSv1.3 protocols by default in server.xml
+- Disabled TLSv1.1 for Traffic Router in Ansible role by default
 - Refactored the Traffic Ops - Traffic Vault integration to more easily support the development of new Traffic Vault backends
 - Updated Apache Tomcat from 8.5.63 to 9.0.43
 

--- a/infrastructure/ansible/roles/traffic-router/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-router/defaults/main.yml
@@ -104,7 +104,7 @@ tr_connectors:
     SSLEnabled: true
     clientAuth: false
     sslProtocol: 'TLS'
-    protocols: '+TLSv1.1,+TLSv1.2,+TLSv1.3'
+    protocols: '+TLSv1.2,+TLSv1.3'
     sslImplementationName: 'com.comcast.cdn.traffic_control.traffic_router.protocol.RouterSslImplementation'
 
 # dns.properties


### PR DESCRIPTION
## What does this PR (Pull Request) do?
This PR causes the TR Ansible playbook to disable TLS 1.1 on port 443 by default, leaving TLS 1.2 and 1.3 enabled.

## Which Traffic Control components are affected by this PR?
- Traffic Router Ansible role

## What is the best way to verify this PR?
Run the TR Ansible deployment automation, verify that TLS 1.1 is disabled by default on TR port 443.

## The following criteria are ALL met by this PR
- [x] Ansible roles don't currently support automated tests
- [x] Ansible role default change, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
