### PR TITLE
Update ansible playbooks for Traffic Vault refactoring

### DIFF
--- a/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
@@ -112,6 +112,8 @@ to_go_supported_ds_metrics:
 
 to_plugin_config: {}
 
+to_traffic_vault_backend: "riak"
+
 to_smtp_enabled: false
 to_smtp_username: ""
 to_smtp_password: ""

--- a/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
@@ -77,6 +77,12 @@
       "write_timeout" : {{ to_go_write_timeout }},
       "supported_ds_metrics" : {{ to_go_supported_ds_metrics | to_json }},
       "plugins": {{ to_plugin_config.keys() | list | to_json }},
-      "plugin_config" : {{ to_plugin_config | to_nice_json(indent=2) }}
+      "plugin_config" : {{ to_plugin_config | to_nice_json(indent=2) }},
+      "traffic_vault_backend": "{{ to_traffic_vault_backend }}",
+      "traffic_vault_config": {
+         "user": "{{ to_riak_username }}",
+         "password": "{{ to_riak_username_password }}",
+         "MaxTLSVersion": "{{ to_riak_tls_max_version }}"
+      }
    }
 }

--- a/infrastructure/ansible/roles/traffic_ops/templates/production/riak.conf.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/production/riak.conf.j2
@@ -10,6 +10,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+#
+# NOTE: riak.conf is DEPRECATED! This template should not be updated anymore
+# and is kept only for backwards-compatibility until ATC 6.1. Riak is now
+# configured via the "traffic_vault_backend" and "traffic_vault_config" fields
+# in cdn.conf.
 #}
 {
 	"user": "{{ to_riak_username }}",


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Update the Traffic Ops Ansible playbook to include the new `traffic_vault_backend` and `traffic_vault_config` options in cdn.conf for Riak.

## Which Traffic Control components are affected by this PR?
- Traffic Ops
- Traffic Vault

## What is the best way to verify this PR?
Use the Ansible playbook to deploy Traffic Ops, verify that cdn.conf includes the proper Riak config in `traffic_vault_backend` and `traffic_vault_config`.

## The following criteria are ALL met by this PR
- [x] Ansible playbooks don't have automated testing support
- [x] Ansible playbook change, no docs necessary
- [x] changelog already has an entry for this general change
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
