### PR TITLE
Set server XMPPID to hostname if empty

### DIFF
--- a/.github/workflows/traffic-ops.yml
+++ b/.github/workflows/traffic-ops.yml
@@ -22,7 +22,7 @@ on:
     paths:
       - .github/actions/todb-init/**
       - .github/actions/to-integration-tests/**
-      - '.github/workflows/traffic ops.yml'
+      - '.github/workflows/traffic-ops.yml'
       - GO_VERSION
       - infrastructure/cdn-in-a-box/traffic_vault/**
       - traffic_ops/*client/**.go
@@ -33,7 +33,7 @@ on:
     paths:
       - .github/actions/todb-init/**
       - .github/actions/to-integration-tests/**
-      - '.github/workflows/traffic ops.yml'
+      - '.github/workflows/traffic-ops.yml'
       - GO_VERSION
       - infrastructure/cdn-in-a-box/traffic_vault/**
       - traffic_ops/*client/**.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5695](https://github.com/apache/trafficcontrol/issues/5695) - Ensure vitals are calculated only against monitored interfaces
 - Fixed Traffic Monitor to report `ONLINE` caches as available.
 - [#5744](https://github.com/apache/trafficcontrol/issues/5744) - Sort TM Delivery Service States page by DS name
+- [#5724](https://github.com/apache/trafficcontrol/issues/5724) - Set XMPPID to hostname if the server had none, don't error on server update when XMPPID is empty
 
 ## [5.1.1] - 2021-03-19
 ### Added

--- a/docs/source/api/v1/servers.rst
+++ b/docs/source/api/v1/servers.rst
@@ -123,7 +123,7 @@ Response Structure
 :type:       The name of the :term:`Type` of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http
@@ -339,7 +339,7 @@ Response Structure
 :type:       The name of the 'type' of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http

--- a/docs/source/api/v1/servers_hostname_name_details.rst
+++ b/docs/source/api/v1/servers_hostname_name_details.rst
@@ -80,7 +80,7 @@ Response Structure
 	.. note:: This is typically thought of as synonymous with "HTTP port", as the port specified by ``httpsPort`` may also be used for incoming TCP connections.
 
 :type:       The name of the 'type' of this server
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http

--- a/docs/source/api/v1/servers_id.rst
+++ b/docs/source/api/v1/servers_id.rst
@@ -123,7 +123,7 @@ Response Structure
 :type:       The name of the 'type' of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http
@@ -355,7 +355,7 @@ Response Structure
 :type:       The name of the 'type' of this server
 :typeId:     The integral, unique identifier of the 'type' of this server
 :updPending: A boolean value which, if ``true``, indicates that the server has updates of some kind pending, typically to be acted upon by Traffic Ops ORT
-:xmppId:     An identifier to be used in XMPP communications with the server - in nearly all cases this will be the same as ``hostName``
+:xmppId:     A system-generated UUID used to generate a server hashId for use in Traffic Router's consistent hashing algorithm. This value is set when a server is created and cannot be changed afterwards.
 :xmppPasswd: The password used in XMPP communications with the server
 
 .. code-block:: http

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -425,6 +425,11 @@ const deleteServerQuery = `DELETE FROM server WHERE id=$1`
 const deleteInterfacesQuery = `DELETE FROM interface WHERE server=$1`
 const deleteIPsQuery = `DELETE FROM ip_address WHERE server = $1`
 
+func newUUID() *string {
+	uuidReference := uuid.New().String()
+	return &uuidReference
+}
+
 func validateCommon(s *tc.CommonServerProperties, tx *sql.Tx) []error {
 
 	noSpaces := validation.NewStringRule(tovalidate.NoSpaces, "cannot contain spaces")
@@ -445,11 +450,6 @@ func validateCommon(s *tc.CommonServerProperties, tx *sql.Tx) []error {
 
 	if len(errs) > 0 {
 		return errs
-	}
-
-	if s.XMPPID == nil || *s.XMPPID == "" {
-		hostName := *s.HostName
-		s.XMPPID = &hostName
 	}
 
 	if _, err := tc.ValidateTypeID(tx, s.TypeID, "server"); err != nil {
@@ -1273,10 +1273,8 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	original := originals[0]
-	if original.XMPPID == nil {
-		sysErr = errors.New("original server had no XMPPID")
-		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
-		return
+	if original.XMPPID == nil || *original.XMPPID == "" {
+		log.Warnf("original server %s had no XMPPID\n", *original.HostName)
 	}
 	if original.StatusID == nil {
 		sysErr = errors.New("original server had no status ID")
@@ -1303,7 +1301,10 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		original.StatusLastUpdated = &original.LastUpdated.Time
 	}
 
-	originalXMPPID := *original.XMPPID
+	var originalXMPPID string
+	if original.XMPPID != nil {
+		originalXMPPID = *original.XMPPID
+	}
 	originalStatusID := *original.StatusID
 
 	var server tc.ServerV30
@@ -1428,7 +1429,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if server.XMPPID != nil && *server.XMPPID != originalXMPPID {
+	if server.XMPPID != nil && *server.XMPPID != "" && originalXMPPID != "" && *server.XMPPID != originalXMPPID {
 		api.WriteAlerts(w, r, http.StatusBadRequest, tc.CreateAlerts(tc.ErrorLevel, fmt.Sprintf("server cannot be updated due to requested XMPPID change. XMPIDD is immutable")))
 		return
 	}
@@ -1591,8 +1592,7 @@ func createV2(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	str := uuid.New().String()
-	server.XMPPID = &str
+	server.XMPPID = newUUID()
 
 	if err := validateV2(&server, tx); err != nil {
 		api.HandleErr(w, r, tx, http.StatusBadRequest, err, nil)
@@ -1662,8 +1662,7 @@ func createV3(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	str := uuid.New().String()
-	server.XMPPID = &str
+	server.XMPPID = newUUID()
 	_, err := validateV3(&server, tx)
 	if err != nil {
 		api.HandleErr(w, r, tx, http.StatusBadRequest, err, nil)


### PR DESCRIPTION
This PR backports #5725 to 5.1.x

* Generate XMPPID on server update if it is empty

* Hyphenate traffic-ops.yml

* Simplify condition

* Do not persistently set XMPPID on PUT if it is empty

* Remove xmpp_id from SQL query

* Include hostname in warning

* Use newer definition of XMPPID for API v1

* More accurate changelog entry

(cherry picked from commit f599571c9e076d1176fed1ba966d0fc43013829c)
