### PR TITLE
Fix `go vet`: call of Unmarshal passes non-pointer as second argument

### DIFF
--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -373,7 +373,7 @@ func (o *OriginHeaders) UnmarshalJSON(data []byte) error {
 	}
 
 	headers := []string{}
-	if err := json.Unmarshal(data, headers); err == nil {
+	if err := json.Unmarshal(data, &headers); err == nil {
 		*o = OriginHeaders(headers)
 		return nil
 	}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #5765

## Which Traffic Control components are affected by this PR?
- Traffic Ops (`go-tc` library)

## What is the best way to verify this PR?
`go vet -unmarshal ./...` should find 0 issues.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)