### PR TITLE
Fix `go vet`: Loop variable captured by func literal

### DIFF
--- a/traffic_ops/testing/api/v1/parameters_test.go
+++ b/traffic_ops/testing/api/v1/parameters_test.go
@@ -104,10 +104,10 @@ func DeleteTestParametersParallel(t *testing.T) {
 	for _, pl := range testData.Parameters {
 
 		wg.Add(1)
-		go func() {
+		go func(p tc.Parameter) {
 			defer wg.Done()
-			DeleteTestParameter(t, pl)
-		}()
+			DeleteTestParameter(t, p)
+		}(pl)
 
 	}
 	wg.Wait()

--- a/traffic_ops/testing/api/v1/profile_parameters_test.go
+++ b/traffic_ops/testing/api/v1/profile_parameters_test.go
@@ -132,10 +132,10 @@ func DeleteTestProfileParametersParallel(t *testing.T) {
 	for _, pp := range testData.ProfileParameters {
 
 		wg.Add(1)
-		go func() {
+		go func(p tc.ProfileParameter) {
 			defer wg.Done()
-			DeleteTestProfileParameter(t, pp)
-		}()
+			DeleteTestProfileParameter(t, p)
+		}(pp)
 
 	}
 	wg.Wait()

--- a/traffic_ops/testing/api/v2/parameters_test.go
+++ b/traffic_ops/testing/api/v2/parameters_test.go
@@ -90,10 +90,10 @@ func DeleteTestParametersParallel(t *testing.T) {
 	for _, pl := range testData.Parameters {
 
 		wg.Add(1)
-		go func() {
+		go func(p tc.Parameter) {
 			defer wg.Done()
-			DeleteTestParameter(t, pl)
-		}()
+			DeleteTestParameter(t, p)
+		}(pl)
 
 	}
 	wg.Wait()

--- a/traffic_ops/testing/api/v2/profile_parameters_test.go
+++ b/traffic_ops/testing/api/v2/profile_parameters_test.go
@@ -77,10 +77,10 @@ func DeleteTestProfileParametersParallel(t *testing.T) {
 	for _, pp := range testData.ProfileParameters {
 
 		wg.Add(1)
-		go func() {
+		go func(p tc.ProfileParameter) {
 			defer wg.Done()
-			DeleteTestProfileParameter(t, pp)
-		}()
+			DeleteTestProfileParameter(t, p)
+		}(pp)
 
 	}
 	wg.Wait()

--- a/traffic_ops/testing/api/v3/parameters_test.go
+++ b/traffic_ops/testing/api/v3/parameters_test.go
@@ -200,10 +200,10 @@ func DeleteTestParametersParallel(t *testing.T) {
 	for _, pl := range testData.Parameters {
 
 		wg.Add(1)
-		go func() {
+		go func(p tc.Parameter) {
 			defer wg.Done()
-			DeleteTestParameter(t, pl)
-		}()
+			DeleteTestParameter(t, p)
+		}(pl)
 
 	}
 	wg.Wait()

--- a/traffic_ops_ort/testing/ort-tests/tcdata/parameters.go
+++ b/traffic_ops_ort/testing/ort-tests/tcdata/parameters.go
@@ -40,10 +40,10 @@ func (r *TCData) DeleteTestParametersParallel(t *testing.T) {
 	for _, pl := range r.TestData.Parameters {
 
 		wg.Add(1)
-		go func() {
+		go func(p tc.Parameter) {
 			defer wg.Done()
-			DeleteTestParameter(t, pl)
-		}()
+			DeleteTestParameter(t, p)
+		}(pl)
 
 	}
 	wg.Wait()

--- a/traffic_ops_ort/testing/ort-tests/tcdata/profile_parameters.go
+++ b/traffic_ops_ort/testing/ort-tests/tcdata/profile_parameters.go
@@ -60,10 +60,10 @@ func (r *TCData) DeleteTestProfileParametersParallel(t *testing.T) {
 	for _, pp := range r.TestData.ProfileParameters {
 
 		wg.Add(1)
-		go func() {
+		go func(p tc.ProfileParameter) {
 			defer wg.Done()
-			DeleteTestProfileParameter(t, pp)
-		}()
+			DeleteTestProfileParameter(t, p)
+		}(pp)
 
 	}
 	wg.Wait()


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #5760

## Which Traffic Control components are affected by this PR?
- Traffic Ops (API tests)
- Traffic Ops ORT

## What is the best way to verify this PR?
`go vet -loopclosure ./...` should find 0 issues.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)