### PR TITLE
CiaB: Do not reuse Dockerfile stage names

### DIFF
--- a/infrastructure/cdn-in-a-box/enroller/Dockerfile
+++ b/infrastructure/cdn-in-a-box/enroller/Dockerfile
@@ -84,5 +84,5 @@ CMD /run.sh
 FROM enroller AS enroller-debug
 COPY --from=get-delve /go/bin /usr/bin
 
-# Makes enroller the last/default stage in the Dockerfile
-FROM enroller AS enroller
+# Makes the default target skip the enroller-debug stage
+FROM enroller

--- a/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
@@ -71,5 +71,5 @@ RUN dnf -y install golang git && \
 FROM trafficmonitor as trafficmonitor-debug
 COPY --from=get-delve /root/go/bin /usr/bin
 
-# Makes trafficmonitor the last/default stage in the Dockerfile
-FROM trafficmonitor as trafficmonitor
+# Makes the default target skip the trafficmonitor-debug stage
+FROM trafficmonitor

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -132,5 +132,5 @@ RUN go get -u github.com/go-delve/delve/cmd/dlv
 FROM trafficops AS trafficops-debug
 COPY --from=get-delve /root/go/bin /usr/bin
 
-# Makes trafficops the last/default stage in the Dockerfile
-FROM trafficops AS trafficops
+# Makes the default target skip the trafficops-debug stage
+FROM trafficops

--- a/infrastructure/cdn-in-a-box/traffic_stats/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_stats/Dockerfile
@@ -63,5 +63,5 @@ RUN dnf -y install golang git && \
 FROM trafficstats AS trafficstats-debug
 COPY --from=get-delve /root/go/bin /usr/bin
 
-# Makes trafficstats the last/default stage in the Dockerfile
-FROM trafficstats AS trafficstats
+# Makes the default target skip the trafficstats-debug stage
+FROM trafficstats


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
This PR fixes an error encountered on Docker 18.x when trying to build the `enroller`, `trafficmonitor`, `trafficops`, or `trafficstats` services after #5710 was merged:

```dockerfile
ERROR: for trafficops  (<Service: trafficops>, 'trafficops stage name already used')
Service 'trafficops' failed to build : trafficops stage name already used
```

Docker version 20.x, which I used to write #5710, has no issues with the duplicate stage names in those Dockefiles, but those duplicate stage names can be removed without losing any functionality in any Docker version.

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Install Docker version 18.06.0-ce, build `0ffa825`
2. Build CDN in a Box services:
    ```shell
    docker-compose build --parallel
    ```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (473d9c2422)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] CDN in a Box affected only, no tests necessary
- [x] Bugfix, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

