### PR TITLE
Fix APIv4 /servers/{{host name}}/update_status to use 'response' object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a logging bug in Traffic Monitor where it wouldn't log errors in certain cases where a backup file could be used instead. Also, Traffic Monitor now rejects monitoring snapshots that have no delivery services.
 - [#5739](https://github.com/apache/trafficcontrol/issues/5739) - Prevent looping in case of a failed login attempt
 - [#5407](https://github.com/apache/trafficcontrol/issues/5407) - Make sure that you cannot add two servers with identical content
-- [#5712](https://github.com/apache/trafficcontrol/issues/5712) - Ensure that 5.x Traffic Stats is compatible with 5.x Traffic Monitor and 5.x Traffic Ops, and that it doesn't log all 0's for `cache_stats`  
+- [#5712](https://github.com/apache/trafficcontrol/issues/5712) - Ensure that 5.x Traffic Stats is compatible with 5.x Traffic Monitor and 5.x Traffic Ops, and that it doesn't log all 0's for `cache_stats`
 - [#2881](https://github.com/apache/trafficcontrol/issues/2881) - Some API endpoints have incorrect Content-Types
 - [#5363](https://github.com/apache/trafficcontrol/issues/5363) - Postgresql version changeable by env variable
 - [#5405](https://github.com/apache/trafficcontrol/issues/5405) - Prevent Tenant update from choosing child as new parent
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated Apache Tomcat from 8.5.63 to 9.0.43
 - Delivery Service Requests now keep a record of the changes they make.
 - Changed the `goose` provider to the maintained fork [`github.com/kevinburke/goose`](https://github.com/kevinburke/goose)
+- The format of the `/servers/{{host name}}/update_status` Traffic Ops API endpoint has been changed to use a top-level `response` property, in keeping with (most of) the rest of the API.
 
 ### Deprecated
 - The `riak.conf` config file and its corresponding `--riakcfg` option in `traffic_ops_golang` have been deprecated. Please use `"traffic_vault_backend": "riak"` and `"traffic_vault_config"` (with the existing contents of riak.conf) instead.

--- a/docs/source/api/v4/servers_hostname_update_status.rst
+++ b/docs/source/api/v4/servers_hostname_update_status.rst
@@ -27,7 +27,10 @@ Retrieves information regarding pending updates and revalidation jobs for a give
 
 :Auth. Required: Yes
 :Roles Required: None
-:Response Type: ``undefined`` - this endpoint will return a top-level array containing the response, as opposed to within a ``response`` object
+:Response Type: Array
+
+.. versionchanged:: 4.0
+	Prior to API version 4.0, the response was a top-level array rather than the normal ``response`` object.
 
 Request Structure
 -----------------
@@ -50,7 +53,7 @@ Request Structure
 
 Response Structure
 ------------------
-Each object in the returned array\ [1]_ will contain the following fields:
+Each object in the returned array\ [#uniqueness]_ will contain the following fields:
 
 :host_id:              The integral, unique identifier for the server for which the other fields in this object represent the pending updates and revalidation status
 :host_name:            The (short) hostname of the server for which the other fields in this object represent the pending updates and revalidation status
@@ -81,7 +84,7 @@ Each object in the returned array\ [1]_ will contain the following fields:
 	Date: Mon, 04 Feb 2019 16:24:01 GMT
 	Content-Length: 174
 
-	[{
+	{ "response": [{
 		"host_name": "edge",
 		"upd_pending": false,
 		"reval_pending": false,
@@ -90,6 +93,6 @@ Each object in the returned array\ [1]_ will contain the following fields:
 		"status": "REPORTED",
 		"parent_pending": false,
 		"parent_reval_pending": false
-	}]
+	}]}
 
-.. [1] The returned object is an array, and there is no guarantee that one server exists for a given hostname. However, for each server in the array, that server's update status will be accurate for the server with that particular server ID.
+.. [#uniqueness] The returned object is an array, and there is no guarantee that one server exists for a given hostname. However, for each server in the array, that server's update status will be accurate for the server with that particular server ID.

--- a/lib/go-tc/servers.go
+++ b/lib/go-tc/servers.go
@@ -1110,6 +1110,19 @@ type ServerUpdateStatus struct {
 	ParentRevalPending bool   `json:"parent_reval_pending"`
 }
 
+// ServerUpdateStatusResponseV40 is the type of a response from the Traffic
+// Ops API to a request to its /servers/{{host name}}/update_status endpoint
+// in API version 4.0.
+type ServerUpdateStatusResponseV40 struct {
+	Response []ServerUpdateStatus `json:"response"`
+	Alerts
+}
+
+// ServerUpdateStatusResponseV4 is the type of a response from the Traffic
+// Ops API to a request to its /servers/{{host name}}/update_status endpoint
+// in the latest minor version of API version 4.
+type ServerUpdateStatusResponseV4 = ServerUpdateStatusResponseV40
+
 type ServerPutStatus struct {
 	Status        util.JSONNameOrIDStr `json:"status"`
 	OfflineReason *string              `json:"offlineReason"`

--- a/traffic_ops/testing/api/v4/serverupdatestatus_test.go
+++ b/traffic_ops/testing/api/v4/serverupdatestatus_test.go
@@ -448,10 +448,14 @@ func TestSetTopologiesServerUpdateStatuses(t *testing.T) {
 			cachesByCacheGroup[cacheGroupName] = srvs.Response[0]
 		}
 		for _, cacheGroupName := range cacheGroupNames {
-			updateStatusByCacheGroup[cacheGroupName], _, err = TOSession.GetServerUpdateStatus(*cachesByCacheGroup[cacheGroupName].HostName, nil)
+			updResp, _, err := TOSession.GetServerUpdateStatus(*cachesByCacheGroup[cacheGroupName].HostName, nil)
 			if err != nil {
-				t.Fatalf("unable to get a server from cachegroup %s: %s", cacheGroupName, err.Error())
+				t.Fatalf("unable to get update status for a server from Cache Group '%s': %v - alerts: %+v", cacheGroupName, err, updResp.Alerts)
 			}
+			if len(updResp.Response) < 1 {
+				t.Fatalf("Expected at least one server with Host Name '%s' to have an update status", *cachesByCacheGroup[cacheGroupName].HostName)
+			}
+			updateStatusByCacheGroup[cacheGroupName] = updResp.Response[0]
 		}
 		// updating the server status does not queue updates within the same cachegroup
 		if *cachesByCacheGroup[midCacheGroup].UpdPending {
@@ -477,10 +481,14 @@ func TestSetTopologiesServerUpdateStatuses(t *testing.T) {
 			t.Fatalf("cannot update server status on %s: %s", *cachesByCacheGroup[midCacheGroup].HostName, err.Error())
 		}
 		for _, cacheGroupName := range cacheGroupNames {
-			updateStatusByCacheGroup[cacheGroupName], _, err = TOSession.GetServerUpdateStatus(*cachesByCacheGroup[cacheGroupName].HostName, nil)
+			updResp, _, err := TOSession.GetServerUpdateStatus(*cachesByCacheGroup[cacheGroupName].HostName, nil)
 			if err != nil {
-				t.Fatalf("unable to get a server from cachegroup %s: %s", cacheGroupName, err.Error())
+				t.Fatalf("unable to get an update status for a server from Cache Group '%s': %v - alerts: %+v", cacheGroupName, err, updResp.Alerts)
 			}
+			if len(updResp.Response) < 1 {
+				t.Fatalf("Expected at least one server with Host Name '%s' to have an update status", *cachesByCacheGroup[cacheGroupName].HostName)
+			}
+			updateStatusByCacheGroup[cacheGroupName] = updResp.Response[0]
 		}
 
 		// edgeCacheGroup is a descendant of midCacheGroup
@@ -499,9 +507,9 @@ func TestSetTopologiesServerUpdateStatuses(t *testing.T) {
 			t.Fatalf("unable to update %s's hostname to %s: %s", edgeHostName, *cachesByCacheGroup[midCacheGroup].HostName, err)
 		}
 
-		_, _, err = TOSession.GetServerUpdateStatus(*cachesByCacheGroup[midCacheGroup].HostName, nil)
+		updResp, _, err := TOSession.GetServerUpdateStatus(*cachesByCacheGroup[midCacheGroup].HostName, nil)
 		if err != nil {
-			t.Fatalf("expected no error getting server updates for a non-unique hostname %s, got %s", *cachesByCacheGroup[midCacheGroup].HostName, err)
+			t.Fatalf("expected no error getting server updates for a non-unique hostname %s, got: %v - alerts: %+v", *cachesByCacheGroup[midCacheGroup].HostName, err, updResp.Alerts)
 		}
 
 		*cachesByCacheGroup[edgeCacheGroup].HostName = edgeHostName

--- a/traffic_ops/traffic_ops_golang/server/servers_update_status.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_update_status.go
@@ -44,7 +44,11 @@ func GetServerUpdateStatusHandler(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
-	api.WriteRespRaw(w, r, serverUpdateStatus)
+	if inf.Version == nil || inf.Version.Major < 4 {
+		api.WriteRespRaw(w, r, serverUpdateStatus)
+	} else {
+		api.WriteResp(w, r, serverUpdateStatus)
+	}
 }
 
 func getServerUpdateStatus(tx *sql.Tx, cfg *config.Config, hostName string) ([]tc.ServerUpdateStatus, error) {

--- a/traffic_ops/v4-client/server.go
+++ b/traffic_ops/v4-client/server.go
@@ -206,15 +206,9 @@ func (to *Session) GetServerIDDeliveryServices(server int, header http.Header) (
 
 // GetServerUpdateStatus retrieves the Server Update Status of the Server with
 // the given (short) hostname.
-func (to *Session) GetServerUpdateStatus(hostName string, header http.Header) (tc.ServerUpdateStatus, toclientlib.ReqInf, error) {
-	path := APIServers + `/` + hostName + `/update_status`
-	data := []tc.ServerUpdateStatus{}
+func (to *Session) GetServerUpdateStatus(hostName string, header http.Header) (tc.ServerUpdateStatusResponseV4, toclientlib.ReqInf, error) {
+	path := APIServers + `/` + url.PathEscape(hostName) + `/update_status`
+	var data tc.ServerUpdateStatusResponseV4
 	reqInf, err := to.get(path, header, &data)
-	if err != nil {
-		return tc.ServerUpdateStatus{}, reqInf, err
-	}
-	if len(data) == 0 {
-		return tc.ServerUpdateStatus{}, reqInf, errors.New("Traffic Ops returned no update statuses for that server")
-	}
-	return data[0], reqInf, nil
+	return data, reqInf, err
 }

--- a/traffic_ops/v4-client/server.go
+++ b/traffic_ops/v4-client/server.go
@@ -16,7 +16,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/http"


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR fixes the response type for the `/servers/{{host name}}/update_status` API endpoint (version 4.0) to use the same consistent `response` object as all the others.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Make sure the API tests still pass, make sure the output reflects the documented behavior, the documentation builds with no errors or warnings, and that the documented/observed behavior is, in fact, consistent with the rest of the API

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**