### PR TITLE
Legacy Server Defaults Monitor to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5695](https://github.com/apache/trafficcontrol/issues/5695) - Ensure vitals are calculated only against monitored interfaces
 - [#5724](https://github.com/apache/trafficcontrol/issues/5724) - Set XMPPID to hostname if the server had none, don't error on server update when XMPPID is empty
 - [#5744](https://github.com/apache/trafficcontrol/issues/5744) - Sort TM Delivery Service States page by DS name
+- Fixed server creation through legacy API versions to default `monitor` to `true`.
 
 ### Changed
 - Updated the Traffic Ops Python client to 3.0

--- a/lib/go-tc/servers.go
+++ b/lib/go-tc/servers.go
@@ -185,8 +185,8 @@ type LegacyInterfaceDetails struct {
 }
 
 // ToInterfaces converts a LegacyInterfaceDetails to a slice of
-// ServerInterfaceInfo structures. No interfaces will be marked for monitoring,
-// and it will generate service addresses according to the passed indicators
+// ServerInterfaceInfo structures. Only one interface is expected and will be marked for monitoring.
+// It will generate service addresses according to the passed indicators
 // for each address family.
 func (lid *LegacyInterfaceDetails) ToInterfaces(ipv4IsService, ipv6IsService bool) ([]ServerInterfaceInfo, error) {
 	var iface ServerInterfaceInfo
@@ -200,6 +200,10 @@ func (lid *LegacyInterfaceDetails) ToInterfaces(ipv4IsService, ipv6IsService boo
 		return nil, errors.New("interfaceName is null")
 	}
 	iface.Name = *lid.InterfaceName
+
+	// default to true since there should only be one interface from legacy API versions
+	// if Monitor is false on all interfaces, then TM will see the server as unhealthy
+	iface.Monitor = true
 
 	var ips []ServerIPAddress
 	if lid.IPAddress != nil && *lid.IPAddress != "" {
@@ -267,6 +271,10 @@ func (lid *LegacyInterfaceDetails) ToInterfacesV4(ipv4IsService, ipv6IsService b
 		return nil, errors.New("interfaceName is null")
 	}
 	iface.Name = *lid.InterfaceName
+
+	// default to true since there should only be one interface from legacy API versions
+	// if Monitor is false on all interfaces, then TM will see the server as unhealthy
+	iface.Monitor = true
 
 	var ips []ServerIPAddress
 	if lid.IPAddress != nil && *lid.IPAddress != "" {

--- a/lib/go-tc/servers_test.go
+++ b/lib/go-tc/servers_test.go
@@ -54,7 +54,7 @@ func ExampleLegacyInterfaceDetails_ToInterfaces() {
 			fmt.Printf("\taddr=%s, gateway=%s, service address=%t\n", ip.Address, *ip.Gateway, ip.ServiceAddress)
 		}
 	}
-	// Output: name=test, monitor=false
+	// Output: name=test, monitor=true
 	// 	addr=1.2.3.4/30, gateway=4.3.2.1, service address=true
 	// 	addr=::14/64, gateway=::15, service address=false
 	//
@@ -1124,8 +1124,8 @@ func TestServerNullableV2_Upgrade(t *testing.T) {
 			t.Errorf("Incorrect Interface MTU after upgrade; want: %d, got: %d", *nullable.InterfaceMtu, *inf.MTU)
 		}
 
-		if inf.Monitor {
-			t.Error("Incorrect Interface Monitor after upgrade; want: false, got: true")
+		if !inf.Monitor {
+			t.Error("Incorrect Interface Monitor after upgrade; want: true, got: false")
 		}
 
 		if inf.MaxBandwidth != nil {


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
This PR updates the legacy conversion functions to default "monitor" to true on servers created using old API versions.  A recent change made it so TM needs this to be checked in order to monitor the server and mark it as available. Old API versions should only have 1 interface so it will need to default to being monitored.


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Create a server using API 1.3 and verify that it does NOT currently mark "Monitor this interface" as true.
Run TO with this code
Create the same server using API 1.3 again and verify that it DOES mark that true by default.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->
No tests/docs/license headers since this is a minor bug fix
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
