### PR TITLE
Ansible roles: Include Grove caches in GET /caches/stats

### DIFF
--- a/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
+++ b/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
@@ -279,7 +279,7 @@ dl_ds_default_divisions:
 # Mapping of eligible TO Profile prefixes to inventory hostvar component name
 dl_ds_merged_profile_prefix_ansible_component_map: "{{ dl_ds_default_profile_prefix_ansible_component_map }}"
 dl_ds_default_profile_prefix_ansible_component_map:
-  grove: GROVE_EDGE_
+  grove: EDGE_GROVE_
   atsec: EDGE_ATS_
   atsmid: MID_ATS_
   fakeorigin: MSO_
@@ -894,7 +894,7 @@ dl_ds_default_profile_cdntemplates:
         configFile: parent.config
         value: '1'
         secure: 0
-  - name: "Grove_Edge_{{ Target_cdn_delegation }}"
+  - name: "{{ dl_ds_merged_profile_prefix_ansible_component_map.grove }}{{ Target_cdn_delegation }}"
     description: "Edge cache({{ Target_cdn_delegation }}) - Grove"
     cdn: "{{ Target_cdn_delegation }}"
     type: GROVE_PROFILE


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] As a follow-up to #5774, this PR addresses #5767 for the Ansible roles for Grove caches<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Ansible Roles

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
* Run the Ansible dataset loader, verify Profiles, Parameters and Servers are created successfully

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (b0cb1e036e)
- RELEASE-5.1.1
- RELEASE-5.1.2 (RC2)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->
- [x] Ansible roles change, no additional tests necessary until we add a testing framework for Ansible roles
- [x] #5773 contains documentation, no additional documentation is necessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
