### PR TITLE
Updates to the ORT plugin verifier

### DIFF
--- a/traffic_ops_ort/plugin_verifier/test-files/etc/astats.config
+++ b/traffic_ops_ort/plugin_verifier/test-files/etc/astats.config
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+config file tests

--- a/traffic_ops_ort/plugin_verifier/test-files/etc/plugin.config
+++ b/traffic_ops_ort/plugin_verifier/test-files/etc/plugin.config
@@ -17,7 +17,10 @@
 #  under the License.
 #
 # plugin.config
-astats_over_http.so 
-regex_revalidate.so --disable-timed-updates --config regex_revalidate.config
+
+# a config file using long options with '='.
+astats_over_http.so --config=astats.config
+# config file using long option followed by a space
+regex_revalidate.so --disable-timed-updates --config regex_revalidate.config --alarm=yes
 remap_stats.so -p
 astats_over_http.so 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Updates the ORT plugin verifier.

- Adds a check to ensure that plugin config files are not empty
- Adds info logging of successful plugin and plugin config file
  verification.
- Changes to the pattern matching for plugin config files in
  plugin.config.
- Adds searching for plugin YAML files

- [x] This PR  is not related to any Issue

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

- Traffic Ops ORT

## What is the best way to verify this PR?

Run the unit tests and ensure that the ORT integration
tests pass.  Also run the plugin_verifier with a copy of a
production remap.config and plugin.config file and verify
that no errors are found.

## If this is a bug fix, what versions of Traffic Control are affected?

This is not a bug fix.

## The following criteria are ALL met by this PR

- [X] This PR includes tests OR I have explained why tests are unnecessary
- [X] This PR includes documentation OR I have explained why documentation is unnecessary
- [X] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information

None

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
