### PR TITLE
Opt out of Google FLoC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added integration to use ACME to generate new SSL certificates.
 - Add a Federation to the Ansible Dataset Loader
 - Added asynchronous status to ACME certificate generation.
+- Added headers to Traffic Portal, Traffic Ops, and Traffic Monitor to opt out of tracking users via Google FLoC.
 
 ### Fixed
 - [#5690](https://github.com/apache/trafficcontrol/issues/5690) - Fixed github action for added/modified db migration file.
@@ -47,7 +48,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a logging bug in Traffic Monitor where it wouldn't log errors in certain cases where a backup file could be used instead. Also, Traffic Monitor now rejects monitoring snapshots that have no delivery services.
 - [#5739](https://github.com/apache/trafficcontrol/issues/5739) - Prevent looping in case of a failed login attempt
 - [#5407](https://github.com/apache/trafficcontrol/issues/5407) - Make sure that you cannot add two servers with identical content
-- [#5712](https://github.com/apache/trafficcontrol/issues/5712) - Ensure that 5.x Traffic Stats is compatible with 5.x Traffic Monitor and 5.x Traffic Ops, and that it doesn't log all 0's for `cache_stats`  
+- [#5712](https://github.com/apache/trafficcontrol/issues/5712) - Ensure that 5.x Traffic Stats is compatible with 5.x Traffic Monitor and 5.x Traffic Ops, and that it doesn't log all 0's for `cache_stats`
 - [#2881](https://github.com/apache/trafficcontrol/issues/2881) - Some API endpoints have incorrect Content-Types
 - [#5363](https://github.com/apache/trafficcontrol/issues/5363) - Postgresql version changeable by env variable
 - [#5405](https://github.com/apache/trafficcontrol/issues/5405) - Prevent Tenant update from choosing child as new parent

--- a/lib/go-rfc/http.go
+++ b/lib/go-rfc/http.go
@@ -36,6 +36,8 @@ const (
 	ContentDisposition = "Content-Disposition" // RFC6266
 	ContentEncoding    = "Content-Encoding"    // RFC7231§3.1.2.2
 	ContentType        = "Content-Type"        // RFC7231§3.1.1.5
+	PermissionsPolicy  = "Permissions-Policy"  // W3C "Permissions Policy"
+	Server             = "Server"              // RFC7231§7.4.2
 	Vary               = "Vary"                // RFC7231§7.1.4
 )
 

--- a/traffic_monitor/datareq/datareq.go
+++ b/traffic_monitor/datareq/datareq.go
@@ -286,6 +286,7 @@ func wrapUnpolledCheck(unpolledCaches threadsafe.UnpolledCaches, errorCount thre
 			return
 		}
 		polledAll = true
+		w.Header().Set(rfc.PermissionsPolicy, "interest-cohort=()")
 		f(w, r)
 	}
 }

--- a/traffic_monitor/srvhttp/srvhttp.go
+++ b/traffic_monitor/srvhttp/srvhttp.go
@@ -235,6 +235,7 @@ func (s *Server) handleScriptFunc(staticFileDir string) (http.HandlerFunc, error
 	}
 	return func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set(rfc.ContentType, rfc.MIME_JS.String())
+		w.Header().Set(rfc.PermissionsPolicy, "interest-cohort=()")
 		w.Write(bytes)
 	}, nil
 }
@@ -246,6 +247,7 @@ func (s *Server) handleStyleFunc(staticFileDir string) (http.HandlerFunc, error)
 	}
 	return func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set(rfc.ContentType, rfc.MIME_CSS.String())
+		w.Header().Set(rfc.PermissionsPolicy, "interest-cohort=()")
 		w.Write(bytes)
 	}, nil
 }
@@ -257,7 +259,8 @@ func (s *Server) handleFile(name string) (http.HandlerFunc, error) {
 	}
 	contentType := http.DetectContentType(bytes)
 	return func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Content-Type", contentType)
+		w.Header().Set(rfc.ContentType, contentType)
+		w.Header().Set(rfc.PermissionsPolicy, "interest-cohort=()")
 		fmt.Fprintf(w, "%s", bytes)
 	}, nil
 }

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers.go
@@ -132,6 +132,7 @@ func WrapHeaders(h http.HandlerFunc) http.HandlerFunc {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set(rfc.Vary, rfc.AcceptEncoding)
 		w.Header().Set("X-Server-Name", ServerName)
+		w.Header().Set(rfc.PermissionsPolicy, "interest-cohort=()")
 		iw := &util.BodyInterceptor{W: w}
 		h(iw, r)
 

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
@@ -72,6 +72,7 @@ func TestWrapHeaders(t *testing.T) {
 		"Content-Type":                     nil,
 		"Whole-Content-Sha512":             nil,
 		"X-Server-Name":                    nil,
+		rfc.PermissionsPolicy:              {"interest-cohorts()"},
 	}
 
 	if len(expected) != len(w.HeaderMap) {

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers_test.go
@@ -72,7 +72,7 @@ func TestWrapHeaders(t *testing.T) {
 		"Content-Type":                     nil,
 		"Whole-Content-Sha512":             nil,
 		"X-Server-Name":                    nil,
-		rfc.PermissionsPolicy:              {"interest-cohorts()"},
+		rfc.PermissionsPolicy:              {"interest-cohort=()"},
 	}
 
 	if len(expected) != len(w.HeaderMap) {

--- a/traffic_portal/server.js
+++ b/traffic_portal/server.js
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,6 @@ var constants = require('constants'),
     express = require('express'),
     http = require('http'),
     https = require('https'),
-    path = require('path'),
     fs = require('fs'),
     morgan = require('morgan'),
     modRewrite = require('connect-modrewrite'),
@@ -58,6 +57,8 @@ app.use(function(req, res, next) {
     if (err){
         console.log(err, req.url);
     }
+
+    res.setHeader("Permissions-Policy", "interest-cohort=()")
     next();
 });
 

--- a/traffic_portal/server.js
+++ b/traffic_portal/server.js
@@ -45,6 +45,10 @@ var logStream = fs.createWriteStream(config.log.stream, { flags: 'a' }),
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = config.reject_unauthorized;
 
 var app = express();
+app.use(function(_, resp, next) {
+    resp.setHeader("Permissions-Policy", "interest-cohort=()")
+    next();
+});
 
 app.use(function(req, res, next) {
     var err = null;
@@ -57,8 +61,6 @@ app.use(function(req, res, next) {
     if (err){
         console.log(err, req.url);
     }
-
-    res.setHeader("Permissions-Policy", "interest-cohort=()")
     next();
 });
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR adds an HTTP header (`Permissions-Policy: interest-cohort()`) to the responses of the Traffic Ops API, Traffic Portal's proxy and static file handlers, and Traffic Monitor's API and static file handlers. It would also add it to Traffic Router if I could figure out how.

This header opts the servers out of Google's new browser-baked-in fingerprinting and tracking system called FLoC. FLoC tracks users browsing activity and reports it to Google to be sold to third parties for the purpose of targeted advertising. For a more accurate and in-depth description, refer to [The Electronic Frontier Foundation's article/open letter to Google on the subject](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea).

The behavior is present in Chrome browsers at version 89 or later (and possibly other Chromium-based browsers, I haven't looked into that).

## Which Traffic Control components are affected by this PR?
- Traffic Monitor
- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
Make requests to the TO API, verify the presence of the new header, do the same with Traffic Monitor, load the TM UI and verify the presence of the new header, load Traffic Portal and verify that both static file requests and proxied API requests have the new header.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**