### PR TITLE
Fixes: `go vet`: Using `http.Response` before checking for errors

### DIFF
--- a/test/router/server/server.go
+++ b/test/router/server/server.go
@@ -67,13 +67,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		url := fmt.Sprintf("https://%v/api/1.2/user/login", r.URL.Query().Get("opsHost"))
 
 		resp, err := client.Post(url, "application/json", r.Body)
-		defer resp.Body.Close()
 
 		if err != nil {
 			fmt.Println("Failed to proxy authentication to traffic ops", err.Error())
 			w.WriteHeader(500)
 			return
 		}
+
+		defer resp.Body.Close()
 
 		if resp.StatusCode != 200 {
 			fmt.Println("Dangit!!!! got non 200", resp)
@@ -140,13 +141,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		fmt.Println(client.Jar)
 
 		resp, err := client.Get(urlString)
-		defer resp.Body.Close()
 
 		if err != nil {
 			fmt.Println("Failed to proxy ", r.URL, "to host", r.URL.Query().Get("opsHost"))
 			w.WriteHeader(500)
 			return
 		}
+
+		defer resp.Body.Close()
 
 		buf, err := ioutil.ReadAll(resp.Body)
 

--- a/test/router/server/server.go
+++ b/test/router/server/server.go
@@ -70,7 +70,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 		if err != nil {
 			fmt.Println("Failed to proxy authentication to traffic ops", err.Error())
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
@@ -144,7 +144,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 		if err != nil {
 			fmt.Println("Failed to proxy ", r.URL, "to host", r.URL.Query().Get("opsHost"))
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #5759

## Which Traffic Control components are affected by this PR?
- CI tests

## What is the best way to verify this PR?
`go vet -httpresponse ./...` should find 0 issues.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)